### PR TITLE
Updates `flutter/test/material` to no longer use `TestWindow`

### DIFF
--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -413,6 +406,9 @@ void main() {
 
   testWidgets("WidgetsApp doesn't rebuild routes when MediaQuery updates", (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/37878
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+    addTearDown(tester.view.reset);
+
     int routeBuildCount = 0;
     int dependentBuildCount = 0;
 
@@ -436,8 +432,7 @@ void main() {
     expect(dependentBuildCount, equals(1));
 
     // didChangeMetrics
-    tester.binding.window.physicalSizeTestValue = const Size(42, 42);
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    tester.view.physicalSize = const Size(42, 42);
 
     await tester.pump();
 
@@ -445,8 +440,7 @@ void main() {
     expect(dependentBuildCount, equals(2));
 
     // didChangeTextScaleFactor
-    tester.binding.platformDispatcher.textScaleFactorTestValue = 42;
-    addTearDown(tester.binding.platformDispatcher.clearTextScaleFactorTestValue);
+    tester.platformDispatcher.textScaleFactorTestValue = 42;
 
     await tester.pump();
 
@@ -454,8 +448,7 @@ void main() {
     expect(dependentBuildCount, equals(3));
 
     // didChangePlatformBrightness
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
-    addTearDown(tester.binding.platformDispatcher.clearPlatformBrightnessTestValue);
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
 
     await tester.pump();
 
@@ -463,8 +456,7 @@ void main() {
     expect(dependentBuildCount, equals(4));
 
     // didChangeAccessibilityFeatures
-    tester.binding.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
-    addTearDown(tester.binding.platformDispatcher.clearAccessibilityFeaturesTestValue);
+    tester.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     await tester.pump();
 
@@ -528,8 +520,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses regular theme when themeMode is light', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a light platformBrightness.
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a light platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
 
     late ThemeData appliedTheme;
     await tester.pumpWidget(
@@ -551,8 +545,8 @@ void main() {
     );
     expect(appliedTheme.brightness, Brightness.light);
 
-    // Mock the Window to explicitly report a dark platformBrightness.
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
@@ -574,8 +568,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses darkTheme when themeMode is dark', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a light platformBrightness.
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a light platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
 
     late ThemeData appliedTheme;
     await tester.pumpWidget(
@@ -597,8 +593,8 @@ void main() {
     );
     expect(appliedTheme.brightness, Brightness.dark);
 
-    // Mock the Window to explicitly report a dark platformBrightness.
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
@@ -620,9 +616,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses regular theme when themeMode is system and platformBrightness is light', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a light platformBrightness.
-    final TestWidgetsFlutterBinding binding = tester.binding;
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a light platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
 
     late ThemeData appliedTheme;
 
@@ -647,8 +644,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses darkTheme when themeMode is system and platformBrightness is dark', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a dark platformBrightness.
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
 
     late ThemeData appliedTheme;
     await tester.pumpWidget(
@@ -671,9 +670,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses light theme when platformBrightness is dark but no dark theme is provided', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a dark platformBrightness.
-    final TestWidgetsFlutterBinding binding = tester.binding;
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
 
     late ThemeData appliedTheme;
 
@@ -695,9 +695,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses fallback light theme when platformBrightness is dark but no theme is provided at all', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a dark platformBrightness.
-    final TestWidgetsFlutterBinding binding = tester.binding;
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
 
     late ThemeData appliedTheme;
 
@@ -716,9 +717,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses fallback light theme when platformBrightness is light and a dark theme is provided', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a dark platformBrightness.
-    final TestWidgetsFlutterBinding binding = tester.binding;
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
 
     late ThemeData appliedTheme;
 
@@ -740,9 +742,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses dark theme when platformBrightness is dark', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a dark platformBrightness.
-    final TestWidgetsFlutterBinding binding = tester.binding;
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a dark platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
 
     late ThemeData appliedTheme;
 
@@ -767,8 +770,10 @@ void main() {
   });
 
   testWidgets('MaterialApp uses high contrast theme when appropriate', (WidgetTester tester) async {
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
-    tester.binding.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+    tester.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     late ThemeData appliedTheme;
 
@@ -790,12 +795,13 @@ void main() {
     );
 
     expect(appliedTheme.primaryColor, Colors.blue);
-    tester.binding.platformDispatcher.clearAccessibilityFeaturesTestValue();
   });
 
   testWidgets('MaterialApp uses high contrast dark theme when appropriate', (WidgetTester tester) async {
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
-    tester.binding.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    tester.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     late ThemeData appliedTheme;
 
@@ -823,12 +829,13 @@ void main() {
     );
 
     expect(appliedTheme.primaryColor, Colors.green);
-    tester.binding.platformDispatcher.clearAccessibilityFeaturesTestValue();
   });
 
   testWidgets('MaterialApp uses dark theme when no high contrast dark theme is provided', (WidgetTester tester) async {
-    tester.binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
-    tester.binding.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    tester.platformDispatcher.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     late ThemeData appliedTheme;
 
@@ -850,8 +857,6 @@ void main() {
     );
 
     expect(appliedTheme.primaryColor, Colors.lightGreen);
-    tester.binding.platformDispatcher.clearAccessibilityFeaturesTestValue();
-    tester.binding.platformDispatcher.clearPlatformBrightnessTestValue();
   });
 
   testWidgets('MaterialApp animates theme changes', (WidgetTester tester) async {
@@ -936,10 +941,11 @@ void main() {
     expect(scaffoldRebuilds, 2);
   });
 
-  testWidgets('MaterialApp switches themes when the Window platformBrightness changes.', (WidgetTester tester) async {
-    // Mock the Window to explicitly report a light platformBrightness.
-    final TestWidgetsFlutterBinding binding = tester.binding;
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+  testWidgets('MaterialApp switches themes when the platformBrightness changes.', (WidgetTester tester) async {
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+
+    // Mock the test to explicitly report a light platformBrightness.
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.light;
 
     ThemeData? themeBeforeBrightnessChange;
     ThemeData? themeAfterBrightnessChange;
@@ -967,7 +973,7 @@ void main() {
 
     // Switch the platformBrightness from light to dark and pump the widget tree
     // to process changes.
-    binding.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+    tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     await tester.pumpAndSettle();
 
     expect(themeBeforeBrightnessChange!.brightness, Brightness.light);

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -275,7 +275,7 @@ void main() {
       // Verify that the time picker is being laid out RTL.
       // We expect the left edge of the 'OK' button in the RTL
       // layout to match the gap between right edge of the 'OK'
-      // button and the right edge of the 800 wide window.
+      // button and the right edge of the 800 wide view.
       expect(tester.getBottomLeft(find.text('OK')).dx, 800 - ltrOkRight);
     });
 
@@ -440,8 +440,8 @@ void main() {
 
       // Portrait layout.
 
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-      tester.binding.window.physicalSizeTestValue = const Size(900, 1200);
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = const Size(900, 1200);
 
       await tester.pumpWidget(buildFrame(TextDirection.ltr));
       await tester.tap(find.text('X'));
@@ -1105,10 +1105,10 @@ void main() {
     const Size kSmallScreenSizeLandscape = Size(521, 320);
 
     Future<void> showPicker(WidgetTester tester, Size size, [double textScaleFactor = 1.0]) async {
-      tester.binding.window.physicalSizeTestValue = size;
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-      tester.binding.window.devicePixelRatioTestValue = 1.0;
-      addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         await tester.tap(find.text('OK'));
       });

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -424,8 +424,8 @@ void main() {
 
   testWidgets('Disposing drawer does not crash if drawer is open and framework is locked', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/34978
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-    tester.binding.window.physicalSizeTestValue = const Size(1800.0, 2400.0);
+    addTearDown(tester.view.reset);
+    tester.view.physicalSize = const Size(1800.0, 2400.0);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -458,15 +458,15 @@ void main() {
 
     // Change the orientation and cause the drawer controller to be disposed
     // while the framework is locked.
-    tester.binding.window.physicalSizeTestValue = const Size(2400.0, 1800.0);
+    tester.view.physicalSize = const Size(2400.0, 1800.0);
     await tester.pumpAndSettle();
     expect(find.byType(BackButton), findsNothing);
   });
 
   testWidgets('Disposing endDrawer does not crash if endDrawer is open and framework is locked', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/34978
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-    tester.binding.window.physicalSizeTestValue = const Size(1800.0, 2400.0);
+    addTearDown(tester.view.reset);
+    tester.view.physicalSize = const Size(1800.0, 2400.0);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -499,7 +499,7 @@ void main() {
 
     // Change the orientation and cause the drawer controller to be disposed
     // while the framework is locked.
-    tester.binding.window.physicalSizeTestValue = const Size(2400.0, 1800.0);
+    tester.view.physicalSize = const Size(2400.0, 1800.0);
     await tester.pumpAndSettle();
     expect(find.byType(BackButton), findsNothing);
   });

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -406,7 +406,7 @@ void main() {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: MediaQuery(
-          data: MediaQueryData.fromView(tester.binding.window),
+          data: MediaQueryData.fromView(tester.view),
           child: Navigator(
             initialRoute: '/',
             onGenerateRoute: (RouteSettings settings) {
@@ -3167,10 +3167,9 @@ void main() {
     // The default item height is 48.0 pixels and needs two items padding since
     // the menu requires empty space surrounding the menu. Finally, the constraint height
     // is 47.0 pixels for the menu rendering.
-    tester.binding.window.physicalSizeTestValue = const Size(800.0, 48.0 * 3 - 1.0);
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-    addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
+    tester.view.physicalSize = const Size(800.0, 48.0 * 3 - 1.0);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
 
     const String value = 'foo';
     final UniqueKey itemKey = UniqueKey();

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -11,7 +11,7 @@ void main() {
     int mutatedIndex = -1;
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     final ThemeData theme= ThemeData.from(colorScheme: const ColorScheme.light());
-    widgetSetup(tester, 3000, windowHeight: 3000);
+    widgetSetup(tester, 3000, viewHeight: 3000);
     final Widget widget = _buildWidget(
       scaffoldKey,
       NavigationDrawer(
@@ -154,7 +154,7 @@ void main() {
 
   testWidgets('Navigation drawer is scrollable', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-    widgetSetup(tester, 500, windowHeight: 300);
+    widgetSetup(tester, 500, viewHeight: 300);
     await tester.pumpWidget(
       _buildWidget(
         scaffoldKey,
@@ -201,8 +201,8 @@ void main() {
 
   testWidgets('Safe Area test', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-    const double windowHeight = 300;
-    widgetSetup(tester, 500, windowHeight: windowHeight);
+    const double viewHeight = 300;
+    widgetSetup(tester, 500, viewHeight: viewHeight);
     await tester.pumpWidget(
       MediaQuery(
         data: const MediaQueryData(padding: EdgeInsets.all(20.0)),
@@ -237,7 +237,7 @@ void main() {
     );
 
     // No Safe area padding at the bottom.
-    expect(tester.getBottomRight(find.widgetWithText(NavigationDrawerDestination,'Label4')).dy, windowHeight);
+    expect(tester.getBottomRight(find.widgetWithText(NavigationDrawerDestination,'Label4')).dy, viewHeight);
    });
 
   testWidgets('Navigation drawer semantics', (WidgetTester tester) async {
@@ -387,11 +387,8 @@ ShapeDecoration? _getIndicatorDecoration(WidgetTester tester) {
       .decoration as ShapeDecoration?;
 }
 
-void widgetSetup(WidgetTester tester, double windowWidth,
-    {double? windowHeight}) {
-  final double height = windowHeight ?? 1000;
-  tester.binding.window.devicePixelRatioTestValue = 2;
-  final double dpi = tester.binding.window.devicePixelRatio;
-  tester.binding.window.physicalSizeTestValue =
-      Size(windowWidth * dpi, height * dpi);
+void widgetSetup(WidgetTester tester, double viewWidth, {double viewHeight = 1000}) {
+  tester.view.devicePixelRatio = 2;
+  final double dpi = tester.view.devicePixelRatio;
+  tester.view.physicalSize = Size(viewWidth * dpi, viewHeight * dpi);
 }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -4,7 +4,6 @@
 
 @Tags(<String>['reduced-test-set'])
 library;
-import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart' show CupertinoPageRoute;
 import 'package:flutter/foundation.dart';
@@ -239,52 +238,44 @@ void main() {
     expect(find.text('Page 2'), findsNothing);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets('test page transition (_ZoomPageTransition) with rasterization re-rasterizes when window insets', (WidgetTester tester) async {
-    late Size oldSize;
-    late ui.ViewPadding oldInsets;
-    try {
-      oldSize = tester.binding.window.physicalSize;
-      oldInsets = tester.binding.window.viewInsets;
-      tester.binding.window.physicalSizeTestValue = const Size(1000, 1000);
-      tester.binding.window.viewInsetsTestValue = ui.ViewPadding.zero;
+  testWidgets('test page transition (_ZoomPageTransition) with rasterization re-rasterizes when view insets change', (WidgetTester tester) async {
+    addTearDown(tester.view.reset);
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.viewInsets = FakeViewPadding.zero;
 
-      // Intentionally use nested scaffolds to simulate the view insets being
-      // consumed.
-      final Key key = GlobalKey();
-      await tester.pumpWidget(
-        RepaintBoundary(
-          key: key,
-          child: MaterialApp(
-            onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<void>(
-                builder: (BuildContext context) {
-                  return const Scaffold(body: Scaffold(
-                    body: Material(child: SizedBox.shrink())
-                  ));
-                },
-              );
-            },
-          ),
+    // Intentionally use nested scaffolds to simulate the view insets being
+    // consumed.
+    final Key key = GlobalKey();
+    await tester.pumpWidget(
+      RepaintBoundary(
+        key: key,
+        child: MaterialApp(
+          onGenerateRoute: (RouteSettings settings) {
+            return MaterialPageRoute<void>(
+              builder: (BuildContext context) {
+                return const Scaffold(body: Scaffold(
+                  body: Material(child: SizedBox.shrink())
+                ));
+              },
+            );
+          },
         ),
-      );
+      ),
+    );
 
-      tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
 
-      await expectLater(find.byKey(key), matchesGoldenFile('zoom_page_transition.small.png'));
+    await expectLater(find.byKey(key), matchesGoldenFile('zoom_page_transition.small.png'));
 
-       // Change the view insets.
-      tester.binding.window.viewInsetsTestValue = const TestViewPadding(left: 0, top: 0, right: 0, bottom: 500);
+    // Change the view insets.
+    tester.view.viewInsets = const FakeViewPadding(bottom: 500);
 
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
 
-      await expectLater(find.byKey(key), matchesGoldenFile('zoom_page_transition.big.png'));
-    } finally {
-      tester.binding.window.physicalSizeTestValue = oldSize;
-      tester.binding.window.viewInsetsTestValue = oldInsets;
-    }
+    await expectLater(find.byKey(key), matchesGoldenFile('zoom_page_transition.big.png'));
   }, variant: TargetPlatformVariant.only(TargetPlatform.android), skip: kIsWeb); // [intended] rasterization is not used on the web.
 
   testWidgets(
@@ -1327,22 +1318,4 @@ class TestDependencies extends StatelessWidget {
       ),
     );
   }
-}
-
-class TestViewPadding implements ui.ViewPadding {
-  const TestViewPadding({
-    required this.left,
-    required this.top,
-    required this.right,
-    required this.bottom,
-  });
-
-  @override
-  final double left;
-  @override
-  final double top;
-  @override
-  final double right;
-  @override
-  final double bottom;
 }

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -5,10 +5,9 @@
 // TODO(gspencergoog): Remove this tag once this test's state leaks/test
 // dependencies have been fixed.
 // https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=382757700"
+// Fails with "flutter test --test-randomize-ordering-seed=20230313"
 @Tags(<String>['no-shuffle'])
 library;
-
 import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart';
@@ -148,7 +147,7 @@ void main() {
       pixels: 0.0,
       viewportDimension: 100.0,
       axisDirection: AxisDirection.down,
-      devicePixelRatio: tester.binding.window.devicePixelRatio,
+      devicePixelRatio: tester.view.devicePixelRatio,
     );
     scrollPainter!.update(metrics, AxisDirection.down);
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2,19 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// no-shuffle:
-//   //TODO(gspencergoog): Remove this tag once this test's state leaks/test
-//   dependencies have been fixed.
-//   https://github.com/flutter/flutter/issues/85160
-//   Fails with "flutter test --test-randomize-ordering-seed=456"
 // reduced-test-set:
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
-@Tags(<String>['reduced-test-set', 'no-shuffle'])
+@Tags(<String>['reduced-test-set'])
 library;
 
 import 'dart:math' as math;
-import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, ViewPadding;
+import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -138,26 +133,6 @@ class TestFormatter extends TextInputFormatter {
     onFormatEditUpdate(oldValue, newValue);
     return newValue;
   }
-}
-
-// Used to set window.viewInsets since the real ui.WindowPadding has only a
-// private constructor.
-class _TestViewPadding implements ui.ViewPadding {
-  const _TestViewPadding({
-    required this.bottom,
-  });
-
-  @override
-  final double bottom;
-
-  @override
-  double get top => 0.0;
-
-  @override
-  double get left => 0.0;
-
-  @override
-  double get right => 0.0;
 }
 
 void main() {
@@ -3549,10 +3524,8 @@ void main() {
       // Add a viewInset tall enough to push the field to the top, where there
       // is no room to display the toolbar above. This is similar to when the
       // keyboard is shown.
-      tester.binding.window.viewInsetsTestValue = const _TestViewPadding(
-        bottom: 500.0,
-      );
-      addTearDown(tester.binding.window.clearViewInsetsTestValue);
+      tester.view.viewInsets = const FakeViewPadding(bottom: 500.0);
+      addTearDown(tester.view.reset);
       await tester.pumpAndSettle();
 
       // Verify the selection toolbar position is below the text.
@@ -3561,7 +3534,7 @@ void main() {
       expect(toolbarTopLeft.dy, greaterThan(textFieldTopLeft.dy));
 
       // Remove the viewInset, as if the keyboard were hidden.
-      tester.binding.window.clearViewInsetsTestValue();
+      tester.view.resetViewInsets();
       await tester.pumpAndSettle();
 
       // Verify the selection toolbar position is below the text.
@@ -4964,9 +4937,9 @@ void main() {
       editable.getLocalRectForCaret(const TextPosition(offset: 0)).topLeft,
     );
 
-    // The overlay() function centers its child within a 800x600 window.
-    // Default cursorWidth is 2.0, test windowWidth is 800
-    // Centered cursor topLeft.dx: 399 == windowWidth/2 - cursorWidth/2
+    // The overlay() function centers its child within a 800x600 view.
+    // Default cursorWidth is 2.0, test viewWidth is 800
+    // Centered cursor topLeft.dx: 399 == viewWidth/2 - cursorWidth/2
     expect(topLeft.dx, equals(399.0));
 
     await tester.enterText(find.byType(TextField), 'abcd');
@@ -5000,9 +4973,9 @@ void main() {
       editable.getLocalRectForCaret(const TextPosition(offset: 0)).topLeft,
     );
 
-    // The overlay() function centers its child within a 800x600 window.
-    // Default cursorWidth is 2.0, test windowWidth is 800
-    // Centered cursor topLeft.dx: 399 == windowWidth/2 - cursorWidth/2
+    // The overlay() function centers its child within a 800x600 view.
+    // Default cursorWidth is 2.0, test viewWidth is 800
+    // Centered cursor topLeft.dx: 399 == viewWidth/2 - cursorWidth/2
     expect(topLeft.dx, equals(399.0));
 
     await tester.enterText(find.byType(TextField), 'abcd');

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -158,8 +158,8 @@ void main() {
 
     testWidgets("When menu items don't fit, an overflow menu is used.", (WidgetTester tester) async {
       // Set the screen size to more narrow, so that Select all can't fit.
-      tester.binding.window.physicalSizeTestValue = const Size(1000, 800);
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+      tester.view.physicalSize = const Size(1000, 800);
+      addTearDown(tester.view.reset);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
       await tester.pumpWidget(MaterialApp(
@@ -232,8 +232,8 @@ void main() {
 
     testWidgets('A smaller menu bumps more items to the overflow menu.', (WidgetTester tester) async {
       // Set the screen size so narrow that only Cut and Copy can fit.
-      tester.binding.window.physicalSizeTestValue = const Size(800, 800);
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+      tester.view.physicalSize = const Size(800, 800);
+      addTearDown(tester.view.reset);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
       await tester.pumpWidget(MaterialApp(
@@ -297,8 +297,8 @@ void main() {
 
     testWidgets('When the menu renders below the text, the overflow menu back button is at the top.', (WidgetTester tester) async {
       // Set the screen size to more narrow, so that Select all can't fit.
-      tester.binding.window.physicalSizeTestValue = const Size(1000, 800);
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+      tester.view.physicalSize = const Size(1000, 800);
+      addTearDown(tester.view.reset);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
       await tester.pumpWidget(MaterialApp(
@@ -371,8 +371,8 @@ void main() {
 
     testWidgets('When the menu items change, the menu is closed and _closedWidth reset.', (WidgetTester tester) async {
       // Set the screen size to more narrow, so that Select all can't fit.
-      tester.binding.window.physicalSizeTestValue = const Size(1000, 800);
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+      tester.view.physicalSize = const Size(1000, 800);
+      addTearDown(tester.view.reset);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
       await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -361,9 +361,11 @@ void main() {
       }
 
       testWidgets('when change orientation, should reflect in render objects', (WidgetTester tester) async {
+        addTearDown(tester.view.reset);
+
         // portrait
-        tester.binding.window.physicalSizeTestValue = const Size(800, 800.5);
-        tester.binding.window.devicePixelRatioTestValue = 1;
+        tester.view.physicalSize = const Size(800, 800.5);
+        tester.view.devicePixelRatio = 1;
         await mediaQueryBoilerplate(tester, materialType: materialType);
 
         RenderObject render = tester.renderObject(
@@ -372,32 +374,28 @@ void main() {
         expect((render as dynamic).orientation, Orientation.portrait); // ignore: avoid_dynamic_calls
 
         // landscape
-        tester.binding.window.physicalSizeTestValue = const Size(800.5, 800);
-        tester.binding.window.devicePixelRatioTestValue = 1;
+        tester.view.physicalSize = const Size(800.5, 800);
+        tester.view.devicePixelRatio = 1;
         await mediaQueryBoilerplate(tester, tapButton: false, materialType: materialType);
 
         render = tester.renderObject(
           find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodInputPadding'),
         );
         expect((render as dynamic).orientation, Orientation.landscape); // ignore: avoid_dynamic_calls
-
-        tester.binding.window.clearPhysicalSizeTestValue();
-        tester.binding.window.clearDevicePixelRatioTestValue();
       });
 
       testWidgets('setting orientation should override MediaQuery orientation', (WidgetTester tester) async {
+        addTearDown(tester.view.reset);
+
         // portrait media query
-        tester.binding.window.physicalSizeTestValue = const Size(800, 800.5);
-        tester.binding.window.devicePixelRatioTestValue = 1;
+        tester.view.physicalSize = const Size(800, 800.5);
+        tester.view.devicePixelRatio = 1;
         await mediaQueryBoilerplate(tester, orientation: Orientation.landscape, materialType: materialType);
 
         final RenderObject render = tester.renderObject(
           find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_DayPeriodInputPadding'),
         );
         expect((render as dynamic).orientation, Orientation.landscape); // ignore: avoid_dynamic_calls
-
-        tester.binding.window.clearPhysicalSizeTestValue();
-        tester.binding.window.clearDevicePixelRatioTestValue();
       });
 
       testWidgets('builder parameter', (WidgetTester tester) async {
@@ -444,7 +442,7 @@ void main() {
         // Verify that the time picker is being laid out RTL.
         // We expect the left edge of the 'OK' button in the RTL
         // layout to match the gap between right edge of the 'OK'
-        // button and the right edge of the 800 wide window.
+        // button and the right edge of the 800 wide view.
         expect(tester.getBottomLeft(find.text(okString)).dx, 800 - ltrOkRight);
       });
 
@@ -783,19 +781,21 @@ void main() {
       group('Works for various view sizes', () {
         for (final Size size in const <Size>[Size(100, 100), Size(300, 300), Size(800, 600)]) {
           testWidgets('Draws dial without overflows at $size', (WidgetTester tester) async {
-            tester.binding.window.physicalSizeTestValue = size;
+            tester.view.physicalSize = size;
+            addTearDown(tester.view.reset);
+
             await mediaQueryBoilerplate(tester, entryMode: TimePickerEntryMode.input, materialType: materialType);
             await tester.pumpAndSettle();
             expect(tester.takeException(), isNot(throwsAssertionError));
-            tester.binding.window.clearPhysicalSizeTestValue();
           });
 
           testWidgets('Draws input without overflows at $size', (WidgetTester tester) async {
-            tester.binding.window.physicalSizeTestValue = size;
+            tester.view.physicalSize = size;
+            addTearDown(tester.view.reset);
+
             await mediaQueryBoilerplate(tester, materialType: materialType);
             await tester.pumpAndSettle();
             expect(tester.takeException(), isNot(throwsAssertionError));
-            tester.binding.window.clearPhysicalSizeTestValue();
           });
         }
       });
@@ -1035,8 +1035,10 @@ void main() {
 
       testWidgets('header touch regions are large enough', (WidgetTester tester) async {
         // Ensure picker is displayed in portrait mode.
-        tester.binding.window.physicalSizeTestValue = const Size(400, 800);
-        tester.binding.window.devicePixelRatioTestValue = 1;
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
         await mediaQueryBoilerplate(tester, materialType: materialType);
 
         final Size dayPeriodControlSize = tester.getSize(
@@ -1058,9 +1060,6 @@ void main() {
         ));
         expect(minuteSize.width, greaterThanOrEqualTo(48));
         expect(minuteSize.height, greaterThanOrEqualTo(48));
-
-        tester.binding.window.clearPhysicalSizeTestValue();
-        tester.binding.window.clearDevicePixelRatioTestValue();
       });
     });
 
@@ -1551,7 +1550,7 @@ Future<void> mediaQueryBoilerplate(
               alwaysUse24HourFormat: alwaysUse24HourFormat,
               textScaleFactor: textScaleFactor,
               accessibleNavigation: accessibleNavigation,
-              size: tester.binding.window.physicalSize / tester.binding.window.devicePixelRatio,
+              size: tester.view.physicalSize / tester.view.devicePixelRatio,
             ),
             child: Material(
               child: Center(

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -124,6 +124,9 @@ class FakeViewPadding implements ViewPadding {
     right = base.right,
     bottom = base.bottom;
 
+  /// A view padding that has zeros for each edge.
+  static const FakeViewPadding zero = FakeViewPadding();
+
   @override
   final double left;
 

--- a/packages/flutter_test/test/view_test.dart
+++ b/packages/flutter_test/test/view_test.dart
@@ -82,7 +82,7 @@ void main() {
       verifyPropertyFaked<ViewPadding>(
         tester: tester,
         realValue: trueImplicitView().padding,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().padding,
         propertyFaker: (_, ViewPadding fakeValue) {
           tester.view.padding = fakeValue as FakeViewPadding;
@@ -94,7 +94,7 @@ void main() {
     testWidgets('can reset padding', (WidgetTester tester) async {
       verifyPropertyReset<ViewPadding>(
         tester: tester,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().padding,
         propertyResetter: () {
           tester.view.resetPadding();
@@ -180,7 +180,7 @@ void main() {
       verifyPropertyFaked<ViewPadding>(
         tester: tester,
         realValue: trueImplicitView().systemGestureInsets,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().systemGestureInsets,
         propertyFaker: (_, ViewPadding fakeValue) {
           tester.view.systemGestureInsets = fakeValue as FakeViewPadding;
@@ -192,7 +192,7 @@ void main() {
     testWidgets('can reset systemGestureInsets', (WidgetTester tester) async {
       verifyPropertyReset<ViewPadding>(
         tester: tester,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().systemGestureInsets,
         propertyResetter: () {
           tester.view.resetSystemGestureInsets();
@@ -208,7 +208,7 @@ void main() {
       verifyPropertyFaked<ViewPadding>(
         tester: tester,
         realValue: trueImplicitView().viewInsets,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().viewInsets,
         propertyFaker: (_, ViewPadding fakeValue) {
           tester.view.viewInsets = fakeValue as FakeViewPadding;
@@ -220,7 +220,7 @@ void main() {
     testWidgets('can reset viewInsets', (WidgetTester tester) async {
       verifyPropertyReset<ViewPadding>(
         tester: tester,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().viewInsets,
         propertyResetter: () {
           tester.view.resetViewInsets();
@@ -236,7 +236,7 @@ void main() {
       verifyPropertyFaked<ViewPadding>(
         tester: tester,
         realValue: trueImplicitView().viewPadding,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().viewPadding,
         propertyFaker: (_, ViewPadding fakeValue) {
           tester.view.viewPadding = fakeValue as FakeViewPadding;
@@ -248,7 +248,7 @@ void main() {
     testWidgets('can reset viewPadding', (WidgetTester tester) async {
       verifyPropertyReset<ViewPadding>(
         tester: tester,
-        fakeValue: const FakeViewPadding(),
+        fakeValue: FakeViewPadding.zero,
         propertyRetriever: () => boundImplicitView().viewPadding,
         propertyResetter: () {
           tester.view.resetViewPadding();
@@ -265,11 +265,11 @@ void main() {
 
       tester.view.devicePixelRatio = 7;
       tester.view.displayFeatures = <DisplayFeature>[const DisplayFeature(bounds: Rect.fromLTWH(0, 0, 20, 300), type: DisplayFeatureType.unknown, state: DisplayFeatureState.unknown)];
-      tester.view.padding = const FakeViewPadding();
+      tester.view.padding = FakeViewPadding.zero;
       tester.view.physicalGeometry = const Rect.fromLTWH(0, 0, 505, 805);
-      tester.view.systemGestureInsets = const FakeViewPadding();
-      tester.view.viewInsets = const FakeViewPadding();
-      tester.view.viewPadding = const FakeViewPadding();
+      tester.view.systemGestureInsets = FakeViewPadding.zero;
+      tester.view.viewInsets = FakeViewPadding.zero;
+      tester.view.viewPadding = FakeViewPadding.zero;
       tester.view.gestureSettings = const GestureSettings(physicalTouchSlop: 4, physicalDoubleTapSlop: 5);
 
       final FlutterViewSnapshot faked = FlutterViewSnapshot(tester.view);

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -54,7 +54,7 @@ void main() {
     verifyPropertyFaked<ViewPadding>(
       tester: tester,
       realValue: ui.window.viewInsets,
-      fakeValue: const FakeViewPadding(),
+      fakeValue: FakeViewPadding.zero,
       propertyRetriever: () {
         return WidgetsBinding.instance.window.viewInsets;
       },
@@ -69,7 +69,7 @@ void main() {
     verifyPropertyFaked<ViewPadding>(
       tester: tester,
       realValue: ui.window.padding,
-      fakeValue: const FakeViewPadding(),
+      fakeValue: FakeViewPadding.zero,
       propertyRetriever: () {
         return WidgetsBinding.instance.window.padding;
       },
@@ -220,11 +220,11 @@ void main() {
   testWidgets('Updates to window also update tester.view', (WidgetTester tester) async {
     tester.binding.window.devicePixelRatioTestValue = 7;
     tester.binding.window.displayFeaturesTestValue = <DisplayFeature>[const DisplayFeature(bounds: Rect.fromLTWH(0, 0, 20, 300), type: DisplayFeatureType.unknown, state: DisplayFeatureState.unknown)];
-    tester.binding.window.paddingTestValue = const FakeViewPadding();
+    tester.binding.window.paddingTestValue = FakeViewPadding.zero;
     tester.binding.window.physicalSizeTestValue = const Size(505, 805);
-    tester.binding.window.systemGestureInsetsTestValue = const FakeViewPadding();
-    tester.binding.window.viewInsetsTestValue = const FakeViewPadding();
-    tester.binding.window.viewPaddingTestValue = const FakeViewPadding();
+    tester.binding.window.systemGestureInsetsTestValue = FakeViewPadding.zero;
+    tester.binding.window.viewInsetsTestValue = FakeViewPadding.zero;
+    tester.binding.window.viewPaddingTestValue = FakeViewPadding.zero;
     tester.binding.window.gestureSettingsTestValue = const GestureSettings(physicalTouchSlop: 4, physicalDoubleTapSlop: 5);
 
     expect(tester.binding.window.devicePixelRatio, tester.view.devicePixelRatio);


### PR DESCRIPTION
Updates `flutter/test/material` to no longer use `TestWindow`
* Adds `FakeViewPadding.zero` and updates `view_test.dart` and `window_test.dart` to use them
* Removes `no-shuffle` tag from `app_test.dart` as the underlying issue seems to be resolved
* Removes `no-shuffle` tag from `text_field_test.dart` as the underlying issue seems to be resolved

Resolves #122240

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.