### PR TITLE
Remove another reference to BindingBase.window

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -33,11 +33,11 @@ Future<void> main() async {
 
     final TestViewConfiguration big = TestViewConfiguration(
       size: const Size(360.0, 640.0),
-      window: RendererBinding.instance.window,
+      window: tester.view,
     );
     final TestViewConfiguration small = TestViewConfiguration(
       size: const Size(355.0, 635.0),
-      window: RendererBinding.instance.window,
+      window: tester.view,
     );
     final RenderView renderView = WidgetsBinding.instance.renderView;
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmark;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/116929.
Follow-up to https://github.com/flutter/flutter/pull/122119.

I missed this reference in https://github.com/flutter/flutter/pull/122119.
