### PR TITLE
[tool][web] Pass invoker flag to dart2js.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -211,6 +211,7 @@ class Dart2JSTarget extends Dart2WebTarget {
       artifacts.getArtifactPath(Artifact.dart2jsSnapshot, platform: TargetPlatform.web_javascript),
       '--platform-binaries=$platformBinariesPath',
       ...decodeCommaSeparated(environment.defines, kExtraFrontEndOptions),
+      '--invoker=flutter_tool',
       if (nativeNullAssertions)
         '--native-null-assertions',
       if (buildMode == BuildMode.profile)

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -374,8 +374,8 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
-        '--invoker=flutter_tool',
         '--enable-experiment=non-nullable',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -389,8 +389,8 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
-        '--invoker=flutter_tool',
         '--enable-experiment=non-nullable',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -335,6 +335,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -348,6 +349,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',
@@ -372,6 +374,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '--enable-experiment=non-nullable',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
@@ -386,6 +389,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '--enable-experiment=non-nullable',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
@@ -408,6 +412,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -421,6 +426,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',
@@ -442,6 +448,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-o',
@@ -455,6 +462,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-O4',
@@ -476,6 +484,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '--native-null-assertions',
         '-Ddart.vm.product=true',
         '--no-source-maps',
@@ -490,6 +499,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '--native-null-assertions',
         '-Ddart.vm.product=true',
         '--no-source-maps',
@@ -512,6 +522,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-o',
@@ -525,6 +536,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-O3',
@@ -545,6 +557,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-o',
@@ -576,6 +589,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -591,6 +605,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -614,6 +629,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
@@ -626,6 +642,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.product=true',
         '-O4',
         '-o',
@@ -647,6 +664,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -662,6 +680,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -686,6 +705,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -699,6 +719,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',
@@ -722,6 +743,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -735,6 +757,7 @@ void main() {
       command: <String>[
         ...kDart2jsLinuxArgs,
         '--platform-binaries=bin/cache/flutter_web_sdk/kernel',
+        '--invoker=flutter_tool',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -67,6 +67,7 @@ int x = 'String';
         result.stderr,
         contains("A value of type 'String' can't be assigned to a variable of type 'int'."),
       );
+      expect(result.stderr, isNot(contains("Warning: The 'dart2js' entrypoint script is deprecated")));
       expect(result.exitCode, 1);
     });
   }


### PR DESCRIPTION
Dart2js currently produces a warning message if it is invoked from its snapshot and not from the `dart compile js` command.

We plan to make it an error to invoke the snapshot directly, potentially in the Dart 3 timeframe.

There are two mechanisms available to avoid this error:
* use `dart compile js` to invoke dart2js instead of the dart2js snapshot
* use the `--invoker` flag to indicate to dart2js that the invocation is from a supported context. 

This CL takes the latter approach, which is the same approach used for the dart-cli and our internal build systems using bazel. Long term Flutter may prefer to start using `dart compile js`, but that would require a more careful validation.


For context see: https://github.com/dart-lang/sdk/issues/51695 and https://github.com/dart-lang/sdk/issues/46100
