### PR TITLE
Updates `flutter/test/rendering` to no longer use `TestWindow`

### DIFF
--- a/packages/flutter/test/rendering/view_chrome_style_test.dart
+++ b/packages/flutter/test/rendering/view_chrome_style_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -16,18 +14,17 @@ void main() {
     const double deviceWidth = 480.0;
     const double devicePixelRatio = 2.0;
 
-    void setupTestDevice() {
-      final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    void setupTestDevice(WidgetTester tester) {
       const FakeViewPadding padding = FakeViewPadding(
         top: statusBarHeight * devicePixelRatio,
         bottom: navigationBarHeight * devicePixelRatio,
       );
 
-      binding.window
-        ..viewPaddingTestValue = padding
-        ..paddingTestValue = padding
-        ..devicePixelRatioTestValue = devicePixelRatio
-        ..physicalSizeTestValue = const Size(
+      tester.view
+        ..viewPadding = padding
+        ..padding = padding
+        ..devicePixelRatio = devicePixelRatio
+        ..physicalSize = const Size(
           deviceWidth * devicePixelRatio,
           deviceHeight * devicePixelRatio,
         );
@@ -52,7 +49,7 @@ void main() {
       testWidgets(
         'statusBarColor is set for annotated view',
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           await tester.pumpWidget(const AnnotatedRegion<SystemUiOverlayStyle>(
             value: SystemUiOverlayStyle(
               statusBarColor: Colors.blue,
@@ -72,7 +69,7 @@ void main() {
       testWidgets(
         "statusBarColor isn't set when view covers less than half of the system status bar",
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           const double lessThanHalfOfTheStatusBarHeight =
               statusBarHeight / 2.0 - 1;
           await tester.pumpWidget(const Align(
@@ -97,7 +94,7 @@ void main() {
       testWidgets(
         'statusBarColor is set when view covers more than half of tye system status bar',
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           const double moreThanHalfOfTheStatusBarHeight =
               statusBarHeight / 2.0 + 1;
           await tester.pumpWidget(const Align(
@@ -127,7 +124,7 @@ void main() {
       testWidgets(
         "systemNavigationBarColor isn't set for non Android device",
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           await tester.pumpWidget(const AnnotatedRegion<SystemUiOverlayStyle>(
             value: SystemUiOverlayStyle(
               systemNavigationBarColor: Colors.blue,
@@ -158,7 +155,7 @@ void main() {
       testWidgets(
         'systemNavigationBarColor is set for annotated view',
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           await tester.pumpWidget(const AnnotatedRegion<SystemUiOverlayStyle>(
             value: SystemUiOverlayStyle(
               systemNavigationBarColor: Colors.blue,
@@ -178,7 +175,7 @@ void main() {
       testWidgets(
         "systemNavigationBarColor isn't set when view covers less than half of navigation bar",
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           const double lessThanHalfOfTheNavigationBarHeight =
               navigationBarHeight / 2.0 - 1;
           await tester.pumpWidget(const Align(
@@ -203,7 +200,7 @@ void main() {
       testWidgets(
         'systemNavigationBarColor is set when view covers more than half of navigation bar',
         (WidgetTester tester) async {
-          setupTestDevice();
+          setupTestDevice(tester);
           const double moreThanHalfOfTheNavigationBarHeight =
               navigationBarHeight / 2.0 + 1;
           await tester.pumpWidget(const Align(
@@ -230,7 +227,7 @@ void main() {
     });
 
     testWidgets('Top AnnotatedRegion provides status bar overlay style and bottom AnnotatedRegion provides navigation bar overlay style', (WidgetTester tester) async {
-      setupTestDevice();
+      setupTestDevice(tester);
       await tester.pumpWidget(
         const Column(children: <Widget>[
           Expanded(child: AnnotatedRegion<SystemUiOverlayStyle>(
@@ -256,7 +253,7 @@ void main() {
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
     testWidgets('Top only AnnotatedRegion provides status bar and navigation bar style properties', (WidgetTester tester) async {
-      setupTestDevice();
+      setupTestDevice(tester);
       await tester.pumpWidget(
         const Column(children: <Widget>[
           Expanded(child: AnnotatedRegion<SystemUiOverlayStyle>(
@@ -276,7 +273,7 @@ void main() {
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
     testWidgets('Bottom only AnnotatedRegion provides status bar and navigation bar style properties', (WidgetTester tester) async {
-      setupTestDevice();
+      setupTestDevice(tester);
       await tester.pumpWidget(
         const Column(children: <Widget>[
           Expanded(child: SizedBox.expand()),
@@ -295,22 +292,4 @@ void main() {
       expect(SystemChrome.latestStyle?.systemNavigationBarColor, Colors.green);
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
-}
-
-class FakeViewPadding implements ViewPadding {
-  const FakeViewPadding({
-    this.left = 0.0,
-    this.top = 0.0,
-    this.right = 0.0,
-    this.bottom = 0.0,
-  });
-
-  @override
-  final double left;
-  @override
-  final double top;
-  @override
-  final double right;
-  @override
-  final double bottom;
 }

--- a/packages/flutter/test/rendering/view_chrome_style_test.dart
+++ b/packages/flutter/test/rendering/view_chrome_style_test.dart
@@ -20,6 +20,7 @@ void main() {
         bottom: navigationBarHeight * devicePixelRatio,
       );
 
+      addTearDown(tester.view.reset);
       tester.view
         ..viewPadding = padding
         ..padding = padding

--- a/packages/flutter/test/rendering/view_test.dart
+++ b/packages/flutter/test/rendering/view_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(identical(view.debugLayer, firstLayer), false);
     });
 
-    test('does not replace the root layer unnecessarily when window resize', () {
+    test('does not replace the root layer unnecessarily when view resizes', () {
       final RenderView view = RenderView(
         configuration: createViewConfiguration(size: const Size(100.0, 100.0)),
         window: RendererBinding.instance.platformDispatcher.views.single,

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -10,8 +10,6 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -782,19 +780,14 @@ void main() {
     }
 
     testWidgets('Reverse List showOnScreen', (WidgetTester tester) async {
-      final ui.Size originalScreenSize = tester.binding.window.physicalSize;
-      final double originalDevicePixelRatio = tester.binding.window.devicePixelRatio;
-      addTearDown(() {
-        tester.binding.window.devicePixelRatioTestValue = originalDevicePixelRatio;
-        tester.binding.window.physicalSizeTestValue = originalScreenSize;
-      });
+      addTearDown(tester.view.reset);
       const double screenHeight = 400.0;
       const double screenWidth = 400.0;
       const double itemHeight = screenHeight / 10.0;
       const ValueKey<String> centerKey = ValueKey<String>('center');
 
-      tester.binding.window.devicePixelRatioTestValue = 1.0;
-      tester.binding.window.physicalSizeTestValue = const Size(screenWidth, screenHeight);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(screenWidth, screenHeight);
 
       await tester.pumpWidget(Directionality(
         textDirection: TextDirection.ltr,


### PR DESCRIPTION
Updates `flutter/test/rendering` to no longer use `TestWindow`.

Resolves #122241

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.