### PR TITLE
Updates `flutter/test/widgets` to no longer reference `TestWindow`

### DIFF
--- a/packages/flutter/test/widgets/default_colors_test.dart
+++ b/packages/flutter/test/widgets/default_colors_test.dart
@@ -146,7 +146,7 @@ Future<void> _expectColors(WidgetTester tester, Finder finder, Set<Color> allowe
     assert(position.dx.round() < image.width);
     assert(position.dy.round() >= 0);
     assert(position.dy.round() < image.height);
-    final Offset precisePosition = position * binding.window.devicePixelRatio;
+    final Offset precisePosition = position * tester.view.devicePixelRatio;
     final Color actual = _getPixel(bytes, precisePosition.dx.round(), precisePosition.dy.round(), image.width);
     expect(actual, expected, reason: 'Pixel at $position is $actual but expected $expected.');
   });

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui;
-import 'dart:ui' show ViewPadding;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -183,25 +182,6 @@ class MyStatefulWidgetState extends State<MyStatefulWidget> {
   @override
   Widget build(BuildContext context) => Text(widget.value);
 }
-
-class FakeViewPadding implements ViewPadding {
-  const FakeViewPadding({
-    this.left = 0.0,
-    this.top = 0.0,
-    this.right = 0.0,
-    this.bottom = 0.0,
-  });
-
-  @override
-  final double left;
-  @override
-  final double top;
-  @override
-  final double right;
-  @override
-  final double bottom;
-}
-
 
 Future<void> main() async {
   final ui.Image testImage = await createTestImage();
@@ -3090,72 +3070,71 @@ Future<void> main() async {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
   });
+
   testWidgets('smooth transition between different incoming data', (WidgetTester tester) async {
-      final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
-      const Key imageKey1 = Key('image1');
-      const Key imageKey2 = Key('image2');
-      final TestImageProvider imageProvider = TestImageProvider(testImage);
-      final TestWidgetsFlutterBinding testBinding = tester.binding;
+    addTearDown(tester.view.reset);
 
-      testBinding.window.paddingTestValue = const FakeViewPadding(top: 50);
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
+    const Key imageKey1 = Key('image1');
+    const Key imageKey2 = Key('image2');
+    final TestImageProvider imageProvider = TestImageProvider(testImage);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorKey: navigatorKey,
-          home: Scaffold(
-            appBar: AppBar(title: const Text('test')),
-            body: Hero(
-              tag: 'imageHero',
-              child: GridView.count(
-                crossAxisCount: 3,
-                shrinkWrap: true,
-                children: <Widget>[
-                  Image(image: imageProvider, key: imageKey1),
-                ],
-              ),
+    tester.view.padding = const FakeViewPadding(top: 50);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: Scaffold(
+          appBar: AppBar(title: const Text('test')),
+          body: Hero(
+            tag: 'imageHero',
+            child: GridView.count(
+              crossAxisCount: 3,
+              shrinkWrap: true,
+              children: <Widget>[
+                Image(image: imageProvider, key: imageKey1),
+              ],
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      final MaterialPageRoute<void> route2 = MaterialPageRoute<void>(
-        builder: (BuildContext context) {
-          return Scaffold(
-            body: Hero(
-              tag: 'imageHero',
-              child: GridView.count(
-                crossAxisCount: 3,
-                shrinkWrap: true,
-                children: <Widget>[
-                  Image(image: imageProvider, key: imageKey2),
-                ],
-              ),
+    final MaterialPageRoute<void> route2 = MaterialPageRoute<void>(
+      builder: (BuildContext context) {
+        return Scaffold(
+          body: Hero(
+            tag: 'imageHero',
+            child: GridView.count(
+              crossAxisCount: 3,
+              shrinkWrap: true,
+              children: <Widget>[
+                Image(image: imageProvider, key: imageKey2),
+              ],
             ),
-          );
-        },
-      );
+          ),
+        );
+      },
+    );
 
-      // Load images.
-      imageProvider.complete();
-      await tester.pump();
+    // Load images.
+    imageProvider.complete();
+    await tester.pump();
 
-      final double forwardRest = tester.getTopLeft(find.byType(Image)).dy;
-      navigatorKey.currentState!.push(route2);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 1));
-      expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
-      await tester.pumpAndSettle();
+    final double forwardRest = tester.getTopLeft(find.byType(Image)).dy;
+    navigatorKey.currentState!.push(route2);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
+    await tester.pumpAndSettle();
 
-      navigatorKey.currentState!.pop(route2);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 300));
-      expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
-      await tester.pumpAndSettle();
-      expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
-
-      testBinding.window.clearAllTestValues();
-    },
-  );
+    navigatorKey.currentState!.pop(route2);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
+  });
 }
 
 class TestDependencies extends StatelessWidget {

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -1190,6 +1190,8 @@ void main() {
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS, TargetPlatform.linux, TargetPlatform.windows }));
 
     testWidgets('viewport changes size', (WidgetTester tester) async {
+      addTearDown(tester.view.reset);
+
       final TransformationController transformationController = TransformationController();
       await tester.pumpWidget(
         MaterialApp(
@@ -1222,8 +1224,7 @@ void main() {
       expect(transformationController.value, equals(Matrix4.identity()));
 
       // Shrink the size of the screen.
-      tester.binding.window.physicalSizeTestValue = const Size(100.0, 100.0);
-      addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+      tester.view.physicalSize = const Size(100.0, 100.0);
       await tester.pump();
 
       // Attempting to drag to pan still doesn't work, because the image has

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -142,7 +142,7 @@ void main() {
 
     // Set the starting viewportDimension to 0.0
     await tester.binding.setSurfaceSize(Size.zero);
-    final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.binding.window);
+    final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.view);
 
     Widget build(Size size) {
       return MediaQuery(
@@ -1048,7 +1048,7 @@ void main() {
       viewportDimension: 25.0,
       axisDirection: AxisDirection.right,
       viewportFraction: 1.0,
-      devicePixelRatio: tester.binding.window.devicePixelRatio,
+      devicePixelRatio: tester.view.devicePixelRatio,
     );
     expect(page.page, 6);
     final PageMetrics page2 = page.copyWith(

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2599,6 +2599,8 @@ void main() {
     );
 
     testWidgets('PlatformViewLink includes offset in create call when using texture layer', (WidgetTester tester) async {
+      addTearDown(tester.view.reset);
+
       late FakeAndroidViewController controller;
 
       final PlatformViewLink platformViewLink = PlatformViewLink(
@@ -2622,8 +2624,8 @@ void main() {
         },
       );
 
-      TestWidgetsFlutterBinding.instance.window.physicalSizeTestValue = const Size(400, 200);
-      TestWidgetsFlutterBinding.instance.window.devicePixelRatioTestValue = 1.0;
+      tester.view.physicalSize= const Size(400, 200);
+      tester.view.devicePixelRatio = 1.0;
 
       await tester.pumpWidget(
         Container(
@@ -2638,9 +2640,6 @@ void main() {
       );
 
       expect(controller.createPosition, const Offset(150, 75));
-
-      TestWidgetsFlutterBinding.instance.window.clearPhysicalSizeTestValue();
-      TestWidgetsFlutterBinding.instance.window.clearDevicePixelRatioTestValue();
     });
 
     testWidgets(

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2038,7 +2038,9 @@ void main() {
     expect(find.byType(RawScrollbar), isNot(paints..rect())); // Hide the bar.
   });
 
-  testWidgets('The bar can show or hide when the window size change', (WidgetTester tester) async {
+  testWidgets('The bar can show or hide when the view size change', (WidgetTester tester) async {
+    addTearDown(tester.view.reset);
+
     final ScrollController scrollController = ScrollController();
     Widget buildFrame() {
       return Directionality(
@@ -2061,21 +2063,19 @@ void main() {
         ),
       );
     }
-    tester.binding.window.physicalSizeTestValue = const Size(800.0, 600.0);
-    tester.binding.window.devicePixelRatioTestValue = 1;
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-    addTearDown(tester.binding.window.clearDevicePixelRatioTestValue);
+    tester.view.physicalSize = const Size(800.0, 600.0);
+    tester.view.devicePixelRatio = 1;
 
     await tester.pumpWidget(buildFrame());
     await tester.pumpAndSettle();
     expect(scrollController.offset, 0.0);
     expect(find.byType(RawScrollbar), isNot(paints..rect())); // Not shown.
 
-    tester.binding.window.physicalSizeTestValue = const Size(800.0, 599.0);
+    tester.view.physicalSize = const Size(800.0, 599.0);
     await tester.pumpAndSettle();
     expect(find.byType(RawScrollbar), paints..rect()..rect()); // Show the bar.
 
-    tester.binding.window.physicalSizeTestValue = const Size(800.0, 600.0);
+    tester.view.physicalSize = const Size(800.0, 600.0);
     await tester.pumpAndSettle();
     expect(find.byType(RawScrollbar), isNot(paints..rect())); // Not shown.
   });

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1668,6 +1668,8 @@ void main() {
   });
 
   testWidgets('toolbar is hidden on mobile when orientation changes', (WidgetTester tester) async {
+    addTearDown(tester.view.reset);
+
     await tester.pumpWidget(
       MaterialApp(
         home: SelectableRegion(
@@ -1677,7 +1679,6 @@ void main() {
         ),
       ),
     );
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 6)); // at the 'r'
@@ -1690,7 +1691,7 @@ void main() {
     expect(find.text('Copy'), findsOneWidget);
 
     // Hide the toolbar by changing orientation.
-    tester.binding.window.physicalSizeTestValue = const Size(1800.0, 2400.0);
+    tester.view.physicalSize = const Size(1800.0, 2400.0);
     await tester.pumpAndSettle();
     expect(find.text('Copy'), findsNothing);
 

--- a/packages/flutter/test/widgets/snapshot_widget_test.dart
+++ b/packages/flutter/test/widgets/snapshot_widget_test.dart
@@ -264,12 +264,11 @@ void main() {
   }, skip: kIsWeb); // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/106689
 
   testWidgets('SnapshotWidget should have same result when enabled', (WidgetTester tester) async {
-    tester.binding.window
-      ..physicalSizeTestValue = const Size(10, 10)
-      ..devicePixelRatioTestValue = 1;
-    addTearDown(() => tester.binding.window
-      ..clearPhysicalSizeTestValue()
-      ..clearDevicePixelRatioTestValue());
+    addTearDown(tester.view.reset);
+
+    tester.view
+      ..physicalSize = const Size(10, 10)
+      ..devicePixelRatio = 1;
 
     const ValueKey<String> repaintBoundaryKey = ValueKey<String>('boundary');
     final SnapshotController controller = SnapshotController();


### PR DESCRIPTION
Updates `flutter/test/widgets` to no longer reference `TestWindow`.

Resolves #122242.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.