### PR TITLE
Updates `integration_test` to no longer use `TestWindow`

### DIFF
--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -77,15 +77,15 @@ Future<void> main() async {
     testWidgets('setSurfaceSize works', (WidgetTester tester) async {
       await tester.pumpWidget(const MaterialApp(home: Center(child: Text('Test'))));
 
-      final Size windowCenter = tester.binding.window.physicalSize /
-          tester.binding.window.devicePixelRatio /
+      final Size viewCenter = tester.view.physicalSize /
+          tester.view.devicePixelRatio /
           2;
-      final double windowCenterX = windowCenter.width;
-      final double windowCenterY = windowCenter.height;
+      final double viewCenterX = viewCenter.width;
+      final double viewCenterY = viewCenter.height;
 
       Offset widgetCenter = tester.getRect(find.byType(Text)).center;
-      expect(widgetCenter.dx, windowCenterX);
-      expect(widgetCenter.dy, windowCenterY);
+      expect(widgetCenter.dx, viewCenterX);
+      expect(widgetCenter.dy, viewCenterY);
 
       await tester.binding.setSurfaceSize(const Size(200, 300));
       await tester.pump();
@@ -96,8 +96,8 @@ Future<void> main() async {
       await tester.binding.setSurfaceSize(null);
       await tester.pump();
       widgetCenter = tester.getRect(find.byType(Text)).center;
-      expect(widgetCenter.dx, windowCenterX);
-      expect(widgetCenter.dy, windowCenterY);
+      expect(widgetCenter.dx, viewCenterX);
+      expect(widgetCenter.dy, viewCenterY);
     });
 
     testWidgets('Test traceAction', (WidgetTester tester) async {


### PR DESCRIPTION
Updates `integration_test` to no longer use `TestWindow`.

Resolves #122243.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.