### PR TITLE
🔥 Remove the build mode name from outputs of Flutter Modules

### DIFF
--- a/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
+++ b/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
@@ -116,7 +116,6 @@ Future<void> main() async {
         'outputs',
         'apk',
         'demo',
-        'debug',
         'app-demo-debug.apk',
       );
 
@@ -159,7 +158,6 @@ Future<void> main() async {
         'outputs',
         'apk',
         'demo',
-        'debug',
         'app-demo-debug.apk',
       );
 
@@ -194,7 +192,6 @@ Future<void> main() async {
         'outputs',
         'apk',
         'demo',
-        'staging',
         'app-demo-staging.apk',
       );
 
@@ -231,7 +228,6 @@ Future<void> main() async {
         'outputs',
         'apk',
         'demo',
-        'release',
         'app-demo-release-unsigned.apk',
       );
 
@@ -269,7 +265,6 @@ Future<void> main() async {
         'outputs',
         'apk',
         'demo',
-        'prod',
         'app-demo-prod-unsigned.apk',
       );
 

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -125,7 +125,6 @@ Future<void> main() async {
         'host',
         'outputs',
         'apk',
-        'release',
         'app-release.apk',
       )));
 
@@ -163,7 +162,6 @@ Future<void> main() async {
         'host',
         'outputs',
         'apk',
-        'release',
         'app-release.apk',
       )));
 
@@ -220,7 +218,6 @@ Future<void> main() async {
         'build',
         'outputs',
         'apk',
-        'debug',
         'app-debug.apk',
       );
       if (!exists(File(debugHostApk))) {
@@ -300,7 +297,6 @@ Future<void> main() async {
         'build',
         'outputs',
         'apk',
-        'release',
         'app-release-unsigned.apk',
       );
       if (!exists(File(releaseHostApk))) {

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -115,13 +115,7 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
     }
 
     if (androidProject.isUsingGradle && androidProject.isSupportedVersion) {
-      Directory apkDirectory = getApkDirectory(androidProject.parent);
-      if (androidProject.parent.isModule) {
-        // Module builds output the apk in a subdirectory that corresponds
-        // to the buildmode of the apk.
-        apkDirectory = apkDirectory.childDirectory(buildInfo!.mode.name);
-      }
-      apkFile = apkDirectory.childFile(filename);
+      apkFile = getApkDirectory(androidProject.parent).childFile(filename);
       if (apkFile.existsSync()) {
         // Grab information from the .apk. The gradle build script might alter
         // the application Id, so we need to look at what was actually built.

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -803,9 +803,7 @@ Iterable<String> findApkFilesModule(
       return <File>[apkFile];
     }
     final BuildInfo buildInfo = androidBuildInfo.buildInfo;
-    final String modeName = camelCase(buildInfo.modeName);
     apkFile = apkDirectory
-      .childDirectory(modeName)
       .childFile(apkFileName);
     if (apkFile.existsSync()) {
       return <File>[apkFile];
@@ -815,7 +813,6 @@ Iterable<String> findApkFilesModule(
       // Android Studio Gradle plugin v3 adds flavor to path.
       apkFile = apkDirectory
         .childDirectory(flavor)
-        .childDirectory(modeName)
         .childFile(apkFileName);
       if (apkFile.existsSync()) {
         return <File>[apkFile];

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -83,7 +83,7 @@ void main() {
             aaptPath,
             'dump',
             'xmltree',
-             fs.path.join('module_project', 'build', 'host', 'outputs', 'apk', 'debug', 'app-debug.apk'),
+             fs.path.join('module_project', 'build', 'host', 'outputs', 'apk', 'app-debug.apk'),
             'AndroidManifest.xml',
           ],
           stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity
@@ -106,7 +106,6 @@ void main() {
         .childDirectory('host')
         .childDirectory('outputs')
         .childDirectory('apk')
-        .childDirectory('debug')
         .childFile('app-debug.apk');
       apkDebugFile.createSync(recursive: true);
       final AndroidApk? androidApk = await AndroidApk.fromAndroidProject(


### PR DESCRIPTION
Follow up and reverts part of #117999.

Generally, we have two kinds of output paths for APKs after this change:
- Apps: `app/outputs/flutter-apk/`
- Modules: `host/outputs/apk/`

All these outputs will no longer have child directories and outputs are flattened, the change also gets rid of additional control flow when checking the output path.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
