### PR TITLE
Adjust the minimum sdk version in the synthetic pkg for new Dart requirements

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1440,7 +1440,7 @@ String generateFakePubspec(
   final bool verbose = doUpgrade;
   result.writeln('name: flutter_update_packages');
   result.writeln('environment:');
-  result.writeln("  sdk: '>=2.10.0 <4.0.0'");
+  result.writeln("  sdk: '>=2.12.0 <4.0.0'");
   result.writeln('dependencies:');
   overrides.writeln('dependency_overrides:');
   if (kManuallyPinnedDependencies.isNotEmpty) {


### PR DESCRIPTION
A new Dart SDK that is being rolled in from the engine requires a new minimum SDK version of 2.12.0, but the synthetic package used by `flutter update-packages` synthetically created a package with a requirement of 2.10.0. This PR updates the data injected into the temp synthetic packages `packages.yaml` to meet the new criteria.