### PR TITLE
Fix: `IndexedStack` says its children are offstage when dumping render tree, but they are indeed onstage and users get confused

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -781,7 +781,11 @@ class RenderIndexedStack extends RenderStack {
     while (child != null) {
       children.add(child.toDiagnosticsNode(
         name: 'child ${i + 1}',
-        style: i != index ? DiagnosticsTreeStyle.offstage : null,
+        // Though those children are indeed offstage, the current 
+        // `debugVisitOnstageChildren` wrongly treat them as onstage.
+        // Thus, the style is deberliately made onstage in order to make
+        // users less surprising.
+        // style: i != index ? DiagnosticsTreeStyle.offstage : null,
       ));
       child = (child.parentData! as StackParentData).nextSibling;
       i += 1;


### PR DESCRIPTION
Close #111478

Please see https://github.com/flutter/flutter/pull/111479#issuecomment-1463754109 for context.

This is a tentative PR, since I am not very sure what do Flutter team think about this. If you think it is OK, I will add tests, polish it (e.g. adding a longer issue) etc!

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
