### PR TITLE
Fix cursor disappear on undo.

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4510,7 +4510,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                 userUpdateTextEditingValue(value, SelectionChangedCause.keyboard);
               },
               shouldChangeUndoStack: (TextEditingValue? oldValue, TextEditingValue newValue) {
-                if (newValue == TextEditingValue.empty) {
+                if (!newValue.selection.isValid) {
                   return false;
                 }
 

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -107,7 +107,7 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
     if (_stack.currentValue == null)  {
       // Returns early if there is not a first value registered in the history.
       // This is important because, if an undo is received while the initial
-      // value is being pushed (a.k.a when the field get the focus but the
+      // value is being pushed (a.k.a when the field gets the focus but the
       // throttling delay is pending), the initial push should not be canceled.
       return;
     }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13012,7 +13012,7 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
     }, variant: TargetPlatformVariant.only(TargetPlatform.android), skip: kIsWeb); // [intended]
 
     // Regression test for https://github.com/flutter/flutter/issues/120194.
-    testWidgets('Cursor do not jump after undo', (WidgetTester tester) async {
+    testWidgets('Cursor does not jump after undo', (WidgetTester tester) async {
       // Initialize the controller with a non empty text.
       final TextEditingController controller = TextEditingController(text: textA);
       final FocusNode focusNode = FocusNode();
@@ -13057,7 +13057,7 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
       // Undo the insertion.
       await sendUndo(tester);
 
-      // Initial text should have been recorded and restore.
+      // Initial text should have been recorded and restored.
       expect(controller.value, textACollapsedAtEnd);
 
     // On web, these keyboard shortcuts are handled by the browser.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13011,6 +13011,58 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
     // On web, these keyboard shortcuts are handled by the browser.
     }, variant: TargetPlatformVariant.only(TargetPlatform.android), skip: kIsWeb); // [intended]
 
+    // Regression test for https://github.com/flutter/flutter/issues/120194.
+    testWidgets('Cursor do not jump after undo', (WidgetTester tester) async {
+      // Initialize the controller with a non empty text.
+      final TextEditingController controller = TextEditingController(text: textA);
+      final FocusNode focusNode = FocusNode();
+      await tester.pumpWidget(boilerplate(controller, focusNode));
+
+      // Focus the field and wait for throttling delay to get the initial
+      // state saved in text editing history.
+      focusNode.requestFocus();
+      await tester.pump();
+      await waitForThrottling(tester);
+      expect(controller.value, textACollapsedAtEnd);
+
+      // Insert some text.
+      await tester.enterText(find.byType(EditableText), textAB);
+      expect(controller.value, textABCollapsedAtEnd);
+
+      // Undo the insertion without waiting for the throttling delay.
+      await sendUndo(tester);
+      expect(controller.value.selection.isValid, true);
+      expect(controller.value, textACollapsedAtEnd);
+
+    // On web, these keyboard shortcuts are handled by the browser.
+    }, variant: TargetPlatformVariant.all(), skip: kIsWeb); // [intended]
+
+    testWidgets('Initial value is recorded when an undo is received just after getting the focus', (WidgetTester tester) async {
+      // Initialize the controller with a non empty text.
+      final TextEditingController controller = TextEditingController(text: textA);
+      final FocusNode focusNode = FocusNode();
+      await tester.pumpWidget(boilerplate(controller, focusNode));
+
+      // Focus the field and do not wait for throttling delay before calling undo.
+      focusNode.requestFocus();
+      await tester.pump();
+      await sendUndo(tester);
+      await waitForThrottling(tester);
+      expect(controller.value, textACollapsedAtEnd);
+
+      // Insert some text.
+      await tester.enterText(find.byType(EditableText), textAB);
+      expect(controller.value, textABCollapsedAtEnd);
+
+      // Undo the insertion.
+      await sendUndo(tester);
+
+      // Initial text should have been recorded and restore.
+      expect(controller.value, textACollapsedAtEnd);
+
+    // On web, these keyboard shortcuts are handled by the browser.
+    }, variant: TargetPlatformVariant.all(), skip: kIsWeb); // [intended]
+
     testWidgets('Can make changes in the middle of the history', (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController();
       final FocusNode focusNode = FocusNode();


### PR DESCRIPTION
## Description

This PR updates the undo logic to fix two problems:
- Values with an invalid selection should not be saved in the history (this leads to the cursor disappearing).
- When an undo is received before the end of the throttling delay, the history should not be undo its last saved value because this will set the text field value to the penultimate value (the last one is not yet in the history).

### Steps to Reproduce

<details>
<summary>Code sample (which creates a TextField with the non empty text, "Flutter").</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      home: Scaffold(
        appBar: AppBar(
          title: const Text("Demo"),
        ),
        body: Center(
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[
              TextFormField(
                initialValue: "Flutter"
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```
</details>


**Problem 1:**  Tap ‘3’ and undo before the throttling delay ends (500ms). 

Before this fix: the text is ‘Flutter’ and the cursor disappeared. Tapping a new key will insert it before ‘Flutter’.
After this fix: the text should be ‘Flutter’ and the cursor at the end.

**Problem 2:** Tap ‘3’, wait for the throttling delay, tap ‘3’ again and undo before the throttling delay ends. 
Before this fix: the text value is ‘Flutter’ (penultimate state).
After this fix: the text value is ‘Flutter3’.


## Related Issue

Fixes https://github.com/flutter/flutter/issues/120194

## Tests

Adds 2 tests.
