### PR TITLE
Reland "Remove single view assumption from TestViewConfiguration (#122352)"

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/stocks/layout_bench.dart
@@ -31,13 +31,13 @@ Future<void> main() async {
     await tester.pump(); // Start drawer animation
     await tester.pump(const Duration(seconds: 1)); // Complete drawer animation
 
-    final TestViewConfiguration big = TestViewConfiguration(
+    final TestViewConfiguration big = TestViewConfiguration.fromView(
       size: const Size(360.0, 640.0),
-      window: RendererBinding.instance.window,
+      view: RendererBinding.instance.window,
     );
-    final TestViewConfiguration small = TestViewConfiguration(
+    final TestViewConfiguration small = TestViewConfiguration.fromView(
       size: const Size(355.0, 635.0),
-      window: RendererBinding.instance.window,
+      view: RendererBinding.instance.window,
     );
     final RenderView renderView = WidgetsBinding.instance.renderView;
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmark;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1912,9 +1912,9 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   ViewConfiguration createViewConfiguration() {
-    return TestViewConfiguration(
+    return TestViewConfiguration.fromView(
       size: _surfaceSize ?? _kDefaultTestViewportSize,
-      window: window,
+      view: window,
     );
   }
 
@@ -1938,20 +1938,31 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 /// size is in logical pixels. The resulting ViewConfiguration maps the given
 /// size onto the actual display using the [BoxFit.contain] algorithm.
 class TestViewConfiguration extends ViewConfiguration {
-  /// Creates a [TestViewConfiguration] with the given size. Defaults to 800x600.
+  /// Deprecated. Will be removed in a future version of Flutter.
   ///
-  /// If a [window] instance is not provided it defaults to [ui.window].
+  /// This property has been deprecated to prepare for Flutter's upcoming
+  /// support for multiple views and multiple windows.
+  ///
+  /// Use [TestViewConfiguration.fromView] instead.
+  @Deprecated(
+    'Use TestViewConfiguration.fromView instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.7.0-32.0.pre.'
+  )
   factory TestViewConfiguration({
     Size size = _kDefaultTestViewportSize,
     ui.FlutterView? window,
   }) {
-    return TestViewConfiguration._(size, window ?? ui.window);
+    return TestViewConfiguration.fromView(size: size, view: window ?? ui.window);
   }
 
-  TestViewConfiguration._(Size size, ui.FlutterView window)
-    : _paintMatrix = _getMatrix(size, window.devicePixelRatio, window),
-      _hitTestMatrix = _getMatrix(size, 1.0, window),
-      super(size: size, devicePixelRatio: window.devicePixelRatio);
+  /// Creates a [TestViewConfiguration] with the given size and view.
+  ///
+  /// The [size] defaults to 800x600.
+  TestViewConfiguration.fromView({required ui.FlutterView view, super.size = _kDefaultTestViewportSize})
+      : _paintMatrix = _getMatrix(size, view.devicePixelRatio, view),
+        _hitTestMatrix = _getMatrix(size, 1.0, view),
+        super(devicePixelRatio: view.devicePixelRatio);
 
   static Matrix4 _getMatrix(Size size, double devicePixelRatio, ui.FlutterView window) {
     final double inverseRatio = devicePixelRatio / window.devicePixelRatio;

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -120,9 +120,9 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   ViewConfiguration createViewConfiguration() {
     final double devicePixelRatio = window.devicePixelRatio;
     final Size size = _surfaceSize ?? window.physicalSize / devicePixelRatio;
-    return TestViewConfiguration(
+    return TestViewConfiguration.fromView(
       size: size,
-      window: window,
+      view: window,
     );
   }
 


### PR DESCRIPTION
Relands #122352.
Partial revert of https://github.com/flutter/flutter/pull/122369.

This change was functionally unrelated to the trouble solved by the revert in https://github.com/flutter/flutter/pull/122369.