### PR TITLE
Update sdk version in temp testing package

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -60,7 +60,7 @@ void main() {
     pubspecFile.writeAsStringSync('''
   name: foo_project
   environment:
-    sdk: '>=2.10.0 <4.0.0'
+    sdk: '>=2.12.0 <4.0.0'
   ''');
 
     final File dartFile = fileSystem.file(fileSystem.path.join(directory.path, 'lib', 'main.dart'));


### PR DESCRIPTION
This test seems to suddenly be timing out when we try to roll an Engine that has a new Dart SDK with a minimum sdk version of 2.12.