### PR TITLE
[Clipboard] Assert at least one clipboard data variant is provided

### DIFF
--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'package:flutter/foundation.dart';
 
 import 'system_channels.dart';
@@ -14,9 +13,12 @@ import 'system_channels.dart';
 @immutable
 class ClipboardData {
   /// Creates data for the system clipboard.
-  const ClipboardData({ this.text });
+  const ClipboardData({ required String this.text });
 
   /// Plain text variant of this clipboard data.
+  // This is nullable as other clipboard data variants, like images, may be
+  // added in the future. Currently, plain text is the only supported variant
+  // and this is guaranteed to be non-null.
   final String? text;
 }
 
@@ -54,7 +56,7 @@ abstract final class Clipboard {
     if (result == null) {
       return null;
     }
-    return ClipboardData(text: result['text'] as String?);
+    return ClipboardData(text: result['text'] as String);
   }
 
   /// Returns a future that resolves to true iff the clipboard contains string

--- a/packages/flutter/test/services/clipboard_test.dart
+++ b/packages/flutter/test/services/clipboard_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../widgets/clipboard_utils.dart';
+
+void main() {
+  final MockClipboard mockClipboard = MockClipboard();
+  TestWidgetsFlutterBinding.ensureInitialized()
+    .defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, mockClipboard.handleMethodCall);
+
+  test('Clipboard.getData returns text', () async {
+    mockClipboard.clipboardData = <String, dynamic>{
+      'text': 'Hello world',
+    };
+
+    final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
+
+    expect(data, isNotNull);
+    expect(data!.text, equals('Hello world'));
+  });
+
+  test('Clipboard.getData returns null', () async {
+    mockClipboard.clipboardData = null;
+
+    final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
+
+    expect(data, isNull);
+  });
+
+  test('Clipboard.getData throws if text is missing', () async {
+    mockClipboard.clipboardData = <String, dynamic>{};
+
+    expect(() => Clipboard.getData(Clipboard.kTextPlain), throwsA(isA<TypeError>()));
+  });
+
+  test('Clipboard.getData throws if text is null', () async {
+    mockClipboard.clipboardData = <String, dynamic>{
+      'text': null,
+    };
+
+    expect(() => Clipboard.getData(Clipboard.kTextPlain), throwsA(isA<TypeError>()));
+  });
+
+  test('Clipboard.setData sets text', () async {
+    await Clipboard.setData(const ClipboardData(text: 'Hello world'));
+
+    expect(mockClipboard.clipboardData, <String, dynamic>{
+      'text': 'Hello world',
+    });
+  });
+}


### PR DESCRIPTION
This change makes the clipboard require at least one clipboard data variant. Today, this effectively makes `ClipboardData.text` required as it is the only data variant supported by `Clipboard`. This is a breaking change.

Part of https://github.com/flutter/flutter/issues/121976

## Background

Currently the different platforms behave unexpectedly if you set your clipboard text to `null`:

1. Android and [iOS](https://github.com/flutter/engine/blob/12f2fdff743a56ced0557c042c29d617af398873/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm#L276) will set your clipboard content to the text `"null"`.
2. [Web assumes incorrectly that the text is non-null](https://github.com/flutter/engine/blob/12f2fdff743a56ced0557c042c29d617af398873/lib/web_ui/lib/src/engine/clipboard.dart#L128)
3. [Linux will return an error if the text is null](https://github.com/flutter/engine/blob/12f2fdff743a56ced0557c042c29d617af398873/shell/platform/linux/fl_platform_plugin.cc#L104-L105)
4. Windows crashes: https://github.com/flutter/flutter/issues/121976

In other words, customers who set their clipboard to `null` today are broken. Instead, they should set their clipboard's text to the empty string `""`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
