### PR TITLE
Revert "Reland "Speed up first asset load by using the binary-formatted asset manifest for image resolution"

### DIFF
--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -30,12 +30,14 @@ abstract class AssetManifest {
   /// information.
   List<String> listAssets();
 
-  /// Retrieves metadata about an asset and its variants. Returns null if the
-  /// key was not found in the asset manifest.
+  /// Retrieves metadata about an asset and its variants.
   ///
   /// This method considers a main asset to be a variant of itself and
   /// includes it in the returned list.
-  List<AssetMetadata>? getAssetVariants(String key);
+  ///
+  /// Throws an [ArgumentError] if [key] cannot be found within the manifest. To
+  /// avoid this, use a key obtained from the [listAssets] method.
+  List<AssetMetadata> getAssetVariants(String key);
 }
 
 // Lazily parses the binary asset manifest into a data structure that's easier to work
@@ -62,14 +64,14 @@ class _AssetManifestBin implements AssetManifest {
   final Map<String, List<AssetMetadata>> _typeCastedData = <String, List<AssetMetadata>>{};
 
   @override
-  List<AssetMetadata>? getAssetVariants(String key) {
+  List<AssetMetadata> getAssetVariants(String key) {
     // We lazily delay typecasting to prevent a performance hiccup when parsing
     // large asset manifests. This is important to keep an app's first asset
     // load fast.
     if (!_typeCastedData.containsKey(key)) {
       final Object? variantData = _data[key];
       if (variantData == null) {
-        return null;
+        throw ArgumentError('Asset key $key was not found within the asset manifest.');
       }
       _typeCastedData[key] = ((_data[key] ?? <Object?>[]) as Iterable<Object?>)
         .cast<Map<Object?, Object?>>()

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -12,14 +13,18 @@ import 'package:flutter_test/flutter_test.dart';
 class TestAssetBundle extends CachingAssetBundle {
   TestAssetBundle(this._assetBundleMap);
 
-  final Map<String, List<Map<Object?, Object?>>> _assetBundleMap;
+  final Map<String, List<String>> _assetBundleMap;
 
   Map<String, int> loadCallCount = <String, int>{};
 
+  String get _assetBundleContents {
+    return json.encode(_assetBundleMap);
+  }
+
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.bin') {
-      return const StandardMessageCodec().encodeMessage(_assetBundleMap)!;
+    if (key == 'AssetManifest.json') {
+      return ByteData.view(Uint8List.fromList(const Utf8Encoder().convert(_assetBundleContents)).buffer);
     }
 
     loadCallCount[key] = loadCallCount[key] ?? 0 + 1;
@@ -40,10 +45,9 @@ class TestAssetBundle extends CachingAssetBundle {
 void main() {
   group('1.0 scale device tests', () {
     void buildAndTestWithOneAsset(String mainAssetPath) {
-      final Map<String, List<Map<Object?, Object?>>> assetBundleMap =
-        <String, List<Map<Object?, Object?>>>{};
+      final Map<String, List<String>> assetBundleMap = <String, List<String>>{};
 
-      assetBundleMap[mainAssetPath] = <Map<Object?, Object?>>[];
+      assetBundleMap[mainAssetPath] = <String>[];
 
       final AssetImage assetImage = AssetImage(
         mainAssetPath,
@@ -89,13 +93,11 @@ void main() {
       const String mainAssetPath = 'assets/normalFolder/normalFile.png';
       const String variantPath = 'assets/normalFolder/3.0x/normalFile.png';
 
-      final Map<String, List<Map<Object?, Object?>>> assetBundleMap =
-        <String, List<Map<Object?, Object?>>>{};
+      final Map<String, List<String>> assetBundleMap =
+      <String, List<String>>{};
 
-      final Map<Object?, Object?> mainAssetVariantManifestEntry = <Object?, Object?>{};
-      mainAssetVariantManifestEntry['asset'] = variantPath;
-      mainAssetVariantManifestEntry['dpr'] = 3.0;
-      assetBundleMap[mainAssetPath] = <Map<Object?, Object?>>[mainAssetVariantManifestEntry];
+      assetBundleMap[mainAssetPath] = <String>[mainAssetPath, variantPath];
+
       final TestAssetBundle testAssetBundle = TestAssetBundle(assetBundleMap);
 
       final AssetImage assetImage = AssetImage(
@@ -121,10 +123,10 @@ void main() {
     test('When high-res device and high-res asset not present in bundle then return main variant', () {
       const String mainAssetPath = 'assets/normalFolder/normalFile.png';
 
-      final Map<String, List<Map<Object?, Object?>>> assetBundleMap =
-        <String, List<Map<Object?, Object?>>>{};
+      final Map<String, List<String>> assetBundleMap =
+      <String, List<String>>{};
 
-      assetBundleMap[mainAssetPath] = <Map<Object?, Object?>>[];
+      assetBundleMap[mainAssetPath] = <String>[mainAssetPath];
 
       final TestAssetBundle testAssetBundle = TestAssetBundle(assetBundleMap);
 
@@ -160,13 +162,10 @@ void main() {
       double chosenAssetRatio,
       String expectedAssetPath,
     ) {
-      final Map<String, List<Map<Object?, Object?>>> assetBundleMap =
-        <String, List<Map<Object?, Object?>>>{};
+      final Map<String, List<String>> assetBundleMap =
+      <String, List<String>>{};
 
-      final Map<Object?, Object?> mainAssetVariantManifestEntry = <Object?, Object?>{};
-      mainAssetVariantManifestEntry['asset'] = variantPath;
-      mainAssetVariantManifestEntry['dpr'] = 3.0;
-      assetBundleMap[mainAssetPath] = <Map<Object?, Object?>>[mainAssetVariantManifestEntry];
+      assetBundleMap[mainAssetPath] = <String>[mainAssetPath, variantPath];
 
       final TestAssetBundle testAssetBundle = TestAssetBundle(assetBundleMap);
 

--- a/packages/flutter/test/services/asset_manifest_test.dart
+++ b/packages/flutter/test/services/asset_manifest_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     expect(manifest.listAssets(), unorderedEquals(<String>['assets/foo.png', 'assets/bar.png']));
 
-    final List<AssetMetadata> fooVariants = manifest.getAssetVariants('assets/foo.png')!;
+    final List<AssetMetadata> fooVariants = manifest.getAssetVariants('assets/foo.png');
     expect(fooVariants.length, 2);
     final AssetMetadata firstFooVariant = fooVariants[0];
     expect(firstFooVariant.key, 'assets/foo.png');
@@ -52,7 +52,7 @@ void main() {
     expect(secondFooVariant.targetDevicePixelRatio, 2.0);
     expect(secondFooVariant.main, false);
 
-    final List<AssetMetadata> barVariants = manifest.getAssetVariants('assets/bar.png')!;
+    final List<AssetMetadata> barVariants = manifest.getAssetVariants('assets/bar.png');
     expect(barVariants.length, 1);
     final AssetMetadata firstBarVariant = barVariants[0];
     expect(firstBarVariant.key, 'assets/bar.png');
@@ -60,8 +60,9 @@ void main() {
     expect(firstBarVariant.main, true);
   });
 
-  test('getAssetVariants returns null if the key not contained in the asset manifest', () async {
+  test('getAssetVariants throws if given a key not contained in the asset manifest', () async {
     final AssetManifest manifest = await AssetManifest.loadFromAssetBundle(TestAssetBundle());
-    expect(manifest.getAssetVariants('invalid asset key'), isNull);
+
+    expect(() => manifest.getAssetVariants('invalid asset key'), throwsArgumentError);
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#121322

I bisected the regression in the issue listed below to this commit. Perhaps there is an issue with the asset variants in the wonderous app? Not sure, if it was just a formatting issue I would expect them to load the default, or error out. but right now they are flashing which is definitely unexpected.

Fixes https://github.com/flutter/flutter/issues/122447