### PR TITLE
Bump lower Dart SDK constraints to 3.0 & add class modifiers

### DIFF
--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_automated_tests
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: complex_layout
 description: A benchmark of a relatively complex layout.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/macrobenchmarks/pubspec.yaml
+++ b/dev/benchmarks/macrobenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: macrobenchmarks
 description: Performance benchmarks using flutter drive.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: microbenchmarks
 description: Small benchmarks for very specific parts of the Flutter framework.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   meta: 1.9.0

--- a/dev/benchmarks/multiple_flutters/module/pubspec.yaml
+++ b/dev/benchmarks/multiple_flutters/module/pubspec.yaml
@@ -4,7 +4,7 @@ description: A module that is embedded in the multiple_flutters benchmark test.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
+++ b/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout
 description: A benchmark for platform views.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout_hybrid_composition
 description: A benchmark for platform views, using hybrid composition on android.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/test_apps/stocks/pubspec.yaml
+++ b/dev/benchmarks/test_apps/stocks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stocks
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/bots/pubspec.yaml
+++ b/dev/bots/pubspec.yaml
@@ -2,7 +2,7 @@ name: tests_on_bots
 description: Scripts which run on bots.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   args: 2.4.0

--- a/dev/conductor/core/pubspec.yaml
+++ b/dev/conductor/core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter Automated Release Tool
 publish_to: none
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   archive: 3.3.2

--- a/dev/customer_testing/pubspec.yaml
+++ b/dev/customer_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: customer_testing
 description: Tool to run the tests listed in the flutter/tests repository.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   args: 2.4.0

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -101,7 +101,7 @@ dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
   flutter: ">=1.5.0"
 ''', flush: true);
 

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   archive: 3.3.2

--- a/dev/integration_tests/deferred_components_test/pubspec.yaml
+++ b/dev/integration_tests/deferred_components_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration test application for basic deferred components function
 publish_to: 'none'
 version: 1.0.0+1
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/external_ui/pubspec.yaml
+++ b/dev/integration_tests/external_ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: external_ui
 description: A test of Flutter integrating external UIs.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/flavors/pubspec.yaml
+++ b/dev/integration_tests/flavors/pubspec.yaml
@@ -2,7 +2,7 @@ name: flavors
 description: Integration test for build flavors.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/flutter_gallery/pubspec.yaml
+++ b/dev/integration_tests/flutter_gallery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gallery
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/gradle_deprecated_settings/pubspec.yaml
+++ b/dev/integration_tests/gradle_deprecated_settings/pubspec.yaml
@@ -2,7 +2,7 @@ name: gradle_deprecated_settings
 description: Integration test for the current settings.gradle.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/hybrid_android_views/pubspec.yaml
+++ b/dev/integration_tests/hybrid_android_views/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 description: An integration test for hybrid composition on Android
 version: 1.0.0+1
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new flutter module project.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -13,7 +13,7 @@ name: ios_app_with_extensions
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
+++ b/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
@@ -3,7 +3,7 @@ name: ios_platform_view_tests
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/non_nullable/pubspec.yaml
+++ b/dev/integration_tests/non_nullable/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/platform_interaction/pubspec.yaml
+++ b/dev/integration_tests/platform_interaction/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_interaction
 description: Integration test for platform interactions.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/release_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/release_smoke_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: release_smoke_test
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/spell_check/pubspec.yaml
+++ b/dev/integration_tests/spell_check/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: integration_ui
 description: Flutter non-plugin UI integration tests.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/web/pubspec.yaml
+++ b/dev/integration_tests/web/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_integration
 description: Integration test for web compilation.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 flutter:
   assets:

--- a/dev/integration_tests/web_compile_tests/pubspec.yaml
+++ b/dev/integration_tests/web_compile_tests/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_compile_tests
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/web_e2e_tests/pubspec.yaml
+++ b/dev/integration_tests/web_e2e_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_e2e_tests
 publish_to: none
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 flutter:
   assets:

--- a/dev/integration_tests/wide_gamut_test/pubspec.yaml
+++ b/dev/integration_tests/wide_gamut_test/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0-157.0.dev <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/windows_startup_test/pubspec.yaml
+++ b/dev/integration_tests/windows_startup_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: windows_startup_test
 description: Integration test for Windows app's startup.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: manual_tests
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/missing_dependency_tests/pubspec.yaml
+++ b/dev/missing_dependency_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: missing_dependency_tests
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -59,7 +59,7 @@ Future<void> main(List<String> arguments) async {
   buf.writeln('homepage: https://flutter.dev');
   buf.writeln('version: 0.0.0');
   buf.writeln('environment:');
-  buf.writeln("  sdk: '>=2.19.0 <4.0.0'");
+  buf.writeln("  sdk: '>=3.0.0-0 <4.0.0'");
   buf.writeln('dependencies:');
   for (final String package in findPackageNames()) {
     buf.writeln('  $package:');

--- a/dev/tools/gen_defaults/pubspec.yaml
+++ b/dev/tools/gen_defaults/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command line script to generate Material component defaults from 
 version: 1.0.0
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
 

--- a/dev/tools/gen_keycodes/pubspec.yaml
+++ b/dev/tools/gen_keycodes/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_keycodes
 description: Generates keycode source files from various resources.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   args: 2.4.0

--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -2,7 +2,7 @@ name: dev_tools
 description: Various repository development tools for flutter.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   archive: 3.3.2

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/tracing_tests/pubspec.yaml
+++ b/dev/tracing_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracing_tests
 description: Various tests for tracing in flutter/flutter
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/api/pubspec.yaml
+++ b/examples/api/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
   flutter: ">=2.5.0-6.0.pre.30 <3.0.0"
 
 dependencies:

--- a/examples/flutter_view/pubspec.yaml
+++ b/examples/flutter_view/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_view
 description: A new flutter project.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hello_world
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/image_list/pubspec.yaml
+++ b/examples/image_list/pubspec.yaml
@@ -4,7 +4,7 @@ description: Simple Flutter project used for benchmarking image loading over net
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_examples_layers
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_channel_swift/pubspec.yaml
+++ b/examples/platform_channel_swift/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel_swift
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_view/pubspec.yaml
+++ b/examples/platform_view/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_view
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/splash/pubspec.yaml
+++ b/examples/splash/pubspec.yaml
@@ -1,7 +1,7 @@
 name: splash
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -109,7 +109,7 @@ const String _flutterFoundationLibrary = 'package:flutter/foundation.dart';
 /// See also:
 ///
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
-class ChangeNotifier implements Listenable {
+mixin class ChangeNotifier implements Listenable {
   int _count = 0;
   // The _listeners is intentionally set to a fixed-length _GrowableList instead
   // of const [].

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -865,16 +865,19 @@ class MaterialScrollBehavior extends ScrollBehavior {
               child: child,
             );
           case AndroidOverscrollIndicator.glow:
-            continue glow;
+            return _buildGlowingOverscrollIndicator(context, details, child);
         }
-      glow:
       case TargetPlatform.fuchsia:
-        return GlowingOverscrollIndicator(
-          axisDirection: details.direction,
-          color: Theme.of(context).colorScheme.secondary,
-          child: child,
-        );
+        return _buildGlowingOverscrollIndicator(context, details, child);
     }
+  }
+
+  GlowingOverscrollIndicator _buildGlowingOverscrollIndicator(BuildContext context, ScrollableDetails details, Widget child) {
+    return GlowingOverscrollIndicator(
+      axisDirection: details.direction,
+      color: Theme.of(context).colorScheme.secondary,
+      child: child,
+    );
   }
 }
 

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -45,7 +45,7 @@ export 'dart:ui' show AppLifecycleState, Locale;
 ///
 /// To respond to other notifications, replace the [didChangeAppLifecycleState]
 /// method above with other methods from this class.
-abstract class WidgetsBindingObserver {
+abstract mixin class WidgetsBindingObserver {
   /// Called when the system tells the app to pop the current route.
   /// For example, on Android, this is called when the user presses
   /// the back button.

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -1638,7 +1638,7 @@ class _OverlayPortalState extends State<OverlayPortal> {
 //
 // Since it can't implement operator== (it's mutable), the same `_OverlayEntryLocation`
 // instance must not be used to represent more than one locations.
-class _OverlayEntryLocation extends LinkedListEntry<_OverlayEntryLocation> {
+final class _OverlayEntryLocation extends LinkedListEntry<_OverlayEntryLocation> {
   _OverlayEntryLocation(this._zOrderIndex, this._childModel, this._theater);
 
   final int _zOrderIndex;
@@ -1954,7 +1954,7 @@ class _DeferredLayout extends SingleChildRenderObjectWidget {
 // 3. When invoked from `PipelineOwner.flushLayout`, or
 //    `_layoutSurrogate.performLayout`, this `RenderObject` behaves like an
 //    `Overlay` that has only one entry.
-class _RenderDeferredLayoutBox extends RenderProxyBox with _RenderTheaterMixin, LinkedListEntry<_RenderDeferredLayoutBox> {
+final class _RenderDeferredLayoutBox extends RenderProxyBox with _RenderTheaterMixin, LinkedListEntry<_RenderDeferredLayoutBox> {
   _RenderDeferredLayoutBox(this._layoutSurrogate);
 
   StackParentData get stackParentData => parentData! as StackParentData;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1959,7 +1959,7 @@ class RouteObserver<R extends Route<dynamic>> extends NavigatorObserver {
 ///
 /// This is used with [RouteObserver] to make a widget aware of changes to the
 /// [Navigator]'s session history.
-abstract class RouteAware {
+abstract mixin class RouteAware {
   /// Called when the top route has been popped off, and the current route
   /// shows up.
   void didPopNext() { }

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -194,16 +194,19 @@ class ScrollBehavior {
               child: child,
             );
           case AndroidOverscrollIndicator.glow:
-            continue glow;
+            return _buildGlowingOverscrollIndicator(details, child);
         }
-      glow:
       case TargetPlatform.fuchsia:
-        return GlowingOverscrollIndicator(
-          axisDirection: details.direction,
-          color: _kDefaultGlowColor,
-          child: child,
-        );
+        return _buildGlowingOverscrollIndicator(details, child);
     }
+  }
+
+  GlowingOverscrollIndicator _buildGlowingOverscrollIndicator(ScrollableDetails details, Widget child) {
+    return GlowingOverscrollIndicator(
+      axisDirection: details.direction,
+      color: _kDefaultGlowColor,
+      child: child,
+    );
   }
 
   /// Specifies the type of velocity tracker to use in the descendant
@@ -379,6 +382,11 @@ class _WrappedScrollBehavior implements ScrollBehavior {
 
   @override
   String toString() => objectRuntimeType(this, '_WrappedScrollBehavior');
+
+  @override
+  GlowingOverscrollIndicator _buildGlowingOverscrollIndicator(ScrollableDetails details, Widget child) {
+    return delegate._buildGlowingOverscrollIndicator(details, child);
+  }
 }
 
 /// Controls how [Scrollable] widgets behave in a subtree.

--- a/packages/flutter/lib/src/widgets/scroll_notification_observer.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification_observer.dart
@@ -35,7 +35,7 @@ class _ScrollNotificationObserverScope extends InheritedWidget {
   bool updateShouldNotify(_ScrollNotificationObserverScope old) => _scrollNotificationObserverState != old._scrollNotificationObserverState;
 }
 
-class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
+final class _ListenerEntry extends LinkedListEntry<_ListenerEntry> {
   _ListenerEntry(this.listener);
   final ScrollNotificationCallback listener;
 }

--- a/packages/flutter/lib/src/widgets/tap_region.dart
+++ b/packages/flutter/lib/src/widgets/tap_region.dart
@@ -174,7 +174,7 @@ class TapRegionSurface extends SingleChildRenderObjectWidget {
 ///    the render tree.
 ///  * [TapRegionRegistry.of], which can find the nearest ancestor
 ///    [RenderTapRegionSurface], which is a [TapRegionRegistry].
-class RenderTapRegionSurface extends RenderProxyBoxWithHitTestBehavior with TapRegionRegistry {
+class RenderTapRegionSurface extends RenderProxyBoxWithHitTestBehavior implements TapRegionRegistry {
   final Expando<BoxHitTestResult> _cachedResults = Expando<BoxHitTestResult>();
   final Set<RenderTapRegion> _registeredRegions = <RenderTapRegion>{};
   final Map<Object?, Set<RenderTapRegion>> _groupIdToRegions = <Object?, Set<RenderTapRegion>>{};

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: A framework for writing Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -329,10 +329,11 @@ void main() {
     const Key child0Key = Key('child0');
     const Key child1Key = Key('child1');
 
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: Center(
-          child: ExpansionTile(
+    // TODO(goderbauer): Reevaluate the following ignores when https://github.com/dart-lang/sdk/issues/51800 is fixed.
+    await tester.pumpWidget(MaterialApp( // ignore: prefer_const_constructors
+      home: Material( // ignore: prefer_const_constructors
+        child: Center( // ignore: prefer_const_constructors
+          child: ExpansionTile( // ignore: prefer_const_constructors
             title: const Text('title'),
             // Set the column's alignment to Alignment.centerRight to test CrossAxisAlignment
             // of children widgets. This helps distinguish the effect of expandedAlignment

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -144,7 +144,8 @@ class RenderSelectionSpy extends RenderProxyBox
 
   @override
   SelectionGeometry get value => _value;
-  SelectionGeometry _value = SelectionGeometry(
+  // TODO(goderbauer): Reevaluate the ignore when https://github.com/dart-lang/sdk/issues/51800 is fixed.
+  SelectionGeometry _value = SelectionGeometry( // ignore: prefer_const_constructors
     hasContent: true,
     status: SelectionStatus.uncollapsed,
     startSelectionPoint: const SelectionPoint(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1995,7 +1995,8 @@ class RenderSelectionSpy extends RenderProxyBox
 
   @override
   SelectionGeometry get value => _value;
-  SelectionGeometry _value = SelectionGeometry(
+  // TODO(goderbauer): Reevaluate the ignore when https://github.com/dart-lang/sdk/issues/51800 is fixed.
+  SelectionGeometry _value = SelectionGeometry( // ignore: prefer_const_constructors
     hasContent: true,
     status: SelectionStatus.uncollapsed,
     startSelectionPoint: const SelectionPoint(
@@ -2084,7 +2085,8 @@ class RenderSelectAll extends RenderProxyBox
 
   @override
   SelectionGeometry get value => _value;
-  SelectionGeometry _value = SelectionGeometry(
+  // TODO(goderbauer): Reevaluate the ignore when https://github.com/dart-lang/sdk/issues/51800 is fixed.
+  SelectionGeometry _value = SelectionGeometry( // ignore: prefer_const_constructors
     hasContent: true,
     status: SelectionStatus.uncollapsed,
     startSelectionPoint: const SelectionPoint(

--- a/packages/flutter/test_private/pubspec.yaml
+++ b/packages/flutter/test_private/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_test_private
 description: Tests private interfaces of the flutter
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test_private/test/pubspec.yaml
+++ b/packages/flutter/test_private/test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animated_icons_private_test
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration and performance test API for Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   file: 6.1.4

--- a/packages/flutter_goldens/pubspec.yaml
+++ b/packages/flutter_goldens/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_goldens
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_goldens_client/pubspec.yaml
+++ b/packages/flutter_goldens_client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_goldens_client
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_localizations/pubspec.yaml
+++ b/packages/flutter_localizations/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_localizations
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_test
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_test/test/test_config/project_root/pubspec.yaml
+++ b/packages/flutter_test/test/test_config/project_root/pubspec.yaml
@@ -4,6 +4,6 @@
 name: dummy
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 # PUBSPEC CHECKSUM: 0000

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1648,7 +1648,7 @@ Directory createTemporaryFlutterSdk(
     // Fill in SDK dependency constraint.
     output.write('''
 environment:
-  sdk: ">=2.7.0 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 ''');
 
     output.writeln('dependencies:');
@@ -1680,7 +1680,7 @@ description: Dart SDK extensions for dart:ui
 homepage: http://flutter.io
 # sky_engine requires sdk_ext support in the analyzer which was added in 1.11.x
 environment:
-  sdk: '>=1.11.0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 ''');
 
   return directory;

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tools for building Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -60,7 +60,7 @@ void main() {
     pubspecFile.writeAsStringSync('''
   name: foo_project
   environment:
-    sdk: '>=2.12.0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
   ''');
 
     final File dartFile = fileSystem.file(fileSystem.path.join(directory.path, 'lib', 'main.dart'));

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -23,7 +23,7 @@ description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 
 environment:
-  sdk: ">=2.2.2 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
@@ -60,7 +60,7 @@ homepage: http://flutter.dev
 version: 1.0.0
 
 environment:
-  sdk: ">=2.14.0-383.0.dev <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
   flutter: ">=2.5.0-6.0.pre.30 <3.0.0"
 
 dependencies:

--- a/packages/flutter_tools/test/data/asset_test/font/pubspec.yaml
+++ b/packages/flutter_tools/test/data/asset_test/font/pubspec.yaml
@@ -2,7 +2,7 @@ name: font
 description: A test project that contains a font.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_tools/test/data/asset_test/main/pubspec.yaml
+++ b/packages/flutter_tools/test/data/asset_test/main/pubspec.yaml
@@ -2,7 +2,7 @@ name: main
 description: A test project that has a package with a font as a dependency.
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   font:

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
@@ -86,7 +86,7 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
   flutter: ">=1.20.0"
 ''';
 

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -166,7 +166,7 @@ flutter:
       linux:
         dartPluginClass: APlugin
 environment:
-  sdk: ">=2.14.0 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
   flutter: ">=2.5.0"
 ''');
 

--- a/packages/flutter_tools/test/general.shard/update_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/update_packages_test.dart
@@ -17,7 +17,7 @@ description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 
 environment:
-  sdk: '>=2.2.2 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".
@@ -51,7 +51,7 @@ description: A dummy pubspec with no dependencies
 homepage: http://flutter.dev
 
 environment:
-  sdk: ">=2.2.2 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 ''';
 
 const String kInvalidGitPubspec = '''
@@ -60,7 +60,7 @@ description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 
 environment:
-  sdk: ">=2.2.2 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -484,7 +484,7 @@ class _MyHomePageState extends State<MyHomePage> {
 const String pubspecYamlSrc = r'''
 name: flutter_project
 environment:
-  sdk: ">=2.1.0 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -732,7 +732,7 @@ class TestProject extends Project {
   final String pubspec = '''
     name: test
     environment:
-      sdk: '>=2.12.0-0 <4.0.0'
+      sdk: '>=3.0.0-0 <4.0.0'
 
     dependencies:
       flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
@@ -12,7 +12,7 @@ class BackgroundProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:
@@ -63,7 +63,7 @@ class RepeatingBackgroundProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
@@ -10,7 +10,7 @@ class BasicProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:
@@ -63,7 +63,7 @@ class BasicProjectThatThrows extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:
@@ -120,7 +120,7 @@ class BasicProjectWithTimelineTraces extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:
@@ -169,7 +169,7 @@ class BasicProjectWithFlutterGen extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:
@@ -194,7 +194,7 @@ class BasicProjectWithUnaryMain extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
   dependencies:
     flutter:
       sdk: flutter

--- a/packages/flutter_tools/test/integration.shard/test_data/compile_error_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/compile_error_project.dart
@@ -10,7 +10,7 @@ class CompileErrorProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -13,7 +13,7 @@ class DeferredComponentsProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
@@ -34,7 +34,7 @@ class GenL10nProject extends Project {
   final String pubspec = '''
 name: test_l10n_project
 environment:
-  sdk: ">=2.12.0-0 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_const_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_const_project.dart
@@ -10,7 +10,7 @@ class HotReloadConstProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_project.dart
@@ -12,7 +12,7 @@ class HotReloadProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset.dart
@@ -10,7 +10,7 @@ class HotReloadWithAssetProject extends Project {
   final String pubspec = '''
 name: test
 environment:
-  sdk: '>=2.12.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/integration_tests_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/integration_tests_project.dart
@@ -14,7 +14,7 @@ class IntegrationTestsProject extends Project implements TestsProject {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/migrate_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/migrate_project.dart
@@ -175,7 +175,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.6.0 <4.0.0"
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
@@ -38,7 +38,7 @@ class MultidexProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/project_with_early_error.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/project_with_early_error.dart
@@ -10,7 +10,7 @@ class ProjectWithEarlyError extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/single_widget_reload_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/single_widget_reload_project.dart
@@ -10,7 +10,7 @@ class SingleWidgetReloadProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_project.dart
@@ -10,7 +10,7 @@ class HotReloadProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <4.0.0"
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/stepping_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stepping_project.dart
@@ -9,7 +9,7 @@ class SteppingProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
   dependencies:
     flutter:
       sdk: flutter
@@ -65,7 +65,7 @@ class WebSteppingProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
   dependencies:
     flutter:
       sdk: flutter

--- a/packages/flutter_tools/test/integration.shard/test_data/test_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/test_project.dart
@@ -10,7 +10,7 @@ class TestProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/tests_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/tests_project.dart
@@ -13,7 +13,7 @@ class TestsProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.12.0-0 <4.0.0'
+    sdk: '>=3.0.0-0 <4.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_web_plugins/pubspec.yaml
+++ b/packages/flutter_web_plugins/pubspec.yaml
@@ -3,7 +3,7 @@ description: Library to register Flutter Web plugins
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/fuchsia_remote_debug_protocol/pubspec.yaml
+++ b/packages/fuchsia_remote_debug_protocol/pubspec.yaml
@@ -4,7 +4,7 @@ description: Provides an API to test/debug Flutter applications on remote Fuchsi
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   process: 4.2.4

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the integration_test plugin.
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
   flutter: ">=1.6.7"
 
 dependencies:

--- a/packages/integration_test/integration_test_macos/pubspec.yaml
+++ b/packages/integration_test/integration_test_macos/pubspec.yaml
@@ -10,7 +10,7 @@ flutter:
         pluginClass: IntegrationTestPlugin
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Runs tests that use the flutter_test API as integration tests.
 publish_to: none
 
 environment:
-  sdk: '>=2.19.0-0 <4.0.0'
+  sdk: '>=3.0.0-0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

This will allow us to use the latest Dart 3.0 features.

This PR also adds class modifiers where necessary: 

* to all classes identified as mixin-able as part of the analysis in http://flutter.dev/go/mixin-modifier
* subclasses of LinkedListEntry (a newly marked `base` class) to make the analyzer warnings below happy
* slight adjustments to how `TapRegionRegistry` is used to fix analyzer warnings

```
  error • The type '_OverlayEntryLocation' must be 'base', 'final' or 'sealed' because the supertype 'LinkedListEntry' is 'base' • packages/flutter/lib/src/widgets/overlay.dart:1641:7 • subtype_of_base_or_final_is_not_base_final_or_sealed
  error • The type '_RenderDeferredLayoutBox' must be 'base', 'final' or 'sealed' because the supertype 'LinkedListEntry' is 'base' • packages/flutter/lib/src/widgets/overlay.dart:1957:7 • subtype_of_base_or_final_is_not_base_final_or_sealed
  error • The type '_ListenerEntry' must be 'base', 'final' or 'sealed' because the supertype 'LinkedListEntry' is 'base' • packages/flutter/lib/src/widgets/scroll_notification_observer.dart:38:7 • subtype_of_base_or_final_is_not_base_final_or_sealed
```

Blocked on waiting for https://github.com/flutter/engine/pull/40178 to roll into the framework.