### PR TITLE
[web] stop using deprecated jsonwire web-driver protocol

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -983,9 +983,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_long_running_tests_2_5
@@ -1004,9 +1004,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_long_running_tests_3_5
@@ -1024,9 +1024,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_long_running_tests_4_5
@@ -1044,9 +1044,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_long_running_tests_5_5
@@ -1064,9 +1064,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_0
@@ -1084,9 +1084,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_1
@@ -1104,9 +1104,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_2
@@ -1124,9 +1124,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_3
@@ -1144,9 +1144,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_4
@@ -1164,9 +1164,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_5
@@ -1184,9 +1184,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_6
@@ -1204,9 +1204,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_tests_7_last
@@ -1224,9 +1224,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux web_canvaskit_tests_0
@@ -1244,9 +1244,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_1
     recipe: flutter/flutter_drone
@@ -1263,9 +1264,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_2
     recipe: flutter/flutter_drone
@@ -1282,9 +1284,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_3
     recipe: flutter/flutter_drone
@@ -1301,9 +1304,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_4
     recipe: flutter/flutter_drone
@@ -1320,9 +1324,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_5
     recipe: flutter/flutter_drone
@@ -1339,9 +1344,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_6
     recipe: flutter/flutter_drone
@@ -1358,9 +1364,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_canvaskit_tests_7_last
     recipe: flutter/flutter_drone
@@ -1377,9 +1384,10 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/
-      - bin/
+      - dev/**
+      - packages/**
+      - bin/**
+      - .ci.yaml
 
   - name: Linux web_tool_tests
     recipe: flutter/flutter_drone
@@ -1397,9 +1405,9 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:
-      - dev/
-      - packages/flutter_tools/
-      - bin/
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
       - .ci.yaml
 
   - name: Linux_android analyzer_benchmark

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -273,11 +273,12 @@ class FlutterWebConnection {
     final String sessionId = settings['session-id'].toString();
     final Uri sessionUri = Uri.parse(settings['session-uri'].toString());
     final async_io.WebDriver driver = async_io.WebDriver(
-        sessionUri,
-        sessionId,
-        json.decode(settings['session-capabilities'] as String) as Map<String, dynamic>,
-        async_io.AsyncIoRequestClient(sessionUri.resolve('session/$sessionId/')),
-        _convertToSpec(settings['session-spec'].toString().toLowerCase()));
+      sessionUri,
+      sessionId,
+      json.decode(settings['session-capabilities'] as String) as Map<String, dynamic>,
+      async_io.AsyncIoRequestClient(sessionUri.resolve('session/$sessionId/')),
+      async_io.WebDriverSpec.W3c,
+    );
     if (settings['android-chrome-on-emulator'] == true) {
       final Uri localUri = Uri.parse(url);
       // Converts to Android Emulator Uri.
@@ -360,15 +361,4 @@ Future<void> waitUntilExtensionInstalled(async_io.WebDriver driver, Duration? ti
       driver.execute(r'return typeof(window.$flutterDriver)', <String>[]),
       matcher: 'function',
       timeout: timeout ?? const Duration(days: 365));
-}
-
-async_io.WebDriverSpec _convertToSpec(String specString) {
-  switch (specString.toLowerCase()) {
-    case 'webdriverspec.w3c':
-      return async_io.WebDriverSpec.W3c;
-    case 'webdriverspec.jsonwire':
-      return async_io.WebDriverSpec.JsonWire;
-    default:
-      return async_io.WebDriverSpec.Auto;
-  }
 }

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -260,7 +260,7 @@ Map<String, dynamic> getDesiredCapabilities(
         'chromeOptions': <String, dynamic>{
           if (chromeBinary != null)
             'binary': chromeBinary,
-          'w3c': false,
+          'w3c': true,
           'args': <String>[
             '--bwsi',
             '--disable-background-timer-throttling',

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -257,7 +257,7 @@ Map<String, dynamic> getDesiredCapabilities(
           async_io.LogType.browser: 'INFO',
           async_io.LogType.performance: 'ALL',
         },
-        'chromeOptions': <String, dynamic>{
+        'goog:chromeOptions': <String, dynamic>{
           if (chromeBinary != null)
             'binary': chromeBinary,
           'w3c': true,

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -44,7 +44,7 @@ void main() {
         sync_io.LogType.performance: 'ALL',
       },
       'chromeOptions': <String, dynamic>{
-        'w3c': false,
+        'w3c': true,
         'args': <String>[
           ...kChromeArgs,
           '--headless',
@@ -72,7 +72,7 @@ void main() {
       },
       'chromeOptions': <String, dynamic>{
         'binary': chromeBinary,
-        'w3c': false,
+        'w3c': true,
         'args': kChromeArgs,
         'perfLoggingPrefs': <String, String>{
           'traceCategories':
@@ -101,7 +101,7 @@ void main() {
         sync_io.LogType.performance: 'ALL',
       },
       'chromeOptions': <String, dynamic>{
-        'w3c': false,
+        'w3c': true,
         'args': <String>[
           ...kChromeArgs,
           '--autoplay-policy=no-user-gesture-required',

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -43,7 +43,7 @@ void main() {
         sync_io.LogType.browser: 'INFO',
         sync_io.LogType.performance: 'ALL',
       },
-      'chromeOptions': <String, dynamic>{
+      'goog:chromeOptions': <String, dynamic>{
         'w3c': true,
         'args': <String>[
           ...kChromeArgs,
@@ -70,7 +70,7 @@ void main() {
         sync_io.LogType.browser: 'INFO',
         sync_io.LogType.performance: 'ALL',
       },
-      'chromeOptions': <String, dynamic>{
+      'goog:chromeOptions': <String, dynamic>{
         'binary': chromeBinary,
         'w3c': true,
         'args': kChromeArgs,
@@ -100,7 +100,7 @@ void main() {
         sync_io.LogType.browser: 'INFO',
         sync_io.LogType.performance: 'ALL',
       },
-      'chromeOptions': <String, dynamic>{
+      'goog:chromeOptions': <String, dynamic>{
         'w3c': true,
         'args': <String>[
           ...kChromeArgs,


### PR DESCRIPTION
Stop using the deprecated jsonwire web-driver protocol. Use the W3C protocol instead.