### PR TITLE
Separate attached and wireless devices

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -89,6 +89,14 @@ class AndroidDevice extends Device {
   final String modelID;
   final String? deviceCodeName;
 
+  @override
+  // Wirelessly paired Android devices should have `adb-tls-connect` in the id.
+  // Source: https://android.googlesource.com/platform/packages/modules/adb/+/f4ba8d73079b99532069dbe888a58167b8723d6c/adb_mdns.h#30
+  DeviceConnectionInterface get connectionInterface =>
+      id.contains('adb-tls-connect')
+          ? DeviceConnectionInterface.wireless
+          : DeviceConnectionInterface.attached;
+
   late final Future<Map<String, String>> _properties = () async {
     Map<String, String> properties = <String, String>{};
 

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -265,7 +265,7 @@ class UserMessages {
       'for information about installing additional components.';
   String flutterNoMatchingDevice(String deviceId) => 'No supported devices found with name or id '
       "matching '$deviceId'.";
-  String get flutterNoDevicesFound => 'No devices found';
+  String get flutterNoDevicesFound => 'No devices found.';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
   String flutterMissPlatformProjects(List<String> unsupportedDevicesType) =>
       'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -114,7 +114,6 @@ class DevicesCommandOutput {
     }
 
     if (allDevices.isEmpty) {
-      globals.printStatus('No devices detected.');
       _printNoDevicesDetected();
     } else {
       if (attachedDevices.isNotEmpty) {
@@ -133,7 +132,8 @@ class DevicesCommandOutput {
   }
 
   void _printNoDevicesDetected() {
-    final StringBuffer status = StringBuffer();
+    final StringBuffer status = StringBuffer('No devices detected.');
+    status.writeln();
     status.writeln();
     status.writeln('Run "flutter emulators" to list and start any available device emulators.');
     status.writeln();

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -79,31 +79,71 @@ class DevicesCommandOutput {
 
   final Duration? deviceDiscoveryTimeout;
 
+  Future<List<Device>> _getAttachedDevices(DeviceManager deviceManager) async {
+    return deviceManager.getAllDevices(
+      filter: DeviceDiscoveryFilter(
+        deviceConnectionInterface: DeviceConnectionInterface.attached,
+      ),
+    );
+  }
+
+  Future<List<Device>> _getWirelessDevices(DeviceManager deviceManager) async {
+    return deviceManager.getAllDevices(
+      filter: DeviceDiscoveryFilter(
+        deviceConnectionInterface: DeviceConnectionInterface.wireless,
+      ),
+    );
+  }
+
   Future<void> findAndOutputAllTargetDevices({required bool machine}) async {
-    final List<Device> devices = await globals.deviceManager?.refreshAllDevices(timeout: deviceDiscoveryTimeout) ?? <Device>[];
+    List<Device> attachedDevices = <Device>[];
+    List<Device> wirelessDevices = <Device>[];
+    final DeviceManager? deviceManager = globals.deviceManager;
+    if (deviceManager != null) {
+      // Refresh the cache and then get the attached and wireless devices from
+      // the cache.
+      await deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
+      attachedDevices = await _getAttachedDevices(deviceManager);
+      wirelessDevices = await _getWirelessDevices(deviceManager);
+    }
+    final List<Device> allDevices = attachedDevices + wirelessDevices;
 
     if (machine) {
-      await printDevicesAsJson(devices);
-    } else {
-      if (devices.isEmpty) {
-        final StringBuffer status = StringBuffer('No devices detected.');
-        status.writeln();
-        status.writeln();
-        status.writeln('Run "flutter emulators" to list and start any available device emulators.');
-        status.writeln();
-        status.write('If you expected your device to be detected, please run "flutter doctor" to diagnose potential issues. ');
-        if (deviceDiscoveryTimeout == null) {
-          status.write('You may also try increasing the time to wait for connected devices with the --${FlutterOptions.kDeviceTimeout} flag. ');
-        }
-        status.write('Visit https://flutter.dev/setup/ for troubleshooting tips.');
-
-        globals.printStatus(status.toString());
-      } else {
-        globals.printStatus('${devices.length} connected ${pluralize('device', devices.length)}:\n');
-        await Device.printDevices(devices, globals.logger);
-      }
-      await _printDiagnostics();
+      await printDevicesAsJson(allDevices);
+      return;
     }
+
+    if (allDevices.isEmpty) {
+      globals.printStatus('No devices detected.');
+      _printNoDevicesDetected();
+    } else {
+      if (attachedDevices.isNotEmpty) {
+        globals.printStatus('${attachedDevices.length} connected ${pluralize('device', attachedDevices.length)}:\n');
+        await Device.printDevices(attachedDevices, globals.logger);
+      }
+      if (wirelessDevices.isNotEmpty) {
+        if (attachedDevices.isNotEmpty) {
+          globals.printStatus('');
+        }
+        globals.printStatus('${wirelessDevices.length} wirelessly connected ${pluralize('device', wirelessDevices.length)}:\n');
+        await Device.printDevices(wirelessDevices, globals.logger);
+      }
+    }
+    await _printDiagnostics();
+  }
+
+  void _printNoDevicesDetected() {
+    final StringBuffer status = StringBuffer();
+    status.writeln();
+    status.writeln('Run "flutter emulators" to list and start any available device emulators.');
+    status.writeln();
+    status.write('If you expected your device to be detected, please run "flutter doctor" to diagnose potential issues. ');
+    if (deviceDiscoveryTimeout == null) {
+      status.write('You may also try increasing the time to wait for connected devices with the --${FlutterOptions.kDeviceTimeout} flag. ');
+    }
+    status.write('Visit https://flutter.dev/setup/ for troubleshooting tips.');
+
+    globals.printStatus(status.toString());
   }
 
   Future<void> _printDiagnostics() async {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -185,6 +185,13 @@ class IOSDevice extends Device {
   final IMobileDevice _iMobileDevice;
   final IProxy _iproxy;
 
+  @override
+  DeviceConnectionInterface get connectionInterface {
+    return interfaceType == IOSDeviceConnectionInterface.network
+        ? DeviceConnectionInterface.wireless
+        : DeviceConnectionInterface.attached;
+  }
+
   /// May be 0 if version cannot be parsed.
   int get majorSdkVersion {
     final String? majorVersionString = _sdkVersion?.split('.').first.trim();

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -8,7 +8,7 @@ import '../base/user_messages.dart';
 import '../device.dart';
 import '../globals.dart' as globals;
 
-const String wirelesslyConnectedDevicesMessage = 'Wirelessly connected devices:';
+const String _wirelesslyConnectedDevicesMessage = 'Wirelessly connected devices:';
 
 /// This class handles functionality of finding and selecting target devices.
 ///
@@ -58,6 +58,14 @@ class TargetDevices {
     );
   }
 
+  DeviceDiscoverySupportFilter _defaultSupportFilter(
+    bool includeDevicesUnsupportedByProject,
+  ) {
+    return _deviceManager.deviceSupportFilter(
+      includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
+    );
+  }
+
   /// Find and return all target [Device]s based upon criteria entered by the
   /// user on the command line.
   ///
@@ -102,14 +110,10 @@ class TargetDevices {
     }
 
     final List<Device> attachedDevices = await _getAttachedDevices(
-      supportFilter: _deviceManager.deviceSupportFilter(
-        includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
-      ),
+      supportFilter: _defaultSupportFilter(includeDevicesUnsupportedByProject),
     );
     final List<Device> wirelessDevices = await _getWirelessDevices(
-      supportFilter: _deviceManager.deviceSupportFilter(
-        includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
-      ),
+      supportFilter: _defaultSupportFilter(includeDevicesUnsupportedByProject),
     );
     final List<Device> allDevices = attachedDevices + wirelessDevices;
 
@@ -154,8 +158,9 @@ class TargetDevices {
   /// ephemeral devices. If a single ephemeral device is found, return it
   /// immediately.
   ///
-  /// Otherwise, prompt the user to select a device if there is a terminal with stdin. If there is not a terminal, display the
-  /// list of devices with instructions to use a device selection flag.
+  /// Otherwise, prompt the user to select a device if there is a terminal
+  /// with stdin. If there is not a terminal, display the list of devices with
+  /// instructions to use a device selection flag.
   Future<List<Device>?> _handleMultipleDevices(
     List<Device> attachedDevices,
     List<Device> wirelessDevices,
@@ -207,7 +212,7 @@ class TargetDevices {
       if (_deviceManager.hasSpecifiedDeviceId || attachedDevices.isNotEmpty) {
         _logger.printStatus('');
       }
-      _logger.printStatus(wirelesslyConnectedDevicesMessage);
+      _logger.printStatus(_wirelesslyConnectedDevicesMessage);
       await Device.printDevices(wirelessDevices, _logger);
     }
 
@@ -235,14 +240,14 @@ class TargetDevices {
 
     if (wirelessDevices.isNotEmpty) {
       _logger.printStatus('');
-      _logger.printStatus(wirelesslyConnectedDevicesMessage);
+      _logger.printStatus(_wirelesslyConnectedDevicesMessage);
       await Device.printDevices(wirelessDevices, _logger);
       _logger.printStatus('');
     }
 
     final Device chosenDevice = await _chooseOneOfAvailableDevices(allDevices);
 
-    // Update the [DeviceManager.specifiedDeviceId] so that we will not be prompted again.
+    // Update the [DeviceManager.specifiedDeviceId] so that the user will not be prompted again.
     _deviceManager.specifiedDeviceId = chosenDevice.id;
 
     return <Device>[chosenDevice];

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -72,7 +72,7 @@ class TargetDevices {
   /// with stdin is not available, print a list of available devices and
   /// return null.
   ///
-  /// When no devices meet user specificiations, print a list of unsupported
+  /// When no devices meet user specifications, print a list of unsupported
   /// devices and return null.
   Future<List<Device>?> findAllTargetDevices({
     Duration? deviceDiscoveryTimeout,
@@ -89,6 +89,10 @@ class TargetDevices {
     }
 
     if (_deviceManager.hasSpecifiedDeviceId) {
+      // Must check for device match separately from `_getAttachedDevices` and
+      // `_getWirelessDevices` because if an exact match is found in one
+      // and a partial match is found in another, there is no way to distinguish
+      // between them.
       final List<Device> devices = await _getDeviceById(
         includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
       );
@@ -146,8 +150,8 @@ class TargetDevices {
 
   /// Determine which device to use when multiple found.
   ///
-  /// If user has not specificed a device id/name, attempt to prioritize
-  /// ephemeral devices. If a single ephermal device is found, return it
+  /// If user has not specified a device id/name, attempt to prioritize
+  /// ephemeral devices. If a single ephemeral device is found, return it
   /// immediately.
   ///
   /// Otherwise, prompt the user to select a device if there is a terminal with stdin. If there is not a terminal, display the

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -2,14 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart';
-
 import '../base/common.dart';
 import '../base/logger.dart';
 import '../base/user_messages.dart';
 import '../device.dart';
 import '../globals.dart' as globals;
 
+const String wirelesslyConnectedDevicesMessage = 'Wirelessly connected devices:';
+
+/// This class handles functionality of finding and selecting target devices.
+///
+/// Target devices are devices that are supported and selectable to run
+/// a flutter application on.
 class TargetDevices {
   TargetDevices({
     required DeviceManager deviceManager,
@@ -20,10 +24,56 @@ class TargetDevices {
   final DeviceManager _deviceManager;
   final Logger _logger;
 
-  /// Find and return all target [Device]s based upon currently connected
-  /// devices and criteria entered by the user on the command line.
-  /// If no device can be found that meets specified criteria,
-  /// then print an error message and return null.
+  Future<List<Device>> _getAttachedDevices({
+    DeviceDiscoverySupportFilter? supportFilter,
+  }) async {
+    return _deviceManager.getDevices(
+      filter: DeviceDiscoveryFilter(
+        deviceConnectionInterface: DeviceConnectionInterface.attached,
+        supportFilter: supportFilter,
+      ),
+    );
+  }
+
+  Future<List<Device>> _getWirelessDevices({
+    DeviceDiscoverySupportFilter? supportFilter,
+  }) async {
+    return _deviceManager.getDevices(
+      filter: DeviceDiscoveryFilter(
+        deviceConnectionInterface: DeviceConnectionInterface.wireless,
+        supportFilter: supportFilter,
+      ),
+    );
+  }
+
+  Future<List<Device>> _getDeviceById({
+    bool includeDevicesUnsupportedByProject = false,
+  }) async {
+    return _deviceManager.getDevices(
+      filter: DeviceDiscoveryFilter(
+        supportFilter: _deviceManager.deviceSupportFilter(
+          includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
+        ),
+      ),
+    );
+  }
+
+  /// Find and return all target [Device]s based upon criteria entered by the
+  /// user on the command line.
+  ///
+  /// When the user has specified `all` devices, return all devices meeting criteria.
+  ///
+  /// When the user has specified a device id/name, attempt to find an exact or
+  /// partial match. If an exact match or a single partial match is found,
+  /// return it immediately.
+  ///
+  /// When multiple devices are found and there is a terminal attached to
+  /// stdin, allow the user to select which device to use. When a terminal
+  /// with stdin is not available, print a list of available devices and
+  /// return null.
+  ///
+  /// When no devices meet user specificiations, print a list of unsupported
+  /// devices and return null.
   Future<List<Device>?> findAllTargetDevices({
     Duration? deviceDiscoveryTimeout,
     bool includeDevicesUnsupportedByProject = false,
@@ -32,67 +82,172 @@ class TargetDevices {
       _logger.printError(userMessages.flutterNoDevelopmentDevice);
       return null;
     }
-    List<Device> devices = await getDevices(
-      includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
-      timeout: deviceDiscoveryTimeout,
-    );
 
-    if (devices.isEmpty) {
-      if (_deviceManager.hasSpecifiedDeviceId) {
-        _logger.printStatus(userMessages.flutterNoMatchingDevice(_deviceManager.specifiedDeviceId!));
-        final List<Device> allDevices = await _deviceManager.getAllDevices();
-        if (allDevices.isNotEmpty) {
-          _logger.printStatus('');
-          _logger.printStatus('The following devices were found:');
-          await Device.printDevices(allDevices, _logger);
-        }
-        return null;
-      } else if (_deviceManager.hasSpecifiedAllDevices) {
-        _logger.printStatus(userMessages.flutterNoDevicesFound);
-        await _printUnsupportedDevice(_deviceManager);
-        return null;
-      } else {
-        _logger.printStatus(userMessages.flutterNoSupportedDevices);
-        await _printUnsupportedDevice(_deviceManager);
-        return null;
-      }
-    } else if (devices.length > 1) {
-      if (_deviceManager.hasSpecifiedDeviceId) {
-        _logger.printStatus(userMessages.flutterFoundSpecifiedDevices(devices.length, _deviceManager.specifiedDeviceId!));
-        return null;
-      } else if (!_deviceManager.hasSpecifiedAllDevices) {
-        if (globals.terminal.stdinHasTerminal) {
-          // If DeviceManager was not able to prioritize a device. For example, if the user
-          // has two active Android devices running, then we request the user to
-          // choose one. If the user has two nonEphemeral devices running, we also
-          // request input to choose one.
-          _logger.printStatus(userMessages.flutterMultipleDevicesFound);
-          await Device.printDevices(devices, _logger);
-          final Device chosenDevice = await _chooseOneOfAvailableDevices(devices);
+    if (deviceDiscoveryTimeout != null) {
+      // Reset the cache with the specified timeout.
+      await _deviceManager.refreshAllDevices(timeout: deviceDiscoveryTimeout);
+    }
 
-          // Update the [DeviceManager.specifiedDeviceId] so that we will not be prompted again.
-          _deviceManager.specifiedDeviceId = chosenDevice.id;
-
-          devices = <Device>[chosenDevice];
-        } else {
-          // Show an error message asking the user to specify `-d all` if they
-          // want to run on multiple devices.
-          final List<Device> allDevices = await _deviceManager.getAllDevices();
-          _logger.printStatus(userMessages.flutterSpecifyDeviceWithAllOption);
-          _logger.printStatus('');
-          await Device.printDevices(allDevices, _logger);
-          return null;
-        }
+    if (_deviceManager.hasSpecifiedDeviceId) {
+      final List<Device> devices = await _getDeviceById(
+        includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
+      );
+      if (devices.length == 1) {
+        return devices;
       }
     }
 
-    return devices;
+    final List<Device> attachedDevices = await _getAttachedDevices(
+      supportFilter: _deviceManager.deviceSupportFilter(
+        includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
+      ),
+    );
+    final List<Device> wirelessDevices = await _getWirelessDevices(
+      supportFilter: _deviceManager.deviceSupportFilter(
+        includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
+      ),
+    );
+    final List<Device> allDevices = attachedDevices + wirelessDevices;
+
+    if (allDevices.isEmpty) {
+      return _handleNoDevices();
+    } else if (_deviceManager.hasSpecifiedAllDevices) {
+      return allDevices;
+    } else if (allDevices.length > 1) {
+      return _handleMultipleDevices(attachedDevices, wirelessDevices);
+    }
+    return allDevices;
   }
 
-  Future<void> _printUnsupportedDevice(DeviceManager deviceManager) async {
-    final List<Device> unsupportedDevices = await deviceManager.getDevices();
+  /// When no supported devices are found, display a message and list of
+  /// unsupported devices found.
+  Future<List<Device>?> _handleNoDevices() async {
+    // Get connected devices from cache, including unsupported ones.
+    final List<Device> unsupportedDevices = await _deviceManager.getAllDevices();
+
+    if (_deviceManager.hasSpecifiedDeviceId) {
+      _logger.printStatus(
+        userMessages.flutterNoMatchingDevice(_deviceManager.specifiedDeviceId!),
+      );
+      if (unsupportedDevices.isNotEmpty) {
+        _logger.printStatus('');
+        _logger.printStatus('The following devices were found:');
+        await Device.printDevices(unsupportedDevices, _logger);
+      }
+      return null;
+    }
+
+    _logger.printStatus(_deviceManager.hasSpecifiedAllDevices
+        ? userMessages.flutterNoDevicesFound
+        : userMessages.flutterNoSupportedDevices);
+    await _printUnsupportedDevice(unsupportedDevices);
+    return null;
+  }
+
+  /// Determine which device to use when multiple found.
+  ///
+  /// If user has not specificed a device id/name, attempt to prioritize
+  /// ephemeral devices. If a single ephermal device is found, return it
+  /// immediately.
+  ///
+  /// Otherwise, prompt the user to select a device if there is a terminal with stdin. If there is not a terminal, display the
+  /// list of devices with instructions to use a device selection flag.
+  Future<List<Device>?> _handleMultipleDevices(
+    List<Device> attachedDevices,
+    List<Device> wirelessDevices,
+  ) async {
+    final List<Device> allDevices = attachedDevices + wirelessDevices;
+
+    final Device? ephemeralDevice = _deviceManager.getSingleEphemeralDevice(allDevices);
+    if (ephemeralDevice != null) {
+      return <Device>[ephemeralDevice];
+    }
+
+    if (globals.terminal.stdinHasTerminal) {
+      return _selectFromMultipleDevices(attachedDevices, wirelessDevices);
+    } else {
+      return _printMultipleDevices(attachedDevices, wirelessDevices);
+    }
+  }
+
+  /// Display a list of found devices. When the user has not specified the
+  /// device id/name, display devices unsupported by the project as well and
+  /// give instructions to use a device selection flag.
+  Future<List<Device>?> _printMultipleDevices(
+    List<Device> attachedDevices,
+    List<Device> wirelessDevices,
+  ) async {
+    if (_deviceManager.hasSpecifiedDeviceId) {
+      final int allDeviceLength = attachedDevices.length + wirelessDevices.length;
+      _logger.printStatus(userMessages.flutterFoundSpecifiedDevices(
+        allDeviceLength,
+        _deviceManager.specifiedDeviceId!,
+      ));
+    } else {
+      // Get connected devices from cache, including ones unsupported for the
+      // project but still supported by Flutter.
+      attachedDevices = await _getAttachedDevices(
+        supportFilter: DeviceDiscoverySupportFilter.excludeDevicesUnsupportedByFlutter(),
+      );
+      wirelessDevices = await _getWirelessDevices(
+        supportFilter: DeviceDiscoverySupportFilter.excludeDevicesUnsupportedByFlutter(),
+      );
+
+      _logger.printStatus(userMessages.flutterSpecifyDeviceWithAllOption);
+      _logger.printStatus('');
+    }
+
+    await Device.printDevices(attachedDevices, _logger);
+
+    if (wirelessDevices.isNotEmpty) {
+      if (_deviceManager.hasSpecifiedDeviceId || attachedDevices.isNotEmpty) {
+        _logger.printStatus('');
+      }
+      _logger.printStatus(wirelesslyConnectedDevicesMessage);
+      await Device.printDevices(wirelessDevices, _logger);
+    }
+
+    return null;
+  }
+
+  /// Display a list of selectable devices, prompt the user to choose one, and
+  /// wait for the user to select a valid option.
+  Future<List<Device>?> _selectFromMultipleDevices(
+    List<Device> attachedDevices,
+    List<Device> wirelessDevices,
+  ) async {
+    final List<Device> allDevices = attachedDevices + wirelessDevices;
+
+    if (_deviceManager.hasSpecifiedDeviceId) {
+      _logger.printStatus(userMessages.flutterFoundSpecifiedDevices(
+        allDevices.length,
+        _deviceManager.specifiedDeviceId!,
+      ));
+    } else {
+      _logger.printStatus(userMessages.flutterMultipleDevicesFound);
+    }
+
+    await Device.printDevices(attachedDevices, _logger);
+
+    if (wirelessDevices.isNotEmpty) {
+      _logger.printStatus('');
+      _logger.printStatus(wirelesslyConnectedDevicesMessage);
+      await Device.printDevices(wirelessDevices, _logger);
+      _logger.printStatus('');
+    }
+
+    final Device chosenDevice = await _chooseOneOfAvailableDevices(allDevices);
+
+    // Update the [DeviceManager.specifiedDeviceId] so that we will not be prompted again.
+    _deviceManager.specifiedDeviceId = chosenDevice.id;
+
+    return <Device>[chosenDevice];
+  }
+
+  Future<void> _printUnsupportedDevice(List<Device> unsupportedDevices) async {
     if (unsupportedDevices.isNotEmpty) {
       final StringBuffer result = StringBuffer();
+      result.writeln();
       result.writeln(userMessages.flutterFoundButUnsupportedDevices);
       result.writeAll(
         (await Device.descriptions(unsupportedDevices))
@@ -104,7 +259,7 @@ class TargetDevices {
       result.writeln(userMessages.flutterMissPlatformProjects(
         Device.devicesPlatformTypes(unsupportedDevices),
       ));
-      _logger.printStatus(result.toString());
+      _logger.printStatus(result.toString(), newline: false);
     }
   }
 
@@ -134,49 +289,5 @@ class TargetDevices {
       prompt: userMessages.flutterChooseOne,
     );
     return result;
-  }
-
-  /// Find and return all target [Device]s based upon currently connected
-  /// devices, the current project, and criteria entered by the user on
-  /// the command line.
-  ///
-  /// Returns a list of devices specified by the user.
-  ///
-  /// * If the user specified '-d all', then return all connected devices which
-  /// support the current project, except for fuchsia and web.
-  ///
-  /// * If the user specified a device id, then do nothing as the list is already
-  /// filtered by [_deviceManager.getDevices].
-  ///
-  /// * If the user did not specify a device id and there is more than one
-  /// device connected, then filter out unsupported devices and prioritize
-  /// ephemeral devices.
-  @visibleForTesting
-  Future<List<Device>> getDevices({
-    bool includeDevicesUnsupportedByProject = false,
-    Duration? timeout,
-  }) async {
-    if (timeout != null) {
-      // Reset the cache with the specified timeout.
-      await _deviceManager.refreshAllDevices(timeout: timeout);
-    }
-
-    final List<Device> devices = await _deviceManager.getDevices(
-      filter: DeviceDiscoveryFilter(
-        supportFilter: _deviceManager.deviceSupportFilter(
-          includeDevicesUnsupportedByProject: includeDevicesUnsupportedByProject,
-        ),
-      ),
-    );
-
-    // If there is more than one device, attempt to prioritize ephemeral devices.
-    if (devices.length > 1) {
-      final Device? ephemeralDevice = _deviceManager.getSingleEphemeralDevice(devices);
-      if (ephemeralDevice != null) {
-        return <Device>[ephemeralDevice];
-      }
-    }
-
-    return devices;
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1238,6 +1238,10 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
 
   @override
+  DeviceConnectionInterface get connectionInterface =>
+      DeviceConnectionInterface.attached;
+
+  @override
   bool isSupported() => true;
 
   @override
@@ -1301,6 +1305,13 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
   @override
   final IOSDeviceConnectionInterface interfaceType;
+
+  @override
+  DeviceConnectionInterface get connectionInterface {
+    return interfaceType == IOSDeviceConnectionInterface.network
+        ? DeviceConnectionInterface.wireless
+        : DeviceConnectionInterface.attached;
+  }
 
   @override
   DevicePortForwarder get portForwarder => _portForwarder!;

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -68,7 +68,7 @@ void main() {
 
     final Device screenshotDevice = ThrowingScreenshotDevice()
       ..supportsScreenshot = false;
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -104,7 +104,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final Device screenshotDevice = ThrowingScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -142,7 +142,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final Device screenshotDevice = ScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -184,7 +184,7 @@ void main() {
     fileSystem.file('drive_screenshots').createSync();
 
     final Device screenshotDevice = ThrowingScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -222,7 +222,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final ScreenshotDevice screenshotDevice = ScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     expect(screenshotDevice.screenshots, isEmpty);
     bool caughtToolExit = false;
@@ -293,7 +293,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final ScreenshotDevice screenshotDevice = ScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     expect(screenshotDevice.screenshots, isEmpty);
 
@@ -424,7 +424,7 @@ void main() {
 
     final Device networkDevice = FakeIosDevice()
       ..interfaceType = IOSDeviceConnectionInterface.network;
-    fakeDeviceManager.devices = <Device>[networkDevice];
+    fakeDeviceManager.wirelessDevices = <Device>[networkDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(<String>[
       'drive',
@@ -457,7 +457,7 @@ void main() {
 
     final Device usbDevice = FakeIosDevice()
       ..interfaceType = IOSDeviceConnectionInterface.usb;
-    fakeDeviceManager.devices = <Device>[usbDevice];
+    fakeDeviceManager.attachedDevices = <Device>[usbDevice];
 
     final DebuggingOptions options = await command.createDebuggingOptions(false);
     expect(options.disablePortPublication, true);
@@ -482,7 +482,7 @@ void main() {
 
     final Device networkDevice = FakeIosDevice()
       ..interfaceType = IOSDeviceConnectionInterface.network;
-    fakeDeviceManager.devices = <Device>[networkDevice];
+    fakeDeviceManager.wirelessDevices = <Device>[networkDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(<String>[
       'drive',

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -36,7 +36,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeAndroidDevice device = FakeAndroidDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       await createTestCommandRunner(command).run(<String>['install']);
     }, overrides: <Type, Generator>{
@@ -50,7 +50,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       expect(() async => createTestCommandRunner(command).run(<String>['install', '--device-user', '10']),
         throwsToolExit(message: '--device-user is only supported for Android'));
@@ -65,7 +65,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeIOSApp());
 
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       await createTestCommandRunner(command).run(<String>['install']);
     }, overrides: <Type, Generator>{
@@ -79,7 +79,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeAndroidDevice device = FakeAndroidDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       expect(() async => createTestCommandRunner(command).run(<String>['install', '--use-application-binary', 'bogus']),
           throwsToolExit(message: 'Prebuilt binary bogus does not exist'));
@@ -94,7 +94,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeAndroidDevice device = FakeAndroidDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
       fileSystem.file('binary').createSync(recursive: true);
 
       await createTestCommandRunner(command).run(<String>['install', '--use-application-binary', 'binary']);
@@ -111,7 +111,7 @@ void main() {
       command.applicationPackages = fakeAppFactory;
 
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       await createTestCommandRunner(command).run(<String>['install', '--flavor', flavor]);
       expect(fakeAppFactory.buildInfo, isNotNull);
@@ -183,4 +183,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   String get name => 'Android';
+
+  @override
+  bool get ephemeral => true;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1058,6 +1058,10 @@ class FakeDevice extends Fake implements Device {
   @override
   bool get isConnected => true;
 
+  @override
+  DeviceConnectionInterface get connectionInterface =>
+      DeviceConnectionInterface.attached;
+
   bool supported = true;
 
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -922,8 +922,15 @@ class _FakeDeviceManager extends DeviceManager {
   @override
   Future<List<Device>> getAllDevices({
     DeviceDiscoveryFilter? filter,
-  }) async => _connectedDevices;
+  }) async => filteredDevices(filter);
 
   @override
   List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[];
+
+  List<Device> filteredDevices(DeviceDiscoveryFilter? filter) {
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.wireless) {
+      return <Device>[];
+    }
+    return _connectedDevices;
+  }
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -88,6 +88,13 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   String? specifiedDeviceId;
 
   @override
+  Future<List<Device>> getAllDevices({
+    DeviceDiscoveryFilter? filter,
+  }) async {
+    return devices;
+  }
+
+  @override
   Future<List<Device>> refreshAllDevices({
     Duration? timeout,
     DeviceDiscoveryFilter? filter,

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -122,7 +122,7 @@ void main() {
     expect(androidDevices.supportsPlatform, false);
   });
 
-  testWithoutContext('AndroidDevices can parse output for physical devices', () async {
+  testWithoutContext('AndroidDevices can parse output for physical attached devices', () async {
     final AndroidDevices androidDevices = AndroidDevices(
       userMessages: UserMessages(),
       androidWorkflow: androidWorkflow,
@@ -147,6 +147,35 @@ List of devices attached
     expect(devices, hasLength(1));
     expect(devices.first.name, 'Nexus 7');
     expect(devices.first.category, Category.mobile);
+    expect(devices.first.connectionInterface, DeviceConnectionInterface.attached);
+  });
+
+  testWithoutContext('AndroidDevices can parse output for physical wireless devices', () async {
+    final AndroidDevices androidDevices = AndroidDevices(
+      userMessages: UserMessages(),
+      androidWorkflow: androidWorkflow,
+      androidSdk: FakeAndroidSdk(),
+      logger: BufferLogger.test(),
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['adb', 'devices', '-l'],
+          stdout: '''
+List of devices attached
+05a02bac._adb-tls-connect._tcp.               device product:razor model:Nexus_7 device:flo
+
+  ''',
+        ),
+      ]),
+      platform: FakePlatform(),
+      fileSystem: MemoryFileSystem.test(),
+    );
+
+    final List<Device> devices = await androidDevices.pollingGetDevices();
+
+    expect(devices, hasLength(1));
+    expect(devices.first.name, 'Nexus 7');
+    expect(devices.first.category, Category.mobile);
+    expect(devices.first.connectionInterface, DeviceConnectionInterface.wireless);
   });
 
   testWithoutContext('AndroidDevices can parse output for emulators and short listings', () async {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -480,22 +481,35 @@ void main() {
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
           expect(devices, hasLength(4));
+
           expect(devices[0].id, '00008027-00192736010F802E');
           expect(devices[0].name, 'An iPhone (Space Gray)');
           expect(await devices[0].sdkNameAndVersion, 'iOS 13.3 17C54');
           expect(devices[0].cpuArchitecture, DarwinArch.arm64);
+          expect(devices[0].interfaceType, IOSDeviceConnectionInterface.usb);
+          expect(devices[0].connectionInterface, DeviceConnectionInterface.attached);
+
           expect(devices[1].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
           expect(devices[1].name, 'iPad 1');
           expect(await devices[1].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[1].cpuArchitecture, DarwinArch.armv7);
+          expect(devices[1].interfaceType, IOSDeviceConnectionInterface.usb);
+          expect(devices[1].connectionInterface, DeviceConnectionInterface.attached);
+
           expect(devices[2].id, '234234234234234234345445687594e089dede3c44');
           expect(devices[2].name, 'A networked iPad');
           expect(await devices[2].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+          expect(devices[2].interfaceType, IOSDeviceConnectionInterface.network);
+          expect(devices[2].connectionInterface, DeviceConnectionInterface.wireless);
+
           expect(devices[3].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
           expect(devices[3].name, 'iPad 2');
           expect(await devices[3].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[3].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+          expect(devices[3].interfaceType, IOSDeviceConnectionInterface.usb);
+          expect(devices[3].connectionInterface, DeviceConnectionInterface.attached);
+
           expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -705,15 +705,15 @@ void main() {
       });
 
       testUsingContext('finds single device', () async {
-        testDeviceManager.addDevice(device1);
+        testDeviceManager.addAttachedDevice(device1);
         final DummyFlutterCommand flutterCommand = DummyFlutterCommand();
         final Device? device = await flutterCommand.findTargetDevice();
         expect(device, device1);
       });
 
       testUsingContext('finds multiple devices', () async {
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
+        testDeviceManager.addAttachedDevice(device1);
+        testDeviceManager.addAttachedDevice(device2);
         testDeviceManager.specifiedDeviceId = 'all';
         final DummyFlutterCommand flutterCommand = DummyFlutterCommand();
         final Device? device = await flutterCommand.findTargetDevice();

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -4,416 +4,1078 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
-import 'package:flutter_tools/src/doctor_validator.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/runner/target_devices.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fake_devices.dart';
 
 void main() {
-   group('When cannot launch anything', () {
-    late BufferLogger logger;
-    late FakeDoctor doctor;
-    final FakeDevice device1 = FakeDevice('device1', 'device1');
+  group('findAllTargetDevices', () {
+    late Platform platform;
+
+    final FakeDevice attachedAndroidDevice1 = FakeDevice(deviceName: 'target-device-1');
+    final FakeDevice attachedAndroidDevice2 = FakeDevice(deviceName: 'target-device-2');
+    final FakeDevice attachedUnsupportedAndroidDevice = FakeDevice(deviceName: 'target-device-3', deviceSupported: false);
+    final FakeDevice attachedUnsupportedForProjectAndroidDevice = FakeDevice(deviceName: 'target-device-4', deviceSupportForProject: false);
+
+    final FakeDevice wirelessAndroidDevice1 = FakeDevice.wireless(deviceName: 'target-device-5');
+    final FakeDevice wirelessAndroidDevice2 = FakeDevice.wireless(deviceName: 'target-device-6');
+    final FakeDevice wirelessUnsupportedAndroidDevice = FakeDevice.wireless(deviceName: 'target-device-7', deviceSupported: false);
+    final FakeDevice wirelessUnsupportedForProjectAndroidDevice = FakeDevice.wireless(deviceName: 'target-device-8', deviceSupportForProject: false);
+
+    final FakeDevice nonEphemeralDevice = FakeDevice(deviceName: 'target-device-9', ephemeral: false);
+    final FakeDevice fuchsiaDevice = FakeDevice.fuchsia(deviceName: 'target-device-10');
+
+    final FakeDevice exactMatchAndroidDevice = FakeDevice(deviceName: 'target-device');
+    final FakeDevice exactMatchWirelessAndroidDevice = FakeDevice.wireless(deviceName: 'target-device');
+    final FakeDevice exactMatchattachedUnsupportedAndroidDevice = FakeDevice(deviceName: 'target-device', deviceSupported: false);
+    final FakeDevice exactMatchUnsupportedByProjectDevice = FakeDevice(deviceName: 'target-device', deviceSupportForProject: false);
 
     setUp(() {
-      logger = BufferLogger.test();
-      doctor = FakeDoctor(logger, canLaunchAnything: false);
+      platform = FakePlatform();
     });
 
-    testUsingContext('does not search for devices', () async {
-      final MockDeviceDiscovery deviceDiscovery = MockDeviceDiscovery()
-        ..deviceValues = <Device>[device1];
+    group('when cannot launch anything', () {
+      late BufferLogger logger;
+      late FakeDoctor doctor;
 
-      final DeviceManager deviceManager = TestDeviceManager(
-        <Device>[],
-        deviceDiscoveryOverrides: <DeviceDiscovery>[
-          deviceDiscovery,
-        ],
-        logger: logger,
-      );
+      setUp(() {
+        logger = BufferLogger.test();
+        doctor = FakeDoctor(canLaunchAnything: false);
+      });
 
-      final TargetDevices targetDevices = TargetDevices(
-        deviceManager: deviceManager,
-        logger: logger,
-      );
-      final List<Device>? devices = await targetDevices.findAllTargetDevices();
+      testUsingContext('does not search for devices', () async {
+        final TestDeviceManager deviceManager = TestDeviceManager(
+          logger: logger,
+          platform: platform,
+        );
+        deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
 
-      expect(logger.errorText, contains(UserMessages().flutterNoDevelopmentDevice));
-      expect(devices, isNull);
-      expect(deviceDiscovery.devicesCalled, 0);
-      expect(deviceDiscovery.discoverDevicesCalled, 0);
-    }, overrides: <Type, Generator>{
-      Doctor: () => doctor,
-    });
-  });
+        final TargetDevices targetDevices = TargetDevices(
+          deviceManager: deviceManager,
+          logger: logger,
+        );
+        final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-  group('Ensure refresh when deviceDiscoveryTimeout is provided', () {
-    late BufferLogger logger;
-    final FakeDevice device1 = FakeDevice('device1', 'device1');
-
-    setUp(() {
-      logger = BufferLogger.test();
+        expect(logger.errorText, equals('''
+Unable to locate a development device; please run 'flutter doctor' for information about installing additional components.
+'''));
+        expect(devices, isNull);
+        expect(deviceManager.androidDiscoverer.devicesCalled, 0);
+        expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+      }, overrides: <Type, Generator>{
+        Doctor: () => doctor,
+      });
     });
 
-    testUsingContext('does not refresh device cache without a timeout', () async {
-      final MockDeviceDiscovery deviceDiscovery = MockDeviceDiscovery()
-        ..deviceValues = <Device>[device1];
-
-      final DeviceManager deviceManager = TestDeviceManager(
-        <Device>[],
-        deviceDiscoveryOverrides: <DeviceDiscovery>[
-          deviceDiscovery,
-        ],
+    testUsingContext('ensure refresh when deviceDiscoveryTimeout is provided', () async {
+      final BufferLogger logger = BufferLogger.test();
+      final TestDeviceManager deviceManager = TestDeviceManager(
         logger: logger,
+        platform: platform,
       );
-      deviceManager.specifiedDeviceId = device1.id;
+      deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
+      deviceManager.androidDiscoverer.refreshDeviceList = <Device>[attachedAndroidDevice1, wirelessAndroidDevice1];
+      deviceManager.hasSpecifiedAllDevices = true;
 
-      final TargetDevices targetDevices = TargetDevices(
-        deviceManager: deviceManager,
-        logger: logger,
-      );
-      final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-      expect(devices?.single, device1);
-      expect(deviceDiscovery.devicesCalled, 1);
-      expect(deviceDiscovery.discoverDevicesCalled, 0);
-    });
-
-    testUsingContext('refreshes device cache with a timeout', () async {
-      final MockDeviceDiscovery deviceDiscovery = MockDeviceDiscovery()
-        ..deviceValues = <Device>[device1];
-
-      final DeviceManager deviceManager = TestDeviceManager(
-        <Device>[],
-        deviceDiscoveryOverrides: <DeviceDiscovery>[
-          deviceDiscovery,
-        ],
-        logger: BufferLogger.test(),
-      );
-      deviceManager.specifiedDeviceId = device1.id;
-
-      const Duration timeout = Duration(seconds: 2);
       final TargetDevices targetDevices = TargetDevices(
         deviceManager: deviceManager,
         logger: logger,
       );
       final List<Device>? devices = await targetDevices.findAllTargetDevices(
-        deviceDiscoveryTimeout: timeout,
+        deviceDiscoveryTimeout: const Duration(seconds: 2),
       );
 
-      expect(devices?.single, device1);
-      expect(deviceDiscovery.devicesCalled, 1);
-      expect(deviceDiscovery.discoverDevicesCalled, 1);
-    });
-  });
-
-  group('findAllTargetDevices', () {
-    late BufferLogger logger;
-    final FakeDevice device1 = FakeDevice('device1', 'device1');
-    final FakeDevice device2 = FakeDevice('device2', 'device2');
-
-    setUp(() {
-      logger = BufferLogger.test();
+      expect(logger.statusText, equals(''));
+      expect(devices, <Device>[attachedAndroidDevice1, wirelessAndroidDevice1]);
+      expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+      expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 1);
+      expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
     });
 
-    group('when specified device id', () {
-      testUsingContext('returns device when device is found', () async {
-        testDeviceManager.specifiedDeviceId = 'device1';
-        testDeviceManager.addDevice(device1);
+    group('finds no devices', () {
+      late BufferLogger logger;
+      late TestDeviceManager deviceManager;
 
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
+      setUp(() {
+        logger = BufferLogger.test();
+        deviceManager = TestDeviceManager(
           logger: logger,
+          platform: platform,
         );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1]);
       });
 
-      testUsingContext('show error when no device found', () async {
-        testDeviceManager.specifiedDeviceId = 'device-id';
+      group('when device not specified', () {
+        testUsingContext('when no devices', () async {
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
+          expect(logger.statusText, equals('''
+No supported devices connected.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
 
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterNoMatchingDevice('device-id')));
+        testUsingContext('when device is unsupported by flutter or project', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            attachedUnsupportedAndroidDevice,
+            attachedUnsupportedForProjectAndroidDevice,
+          ];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No supported devices connected.
+
+The following devices were found, but are not supported by this project:
+target-device-3 (mobile) • xxx • android • Android 10 (unsupported)
+target-device-4 (mobile) • xxx • android • Android 10
+If you would like your app to run on android, consider running `flutter create .` to generate projects for these platforms.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
       });
 
-      testUsingContext('show error when multiple devices found', () async {
-        testDeviceManager.specifiedDeviceId = 'device';
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterFoundSpecifiedDevices(2, 'device')));
-      });
-    });
-
-    group('when specified all', () {
-      testUsingContext('can return one device', () async {
-        testDeviceManager.specifiedDeviceId = 'all';
-        testDeviceManager.addDevice(device1);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1]);
-      });
-
-      testUsingContext('can return multiple devices', () async {
-        testDeviceManager.specifiedDeviceId = 'all';
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1, device2]);
-      });
-
-      testUsingContext('show error when no device found', () async {
-        testDeviceManager.specifiedDeviceId = 'all';
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterNoDevicesFound));
-      });
-    });
-
-    group('when device not specified', () {
-      testUsingContext('returns one device when only one device connected', () async {
-        testDeviceManager.addDevice(device1);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1]);
-      });
-
-      testUsingContext('show error when no device found', () async {
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterNoSupportedDevices));
-      });
-
-      testUsingContext('show error when multiple devices found and not connected to terminal', () async {
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterSpecifyDeviceWithAllOption));
-      }, overrides: <Type, Generator>{
-        AnsiTerminal: () => FakeTerminal(stdinHasTerminal: false),
-      });
-
-      // Prompt to choose device when multiple devices found and connected to terminal
-      group('show prompt', () {
-        late FakeTerminal terminal;
+      group('with hasSpecifiedDeviceId', () {
         setUp(() {
-          terminal = FakeTerminal();
+          deviceManager.specifiedDeviceId = 'target-device';
         });
 
-        testUsingContext('choose first device', () async {
-          testDeviceManager.addDevice(device1);
-          testDeviceManager.addDevice(device2);
-          terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
-
+        testUsingContext('when no devices', () async {
           final TargetDevices targetDevices = TargetDevices(
-            deviceManager: testDeviceManager,
+            deviceManager: deviceManager,
             logger: logger,
           );
           final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-          expect(devices, <Device>[device1]);
-        }, overrides: <Type, Generator>{
-          AnsiTerminal: () => terminal,
+          expect(logger.statusText, equals('''
+No supported devices found with name or id matching 'target-device'.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
         });
 
-        testUsingContext('choose second device', () async {
-          testDeviceManager.addDevice(device1);
-          testDeviceManager.addDevice(device2);
-          terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '2');
+        testUsingContext('when no devices match', () async {
+          final FakeDevice device1 = FakeDevice(deviceName: 'no-match-1');
+          final FakeDevice device2 = FakeDevice.wireless(deviceName: 'no-match-2');
+          deviceManager.androidDiscoverer.deviceList = <Device>[device1, device2];
 
           final TargetDevices targetDevices = TargetDevices(
-            deviceManager: testDeviceManager,
+            deviceManager: deviceManager,
             logger: logger,
           );
           final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-            expect(devices, <Device>[device2]);
+          expect(logger.statusText, equals('''
+No supported devices found with name or id matching 'target-device'.
+
+The following devices were found:
+no-match-1 (mobile) • xxx • android • Android 10
+no-match-2 (mobile) • xxx • android • Android 10
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching device is unsupported by flutter', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchattachedUnsupportedAndroidDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No supported devices found with name or id matching 'target-device'.
+
+The following devices were found:
+target-device (mobile) • xxx • android • Android 10 (unsupported)
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+      group('with hasSpecifiedAllDevices', () {
+        setUp(() {
+          deviceManager.hasSpecifiedAllDevices = true;
+        });
+
+        testUsingContext('when no devices', () async {
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No devices found.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when devices are either unsupported by flutter or project or all', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            attachedUnsupportedAndroidDevice,
+            attachedUnsupportedForProjectAndroidDevice,
+          ];
+          deviceManager.otherDiscoverer.deviceList = <Device>[fuchsiaDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No devices found.
+
+The following devices were found, but are not supported by this project:
+target-device-3 (mobile)  • xxx • android       • Android 10 (unsupported)
+target-device-4 (mobile)  • xxx • android       • Android 10
+target-device-10 (mobile) • xxx • fuchsia-arm64 • tester
+If you would like your app to run on android or fuchsia, consider running `flutter create .` to generate projects for these platforms.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+      });
+
+    });
+
+    group('finds single device', () {
+      late BufferLogger logger;
+      late TestDeviceManager deviceManager;
+
+      setUp(() {
+        logger = BufferLogger.test();
+        deviceManager = TestDeviceManager(
+          logger: logger,
+          platform: platform,
+        );
+      });
+
+      group('when device not specified', () {
+        testUsingContext('when single attached device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[attachedAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when single wireless device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[wirelessAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when multiple but only one ephemeral', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[nonEphemeralDevice, wirelessAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[wirelessAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+      group('with hasSpecifiedDeviceId', () {
+        setUp(() {
+          deviceManager.specifiedDeviceId = 'target-device';
+        });
+
+        testUsingContext('when multiple matches but first is unsupported by flutter', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            exactMatchattachedUnsupportedAndroidDevice,
+            exactMatchAndroidDevice,
+          ];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching device is unsupported by project', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchUnsupportedByProjectDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchUnsupportedByProjectDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching attached device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchAndroidDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching wireless device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchWirelessAndroidDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchWirelessAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when exact match attached device and partial match wireless device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchAndroidDevice, wirelessAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+      group('with hasSpecifiedAllDevices', () {
+        setUp(() {
+          deviceManager.hasSpecifiedAllDevices = true;
+        });
+
+        testUsingContext('when only one device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[attachedAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+    });
+
+    group('Finds multiple devices', () {
+      late BufferLogger logger;
+      late TestDeviceManager deviceManager;
+
+      setUp(() {
+        logger = BufferLogger.test();
+        deviceManager = TestDeviceManager(
+          logger: logger,
+          platform: platform,
+        );
+      });
+
+      group('when device not specified', () {
+        group('with stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal();
+          });
+
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '2');
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Multiple devices found:
+target-device-1 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+
+[1]: target-device-1 (xxx)
+[2]: target-device-5 (xxx)
+'''));
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
           }, overrides: <Type, Generator>{
             AnsiTerminal: () => terminal,
           });
 
-        testUsingContext('exits without choosing device', () async {
-          testDeviceManager.addDevice(device1);
-          testDeviceManager.addDevice(device2);
-          terminal.setPrompt(<String>['1', '2', 'q', 'Q'], 'q');
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Multiple devices found:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+[1]: target-device-1 (xxx)
+[2]: target-device-2 (xxx)
+'''));
+            expect(devices, <Device>[attachedAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Multiple devices found:
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+
+[1]: target-device-5 (xxx)
+[2]: target-device-6 (xxx)
+'''));
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+        });
+
+        group('without stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal(stdinHasTerminal: false);
+          });
+
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
+
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-4 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-8 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
+
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+        });
+      });
+
+      group('with hasSpecifiedDeviceId', () {
+        setUp(() {
+          deviceManager.specifiedDeviceId = 'target-device';
+        });
+
+        group('with stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal();
+          });
+
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            terminal.setPrompt(<String>['1', '2', '3', '4', 'q', 'Q'], '2');
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 4 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-4 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-8 (mobile) • xxx • android • Android 10
+
+[1]: target-device-1 (xxx)
+[2]: target-device-4 (xxx)
+[3]: target-device-5 (xxx)
+[4]: target-device-8 (xxx)
+'''));
+            expect(devices, <Device>[attachedUnsupportedForProjectAndroidDevice]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+[1]: target-device-1 (xxx)
+[2]: target-device-2 (xxx)
+'''));
+            expect(devices, <Device>[attachedAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+
+[1]: target-device-5 (xxx)
+[2]: target-device-6 (xxx)
+'''));
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+        });
+
+        group('without stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal(stdinHasTerminal: false);
+          });
+
+          testUsingContext('including only one ephemeral', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[nonEphemeralDevice, attachedAndroidDevice1];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+target-device-9 (mobile) • xxx • android • Android 10
+target-device-1 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including matching attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 4 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-4 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-8 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+        });
+      });
+
+      group('with hasSpecifiedAllDevices', () {
+        setUp(() {
+          deviceManager.hasSpecifiedAllDevices = true;
+        });
+
+        testUsingContext('including attached, wireless, unsupported devices', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            attachedAndroidDevice1,
+            attachedUnsupportedAndroidDevice,
+            attachedUnsupportedForProjectAndroidDevice,
+            wirelessAndroidDevice1,
+            wirelessUnsupportedAndroidDevice,
+            wirelessUnsupportedForProjectAndroidDevice,
+          ];
+          deviceManager.otherDiscoverer.deviceList = <Device>[fuchsiaDevice];
 
           final TargetDevices targetDevices = TargetDevices(
-            deviceManager: testDeviceManager,
+            deviceManager: deviceManager,
             logger: logger,
           );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-          await expectLater(
-            targetDevices.findAllTargetDevices(),
-            throwsToolExit(),
-          );
-        }, overrides: <Type, Generator>{
-          AnsiTerminal: () => terminal,
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[attachedAndroidDevice1, wirelessAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
         });
       });
     });
-  });
 
-  group('Filter devices', () {
-    late BufferLogger logger;
-    final FakeDevice ephemeralOne = FakeDevice('ephemeralOne', 'ephemeralOne');
-    final FakeDevice ephemeralTwo = FakeDevice('ephemeralTwo', 'ephemeralTwo');
-    final FakeDevice nonEphemeralOne = FakeDevice('nonEphemeralOne', 'nonEphemeralOne', ephemeral: false);
-
-    setUp(() {
-      logger = BufferLogger.test();
-    });
-
-    testUsingContext('chooses ephemeral device', () async {
-      final List<Device> devices = <Device>[
-        ephemeralOne,
-        nonEphemeralOne,
-      ];
-      final DeviceManager deviceManager = TestDeviceManager(
-        devices,
-        logger: logger,
-      );
-
-      final TargetDevices targetDevices = TargetDevices(deviceManager: deviceManager, logger: logger);
-      final List<Device> filtered = await targetDevices.getDevices();
-
-      expect(filtered, <Device>[ephemeralOne]);
-    });
-
-    testUsingContext('returns all devices when multiple non ephemeral devices are found', () async {
-      final List<Device> devices = <Device>[
-        ephemeralOne,
-        ephemeralTwo,
-        nonEphemeralOne,
-      ];
-      final DeviceManager deviceManager = TestDeviceManager(
-        devices,
-        logger: logger,
-      );
-
-      final TargetDevices targetDevices = TargetDevices(deviceManager: deviceManager, logger: logger);
-      final List<Device> filtered = await targetDevices.getDevices();
-
-      expect(filtered, <Device>[
-        ephemeralOne,
-        ephemeralTwo,
-        nonEphemeralOne,
-      ]);
-    });
   });
 }
 
 class TestDeviceManager extends DeviceManager {
-  TestDeviceManager(
-    List<Device> allDevices, {
-    List<DeviceDiscovery>? deviceDiscoveryOverrides,
-    required super.logger,
-    String? wellKnownId,
-    FakePollingDeviceDiscovery? fakeDiscoverer,
-  }) : _fakeDeviceDiscoverer = fakeDiscoverer ?? FakePollingDeviceDiscovery(),
-       _deviceDiscoverers = <DeviceDiscovery>[],
-       super() {
-    if (wellKnownId != null) {
-      _fakeDeviceDiscoverer.wellKnownIds.add(wellKnownId);
-    }
-    _deviceDiscoverers.add(_fakeDeviceDiscoverer);
-    if (deviceDiscoveryOverrides != null) {
-      _deviceDiscoverers.addAll(deviceDiscoveryOverrides);
-    }
-    resetDevices(allDevices);
-  }
-  @override
-  List<DeviceDiscovery> get deviceDiscoverers => _deviceDiscoverers;
-  final List<DeviceDiscovery> _deviceDiscoverers;
-  final FakePollingDeviceDiscovery _fakeDeviceDiscoverer;
+  TestDeviceManager({
+    required this.logger,
+    required this.platform,
+  }) : super(logger: logger);
 
-  void resetDevices(List<Device> allDevices) {
-    _fakeDeviceDiscoverer.setDevices(allDevices);
+  final Logger logger;
+  final Platform platform;
+
+  @override
+  String? specifiedDeviceId;
+
+  @override
+  bool hasSpecifiedAllDevices = false;
+
+  final TestPollingDeviceDiscovery androidDiscoverer = TestPollingDeviceDiscovery(
+    'android',
+  );
+  final TestPollingDeviceDiscovery otherDiscoverer = TestPollingDeviceDiscovery(
+    'other',
+  );
+  final TestPollingDeviceDiscovery iosDiscoverer = TestPollingDeviceDiscovery(
+    'ios',
+  );
+
+  @override
+  List<DeviceDiscovery> get deviceDiscoverers {
+    return <DeviceDiscovery>[
+      androidDiscoverer,
+      otherDiscoverer,
+      iosDiscoverer,
+    ];
   }
 }
 
-class MockDeviceDiscovery extends Fake implements DeviceDiscovery {
+class TestPollingDeviceDiscovery extends PollingDeviceDiscovery {
+  TestPollingDeviceDiscovery(super.name);
+
+  List<Device> deviceList = <Device>[];
+  List<Device> refreshDeviceList = <Device>[];
   int devicesCalled = 0;
   int discoverDevicesCalled = 0;
+  int numberOfTimesPolled = 0;
 
   @override
-  bool supportsPlatform = true;
+  bool get supportsPlatform => true;
 
-  List<Device> deviceValues = <Device>[];
+  @override
+  List<String> get wellKnownIds => const <String>[];
+
+  @override
+  Future<List<Device>> pollingGetDevices({Duration? timeout}) async {
+    numberOfTimesPolled++;
+    return deviceList;
+  }
 
   @override
   Future<List<Device>> devices({DeviceDiscoveryFilter? filter}) async {
     devicesCalled += 1;
-    return deviceValues;
+    return super.devices(filter: filter);
   }
 
   @override
   Future<List<Device>> discoverDevices({
     Duration? timeout,
     DeviceDiscoveryFilter? filter,
-  }) async {
-    discoverDevicesCalled += 1;
-    return deviceValues;
+  }) {
+    discoverDevicesCalled++;
+    if (refreshDeviceList.isNotEmpty) {
+      deviceList = refreshDeviceList;
+    }
+    return super.discoverDevices(timeout: timeout, filter: filter);
   }
 
   @override
-  List<String> get wellKnownIds => <String>[];
+  bool get canListAnything => true;
+}
+
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
+class FakeDevice extends Fake implements Device {
+  FakeDevice({
+    String? deviceId,
+    String? deviceName,
+    bool deviceSupported = true,
+    bool deviceSupportForProject = true,
+    this.ephemeral = true,
+    this.isConnected = true,
+    this.connectionInterface = DeviceConnectionInterface.attached,
+    this.platformType = PlatformType.android,
+    TargetPlatform deviceTargetPlatform = TargetPlatform.android,
+  })  : id = deviceId ?? 'xxx',
+        name = deviceName ?? 'test',
+        _isSupported = deviceSupported,
+        _isSupportedForProject = deviceSupportForProject,
+        _targetPlatform = deviceTargetPlatform;
+
+  FakeDevice.wireless({
+    String? deviceId,
+    String? deviceName,
+    bool deviceSupported = true,
+    bool deviceSupportForProject = true,
+    this.ephemeral = true,
+    this.isConnected = true,
+    this.connectionInterface = DeviceConnectionInterface.wireless,
+    this.platformType = PlatformType.android,
+    TargetPlatform deviceTargetPlatform = TargetPlatform.android,
+  })  : id = deviceId ?? 'xxx',
+        name = deviceName ?? 'test',
+        _isSupported = deviceSupported,
+        _isSupportedForProject = deviceSupportForProject,
+        _targetPlatform = deviceTargetPlatform;
+
+  FakeDevice.fuchsia({
+    String? deviceId,
+    String? deviceName,
+    bool deviceSupported = true,
+    bool deviceSupportForProject = true,
+    this.ephemeral = true,
+    this.isConnected = true,
+    this.connectionInterface = DeviceConnectionInterface.attached,
+    this.platformType = PlatformType.fuchsia,
+    TargetPlatform deviceTargetPlatform = TargetPlatform.fuchsia_arm64,
+  })  : id = deviceId ?? 'xxx',
+        name = deviceName ?? 'test',
+        _isSupported = deviceSupported,
+        _isSupportedForProject = deviceSupportForProject,
+        _targetPlatform = deviceTargetPlatform,
+        _sdkNameAndVersion = 'tester';
+
+  final bool _isSupported;
+  final bool _isSupportedForProject;
+  final TargetPlatform _targetPlatform;
+  String _sdkNameAndVersion = 'Android 10';
+
+  @override
+  String name;
+
+  @override
+  final bool ephemeral;
+
+  @override
+  String id;
+
+  @override
+  bool isSupported() => _isSupported;
+
+  @override
+  bool isSupportedForProject(FlutterProject project) => _isSupportedForProject;
+
+  @override
+  DeviceConnectionInterface connectionInterface;
+
+  @override
+  bool isConnected;
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => _targetPlatform;
+
+  @override
+  final PlatformType? platformType;
+
+  @override
+  Future<String> get sdkNameAndVersion async => _sdkNameAndVersion;
+
+  @override
+  Future<bool> get isLocalEmulator async => false;
+
+  @override
+  Category? get category => Category.mobile;
+
+  @override
+  Future<String> get targetPlatformDisplayName async =>
+      getNameForTargetPlatform(await targetPlatform);
 }
 
 class FakeTerminal extends Fake implements AnsiTerminal {
@@ -446,31 +1108,11 @@ class FakeTerminal extends Fake implements AnsiTerminal {
   }
 }
 
-class FakeDoctor extends Doctor {
-  FakeDoctor(
-    Logger logger, {
+class FakeDoctor extends Fake implements Doctor {
+  FakeDoctor({
     this.canLaunchAnything = true,
-  }) : super(logger: logger);
+  });
 
-  // True for testing.
-  @override
-  bool get canListAnything => true;
-
-  // True for testing.
   @override
   bool canLaunchAnything;
-
-  @override
-  /// Replaces the android workflow with a version that overrides licensesAccepted,
-  /// to prevent individual tests from having to mock out the process for
-  /// the Doctor.
-  List<DoctorValidator> get validators {
-    final List<DoctorValidator> superValidators = super.validators;
-    return superValidators.map<DoctorValidator>((DoctorValidator v) {
-      if (v is AndroidLicenseValidator) {
-        return FakeAndroidLicenseValidator();
-      }
-      return v;
-    }).toList();
-  }
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -181,7 +181,8 @@ void _printBufferedErrors(AppContext testContext) {
 }
 
 class FakeDeviceManager implements DeviceManager {
-  List<Device> devices = <Device>[];
+  List<Device> attachedDevices = <Device>[];
+  List<Device> wirelessDevices = <Device>[];
 
   String? _specifiedDeviceId;
 
@@ -209,20 +210,20 @@ class FakeDeviceManager implements DeviceManager {
   @override
   Future<List<Device>> getAllDevices({
     DeviceDiscoveryFilter? filter,
-  }) async => devices;
+  }) async => filteredDevices(filter);
 
   @override
   Future<List<Device>> refreshAllDevices({
     Duration? timeout,
     DeviceDiscoveryFilter? filter,
-  }) async => devices;
+  }) async => filteredDevices(filter);
 
   @override
   Future<List<Device>> getDevicesById(
     String deviceId, {
     DeviceDiscoveryFilter? filter,
   }) async {
-    return devices.where((Device device) {
+    return filteredDevices(filter).where((Device device) {
       return device.id == deviceId || device.id.startsWith(deviceId);
     }).toList();
   }
@@ -236,7 +237,8 @@ class FakeDeviceManager implements DeviceManager {
         : getAllDevices(filter: filter);
   }
 
-  void addDevice(Device device) => devices.add(device);
+  void addAttachedDevice(Device device) => attachedDevices.add(device);
+  void addWirelessDevice(Device device) => wirelessDevices.add(device);
 
   @override
   bool get canListAnything => true;
@@ -257,6 +259,16 @@ class FakeDeviceManager implements DeviceManager {
 
   @override
   Device? getSingleEphemeralDevice(List<Device> devices) => null;
+
+  List<Device> filteredDevices(DeviceDiscoveryFilter? filter) {
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.attached) {
+      return attachedDevices;
+    }
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.wireless) {
+      return wirelessDevices;
+    }
+    return attachedDevices + wirelessDevices;
+  }
 }
 
 class TestDeviceDiscoverySupportFilter extends Fake implements DeviceDiscoverySupportFilter {

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -54,6 +54,31 @@ List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
       },
     },
   ),
+  FakeDeviceJsonData(
+    FakeDevice(
+      'wireless android',
+      'wireless-android',
+      type: PlatformType.android,
+      connectionInterface: DeviceConnectionInterface.wireless,
+    ),
+    <String, Object>{
+      'name': 'wireless android',
+      'id': 'wireless-android',
+      'isSupported': true,
+      'targetPlatform': 'android-arm',
+      'emulator': true,
+      'sdk': 'Test SDK (1.2.3)',
+      'capabilities': <String, Object>{
+        'hotReload': true,
+        'hotRestart': true,
+        'screenshot': false,
+        'fastStart': false,
+        'flutterExit': true,
+        'hardwareRendering': true,
+        'startPaused': true,
+      },
+    }
+  ),
 ];
 
 /// Fake device to test `devices` command.


### PR DESCRIPTION
This PR includes 3 changes:
1. Separates attached and wireless devices in device selection flow when running commands like `flutter run`. 

```
Multiple devices found:
target-device-1 (mobile) • xxx • android • Android 10

Wirelessly connected devices:
target-device-4 (mobile) • xxx • android • Android 10

[1]: target-device-1 (xxx)
[2]: target-device-4 (xxx)
```
2. Separates attached and wireless devices in `flutter devices` command.
```
2 connected devices:

ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)

1 wirelessly connected device:

wireless android (mobile) • wireless-android • android-arm • Test SDK (1.2.3) (emulator)
```
3. Fixes https://github.com/flutter/flutter/issues/119271. When more than 1 match for the -d flag is found, either allow the user to select from them (if stdin is available) or display the list of them (if no stdin).
```
Found 2 devices with name or id matching target-device:
target-device-1 (mobile) • xxx • android • Android 10

Wirelessly connected devices:
target-device-4 (mobile) • xxx • android • Android 10

[1]: target-device-1 (xxx)
[3]: target-device-4 (xxx)
```
Part 3 in breakdown of https://github.com/flutter/flutter/pull/121262.

Fixes https://github.com/flutter/flutter/issues/119271.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
