### PR TITLE
Separate attached and wireless devices

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -89,6 +89,14 @@ class AndroidDevice extends Device {
   final String modelID;
   final String? deviceCodeName;
 
+  @override
+  // Wirelessly paired Android devices should have `adb-tls-connect` in the id.
+  // Source: https://android.googlesource.com/platform/packages/modules/adb/+/f4ba8d73079b99532069dbe888a58167b8723d6c/adb_mdns.h#30
+  DeviceConnectionInterface get connectionInterface =>
+      id.contains('adb-tls-connect')
+          ? DeviceConnectionInterface.wireless
+          : DeviceConnectionInterface.attached;
+
   late final Future<Map<String, String>> _properties = () async {
     Map<String, String> properties = <String, String>{};
 

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -265,7 +265,7 @@ class UserMessages {
       'for information about installing additional components.';
   String flutterNoMatchingDevice(String deviceId) => 'No supported devices found with name or id '
       "matching '$deviceId'.";
-  String get flutterNoDevicesFound => 'No devices found';
+  String get flutterNoDevicesFound => 'No devices found.';
   String get flutterNoSupportedDevices => 'No supported devices connected.';
   String flutterMissPlatformProjects(List<String> unsupportedDevicesType) =>
       'If you would like your app to run on ${unsupportedDevicesType.join(' or ')}, consider running `flutter create .` to generate projects for these platforms.';

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -24,7 +24,6 @@ import '../device.dart';
 import '../device_port_forwarder.dart';
 import '../fuchsia/fuchsia_device.dart';
 import '../ios/devices.dart';
-import '../ios/iproxy.dart';
 import '../ios/simulators.dart';
 import '../macos/macos_ipad_device.dart';
 import '../mdns_discovery.dart';
@@ -287,7 +286,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
     final String ipv6Loopback = InternetAddress.loopbackIPv6.address;
     final String ipv4Loopback = InternetAddress.loopbackIPv4.address;
     final String hostname = usesIpv6 ? ipv6Loopback : ipv4Loopback;
-    final bool isNetworkDevice = (device is IOSDevice) && device.interfaceType == IOSDeviceConnectionInterface.network;
+    final bool isNetworkDevice = (device is IOSDevice) && device.isWirelesslyConnected;
 
     if ((debugPort == null && debugUri == null) || isNetworkDevice) {
       if (device is FuchsiaDevice) {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -23,7 +23,6 @@ import '../device.dart';
 import '../drive/drive_service.dart';
 import '../globals.dart' as globals;
 import '../ios/devices.dart';
-import '../ios/iproxy.dart';
 import '../resident_runner.dart';
 import '../runner/flutter_command.dart' show FlutterCommandCategory, FlutterCommandResult, FlutterOptions;
 import '../web/web_device.dart';
@@ -220,7 +219,7 @@ class DriveCommand extends RunCommandBase {
   Future<bool> get disablePortPublication async {
     final ArgResults? localArgResults = argResults;
     final Device? device = await targetedDevice;
-    final bool isNetworkDevice = device is IOSDevice && device.interfaceType == IOSDeviceConnectionInterface.network;
+    final bool isNetworkDevice = device is IOSDevice && device.isWirelesslyConnected;
     if (isNetworkDevice && localArgResults != null && !localArgResults.wasParsed('publish-port')) {
       _logger.printTrace('Network device is being used. Changing `publish-port` to be enabled.');
       return false;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -20,7 +20,6 @@ import '../device.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
 import '../ios/devices.dart';
-import '../ios/iproxy.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../resident_runner.dart';
@@ -426,7 +425,7 @@ class RunCommand extends RunCommandBase {
       final TargetPlatform platform = await device.targetPlatform;
       anyAndroidDevices = platform == TargetPlatform.android;
       anyIOSDevices = platform == TargetPlatform.ios;
-      if (device is IOSDevice && device.interfaceType == IOSDeviceConnectionInterface.network) {
+      if (device is IOSDevice && device.isWirelesslyConnected) {
         anyIOSNetworkDevices = true;
       }
       deviceType = getNameForTargetPlatform(platform);
@@ -440,7 +439,7 @@ class RunCommand extends RunCommandBase {
         final TargetPlatform platform = await device.targetPlatform;
         anyAndroidDevices = anyAndroidDevices || (platform == TargetPlatform.android);
         anyIOSDevices = anyIOSDevices || (platform == TargetPlatform.ios);
-        if (device is IOSDevice && device.interfaceType == IOSDeviceConnectionInterface.network) {
+        if (device is IOSDevice && device.isWirelesslyConnected) {
           anyIOSNetworkDevices = true;
         }
         if (anyAndroidDevices && anyIOSDevices) {

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -17,7 +17,6 @@ import 'base/utils.dart';
 import 'build_info.dart';
 import 'devfs.dart';
 import 'device_port_forwarder.dart';
-import 'ios/iproxy.dart';
 import 'project.dart';
 import 'vmservice.dart';
 
@@ -1098,7 +1097,7 @@ class DebuggingOptions {
     String? route,
     Map<String, Object?> platformArgs, {
     bool ipv6 = false,
-    IOSDeviceConnectionInterface interfaceType = IOSDeviceConnectionInterface.none
+    DeviceConnectionInterface interfaceType = DeviceConnectionInterface.attached,
   }) {
     final String dartVmFlags = computeDartVmFlags(this);
     return <String>[
@@ -1137,7 +1136,7 @@ class DebuggingOptions {
       if (environmentType == EnvironmentType.simulator && hostVmServicePort != null)
         '--vm-service-port=$hostVmServicePort',
       // Tell the VM service to listen on all interfaces, don't restrict to the loopback.
-      if (interfaceType == IOSDeviceConnectionInterface.network)
+      if (interfaceType == DeviceConnectionInterface.wireless)
         '--vm-service-host=${ipv6 ? '::0' : '0.0.0.0'}',
       if (enableEmbedderApi) '--enable-embedder-api',
     ];

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -185,6 +185,13 @@ class IOSDevice extends Device {
   final IMobileDevice _iMobileDevice;
   final IProxy _iproxy;
 
+  @override
+  DeviceConnectionInterface get connectionInterface {
+    return interfaceType == IOSDeviceConnectionInterface.network
+        ? DeviceConnectionInterface.wireless
+        : DeviceConnectionInterface.attached;
+  }
+
   /// May be 0 if version cannot be parsed.
   int get majorSdkVersion {
     final String? majorVersionString = _sdkVersion?.split('.').first.trim();

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -15,8 +15,8 @@ import '../base/platform.dart';
 import '../base/process.dart';
 import '../cache.dart';
 import '../convert.dart';
+import '../device.dart';
 import 'code_signing.dart';
-import 'iproxy.dart';
 
 // Error message patterns from ios-deploy output
 const String noProvisioningProfileErrorOne = 'Error 0xe8008015';
@@ -88,7 +88,7 @@ class IOSDeploy {
     required String deviceId,
     required String bundlePath,
     required List<String>launchArguments,
-    required IOSDeviceConnectionInterface interfaceType,
+    required DeviceConnectionInterface interfaceType,
     Directory? appDeltaDirectory,
   }) async {
     appDeltaDirectory?.createSync(recursive: true);
@@ -102,7 +102,7 @@ class IOSDeploy {
         '--app_deltas',
         appDeltaDirectory.path,
       ],
-      if (interfaceType != IOSDeviceConnectionInterface.network)
+      if (interfaceType != DeviceConnectionInterface.wireless)
         '--no-wifi',
       if (launchArguments.isNotEmpty) ...<String>[
         '--args',
@@ -126,7 +126,7 @@ class IOSDeploy {
     required String deviceId,
     required String bundlePath,
     required List<String> launchArguments,
-    required IOSDeviceConnectionInterface interfaceType,
+    required DeviceConnectionInterface interfaceType,
     Directory? appDeltaDirectory,
     required bool uninstallFirst,
   }) {
@@ -149,7 +149,7 @@ class IOSDeploy {
       if (uninstallFirst)
         '--uninstall',
       '--debug',
-      if (interfaceType != IOSDeviceConnectionInterface.network)
+      if (interfaceType != DeviceConnectionInterface.wireless)
         '--no-wifi',
       if (launchArguments.isNotEmpty) ...<String>[
         '--args',
@@ -171,7 +171,7 @@ class IOSDeploy {
     required String deviceId,
     required String bundlePath,
     required List<String> launchArguments,
-    required IOSDeviceConnectionInterface interfaceType,
+    required DeviceConnectionInterface interfaceType,
     required bool uninstallFirst,
     Directory? appDeltaDirectory,
   }) async {
@@ -186,7 +186,7 @@ class IOSDeploy {
         '--app_deltas',
         appDeltaDirectory.path,
       ],
-      if (interfaceType != IOSDeviceConnectionInterface.network)
+      if (interfaceType != DeviceConnectionInterface.wireless)
         '--no-wifi',
       if (uninstallFirst)
         '--uninstall',

--- a/packages/flutter_tools/lib/src/ios/iproxy.dart
+++ b/packages/flutter_tools/lib/src/ios/iproxy.dart
@@ -8,12 +8,6 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 
-enum IOSDeviceConnectionInterface {
-  none,
-  usb,
-  network,
-}
-
 /// Wraps iproxy command line tool port forwarding.
 ///
 /// See https://github.com/libimobiledevice/libusbmuxd.

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -16,6 +16,7 @@ import '../base/project_migrator.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
+import '../device.dart';
 import '../flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
@@ -27,7 +28,6 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import 'application_package.dart';
 import 'code_signing.dart';
-import 'iproxy.dart';
 import 'migrations/host_app_info_plist_migration.dart';
 import 'migrations/ios_deployment_target_migration.dart';
 import 'migrations/project_base_configuration_migration.dart';
@@ -87,7 +87,7 @@ class IMobileDevice {
   Future<void> takeScreenshot(
     File outputFile,
     String deviceID,
-    IOSDeviceConnectionInterface interfaceType,
+    DeviceConnectionInterface interfaceType,
   ) {
     return _processUtils.run(
       <String>[
@@ -95,7 +95,7 @@ class IMobileDevice {
         outputFile.path,
         '--udid',
         deviceID,
-        if (interfaceType == IOSDeviceConnectionInterface.network)
+        if (interfaceType == DeviceConnectionInterface.wireless)
           '--network',
       ],
       throwOnError: true,

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -14,6 +14,7 @@ import '../base/process.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../convert.dart';
+import '../device.dart';
 import '../globals.dart' as globals;
 import '../ios/devices.dart';
 import '../ios/ios_deploy.dart';
@@ -303,8 +304,6 @@ class XCDevice {
           }
         }
 
-        final IOSDeviceConnectionInterface interface = _interfaceType(device);
-
         String? sdkVersion = _sdkVersion(device);
 
         if (sdkVersion != null) {
@@ -318,7 +317,7 @@ class XCDevice {
           identifier,
           name: name,
           cpuArchitecture: _cpuArchitecture(device),
-          interfaceType: interface,
+          connectionInterface: _interfaceType(device),
           sdkVersion: sdkVersion,
           iProxy: _iProxy,
           fileSystem: globals.fs,
@@ -356,19 +355,16 @@ class XCDevice {
     return code is int ? code : null;
   }
 
-  static IOSDeviceConnectionInterface _interfaceType(Map<String, Object?> deviceProperties) {
-    // Interface can be "usb", "network", or "none" for simulators
-    // and unknown future interfaces.
+  static DeviceConnectionInterface _interfaceType(Map<String, Object?> deviceProperties) {
+    // Interface can be "usb" or "network". It can also be missing
+    // (e.g. simulators do not have an interface property).
+    // If the interface is "network", use `DeviceConnectionInterface.wireless`,
+    // otherwise use `DeviceConnectionInterface.attached.
     final Object? interface = deviceProperties['interface'];
-    if (interface is String) {
-      if (interface.toLowerCase() == 'network') {
-        return IOSDeviceConnectionInterface.network;
-      } else {
-        return IOSDeviceConnectionInterface.usb;
-      }
+    if (interface is String && interface.toLowerCase() == 'network') {
+      return DeviceConnectionInterface.wireless;
     }
-
-    return IOSDeviceConnectionInterface.none;
+    return DeviceConnectionInterface.attached;
   }
 
   static String? _sdkVersion(Map<String, Object?> deviceProperties) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1238,6 +1238,10 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
 
   @override
+  DeviceConnectionInterface get connectionInterface =>
+      DeviceConnectionInterface.attached;
+
+  @override
   bool isSupported() => true;
 
   @override
@@ -1301,6 +1305,13 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
   @override
   final IOSDeviceConnectionInterface interfaceType;
+
+  @override
+  DeviceConnectionInterface get connectionInterface {
+    return interfaceType == IOSDeviceConnectionInterface.network
+        ? DeviceConnectionInterface.wireless
+        : DeviceConnectionInterface.attached;
+  }
 
   @override
   DevicePortForwarder get portForwarder => _portForwarder!;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -23,7 +23,6 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
-import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/macos/macos_ipad_device.dart';
 import 'package:flutter_tools/src/mdns_discovery.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -241,7 +240,7 @@ void main() {
           logReader: fakeLogReader,
           portForwarder: portForwarder,
           majorSdkVersion: 16,
-          interfaceType: IOSDeviceConnectionInterface.network,
+          connectionInterface: DeviceConnectionInterface.wireless,
         );
         testDeviceManager.devices = <Device>[device];
         final FakeHotRunner hotRunner = FakeHotRunner();
@@ -313,7 +312,7 @@ void main() {
           logReader: fakeLogReader,
           portForwarder: portForwarder,
           majorSdkVersion: 16,
-          interfaceType: IOSDeviceConnectionInterface.network,
+          connectionInterface: DeviceConnectionInterface.wireless,
         );
         testDeviceManager.devices = <Device>[device];
         final FakeHotRunner hotRunner = FakeHotRunner();
@@ -389,7 +388,7 @@ void main() {
           logReader: fakeLogReader,
           portForwarder: portForwarder,
           majorSdkVersion: 16,
-          interfaceType: IOSDeviceConnectionInterface.network,
+          connectionInterface: DeviceConnectionInterface.wireless,
         );
         testDeviceManager.devices = <Device>[device];
         final FakeHotRunner hotRunner = FakeHotRunner();
@@ -1295,7 +1294,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
     DevicePortForwarder? portForwarder,
     DeviceLogReader? logReader,
     this.onGetLogReader,
-    this.interfaceType = IOSDeviceConnectionInterface.none,
+    this.connectionInterface = DeviceConnectionInterface.attached,
     this.majorSdkVersion = 0,
   }) : _portForwarder = portForwarder, _logReader = logReader;
 
@@ -1304,14 +1303,11 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   int majorSdkVersion;
 
   @override
-  final IOSDeviceConnectionInterface interfaceType;
+  final DeviceConnectionInterface connectionInterface;
 
   @override
-  DeviceConnectionInterface get connectionInterface {
-    return interfaceType == IOSDeviceConnectionInterface.network
-        ? DeviceConnectionInterface.wireless
-        : DeviceConnectionInterface.attached;
-  }
+  bool get isWirelesslyConnected =>
+      connectionInterface == DeviceConnectionInterface.wireless;
 
   @override
   DevicePortForwarder get portForwarder => _portForwarder!;

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -68,7 +68,7 @@ void main() {
 
     final Device screenshotDevice = ThrowingScreenshotDevice()
       ..supportsScreenshot = false;
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -104,7 +104,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final Device screenshotDevice = ThrowingScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -142,7 +142,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final Device screenshotDevice = ScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -184,7 +184,7 @@ void main() {
     fileSystem.file('drive_screenshots').createSync();
 
     final Device screenshotDevice = ThrowingScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(
       <String>[
@@ -222,7 +222,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final ScreenshotDevice screenshotDevice = ScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     expect(screenshotDevice.screenshots, isEmpty);
     bool caughtToolExit = false;
@@ -293,7 +293,7 @@ void main() {
     fileSystem.directory('drive_screenshots').createSync();
 
     final ScreenshotDevice screenshotDevice = ScreenshotDevice();
-    fakeDeviceManager.devices = <Device>[screenshotDevice];
+    fakeDeviceManager.attachedDevices = <Device>[screenshotDevice];
 
     expect(screenshotDevice.screenshots, isEmpty);
 
@@ -424,7 +424,7 @@ void main() {
 
     final Device networkDevice = FakeIosDevice()
       ..interfaceType = IOSDeviceConnectionInterface.network;
-    fakeDeviceManager.devices = <Device>[networkDevice];
+    fakeDeviceManager.wirelessDevices = <Device>[networkDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(<String>[
       'drive',
@@ -457,7 +457,7 @@ void main() {
 
     final Device usbDevice = FakeIosDevice()
       ..interfaceType = IOSDeviceConnectionInterface.usb;
-    fakeDeviceManager.devices = <Device>[usbDevice];
+    fakeDeviceManager.attachedDevices = <Device>[usbDevice];
 
     final DebuggingOptions options = await command.createDebuggingOptions(false);
     expect(options.disablePortPublication, true);
@@ -482,7 +482,7 @@ void main() {
 
     final Device networkDevice = FakeIosDevice()
       ..interfaceType = IOSDeviceConnectionInterface.network;
-    fakeDeviceManager.devices = <Device>[networkDevice];
+    fakeDeviceManager.wirelessDevices = <Device>[networkDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(<String>[
       'drive',

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -22,7 +22,6 @@ import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/drive/drive_service.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
-import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
@@ -423,7 +422,7 @@ void main() {
     fileSystem.file('pubspec.yaml').createSync();
 
     final Device networkDevice = FakeIosDevice()
-      ..interfaceType = IOSDeviceConnectionInterface.network;
+      ..connectionInterface = DeviceConnectionInterface.wireless;
     fakeDeviceManager.wirelessDevices = <Device>[networkDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(<String>[
@@ -456,7 +455,7 @@ void main() {
     ]), throwsToolExit());
 
     final Device usbDevice = FakeIosDevice()
-      ..interfaceType = IOSDeviceConnectionInterface.usb;
+      ..connectionInterface = DeviceConnectionInterface.attached;
     fakeDeviceManager.attachedDevices = <Device>[usbDevice];
 
     final DebuggingOptions options = await command.createDebuggingOptions(false);
@@ -481,7 +480,7 @@ void main() {
     fileSystem.file('pubspec.yaml').createSync();
 
     final Device networkDevice = FakeIosDevice()
-      ..interfaceType = IOSDeviceConnectionInterface.network;
+      ..connectionInterface = DeviceConnectionInterface.wireless;
     fakeDeviceManager.wirelessDevices = <Device>[networkDevice];
 
     await expectLater(() => createTestCommandRunner(command).run(<String>[
@@ -661,7 +660,11 @@ class FakeProcessSignal extends Fake implements io.ProcessSignal {
 // ignore: avoid_implementing_value_types
 class FakeIosDevice extends Fake implements IOSDevice {
   @override
-  IOSDeviceConnectionInterface interfaceType = IOSDeviceConnectionInterface.usb;
+  DeviceConnectionInterface connectionInterface = DeviceConnectionInterface.attached;
+
+  @override
+  bool get isWirelesslyConnected =>
+      connectionInterface == DeviceConnectionInterface.wireless;
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -36,7 +36,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeAndroidDevice device = FakeAndroidDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       await createTestCommandRunner(command).run(<String>['install']);
     }, overrides: <Type, Generator>{
@@ -50,7 +50,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       expect(() async => createTestCommandRunner(command).run(<String>['install', '--device-user', '10']),
         throwsToolExit(message: '--device-user is only supported for Android'));
@@ -65,7 +65,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeIOSApp());
 
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       await createTestCommandRunner(command).run(<String>['install']);
     }, overrides: <Type, Generator>{
@@ -79,7 +79,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeAndroidDevice device = FakeAndroidDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       expect(() async => createTestCommandRunner(command).run(<String>['install', '--use-application-binary', 'bogus']),
           throwsToolExit(message: 'Prebuilt binary bogus does not exist'));
@@ -94,7 +94,7 @@ void main() {
       command.applicationPackages = FakeApplicationPackageFactory(FakeAndroidApk());
 
       final FakeAndroidDevice device = FakeAndroidDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
       fileSystem.file('binary').createSync(recursive: true);
 
       await createTestCommandRunner(command).run(<String>['install', '--use-application-binary', 'binary']);
@@ -111,7 +111,7 @@ void main() {
       command.applicationPackages = fakeAppFactory;
 
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.addAttachedDevice(device);
 
       await createTestCommandRunner(command).run(<String>['install', '--flavor', flavor]);
       expect(fakeAppFactory.buildInfo, isNotNull);
@@ -183,4 +183,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   String get name => 'Android';
+
+  @override
+  bool get ephemeral => true;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1126,6 +1126,10 @@ class FakeDevice extends Fake implements Device {
   @override
   bool get isConnected => true;
 
+  @override
+  DeviceConnectionInterface get connectionInterface =>
+      DeviceConnectionInterface.attached;
+
   bool supported = true;
 
   @override

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -26,7 +26,6 @@ import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
-import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
@@ -711,7 +710,7 @@ void main() {
 
       testUsingContext('with only iOS usb device', () async {
         final List<Device> devices = <Device>[
-          FakeIOSDevice(interfaceType: IOSDeviceConnectionInterface.usb, sdkNameAndVersion: 'iOS 16.2'),
+          FakeIOSDevice(sdkNameAndVersion: 'iOS 16.2'),
         ];
         final TestRunCommandForUsageValues command = TestRunCommandForUsageValues(devices: devices);
         final CommandRunner<void> runner = createTestCommandRunner(command);
@@ -752,7 +751,10 @@ void main() {
 
       testUsingContext('with only iOS network device', () async {
         final List<Device> devices = <Device>[
-          FakeIOSDevice(interfaceType: IOSDeviceConnectionInterface.network, sdkNameAndVersion: 'iOS 16.2'),
+          FakeIOSDevice(
+            connectionInterface: DeviceConnectionInterface.wireless,
+            sdkNameAndVersion: 'iOS 16.2',
+          ),
         ];
         final TestRunCommandForUsageValues command = TestRunCommandForUsageValues(devices: devices);
         final CommandRunner<void> runner = createTestCommandRunner(command);
@@ -793,8 +795,11 @@ void main() {
 
       testUsingContext('with both iOS usb and network devices', () async {
         final List<Device> devices = <Device>[
-          FakeIOSDevice(interfaceType: IOSDeviceConnectionInterface.network, sdkNameAndVersion: 'iOS 16.2'),
-          FakeIOSDevice(interfaceType: IOSDeviceConnectionInterface.usb, sdkNameAndVersion: 'iOS 16.2'),
+          FakeIOSDevice(
+            connectionInterface: DeviceConnectionInterface.wireless,
+            sdkNameAndVersion: 'iOS 16.2',
+          ),
+          FakeIOSDevice(sdkNameAndVersion: 'iOS 16.2'),
         ];
         final TestRunCommandForUsageValues command = TestRunCommandForUsageValues(devices: devices);
         final CommandRunner<void> runner = createTestCommandRunner(command);
@@ -1213,7 +1218,7 @@ class FakeDevice extends Fake implements Device {
 // ignore: avoid_implementing_value_types
 class FakeIOSDevice extends Fake implements IOSDevice {
   FakeIOSDevice({
-    this.interfaceType = IOSDeviceConnectionInterface.none,
+    this.connectionInterface = DeviceConnectionInterface.attached,
     bool isLocalEmulator = false,
     String sdkNameAndVersion = '',
   }): _isLocalEmulator = isLocalEmulator,
@@ -1229,7 +1234,11 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   Future<String> get sdkNameAndVersion => Future<String>.value(_sdkNameAndVersion);
 
   @override
-  final IOSDeviceConnectionInterface interfaceType;
+  final DeviceConnectionInterface connectionInterface;
+
+  @override
+  bool get isWirelesslyConnected =>
+      connectionInterface == DeviceConnectionInterface.wireless;
 
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -922,8 +922,15 @@ class _FakeDeviceManager extends DeviceManager {
   @override
   Future<List<Device>> getAllDevices({
     DeviceDiscoveryFilter? filter,
-  }) async => _connectedDevices;
+  }) async => filteredDevices(filter);
 
   @override
   List<DeviceDiscovery> get deviceDiscoverers => <DeviceDiscovery>[];
+
+  List<Device> filteredDevices(DeviceDiscoveryFilter? filter) {
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.wireless) {
+      return <Device>[];
+    }
+    return _connectedDevices;
+  }
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/devices_test.dart
@@ -88,6 +88,13 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   String? specifiedDeviceId;
 
   @override
+  Future<List<Device>> getAllDevices({
+    DeviceDiscoveryFilter? filter,
+  }) async {
+    return devices;
+  }
+
+  @override
   Future<List<Device>> refreshAllDevices({
     Duration? timeout,
     DeviceDiscoveryFilter? filter,

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -122,7 +122,7 @@ void main() {
     expect(androidDevices.supportsPlatform, false);
   });
 
-  testWithoutContext('AndroidDevices can parse output for physical devices', () async {
+  testWithoutContext('AndroidDevices can parse output for physical attached devices', () async {
     final AndroidDevices androidDevices = AndroidDevices(
       userMessages: UserMessages(),
       androidWorkflow: androidWorkflow,
@@ -147,6 +147,35 @@ List of devices attached
     expect(devices, hasLength(1));
     expect(devices.first.name, 'Nexus 7');
     expect(devices.first.category, Category.mobile);
+    expect(devices.first.connectionInterface, DeviceConnectionInterface.attached);
+  });
+
+  testWithoutContext('AndroidDevices can parse output for physical wireless devices', () async {
+    final AndroidDevices androidDevices = AndroidDevices(
+      userMessages: UserMessages(),
+      androidWorkflow: androidWorkflow,
+      androidSdk: FakeAndroidSdk(),
+      logger: BufferLogger.test(),
+      processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['adb', 'devices', '-l'],
+          stdout: '''
+List of devices attached
+05a02bac._adb-tls-connect._tcp.               device product:razor model:Nexus_7 device:flo
+
+  ''',
+        ),
+      ]),
+      platform: FakePlatform(),
+      fileSystem: MemoryFileSystem.test(),
+    );
+
+    final List<Device> devices = await androidDevices.pollingGetDevices();
+
+    expect(devices, hasLength(1));
+    expect(devices.first.name, 'Nexus 7');
+    expect(devices.first.category, Category.mobile);
+    expect(devices.first.connectionInterface, DeviceConnectionInterface.wireless);
   });
 
   testWithoutContext('AndroidDevices can parse output for emulators and short listings', () async {

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
@@ -832,7 +831,7 @@ void main() {
         EnvironmentType.physical,
         null,
         <String, Object?>{},
-        interfaceType: IOSDeviceConnectionInterface.network,
+        interfaceType: DeviceConnectionInterface.wireless,
       );
 
       expect(
@@ -856,7 +855,7 @@ void main() {
         null,
         <String, Object?>{},
         ipv6: true,
-        interfaceType: IOSDeviceConnectionInterface.network,
+        interfaceType: DeviceConnectionInterface.wireless,
       );
 
       expect(

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -74,7 +74,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       );
       expect(device.isSupported(), isTrue);
     });
@@ -90,7 +90,7 @@ void main() {
         iMobileDevice: iMobileDevice,
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.armv7,
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       );
       expect(device.isSupported(), isFalse);
     });
@@ -107,7 +107,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '1.0.0',
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       ).majorSdkVersion, 1);
       expect(IOSDevice(
         'device-123',
@@ -120,7 +120,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '13.1.1',
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       ).majorSdkVersion, 13);
       expect(IOSDevice(
         'device-123',
@@ -133,7 +133,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '10',
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       ).majorSdkVersion, 10);
       expect(IOSDevice(
         'device-123',
@@ -146,7 +146,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '0',
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       ).majorSdkVersion, 0);
       expect(IOSDevice(
         'device-123',
@@ -159,7 +159,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: 'bogus',
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       ).majorSdkVersion, 0);
     });
 
@@ -175,7 +175,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3 17C54',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       );
 
       expect(await device.sdkNameAndVersion,'iOS 13.3 17C54');
@@ -193,7 +193,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       );
 
       expect(device.supportsRuntimeMode(BuildMode.debug), true);
@@ -217,7 +217,7 @@ void main() {
               name: 'iPhone 1',
               sdkVersion: '13.3',
               cpuArchitecture: DarwinArch.arm64,
-              interfaceType: IOSDeviceConnectionInterface.usb,
+              connectionInterface: DeviceConnectionInterface.attached,
             );
           },
           throwsAssertionError,
@@ -307,7 +307,7 @@ void main() {
           name: 'iPhone 1',
           sdkVersion: '13.3',
           cpuArchitecture: DarwinArch.arm64,
-          interfaceType: IOSDeviceConnectionInterface.usb,
+          connectionInterface: DeviceConnectionInterface.attached,
         );
         logReader1 = createLogReader(device, appPackage1, process1);
         logReader2 = createLogReader(device, appPackage2, process2);
@@ -368,7 +368,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         fileSystem: MemoryFileSystem.test(),
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       );
 
       device2 = IOSDevice(
@@ -382,7 +382,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         fileSystem: MemoryFileSystem.test(),
-        interfaceType: IOSDeviceConnectionInterface.usb,
+        connectionInterface: DeviceConnectionInterface.attached,
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -12,8 +12,8 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
-import 'package:flutter_tools/src/ios/iproxy.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -73,7 +73,7 @@ void main () {
         bundlePath: '/',
         appDeltaDirectory: appDeltaDirectory,
         launchArguments: <String>['--enable-dart-profiling'],
-        interfaceType: IOSDeviceConnectionInterface.network,
+        interfaceType: DeviceConnectionInterface.wireless,
         uninstallFirst: true,
       );
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
@@ -62,7 +63,7 @@ void main() {
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
       fileSystem: fileSystem,
-      interfaceType: IOSDeviceConnectionInterface.usb,
+      interfaceType: DeviceConnectionInterface.attached,
       artifacts: artifacts,
     );
     final bool wasInstalled = await device.installApp(iosApp);
@@ -95,7 +96,7 @@ void main() {
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
       fileSystem: fileSystem,
-      interfaceType: IOSDeviceConnectionInterface.network,
+      interfaceType: DeviceConnectionInterface.wireless,
       artifacts: artifacts,
     );
     final bool wasInstalled = await device.installApp(iosApp);
@@ -319,7 +320,7 @@ IOSDevice setUpIOSDevice({
   required ProcessManager processManager,
   FileSystem? fileSystem,
   Logger? logger,
-  IOSDeviceConnectionInterface? interfaceType,
+  DeviceConnectionInterface? interfaceType,
   Artifacts? artifacts,
 }) {
   logger ??= BufferLogger.test();
@@ -357,6 +358,6 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     iProxy: IProxy.test(logger: logger, processManager: processManager),
-    interfaceType: interfaceType ?? IOSDeviceConnectionInterface.usb,
+    connectionInterface: interfaceType ?? DeviceConnectionInterface.attached,
   );
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
@@ -98,6 +99,6 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     sdkVersion: '13.3',
     cpuArchitecture: DarwinArch.arm64,
     iProxy: IProxy.test(logger: logger, processManager: processManager),
-    interfaceType: IOSDeviceConnectionInterface.usb,
+    connectionInterface: DeviceConnectionInterface.attached,
   );
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -337,7 +337,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     cpuArchitecture: DarwinArch.arm64,
-    interfaceType: IOSDeviceConnectionInterface.usb,
+    connectionInterface: DeviceConnectionInterface.attached,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -250,7 +250,7 @@ void main() {
       processManager: processManager,
       fileSystem: fileSystem,
       logger: logger,
-      interfaceType: IOSDeviceConnectionInterface.network,
+      interfaceType: DeviceConnectionInterface.wireless,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -560,7 +560,7 @@ IOSDevice setUpIOSDevice({
   Logger? logger,
   ProcessManager? processManager,
   IOSDeploy? iosDeploy,
-  IOSDeviceConnectionInterface interfaceType = IOSDeviceConnectionInterface.usb,
+  DeviceConnectionInterface interfaceType = DeviceConnectionInterface.attached,
 }) {
   final Artifacts artifacts = Artifacts.test();
   final FakePlatform macPlatform = FakePlatform(
@@ -598,7 +598,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     cpuArchitecture: DarwinArch.arm64,
-    interfaceType: interfaceType,
+    connectionInterface: interfaceType,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -10,8 +10,8 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/code_signing.dart';
-import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcresult.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -77,7 +77,7 @@ void main() {
         expect(() async => iMobileDevice.takeScreenshot(
           outputFile,
           '1234',
-          IOSDeviceConnectionInterface.usb,
+          DeviceConnectionInterface.attached,
         ), throwsA(anything));
         expect(fakeProcessManager, hasNoRemainingExpectations);
       });
@@ -100,7 +100,7 @@ void main() {
         await iMobileDevice.takeScreenshot(
           outputFile,
           '1234',
-          IOSDeviceConnectionInterface.usb,
+          DeviceConnectionInterface.attached,
         );
         expect(fakeProcessManager, hasNoRemainingExpectations);
       });
@@ -123,7 +123,7 @@ void main() {
         await iMobileDevice.takeScreenshot(
           outputFile,
           '1234',
-          IOSDeviceConnectionInterface.network,
+          DeviceConnectionInterface.wireless,
         );
         expect(fakeProcessManager, hasNoRemainingExpectations);
       });

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -486,28 +486,24 @@ void main() {
           expect(devices[0].name, 'An iPhone (Space Gray)');
           expect(await devices[0].sdkNameAndVersion, 'iOS 13.3 17C54');
           expect(devices[0].cpuArchitecture, DarwinArch.arm64);
-          expect(devices[0].interfaceType, IOSDeviceConnectionInterface.usb);
           expect(devices[0].connectionInterface, DeviceConnectionInterface.attached);
 
           expect(devices[1].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
           expect(devices[1].name, 'iPad 1');
           expect(await devices[1].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[1].cpuArchitecture, DarwinArch.armv7);
-          expect(devices[1].interfaceType, IOSDeviceConnectionInterface.usb);
           expect(devices[1].connectionInterface, DeviceConnectionInterface.attached);
 
           expect(devices[2].id, '234234234234234234345445687594e089dede3c44');
           expect(devices[2].name, 'A networked iPad');
           expect(await devices[2].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
-          expect(devices[2].interfaceType, IOSDeviceConnectionInterface.network);
           expect(devices[2].connectionInterface, DeviceConnectionInterface.wireless);
 
           expect(devices[3].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
           expect(devices[3].name, 'iPad 2');
           expect(await devices[3].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[3].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
-          expect(devices[3].interfaceType, IOSDeviceConnectionInterface.usb);
           expect(devices[3].connectionInterface, DeviceConnectionInterface.attached);
 
           expect(fakeProcessManager, hasNoRemainingExpectations);

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
@@ -480,22 +481,35 @@ void main() {
           ));
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
           expect(devices, hasLength(4));
+
           expect(devices[0].id, '00008027-00192736010F802E');
           expect(devices[0].name, 'An iPhone (Space Gray)');
           expect(await devices[0].sdkNameAndVersion, 'iOS 13.3 17C54');
           expect(devices[0].cpuArchitecture, DarwinArch.arm64);
+          expect(devices[0].interfaceType, IOSDeviceConnectionInterface.usb);
+          expect(devices[0].connectionInterface, DeviceConnectionInterface.attached);
+
           expect(devices[1].id, '98206e7a4afd4aedaff06e687594e089dede3c44');
           expect(devices[1].name, 'iPad 1');
           expect(await devices[1].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[1].cpuArchitecture, DarwinArch.armv7);
+          expect(devices[1].interfaceType, IOSDeviceConnectionInterface.usb);
+          expect(devices[1].connectionInterface, DeviceConnectionInterface.attached);
+
           expect(devices[2].id, '234234234234234234345445687594e089dede3c44');
           expect(devices[2].name, 'A networked iPad');
           expect(await devices[2].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+          expect(devices[2].interfaceType, IOSDeviceConnectionInterface.network);
+          expect(devices[2].connectionInterface, DeviceConnectionInterface.wireless);
+
           expect(devices[3].id, 'f577a7903cc54959be2e34bc4f7f80b7009efcf4');
           expect(devices[3].name, 'iPad 2');
           expect(await devices[3].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[3].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
+          expect(devices[3].interfaceType, IOSDeviceConnectionInterface.usb);
+          expect(devices[3].connectionInterface, DeviceConnectionInterface.attached);
+
           expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -705,15 +705,15 @@ void main() {
       });
 
       testUsingContext('finds single device', () async {
-        testDeviceManager.addDevice(device1);
+        testDeviceManager.addAttachedDevice(device1);
         final DummyFlutterCommand flutterCommand = DummyFlutterCommand();
         final Device? device = await flutterCommand.findTargetDevice();
         expect(device, device1);
       });
 
       testUsingContext('finds multiple devices', () async {
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
+        testDeviceManager.addAttachedDevice(device1);
+        testDeviceManager.addAttachedDevice(device2);
         testDeviceManager.specifiedDeviceId = 'all';
         final DummyFlutterCommand flutterCommand = DummyFlutterCommand();
         final Device? device = await flutterCommand.findTargetDevice();

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -4,416 +4,1078 @@
 
 import 'dart:async';
 
-import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
-import 'package:flutter_tools/src/doctor_validator.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/runner/target_devices.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fake_devices.dart';
 
 void main() {
-   group('When cannot launch anything', () {
-    late BufferLogger logger;
-    late FakeDoctor doctor;
-    final FakeDevice device1 = FakeDevice('device1', 'device1');
+  group('findAllTargetDevices', () {
+    late Platform platform;
+
+    final FakeDevice attachedAndroidDevice1 = FakeDevice(deviceName: 'target-device-1');
+    final FakeDevice attachedAndroidDevice2 = FakeDevice(deviceName: 'target-device-2');
+    final FakeDevice attachedUnsupportedAndroidDevice = FakeDevice(deviceName: 'target-device-3', deviceSupported: false);
+    final FakeDevice attachedUnsupportedForProjectAndroidDevice = FakeDevice(deviceName: 'target-device-4', deviceSupportForProject: false);
+
+    final FakeDevice wirelessAndroidDevice1 = FakeDevice.wireless(deviceName: 'target-device-5');
+    final FakeDevice wirelessAndroidDevice2 = FakeDevice.wireless(deviceName: 'target-device-6');
+    final FakeDevice wirelessUnsupportedAndroidDevice = FakeDevice.wireless(deviceName: 'target-device-7', deviceSupported: false);
+    final FakeDevice wirelessUnsupportedForProjectAndroidDevice = FakeDevice.wireless(deviceName: 'target-device-8', deviceSupportForProject: false);
+
+    final FakeDevice nonEphemeralDevice = FakeDevice(deviceName: 'target-device-9', ephemeral: false);
+    final FakeDevice fuchsiaDevice = FakeDevice.fuchsia(deviceName: 'target-device-10');
+
+    final FakeDevice exactMatchAndroidDevice = FakeDevice(deviceName: 'target-device');
+    final FakeDevice exactMatchWirelessAndroidDevice = FakeDevice.wireless(deviceName: 'target-device');
+    final FakeDevice exactMatchattachedUnsupportedAndroidDevice = FakeDevice(deviceName: 'target-device', deviceSupported: false);
+    final FakeDevice exactMatchUnsupportedByProjectDevice = FakeDevice(deviceName: 'target-device', deviceSupportForProject: false);
 
     setUp(() {
-      logger = BufferLogger.test();
-      doctor = FakeDoctor(logger, canLaunchAnything: false);
+      platform = FakePlatform();
     });
 
-    testUsingContext('does not search for devices', () async {
-      final MockDeviceDiscovery deviceDiscovery = MockDeviceDiscovery()
-        ..deviceValues = <Device>[device1];
+    group('when cannot launch anything', () {
+      late BufferLogger logger;
+      late FakeDoctor doctor;
 
-      final DeviceManager deviceManager = TestDeviceManager(
-        <Device>[],
-        deviceDiscoveryOverrides: <DeviceDiscovery>[
-          deviceDiscovery,
-        ],
-        logger: logger,
-      );
+      setUp(() {
+        logger = BufferLogger.test();
+        doctor = FakeDoctor(canLaunchAnything: false);
+      });
 
-      final TargetDevices targetDevices = TargetDevices(
-        deviceManager: deviceManager,
-        logger: logger,
-      );
-      final List<Device>? devices = await targetDevices.findAllTargetDevices();
+      testUsingContext('does not search for devices', () async {
+        final TestDeviceManager deviceManager = TestDeviceManager(
+          logger: logger,
+          platform: platform,
+        );
+        deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
 
-      expect(logger.errorText, contains(UserMessages().flutterNoDevelopmentDevice));
-      expect(devices, isNull);
-      expect(deviceDiscovery.devicesCalled, 0);
-      expect(deviceDiscovery.discoverDevicesCalled, 0);
-    }, overrides: <Type, Generator>{
-      Doctor: () => doctor,
-    });
-  });
+        final TargetDevices targetDevices = TargetDevices(
+          deviceManager: deviceManager,
+          logger: logger,
+        );
+        final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-  group('Ensure refresh when deviceDiscoveryTimeout is provided', () {
-    late BufferLogger logger;
-    final FakeDevice device1 = FakeDevice('device1', 'device1');
-
-    setUp(() {
-      logger = BufferLogger.test();
+        expect(logger.errorText, equals('''
+Unable to locate a development device; please run 'flutter doctor' for information about installing additional components.
+'''));
+        expect(devices, isNull);
+        expect(deviceManager.androidDiscoverer.devicesCalled, 0);
+        expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+      }, overrides: <Type, Generator>{
+        Doctor: () => doctor,
+      });
     });
 
-    testUsingContext('does not refresh device cache without a timeout', () async {
-      final MockDeviceDiscovery deviceDiscovery = MockDeviceDiscovery()
-        ..deviceValues = <Device>[device1];
-
-      final DeviceManager deviceManager = TestDeviceManager(
-        <Device>[],
-        deviceDiscoveryOverrides: <DeviceDiscovery>[
-          deviceDiscovery,
-        ],
+    testUsingContext('ensure refresh when deviceDiscoveryTimeout is provided', () async {
+      final BufferLogger logger = BufferLogger.test();
+      final TestDeviceManager deviceManager = TestDeviceManager(
         logger: logger,
+        platform: platform,
       );
-      deviceManager.specifiedDeviceId = device1.id;
+      deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
+      deviceManager.androidDiscoverer.refreshDeviceList = <Device>[attachedAndroidDevice1, wirelessAndroidDevice1];
+      deviceManager.hasSpecifiedAllDevices = true;
 
-      final TargetDevices targetDevices = TargetDevices(
-        deviceManager: deviceManager,
-        logger: logger,
-      );
-      final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-      expect(devices?.single, device1);
-      expect(deviceDiscovery.devicesCalled, 1);
-      expect(deviceDiscovery.discoverDevicesCalled, 0);
-    });
-
-    testUsingContext('refreshes device cache with a timeout', () async {
-      final MockDeviceDiscovery deviceDiscovery = MockDeviceDiscovery()
-        ..deviceValues = <Device>[device1];
-
-      final DeviceManager deviceManager = TestDeviceManager(
-        <Device>[],
-        deviceDiscoveryOverrides: <DeviceDiscovery>[
-          deviceDiscovery,
-        ],
-        logger: BufferLogger.test(),
-      );
-      deviceManager.specifiedDeviceId = device1.id;
-
-      const Duration timeout = Duration(seconds: 2);
       final TargetDevices targetDevices = TargetDevices(
         deviceManager: deviceManager,
         logger: logger,
       );
       final List<Device>? devices = await targetDevices.findAllTargetDevices(
-        deviceDiscoveryTimeout: timeout,
+        deviceDiscoveryTimeout: const Duration(seconds: 2),
       );
 
-      expect(devices?.single, device1);
-      expect(deviceDiscovery.devicesCalled, 1);
-      expect(deviceDiscovery.discoverDevicesCalled, 1);
-    });
-  });
-
-  group('findAllTargetDevices', () {
-    late BufferLogger logger;
-    final FakeDevice device1 = FakeDevice('device1', 'device1');
-    final FakeDevice device2 = FakeDevice('device2', 'device2');
-
-    setUp(() {
-      logger = BufferLogger.test();
+      expect(logger.statusText, equals(''));
+      expect(devices, <Device>[attachedAndroidDevice1, wirelessAndroidDevice1]);
+      expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+      expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 1);
+      expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
     });
 
-    group('when specified device id', () {
-      testUsingContext('returns device when device is found', () async {
-        testDeviceManager.specifiedDeviceId = 'device1';
-        testDeviceManager.addDevice(device1);
+    group('finds no devices', () {
+      late BufferLogger logger;
+      late TestDeviceManager deviceManager;
 
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
+      setUp(() {
+        logger = BufferLogger.test();
+        deviceManager = TestDeviceManager(
           logger: logger,
+          platform: platform,
         );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1]);
       });
 
-      testUsingContext('show error when no device found', () async {
-        testDeviceManager.specifiedDeviceId = 'device-id';
+      group('when device not specified', () {
+        testUsingContext('when no devices', () async {
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
+          expect(logger.statusText, equals('''
+No supported devices connected.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
 
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterNoMatchingDevice('device-id')));
+        testUsingContext('when device is unsupported by flutter or project', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            attachedUnsupportedAndroidDevice,
+            attachedUnsupportedForProjectAndroidDevice,
+          ];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No supported devices connected.
+
+The following devices were found, but are not supported by this project:
+target-device-3 (mobile) • xxx • android • Android 10 (unsupported)
+target-device-4 (mobile) • xxx • android • Android 10
+If you would like your app to run on android, consider running `flutter create .` to generate projects for these platforms.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
       });
 
-      testUsingContext('show error when multiple devices found', () async {
-        testDeviceManager.specifiedDeviceId = 'device';
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterFoundSpecifiedDevices(2, 'device')));
-      });
-    });
-
-    group('when specified all', () {
-      testUsingContext('can return one device', () async {
-        testDeviceManager.specifiedDeviceId = 'all';
-        testDeviceManager.addDevice(device1);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1]);
-      });
-
-      testUsingContext('can return multiple devices', () async {
-        testDeviceManager.specifiedDeviceId = 'all';
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1, device2]);
-      });
-
-      testUsingContext('show error when no device found', () async {
-        testDeviceManager.specifiedDeviceId = 'all';
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterNoDevicesFound));
-      });
-    });
-
-    group('when device not specified', () {
-      testUsingContext('returns one device when only one device connected', () async {
-        testDeviceManager.addDevice(device1);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, <Device>[device1]);
-      });
-
-      testUsingContext('show error when no device found', () async {
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterNoSupportedDevices));
-      });
-
-      testUsingContext('show error when multiple devices found and not connected to terminal', () async {
-        testDeviceManager.addDevice(device1);
-        testDeviceManager.addDevice(device2);
-
-        final TargetDevices targetDevices = TargetDevices(
-          deviceManager: testDeviceManager,
-          logger: logger,
-        );
-        final List<Device>? devices = await targetDevices.findAllTargetDevices();
-
-        expect(devices, null);
-        expect(logger.statusText, contains(UserMessages().flutterSpecifyDeviceWithAllOption));
-      }, overrides: <Type, Generator>{
-        AnsiTerminal: () => FakeTerminal(stdinHasTerminal: false),
-      });
-
-      // Prompt to choose device when multiple devices found and connected to terminal
-      group('show prompt', () {
-        late FakeTerminal terminal;
+      group('with hasSpecifiedDeviceId', () {
         setUp(() {
-          terminal = FakeTerminal();
+          deviceManager.specifiedDeviceId = 'target-device';
         });
 
-        testUsingContext('choose first device', () async {
-          testDeviceManager.addDevice(device1);
-          testDeviceManager.addDevice(device2);
-          terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
-
+        testUsingContext('when no devices', () async {
           final TargetDevices targetDevices = TargetDevices(
-            deviceManager: testDeviceManager,
+            deviceManager: deviceManager,
             logger: logger,
           );
           final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-          expect(devices, <Device>[device1]);
-        }, overrides: <Type, Generator>{
-          AnsiTerminal: () => terminal,
+          expect(logger.statusText, equals('''
+No supported devices found with name or id matching 'target-device'.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
         });
 
-        testUsingContext('choose second device', () async {
-          testDeviceManager.addDevice(device1);
-          testDeviceManager.addDevice(device2);
-          terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '2');
+        testUsingContext('when no devices match', () async {
+          final FakeDevice device1 = FakeDevice(deviceName: 'no-match-1');
+          final FakeDevice device2 = FakeDevice.wireless(deviceName: 'no-match-2');
+          deviceManager.androidDiscoverer.deviceList = <Device>[device1, device2];
 
           final TargetDevices targetDevices = TargetDevices(
-            deviceManager: testDeviceManager,
+            deviceManager: deviceManager,
             logger: logger,
           );
           final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-            expect(devices, <Device>[device2]);
+          expect(logger.statusText, equals('''
+No supported devices found with name or id matching 'target-device'.
+
+The following devices were found:
+no-match-1 (mobile) • xxx • android • Android 10
+no-match-2 (mobile) • xxx • android • Android 10
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching device is unsupported by flutter', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchattachedUnsupportedAndroidDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No supported devices found with name or id matching 'target-device'.
+
+The following devices were found:
+target-device (mobile) • xxx • android • Android 10 (unsupported)
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+      group('with hasSpecifiedAllDevices', () {
+        setUp(() {
+          deviceManager.hasSpecifiedAllDevices = true;
+        });
+
+        testUsingContext('when no devices', () async {
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No devices found.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when devices are either unsupported by flutter or project or all', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            attachedUnsupportedAndroidDevice,
+            attachedUnsupportedForProjectAndroidDevice,
+          ];
+          deviceManager.otherDiscoverer.deviceList = <Device>[fuchsiaDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals('''
+No devices found.
+
+The following devices were found, but are not supported by this project:
+target-device-3 (mobile)  • xxx • android       • Android 10 (unsupported)
+target-device-4 (mobile)  • xxx • android       • Android 10
+target-device-10 (mobile) • xxx • fuchsia-arm64 • tester
+If you would like your app to run on android or fuchsia, consider running `flutter create .` to generate projects for these platforms.
+'''));
+          expect(devices, isNull);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+      });
+
+    });
+
+    group('finds single device', () {
+      late BufferLogger logger;
+      late TestDeviceManager deviceManager;
+
+      setUp(() {
+        logger = BufferLogger.test();
+        deviceManager = TestDeviceManager(
+          logger: logger,
+          platform: platform,
+        );
+      });
+
+      group('when device not specified', () {
+        testUsingContext('when single attached device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[attachedAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when single wireless device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[wirelessAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when multiple but only one ephemeral', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[nonEphemeralDevice, wirelessAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[wirelessAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+      group('with hasSpecifiedDeviceId', () {
+        setUp(() {
+          deviceManager.specifiedDeviceId = 'target-device';
+        });
+
+        testUsingContext('when multiple matches but first is unsupported by flutter', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            exactMatchattachedUnsupportedAndroidDevice,
+            exactMatchAndroidDevice,
+          ];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching device is unsupported by project', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchUnsupportedByProjectDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchUnsupportedByProjectDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching attached device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchAndroidDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when matching wireless device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchWirelessAndroidDevice];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchWirelessAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+
+        testUsingContext('when exact match attached device and partial match wireless device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[exactMatchAndroidDevice, wirelessAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[exactMatchAndroidDevice]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 1);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+      group('with hasSpecifiedAllDevices', () {
+        setUp(() {
+          deviceManager.hasSpecifiedAllDevices = true;
+        });
+
+        testUsingContext('when only one device', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1];
+
+          final TargetDevices targetDevices = TargetDevices(
+            deviceManager: deviceManager,
+            logger: logger,
+          );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[attachedAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+        });
+      });
+
+    });
+
+    group('Finds multiple devices', () {
+      late BufferLogger logger;
+      late TestDeviceManager deviceManager;
+
+      setUp(() {
+        logger = BufferLogger.test();
+        deviceManager = TestDeviceManager(
+          logger: logger,
+          platform: platform,
+        );
+      });
+
+      group('when device not specified', () {
+        group('with stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal();
+          });
+
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '2');
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Multiple devices found:
+target-device-1 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+
+[1]: target-device-1 (xxx)
+[2]: target-device-5 (xxx)
+'''));
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
           }, overrides: <Type, Generator>{
             AnsiTerminal: () => terminal,
           });
 
-        testUsingContext('exits without choosing device', () async {
-          testDeviceManager.addDevice(device1);
-          testDeviceManager.addDevice(device2);
-          terminal.setPrompt(<String>['1', '2', 'q', 'Q'], 'q');
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Multiple devices found:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+[1]: target-device-1 (xxx)
+[2]: target-device-2 (xxx)
+'''));
+            expect(devices, <Device>[attachedAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Multiple devices found:
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+
+[1]: target-device-5 (xxx)
+[2]: target-device-6 (xxx)
+'''));
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+        });
+
+        group('without stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal(stdinHasTerminal: false);
+          });
+
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
+
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-4 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-8 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
+
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+More than one device connected; please specify a device with the '-d <deviceId>' flag, or use '-d all' to act on all devices.
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 4);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+        });
+      });
+
+      group('with hasSpecifiedDeviceId', () {
+        setUp(() {
+          deviceManager.specifiedDeviceId = 'target-device';
+        });
+
+        group('with stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal();
+          });
+
+          testUsingContext('including attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            terminal.setPrompt(<String>['1', '2', '3', '4', 'q', 'Q'], '2');
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 4 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-4 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-8 (mobile) • xxx • android • Android 10
+
+[1]: target-device-1 (xxx)
+[2]: target-device-4 (xxx)
+[3]: target-device-5 (xxx)
+[4]: target-device-8 (xxx)
+'''));
+            expect(devices, <Device>[attachedUnsupportedForProjectAndroidDevice]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+[1]: target-device-1 (xxx)
+[2]: target-device-2 (xxx)
+'''));
+            expect(devices, <Device>[attachedAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+
+[1]: target-device-5 (xxx)
+[2]: target-device-6 (xxx)
+'''));
+            expect(devices, <Device>[wirelessAndroidDevice1]);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+        });
+
+        group('without stdinHasTerminal', () {
+          late FakeTerminal terminal;
+
+          setUp(() {
+            terminal = FakeTerminal(stdinHasTerminal: false);
+          });
+
+          testUsingContext('including only one ephemeral', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[nonEphemeralDevice, attachedAndroidDevice1];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+target-device-9 (mobile) • xxx • android • Android 10
+target-device-1 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including matching attached, wireless, unsupported devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[
+              attachedAndroidDevice1,
+              attachedUnsupportedAndroidDevice,
+              attachedUnsupportedForProjectAndroidDevice,
+              wirelessAndroidDevice1,
+              wirelessUnsupportedAndroidDevice,
+              wirelessUnsupportedForProjectAndroidDevice,
+            ];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 4 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-4 (mobile) • xxx • android • Android 10
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-8 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only attached devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[attachedAndroidDevice1, attachedAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+target-device-1 (mobile) • xxx • android • Android 10
+target-device-2 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+
+          testUsingContext('including only wireless devices', () async {
+            deviceManager.androidDiscoverer.deviceList = <Device>[wirelessAndroidDevice1, wirelessAndroidDevice2];
+
+            final TargetDevices targetDevices = TargetDevices(
+              deviceManager: deviceManager,
+              logger: logger,
+            );
+            final List<Device>? devices = await targetDevices.findAllTargetDevices();
+
+            expect(logger.statusText, equals('''
+Found 2 devices with name or id matching target-device:
+
+Wirelessly connected devices:
+target-device-5 (mobile) • xxx • android • Android 10
+target-device-6 (mobile) • xxx • android • Android 10
+'''));
+            expect(devices, isNull);
+            expect(deviceManager.androidDiscoverer.devicesCalled, 3);
+            expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+            expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
+          }, overrides: <Type, Generator>{
+            AnsiTerminal: () => terminal,
+          });
+        });
+      });
+
+      group('with hasSpecifiedAllDevices', () {
+        setUp(() {
+          deviceManager.hasSpecifiedAllDevices = true;
+        });
+
+        testUsingContext('including attached, wireless, unsupported devices', () async {
+          deviceManager.androidDiscoverer.deviceList = <Device>[
+            attachedAndroidDevice1,
+            attachedUnsupportedAndroidDevice,
+            attachedUnsupportedForProjectAndroidDevice,
+            wirelessAndroidDevice1,
+            wirelessUnsupportedAndroidDevice,
+            wirelessUnsupportedForProjectAndroidDevice,
+          ];
+          deviceManager.otherDiscoverer.deviceList = <Device>[fuchsiaDevice];
 
           final TargetDevices targetDevices = TargetDevices(
-            deviceManager: testDeviceManager,
+            deviceManager: deviceManager,
             logger: logger,
           );
+          final List<Device>? devices = await targetDevices.findAllTargetDevices();
 
-          await expectLater(
-            targetDevices.findAllTargetDevices(),
-            throwsToolExit(),
-          );
-        }, overrides: <Type, Generator>{
-          AnsiTerminal: () => terminal,
+          expect(logger.statusText, equals(''));
+          expect(devices, <Device>[attachedAndroidDevice1, wirelessAndroidDevice1]);
+          expect(deviceManager.androidDiscoverer.devicesCalled, 2);
+          expect(deviceManager.androidDiscoverer.discoverDevicesCalled, 0);
+          expect(deviceManager.androidDiscoverer.numberOfTimesPolled, 1);
         });
       });
     });
-  });
 
-  group('Filter devices', () {
-    late BufferLogger logger;
-    final FakeDevice ephemeralOne = FakeDevice('ephemeralOne', 'ephemeralOne');
-    final FakeDevice ephemeralTwo = FakeDevice('ephemeralTwo', 'ephemeralTwo');
-    final FakeDevice nonEphemeralOne = FakeDevice('nonEphemeralOne', 'nonEphemeralOne', ephemeral: false);
-
-    setUp(() {
-      logger = BufferLogger.test();
-    });
-
-    testUsingContext('chooses ephemeral device', () async {
-      final List<Device> devices = <Device>[
-        ephemeralOne,
-        nonEphemeralOne,
-      ];
-      final DeviceManager deviceManager = TestDeviceManager(
-        devices,
-        logger: logger,
-      );
-
-      final TargetDevices targetDevices = TargetDevices(deviceManager: deviceManager, logger: logger);
-      final List<Device> filtered = await targetDevices.getDevices();
-
-      expect(filtered, <Device>[ephemeralOne]);
-    });
-
-    testUsingContext('returns all devices when multiple non ephemeral devices are found', () async {
-      final List<Device> devices = <Device>[
-        ephemeralOne,
-        ephemeralTwo,
-        nonEphemeralOne,
-      ];
-      final DeviceManager deviceManager = TestDeviceManager(
-        devices,
-        logger: logger,
-      );
-
-      final TargetDevices targetDevices = TargetDevices(deviceManager: deviceManager, logger: logger);
-      final List<Device> filtered = await targetDevices.getDevices();
-
-      expect(filtered, <Device>[
-        ephemeralOne,
-        ephemeralTwo,
-        nonEphemeralOne,
-      ]);
-    });
   });
 }
 
 class TestDeviceManager extends DeviceManager {
-  TestDeviceManager(
-    List<Device> allDevices, {
-    List<DeviceDiscovery>? deviceDiscoveryOverrides,
-    required super.logger,
-    String? wellKnownId,
-    FakePollingDeviceDiscovery? fakeDiscoverer,
-  }) : _fakeDeviceDiscoverer = fakeDiscoverer ?? FakePollingDeviceDiscovery(),
-       _deviceDiscoverers = <DeviceDiscovery>[],
-       super() {
-    if (wellKnownId != null) {
-      _fakeDeviceDiscoverer.wellKnownIds.add(wellKnownId);
-    }
-    _deviceDiscoverers.add(_fakeDeviceDiscoverer);
-    if (deviceDiscoveryOverrides != null) {
-      _deviceDiscoverers.addAll(deviceDiscoveryOverrides);
-    }
-    resetDevices(allDevices);
-  }
-  @override
-  List<DeviceDiscovery> get deviceDiscoverers => _deviceDiscoverers;
-  final List<DeviceDiscovery> _deviceDiscoverers;
-  final FakePollingDeviceDiscovery _fakeDeviceDiscoverer;
+  TestDeviceManager({
+    required this.logger,
+    required this.platform,
+  }) : super(logger: logger);
 
-  void resetDevices(List<Device> allDevices) {
-    _fakeDeviceDiscoverer.setDevices(allDevices);
+  final Logger logger;
+  final Platform platform;
+
+  @override
+  String? specifiedDeviceId;
+
+  @override
+  bool hasSpecifiedAllDevices = false;
+
+  final TestPollingDeviceDiscovery androidDiscoverer = TestPollingDeviceDiscovery(
+    'android',
+  );
+  final TestPollingDeviceDiscovery otherDiscoverer = TestPollingDeviceDiscovery(
+    'other',
+  );
+  final TestPollingDeviceDiscovery iosDiscoverer = TestPollingDeviceDiscovery(
+    'ios',
+  );
+
+  @override
+  List<DeviceDiscovery> get deviceDiscoverers {
+    return <DeviceDiscovery>[
+      androidDiscoverer,
+      otherDiscoverer,
+      iosDiscoverer,
+    ];
   }
 }
 
-class MockDeviceDiscovery extends Fake implements DeviceDiscovery {
+class TestPollingDeviceDiscovery extends PollingDeviceDiscovery {
+  TestPollingDeviceDiscovery(super.name);
+
+  List<Device> deviceList = <Device>[];
+  List<Device> refreshDeviceList = <Device>[];
   int devicesCalled = 0;
   int discoverDevicesCalled = 0;
+  int numberOfTimesPolled = 0;
 
   @override
-  bool supportsPlatform = true;
+  bool get supportsPlatform => true;
 
-  List<Device> deviceValues = <Device>[];
+  @override
+  List<String> get wellKnownIds => const <String>[];
+
+  @override
+  Future<List<Device>> pollingGetDevices({Duration? timeout}) async {
+    numberOfTimesPolled++;
+    return deviceList;
+  }
 
   @override
   Future<List<Device>> devices({DeviceDiscoveryFilter? filter}) async {
     devicesCalled += 1;
-    return deviceValues;
+    return super.devices(filter: filter);
   }
 
   @override
   Future<List<Device>> discoverDevices({
     Duration? timeout,
     DeviceDiscoveryFilter? filter,
-  }) async {
-    discoverDevicesCalled += 1;
-    return deviceValues;
+  }) {
+    discoverDevicesCalled++;
+    if (refreshDeviceList.isNotEmpty) {
+      deviceList = refreshDeviceList;
+    }
+    return super.discoverDevices(timeout: timeout, filter: filter);
   }
 
   @override
-  List<String> get wellKnownIds => <String>[];
+  bool get canListAnything => true;
+}
+
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
+class FakeDevice extends Fake implements Device {
+  FakeDevice({
+    String? deviceId,
+    String? deviceName,
+    bool deviceSupported = true,
+    bool deviceSupportForProject = true,
+    this.ephemeral = true,
+    this.isConnected = true,
+    this.connectionInterface = DeviceConnectionInterface.attached,
+    this.platformType = PlatformType.android,
+    TargetPlatform deviceTargetPlatform = TargetPlatform.android,
+  })  : id = deviceId ?? 'xxx',
+        name = deviceName ?? 'test',
+        _isSupported = deviceSupported,
+        _isSupportedForProject = deviceSupportForProject,
+        _targetPlatform = deviceTargetPlatform;
+
+  FakeDevice.wireless({
+    String? deviceId,
+    String? deviceName,
+    bool deviceSupported = true,
+    bool deviceSupportForProject = true,
+    this.ephemeral = true,
+    this.isConnected = true,
+    this.connectionInterface = DeviceConnectionInterface.wireless,
+    this.platformType = PlatformType.android,
+    TargetPlatform deviceTargetPlatform = TargetPlatform.android,
+  })  : id = deviceId ?? 'xxx',
+        name = deviceName ?? 'test',
+        _isSupported = deviceSupported,
+        _isSupportedForProject = deviceSupportForProject,
+        _targetPlatform = deviceTargetPlatform;
+
+  FakeDevice.fuchsia({
+    String? deviceId,
+    String? deviceName,
+    bool deviceSupported = true,
+    bool deviceSupportForProject = true,
+    this.ephemeral = true,
+    this.isConnected = true,
+    this.connectionInterface = DeviceConnectionInterface.attached,
+    this.platformType = PlatformType.fuchsia,
+    TargetPlatform deviceTargetPlatform = TargetPlatform.fuchsia_arm64,
+  })  : id = deviceId ?? 'xxx',
+        name = deviceName ?? 'test',
+        _isSupported = deviceSupported,
+        _isSupportedForProject = deviceSupportForProject,
+        _targetPlatform = deviceTargetPlatform,
+        _sdkNameAndVersion = 'tester';
+
+  final bool _isSupported;
+  final bool _isSupportedForProject;
+  final TargetPlatform _targetPlatform;
+  String _sdkNameAndVersion = 'Android 10';
+
+  @override
+  String name;
+
+  @override
+  final bool ephemeral;
+
+  @override
+  String id;
+
+  @override
+  bool isSupported() => _isSupported;
+
+  @override
+  bool isSupportedForProject(FlutterProject project) => _isSupportedForProject;
+
+  @override
+  DeviceConnectionInterface connectionInterface;
+
+  @override
+  bool isConnected;
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => _targetPlatform;
+
+  @override
+  final PlatformType? platformType;
+
+  @override
+  Future<String> get sdkNameAndVersion async => _sdkNameAndVersion;
+
+  @override
+  Future<bool> get isLocalEmulator async => false;
+
+  @override
+  Category? get category => Category.mobile;
+
+  @override
+  Future<String> get targetPlatformDisplayName async =>
+      getNameForTargetPlatform(await targetPlatform);
 }
 
 class FakeTerminal extends Fake implements AnsiTerminal {
@@ -446,31 +1108,11 @@ class FakeTerminal extends Fake implements AnsiTerminal {
   }
 }
 
-class FakeDoctor extends Doctor {
-  FakeDoctor(
-    Logger logger, {
+class FakeDoctor extends Fake implements Doctor {
+  FakeDoctor({
     this.canLaunchAnything = true,
-  }) : super(logger: logger);
+  });
 
-  // True for testing.
-  @override
-  bool get canListAnything => true;
-
-  // True for testing.
   @override
   bool canLaunchAnything;
-
-  @override
-  /// Replaces the android workflow with a version that overrides licensesAccepted,
-  /// to prevent individual tests from having to mock out the process for
-  /// the Doctor.
-  List<DoctorValidator> get validators {
-    final List<DoctorValidator> superValidators = super.validators;
-    return superValidators.map<DoctorValidator>((DoctorValidator v) {
-      if (v is AndroidLicenseValidator) {
-        return FakeAndroidLicenseValidator();
-      }
-      return v;
-    }).toList();
-  }
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -181,7 +181,8 @@ void _printBufferedErrors(AppContext testContext) {
 }
 
 class FakeDeviceManager implements DeviceManager {
-  List<Device> devices = <Device>[];
+  List<Device> attachedDevices = <Device>[];
+  List<Device> wirelessDevices = <Device>[];
 
   String? _specifiedDeviceId;
 
@@ -209,20 +210,20 @@ class FakeDeviceManager implements DeviceManager {
   @override
   Future<List<Device>> getAllDevices({
     DeviceDiscoveryFilter? filter,
-  }) async => devices;
+  }) async => filteredDevices(filter);
 
   @override
   Future<List<Device>> refreshAllDevices({
     Duration? timeout,
     DeviceDiscoveryFilter? filter,
-  }) async => devices;
+  }) async => filteredDevices(filter);
 
   @override
   Future<List<Device>> getDevicesById(
     String deviceId, {
     DeviceDiscoveryFilter? filter,
   }) async {
-    return devices.where((Device device) {
+    return filteredDevices(filter).where((Device device) {
       return device.id == deviceId || device.id.startsWith(deviceId);
     }).toList();
   }
@@ -236,7 +237,8 @@ class FakeDeviceManager implements DeviceManager {
         : getAllDevices(filter: filter);
   }
 
-  void addDevice(Device device) => devices.add(device);
+  void addAttachedDevice(Device device) => attachedDevices.add(device);
+  void addWirelessDevice(Device device) => wirelessDevices.add(device);
 
   @override
   bool get canListAnything => true;
@@ -257,6 +259,16 @@ class FakeDeviceManager implements DeviceManager {
 
   @override
   Device? getSingleEphemeralDevice(List<Device> devices) => null;
+
+  List<Device> filteredDevices(DeviceDiscoveryFilter? filter) {
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.attached) {
+      return attachedDevices;
+    }
+    if (filter?.deviceConnectionInterface == DeviceConnectionInterface.wireless) {
+      return wirelessDevices;
+    }
+    return attachedDevices + wirelessDevices;
+  }
 }
 
 class TestDeviceDiscoverySupportFilter extends Fake implements DeviceDiscoverySupportFilter {

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -54,6 +54,31 @@ List<FakeDeviceJsonData> fakeDevices = <FakeDeviceJsonData>[
       },
     },
   ),
+  FakeDeviceJsonData(
+    FakeDevice(
+      'wireless android',
+      'wireless-android',
+      type: PlatformType.android,
+      connectionInterface: DeviceConnectionInterface.wireless,
+    ),
+    <String, Object>{
+      'name': 'wireless android',
+      'id': 'wireless-android',
+      'isSupported': true,
+      'targetPlatform': 'android-arm',
+      'emulator': true,
+      'sdk': 'Test SDK (1.2.3)',
+      'capabilities': <String, Object>{
+        'hotReload': true,
+        'hotRestart': true,
+        'screenshot': false,
+        'fastStart': false,
+        'flutterExit': true,
+        'hardwareRendering': true,
+        'startPaused': true,
+      },
+    }
+  ),
 ];
 
 /// Fake device to test `devices` command.


### PR DESCRIPTION
This PR includes 4 changes:
1. Separates attached and wireless devices in device selection flow when running commands like `flutter run`. 

```
Multiple devices found:
target-device-1 (mobile) • xxx • android • Android 10

Wirelessly connected devices:
target-device-4 (mobile) • xxx • android • Android 10

[1]: target-device-1 (xxx)
[2]: target-device-4 (xxx)
```

2. Separates attached and wireless devices in `flutter devices` command.

```
2 connected devices:

ephemeral (mobile) • ephemeral • android-arm    • Test SDK (1.2.3) (emulator)
webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulator)

1 wirelessly connected device:

wireless android (mobile) • wireless-android • android-arm • Test SDK (1.2.3) (emulator)
```

3. Fixes https://github.com/flutter/flutter/issues/119271. When more than 1 match for the -d flag is found, either allow the user to select from them (if stdin is available) or display the list of them (if no stdin).

```
Found 2 devices with name or id matching target-device:
target-device-1 (mobile) • xxx • android • Android 10

Wirelessly connected devices:
target-device-4 (mobile) • xxx • android • Android 10

[1]: target-device-1 (xxx)
[3]: target-device-4 (xxx)
```

4. Replaces `IOSDeviceConnectionInterface` with `DeviceConnectionInterface` since it's no longer needed. 
* `IOSDeviceConnectionInterface.network` -> `DeviceConnectionInterface.wireless`
* `IOSDeviceConnectionInterface.usb` -> `DeviceConnectionInterface.attached`
* `IOSDeviceConnectionInterface.none` -> `DeviceConnectionInterface.attached`

Note: This PR does not include updates for extended search for wireless iOS devices.

Part 3 in breakdown of https://github.com/flutter/flutter/pull/121262.

Fixes https://github.com/flutter/flutter/issues/119271.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
