### PR TITLE
Reland: Updates `flutter/test/gestures` to no longer reference `TestWindow`

### DIFF
--- a/packages/flutter/test/gestures/gesture_config_regression_test.dart
+++ b/packages/flutter/test/gestures/gesture_config_regression_test.dart
@@ -90,7 +90,9 @@ class NestedDraggableCase extends StatelessWidget {
 
 void main() {
   testWidgets('Scroll Views get the same ScrollConfiguration as GestureDetectors', (WidgetTester tester) async {
-    tester.binding.window.gestureSettingsTestValue = const ui.GestureSettings(physicalTouchSlop: 4);
+    tester.view.gestureSettings = const ui.GestureSettings(physicalTouchSlop: 4);
+    addTearDown(tester.view.reset);
+
     final TestResult result = TestResult();
 
     await tester.pumpWidget(MaterialApp(
@@ -108,11 +110,11 @@ void main() {
 
    expect(result.dragStarted, true);
    expect(result.dragUpdate, true);
-   tester.binding.window.clearGestureSettingsTestValue();
   });
 
   testWidgets('Scroll Views get the same ScrollConfiguration as Draggables', (WidgetTester tester) async {
-    tester.binding.window.gestureSettingsTestValue = const ui.GestureSettings(physicalTouchSlop: 4);
+    tester.view.gestureSettings = const ui.GestureSettings(physicalTouchSlop: 4);
+    addTearDown(tester.view.reset);
 
     final TestResult result = TestResult();
 
@@ -131,6 +133,5 @@ void main() {
 
    expect(result.dragStarted, true);
    expect(result.dragUpdate, true);
-   tester.binding.window.clearGestureSettingsTestValue();
   });
 }


### PR DESCRIPTION
Updates `flutter/test/gestures` to no longer reference `TestWindow`.

Resolves #122239

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.