### PR TITLE
Remove ownership on ci.yaml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,6 @@
 # Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
 
 /CODEOWNERS @jmagman
-/.ci.yaml @keyonghan
 /packages/flutter_tools/pubspec.yaml @christopherfujino
 /packages/flutter_tools/templates/module/ios/ @jmagman
 /packages/flutter_tools/templates/**/Podfile* @jmagman


### PR DESCRIPTION
Put myself as owner of ci.yaml to monitor targets being added as `bringup: true` per flakiness reduction workflow. Now the process is stable and is being enforced by cocoon, this PR removes my ownership.