### PR TITLE
Do not use colors in output if running from CI.

### DIFF
--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -95,6 +95,7 @@ void foundError(List<String> messages) {
   // Make the error message easy to notice in the logs by
   // wrapping it in a red box.
   final int width = math.max(15, (hasColor ? stdout.terminalColumns : 80) - 1);
+  print('hascolor: $hasColor, isLuci $isLuci');
   print('$red╔═╡${bold}ERROR$reset$red╞═${"═" * (width - 9)}');
   for (final String message in messages.expand((String line) => line.split('\n'))) {
     print('$red║$reset $message');

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -95,7 +95,7 @@ void foundError(List<String> messages) {
   // Make the error message easy to notice in the logs by
   // wrapping it in a red box.
   final int width = math.max(15, (hasColor ? stdout.terminalColumns : 80) - 1);
-  print('hascolor: $hasColor, isLuci $isLuci');
+  print('hascolor: $hasColor, isLuci $isLuci ╔═╡  --- $red  -- ');
   print('$red╔═╡${bold}ERROR$reset$red╞═${"═" * (width - 9)}');
   for (final String message in messages.expand((String line) => line.split('\n'))) {
     print('$red║$reset $message');

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -95,7 +95,6 @@ void foundError(List<String> messages) {
   // Make the error message easy to notice in the logs by
   // wrapping it in a red box.
   final int width = math.max(15, (hasColor ? stdout.terminalColumns : 80) - 1);
-  print('hascolor: $hasColor, isLuci $isLuci ╔═╡  --- $red  -- ');
   print('$red╔═╡${bold}ERROR$reset$red╞═${"═" * (width - 9)}');
   for (final String message in messages.expand((String line) => line.split('\n'))) {
     print('$red║$reset $message');

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -12,7 +12,8 @@ import 'package:meta/meta.dart';
 
 const Duration _quietTimeout = Duration(minutes: 10); // how long the output should be hidden between calls to printProgress before just being verbose
 
-final bool hasColor = stdout.supportsAnsiEscapes;
+final bool isLuci =  Platform.environment['LUCI_CI'] == 'True';
+final bool hasColor = !isLuci && stdout.supportsAnsiEscapes;
 
 final String bold = hasColor ? '\x1B[1m' : ''; // shard titles
 final String red = hasColor ? '\x1B[31m' : ''; // errors

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -12,11 +12,10 @@ import 'package:meta/meta.dart';
 
 const Duration _quietTimeout = Duration(minutes: 10); // how long the output should be hidden between calls to printProgress before just being verbose
 
-bool hasColor = stdout.supportsAnsiEscapes;
-
-// Override hasColor to false if it is LUCI.
+// If running from LUCI set to False.
 final bool isLuci =  Platform.environment['LUCI_CI'] == 'True';
-hasColor = isLuci ? false : hasColor;
+final bool hasColor = stdout.supportsAnsiEscapes && !isLuci;
+
 
 final String bold = hasColor ? '\x1B[1m' : ''; // shard titles
 final String red = hasColor ? '\x1B[31m' : ''; // errors

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -12,8 +12,11 @@ import 'package:meta/meta.dart';
 
 const Duration _quietTimeout = Duration(minutes: 10); // how long the output should be hidden between calls to printProgress before just being verbose
 
+bool hasColor = stdout.supportsAnsiEscapes;
+
+// Override hasColor to false if it is LUCI.
 final bool isLuci =  Platform.environment['LUCI_CI'] == 'True';
-final bool hasColor = !isLuci && stdout.supportsAnsiEscapes;
+hasColor = isLuci ? false : hasColor;
 
 final String bold = hasColor ? '\x1B[1m' : ''; // shard titles
 final String red = hasColor ? '\x1B[31m' : ''; // errors

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -28,6 +28,7 @@ void main() {
         expect(analyze.allProjectValidators().length, 2);
       }
     }
+    expect('a', 'b');
   }));
 
   testUsingContext('bool? safe argResults', () async {

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/executable.dart' as executable;
@@ -28,6 +30,7 @@ void main() {
         expect(analyze.allProjectValidators().length, 2);
       }
     }
+    expect(Platform.environment['LUCI_CI'], 'azx');
     expect('a', 'b');
   }));
 

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/executable.dart' as executable;
@@ -30,8 +28,6 @@ void main() {
         expect(analyze.allProjectValidators().length, 2);
       }
     }
-    expect(Platform.environment['LUCI_CI'], 'True');
-    expect('a', 'b');
   }));
 
   testUsingContext('bool? safe argResults', () async {

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -30,7 +30,7 @@ void main() {
         expect(analyze.allProjectValidators().length, 2);
       }
     }
-    expect(Platform.environment['LUCI_CI'], 'azx');
+    expect(Platform.environment['LUCI_CI'], 'True');
     expect('a', 'b');
   }));
 


### PR DESCRIPTION
This is to fix the error where non ascii symbols are printed in GitHub's UI.

Bug: https://github.com/flutter/flutter/issues/117099

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
