### PR TITLE
Add `StrokeCap` to `CircularProgressIndicator`

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -567,7 +567,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// Setting [strokeCap] to [StrokeCap.square] with [value] != null will
   /// result in a different display of [value]. The indicator will start
   /// drawing from slightly less than the start, and end slightly after
-  /// the end. the end. This will produce an alternative result, as the
+  /// the end. This will produce an alternative result, as the
   /// default behavior, for example, that a [value] of 0.5 starts at 90 degrees
   /// and ends at 270 degrees. With [StrokeCap.square], it could start 85
   /// degrees and end at 275 degrees.

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -735,7 +735,7 @@ class _RefreshProgressIndicatorPainter extends _CircularProgressIndicatorPainter
       ..lineTo(radius + ux * outerRadius, radius + uy * outerRadius)
       ..lineTo(arrowheadPointX, arrowheadPointY)
       ..close();
-    
+
     final Paint paint = Paint()
       ..color = valueColor
       ..strokeWidth = strokeWidth

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -396,7 +396,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
     required this.offsetValue,
     required this.rotationValue,
     required this.strokeWidth,
-    required this.strokeCap,
+    this.strokeCap,
   }) : arcStart = value != null
          ? _startAngle
          : _startAngle + tailValue * 3 / 2 * math.pi + rotationValue * math.pi * 2.0 + offsetValue * 0.5 * math.pi,
@@ -556,8 +556,9 @@ class CircularProgressIndicator extends ProgressIndicator {
   ///
   /// Determines the appearance of the stroke ends in the progress indicator.
   /// By default, [strokeCap] is null, causing the stroke ends to be set to
-  /// [StrokeCap.square] when [value] is null (indeterminate), and to
-  /// [StrokeCap.butt] when [value] is not null (determinate).
+  /// [StrokeCap.square] when [value] is null (indeterminate progress
+  /// indicator), and to [StrokeCap.butt] when [value] is not null
+  /// (determinate progress indicator).
   ///
   /// Setting [strokeCap] to [StrokeCap.round] results in rounded stroke ends.
   /// With [strokeCap] set to [StrokeCap.butt] and [value] == null, the
@@ -566,10 +567,11 @@ class CircularProgressIndicator extends ProgressIndicator {
   ///
   /// Using [strokeCap] as [StrokeCap.square] when [value] is not null leads to
   /// an unconventional display of [value], starting and ending slightly
-  /// off the expected angles. While not recommended, this behavior can be
-  /// observed with a [value] of 0.5, where the expected start and end angles
-  /// are 90 and 270 degrees, but the indicator may start at 85 degrees and
-  /// end at 275 degrees.
+  /// off the expected angles. This behavior can be observed with a [value]
+  /// of 0.5, where the expected start and end angles are 90 and 270 degrees,
+  /// but the indicator may start at 85 degrees and end at 275 degrees. This
+  /// doesn't match the Material Design specification and should be used with
+  /// caution.
   final StrokeCap? strokeCap;
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -567,10 +567,10 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// Setting [strokeCap] to [StrokeCap.square] with [value] != null will
   /// result in a different display of [value]. The indicator will start
   /// drawing from slightly less than the start, and end slightly after
-  /// the end. This might produce unintended results, as the expected behavior
-  /// is, for example, that a [value] of 0.5 starts at 90 degrees and ends at
-  /// 270 degrees. With [StrokeCap.square], it could start at 85 degrees and
-  /// end at 275 degrees.
+  /// the end. the end. This will produce an alternative result, as the
+  /// default behavior, for example, that a [value] of 0.5 starts at 90 degrees
+  /// and ends at 270 degrees. With [StrokeCap.square], it could start 85
+  /// degrees and end at 275 degrees.
   final StrokeCap? strokeCap;
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -552,24 +552,23 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// The width of the line used to draw the circle.
   final double strokeWidth;
 
-  /// The progress indicator's line ending.
+  /// The shape of the progress indicator's stroke ends.
   ///
-  /// This determines the shape of the stroke ends of the progress indicator.
-  /// By default, [strokeCap] is null.
-  /// When [value] is null (indeterminate), the stroke ends are set to
-  /// [StrokeCap.square]. When [value] is not null, the stroke
-  /// ends are set to [StrokeCap.butt].
+  /// Determines the appearance of the stroke ends in the progress indicator.
+  /// By default, [strokeCap] is null, causing the stroke ends to be set to
+  /// [StrokeCap.square] when [value] is null (indeterminate), and to
+  /// [StrokeCap.butt] when [value] is not null (determinate).
   ///
-  /// Setting [strokeCap] to [StrokeCap.round] will result in a rounded end.
-  /// Setting [strokeCap] to [StrokeCap.butt] with [value] == null will result
-  /// in a slightly different indeterminate animation; the indicator completely
-  /// disappears and reappears on its minimum value.
-  /// Setting [strokeCap] to [StrokeCap.square] with [value] != null will
-  /// result in a different display of [value]. The indicator will start
-  /// drawing from slightly less than the start, and end slightly after
-  /// the end. This is not reccomended, as the expected behavior is, for
-  /// example, that a [value] of 0.5 starts at 90 degrees and ends at 270
-  /// degrees. With [strokeCap.square], it could start at 85 degrees and
+  /// Setting [strokeCap] to [StrokeCap.round] results in rounded stroke ends.
+  /// With [strokeCap] set to [StrokeCap.butt] and [value] == null, the
+  /// indicator exhibits a different indeterminate animation, disappearing
+  /// completely before reappearing at its minimum value.
+  ///
+  /// Using [strokeCap] as [StrokeCap.square] when [value] is not null leads to
+  /// an unconventional display of [value], starting and ending slightly
+  /// off the expected angles. While not recommended, this behavior can be
+  /// observed with a [value] of 0.5, where the expected start and end angles
+  /// are 90 and 270 degrees, but the indicator may start at 85 degrees and
   /// end at 275 degrees.
   final StrokeCap? strokeCap;
 

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -565,13 +565,12 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// indicator exhibits a different indeterminate animation, disappearing
   /// completely before reappearing at its minimum value.
   ///
-  /// Using [strokeCap] as [StrokeCap.square] when [value] is not null leads to
-  /// an unconventional display of [value], starting and ending slightly
-  /// off the expected angles. This behavior can be observed with a [value]
-  /// of 0.5, where the expected start and end angles are 90 and 270 degrees,
-  /// but the indicator may start at 85 degrees and end at 275 degrees. This
-  /// doesn't match the Material Design specification and should be used with
-  /// caution.
+  /// Keep in mind that when [StrokeCap.square] is used with a non-null
+  /// [value], the start and end angles might differ slightly from the expected
+  /// values. For example, with a [value] of 0.5, you might anticipate the
+  /// angles to be 90 and 270 degrees. However, the indicator may start at 85
+  /// degrees and end at 275 degrees. This deviation does not adhere to the
+  /// Material Design guidelines, so consider using it thoughtfully.
   final StrokeCap? strokeCap;
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -735,18 +735,10 @@ class _RefreshProgressIndicatorPainter extends _CircularProgressIndicatorPainter
       ..lineTo(radius + ux * outerRadius, radius + uy * outerRadius)
       ..lineTo(arrowheadPointX, arrowheadPointY)
       ..close();
-
-    final StrokeCap internalStrokeCap;
-    if (strokeCap == null) {
-      internalStrokeCap = StrokeCap.butt;
-    } else {
-      internalStrokeCap = strokeCap!;
-    }
     
     final Paint paint = Paint()
       ..color = valueColor
       ..strokeWidth = strokeWidth
-      ..strokeCap = internalStrokeCap
       ..style = PaintingStyle.fill;
     canvas.drawPath(path, paint);
   }

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -569,7 +569,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// drawing from slightly less than the start, and end slightly after
   /// the end. This might produce unintended results, as the expected behavior
   /// is, for example, that a [value] of 0.5 starts at 90 degrees and ends at
-  /// 270 degrees. With [strokeCap.square], it could start at 85 degrees and
+  /// 270 degrees. With [StrokeCap.square], it could start at 85 degrees and
   /// end at 275 degrees.
   final StrokeCap? strokeCap;
 

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -552,25 +552,25 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// The width of the line used to draw the circle.
   final double strokeWidth;
 
-  /// The shape of the progress indicator's stroke ends.
+  /// The progress indicator's line ending.
   ///
-  /// Determines the appearance of the stroke ends in the progress indicator.
-  /// By default, [strokeCap] is null, causing the stroke ends to be set to
-  /// [StrokeCap.square] when [value] is null (indeterminate progress
-  /// indicator), and to [StrokeCap.butt] when [value] is not null
-  /// (determinate progress indicator).
+  /// This determines the shape of the stroke ends of the progress indicator.
+  /// By default, [strokeCap] is null.
+  /// When [value] is null (indeterminate), the stroke ends are set to
+  /// [StrokeCap.square]. When [value] is not null, the stroke
+  /// ends are set to [StrokeCap.butt].
   ///
-  /// Setting [strokeCap] to [StrokeCap.round] results in rounded stroke ends.
-  /// With [strokeCap] set to [StrokeCap.butt] and [value] == null, the
-  /// indicator exhibits a different indeterminate animation, disappearing
-  /// completely before reappearing at its minimum value.
-  ///
-  /// It should be noted that when [StrokeCap.square] is used with a non-null
-  /// [value], the start and end angles might differ slightly from the expected
-  /// values. For example, with a [value] of 0.5, one might anticipate the
-  /// angles to be 90 and 270 degrees. However, the indicator may start at 85
-  /// degrees and end at 275 degrees. This deviation does not adhere to the
-  /// Material Design guidelines, so consider using it thoughtfully.
+  /// Setting [strokeCap] to [StrokeCap.round] will result in a rounded end.
+  /// Setting [strokeCap] to [StrokeCap.butt] with [value] == null will result
+  /// in a slightly different indeterminate animation; the indicator completely
+  /// disappears and reappears on its minimum value.
+  /// Setting [strokeCap] to [StrokeCap.square] with [value] != null will
+  /// result in a different display of [value]. The indicator will start
+  /// drawing from slightly less than the start, and end slightly after
+  /// the end. This might produce unintended results, as the expected behavior
+  /// is, for example, that a [value] of 0.5 starts at 90 degrees and ends at
+  /// 270 degrees. With [strokeCap.square], it could start at 85 degrees and
+  /// end at 275 degrees.
   final StrokeCap? strokeCap;
 
   @override

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -49,6 +49,7 @@ abstract class ProgressIndicator extends StatefulWidget {
     this.valueColor,
     this.semanticsLabel,
     this.semanticsValue,
+    this.strokeCap = StrokeCap.square,
   });
 
   /// If non-null, the value of this progress indicator.
@@ -107,6 +108,11 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// become '10%'.
   /// {@endtemplate}
   final String? semanticsValue;
+
+  /// The Progress Indicator's line endings
+  ///
+  /// Defaults to [StrokeCap.square]
+  final StrokeCap strokeCap;
 
   Color _getValueColor(BuildContext context, {Color? defaultColor}) {
     return valueColor?.value ??
@@ -396,6 +402,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
     required this.offsetValue,
     required this.rotationValue,
     required this.strokeWidth,
+    required this.strokeCap,
   }) : arcStart = value != null
          ? _startAngle
          : _startAngle + tailValue * 3 / 2 * math.pi + rotationValue * math.pi * 2.0 + offsetValue * 0.5 * math.pi,
@@ -413,6 +420,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
   final double strokeWidth;
   final double arcStart;
   final double arcSweep;
+  final StrokeCap strokeCap;
 
   static const double _twoPi = math.pi * 2.0;
   static const double _epsilon = .001;
@@ -434,9 +442,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
       canvas.drawArc(Offset.zero & size, 0, _sweep, false, backgroundPaint);
     }
 
-    if (value == null) { // Indeterminate
-      paint.strokeCap = StrokeCap.square;
-    }
+    paint.strokeCap = strokeCap;
 
     canvas.drawArc(Offset.zero & size, arcStart, arcSweep, false, paint);
   }
@@ -507,6 +513,7 @@ class CircularProgressIndicator extends ProgressIndicator {
     this.strokeWidth = 4.0,
     super.semanticsLabel,
     super.semanticsValue,
+    super.strokeCap,
   }) : _indicatorType = _ActivityIndicatorType.material;
 
   /// Creates an adaptive progress indicator that is a
@@ -525,6 +532,7 @@ class CircularProgressIndicator extends ProgressIndicator {
     this.strokeWidth = 4.0,
     super.semanticsLabel,
     super.semanticsValue,
+    super.strokeCap,
   }) : _indicatorType = _ActivityIndicatorType.adaptive;
 
   final _ActivityIndicatorType _indicatorType;
@@ -621,6 +629,7 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> w
             offsetValue: offsetValue,
             rotationValue: rotationValue,
             strokeWidth: widget.strokeWidth,
+            strokeCap: widget.strokeCap,
           ),
         ),
       ),
@@ -679,6 +688,7 @@ class _RefreshProgressIndicatorPainter extends _CircularProgressIndicatorPainter
     required super.rotationValue,
     required super.strokeWidth,
     required this.arrowheadScale,
+    required super.strokeCap,
   });
 
   final double arrowheadScale;
@@ -748,6 +758,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
     super.strokeWidth = defaultStrokeWidth, // Different default than CircularProgressIndicator.
     super.semanticsLabel,
     super.semanticsValue,
+    super.strokeCap,
   });
 
   /// Default stroke width.
@@ -877,6 +888,7 @@ class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {
                     rotationValue: rotationValue,
                     strokeWidth: widget.strokeWidth,
                     arrowheadScale: arrowheadScale,
+                    strokeCap: widget.strokeCap,
                   ),
                 ),
               ),

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -565,9 +565,9 @@ class CircularProgressIndicator extends ProgressIndicator {
   /// indicator exhibits a different indeterminate animation, disappearing
   /// completely before reappearing at its minimum value.
   ///
-  /// Keep in mind that when [StrokeCap.square] is used with a non-null
+  /// It should be noted that when [StrokeCap.square] is used with a non-null
   /// [value], the start and end angles might differ slightly from the expected
-  /// values. For example, with a [value] of 0.5, you might anticipate the
+  /// values. For example, with a [value] of 0.5, one might anticipate the
   /// angles to be 90 and 270 degrees. However, the indicator may start at 85
   /// degrees and end at 275 degrees. This deviation does not adhere to the
   /// Material Design guidelines, so consider using it thoughtfully.

--- a/packages/flutter/lib/src/material/progress_indicator_theme.dart
+++ b/packages/flutter/lib/src/material/progress_indicator_theme.dart
@@ -35,6 +35,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     this.linearMinHeight,
     this.circularTrackColor,
     this.refreshBackgroundColor,
+    this.preferRoundIndicator,
   });
 
   /// The color of the [ProgressIndicator]'s indicator.
@@ -62,6 +63,9 @@ class ProgressIndicatorThemeData with Diagnosticable {
   /// {@macro flutter.material.RefreshProgressIndicator.backgroundColor}
   final Color? refreshBackgroundColor;
 
+  /// {@macro flutter.material.ProgressIndicator.preferRoundIndicator}
+  final bool? preferRoundIndicator;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   ProgressIndicatorThemeData copyWith({
@@ -70,6 +74,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     double? linearMinHeight,
     Color? circularTrackColor,
     Color? refreshBackgroundColor,
+    bool? preferRoundIndicator,
   }) {
     return ProgressIndicatorThemeData(
       color: color ?? this.color,
@@ -77,6 +82,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
       linearMinHeight : linearMinHeight ?? this.linearMinHeight,
       circularTrackColor : circularTrackColor ?? this.circularTrackColor,
       refreshBackgroundColor : refreshBackgroundColor ?? this.refreshBackgroundColor,
+      preferRoundIndicator: preferRoundIndicator ?? this.preferRoundIndicator,
     );
   }
 
@@ -93,6 +99,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
       linearMinHeight : lerpDouble(a?.linearMinHeight, b?.linearMinHeight, t),
       circularTrackColor : Color.lerp(a?.circularTrackColor, b?.circularTrackColor, t),
       refreshBackgroundColor : Color.lerp(a?.refreshBackgroundColor, b?.refreshBackgroundColor, t),
+      preferRoundIndicator: t < 0.5 ? a?.preferRoundIndicator : b?.preferRoundIndicator,
     );
   }
 
@@ -103,6 +110,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     linearMinHeight,
     circularTrackColor,
     refreshBackgroundColor,
+    preferRoundIndicator,
   );
 
   @override
@@ -118,7 +126,8 @@ class ProgressIndicatorThemeData with Diagnosticable {
       && other.linearTrackColor == linearTrackColor
       && other.linearMinHeight == linearMinHeight
       && other.circularTrackColor == circularTrackColor
-      && other.refreshBackgroundColor == refreshBackgroundColor;
+      && other.refreshBackgroundColor == refreshBackgroundColor
+      && other.preferRoundIndicator == preferRoundIndicator;
   }
 
   @override
@@ -129,6 +138,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
     properties.add(DoubleProperty('linearMinHeight', linearMinHeight, defaultValue: null));
     properties.add(ColorProperty('circularTrackColor', circularTrackColor, defaultValue: null));
     properties.add(ColorProperty('refreshBackgroundColor', refreshBackgroundColor, defaultValue: null));
+    properties.add(FlagProperty('preferRoundIndicator', value: preferRoundIndicator, ifTrue: 'has round stroke', defaultValue: false));
   }
 }
 

--- a/packages/flutter/lib/src/material/progress_indicator_theme.dart
+++ b/packages/flutter/lib/src/material/progress_indicator_theme.dart
@@ -35,7 +35,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
     this.linearMinHeight,
     this.circularTrackColor,
     this.refreshBackgroundColor,
-    this.preferRoundIndicator,
   });
 
   /// The color of the [ProgressIndicator]'s indicator.
@@ -63,9 +62,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
   /// {@macro flutter.material.RefreshProgressIndicator.backgroundColor}
   final Color? refreshBackgroundColor;
 
-  /// {@macro flutter.material.ProgressIndicator.preferRoundIndicator}
-  final bool? preferRoundIndicator;
-
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   ProgressIndicatorThemeData copyWith({
@@ -74,7 +70,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
     double? linearMinHeight,
     Color? circularTrackColor,
     Color? refreshBackgroundColor,
-    bool? preferRoundIndicator,
   }) {
     return ProgressIndicatorThemeData(
       color: color ?? this.color,
@@ -82,7 +77,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
       linearMinHeight : linearMinHeight ?? this.linearMinHeight,
       circularTrackColor : circularTrackColor ?? this.circularTrackColor,
       refreshBackgroundColor : refreshBackgroundColor ?? this.refreshBackgroundColor,
-      preferRoundIndicator: preferRoundIndicator ?? this.preferRoundIndicator,
     );
   }
 
@@ -99,7 +93,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
       linearMinHeight : lerpDouble(a?.linearMinHeight, b?.linearMinHeight, t),
       circularTrackColor : Color.lerp(a?.circularTrackColor, b?.circularTrackColor, t),
       refreshBackgroundColor : Color.lerp(a?.refreshBackgroundColor, b?.refreshBackgroundColor, t),
-      preferRoundIndicator: t < 0.5 ? a?.preferRoundIndicator : b?.preferRoundIndicator,
     );
   }
 
@@ -110,7 +103,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
     linearMinHeight,
     circularTrackColor,
     refreshBackgroundColor,
-    preferRoundIndicator,
   );
 
   @override
@@ -126,8 +118,7 @@ class ProgressIndicatorThemeData with Diagnosticable {
       && other.linearTrackColor == linearTrackColor
       && other.linearMinHeight == linearMinHeight
       && other.circularTrackColor == circularTrackColor
-      && other.refreshBackgroundColor == refreshBackgroundColor
-      && other.preferRoundIndicator == preferRoundIndicator;
+      && other.refreshBackgroundColor == refreshBackgroundColor;
   }
 
   @override
@@ -138,7 +129,6 @@ class ProgressIndicatorThemeData with Diagnosticable {
     properties.add(DoubleProperty('linearMinHeight', linearMinHeight, defaultValue: null));
     properties.add(ColorProperty('circularTrackColor', circularTrackColor, defaultValue: null));
     properties.add(ColorProperty('refreshBackgroundColor', refreshBackgroundColor, defaultValue: null));
-    properties.add(FlagProperty('preferRoundIndicator', value: preferRoundIndicator, ifTrue: 'has round stroke', defaultValue: false));
   }
 }
 

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -447,7 +447,7 @@ void main() {
     await tester.pumpWidget(const CircularProgressIndicator());
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
-    await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: true));
+    await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.round));
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 
@@ -613,7 +613,7 @@ void main() {
     await tester.pumpWidget(const RefreshProgressIndicator());
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
-    await tester.pumpWidget(const RefreshProgressIndicator(preferRoundIndicator: true));
+    await tester.pumpWidget(const RefreshProgressIndicator(strokeCap: StrokeCap.round));
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -443,36 +443,44 @@ void main() {
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 16.0));
   });
 
-  testWidgets('CircularProgressIndicator stroke cap', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator with a round indicator', (WidgetTester tester) async {
     await tester.pumpWidget(const CircularProgressIndicator());
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
-    await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: false));
-    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
-
     await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: true));
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
+  });
 
-    // With ProgressIndicatorTheme
-    await tester.pumpWidget(Theme(
-      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
-        preferRoundIndicator: true,
-      )),
-      child: const CircularProgressIndicator(),
-    ));
-    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
-
-    // With ProgressIndicatorTheme, CircularProgressIndicator takes precedence.
-    await tester.pumpWidget(Theme(
-      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
-        preferRoundIndicator: false,
-      )),
-      child: const CircularProgressIndicator(preferRoundIndicator: true),
-    ));
-    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
-
-    await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: true));
-    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
+  testWidgets('LinearProgressIndicator with indicatorBorderRadius', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Theme(
+        data: theme,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 100.0,
+              height: 4.0,
+              child: LinearProgressIndicator(
+                value: 0.25,
+                indicatorBorderRadius: BorderRadius.all(Radius.circular(10)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(
+        find.byType(LinearProgressIndicator),
+        paints
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(0.0, 0.0, 25.0, 4.0,
+            topRight: const Radius.circular(10.0),
+            bottomRight: const Radius.circular(10.0),
+          ),
+        ),
+    );
+    expect(tester.binding.transientCallbackCount, 0);
   });
 
   testWidgets('CircularProgressIndicator paint colors', (WidgetTester tester) async {
@@ -601,30 +609,9 @@ void main() {
     expect(themeBackgroundMaterial.color, blue);
   });
 
-  testWidgets('RefreshProgressIndicator stroke cap', (WidgetTester tester) async {
+  testWidgets('RefreshProgressIndicator with a round indicator', (WidgetTester tester) async {
     await tester.pumpWidget(const RefreshProgressIndicator());
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
-
-    await tester.pumpWidget(const RefreshProgressIndicator(preferRoundIndicator: false));
-    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
-
-    // With ProgressIndicatorTheme
-    await tester.pumpWidget(Theme(
-      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
-        preferRoundIndicator: true,
-      )),
-      child: const RefreshProgressIndicator(),
-    ));
-    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
-
-    // With ProgressIndicatorTheme, RefreshProgressIndicator takes precedence.
-    await tester.pumpWidget(Theme(
-      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
-        preferRoundIndicator: false,
-      )),
-      child: const RefreshProgressIndicator(preferRoundIndicator: true),
-    ));
-    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
 
     await tester.pumpWidget(const RefreshProgressIndicator(preferRoundIndicator: true));
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -451,38 +451,6 @@ void main() {
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 
-  testWidgets('LinearProgressIndicator with indicatorBorderRadius', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: const Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox(
-              width: 100.0,
-              height: 4.0,
-              child: LinearProgressIndicator(
-                value: 0.25,
-                indicatorBorderRadius: BorderRadius.all(Radius.circular(10)),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(
-        find.byType(LinearProgressIndicator),
-        paints
-        ..rrect(
-          rrect: RRect.fromLTRBAndCorners(0.0, 0.0, 25.0, 4.0,
-            topRight: const Radius.circular(10.0),
-            bottomRight: const Radius.circular(10.0),
-          ),
-        ),
-    );
-    expect(tester.binding.transientCallbackCount, 0);
-  });
-
   testWidgets('CircularProgressIndicator paint colors', (WidgetTester tester) async {
     const Color green = Color(0xFF00FF00);
     const Color blue = Color(0xFF0000FF);

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -443,9 +443,23 @@ void main() {
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 16.0));
   });
 
-  testWidgets('CircularProgressIndicator with a round indicator', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator with strokeCap', (WidgetTester tester) async {
     await tester.pumpWidget(const CircularProgressIndicator());
-    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
+    expect(find.byType(CircularProgressIndicator),
+        paints..arc(strokeCap: StrokeCap.square),
+        reason: 'Default indeterminate strokeCap is StrokeCap.square.');
+
+    await tester.pumpWidget(const Directionality(
+        textDirection: TextDirection.ltr,
+        child: CircularProgressIndicator(value: 0.5)));
+    expect(find.byType(CircularProgressIndicator),
+        paints..arc(strokeCap: StrokeCap.butt),
+        reason: 'Default determinate strokeCap is StrokeCap.butt.');
+
+    await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.butt));
+    expect(find.byType(CircularProgressIndicator),
+        paints..arc(strokeCap: StrokeCap.butt),
+        reason: 'strokeCap can be set to StrokeCap.butt, and will not be overidden.');
 
     await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.round));
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
@@ -579,9 +593,24 @@ void main() {
 
   testWidgets('RefreshProgressIndicator with a round indicator', (WidgetTester tester) async {
     await tester.pumpWidget(const RefreshProgressIndicator());
-    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
+    expect(find.byType(RefreshProgressIndicator),
+        paints..arc(strokeCap: StrokeCap.square),
+        reason: 'Default indeterminate strokeCap is StrokeCap.square');
 
-    await tester.pumpWidget(const RefreshProgressIndicator(strokeCap: StrokeCap.round));
+    await tester.pumpWidget(
+      Theme(
+        data: theme,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 200.0,
+              child: RefreshProgressIndicator(strokeCap: StrokeCap.round),
+            ),
+          ),
+        ),
+      ),
+    );
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -434,7 +434,7 @@ void main() {
   });
 
   testWidgets('CircularProgressIndicator stroke width', (WidgetTester tester) async {
-    await tester.pumpWidget(const CircularProgressIndicator());
+    await tester.pumpWidget(Theme(data: theme, child: const CircularProgressIndicator()));
 
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 4.0));
 
@@ -445,16 +445,34 @@ void main() {
 
   testWidgets('CircularProgressIndicator stroke cap', (WidgetTester tester) async {
     await tester.pumpWidget(const CircularProgressIndicator());
-
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
-    await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.round,));
+    await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: false));
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
+    await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: true));
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
 
-    await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.butt,));
+    // With ProgressIndicatorTheme
+    await tester.pumpWidget(Theme(
+      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
+        preferRoundIndicator: true,
+      )),
+      child: const CircularProgressIndicator(),
+    ));
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
 
-    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.butt));
+    // With ProgressIndicatorTheme, CircularProgressIndicator takes precedence.
+    await tester.pumpWidget(Theme(
+      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
+        preferRoundIndicator: false,
+      )),
+      child: const CircularProgressIndicator(preferRoundIndicator: true),
+    ));
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
+
+    await tester.pumpWidget(const CircularProgressIndicator(preferRoundIndicator: true));
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 
   testWidgets('CircularProgressIndicator paint colors', (WidgetTester tester) async {
@@ -585,16 +603,31 @@ void main() {
 
   testWidgets('RefreshProgressIndicator stroke cap', (WidgetTester tester) async {
     await tester.pumpWidget(const RefreshProgressIndicator());
-
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
-    await tester.pumpWidget(const RefreshProgressIndicator(strokeCap: StrokeCap.round,));
+    await tester.pumpWidget(const RefreshProgressIndicator(preferRoundIndicator: false));
+    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
 
+    // With ProgressIndicatorTheme
+    await tester.pumpWidget(Theme(
+      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
+        preferRoundIndicator: true,
+      )),
+      child: const RefreshProgressIndicator(),
+    ));
     expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
 
-    await tester.pumpWidget(const RefreshProgressIndicator(strokeCap: StrokeCap.butt,));
+    // With ProgressIndicatorTheme, RefreshProgressIndicator takes precedence.
+    await tester.pumpWidget(Theme(
+      data: theme.copyWith(progressIndicatorTheme: const ProgressIndicatorThemeData(
+        preferRoundIndicator: false,
+      )),
+      child: const RefreshProgressIndicator(preferRoundIndicator: true),
+    ));
+    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
 
-    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.butt));
+    await tester.pumpWidget(const RefreshProgressIndicator(preferRoundIndicator: true));
+    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 
   testWidgets('Indeterminate RefreshProgressIndicator keeps spinning until end of time (approximate)', (WidgetTester tester) async {

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -433,14 +433,28 @@ void main() {
     expect(layers1, isNot(equals(layers2)));
   });
 
-  testWidgets('CircularProgressIndicator stoke width', (WidgetTester tester) async {
-    await tester.pumpWidget(Theme(data: theme, child: const CircularProgressIndicator()));
+  testWidgets('CircularProgressIndicator stroke width', (WidgetTester tester) async {
+    await tester.pumpWidget(const CircularProgressIndicator());
 
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 4.0));
 
     await tester.pumpWidget(Theme(data: theme, child: const CircularProgressIndicator(strokeWidth: 16.0)));
 
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 16.0));
+  });
+
+  testWidgets('CircularProgressIndicator stroke cap', (WidgetTester tester) async {
+    await tester.pumpWidget(const CircularProgressIndicator());
+
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
+
+    await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.round,));
+
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
+
+    await tester.pumpWidget(const CircularProgressIndicator(strokeCap: StrokeCap.butt,));
+
+    expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.butt));
   });
 
   testWidgets('CircularProgressIndicator paint colors', (WidgetTester tester) async {
@@ -567,6 +581,20 @@ void main() {
     ));
     expect(themeBackgroundMaterial.type, MaterialType.circle);
     expect(themeBackgroundMaterial.color, blue);
+  });
+
+  testWidgets('RefreshProgressIndicator stroke cap', (WidgetTester tester) async {
+    await tester.pumpWidget(const RefreshProgressIndicator());
+
+    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.square));
+
+    await tester.pumpWidget(const RefreshProgressIndicator(strokeCap: StrokeCap.round,));
+
+    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
+
+    await tester.pumpWidget(const RefreshProgressIndicator(strokeCap: StrokeCap.butt,));
+
+    expect(find.byType(RefreshProgressIndicator), paints..arc(strokeCap: StrokeCap.butt));
   });
 
   testWidgets('Indeterminate RefreshProgressIndicator keeps spinning until end of time (approximate)', (WidgetTester tester) async {

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -318,7 +318,7 @@ abstract class PaintPattern {
   /// painting has completed, not at the time of the call. If the same [Paint]
   /// object is reused multiple times, then this may not match the actual
   /// arguments as they were seen by the method.
-  void arc({ Color? color, double? strokeWidth, bool? hasMaskFilter, PaintingStyle? style });
+  void arc({ Color? color, double? strokeWidth, bool? hasMaskFilter, PaintingStyle? style, StrokeCap? strokeCap });
 
   /// Indicates that a paragraph is expected next.
   ///
@@ -769,8 +769,8 @@ class _TestRecordingCanvasPatternMatcher extends _TestRecordingCanvasMatcher imp
   }
 
   @override
-  void arc({ Color? color, double? strokeWidth, bool? hasMaskFilter, PaintingStyle? style }) {
-    _predicates.add(_ArcPaintPredicate(color: color, strokeWidth: strokeWidth, hasMaskFilter: hasMaskFilter, style: style));
+  void arc({ Color? color, double? strokeWidth, bool? hasMaskFilter, PaintingStyle? style, StrokeCap? strokeCap }) {
+    _predicates.add(_ArcPaintPredicate(color: color, strokeWidth: strokeWidth, hasMaskFilter: hasMaskFilter, style: style, strokeCap: strokeCap));
   }
 
   @override
@@ -892,6 +892,7 @@ abstract class _DrawCommandPaintPredicate extends _PaintPredicate {
     this.hasMaskFilter,
     this.style,
     this.shader,
+    this.strokeCap,
   });
 
   final Symbol symbol;
@@ -903,6 +904,7 @@ abstract class _DrawCommandPaintPredicate extends _PaintPredicate {
   final bool? hasMaskFilter;
   final PaintingStyle? style;
   final Matcher? shader;
+  final StrokeCap? strokeCap;
 
   String get methodName => _symbolName(symbol);
 
@@ -939,6 +941,9 @@ abstract class _DrawCommandPaintPredicate extends _PaintPredicate {
     }
     if (shader != null && !shader!.matches(paintArgument.shader, <dynamic, dynamic>{})) {
       throw 'It called $methodName with a paint whose shader, ${paintArgument.shader}, was not exactly the expected shader ($shader).';
+    }
+    if(strokeCap != null && paintArgument.strokeCap != strokeCap) {
+      throw 'It called $methodName with a paint whose strokeCap, ${paintArgument.strokeCap}, was not exactly the expected strokeCap ($strokeCap).';
     }
   }
 
@@ -1276,8 +1281,8 @@ class _LinePaintPredicate extends _DrawCommandPaintPredicate {
 }
 
 class _ArcPaintPredicate extends _DrawCommandPaintPredicate {
-  _ArcPaintPredicate({ Color? color, double? strokeWidth, bool? hasMaskFilter, PaintingStyle? style }) : super(
-    #drawArc, 'an arc', 5, 4, color: color, strokeWidth: strokeWidth, hasMaskFilter: hasMaskFilter, style: style,
+  _ArcPaintPredicate({ Color? color, double? strokeWidth, bool? hasMaskFilter, PaintingStyle? style, StrokeCap? strokeCap }) : super(
+    #drawArc, 'an arc', 5, 4, color: color, strokeWidth: strokeWidth, hasMaskFilter: hasMaskFilter, style: style, strokeCap: strokeCap,
   );
 }
 

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -942,7 +942,7 @@ abstract class _DrawCommandPaintPredicate extends _PaintPredicate {
     if (shader != null && !shader!.matches(paintArgument.shader, <dynamic, dynamic>{})) {
       throw 'It called $methodName with a paint whose shader, ${paintArgument.shader}, was not exactly the expected shader ($shader).';
     }
-    if(strokeCap != null && paintArgument.strokeCap != strokeCap) {
+    if (strokeCap != null && paintArgument.strokeCap != strokeCap) {
       throw 'It called $methodName with a paint whose strokeCap, ${paintArgument.strokeCap}, was not exactly the expected strokeCap ($strokeCap).';
     }
   }


### PR DESCRIPTION
Sequel to https://github.com/flutter/flutter/pull/109111
Fix https://github.com/flutter/flutter/issues/109137

![image](https://user-images.githubusercontent.com/351125/225201457-716f7263-cbb1-4d22-95ba-63a254dbc95a.png)

~I can make `LinearProgressIndicator` accept BorderRadius (instead of round/square), but I can't (and no one can) make `CircularProgressIndicator` work with that. You would need someone from Dart/Skia team that is good at math to make drawArc more flexible.~

~So I used strokeCap everywhere, even though borderRadius (`LinearProgressIndicator`) + strokeCap (`CircularProgressIndicator`) would be better IMO. In a future PR I think I could add borderRadius to the "background" of the LinearProgressIndicator, so a borderRadius to the foreground could make a lot of sense. But I think people would be happy already with the round option. What do you think? Option 1 or 2?~

Disclaimer: I don't think StrokeCap works that well for what we are doing. It has 3 options, butt, square and round, but 99% of the time you want two of them, and you never know which two you want. `CircularProgressIndicator` uses square for indeterminate (paints a bit more, so it is always visible, even on 0), butt for determinate (paints exactly). `CircularProgressIndicator` doesn't use it.

Something like `isIndicatorRound` would be better, since all we want is true/false. Do you agree?

```dart
CircularProgressIndicator(
  strokeCap: StrokeCap.round,
),
// Option 1. This PR.
LinearProgressIndicator(
  strokeCap: StrokeCap.round,
),
```
or
```dart
// Option 2. Different proposal. LinearProgressIndicator only.
LinearProgressIndicator(
  backgroundRadius: BorderRadius.circular(8),
  indicatorRadius: BorderRadius.circular(8),
),
```

cc @Piinks