### PR TITLE
Fix MenuAnchor closes on internal scroll

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -463,10 +463,10 @@ class _MenuAnchorState extends State<MenuAnchor> {
   }
 
   void _handleScroll() {
-    // If an ancestor scrolls, and we're a top level or root anchor, then close
-    // the menus. Don't just close it on *any* scroll, since we want to be able
-    // to scroll menus themselves if they're too big for the view.
-    if (_isTopLevel || _isRoot) {
+    // If an ancestor scrolls, and we're a root anchor, then close the menus.
+    // Don't just close it on *any* scroll, since we want to be able to scroll
+    // menus themselves if they're too big for the view.
+    if (_isRoot) {
       _root._close();
     }
   }


### PR DESCRIPTION
## Description

This PR modifies `_MenuAnchorState._handleScroll` logic.
Before this PR, if the root menu was scrollable and a scroll event is emitted, top level menus will react to this scroll event and close the root menu.
After this PR, only the root menu reacts to external scroll events and closes itself.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/122168

## Tests

Adds 1 test.
