### PR TITLE
replace some ._() constructors with class modifiers

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -42,7 +42,7 @@ linter:
     - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # blocked on https://github.com/dart-lang/linter/issues/3023
     # - avoid_catching_errors # blocked on https://github.com/dart-lang/linter/issues/3023
-    - avoid_classes_with_only_static_members
+    # avoid_classes_with_only_static_members # # we do this commonly for `abstract final class`es
     - avoid_double_and_int_checks
     - avoid_dynamic_calls
     - avoid_empty_else

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
@@ -116,9 +116,7 @@ class BenchMouseRegionGridHover extends WidgetRecorder {
   }
 }
 
-class _UntilNextFrame {
-  _UntilNextFrame._();
-
+abstract final class _UntilNextFrame {
   static Completer<void>? _completer;
 
   static Future<void> wait() {

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_scroll.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_scroll.dart
@@ -88,9 +88,7 @@ class BenchMouseRegionGridScroll extends WidgetRecorder {
   }
 }
 
-class _UntilNextFrame {
-  _UntilNextFrame._();
-
+abstract final class _UntilNextFrame {
   static Completer<void>? _completer;
 
   static Future<void> wait() {

--- a/dev/integration_tests/flutter_gallery/lib/gallery/icons.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/icons.dart
@@ -4,11 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-class GalleryIcons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  GalleryIcons._();
-
+abstract final class GalleryIcons {
   static const IconData tooltip = IconData(0xe900, fontFamily: 'GalleryIcons');
   static const IconData text_fields_alt = IconData(0xe901, fontFamily: 'GalleryIcons');
   static const IconData tabs = IconData(0xe902, fontFamily: 'GalleryIcons');

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -1353,11 +1353,7 @@ class ElasticInOutCurve extends Curve {
 ///
 ///  * [Curve], the interface implemented by the constants available from the
 ///    [Curves] class.
-class Curves {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Curves._();
-
+abstract final class Curves {
   /// A linear animation curve.
   ///
   /// This is the identity map over the unit interval: its [Curve.transform]

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -37,11 +37,7 @@ import 'theme.dart';
 /// ### Background Colors
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/cupertino/cupertino_background_colors.png)
 ///
-class CupertinoColors {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  CupertinoColors._();
-
+abstract final class CupertinoColors {
   /// iOS 13's default blue color. Used to indicate active elements such as
   /// buttons, selected tabs and your own chat bubbles.
   ///

--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -60,11 +60,7 @@ import 'package:flutter/widgets.dart';
 ///
 ///  * [Icon], used to show these icons.
 @staticIconProvider
-class CupertinoIcons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  CupertinoIcons._();
-
+abstract final class CupertinoIcons {
   /// The icon font used for Cupertino icons.
   static const String iconFont = 'CupertinoIcons';
 

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -282,11 +282,7 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
 ///    uses this API to select licenses to show.
 ///  * [AboutListTile], which is a widget that can be added to a [Drawer]. When
 ///    tapped it calls [showAboutDialog].
-class LicenseRegistry {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  LicenseRegistry._();
-
+abstract final class LicenseRegistry {
   static List<LicenseEntryCollector>? _collectors;
 
   /// Adds licenses to the registry.

--- a/packages/flutter/lib/src/foundation/unicode.dart
+++ b/packages/flutter/lib/src/foundation/unicode.dart
@@ -10,10 +10,7 @@
 ///
 ///  * <http://unicode.org/reports/tr9/>, which describes the Unicode
 ///    bidirectional text algorithm.
-class Unicode {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Unicode._();
+abstract final class Unicode {
   /// `U+202A LEFT-TO-RIGHT EMBEDDING`
   ///
   /// Treat the following text as embedded left-to-right.

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -37,11 +37,7 @@ int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
 /// This takes [PointerDataPacket] objects, as received from the engine via
 /// [dart:ui.PlatformDispatcher.onPointerDataPacket], and converts them to
 /// [PointerEvent] objects.
-class PointerEventConverter {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  PointerEventConverter._();
-
+abstract final class PointerEventConverter {
   /// Expand the given packet of pointer data into a sequence of framework
   /// pointer events.
   ///

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -15,11 +15,7 @@ export 'package:vector_math/vector_math_64.dart' show Matrix4;
 export 'events.dart' show PointerEvent;
 
 /// An object that can hit-test pointers.
-abstract class HitTestable {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  HitTestable._();
-
+abstract interface class HitTestable {
   /// Check whether the given position hits this object.
   ///
   /// If this given position hits this object, consider adding a [HitTestEntry]
@@ -28,21 +24,13 @@ abstract class HitTestable {
 }
 
 /// An object that can dispatch events.
-abstract class HitTestDispatcher {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  HitTestDispatcher._();
-
+abstract interface class HitTestDispatcher {
   /// Override this method to dispatch events.
   void dispatchEvent(PointerEvent event, HitTestResult result);
 }
 
 /// An object that can handle events.
-abstract class HitTestTarget {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  HitTestTarget._();
-
+abstract interface class HitTestTarget {
   /// Override this method to receive events.
   void handleEvent(PointerEvent event, HitTestEntry<HitTestTarget> entry);
 }

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons_data.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons_data.dart
@@ -24,11 +24,7 @@ part of material_animated_icons; // ignore: use_string_in_part_of_directives
 /// See also:
 ///
 ///  * [Icons], for the list of available static Material Icons.
-abstract class AnimatedIcons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  AnimatedIcons._();
-
+abstract final class AnimatedIcons {
   /// The Material Design add to event icon animation.
   ///
   /// {@animation 72 72 https://flutter.github.io/assets-for-api-docs/assets/widgets/add_event.mp4}

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -62,11 +62,7 @@ const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * [ActionChip], represents an action related to primary content.
 ///  * <https://material.io/design/components/chips.html>
-abstract class ChipAttributes {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  ChipAttributes._();
-
+abstract interface class ChipAttributes {
   /// The primary content of the chip.
   ///
   /// Typically a [Text] widget.
@@ -214,11 +210,7 @@ abstract class ChipAttributes {
 ///    as an entity (person, place, or thing) or conversational text, in a
 ///    compact form.
 ///  * <https://material.io/design/components/chips.html>
-abstract class DeletableChipAttributes {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  DeletableChipAttributes._();
-
+abstract interface class DeletableChipAttributes {
   /// The icon displayed when [onDeleted] is set.
   ///
   /// Defaults to an [Icon] widget set to use [Icons.cancel].
@@ -284,11 +276,7 @@ abstract class DeletableChipAttributes {
 ///    compact form.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * <https://material.io/design/components/chips.html>
-abstract class CheckmarkableChipAttributes {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  CheckmarkableChipAttributes._();
-
+abstract interface class CheckmarkableChipAttributes {
   /// Whether or not to show a check mark when
   /// [SelectableChipAttributes.selected] is true.
   ///
@@ -319,11 +307,7 @@ abstract class CheckmarkableChipAttributes {
 ///    chips contain related descriptive text or categories.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * <https://material.io/design/components/chips.html>
-abstract class SelectableChipAttributes {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  SelectableChipAttributes._();
-
+abstract interface class SelectableChipAttributes {
   /// Whether or not this chip is selected.
   ///
   /// If [onSelected] is not null, this value will be used to determine if the
@@ -429,11 +413,7 @@ abstract class SelectableChipAttributes {
 ///    chips contain related descriptive text or categories.
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * <https://material.io/design/components/chips.html>
-abstract class DisabledChipAttributes {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  DisabledChipAttributes._();
-
+abstract interface class DisabledChipAttributes {
   /// Whether or not this chip is enabled for input.
   ///
   /// If this is true, but all of the user action callbacks are null (i.e.
@@ -477,11 +457,7 @@ abstract class DisabledChipAttributes {
 ///  * [FilterChip], uses tags or descriptive words as a way to filter content.
 ///  * [ActionChip], represents an action related to primary content.
 ///  * <https://material.io/design/components/chips.html>
-abstract class TappableChipAttributes {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  TappableChipAttributes._();
-
+abstract interface class TappableChipAttributes {
   /// Called when the user taps the chip.
   ///
   /// If [onPressed] is set, then this callback will be called when the user

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -190,11 +190,7 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// See also:
 ///
 ///  * Cookbook: [Use themes to share colors and font styles](https://flutter.dev/docs/cookbook/design/themes)
-class Colors {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Colors._();
-
+abstract final class Colors {
   /// Completely invisible.
   static const Color transparent = Color(0x00000000);
 

--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -7,11 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'material_localizations.dart';
 
 /// Utility functions for working with dates.
-class DateUtils {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  DateUtils._();
-
+abstract final class DateUtils {
   /// Returns a [DateTime] with the date of the original, but time set to
   /// midnight.
   static DateTime dateOnly(DateTime date) {

--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -11,11 +11,7 @@ import 'theme.dart';
 
 /// A utility class for dealing with the overlay color needed
 /// to indicate elevation of surfaces.
-class ElevationOverlay {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  ElevationOverlay._();
-
+abstract final class ElevationOverlay {
   /// Applies a surface tint color to a given container color to indicate
   /// the level of its elevation.
   ///

--- a/packages/flutter/lib/src/material/feedback.dart
+++ b/packages/flutter/lib/src/material/feedback.dart
@@ -81,11 +81,7 @@ import 'theme.dart';
 /// }
 /// ```
 /// {@end-tool}
-class Feedback {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Feedback._();
-
+abstract final class Feedback {
   /// Provides platform-specific feedback for a tap.
   ///
   /// On Android the click system sound is played. On iOS this is a no-op.

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 /// A set of platform-adaptive Material Design icons.
 ///
 /// Use [Icons.adaptive] to access a static instance of this class.
-class PlatformAdaptiveIcons implements Icons {
+final class PlatformAdaptiveIcons implements Icons {
   const PlatformAdaptiveIcons._();
 
   static bool _isCupertino() {

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -150,11 +150,7 @@ class PlatformAdaptiveIcons implements Icons {
 ///  * <https://material.io/resources/icons>
 ///  * [AnimatedIcons], for the list of available animated Material Icons.
 @staticIconProvider
-class Icons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Icons._();
-
+abstract final class Icons {
   /// A set of platform-adaptive Material Design icons.
   ///
   /// Provides a convenient way to show a certain set of platform-appropriate

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -8,11 +8,7 @@ import 'package:vector_math/vector_math_64.dart';
 import 'basic_types.dart';
 
 /// Utility functions for working with matrices.
-class MatrixUtils {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  MatrixUtils._();
-
+abstract final class MatrixUtils {
   /// Returns the given [transform] matrix as an [Offset], if the matrix is
   /// nothing but a 2D translation.
   ///

--- a/packages/flutter/lib/src/rendering/layout_helper.dart
+++ b/packages/flutter/lib/src/rendering/layout_helper.dart
@@ -17,11 +17,7 @@ typedef ChildLayouter = Size Function(RenderBox child, BoxConstraints constraint
 /// given set of [BoxConstraints].
 ///
 /// All of the functions adhere to the [ChildLayouter] signature.
-class ChildLayoutHelper {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  const ChildLayoutHelper._();
-
+abstract final class ChildLayoutHelper {
   /// Returns the [Size] that the [RenderBox] would have if it were to
   /// be laid out with the given [BoxConstraints].
   ///

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -206,9 +206,7 @@ mixin SelectionRegistrant on Selectable {
 }
 
 /// A utility class that provides useful methods for handling selection events.
-class SelectionUtils {
-  SelectionUtils._();
-
+abstract final class SelectionUtils {
   /// Determines [SelectionResult] purely based on the target rectangle.
   ///
   /// This method returns [SelectionResult.end] if the `point` is inside the

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -29,11 +29,7 @@ enum CacheExtentStyle {
 /// content, which can be controlled by a [ViewportOffset]. This interface lets
 /// the framework recognize such render objects and interact with them without
 /// having specific knowledge of all the various types of viewports.
-abstract class RenderAbstractViewport extends RenderObject {
-  // This class is intended to be used as an interface, and should not be
-  // extended directly; this constructor prevents instantiation and extension.
-  RenderAbstractViewport._();
-
+abstract interface class RenderAbstractViewport extends RenderObject {
   /// Returns the [RenderAbstractViewport] that most tightly encloses the given
   /// render object.
   ///

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -17,11 +17,7 @@ export 'dart:ui' show TextDirection;
 ///
 /// When possible, prefer using mechanisms like [Semantics] to implicitly
 /// trigger announcements over using this event.
-class SemanticsService {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SemanticsService._();
-
+abstract final class SemanticsService {
   /// Sends a semantic announcement.
   ///
   /// This should be used for announcement that are not seamlessly announced by

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -21,11 +21,7 @@ class ClipboardData {
 }
 
 /// Utility methods for interacting with the system's clipboard.
-class Clipboard {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Clipboard._();
-
+abstract final class Clipboard {
   // Constants for common [getData] [format] types.
 
   /// Plain text data format string.

--- a/packages/flutter/lib/src/services/deferred_component.dart
+++ b/packages/flutter/lib/src/services/deferred_component.dart
@@ -24,11 +24,7 @@ import 'system_channels.dart';
 /// Deferred components are currently an Android-only feature. The methods in
 /// this class are a no-op and all assets and dart code are already available
 /// without installation if called on other platforms.
-class DeferredComponent {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  DeferredComponent._();
-
+abstract final class DeferredComponent {
   // TODO(garyq): We should eventually expand this to install components by loadingUnitId
   // as well as componentName, but currently, loadingUnitId is opaque to the dart code
   // so this is not possible. The API has been left flexible to allow adding

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -9,11 +9,7 @@ import 'system_channels.dart';
 ///
 /// This API is intentionally terse since it calls default platform behavior. It
 /// is not suitable for precise control of the system's haptic feedback module.
-class HapticFeedback {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  HapticFeedback._();
-
+abstract final class HapticFeedback {
   /// Provides vibration haptic feedback to the user for a short duration.
   ///
   /// On iOS devices that support haptic feedback, this uses the default system

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -340,10 +340,7 @@ class MethodChannel {
   /// <https://flutter.dev/developing-packages/>:
   ///
   /// ```dart
-  /// class Music {
-  ///   // Class cannot be instantiated.
-  ///   const Music._();
-  ///
+  /// abstract final class Music {
   ///   static const MethodChannel _channel = MethodChannel('music');
   ///
   ///   static Future<bool> isLicensed() async {

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -10,11 +10,7 @@ import 'platform_channel.dart';
 export 'platform_channel.dart' show BasicMessageChannel, MethodChannel;
 
 /// Platform channels used by the Flutter system.
-class SystemChannels {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemChannels._();
-
+abstract final class SystemChannels {
   /// A JSON [MethodChannel] for navigation.
   ///
   /// The following incoming methods are defined for this channel (registered

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -358,11 +358,7 @@ List<String> _stringify(List<dynamic> list) => <String>[
 
 /// Controls specific aspects of the operating system's graphical interface and
 /// how it interacts with the application.
-class SystemChrome {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemChrome._();
-
+abstract final class SystemChrome {
   /// Specifies the set of orientations the application interface can
   /// be displayed in.
   ///

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -5,11 +5,7 @@
 import 'system_channels.dart';
 
 /// Controls specific aspects of the system navigation stack.
-class SystemNavigator {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemNavigator._();
-
+abstract final class SystemNavigator {
   /// Removes the topmost Flutter instance, presenting what was before
   /// it.
   ///

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -26,11 +26,7 @@ enum SystemSoundType {
 
 /// Provides access to the library of short system specific sounds for common
 /// tasks.
-class SystemSound {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemSound._();
-
+abstract final class SystemSound {
   /// Play the specified system sound. If that sound is not present on the
   /// system, the call is ignored.
   ///

--- a/packages/flutter/lib/src/widgets/window.dart
+++ b/packages/flutter/lib/src/widgets/window.dart
@@ -3,6 +3,4 @@
 // found in the LICENSE file.
 
 /// Placeholder to be used in a future version of Flutter.
-abstract class Window {
-  const Window._();
-}
+abstract final class Window { }

--- a/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
+++ b/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
@@ -79,11 +79,7 @@ Future<PortForwarder> _dummyPortForwardingFunction(
 /// [FuchsiaRemoteConnection.connect] whereby the `FUCHSIA_REMOTE_URL` and
 /// `FUCHSIA_SSH_CONFIG` variables must be set. If run on a Fuchsia device, will
 /// connect locally without need for environment variables.
-class FuchsiaCompat {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  FuchsiaCompat._();
-
+abstract final class FuchsiaCompat {
   static void _init() {
     fuchsiaPortForwardingFunction = _dummyPortForwardingFunction;
   }

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -38,11 +38,7 @@ String? _keyLabel(LogicalKeyboardKey key) {
 
 /// A class that serves as a namespace for a bunch of keyboard-key generation
 /// utilities.
-class KeyEventSimulator {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  KeyEventSimulator._();
-
+abstract final class KeyEventSimulator {
   // Look up a synonym key, and just return the left version of it.
   static LogicalKeyboardKey _getKeySynonym(LogicalKeyboardKey origKey) {
     if (origKey == LogicalKeyboardKey.shift) {

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -44,10 +44,7 @@ class _AsyncScope {
 ///   // ...
 /// });
 /// ```
-class TestAsyncUtils {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  TestAsyncUtils._();
+abstract final class TestAsyncUtils {
   static const String _className = 'TestAsyncUtils';
 
   static final List<_AsyncScope> _scopeStack = <_AsyncScope>[];

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -394,10 +394,7 @@ abstract class CopyFlutterAotBundle extends Target {
 }
 
 /// Lipo CLI tool wrapper shared by iOS and macOS builds.
-class Lipo {
-  /// Static only.
-  Lipo._();
-
+abstract final class Lipo {
   /// Create a "fat" binary by combining multiple architecture-specific ones.
   /// `skipMissingInputs` can be changed to `true` to first check whether
   /// the expected input paths exist and ignore the command if they don't.

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -100,10 +100,7 @@ Future<void> pollForServiceExtensionValue<T>({
   );
 }
 
-class AppleTestUtils {
-  // static only
-  AppleTestUtils._();
-
+abstract final class AppleTestUtils {
   static const List<String> requiredSymbols = <String>[
     '_kDartIsolateSnapshotData',
     '_kDartIsolateSnapshotInstructions',


### PR DESCRIPTION
These constructors were only there to prevent instantiation and extension. We now have class modifiers for that!

Part of https://github.com/flutter/flutter/issues/118837.

To be submitted after https://github.com/flutter/flutter/pull/122546. (presubmits will fail until it is merged)