### PR TITLE
Deprecates `TestWindow`

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -189,6 +189,32 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     debugDisableShadows = disableShadows;
   }
 
+  /// Deprecated. Will be removed in a future version of Flutter.
+  ///
+  /// This property has been deprecated to prepare for Flutter's upcoming
+  /// support for multiple views and multiple windows.
+  ///
+  /// This represents a combination of a [TestPlatformDispatcher] and a singular
+  /// [TestFlutterView]. Platform-specific test values can be set through
+  /// [WidgetTester.platformDispatcher] instead. When testing individual widgets
+  /// or applications using [WidgetTester.pumpWidget], view-specific test values
+  /// can be set through [WidgetTester.view]. If multiple views are defined, the
+  /// appropriate view can be found using [WidgetTester.viewOf] if a sub-view
+  /// is needed.
+  ///
+  /// See also:
+  ///
+  /// * [WidgetTester.platformDispatcher] for changing platform-specific values
+  ///   for testing.
+  /// * [WidgetTester.view] and [WidgetTester.viewOf] for changing view-specific
+  ///   values for testing.
+  /// * [BindingBase.window] for guidance dealing with this property outside of
+  ///   a testing context.
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher or WidgetTester.view instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   late final TestWindow window;
 

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -949,6 +949,11 @@ class TestFlutterView implements FlutterView {
   }
 }
 
+/// Deprecated. Will be removed in a future version of Flutter.
+///
+/// This class has been deprecated to prepare for Flutter's upcoming support
+/// for multiple views and multiple windows.
+///
 /// [SingletonFlutterWindow] that wraps another [SingletonFlutterWindow] and
 /// allows faking of some properties for testing purposes.
 ///
@@ -984,19 +989,29 @@ class TestFlutterView implements FlutterView {
 /// If a test needs to override a real [SingletonFlutterWindow] property and
 /// then later return to using the real [SingletonFlutterWindow] property,
 /// [TestWindow] provides methods to clear each individual test value, e.g.,
-/// [clearLocaleTestValue()].
+/// [clearLocaleTestValue].
 ///
 /// To clear all fake test values in a [TestWindow], consider using
-/// [clearAllTestValues()].
+/// [clearAllTestValues].
 ///
 /// See also:
 ///
 ///   * [TestPlatformDispatcher], which wraps a [PlatformDispatcher] for
 ///     testing purposes and is used by the [platformDispatcher] property of
 ///     this class.
+@Deprecated(
+  'Use TestPlatformDispatcher (via WidgetTester.platformDispatcher) or TestFlutterView (via WidgetTester.view) instead. '
+  'Deprecated to prepare for the upcoming multi-window support. '
+  'This feature was deprecated after v3.9.0-0.1.pre.'
+)
 class TestWindow implements SingletonFlutterWindow {
   /// Constructs a [TestWindow] that defers all behavior to the given
   /// [SingletonFlutterWindow] unless explicitly overridden for test purposes.
+  @Deprecated(
+    'Use TestPlatformDispatcher (via WidgetTester.platformDispatcher) or TestFlutterView (via WidgetTester.view) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   TestWindow({
     required SingletonFlutterWindow window,
   }) : platformDispatcher = TestPlatformDispatcher(platformDispatcher: window.platformDispatcher);
@@ -1014,154 +1029,297 @@ class TestWindow implements SingletonFlutterWindow {
   ///     testing purposes.
   ///   * [TestFlutterView] which allows faking of view-specific values for
   ///     testing purposes.
+  @Deprecated(
+    'Use TestPlatformDispatcher (via WidgetTester.platformDispatcher) or TestFlutterView (via WidgetTester.view) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   TestWindow.fromPlatformDispatcher({
+    @Deprecated(
+      'Use WidgetTester.platformDispatcher instead. '
+      'Deprecated to prepare for the upcoming multi-window support. '
+      'This feature was deprecated after v3.9.0-0.1.pre.'
+    )
     required this.platformDispatcher,
   });
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   final TestPlatformDispatcher platformDispatcher;
 
   TestFlutterView get _view => platformDispatcher.implicitView!;
 
+  @Deprecated(
+    'Use WidgetTester.view.devicePixelRatio instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   double get devicePixelRatio => _view.devicePixelRatio;
   /// Hides the real device pixel ratio and reports the given [devicePixelRatio]
   /// instead.
-  // ignore: avoid_setters_without_getters
-  set devicePixelRatioTestValue(double devicePixelRatio) {
+  @Deprecated(
+    'Use WidgetTester.view.devicePixelRatio instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set devicePixelRatioTestValue(double devicePixelRatio) { // ignore: avoid_setters_without_getters
     _view.devicePixelRatio = devicePixelRatio;
   }
 
   /// Deletes any existing test device pixel ratio and returns to using the real
   /// device pixel ratio.
+  @Deprecated(
+    'Use WidgetTester.view.resetDevicePixelRatio() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearDevicePixelRatioTestValue() {
     _view.resetDevicePixelRatio();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.physicalSize instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   Size get physicalSize => _view.physicalSize;
   /// Hides the real physical size and reports the given [physicalSizeTestValue]
   /// instead.
-  // ignore: avoid_setters_without_getters
-  set physicalSizeTestValue (Size physicalSizeTestValue) {
+  @Deprecated(
+    'Use WidgetTester.view.physicalSize instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set physicalSizeTestValue (Size physicalSizeTestValue) { // ignore: avoid_setters_without_getters
     _view.physicalSize = physicalSizeTestValue;
   }
 
   /// Deletes any existing test physical size and returns to using the real
   /// physical size.
+  @Deprecated(
+    'Use WidgetTester.view.resetPhysicalSize() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearPhysicalSizeTestValue() {
     _view.resetPhysicalSize();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.viewInsets instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   ViewPadding get viewInsets => _view.viewInsets;
   /// Hides the real view insets and reports the given [viewInsetsTestValue]
   /// instead.
   ///
   /// Use [FakeViewPadding] to set this value for testing.
-  // ignore: avoid_setters_without_getters
-  set viewInsetsTestValue(ViewPadding value) {
+  @Deprecated(
+    'Use WidgetTester.view.viewInsets instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set viewInsetsTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
     _view.viewInsets = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
   /// Deletes any existing test view insets and returns to using the real view
   /// insets.
+  @Deprecated(
+    'Use WidgetTester.view.resetViewInsets() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearViewInsetsTestValue() {
     _view.resetViewInsets();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.viewPadding instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   ViewPadding get viewPadding => _view.viewPadding;
   /// Hides the real view padding and reports the given [paddingTestValue]
   /// instead.
   ///
   /// Use [FakeViewPadding] to set this value for testing.
-  // ignore: avoid_setters_without_getters
-  set viewPaddingTestValue(ViewPadding value) {
+  @Deprecated(
+    'Use WidgetTester.view.viewPadding instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set viewPaddingTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
     _view.viewPadding = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
   /// Deletes any existing test view padding and returns to using the real
   /// viewPadding.
+  @Deprecated(
+    'Use WidgetTester.view.resetViewPadding() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearViewPaddingTestValue() {
     _view.resetViewPadding();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.padding instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   ViewPadding get padding => _view.padding;
   /// Hides the real padding and reports the given [paddingTestValue] instead.
   ///
   /// Use [FakeViewPadding] to set this value for testing.
-  // ignore: avoid_setters_without_getters
-  set paddingTestValue(ViewPadding value) {
+  @Deprecated(
+    'Use WidgetTester.view.padding instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set paddingTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
     _view.padding = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
   /// Deletes any existing test padding and returns to using the real padding.
+  @Deprecated(
+    'Use WidgetTester.view.resetPadding() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearPaddingTestValue() {
     _view.resetPadding();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.gestureSettings instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   GestureSettings get gestureSettings => _view.gestureSettings;
   /// Hides the real gesture settings and reports the given [gestureSettingsTestValue] instead.
-  // ignore: avoid_setters_without_getters
-  set gestureSettingsTestValue(GestureSettings gestureSettingsTestValue) {
+  @Deprecated(
+    'Use WidgetTester.view.gestureSettings instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set gestureSettingsTestValue(GestureSettings gestureSettingsTestValue) { // ignore: avoid_setters_without_getters
     _view.gestureSettings = gestureSettingsTestValue;
   }
 
   /// Deletes any existing test gesture settings and returns to using the real gesture settings.
+  @Deprecated(
+    'Use WidgetTester.view.resetGestureSettings() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearGestureSettingsTestValue() {
     _view.resetGestureSettings();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.displayFeatures instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   List<DisplayFeature> get displayFeatures => _view.displayFeatures;
   /// Hides the real displayFeatures and reports the given [displayFeaturesTestValue] instead.
-  // ignore: avoid_setters_without_getters
-  set displayFeaturesTestValue(List<DisplayFeature> displayFeaturesTestValue) {
+  @Deprecated(
+    'Use WidgetTester.view.displayFeatures instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
+  set displayFeaturesTestValue(List<DisplayFeature> displayFeaturesTestValue) { // ignore: avoid_setters_without_getters
     _view.displayFeatures = displayFeaturesTestValue;
   }
 
   /// Deletes any existing test padding and returns to using the real padding.
+  @Deprecated(
+    'Use WidgetTester.view.resetDisplayFeatures() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearDisplayFeaturesTestValue() {
     _view.resetDisplayFeatures();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.systemGestureInsets instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   ViewPadding get systemGestureInsets => _view.systemGestureInsets;
   /// Hides the real system gesture insets and reports the given
   /// [systemGestureInsetsTestValue] instead.
   ///
   /// Use [FakeViewPadding] to set this value for testing.
+  @Deprecated(
+    'Use WidgetTester.view.systemGestureInsets instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   set systemGestureInsetsTestValue(ViewPadding value) { // ignore: avoid_setters_without_getters
     _view.systemGestureInsets = value is FakeViewPadding ? value : FakeViewPadding._wrap(value);
   }
 
   /// Deletes any existing test system gesture insets and returns to using the real system gesture insets.
+  @Deprecated(
+    'Use WidgetTester.view.resetSystemGestureInsets() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearSystemGestureInsetsTestValue() {
     _view.resetSystemGestureInsets();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onMetricsChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onMetricsChanged => platformDispatcher.onMetricsChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onMetricsChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onMetricsChanged(VoidCallback? callback) {
     platformDispatcher.onMetricsChanged = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.locale instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   Locale get locale => platformDispatcher.locale;
   /// Hides the real locale and reports the given [localeTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.localeTestValue instead. '
+    'Use WidgetTester.platformDispatcher.localeTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set localeTestValue(Locale localeTestValue) { // ignore: avoid_setters_without_getters
     platformDispatcher.localeTestValue = localeTestValue;
   }
   @Deprecated(
-    'Use platformDispatcher.clearLocaleTestValue() instead. '
+    'Use WidgetTester.platformDispatcher.clearLocaleTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   /// Deletes any existing test locale and returns to using the real locale.
@@ -1169,11 +1327,16 @@ class TestWindow implements SingletonFlutterWindow {
     platformDispatcher.clearLocaleTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.locales instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   List<Locale> get locales => platformDispatcher.locales;
   /// Hides the real locales and reports the given [localesTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.localesTestValue instead. '
+    'Use WidgetTester.platformDispatcher.localesTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set localesTestValue(List<Locale> localesTestValue) { // ignore: avoid_setters_without_getters
@@ -1181,37 +1344,57 @@ class TestWindow implements SingletonFlutterWindow {
   }
   /// Deletes any existing test locales and returns to using the real locales.
   @Deprecated(
-    'Use platformDispatcher.clearLocalesTestValue() instead. '
+    'Use WidgetTester.platformDispatcher.clearLocalesTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearLocalesTestValue() {
     platformDispatcher.clearLocalesTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onLocaleChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onLocaleChanged => platformDispatcher.onLocaleChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onLocaleChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onLocaleChanged(VoidCallback? callback) {
     platformDispatcher.onLocaleChanged = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.initialLifecycleState instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   String get initialLifecycleState => platformDispatcher.initialLifecycleState;
   /// Sets a faked initialLifecycleState for testing.
   @Deprecated(
-    'Use platformDispatcher.initialLifecycleStateTestValue instead. '
+    'Use WidgetTester.platformDispatcher.initialLifecycleStateTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set initialLifecycleStateTestValue(String state) { // ignore: avoid_setters_without_getters
     platformDispatcher.initialLifecycleStateTestValue = state;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.textScaleFactor instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   double get textScaleFactor => platformDispatcher.textScaleFactor;
   /// Hides the real text scale factor and reports the given
   /// [textScaleFactorTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.textScaleFactorTestValue instead. '
+    'Use WidgetTester.platformDispatcher.textScaleFactorTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set textScaleFactorTestValue(double textScaleFactorTestValue) { // ignore: avoid_setters_without_getters
@@ -1220,17 +1403,32 @@ class TestWindow implements SingletonFlutterWindow {
   /// Deletes any existing test text scale factor and returns to using the real
   /// text scale factor.
   @Deprecated(
-    'Use platformDispatcher.clearTextScaleFactorTestValue() instead. '
+    'Use WidgetTester.platformDispatcher.clearTextScaleFactorTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearTextScaleFactorTestValue() {
     platformDispatcher.clearTextScaleFactorTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.platformBrightness instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   Brightness get platformBrightness => platformDispatcher.platformBrightness;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onPlatformBrightnessChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onPlatformBrightnessChanged => platformDispatcher.onPlatformBrightnessChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onPlatformBrightnessChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onPlatformBrightnessChanged(VoidCallback? callback) {
     platformDispatcher.onPlatformBrightnessChanged = callback;
@@ -1238,7 +1436,7 @@ class TestWindow implements SingletonFlutterWindow {
   /// Hides the real text scale factor and reports the given
   /// [platformBrightnessTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.platformBrightnessTestValue instead. '
+    'Use WidgetTester.platformDispatcher.platformBrightnessTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set platformBrightnessTestValue(Brightness platformBrightnessTestValue) { // ignore: avoid_setters_without_getters
@@ -1247,19 +1445,24 @@ class TestWindow implements SingletonFlutterWindow {
   /// Deletes any existing test platform brightness and returns to using the
   /// real platform brightness.
   @Deprecated(
-    'Use platformDispatcher.clearPlatformBrightnessTestValue() instead. '
+    'Use WidgetTester.platformDispatcher.clearPlatformBrightnessTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearPlatformBrightnessTestValue() {
     platformDispatcher.clearPlatformBrightnessTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.alwaysUse24HourFormat instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   bool get alwaysUse24HourFormat => platformDispatcher.alwaysUse24HourFormat;
   /// Hides the real clock format and reports the given
   /// [alwaysUse24HourFormatTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.alwaysUse24HourFormatTestValue instead. '
+    'Use WidgetTester.platformDispatcher.alwaysUse24HourFormatTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set alwaysUse24HourFormatTestValue(bool alwaysUse24HourFormatTestValue) { // ignore: avoid_setters_without_getters
@@ -1268,72 +1471,142 @@ class TestWindow implements SingletonFlutterWindow {
   /// Deletes any existing test clock format and returns to using the real clock
   /// format.
   @Deprecated(
-    'Use platformDispatcher.clearAlwaysUse24HourTestValue() instead. '
+    'Use WidgetTester.platformDispatcher.clearAlwaysUse24HourTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearAlwaysUse24HourTestValue() {
     platformDispatcher.clearAlwaysUse24HourTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onTextScaleFactorChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onTextScaleFactorChanged => platformDispatcher.onTextScaleFactorChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onTextScaleFactorChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onTextScaleFactorChanged(VoidCallback? callback) {
     platformDispatcher.onTextScaleFactorChanged = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.nativeSpellCheckServiceDefined instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   bool get nativeSpellCheckServiceDefined => platformDispatcher.nativeSpellCheckServiceDefined;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.nativeSpellCheckServiceDefinedTestValue instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   set nativeSpellCheckServiceDefinedTestValue(bool nativeSpellCheckServiceDefinedTestValue) { // ignore: avoid_setters_without_getters
     platformDispatcher.nativeSpellCheckServiceDefinedTestValue = nativeSpellCheckServiceDefinedTestValue;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.brieflyShowPassword instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   bool get brieflyShowPassword => platformDispatcher.brieflyShowPassword;
   /// Hides the real [brieflyShowPassword] and reports the given
   /// `brieflyShowPasswordTestValue` instead.
   @Deprecated(
-    'Use platformDispatcher.brieflyShowPasswordTestValue instead. '
+    'Use WidgetTester.platformDispatcher.brieflyShowPasswordTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set brieflyShowPasswordTestValue(bool brieflyShowPasswordTestValue) { // ignore: avoid_setters_without_getters
     platformDispatcher.brieflyShowPasswordTestValue = brieflyShowPasswordTestValue;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onBeginFrame instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   FrameCallback? get onBeginFrame => platformDispatcher.onBeginFrame;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onBeginFrame instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onBeginFrame(FrameCallback? callback) {
     platformDispatcher.onBeginFrame = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onDrawFrame instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onDrawFrame => platformDispatcher.onDrawFrame;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onDrawFrame instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onDrawFrame(VoidCallback? callback) {
     platformDispatcher.onDrawFrame = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onReportTimings instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   TimingsCallback? get onReportTimings => platformDispatcher.onReportTimings;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onReportTimings instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onReportTimings(TimingsCallback? callback) {
     platformDispatcher.onReportTimings = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onPointerDataPacket instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   PointerDataPacketCallback? get onPointerDataPacket => platformDispatcher.onPointerDataPacket;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onPointerDataPacket instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onPointerDataPacket(PointerDataPacketCallback? callback) {
     platformDispatcher.onPointerDataPacket = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.defaultRouteName instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   String get defaultRouteName => platformDispatcher.defaultRouteName;
   /// Hides the real default route name and reports the given
   /// [defaultRouteNameTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.defaultRouteNameTestValue instead. '
+    'Use WidgetTester.platformDispatcher.defaultRouteNameTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set defaultRouteNameTestValue(String defaultRouteNameTestValue) { // ignore: avoid_setters_without_getters
@@ -1342,29 +1615,44 @@ class TestWindow implements SingletonFlutterWindow {
   /// Deletes any existing test default route name and returns to using the real
   /// default route name.
   @Deprecated(
-    'Use platformDispatcher.clearDefaultRouteNameTestValue instead. '
+    'Use WidgetTester.platformDispatcher.clearDefaultRouteNameTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearDefaultRouteNameTestValue() {
     platformDispatcher.clearDefaultRouteNameTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.scheduleFrame() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   void scheduleFrame() {
     platformDispatcher.scheduleFrame();
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.render(scene) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   void render(Scene scene) {
     _view.render(scene);
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.semanticsEnabled instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   bool get semanticsEnabled => platformDispatcher.semanticsEnabled;
   /// Hides the real semantics enabled and reports the given
   /// [semanticsEnabledTestValue] instead.
   @Deprecated(
-    'Use platformDispatcher.semanticsEnabledTestValue instead. '
+    'Use WidgetTester.platformDispatcher.semanticsEnabledTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set semanticsEnabledTestValue(bool semanticsEnabledTestValue) { // ignore: avoid_setters_without_getters
@@ -1373,27 +1661,52 @@ class TestWindow implements SingletonFlutterWindow {
   /// Deletes any existing test semantics enabled and returns to using the real
   /// semantics enabled.
   @Deprecated(
-    'Use platformDispatcher.clearSemanticsEnabledTestValue instead. '
+    'Use WidgetTester.platformDispatcher.clearSemanticsEnabledTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearSemanticsEnabledTestValue() {
     platformDispatcher.clearSemanticsEnabledTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onSemanticsEnabledChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onSemanticsEnabledChanged => platformDispatcher.onSemanticsEnabledChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onSemanticsEnabledChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onSemanticsEnabledChanged(VoidCallback? callback) {
     platformDispatcher.onSemanticsEnabledChanged = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onSemanticsAction instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   SemanticsActionCallback? get onSemanticsAction => platformDispatcher.onSemanticsAction;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onSemanticsAction instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onSemanticsAction(SemanticsActionCallback? callback) {
     platformDispatcher.onSemanticsAction = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.accessibilityFeatures instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   AccessibilityFeatures get accessibilityFeatures => platformDispatcher.accessibilityFeatures;
   /// Hides the real accessibility features and reports the given
@@ -1402,7 +1715,7 @@ class TestWindow implements SingletonFlutterWindow {
   /// Consider using [FakeAccessibilityFeatures] to provide specific
   /// values for the various accessibility features under test.
   @Deprecated(
-    'Use platformDispatcher.accessibilityFeaturesTestValue instead. '
+    'Use WidgetTester.platformDispatcher.accessibilityFeaturesTestValue instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   set accessibilityFeaturesTestValue(AccessibilityFeatures accessibilityFeaturesTestValue) { // ignore: avoid_setters_without_getters
@@ -1411,30 +1724,55 @@ class TestWindow implements SingletonFlutterWindow {
   /// Deletes any existing test accessibility features and returns to using the
   /// real accessibility features.
   @Deprecated(
-    'Use platformDispatcher.clearAccessibilityFeaturesTestValue() instead. '
+    'Use WidgetTester.platformDispatcher.clearAccessibilityFeaturesTestValue() instead. '
     'This feature was deprecated after v2.11.0-0.0.pre.'
   )
   void clearAccessibilityFeaturesTestValue() {
     platformDispatcher.clearAccessibilityFeaturesTestValue();
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onAccessibilityFeaturesChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onAccessibilityFeaturesChanged => platformDispatcher.onAccessibilityFeaturesChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onAccessibilityFeaturesChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onAccessibilityFeaturesChanged(VoidCallback? callback) {
     platformDispatcher.onAccessibilityFeaturesChanged = callback;
   }
 
+  @Deprecated(
+    'Use WidgetTester.view.updateSemantics(update) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   void updateSemantics(SemanticsUpdate update) {
     _view.updateSemantics(update);
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.setIsolateDebugName(name) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   void setIsolateDebugName(String name) {
     platformDispatcher.setIsolateDebugName(name);
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.sendPlatformMessage(name, data, callback) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   void sendPlatformMessage(
     String name,
@@ -1467,6 +1805,11 @@ class TestWindow implements SingletonFlutterWindow {
   ///
   /// If desired, clearing of properties can be done on an individual basis,
   /// e.g., [clearLocaleTestValue].
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.clearAllTestValues() and WidgetTester.view.reset() instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   void clearAllTestValues() {
     clearDevicePixelRatioTestValue();
     clearPaddingTestValue();
@@ -1478,40 +1821,95 @@ class TestWindow implements SingletonFlutterWindow {
   }
 
   @override
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onFrameDataChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   VoidCallback? get onFrameDataChanged => platformDispatcher.onFrameDataChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onFrameDataChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onFrameDataChanged(VoidCallback? value) {
     platformDispatcher.onFrameDataChanged = value;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onKeyData instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   KeyDataCallback? get onKeyData => platformDispatcher.onKeyData;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onKeyData instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onKeyData(KeyDataCallback? value) {
     platformDispatcher.onKeyData = value;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onSystemFontFamilyChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   VoidCallback? get onSystemFontFamilyChanged => platformDispatcher.onSystemFontFamilyChanged;
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.onSystemFontFamilyChanged instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   set onSystemFontFamilyChanged(VoidCallback? value) {
     platformDispatcher.onSystemFontFamilyChanged = value;
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.computePlatformResolvedLocale(supportedLocales) instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   Locale? computePlatformResolvedLocale(List<Locale> supportedLocales) {
     return platformDispatcher.computePlatformResolvedLocale(supportedLocales);
   }
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.frameData instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   FrameData get frameData => platformDispatcher.frameData;
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.physicalGeometry instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   Rect get physicalGeometry => _view.physicalGeometry;
 
+  @Deprecated(
+    'Use WidgetTester.platformDispatcher.systemFontFamily instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   String? get systemFontFamily => platformDispatcher.systemFontFamily;
 
+  @Deprecated(
+    'Use WidgetTester.view.viewId instead. '
+    'Deprecated to prepare for the upcoming multi-window support. '
+    'This feature was deprecated after v3.9.0-0.1.pre.'
+  )
   @override
   Object get viewId => _view.viewId;
 


### PR DESCRIPTION
Deprecates `TestWindow`

* Adds `Deprecated` annotations to `TestWindow` and its constructors.
* Adds `Deprecated` annotations to all properties and methods on `TestWindow` except `noSuchMethod`.
* Adds `Deprecated` annotation to `TestWidgetsFlutterBinding.window`.
* Adds `flutter_test` specific deprecation documentation to `TestWidgetsFlutterBinding.window`.

Resolves #121915.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.