### PR TITLE
[Tool] [Windows] Output app path on build completion

### DIFF
--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -177,6 +177,9 @@ class WindowsRunOutputTest extends DesktopRunOutputTest {
     r'Building Windows application\.\.\.\s*\d+(\.\d+)?(ms|s)',
     multiLine: true,
   );
+  static final RegExp _builtOutput = RegExp(
+    r'Built build\\windows\\runner\\(Debug|Release)\\\w+\.exe( \(\d+(\.\d+)?MB\))?\.',
+  );
 
   @override
   void verifyBuildOutput(List<String> stdout) {
@@ -184,6 +187,25 @@ class WindowsRunOutputTest extends DesktopRunOutputTest {
       stdout,
       _buildOutput.hasMatch,
       'Building Windows application...',
+    );
+
+    final String buildMode = release ? 'Release' : 'Debug';
+    _findNextMatcherInList(
+      stdout,
+      (String line) {
+        if (!_builtOutput.hasMatch(line) || !line.contains(buildMode)) {
+          return false;
+        }
+
+        // Size information is only included in release builds.
+        final bool hasSize = line.contains('MB).');
+        if (release != hasSize) {
+          return false;
+        }
+
+        return true;
+      },
+      'Built build\\windows\\runner\\$buildMode\\app.exe',
     );
   }
 }

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -8,6 +8,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/project_migrator.dart';
+import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -92,6 +93,22 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
   } finally {
     status.stop();
   }
+
+  final File appFile = buildDirectory
+    .childDirectory('runner')
+    .childDirectory(sentenceCase(buildModeName))
+    .childFile('${windowsProject.parent.manifest.appName}.exe');
+  if (appFile.existsSync()) {
+    final String appSize = (buildInfo.mode == BuildMode.debug)
+        ? '' // Don't display the size when building a debug variant.
+        : ' (${getSizeAsMB(appFile.lengthSync())})';
+    globals.logger.printStatus(
+      '${globals.logger.terminal.successMark}  '
+      'Built ${globals.fs.path.relative(appFile.path)}$appSize.',
+      color: TerminalColor.green,
+    );
+  }
+
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
     final String arch = getNameForTargetPlatform(TargetPlatform.windows_x64);
     final File codeSizeFile = globals.fs.directory(buildInfo.codeSizeDirectory)


### PR DESCRIPTION
Improves the build output:

1. Gives confirmation that the build succeeded
2. Gives the path to the built executable

This matches the behavior of other Flutter platforms like Android.

Part of https://github.com/flutter/flutter/issues/120127

### Flutter run

```
> flutter run -d windows
Launching lib\main.dart on Windows in debug mode...
Building Windows application...                                    11.1s
✓  Built build\windows\runner\Debug\x10.exe.
Syncing files to device Windows...                                  60ms

Flutter run key commands.
r Hot reload. 🔥🔥🔥
R Hot restart.
h List all available interactive commands.
d Detach (terminate "flutter run" but leave application running).
c Clear the screen
q Quit (terminate the application on the device).
```

### Flutter build

```
> flutter build windows
Building Windows application...                                    25.9s
✓  Built build\windows\runner\Release\x10.exe (0.1MB).
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
