### PR TITLE
Fix `TimePicker` input mode width for 12-hour format

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -2338,7 +2338,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
             break;
           case TimeOfDayFormat.a_space_h_colon_mm:
           case TimeOfDayFormat.h_colon_mm_space_a:
-            timePickerWidth = _kTimePickerMinInputSize.width;
+            timePickerWidth = _kTimePickerMinInputSize.width - (useMaterial3 ? 32 : 0);
             break;
         }
         return Size(timePickerWidth, _kTimePickerMinInputSize.height);
@@ -2383,7 +2383,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
             break;
           case TimeOfDayFormat.a_space_h_colon_mm:
           case TimeOfDayFormat.h_colon_mm_space_a:
-            timePickerWidth = _kTimePickerInputSize.width;
+            timePickerWidth = _kTimePickerInputSize.width - (useMaterial3 ? 32 : 0);
             break;
         }
         timePickerSize = Size(timePickerWidth, _kTimePickerInputSize.height);
@@ -2457,7 +2457,6 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
         tapTargetSizeOffset = const Offset(0, -12);
         break;
     }
-
     final Size dialogSize = _dialogSize(context, useMaterial3: theme.useMaterial3) + tapTargetSizeOffset;
     final Size minDialogSize = _minDialogSize(context, useMaterial3: theme.useMaterial3) + tapTargetSizeOffset;
     return Dialog(

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -281,6 +281,10 @@ void main() {
     });
 
     group('Dialog (${materialType.name})', () {
+      Material getMaterialFromDialog(WidgetTester tester) {
+        return tester.widget<Material>(find.descendant(of: find.byType(Dialog), matching: find.byType(Material)).first);
+      }
+
       testWidgets('Widgets have correct label capitalization', (WidgetTester tester) async {
         await startPicker(tester, (TimeOfDay? time) {}, materialType: materialType);
         expect(find.text(selectTimeString), findsOneWidget);
@@ -313,6 +317,84 @@ void main() {
 
       switch (materialType) {
         case MaterialType.material2:
+          testWidgets('Dialog size - dial mode', (WidgetTester tester) async {
+            addTearDown(tester.view.reset);
+
+            const Size timePickerPortraitSize =  Size(310, 468);
+            const Size timePickerLandscapeSize = Size(524, 342);
+            const Size timePickerLandscapeSizeM2 = Size(508, 300);
+            const EdgeInsets padding = EdgeInsets.fromLTRB(8, 18, 8, 8);
+            double width;
+            double height;
+
+            // portrait
+            tester.view.physicalSize = const Size(800, 800.5);
+            tester.view.devicePixelRatio = 1;
+            await mediaQueryBoilerplate(tester, materialType: materialType);
+
+            width = timePickerPortraitSize.width + padding.horizontal;
+            height = timePickerPortraitSize.height + padding.vertical;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+
+            await tester.tap(find.text(okString)); // dismiss the dialog
+            await tester.pumpAndSettle();
+
+            // landscape
+            tester.view.physicalSize = const Size(800.5, 800);
+            tester.view.devicePixelRatio = 1;
+            await mediaQueryBoilerplate(
+              tester,
+              alwaysUse24HourFormat: true,
+              materialType: materialType,
+            );
+
+            width =  timePickerLandscapeSize.width + padding.horizontal;
+            height = timePickerLandscapeSizeM2.height + padding.vertical;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+          });
+
+          testWidgets('Dialog size - input mode', (WidgetTester tester) async {
+            const TimePickerEntryMode entryMode = TimePickerEntryMode.input;
+            const Size timePickerInputSize = Size(312, 216);
+            const Size dayPeriodPortraitSize = Size(52, 80);
+            const EdgeInsets padding = EdgeInsets.fromLTRB(8, 18, 8, 8);
+            final double height = timePickerInputSize.height + padding.vertical;
+            double width;
+
+            await mediaQueryBoilerplate(
+              tester,
+              entryMode: entryMode,
+              materialType: materialType,
+            );
+
+            width = timePickerInputSize.width + padding.horizontal;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+
+            await tester.tap(find.text(okString)); // dismiss the dialog
+            await tester.pumpAndSettle();
+
+            await mediaQueryBoilerplate(
+              tester,
+              alwaysUse24HourFormat: true,
+              entryMode: entryMode,
+              materialType: materialType,
+            );
+            width = timePickerInputSize.width - dayPeriodPortraitSize.width - 12 + padding.horizontal + 16;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+          });
+
           testWidgets('respects MediaQueryData.alwaysUse24HourFormat == true', (WidgetTester tester) async {
             await mediaQueryBoilerplate(tester, alwaysUse24HourFormat: true, materialType: materialType);
 
@@ -333,6 +415,86 @@ void main() {
           });
           break;
         case MaterialType.material3:
+          testWidgets('Dialog size - dial mode', (WidgetTester tester) async {
+            addTearDown(tester.view.reset);
+
+            const Size timePickerPortraitSize =  Size(310, 468);
+            const Size timePickerLandscapeSize = Size(524, 342);
+            const EdgeInsets padding = EdgeInsets.all(24.0);
+            double width;
+            double height;
+
+            // portrait
+            tester.view.physicalSize = const Size(800, 800.5);
+            tester.view.devicePixelRatio = 1;
+            await mediaQueryBoilerplate(tester, materialType: materialType);
+
+            width = timePickerPortraitSize.width + padding.horizontal;
+            height = timePickerPortraitSize.height + padding.vertical;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+
+            await tester.tap(find.text(okString)); // dismiss the dialog
+            await tester.pumpAndSettle();
+
+            // landscape
+            tester.view.physicalSize = const Size(800.5, 800);
+            tester.view.devicePixelRatio = 1;
+            await mediaQueryBoilerplate(
+              tester,
+              alwaysUse24HourFormat: true,
+              materialType: materialType,
+            );
+
+            width =  timePickerLandscapeSize.width + padding.horizontal;
+            height = timePickerLandscapeSize.height + padding.vertical;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+          });
+
+          testWidgets('Dialog size - input mode', (WidgetTester tester) async {
+            final ThemeData theme = ThemeData(useMaterial3: true);
+            const TimePickerEntryMode entryMode = TimePickerEntryMode.input;
+            const double textScaleFactor = 1.0;
+            const Size timePickerMinInputSize = Size(312, 216);
+            const Size dayPeriodPortraitSize = Size(52, 80);
+            const EdgeInsets padding = EdgeInsets.all(24.0);
+            final double height = timePickerMinInputSize.height * textScaleFactor + padding.vertical;
+            double width;
+
+            await mediaQueryBoilerplate(
+              tester,
+              entryMode: entryMode,
+              materialType: materialType,
+            );
+
+            width = timePickerMinInputSize.width - (theme.useMaterial3 ? 32 : 0) + padding.horizontal;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+
+            await tester.tap(find.text(okString)); // dismiss the dialog
+            await tester.pumpAndSettle();
+
+            await mediaQueryBoilerplate(
+              tester,
+              alwaysUse24HourFormat: true,
+              entryMode: entryMode,
+              materialType: materialType,
+            );
+
+            width = timePickerMinInputSize.width - dayPeriodPortraitSize.width - 12 + padding.horizontal;
+            expect(
+              tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
+              Size(width, height),
+            );
+          });
+
           testWidgets('respects MediaQueryData.alwaysUse24HourFormat == true', (WidgetTester tester) async {
             await mediaQueryBoilerplate(tester, alwaysUse24HourFormat: true, materialType: materialType);
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/122471

<details> 
<summary>code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(useMaterial3: true),
      home: const Example(),
    );
  }
}

class Example extends StatelessWidget {
  const Example({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: Builder(builder: (BuildContext context) {
          return FilledButton(
            onPressed: () async {
              await showTimePicker(
                initialTime: TimeOfDay.now(),
                initialEntryMode: TimePickerEntryMode.input,
                context: context,
              );
            },
            child: const Text('Open Time Picker'),
          );
        }),
      ),
    );
  }
}
``` 
	
</details>

### Before
| Preview | 
| --------------- | 
| <img src="https://user-images.githubusercontent.com/48603081/225846402-4765388f-3b9b-4f02-8c3b-44df29ef8549.png" height="450" />	|

### After
| Preview | 
| --------------- | 
| <img src="https://user-images.githubusercontent.com/48603081/225846447-45d063f6-fc5a-4404-adc6-77ba4a1d82ca.png" height="450" />	|





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
