### PR TITLE
Add a channel to query the engine keyboard state

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -68,8 +68,10 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
   void _initKeyboard() {
     _keyboard = HardwareKeyboard();
     _keyEventManager = KeyEventManager(_keyboard, RawKeyboard.instance);
-    platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
-    SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
+    _keyboard.syncKeyboardState().then((_) {
+      platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
+      SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
+    });
   }
 
   /// The default instance of [BinaryMessenger].

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -68,10 +68,18 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
   void _initKeyboard() {
     _keyboard = HardwareKeyboard();
     _keyEventManager = KeyEventManager(_keyboard, RawKeyboard.instance);
-    _keyboard.syncKeyboardState().then((_) {
+    if (!kIsWeb) {
+      // On non web platforms query the initial keyboard state.
+      _keyboard.syncKeyboardState().then((_) {
+        platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
+        SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
+      });
+    } else {
+      // TODO(bleroux): find a way to get the async call working on web, for the moment
+      // it results in many test failures.
       platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
       SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
-    });
+    }
   }
 
   /// The default instance of [BinaryMessenger].

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -68,18 +68,10 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
   void _initKeyboard() {
     _keyboard = HardwareKeyboard();
     _keyEventManager = KeyEventManager(_keyboard, RawKeyboard.instance);
-    if (!kIsWeb) {
-      // On non web platforms query the initial keyboard state.
-      _keyboard.syncKeyboardState().then((_) {
-        platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
-        SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
-      });
-    } else {
-      // TODO(bleroux): find a way to get the async call working on web, for the moment
-      // it results in many test failures.
+    _keyboard.syncKeyboardState().then((_) {
       platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
       SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
-    }
+    });
   }
 
   /// The default instance of [BinaryMessenger].

--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 
 import 'binding.dart';
 import 'raw_keyboard.dart';
+import 'system_channels.dart';
 
 export 'dart:ui' show KeyData;
 
@@ -491,6 +492,20 @@ class HardwareKeyboard {
       _modifiedHandlers!.remove(handler);
     } else {
       _handlers.remove(handler);
+    }
+  }
+
+  /// Query the engine and update _pressedKeys accordingly to the engine answer.
+  Future<void> syncKeyboardState() async {
+    final Map<int, int>? keyboardState = await SystemChannels.keyboard.invokeMapMethod<int, int>(
+      'getKeyboardState',
+    );
+    if (keyboardState != null) {
+      for (final int key in keyboardState.keys) {
+        final PhysicalKeyboardKey physicalKey = PhysicalKeyboardKey(key);
+        final LogicalKeyboardKey logicalKey = LogicalKeyboardKey(keyboardState[key]!);
+        _pressedKeys[physicalKey] = logicalKey;
+      }
     }
   }
 

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -495,6 +495,14 @@ abstract final class SystemChannels {
   /// [OptionalMethodChannel.invokeMethod]):
   ///
   ///  * `getKeyboardState`: Obtains keyboard pressed keys from the engine.
+  ///    The keyboard state is sent as a `Map<int, int>?` where each entry
+  ///    represents a pressed keyboard key.  The entry key is the physical key ID
+  ///    and the entry value is the logical key ID.
+  ///
+  /// See also:
+  ///
+  ///  * [HardwareKeyboard.syncKeyboardState], which uses this channel to synchronize
+  ///    the `HardwareKeyboard` pressed state.
   static const MethodChannel keyboard = OptionalMethodChannel(
     'flutter/keyboard',
   );

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -495,14 +495,6 @@ abstract final class SystemChannels {
   /// [OptionalMethodChannel.invokeMethod]):
   ///
   ///  * `getKeyboardState`: Obtains keyboard pressed keys from the engine.
-  ///    The keyboard state is sent as a `Map<int, int>?` where each entry
-  ///    represents a pressed keyboard key.  The entry key is the physical key ID
-  ///    and the entry value is the logical key ID.
-  ///
-  /// See also:
-  ///
-  ///  * [HardwareKeyboard.syncKeyboardState], which uses this channel to synchronize
-  ///    the `HardwareKeyboard` pressed state.
   static const MethodChannel keyboard = OptionalMethodChannel(
     'flutter/keyboard',
   );

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -488,4 +488,14 @@ abstract final class SystemChannels {
     'flutter/contextmenu',
     JSONMethodCodec(),
   );
+
+  /// A [MethodChannel] for retrieving keyboard pressed keys from the engine.
+  ///
+  /// The following outgoing methods are defined for this channel (invoked using
+  /// [OptionalMethodChannel.invokeMethod]):
+  ///
+  ///  * `getKeyboardState`: Obtains keyboard pressed keys from the engine.
+  static const MethodChannel keyboard = OptionalMethodChannel(
+    'flutter/keyboard',
+  );
 }

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -495,6 +495,14 @@ abstract final class SystemChannels {
   /// [OptionalMethodChannel.invokeMethod]):
   ///
   ///  * `getKeyboardState`: Obtains keyboard pressed keys from the engine.
+  ///    The keyboard state is sent as a `Map<int, int>?` where each entry
+  ///    represents a pressed keyboard key. The entry key is the physical
+  ///    key ID and the entry value is the logical key ID.
+  ///
+  /// See also:
+  ///
+  ///  * [HardwareKeyboard.syncKeyboardState], which uses this channel to synchronize
+  ///    the `HardwareKeyboard` pressed state.
   static const MethodChannel keyboard = OptionalMethodChannel(
     'flutter/keyboard',
   );

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -46,7 +46,13 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
 
   @override
   TestDefaultBinaryMessenger createBinaryMessenger() {
-    return TestDefaultBinaryMessenger(super.createBinaryMessenger());
+    Future<ByteData?> keyboardHandler(ByteData? message) async {
+      return const StandardMethodCodec().encodeSuccessEnvelope(<int, int>{1:1});
+    }
+    return TestDefaultBinaryMessenger(
+      super.createBinaryMessenger(),
+      outboundHandlers: <String, MessageHandler>{'flutter/keyboard': keyboardHandler},
+    );
   }
 }
 
@@ -144,5 +150,15 @@ void main() {
     expect(receivedReply, isTrue);
     expect(result, isNotNull);
     expect(result!['response'], equals('exit'));
+  });
+
+  test('initInstances synchronizes keyboard state', () async {
+    final Set<PhysicalKeyboardKey> physicalKeys = HardwareKeyboard.instance.physicalKeysPressed;
+    final Set<LogicalKeyboardKey> logicalKeys = HardwareKeyboard.instance.logicalKeysPressed;
+
+    expect(physicalKeys.length, 1);
+    expect(logicalKeys.length, 1);
+    expect(physicalKeys.first, const PhysicalKeyboardKey(1));
+    expect(logicalKeys.first, const LogicalKeyboardKey(1));
   });
 }

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -153,8 +153,6 @@ void main() {
   });
 
   test('initInstances synchronizes keyboard state', () async {
-    await KeyEventSimulator.ensureKeyboardInitialized();
-
     final Set<PhysicalKeyboardKey> physicalKeys = HardwareKeyboard.instance.physicalKeysPressed;
     final Set<LogicalKeyboardKey> logicalKeys = HardwareKeyboard.instance.logicalKeysPressed;
 
@@ -162,5 +160,5 @@ void main() {
     expect(logicalKeys.length, 1);
     expect(physicalKeys.first, const PhysicalKeyboardKey(1));
     expect(logicalKeys.first, const LogicalKeyboardKey(1));
-  }, skip: kIsWeb); // [intended]
+  });
 }

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -153,6 +153,8 @@ void main() {
   });
 
   test('initInstances synchronizes keyboard state', () async {
+    await KeyEventSimulator.ensureKeyboardInitialized();
+
     final Set<PhysicalKeyboardKey> physicalKeys = HardwareKeyboard.instance.physicalKeysPressed;
     final Set<LogicalKeyboardKey> logicalKeys = HardwareKeyboard.instance.logicalKeysPressed;
 
@@ -160,5 +162,5 @@ void main() {
     expect(logicalKeys.length, 1);
     expect(physicalKeys.first, const PhysicalKeyboardKey(1));
     expect(logicalKeys.first, const LogicalKeyboardKey(1));
-  });
+  }, skip: kIsWeb); // [intended]
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -107,7 +107,13 @@ mixin TestDefaultBinaryMessengerBinding on BindingBase, ServicesBinding {
 
   @override
   TestDefaultBinaryMessenger createBinaryMessenger() {
-    return TestDefaultBinaryMessenger(super.createBinaryMessenger());
+    Future<ByteData?> keyboardHandler(ByteData? message) async {
+      return const StandardMethodCodec().encodeSuccessEnvelope(<int, int>{});
+    }
+    return TestDefaultBinaryMessenger(
+      super.createBinaryMessenger(),
+      outboundHandlers: <String, MessageHandler>{'flutter/keyboard': keyboardHandler},
+    );
   }
 }
 

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -707,15 +707,6 @@ abstract final class KeyEventSimulator {
 
   static String get _defaultPlatform => kIsWeb ? 'web' : Platform.operatingSystem;
 
-  /// Waits until key event handling is ready.
-  static Future<void> ensureKeyboardInitialized() async {
-    if (!kIsWeb) {
-      while (ServicesBinding.instance.platformDispatcher.onKeyData == null) {
-        await TestWidgetsFlutterBinding.instance.pump(const Duration(milliseconds: 10));
-      }
-    }
-  }
-
   /// Simulates sending a hardware key down event.
   ///
   /// This only simulates key presses coming from a physical keyboard, not from a
@@ -738,7 +729,6 @@ abstract final class KeyEventSimulator {
     PhysicalKeyboardKey? physicalKey,
     String? character,
   }) async {
-    await ensureKeyboardInitialized();
     Future<bool> simulateByRawEvent() {
       return _simulateKeyEventByRawEvent(() {
         platform ??= _defaultPlatform;
@@ -783,7 +773,6 @@ abstract final class KeyEventSimulator {
     String? platform,
     PhysicalKeyboardKey? physicalKey,
   }) async {
-    await ensureKeyboardInitialized();
     Future<bool> simulateByRawEvent() {
       return _simulateKeyEventByRawEvent(() {
         platform ??= _defaultPlatform;
@@ -829,7 +818,6 @@ abstract final class KeyEventSimulator {
     PhysicalKeyboardKey? physicalKey,
     String? character,
   }) async {
-    await ensureKeyboardInitialized();
     Future<bool> simulateByRawEvent() {
       return _simulateKeyEventByRawEvent(() {
         platform ??= _defaultPlatform;

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -707,6 +707,15 @@ abstract final class KeyEventSimulator {
 
   static String get _defaultPlatform => kIsWeb ? 'web' : Platform.operatingSystem;
 
+  /// Waits until key event handling is ready.
+  static Future<void> ensureKeyboardInitialized() async {
+    if (!kIsWeb) {
+      while (ServicesBinding.instance.platformDispatcher.onKeyData == null) {
+        await TestWidgetsFlutterBinding.instance.pump(const Duration(milliseconds: 10));
+      }
+    }
+  }
+
   /// Simulates sending a hardware key down event.
   ///
   /// This only simulates key presses coming from a physical keyboard, not from a
@@ -729,6 +738,7 @@ abstract final class KeyEventSimulator {
     PhysicalKeyboardKey? physicalKey,
     String? character,
   }) async {
+    await ensureKeyboardInitialized();
     Future<bool> simulateByRawEvent() {
       return _simulateKeyEventByRawEvent(() {
         platform ??= _defaultPlatform;
@@ -773,6 +783,7 @@ abstract final class KeyEventSimulator {
     String? platform,
     PhysicalKeyboardKey? physicalKey,
   }) async {
+    await ensureKeyboardInitialized();
     Future<bool> simulateByRawEvent() {
       return _simulateKeyEventByRawEvent(() {
         platform ??= _defaultPlatform;
@@ -818,6 +829,7 @@ abstract final class KeyEventSimulator {
     PhysicalKeyboardKey? physicalKey,
     String? character,
   }) async {
+    await ensureKeyboardInitialized();
     Future<bool> simulateByRawEvent() {
       return _simulateKeyEventByRawEvent(() {
         platform ??= _defaultPlatform;

--- a/packages/flutter_test/lib/src/test_default_binary_messenger.dart
+++ b/packages/flutter_test/lib/src/test_default_binary_messenger.dart
@@ -49,7 +49,12 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
   /// Creates a [TestDefaultBinaryMessenger] instance.
   ///
   /// The [delegate] instance must not be null.
-  TestDefaultBinaryMessenger(this.delegate);
+  TestDefaultBinaryMessenger(
+    this.delegate, {
+    Map<String, MessageHandler> outboundHandlers = const <String, MessageHandler>{},
+  }) {
+    _outboundHandlers.addAll(outboundHandlers);
+  }
 
   /// The delegate [BinaryMessenger].
   final BinaryMessenger delegate;


### PR DESCRIPTION
## Description

This PR adds a new channel to query the engine keyboard state.
See https://github.com/flutter/flutter/issues/87391#issuecomment-1228975571 for motivation. 

## Related Issue

Framework side implementation for https://github.com/flutter/flutter/issues/87391.

Once approved the framework will try to query the initial keyboard state from the engine. PRs will be needed on the engine side to answer the framework query.

## Tests

Adds 1 test.