### PR TITLE
[cherry pick] add dimenstion for arm packaging 

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4954,6 +4954,8 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+    dimensions:
+      cpu: "arm64"
 
   - name: Windows flutter_packaging
     recipe: packaging_v2/packaging_v2


### PR DESCRIPTION
Add dimention for arm packaging

cherry picks (#122770) since dart internal has a different logic to parse .ci.yaml targets
