### PR TITLE
[cherry pick] add dimenstion for arm packaging 

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4954,6 +4954,8 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+    dimensions:
+      cpu: "arm64"
 
   - name: Windows flutter_packaging
     recipe: packaging/packaging


### PR DESCRIPTION
Add cpu dimenstion for arm packaging

cherry picks (https://github.com/flutter/flutter/pull/122770) since dart internal has a different logic to parse .ci.yaml targets