### PR TITLE
Remove unused replacement from Visibility.maintain

### DIFF
--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -81,8 +81,6 @@ class Visibility extends StatelessWidget {
 
   /// Control whether the given [child] is [visible].
   ///
-  /// The [child] and [replacement] arguments must not be null.
-  ///
   /// This is equivalent to the default [Visibility] constructor with all
   /// "maintain" fields set to true. This constructor should be used in place of
   /// an [Opacity] widget that only takes on values of `0.0` or `1.0`, as it

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -90,13 +90,13 @@ class Visibility extends StatelessWidget {
   const Visibility.maintain({
     super.key,
     required this.child,
-    this.replacement = const SizedBox.shrink(),
     this.visible = true,
   }) :  maintainState = true,
         maintainAnimation = true,
         maintainSize = true,
         maintainSemantics = true,
-        maintainInteractivity = true;
+        maintainInteractivity = true,
+        replacement = const SizedBox.shrink(); // Unused since maintainState is always true.
 
   /// The widget to show or hide, as controlled by [visible].
   ///


### PR DESCRIPTION
While reviewing https://github.com/flutter/flutter/pull/122585 I noticed that the `replacement` parameter on `Visibility.maintain` doesn't make any sense. It is always ignored because the constructor forces `maintainState` to true:

https://github.com/flutter/flutter/blob/e0ea39fee5d675e677c66974b68432c484f8a77d/packages/flutter/lib/src/widgets/visibility.dart#L139-L140

Therefore, this PR removed the `replacement` parameter from `Visibility.maintain`.