### PR TITLE
[cherry pick] Fix field cleared by TestWindow.clearGestureSettingsTestValue 

### DIFF
--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -153,7 +153,7 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
   /// Deletes any existing test gesture settings and returns to using the real gesture settings.
   void clearGestureSettingsTestValue() {
-    _paddingTestValue = null;
+    _gestureSettings = null;
     onMetricsChanged?.call();
   }
 


### PR DESCRIPTION
context: https://chat.google.com/room/AAAAc_4rqiI/5ID913zNyOU

we are seeing test failures on beta branches. And it seems like the cp in (#121956) would fix it