### PR TITLE
[flutter_tools] land web_tool_tests fix

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1407,7 +1407,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Linux web_tool_tests_1_2
+  - name: Linux web_tool_tests
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1419,30 +1419,10 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
       shard: web_tool_tests
-      subshard: "1_2"
+      subshard: "1_1"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Linux web_tool_tests_2_2
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:33v6"},
-          {"dependency": "chrome_and_driver", "version": "version:96.2"},
-          {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
-        ]
-      shard: web_tool_tests
-      subshard: "2_2"
-      tags: >
-        ["framework", "hostonly", "shard", "linux"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1407,7 +1407,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Linux web_tool_tests
+  - name: Linux web_tool_tests_1_2
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -1419,7 +1419,28 @@ targets:
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
       shard: web_tool_tests
-      subshard: "1_1"
+      subshard: "1_2"
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
+
+  - name: Linux web_tool_tests_2_2
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:33v6"},
+          {"dependency": "chrome_and_driver", "version": "version:96.2"},
+          {"dependency": "open_jdk", "version": "version:11"},
+          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
+        ]
+      shard: web_tool_tests
+      subshard: "2_2"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3314,6 +3314,7 @@ targets:
       subshard: "1_1"
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4698,6 +4699,7 @@ targets:
       subshard: "1_2"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4719,6 +4721,7 @@ targets:
       subshard: "2_2"
       tags: >
         ["framework", "hostonly", "shard"]
+      test_timeout_secs: "2700"
     runIf:
     - dev/**
     - packages/flutter_tools/**

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1019,7 +1019,10 @@ class FlutterVmService {
         onError: (Object? error, StackTrace stackTrace) {
           if (error is vm_service.SentinelException ||
             error == null ||
-            (error is vm_service.RPCError && error.code == RPCErrorCodes.kServiceDisappeared)) {
+            error is vm_service.RPCError &&
+              (error.code == RPCErrorCodes.kServiceDisappeared ||
+                error.code == RPCErrorCodes.kInternalError &&
+                error.message.contains('Sentinel kind: Collected'))) {
             return null;
           }
           return Future<vm_service.Isolate?>.error(error, stackTrace);

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -45,6 +45,20 @@ Future<void> _testProject(HotReloadProject project, {String name = 'Default'}) a
     await flutter.hotRestart();
   }, skip: true); // Skipped for https://github.com/flutter/flutter/issues/123018
 
+  testWithoutContext('$testName: hot restart works without error after delay', () async {
+    flutter.stdout.listen(printOnFailure);
+    await flutter.run(chrome: true, additionalCommandArgs: <String>['--verbose', '--web-renderer=html']);
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    await flutter.hotRestart();
+  });
+
+  testWithoutContext('$testName: multiple hot restarts work without error', () async {
+    flutter.stdout.listen(printOnFailure);
+    await flutter.run(chrome: true, additionalCommandArgs: <String>['--verbose', '--web-renderer=html']);
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    await Future.wait(<Future<void>>[ flutter.hotRestart(), flutter.hotRestart()]);
+  });
+
   testWithoutContext('$testName: newly added code executes during hot restart', () async {
     final Completer<void> completer = Completer<void>();
     final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -43,7 +43,7 @@ Future<void> _testProject(HotReloadProject project, {String name = 'Default'}) a
     flutter.stdout.listen(printOnFailure);
     await flutter.run(chrome: true, additionalCommandArgs: <String>['--verbose', '--web-renderer=html']);
     await flutter.hotRestart();
-  }, skip: true); // Skipped for https://github.com/flutter/flutter/issues/123018
+  });
 
   testWithoutContext('$testName: hot restart works without error after delay', () async {
     flutter.stdout.listen(printOnFailure);
@@ -75,7 +75,7 @@ Future<void> _testProject(HotReloadProject project, {String name = 'Default'}) a
     } finally {
       await subscription.cancel();
     }
-  }, skip: true); // Skipped for https://github.com/flutter/flutter/issues/123018
+  });
 
   testWithoutContext('$testName: newly added code executes during hot restart - canvaskit', () async {
     final Completer<void> completer = Completer<void>();


### PR DESCRIPTION
Re-land of https://github.com/flutter/flutter/pull/122776 plus un-skip of https://github.com/flutter/flutter/pull/123019 (since the #122776 will fix those flakes).

Which was reverted in https://github.com/flutter/flutter/pull/122855 because of intermittent timeouts on Windows (e.g. https://ci.chromium.org/p/flutter/builders/try/Windows%20web_tool_tests_1_2/5036?).

Note because of the way this test file is structured, adding a new "test" actually adds 5 tests across the web runtime variants. On Linux, each of these tests runs a little over 30 seconds (I imagine most of the that is spinning up an instance of headless chrome) and this is obviously more on Windows (since there are two shards on Windows and one on Linux).

Note, before the revert, `Linux web_tool_tests` reached 28' 9" for the test step, dangerously close to the default 30 minute timeout, thus the bump to 45 minutes or 2700 seconds https://ci.chromium.org/p/flutter/builders/prod/Linux%20web_tool_tests/11235