### PR TITLE
TapAndDragGestureRecognizer should declare victory immediately when drag is detected

### DIFF
--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -25,7 +25,7 @@ double _getGlobalDistance(PointerEvent event, OffsetPair? originPosition) {
 //   state as long as it continues to track a pointer.
 // * If a [PointerMoveEvent] is tracked that has moved a sufficient global distance
 //   from the initial [PointerDownEvent] and it came before a [PointerUpEvent], then
-//   when this recognizer wins the arena, it will move from the [possible] state to [accepted].
+//   this recognizer moves from the [possible] state to [accepted].
 // * If a [PointerUpEvent] is tracked before the pointer has moved a sufficient global
 //   distance to be considered a drag, then this recognizer moves from the [possible]
 //   state to [ready].
@@ -664,12 +664,13 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 /// screen) or a drag (e.g. if the pointer was not dragged far enough to
 /// be considered a drag.
 ///
-/// This recognizer will not immediately declare victory for every tap or drag that it
-/// recognizes.
+/// This recognizer will not immediately declare victory for every tap that it
+/// recognizes, but it declares victory for every drag.
 ///
 /// The recognizer will declare victory when all other recognizer's in
 /// the arena have lost, if the timer of [kPressTimeout] elapses and a tap
-/// series greater than 1 is being tracked.
+/// series greater than 1 is being tracked, or until the pointer has moved
+/// a sufficient global distance from the origin to be considered a drag.
 ///
 /// If this recognizer loses the arena (either by declaring defeat or by
 /// another recognizer declaring victory) while the pointer is contacting the
@@ -689,8 +690,8 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 ///
 /// When competing against [DragGestureRecognizer], if the pointer does not move a sufficient
 /// global distance to be considered a drag, the recognizers will tie in the arena. If the
-/// pointer does travel enough distance then the [TapAndDragGestureRecognizer] will lose because
-/// the [DragGestureRecognizer] will declare self-victory when the drag threshold is met.
+/// pointer does travel enough distance then the recognizer that entered the arena
+/// first will win. The gesture detected in this case is a drag.
 class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _TapStatusTrackerMixin {
   /// Creates a tap and drag gesture recognizer.
   ///
@@ -955,7 +956,9 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
 
     _wonArenaForPrimaryPointer = true;
 
-    if (_start != null) {
+    // resolve(GestureDisposition.accepted) will be called when the [PointerMoveEvent] has
+    // moved a sufficient global distance.
+    if (_dragState == _DragState.accepted && _start != null) {
       _acceptDrag(_start!);
     }
 
@@ -979,6 +982,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
             // but the pointer has exceeded the tap tolerance, then the pointer is accepted as a
             // drag gesture.
             if (currentDown != null) {
+              _dragState = _DragState.accepted;
               _acceptDrag(currentDown!);
               _checkDragEnd();
             }
@@ -1084,7 +1088,6 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
     if (!_wonArenaForPrimaryPointer) {
       return;
     }
-    _dragState = _DragState.accepted;
     if (dragStartBehavior == DragStartBehavior.start) {
       _initialPosition = _initialPosition + OffsetPair(global: event.delta, local: event.localDelta);
     }
@@ -1113,6 +1116,8 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
     ).distance * 1.sign;
     if (_hasSufficientGlobalDistanceToAccept(event.kind, gestureSettings?.touchSlop)) {
       _start = event;
+      _dragState = _DragState.accepted;
+      resolve(GestureDisposition.accepted);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -895,7 +895,7 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
   @protected
   double? getPrimaryValueFromOffset(Offset value);
 
-  /// Determines whether the `globalDistance` on the desired axis has passed
+  /// Determines whether the global distance on the desired axis has passed
   /// the threshold to be considered a drag.
   ///
   /// This method can be overriden to define a custom threshold for a drag.
@@ -908,7 +908,11 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
   ///   defines the default threshold the global distance should pass for movement
   ///   on a plane to be considered a drag.
   @protected
-  bool hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double globalDistanceMoved);
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double globalDistanceMovedOnAxis,
+    double globalDistanceMovedAllAxes,
+    bool wonArenaForPrimaryPointer);
 
   // Drag updates may require throttling to avoid excessive updating, such as for text layouts in text
   // fields. The frequency of invocations is controlled by the [dragUpdateThrottleFrequency].
@@ -1154,8 +1158,7 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
       untransformedDelta: event.localDelta,
       untransformedEndPosition: event.localPosition
     ).distance * 1.sign;
-    if (hasSufficientGlobalDistanceToAccept(event.kind, _globalDistanceMoved)
-        || (_wonArenaForPrimaryPointer && _globalDistanceMovedAllAxes.abs() > computePanSlop(event.kind, gestureSettings))) {
+    if (hasSufficientGlobalDistanceToAccept(event.kind, _globalDistanceMoved, _globalDistanceMovedAllAxes, _wonArenaForPrimaryPointer)) {
       _start = event;
       _dragState = _DragState.accepted;
       resolve(GestureDisposition.accepted);
@@ -1351,8 +1354,12 @@ class TapAndHorizontalDragGestureRecognizer extends BaseTapAndDragGestureRecogni
   });
 
   @override
-  bool hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double globalDistanceMoved) {
-    return globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double globalDistanceMovedOnAxis,
+    double globalDistanceMovedAllAxes,
+    bool wonArenaForPrimaryPointer) {
+    return globalDistanceMovedOnAxis.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
@@ -1381,8 +1388,12 @@ class TapAndPanGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   });
 
   @override
-  bool hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double globalDistanceMoved) {
-    return globalDistanceMoved.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double globalDistanceMovedOnAxis,
+    double globalDistanceMovedAllAxes,
+    bool wonArenaForPrimaryPointer) {
+    return globalDistanceMovedOnAxis.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
@@ -1414,8 +1425,12 @@ class TapAndDragGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   });
 
   @override
-  bool hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double globalDistanceMoved) {
-    return globalDistanceMoved.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double globalDistanceMovedOnAxis,
+    double globalDistanceMovedAllAxes,
+    bool wonArenaForPrimaryPointer) {
+    return globalDistanceMovedOnAxis.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -14,10 +14,10 @@ double _getGlobalDistance(PointerEvent event, OffsetPair? originPosition) {
   return offset.distance;
 }
 
-// The possible states of a [TapAndDragGestureRecognizer].
+// The possible states of a [BaseTapAndDragGestureRecognizer].
 //
 // The recognizer advances from [ready] to [possible] when it starts tracking
-// a pointer in [TapAndDragGestureRecognizer.addAllowedPointer]. Where it advances
+// a pointer in [BaseTapAndDragGestureRecognizer.addAllowedPointer]. Where it advances
 // from there depends on the sequence of pointer events that is tracked by the
 // recognizer, following the initial [PointerDownEvent]:
 //
@@ -51,7 +51,7 @@ enum _DragState {
 /// The consecutive tap count at the time the pointer contacted the
 /// screen is given by [TapDragDownDetails.consecutiveTapCount].
 ///
-/// Used by [TapAndDragGestureRecognizer.onTapDown].
+/// Used by [BaseTapAndDragGestureRecognizer.onTapDown].
 typedef GestureTapDragDownCallback  = void Function(TapDragDownDetails details);
 
 /// Details for [GestureTapDragDownCallback], such as the number of
@@ -59,8 +59,8 @@ typedef GestureTapDragDownCallback  = void Function(TapDragDownDetails details);
 ///
 /// See also:
 ///
-///  * [TapAndDragGestureRecognizer], which passes this information to its
-///    [TapAndDragGestureRecognizer.onTapDown] callback.
+///  * [BaseTapAndDragGestureRecognizer], which passes this information to its
+///    [BaseTapAndDragGestureRecognizer.onTapDown] callback.
 ///  * [TapDragUpDetails], the details for [GestureTapDragUpCallback].
 ///  * [TapDragStartDetails], the details for [GestureTapDragStartCallback].
 ///  * [TapDragUpdateDetails], the details for [GestureTapDragUpdateCallback].
@@ -110,7 +110,7 @@ class TapDragDownDetails with Diagnosticable {
 /// The consecutive tap count at the time the pointer contacted the
 /// screen is given by [TapDragUpDetails.consecutiveTapCount].
 ///
-/// Used by [TapAndDragGestureRecognizer.onTapUp].
+/// Used by [BaseTapAndDragGestureRecognizer.onTapUp].
 typedef GestureTapDragUpCallback  = void Function(TapDragUpDetails details);
 
 /// Details for [GestureTapDragUpCallback], such as the number of
@@ -118,8 +118,8 @@ typedef GestureTapDragUpCallback  = void Function(TapDragUpDetails details);
 ///
 /// See also:
 ///
-///  * [TapAndDragGestureRecognizer], which passes this information to its
-///    [TapAndDragGestureRecognizer.onTapUp] callback.
+///  * [BaseTapAndDragGestureRecognizer], which passes this information to its
+///    [BaseTapAndDragGestureRecognizer.onTapUp] callback.
 ///  * [TapDragDownDetails], the details for [GestureTapDragDownCallback].
 ///  * [TapDragStartDetails], the details for [GestureTapDragStartCallback].
 ///  * [TapDragUpdateDetails], the details for [GestureTapDragUpdateCallback].
@@ -169,7 +169,7 @@ class TapDragUpDetails with Diagnosticable {
 /// The consecutive tap count at the time the pointer contacted the
 /// screen is given by [TapDragStartDetails.consecutiveTapCount].
 ///
-/// Used by [TapAndDragGestureRecognizer.onDragStart].
+/// Used by [BaseTapAndDragGestureRecognizer.onDragStart].
 typedef GestureTapDragStartCallback = void Function(TapDragStartDetails details);
 
 /// Details for [GestureTapDragStartCallback], such as the number of
@@ -177,8 +177,8 @@ typedef GestureTapDragStartCallback = void Function(TapDragStartDetails details)
 ///
 /// See also:
 ///
-///  * [TapAndDragGestureRecognizer], which passes this information to its
-///    [TapAndDragGestureRecognizer.onDragStart] callback.
+///  * [BaseTapAndDragGestureRecognizer], which passes this information to its
+///    [BaseTapAndDragGestureRecognizer.onDragStart] callback.
 ///  * [TapDragDownDetails], the details for [GestureTapDragDownCallback].
 ///  * [TapDragUpDetails], the details for [GestureTapDragUpCallback].
 ///  * [TapDragUpdateDetails], the details for [GestureTapDragUpdateCallback].
@@ -242,7 +242,7 @@ class TapDragStartDetails with Diagnosticable {
 /// The consecutive tap count at the time the pointer contacted the
 /// screen is given by [TapDragUpdateDetails.consecutiveTapCount].
 ///
-/// Used by [TapAndDragGestureRecognizer.onDragUpdate].
+/// Used by [BaseTapAndDragGestureRecognizer.onDragUpdate].
 typedef GestureTapDragUpdateCallback = void Function(TapDragUpdateDetails details);
 
 /// Details for [GestureTapDragUpdateCallback], such as the number of
@@ -250,8 +250,8 @@ typedef GestureTapDragUpdateCallback = void Function(TapDragUpdateDetails detail
 ///
 /// See also:
 ///
-///  * [TapAndDragGestureRecognizer], which passes this information to its
-///    [TapAndDragGestureRecognizer.onDragUpdate] callback.
+///  * [BaseTapAndDragGestureRecognizer], which passes this information to its
+///    [BaseTapAndDragGestureRecognizer.onDragUpdate] callback.
 ///  * [TapDragDownDetails], the details for [GestureTapDragDownCallback].
 ///  * [TapDragUpDetails], the details for [GestureTapDragUpCallback].
 ///  * [TapDragStartDetails], the details for [GestureTapDragStartCallback].
@@ -374,7 +374,7 @@ class TapDragUpdateDetails with Diagnosticable {
 /// The consecutive tap count at the time the pointer contacted the
 /// screen is given by [TapDragEndDetails.consecutiveTapCount].
 ///
-/// Used by [TapAndDragGestureRecognizer.onDragEnd].
+/// Used by [BaseTapAndDragGestureRecognizer.onDragEnd].
 typedef GestureTapDragEndCallback = void Function(TapDragEndDetails endDetails);
 
 /// Details for [GestureTapDragEndCallback], such as the number of
@@ -382,8 +382,8 @@ typedef GestureTapDragEndCallback = void Function(TapDragEndDetails endDetails);
 ///
 /// See also:
 ///
-///  * [TapAndDragGestureRecognizer], which passes this information to its
-///    [TapAndDragGestureRecognizer.onDragEnd] callback.
+///  * [BaseTapAndDragGestureRecognizer], which passes this information to its
+///    [BaseTapAndDragGestureRecognizer.onDragEnd] callback.
 ///  * [TapDragDownDetails], the details for [GestureTapDragDownCallback].
 ///  * [TapDragUpDetails], the details for [GestureTapDragUpCallback].
 ///  * [TapDragStartDetails], the details for [GestureTapDragStartCallback].
@@ -443,7 +443,7 @@ class TapDragEndDetails with Diagnosticable {
 /// Signature for when the pointer that previously triggered a
 /// [GestureTapDragDownCallback] did not complete.
 ///
-/// Used by [TapAndDragGestureRecognizer.onCancel].
+/// Used by [BaseTapAndDragGestureRecognizer.onCancel].
 typedef GestureCancelCallback = void Function();
 
 // A mixin for [OneSequenceGestureRecognizer] that tracks the number of taps
@@ -642,14 +642,14 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   }
 }
 
-/// Recognizes taps and movements.
+///  A base class for gesture recognizers that recognize taps and movements.
 ///
 /// Takes on the responsibilities of [TapGestureRecognizer] and
 /// [DragGestureRecognizer] in one [GestureRecognizer].
 ///
 /// ### Gesture arena behavior
 ///
-/// [TapAndDragGestureRecognizer] competes on the pointer events of
+/// [BaseTapAndDragGestureRecognizer] competes on the pointer events of
 /// [kPrimaryButton] only when it has at least one non-null `onTap*`
 /// or `onDrag*` callback.
 ///
@@ -673,7 +673,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 /// ### When competing with `TapGestureRecognizer` and `DragGestureRecognizer`
 ///
 /// Similar to [TapGestureRecognizer] and [DragGestureRecognizer],
-/// [TapAndDragGestureRecognizer] will not aggressively declare victory when it detects
+/// [BaseTapAndDragGestureRecognizer] will not aggressively declare victory when it detects
 /// a tap, so when it is competing with those gesture recognizers and others it has a chance
 /// of losing.
 ///
@@ -686,11 +686,11 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 /// global distance to be considered a drag, the recognizers will tie in the arena. If the
 /// pointer does travel enough distance then the recognizer that entered the arena
 /// first will win. The gesture detected in this case is a drag.
-abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _TapStatusTrackerMixin {
+abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _TapStatusTrackerMixin {
   /// Creates a tap and drag gesture recognizer.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
-  TapAndDragGestureRecognizer({
+  BaseTapAndDragGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
     super.allowedButtonsFilter,
@@ -740,7 +740,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
   /// The position of the pointer is provided in the callback's `details`
   /// argument, which is a [TapDragDownDetails] object.
   ///
-  /// {@template flutter.gestures.selectionrecognizers.TapAndDragGestureRecognizer.tapStatusTrackerData}
+  /// {@template flutter.gestures.selectionrecognizers.BaseTapAndDragGestureRecognizer.tapStatusTrackerData}
   /// The number of consecutive taps, and the keys that were pressed on tap down
   /// are also provided in the callback's `details` argument.
   /// {@endtemplate}
@@ -759,7 +759,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
   /// The position of the pointer is provided in the callback's `details`
   /// argument, which is a [TapDragUpDetails] object.
   ///
-  /// {@macro flutter.gestures.selectionrecognizers.TapAndDragGestureRecognizer.tapStatusTrackerData}
+  /// {@macro flutter.gestures.selectionrecognizers.BaseTapAndDragGestureRecognizer.tapStatusTrackerData}
   ///
   /// See also:
   ///
@@ -773,7 +773,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
   /// argument, which is a [TapDragStartDetails] object. The [dragStartBehavior]
   /// determines this position.
   ///
-  /// {@macro flutter.gestures.selectionrecognizers.TapAndDragGestureRecognizer.tapStatusTrackerData}
+  /// {@macro flutter.gestures.selectionrecognizers.BaseTapAndDragGestureRecognizer.tapStatusTrackerData}
   ///
   /// See also:
   ///
@@ -786,7 +786,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
   /// The distance traveled by the pointer since the last update is provided in
   /// the callback's `details` argument, which is a [TapDragUpdateDetails] object.
   ///
-  /// {@macro flutter.gestures.selectionrecognizers.TapAndDragGestureRecognizer.tapStatusTrackerData}
+  /// {@macro flutter.gestures.selectionrecognizers.BaseTapAndDragGestureRecognizer.tapStatusTrackerData}
   ///
   /// See also:
   ///
@@ -799,7 +799,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
   /// The velocity is provided in the callback's `details` argument, which is a
   /// [TapDragEndDetails] object.
   ///
-  /// {@macro flutter.gestures.selectionrecognizers.TapAndDragGestureRecognizer.tapStatusTrackerData}
+  /// {@macro flutter.gestures.selectionrecognizers.BaseTapAndDragGestureRecognizer.tapStatusTrackerData}
   ///
   /// See also:
   ///
@@ -1285,7 +1285,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
 ///
 ///  * [HorizontalDragGestureRecognizer], for a similar recognizer that only recognizes
 ///  horizontal movement.
-class TapAndHorizontalDragGestureRecognizer extends TapAndDragGestureRecognizer {
+class TapAndHorizontalDragGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   /// Create a gesture recognizer for interactions in the horizontal axis.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
@@ -1315,9 +1315,9 @@ class TapAndHorizontalDragGestureRecognizer extends TapAndDragGestureRecognizer 
 ///
 ///  * [PanGestureRecognizer], for a similar recognizer that only recognizes
 ///  movement.
-class TapAndPanGestureRecognizer extends TapAndDragGestureRecognizer {
+class TapAndDragGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   /// Create a gesture recognizer for interactions on a plane.
-  TapAndPanGestureRecognizer({
+  TapAndDragGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
   });

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart' show HardwareKeyboard, LogicalKeyboardKey;
 
 import 'framework.dart';

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1271,6 +1271,12 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
   }
 }
 
+/// Recognizes taps along with movement in the horizontal direction.
+///
+/// See also:
+///
+///  * [HorizontalDragGestureRecognizer], for a similar recognizer that only recognizes
+///  horizontal movement.
 class TapAndHorizontalDragGestureRecognizer extends TapAndDragGestureRecognizer {
   /// Create a gesture recognizer for interactions in the horizontal axis.
   ///
@@ -1295,8 +1301,14 @@ class TapAndHorizontalDragGestureRecognizer extends TapAndDragGestureRecognizer 
   String get debugDescription => 'tap and horizontal drag';
 }
 
+/// Recognizes taps along with both horizontal and vertical movement.
+///
+/// See also:
+///
+///  * [PanGestureRecognizer], for a similar recognizer that only recognizes
+///  movement.
 class TapAndPanGestureRecognizer extends TapAndDragGestureRecognizer {
-  /// Create a gesture recognizer for tracking movement on a plane.
+  /// Create a gesture recognizer for interactions on a plane.
   TapAndPanGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1342,17 +1342,17 @@ class TapAndPanGestureRecognizer extends BaseTapAndDragGestureRecognizer {
 }
 
 @Deprecated(
-  'Use [TapAndPanGestureRecognizer] instead. '
-  '[TapAndPanGestureRecognizer] works exactly the same but has a more disambiguated name from [BaseTapAndDragGestureRecognizer]. '
-  'This feature was deprecated after v3.9.0-19.0.pre.36.'
+  'Use TapAndPanGestureRecognizer instead. '
+  'TapAndPanGestureRecognizer works exactly the same but has a more disambiguated name from BaseTapAndDragGestureRecognizer. '
+  'This feature was deprecated after v3.9.0-19.0.pre.'
 )
 /// {@macro flutter.gestures.selectionrecognizers.TapAndPanGestureRecognizer}
 class TapAndDragGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   /// Create a gesture recognizer for interactions on a plane.
   @Deprecated(
-    'Use [TapAndPanGestureRecognizer] instead. '
-    '[TapAndPanGestureRecognizer] works exactly the same but has a more disambiguated name from [BaseTapAndDragGestureRecognizer]. '
-    'This feature was deprecated after v3.9.0-19.0.pre.36.'
+    'Use TapAndPanGestureRecognizer instead. '
+    'TapAndPanGestureRecognizer works exactly the same but has a more disambiguated name from BaseTapAndDragGestureRecognizer. '
+    'This feature was deprecated after v3.9.0-19.0.pre.'
   )
   TapAndDragGestureRecognizer({
     super.debugOwner,

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1031,6 +1031,7 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
       if (_dragState == _DragState.possible) {
         // The drag has not been accepted before a [PointerUpEvent], therefore the recognizer
         // attempts to recognize a tap.
+        _acceptedActivePointers.remove(event.pointer);
         stopTrackingIfPointerNoLongerDown(event);
       } else if (_dragState == _DragState.accepted) {
         _giveUpPointer(event.pointer);

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -962,6 +962,9 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
             // but the pointer has exceeded the tap tolerance, then the pointer is accepted as a
             // drag gesture.
             if (currentDown != null) {
+              if (!_acceptedActivePointers.remove(pointer)) {
+                resolvePointer(pointer, GestureDisposition.rejected);
+              }
               _dragState = _DragState.accepted;
               _acceptDrag(currentDown!);
               _checkDragEnd();
@@ -1031,7 +1034,7 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
       if (_dragState == _DragState.possible) {
         // The drag has not been accepted before a [PointerUpEvent], therefore the recognizer
         // attempts to recognize a tap.
-        _acceptedActivePointers.remove(event.pointer);
+        // _acceptedActivePointers.remove(event.pointer);
         stopTrackingIfPointerNoLongerDown(event);
       } else if (_dragState == _DragState.accepted) {
         _giveUpPointer(event.pointer);

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -11,6 +11,10 @@ import 'package:flutter/services.dart' show HardwareKeyboard, LogicalKeyboardKey
 import 'framework.dart';
 import 'gesture_detector.dart';
 
+// Examples can assume:
+// void setState(VoidCallback fn) { }
+// late String _last;
+
 double _getGlobalDistance(PointerEvent event, OffsetPair? originPosition) {
   assert(originPosition != null);
   final Offset offset = event.position - originPosition!.global;

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -936,7 +936,9 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
 
     // resolve(GestureDisposition.accepted) will be called when the [PointerMoveEvent] has
     // moved a sufficient global distance.
-    if (_dragState == _DragState.accepted && _start != null) {
+    if (_start != null) {
+      assert(_dragState == _DragState.accepted);
+      assert(currentUp == null);
       _acceptDrag(_start!);
     }
 

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -733,7 +733,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 ///   child: Container(
 ///     width: 300.0,
 ///     height: 300.0,
-///     color: Colors.yellow,
+///     color: Colors.yellow,
 ///     alignment: Alignment.center,
 ///     child: RawGestureDetector(
 ///       gestures: <Type, GestureRecognizerFactory>{

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1104,7 +1104,9 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
         || (_wonArenaForPrimaryPointer && _globalDistanceMovedAllAxes.abs() > computePanSlop(event.kind, gestureSettings))) {
       _start = event;
       _dragState = _DragState.accepted;
-      resolve(GestureDisposition.accepted);
+      if (!_wonArenaForPrimaryPointer) {
+        resolve(GestureDisposition.accepted);
+      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart' show HardwareKeyboard, LogicalKeyboardKey;
 
 import 'framework.dart';

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1216,7 +1216,9 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
         keysPressedOnDown: keysPressedOnDown,
       );
 
-    invokeCallback<void>('onDragEnd', () => onDragEnd!(endDetails));
+    if (onDragEnd != null) {
+      invokeCallback<void>('onDragEnd', () => onDragEnd!(endDetails));
+    }
 
     _resetTaps();
     _resetDragUpdateThrottle();

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1216,9 +1216,7 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
         keysPressedOnDown: keysPressedOnDown,
       );
 
-    if (onDragEnd != null) {
-      invokeCallback<void>('onDragEnd', () => onDragEnd!(endDetails));
-    }
+    invokeCallback<void>('onDragEnd', () => onDragEnd!(endDetails));
 
     _resetTaps();
     _resetDragUpdateThrottle();

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -850,69 +850,9 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
 
   final Set<int> _acceptedActivePointers = <int>{};
 
-  /// Computes the effective drag delta based on the given `delta` value.
-  ///
-  /// The value returned from this method is used in calculating the global distance
-  /// that a pointer has moved, and can be overriden to customize the drag behavior of this recognizer.
-  ///
-  /// For example, to limit this recognizer to horizontal dragging, the global distance
-  /// calculation should only take into account movement on the x-axis. In that
-  /// case this method should return `Offset(delta.dx, 0.0)`.
-  ///
-  /// When overriding this method, both this and [getPrimaryValueFromOffset]
-  /// should be overriden with the same direction in mind, or unexpected behavior
-  /// may be observed.
-  ///
-  /// See also:
-  ///   * [TapAndHorizontalDragGestureRecognizer.getDeltaForDetails], which returns
-  ///   a modified `delta` that only takes into account the value on the x-axis.
-  ///   * [TapAndPanGestureRecognizer.getDeltaForDetails], which returns the given
-  ///   `delta` unmodified so a drag can be allowed in any direction.
-  @protected
-  Offset getDeltaForDetails(Offset delta);
-
-  /// Returns the primary value from the given [Offset] based on the desired
-  /// drag direction of this recognizer.
-  ///
-  /// The value returned from this method is used in calculating the directional
-  /// component of the global distance that a pointer has moved, and can be 
-  /// overriden to customize the drag behavior of this recognizer.
-  ///
-  /// For example, to limit this recognizer to horizontal dragging, the global distance
-  /// calculation should only take into account movement on the x-axis. In that
-  /// case this method should return `value.dx`.
-  /// 
-  /// When overriding this method, both this and [getDeltaForDetails] should be
-  /// overriden with the same direction in mind, or unexpected behavior may be
-  /// observed.
-  ///
-  /// See also:
-  ///   * [TapAndHorizontalDragGestureRecognizer.getPrimaryValueFromOffset], which returns
-  ///   the horizontal component of the given [Offset].
-  ///   * [TapAndPanGestureRecognizer.getPrimaryValueFromOffset], which returns null
-  ///   and indicates that the recognizer should use both horizontal and vertical
-  ///   components when calculating the global distance moved by a pointer.
-  @protected
-  double? getPrimaryValueFromOffset(Offset value);
-
-  /// Determines whether the global distance on the desired axis has passed
-  /// the threshold to be considered a drag.
-  ///
-  /// This method can be overriden to define a custom threshold for a drag.
-  ///
-  /// See also:
-  ///   * [TapAndHorizontalDragGestureRecognizer.hasSufficientGlobalDistanceToAccept], which
-  ///   defines the default threshold the global distance should pass for a horizontal movement
-  ///  to be considered a drag.
-  ///   * [TapAndPanGestureRecognizer.hasSufficientGlobalDistanceToAccept], which
-  ///   defines the default threshold the global distance should pass for movement
-  ///   on a plane to be considered a drag.
-  @protected
-  bool hasSufficientGlobalDistanceToAccept(
-    PointerDeviceKind pointerDeviceKind,
-    double globalDistanceMovedOnAxis,
-    double globalDistanceMovedAllAxes,
-    bool wonArenaForPrimaryPointer);
+  Offset _getDeltaForDetails(Offset delta);
+  double? _getPrimaryValueFromOffset(Offset value);
+  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind);
 
   // Drag updates may require throttling to avoid excessive updating, such as for text layouts in text
   // fields. The frequency of invocations is controlled by the [dragUpdateThrottleFrequency].
@@ -1062,7 +1002,7 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
       //
       // To be recognized as a drag, the [PointerMoveEvent] must also have moved
       // a sufficient global distance from the initial [PointerDownEvent] to be
-      // accepted as a drag. This logic is handled in [hasSufficientGlobalDistanceToAccept].
+      // accepted as a drag. This logic is handled in [_hasSufficientGlobalDistanceToAccept].
       //
       // The recognizer will also detect the gesture as a drag when the pointer
       // has been accepted and it has moved past the [slopTolerance] but has not moved
@@ -1147,18 +1087,19 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
 
   void _checkDrag(PointerMoveEvent event) {
     final Matrix4? localToGlobalTransform = event.transform == null ? null : Matrix4.tryInvert(event.transform!);
-    final Offset movedLocally = getDeltaForDetails(event.localDelta);
+    final Offset movedLocally = _getDeltaForDetails(event.localDelta);
     _globalDistanceMoved += PointerEvent.transformDeltaViaPositions(
       transform: localToGlobalTransform,
       untransformedDelta: movedLocally,
       untransformedEndPosition: event.localPosition
-    ).distance * (getPrimaryValueFromOffset(movedLocally) ?? 1).sign;
+    ).distance * (_getPrimaryValueFromOffset(movedLocally) ?? 1).sign;
     _globalDistanceMovedAllAxes += PointerEvent.transformDeltaViaPositions(
       transform: localToGlobalTransform,
       untransformedDelta: event.localDelta,
       untransformedEndPosition: event.localPosition
     ).distance * 1.sign;
-    if (hasSufficientGlobalDistanceToAccept(event.kind, _globalDistanceMoved, _globalDistanceMovedAllAxes, _wonArenaForPrimaryPointer)) {
+    if (_hasSufficientGlobalDistanceToAccept(event.kind)
+        || (_wonArenaForPrimaryPointer && _globalDistanceMovedAllAxes.abs() > computePanSlop(event.kind, gestureSettings))) {
       _start = event;
       _dragState = _DragState.accepted;
       resolve(GestureDisposition.accepted);
@@ -1354,19 +1295,15 @@ class TapAndHorizontalDragGestureRecognizer extends BaseTapAndDragGestureRecogni
   });
 
   @override
-  bool hasSufficientGlobalDistanceToAccept(
-    PointerDeviceKind pointerDeviceKind,
-    double globalDistanceMovedOnAxis,
-    double globalDistanceMovedAllAxes,
-    bool wonArenaForPrimaryPointer) {
-    return globalDistanceMovedOnAxis.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
+  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind) {
+    return _globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
-  Offset getDeltaForDetails(Offset delta) => Offset(delta.dx, 0.0);
+  Offset _getDeltaForDetails(Offset delta) => Offset(delta.dx, 0.0);
 
   @override
-  double getPrimaryValueFromOffset(Offset value) => value.dx;
+  double _getPrimaryValueFromOffset(Offset value) => value.dx;
 
   @override
   String get debugDescription => 'tap and horizontal drag';
@@ -1388,19 +1325,15 @@ class TapAndPanGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   });
 
   @override
-  bool hasSufficientGlobalDistanceToAccept(
-    PointerDeviceKind pointerDeviceKind,
-    double globalDistanceMovedOnAxis,
-    double globalDistanceMovedAllAxes,
-    bool wonArenaForPrimaryPointer) {
-    return globalDistanceMovedOnAxis.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
+  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind) {
+    return _globalDistanceMoved.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
-  Offset getDeltaForDetails(Offset delta) => delta;
+  Offset _getDeltaForDetails(Offset delta) => delta;
 
   @override
-  double? getPrimaryValueFromOffset(Offset value) => null;
+  double? _getPrimaryValueFromOffset(Offset value) => null;
 
   @override
   String get debugDescription => 'tap and pan';
@@ -1425,19 +1358,15 @@ class TapAndDragGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   });
 
   @override
-  bool hasSufficientGlobalDistanceToAccept(
-    PointerDeviceKind pointerDeviceKind,
-    double globalDistanceMovedOnAxis,
-    double globalDistanceMovedAllAxes,
-    bool wonArenaForPrimaryPointer) {
-    return globalDistanceMovedOnAxis.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
+  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind) {
+    return _globalDistanceMoved.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
-  Offset getDeltaForDetails(Offset delta) => delta;
+  Offset _getDeltaForDetails(Offset delta) => delta;
 
   @override
-  double? getPrimaryValueFromOffset(Offset value) => null;
+  double? _getPrimaryValueFromOffset(Offset value) => null;
 
   @override
   String get debugDescription => 'tap and pan';

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -859,6 +859,10 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
   /// calculation should only take into account movement on the x-axis. In that
   /// case this method should return `Offset(delta.dx, 0.0)`.
   ///
+  /// When overriding this method, both this and [getPrimaryValueFromOffset]
+  /// should be overriden with the same direction in mind, or unexpected behavior
+  /// may be observed.
+  ///
   /// See also:
   ///   * [TapAndHorizontalDragGestureRecognizer.getDeltaForDetails], which returns
   ///   a modified `delta` that only takes into account the value on the x-axis.
@@ -877,6 +881,10 @@ abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecogni
   /// For example, to limit this recognizer to horizontal dragging, the global distance
   /// calculation should only take into account movement on the x-axis. In that
   /// case this method should return `value.dx`.
+  /// 
+  /// When overriding this method, both this and [getDeltaForDetails] should be
+  /// overriden with the same direction in mind, or unexpected behavior may be
+  /// observed.
   ///
   /// See also:
   ///   * [TapAndHorizontalDragGestureRecognizer.getPrimaryValueFromOffset], which returns

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1309,14 +1309,49 @@ class TapAndHorizontalDragGestureRecognizer extends BaseTapAndDragGestureRecogni
   String get debugDescription => 'tap and horizontal drag';
 }
 
+/// {@template flutter.gestures.selectionrecognizers.TapAndPanGestureRecognizer}
 /// Recognizes taps along with both horizontal and vertical movement.
 ///
 /// See also:
 ///
 ///  * [PanGestureRecognizer], for a similar recognizer that only recognizes
 ///  movement.
+/// {@endtemplate}
+class TapAndPanGestureRecognizer extends BaseTapAndDragGestureRecognizer {
+  /// Create a gesture recognizer for interactions on a plane.
+  TapAndPanGestureRecognizer({
+    super.debugOwner,
+    super.supportedDevices,
+  });
+
+  @override
+  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind) {
+    return _globalDistanceMoved.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
+  }
+
+  @override
+  Offset _getDeltaForDetails(Offset delta) => delta;
+
+  @override
+  double? _getPrimaryValueFromOffset(Offset value) => null;
+
+  @override
+  String get debugDescription => 'tap and pan';
+}
+
+@Deprecated(
+  'Use [TapAndPanGestureRecognizer] instead. '
+  '[TapAndPanGestureRecognizer] works exactly the same but has a more disambiguated name from [BaseTapAndDragGestureRecognizer]. '
+  'This feature was deprecated after v3.9.0-19.0.pre.36.'
+)
+/// {@macro flutter.gestures.selectionrecognizers.TapAndPanGestureRecognizer}
 class TapAndDragGestureRecognizer extends BaseTapAndDragGestureRecognizer {
   /// Create a gesture recognizer for interactions on a plane.
+  @Deprecated(
+    'Use [TapAndPanGestureRecognizer] instead. '
+    '[TapAndPanGestureRecognizer] works exactly the same but has a more disambiguated name from [BaseTapAndDragGestureRecognizer]. '
+    'This feature was deprecated after v3.9.0-19.0.pre.36.'
+  )
   TapAndDragGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -689,13 +689,13 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 /// global distance to be considered a drag, the recognizers will tie in the arena. If the
 /// pointer does travel enough distance then the recognizer that entered the arena
 /// first will win. The gesture detected in this case is a drag.
-/// 
+///
 /// {@tool snippet}
 ///
 /// This example shows how to hook up [TapAndPanGestureRecognizer]s' to nested
 /// [RawGestureDetector]s'. It assumes that the code is being used inside a [State]
 /// object with a `_last` field that is then displayed as the child of the gesture detector.
-/// 
+///
 /// In this example, if the pointer has moved past the drag threshold, then the
 /// the first [TapAndPanGestureRecognizer] instance to receive the [PointerEvent]
 /// will win the arena because the recognizer will immediately declare victory.
@@ -705,7 +705,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 /// area of both containers, then the inner-most widget will receive the event first.
 /// If your pointer begins in the yellow container then it will be the first to
 /// receive the event.
-/// 
+///
 /// If the pointer has not moved past the drag threshold, then the first recognizer
 /// to enter the arena will win (i.e. they both tie and the gesture arena will call
 /// [GestureArenaManager.sweep] so the first member of the arena will win).

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -642,7 +642,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   }
 }
 
-///  A base class for gesture recognizers that recognize taps and movements.
+/// A base class for gesture recognizers that recognize taps and movements.
 ///
 /// Takes on the responsibilities of [TapGestureRecognizer] and
 /// [DragGestureRecognizer] in one [GestureRecognizer].
@@ -686,7 +686,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
 /// global distance to be considered a drag, the recognizers will tie in the arena. If the
 /// pointer does travel enough distance then the recognizer that entered the arena
 /// first will win. The gesture detected in this case is a drag.
-abstract class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _TapStatusTrackerMixin {
+sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _TapStatusTrackerMixin {
   /// Creates a tap and drag gesture recognizer.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1109,7 +1109,6 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
       if (_dragState == _DragState.possible) {
         // The drag has not been accepted before a [PointerUpEvent], therefore the recognizer
         // attempts to recognize a tap.
-        // _acceptedActivePointers.remove(event.pointer);
         stopTrackingIfPointerNoLongerDown(event);
       } else if (_dragState == _DragState.accepted) {
         _giveUpPointer(event.pointer);

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -1091,7 +1091,7 @@ abstract class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer 
       untransformedDelta: movedLocally,
       untransformedEndPosition: event.localPosition
     ).distance * (_getPrimaryValueFromOffset(movedLocally) ?? 1).sign;
-    if (_hasSufficientGlobalDistanceToAccept(event.kind, gestureSettings?.touchSlop)) {
+    if (_hasSufficientGlobalDistanceToAccept(event.kind, gestureSettings?.touchSlop) || (_wonArenaForPrimaryPointer && _pastSlopTolerance)) {
       _start = event;
       _dragState = _DragState.accepted;
       resolve(GestureDisposition.accepted);

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3112,22 +3112,46 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     if (widget.onDragSelectionStart != null ||
         widget.onDragSelectionUpdate != null ||
         widget.onDragSelectionEnd != null) {
-      gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
-        () => TapAndDragGestureRecognizer(debugOwner: this),
-        (TapAndDragGestureRecognizer instance) {
-          instance
-            // Text selection should start from the position of the first pointer
-            // down event.
-            ..dragStartBehavior = DragStartBehavior.down
-            ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
-            ..onTapDown = _handleTapDown
-            ..onDragStart = _handleDragStart
-            ..onDragUpdate = _handleDragUpdate
-            ..onDragEnd = _handleDragEnd
-            ..onTapUp = _handleTapUp
-            ..onCancel = _handleTapCancel;
-        },
-      );
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.iOS:
+          gestures[TapAndHorizontalDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndHorizontalDragGestureRecognizer>(
+            () => TapAndHorizontalDragGestureRecognizer(debugOwner: this),
+            (TapAndHorizontalDragGestureRecognizer instance) {
+              instance
+                // Text selection should start from the position of the first pointer
+                // down event.
+                ..dragStartBehavior = DragStartBehavior.down
+                ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
+                ..onTapDown = _handleTapDown
+                ..onDragStart = _handleDragStart
+                ..onDragUpdate = _handleDragUpdate
+                ..onDragEnd = _handleDragEnd
+                ..onTapUp = _handleTapUp
+                ..onCancel = _handleTapCancel;
+            },
+          );
+        case TargetPlatform.linux:
+        case TargetPlatform.macOS:
+        case TargetPlatform.windows:
+          gestures[TapAndPanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
+            () => TapAndPanGestureRecognizer(debugOwner: this),
+            (TapAndPanGestureRecognizer instance) {
+              instance
+                // Text selection should start from the position of the first pointer
+                // down event.
+                ..dragStartBehavior = DragStartBehavior.down
+                ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
+                ..onTapDown = _handleTapDown
+                ..onDragStart = _handleDragStart
+                ..onDragUpdate = _handleDragUpdate
+                ..onDragEnd = _handleDragEnd
+                ..onTapUp = _handleTapUp
+                ..onCancel = _handleTapCancel;
+            },
+          );
+      }
     }
 
     if (widget.onForcePressStart != null || widget.onForcePressEnd != null) {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3135,9 +3135,9 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
-          gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
-            () => TapAndDragGestureRecognizer(debugOwner: this),
-            (TapAndDragGestureRecognizer instance) {
+          gestures[TapAndPanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
+            () => TapAndPanGestureRecognizer(debugOwner: this),
+            (TapAndPanGestureRecognizer instance) {
               instance
                 // Text selection should start from the position of the first pointer
                 // down event.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3135,9 +3135,9 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
-          gestures[TapAndPanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
-            () => TapAndPanGestureRecognizer(debugOwner: this),
-            (TapAndPanGestureRecognizer instance) {
+          gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
+            () => TapAndDragGestureRecognizer(debugOwner: this),
+            (TapAndDragGestureRecognizer instance) {
               instance
                 // Text selection should start from the position of the first pointer
                 // down event.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3112,46 +3112,22 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     if (widget.onDragSelectionStart != null ||
         widget.onDragSelectionUpdate != null ||
         widget.onDragSelectionEnd != null) {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.iOS:
-          gestures[TapAndHorizontalDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndHorizontalDragGestureRecognizer>(
-            () => TapAndHorizontalDragGestureRecognizer(debugOwner: this),
-            (TapAndHorizontalDragGestureRecognizer instance) {
-              instance
-                // Text selection should start from the position of the first pointer
-                // down event.
-                ..dragStartBehavior = DragStartBehavior.down
-                ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
-                ..onTapDown = _handleTapDown
-                ..onDragStart = _handleDragStart
-                ..onDragUpdate = _handleDragUpdate
-                ..onDragEnd = _handleDragEnd
-                ..onTapUp = _handleTapUp
-                ..onCancel = _handleTapCancel;
-            },
-          );
-        case TargetPlatform.linux:
-        case TargetPlatform.macOS:
-        case TargetPlatform.windows:
-          gestures[TapAndPanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
-            () => TapAndPanGestureRecognizer(debugOwner: this),
-            (TapAndPanGestureRecognizer instance) {
-              instance
-                // Text selection should start from the position of the first pointer
-                // down event.
-                ..dragStartBehavior = DragStartBehavior.down
-                ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
-                ..onTapDown = _handleTapDown
-                ..onDragStart = _handleDragStart
-                ..onDragUpdate = _handleDragUpdate
-                ..onDragEnd = _handleDragEnd
-                ..onTapUp = _handleTapUp
-                ..onCancel = _handleTapCancel;
-            },
-          );
-      }
+      gestures[_TextSelectionTapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<_TextSelectionTapAndDragGestureRecognizer>(
+        () => _TextSelectionTapAndDragGestureRecognizer(debugOwner: this),
+        (_TextSelectionTapAndDragGestureRecognizer instance) {
+          instance
+            // Text selection should start from the position of the first pointer
+            // down event.
+            ..dragStartBehavior = DragStartBehavior.down
+            ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
+            ..onTapDown = _handleTapDown
+            ..onDragStart = _handleDragStart
+            ..onDragUpdate = _handleDragUpdate
+            ..onDragEnd = _handleDragEnd
+            ..onTapUp = _handleTapUp
+            ..onCancel = _handleTapCancel;
+        },
+      );
     }
 
     if (widget.onForcePressStart != null || widget.onForcePressEnd != null) {
@@ -3322,4 +3298,18 @@ mixin TextSelectionHandleControls on TextSelectionControls {
 
   @override
   void handleSelectAll(TextSelectionDelegate delegate) {}
+}
+
+class _TextSelectionTapAndDragGestureRecognizer extends TapAndHorizontalDragGestureRecognizer {
+  _TextSelectionTapAndDragGestureRecognizer({super.debugOwner});
+
+  @override
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double globalDistanceMovedOnAxis,
+    double globalDistanceMovedAllAxes,
+    bool wonArenaForPrimaryPointer) {
+    return globalDistanceMovedOnAxis.abs() > computePanSlop(pointerDeviceKind, gestureSettings)
+      || (wonArenaForPrimaryPointer && globalDistanceMovedAllAxes.abs() > computePanSlop(pointerDeviceKind, gestureSettings));
+  }
 }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3112,22 +3112,46 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     if (widget.onDragSelectionStart != null ||
         widget.onDragSelectionUpdate != null ||
         widget.onDragSelectionEnd != null) {
-      gestures[_TextSelectionTapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<_TextSelectionTapAndDragGestureRecognizer>(
-        () => _TextSelectionTapAndDragGestureRecognizer(debugOwner: this),
-        (_TextSelectionTapAndDragGestureRecognizer instance) {
-          instance
-            // Text selection should start from the position of the first pointer
-            // down event.
-            ..dragStartBehavior = DragStartBehavior.down
-            ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
-            ..onTapDown = _handleTapDown
-            ..onDragStart = _handleDragStart
-            ..onDragUpdate = _handleDragUpdate
-            ..onDragEnd = _handleDragEnd
-            ..onTapUp = _handleTapUp
-            ..onCancel = _handleTapCancel;
-        },
-      );
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.iOS:
+          gestures[TapAndHorizontalDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndHorizontalDragGestureRecognizer>(
+            () => TapAndHorizontalDragGestureRecognizer(debugOwner: this),
+            (TapAndHorizontalDragGestureRecognizer instance) {
+              instance
+                // Text selection should start from the position of the first pointer
+                // down event.
+                ..dragStartBehavior = DragStartBehavior.down
+                ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
+                ..onTapDown = _handleTapDown
+                ..onDragStart = _handleDragStart
+                ..onDragUpdate = _handleDragUpdate
+                ..onDragEnd = _handleDragEnd
+                ..onTapUp = _handleTapUp
+                ..onCancel = _handleTapCancel;
+            },
+          );
+        case TargetPlatform.linux:
+        case TargetPlatform.macOS:
+        case TargetPlatform.windows:
+          gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
+            () => TapAndDragGestureRecognizer(debugOwner: this),
+            (TapAndDragGestureRecognizer instance) {
+              instance
+                // Text selection should start from the position of the first pointer
+                // down event.
+                ..dragStartBehavior = DragStartBehavior.down
+                ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
+                ..onTapDown = _handleTapDown
+                ..onDragStart = _handleDragStart
+                ..onDragUpdate = _handleDragUpdate
+                ..onDragEnd = _handleDragEnd
+                ..onTapUp = _handleTapUp
+                ..onCancel = _handleTapCancel;
+            },
+          );
+      }
     }
 
     if (widget.onForcePressStart != null || widget.onForcePressEnd != null) {
@@ -3298,18 +3322,4 @@ mixin TextSelectionHandleControls on TextSelectionControls {
 
   @override
   void handleSelectAll(TextSelectionDelegate delegate) {}
-}
-
-class _TextSelectionTapAndDragGestureRecognizer extends TapAndHorizontalDragGestureRecognizer {
-  _TextSelectionTapAndDragGestureRecognizer({super.debugOwner});
-
-  @override
-  bool hasSufficientGlobalDistanceToAccept(
-    PointerDeviceKind pointerDeviceKind,
-    double globalDistanceMovedOnAxis,
-    double globalDistanceMovedAllAxes,
-    bool wonArenaForPrimaryPointer) {
-    return globalDistanceMovedOnAxis.abs() > computePanSlop(pointerDeviceKind, gestureSettings)
-      || (wonArenaForPrimaryPointer && globalDistanceMovedAllAxes.abs() > computePanSlop(pointerDeviceKind, gestureSettings));
-  }
 }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3135,9 +3135,9 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
-          gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
-            () => TapAndDragGestureRecognizer(debugOwner: this),
-            (TapAndDragGestureRecognizer instance) {
+          gestures[TapAndHorizontalDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndHorizontalDragGestureRecognizer>(
+            () => TapAndHorizontalDragGestureRecognizer(debugOwner: this),
+            (TapAndHorizontalDragGestureRecognizer instance) {
               instance
                 // Text selection should start from the position of the first pointer
                 // down event.
@@ -3151,6 +3151,22 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
                 ..onCancel = _handleTapCancel;
             },
           );
+          // gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
+          //   () => TapAndDragGestureRecognizer(debugOwner: this),
+          //   (TapAndDragGestureRecognizer instance) {
+          //     instance
+          //       // Text selection should start from the position of the first pointer
+          //       // down event.
+          //       ..dragStartBehavior = DragStartBehavior.down
+          //       ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
+          //       ..onTapDown = _handleTapDown
+          //       ..onDragStart = _handleDragStart
+          //       ..onDragUpdate = _handleDragUpdate
+          //       ..onDragEnd = _handleDragEnd
+          //       ..onTapUp = _handleTapUp
+          //       ..onCancel = _handleTapCancel;
+          //   },
+          // );
       }
     }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3135,9 +3135,9 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
-          gestures[TapAndHorizontalDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndHorizontalDragGestureRecognizer>(
-            () => TapAndHorizontalDragGestureRecognizer(debugOwner: this),
-            (TapAndHorizontalDragGestureRecognizer instance) {
+          gestures[TapAndPanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
+            () => TapAndPanGestureRecognizer(debugOwner: this),
+            (TapAndPanGestureRecognizer instance) {
               instance
                 // Text selection should start from the position of the first pointer
                 // down event.
@@ -3151,22 +3151,6 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
                 ..onCancel = _handleTapCancel;
             },
           );
-          // gestures[TapAndDragGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndDragGestureRecognizer>(
-          //   () => TapAndDragGestureRecognizer(debugOwner: this),
-          //   (TapAndDragGestureRecognizer instance) {
-          //     instance
-          //       // Text selection should start from the position of the first pointer
-          //       // down event.
-          //       ..dragStartBehavior = DragStartBehavior.down
-          //       ..dragUpdateThrottleFrequency = _kDragSelectionUpdateThrottle
-          //       ..onTapDown = _handleTapDown
-          //       ..onDragStart = _handleDragStart
-          //       ..onDragUpdate = _handleDragUpdate
-          //       ..onDragEnd = _handleDragEnd
-          //       ..onTapUp = _handleTapUp
-          //       ..onCancel = _handleTapCancel;
-          //   },
-          // );
       }
     }
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -5436,8 +5436,8 @@ void main() {
 
     // Tap on text field to gain focus, and set selection to '|a'. On iOS
     // the selection is set to the word edge closest to the tap position.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(aPos);
     await tester.pump();
     await gesture.up();
@@ -5487,8 +5487,8 @@ void main() {
 
     // Tap on text field to gain focus, and set selection to '|a'. On iOS
     // the selection is set to the word edge closest to the tap position.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(aPos);
     await tester.pump();
     await gesture.up();

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -5412,6 +5412,130 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS) - multiline', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            maxLines: null,
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc\ndef\nghi';
+    await tester.enterText(find.byType(CupertinoTextField), testValue);
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+    final Offset aPos = textOffsetToPosition(tester, testValue.indexOf('a'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+
+    // Tap on text field to gain focus, and set selection to '|a'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for 300ms after the up event, so our next down event does not
+    // register as a double tap.
+    final TestGesture gesture = await tester.startGesture(aPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 0);
+
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|a', where our selection was previously, and move to '|i'.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
+  );
+
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS) - ListView', (WidgetTester tester) async {
+    // This is a regression test for
+    // https://github.com/flutter/flutter/issues/122519
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CupertinoTextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            maxLines: null,
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc\ndef\nghi';
+    await tester.enterText(find.byType(CupertinoTextField), testValue);
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+
+    final Offset aPos = textOffsetToPosition(tester, testValue.indexOf('a'));
+    final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+
+    // Tap on text field to gain focus, and set selection to '|a'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for 300ms after the up event, so our next down event does not
+    // register as a double tap.
+    final TestGesture gesture = await tester.startGesture(aPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 0);
+
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|a', where our selection was previously, and attempt move
+    // to '|g'. The cursor will not move because the `VerticalDragGestureRecognizer`
+    // in the scrollable will beat the `TapAndHorizontalDragGestureRecognizer`
+    // in the TextField. This is because moving from `|a` to `|g` is a completely
+    // vertical movement.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(gPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 0);
+
+    // Release the pointer.
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|a', where our selection was previously, and move to '|i'.
+    // Unlike our previous attempt to drag to `|g`, this works because moving
+    // to `|i` includes a horizontal movement so the `TapAndHorizontalDragGestureRecognizer`
+    // in TextField can beat the `VerticalDragGestureRecognizer` in the scrollable.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
+  );
+
   testWidgets('Can move cursor when dragging (Android)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2189,6 +2189,131 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS) - multiline', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            maxLines: null,
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc\ndef\nghi';
+    await tester.enterText(find.byType(TextField), testValue);
+    await skipPastScrollingAnimation(tester);
+
+    final Offset aPos = textOffsetToPosition(tester, testValue.indexOf('a'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+
+    // Tap on text field to gain focus, and set selection to '|a'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for 300ms after the up event, so our next down event does not
+    // register as a double tap.
+    final TestGesture gesture = await tester.startGesture(aPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 0);
+
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|a', where our selection was previously, and move to '|i'.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
+  );
+
+  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS) - ListView', (WidgetTester tester) async {
+    // This is a regression test for
+    // https://github.com/flutter/flutter/issues/122519
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              TextField(
+                dragStartBehavior: DragStartBehavior.down,
+                controller: controller,
+                maxLines: null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc\ndef\nghi';
+    await tester.enterText(find.byType(TextField), testValue);
+    await skipPastScrollingAnimation(tester);
+
+    final Offset aPos = textOffsetToPosition(tester, testValue.indexOf('a'));
+    final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
+    final Offset iPos = textOffsetToPosition(tester, testValue.indexOf('i'));
+
+    // Tap on text field to gain focus, and set selection to '|a'. On iOS
+    // the selection is set to the word edge closest to the tap position.
+    // We await for 300ms after the up event, so our next down event does not
+    // register as a double tap.
+    final TestGesture gesture = await tester.startGesture(aPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 0);
+
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|a', where our selection was previously, and attempt move
+    // to '|g'. The cursor will not move because the `VerticalDragGestureRecognizer`
+    // in the scrollable will beat the `TapAndHorizontalDragGestureRecognizer`
+    // in the TextField. This is because moving from `|a` to `|g` is a completely
+    // vertical movement.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(gPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, 0);
+
+    // Release the pointer.
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // If the position we tap during a drag start is on the collapsed selection, then
+    // we can move the cursor with a drag.
+    // Here we tap on '|a', where our selection was previously, and move to '|i'.
+    // Unlike our previous attempt to drag to `|g`, this works because moving
+    // to `|i` includes a horizontal movement so the `TapAndHorizontalDragGestureRecognizer`
+    // in TextField can beat the `VerticalDragGestureRecognizer` in the scrollable.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(iPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('i'));
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
+  );
+
   testWidgets('Can move cursor when dragging (Android)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
 
@@ -2223,6 +2348,122 @@ void main() {
 
     // Here we tap on '|d', and move to '|g'.
     await gesture.down(textOffsetToPosition(tester, testValue.indexOf('d')));
+    await tester.pump();
+    await gesture.moveTo(gPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('g'));
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }),
+  );
+
+  testWidgets('Can move cursor when dragging (Android) - multiline', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            maxLines: null,
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc\ndef\nghi';
+    await tester.enterText(find.byType(TextField), testValue);
+    await skipPastScrollingAnimation(tester);
+
+    final Offset aPos = textOffsetToPosition(tester, testValue.indexOf('a'));
+    final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
+
+    // Tap on text field to gain focus, and set selection to '|a'.
+    // We await for 300ms after the up event, so our next down event does not
+    // register as a double tap.
+    final TestGesture gesture = await tester.startGesture(aPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('a'));
+
+    // Here we tap on '|c', and move down to '|g'.
+    await gesture.down(textOffsetToPosition(tester, testValue.indexOf('c')));
+    await tester.pump();
+    await gesture.moveTo(gPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('g'));
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }),
+  );
+
+  testWidgets('Can move cursor when dragging (Android) - ListView', (WidgetTester tester) async {
+    // This is a regression test for
+    // https://github.com/flutter/flutter/issues/122519
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              TextField(
+                dragStartBehavior: DragStartBehavior.down,
+                controller: controller,
+                maxLines: null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc\ndef\nghi';
+    await tester.enterText(find.byType(TextField), testValue);
+    await skipPastScrollingAnimation(tester);
+
+    final Offset aPos = textOffsetToPosition(tester, testValue.indexOf('a'));
+    final Offset cPos = textOffsetToPosition(tester, testValue.indexOf('c'));
+    final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
+
+    // Tap on text field to gain focus, and set selection to '|c'.
+    // We await for 300ms after the up event, so our next down event does not
+    // register as a double tap.
+    final TestGesture gesture = await tester.startGesture(cPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('c'));
+
+    // Here we tap on '|a', and attempt move to '|g'. The cursor will not move
+    // because the `VerticalDragGestureRecognizer` in the scrollable will beat
+    // the `TapAndHorizontalDragGestureRecognizer` in the TextField. This is
+    // because moving from `|a` to `|g` is a completely vertical movement.
+    await gesture.down(aPos);
+    await tester.pump();
+    await gesture.moveTo(gPos);
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('c'));
+
+    // Release the pointer.
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Here we tap on '|c', and move to '|g'. Unlike our previous attempt to
+    // drag to `|g`, this works because moving from `|c` to `|g` includes a
+    // horizontal movement so the `TapAndHorizontalDragGestureRecognizer`
+    // in TextField can beat the `VerticalDragGestureRecognizer` in the scrollable.
+    await gesture.down(cPos);
     await tester.pump();
     await gesture.moveTo(gPos);
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2165,8 +2165,8 @@ void main() {
 
     // Tap on text field to gain focus, and set selection to '|g'. On iOS
     // the selection is set to the word edge closest to the tap position.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(ePos);
     await tester.pump();
     await gesture.up();
@@ -2213,8 +2213,8 @@ void main() {
 
     // Tap on text field to gain focus, and set selection to '|a'. On iOS
     // the selection is set to the word edge closest to the tap position.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(aPos);
     await tester.pump();
     await gesture.up();
@@ -2268,8 +2268,8 @@ void main() {
 
     // Tap on text field to gain focus, and set selection to '|a'. On iOS
     // the selection is set to the word edge closest to the tap position.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(aPos);
     await tester.pump();
     await gesture.up();
@@ -2336,8 +2336,8 @@ void main() {
     final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
 
     // Tap on text field to gain focus, and set selection to '|e'.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(ePos);
     await tester.pump();
     await gesture.up();
@@ -2381,8 +2381,8 @@ void main() {
     final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
 
     // Tap on text field to gain focus, and set selection to '|a'.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(aPos);
     await tester.pump();
     await gesture.up();
@@ -2433,8 +2433,8 @@ void main() {
     final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
 
     // Tap on text field to gain focus, and set selection to '|c'.
-    // We await for 300ms after the up event, so our next down event does not
-    // register as a double tap.
+    // We await for kDoubleTapTimeout after the up event, so our next down event
+    // does not register as a double tap.
     final TestGesture gesture = await tester.startGesture(cPos);
     await tester.pump();
     await gesture.up();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11662,7 +11662,7 @@ void main() {
      skip: isBrowser, // [intended] Browser handles arrow keys differently.
   );
 
-  testWidgets('mouse click and drag can edge scroll vertically on desktop platforms', (WidgetTester tester) async {
+  testWidgets('mouse click and drag can edge scroll vertically', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
     );
@@ -11739,7 +11739,7 @@ void main() {
       textOffsetToPosition(tester, 0).dy,
       moreOrLessEquals(firstCharY - lineHeight, epsilon: 1),
     );
-  }, variant: TargetPlatformVariant.desktop());
+  }, variant: TargetPlatformVariant.all());
 
   testWidgets(
     'long tap after a double tap select is not affected',

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11662,7 +11662,7 @@ void main() {
      skip: isBrowser, // [intended] Browser handles arrow keys differently.
   );
 
-  testWidgets('mouse click and drag can edge scroll vertically', (WidgetTester tester) async {
+  testWidgets('mouse click and drag can edge scroll vertically on desktop platforms', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
     );
@@ -11739,7 +11739,7 @@ void main() {
       textOffsetToPosition(tester, 0).dy,
       moreOrLessEquals(firstCharY - lineHeight, epsilon: 1),
     );
-  }, variant: TargetPlatformVariant.all());
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets(
     'long tap after a double tap select is not affected',

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -436,8 +436,7 @@ void main() {
   testGesture('Beats TapGestureRecognizer when mouse pointer moves past kPrecisePointerPanSlop', (GestureTester tester) {
     setUpTapAndPanGestureRecognizer();
 
-    // Regression test for https://github.com/flutter/flutter/issues/122141 and
-    // https://github.com/flutter/flutter/issues/102084
+    // This is a regression test for https://github.com/flutter/flutter/issues/122141.
     final TapGestureRecognizer taps = TapGestureRecognizer()
       ..onTapDown = (TapDownDetails details) {
         events.add('tapdown');

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -16,11 +16,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late List<String> events;
-  late TapAndPanGestureRecognizer tapAndDrag;
+  late TapAndDragGestureRecognizer tapAndDrag;
 
   setUp(() {
     events = <String>[];
-    tapAndDrag = TapAndPanGestureRecognizer()
+    tapAndDrag = TapAndDragGestureRecognizer()
       ..dragStartBehavior = DragStartBehavior.down
       ..maxConsecutiveTap = 3
       ..onTapDown = (TapDragDownDetails details) {

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -16,10 +16,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late List<String> events;
-  late TapAndPanGestureRecognizer tapAndDrag;
+  late BaseTapAndDragGestureRecognizer tapAndDrag;
 
-  setUp(() {
-    events = <String>[];
+  void setUpTapAndPanGestureRecognizer() {
     tapAndDrag = TapAndPanGestureRecognizer()
       ..dragStartBehavior = DragStartBehavior.down
       ..maxConsecutiveTap = 3
@@ -30,17 +29,45 @@ void main() {
         events.add('up#${details.consecutiveTapCount}');
       }
       ..onDragStart = (TapDragStartDetails details) {
-        events.add('dragstart#${details.consecutiveTapCount}');
+        events.add('panstart#${details.consecutiveTapCount}');
       }
       ..onDragUpdate = (TapDragUpdateDetails details) {
-        events.add('dragupdate#${details.consecutiveTapCount}');
+        events.add('panupdate#${details.consecutiveTapCount}');
       }
       ..onDragEnd = (TapDragEndDetails details) {
-        events.add('dragend#${details.consecutiveTapCount}');
+        events.add('panend#${details.consecutiveTapCount}');
       }
       ..onCancel = () {
         events.add('cancel');
       };
+  }
+
+  void setUpTapAndHorizontalDragGestureRecognizer() {
+    tapAndDrag = TapAndHorizontalDragGestureRecognizer()
+      ..dragStartBehavior = DragStartBehavior.down
+      ..maxConsecutiveTap = 3
+      ..onTapDown = (TapDragDownDetails details) {
+        events.add('down#${details.consecutiveTapCount}');
+      }
+      ..onTapUp = (TapDragUpDetails details) {
+        events.add('up#${details.consecutiveTapCount}');
+      }
+      ..onDragStart = (TapDragStartDetails details) {
+        events.add('horizontaldragstart#${details.consecutiveTapCount}');
+      }
+      ..onDragUpdate = (TapDragUpdateDetails details) {
+        events.add('horizontaldragupdate#${details.consecutiveTapCount}');
+      }
+      ..onDragEnd = (TapDragEndDetails details) {
+        events.add('horizontaldragend#${details.consecutiveTapCount}');
+      }
+      ..onCancel = () {
+        events.add('cancel');
+      };
+  }
+
+  setUp(() {
+    events = <String>[];
   });
 
   // Down/up pair 1: normal tap sequence
@@ -128,6 +155,8 @@ void main() {
   );
 
   testGesture('Recognizes consecutive taps', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     tester.route(down1);
@@ -155,6 +184,8 @@ void main() {
   });
 
   testGesture('Resets if times out in between taps', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     tester.route(down1);
@@ -173,6 +204,8 @@ void main() {
   });
 
   testGesture('Resets if taps are far apart', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     tester.route(down1);
@@ -191,6 +224,8 @@ void main() {
   });
 
   testGesture('Resets if consecutiveTapCount reaches maxConsecutiveTap', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     // First tap.
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
@@ -229,6 +264,8 @@ void main() {
   });
 
   testGesture('Should recognize drag', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final TestPointer pointer = TestPointer(5);
     final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
     tapAndDrag.addPointer(down);
@@ -237,10 +274,12 @@ void main() {
     tester.route(pointer.move(const Offset(40.0, 45.0)));
     tester.route(pointer.up());
     GestureBinding.instance.gestureArena.sweep(5);
-    expect(events, <String>['down#1', 'dragstart#1', 'dragupdate#1', 'dragend#1']);
+    expect(events, <String>['down#1', 'panstart#1', 'panupdate#1', 'panend#1']);
   });
 
   testGesture('Recognizes consecutive taps + drag', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final TestPointer pointer = TestPointer(5);
     final PointerDownEvent downA = pointer.down(const Offset(10.0, 10.0));
     tapAndDrag.addPointer(downA);
@@ -272,12 +311,14 @@ void main() {
       'down#2',
       'up#2',
       'down#3',
-      'dragstart#3',
-      'dragupdate#3',
-      'dragend#3']);
+      'panstart#3',
+      'panupdate#3',
+      'panend#3']);
   });
 
   testGesture('Recognizer rejects pointer that is not the primary one (FIFO) - before acceptance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tapAndDrag.addPointer(down2);
     tester.closeArena(1);
@@ -295,6 +336,8 @@ void main() {
   });
 
   testGesture('Calls tap up when the recognizer accepts before handleEvent is called', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     GestureBinding.instance.gestureArena.sweep(1);
@@ -304,6 +347,8 @@ void main() {
   });
 
   testGesture('Recognizer rejects pointer that is not the primary one (FILO) - before acceptance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tapAndDrag.addPointer(down2);
     tester.closeArena(1);
@@ -321,6 +366,8 @@ void main() {
   });
 
   testGesture('Recognizer rejects pointer that is not the primary one (FIFO) - after acceptance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     tester.route(down1);
@@ -339,6 +386,8 @@ void main() {
   });
 
   testGesture('Recognizer rejects pointer that is not the primary one (FILO) - after acceptance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     tester.route(down1);
@@ -356,6 +405,8 @@ void main() {
   });
 
   testGesture('Recognizer detects tap gesture when pointer does not move past tap tolerance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     // In this test the tap has not travelled past the tap tolerance defined by
     // [kDoubleTapTouchSlop]. It is expected for the recognizer to detect a tap
     // and fire drag cancel.
@@ -368,6 +419,8 @@ void main() {
   });
 
   testGesture('Recognizer detects drag gesture when pointer moves past tap tolerance but not the drag minimum', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     // In this test, the pointer has moved past the tap tolerance but it has
     // not reached the distance travelled to be considered a drag gesture. In
     // this case it is expected for the recognizer to detect a drag and fire tap cancel.
@@ -377,10 +430,12 @@ void main() {
     tester.route(move5);
     tester.route(up5);
     GestureBinding.instance.gestureArena.sweep(5);
-    expect(events, <String>['down#1', 'dragstart#1', 'dragend#1']);
+    expect(events, <String>['down#1', 'panstart#1', 'panend#1']);
   });
 
   testGesture('Beats TapGestureRecognizer when mouse pointer moves past kPrecisePointerPanSlop', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     // Regression test for https://github.com/flutter/flutter/issues/122141
     final TapGestureRecognizer taps = TapGestureRecognizer()
       ..onTapDown = (TapDownDetails details) {
@@ -401,10 +456,12 @@ void main() {
     tester.route(up6);
     GestureBinding.instance.gestureArena.sweep(6);
 
-    expect(events, <String>['down#1', 'dragstart#1', 'dragupdate#1', 'dragend#1']);
+    expect(events, <String>['down#1', 'panstart#1', 'panupdate#1', 'panend#1']);
   });
 
   testGesture('Recognizer declares self-victory in a non-empty arena when pointer travels minimum distance to be considered a drag', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final PanGestureRecognizer pans = PanGestureRecognizer()
       ..onStart = (DragStartDetails details) {
         events.add('panstart');
@@ -432,12 +489,148 @@ void main() {
     expect(events, <String>[
       'pancancel',
       'down#1',
-      'dragstart#1',
-      'dragupdate#1',
-      'dragend#1']);
+      'panstart#1',
+      'panupdate#1',
+      'panend#1']);
+  });
+
+  testGesture('TapAndHorizontalDragGestureRecognizer loses to VerticalDragGestureRecognizer on a vertical drag', (GestureTester tester) {
+    setUpTapAndHorizontalDragGestureRecognizer();
+
+    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+      ..onStart = (DragStartDetails details) {
+        events.add('verticalstart');
+      }
+      ..onUpdate =  (DragUpdateDetails details) {
+        events.add('verticalupdate');
+      }
+      ..onEnd = (DragEndDetails details) {
+        events.add('verticalend');
+      }
+      ..onCancel = () {
+        events.add('verticalcancel');
+      };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+
+    tapAndDrag.addPointer(downB);
+    pans.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.move(const Offset(10.0, 45.0)));
+    tester.route(pointer.move(const Offset(10.0, 100.0)));
+    tester.route(pointer.up());
+    expect(events, <String>[
+      'verticalstart',
+      'verticalupdate',
+      'verticalend']);
+  });
+
+  testGesture('TapAndPanGestureRecognizer loses to VerticalDragGestureRecognizer on a vertical drag', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
+    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+      ..onStart = (DragStartDetails details) {
+        events.add('verticalstart');
+      }
+      ..onUpdate =  (DragUpdateDetails details) {
+        events.add('verticalupdate');
+      }
+      ..onEnd = (DragEndDetails details) {
+        events.add('verticalend');
+      }
+      ..onCancel = () {
+        events.add('verticalcancel');
+      };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+
+    tapAndDrag.addPointer(downB);
+    pans.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.move(const Offset(10.0, 45.0)));
+    tester.route(pointer.move(const Offset(10.0, 100.0)));
+    tester.route(pointer.up());
+    expect(events, <String>[
+      'verticalstart',
+      'verticalupdate',
+      'verticalend']);
+  });
+
+  testGesture('TapAndHorizontalDragGestureRecognizer beats VerticalDragGestureRecognizer on a horizontal drag', (GestureTester tester) {
+    setUpTapAndHorizontalDragGestureRecognizer();
+
+    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+      ..onStart = (DragStartDetails details) {
+        events.add('verticalstart');
+      }
+      ..onUpdate =  (DragUpdateDetails details) {
+        events.add('verticalupdate');
+      }
+      ..onEnd = (DragEndDetails details) {
+        events.add('verticalend');
+      }
+      ..onCancel = () {
+        events.add('verticalcancel');
+      };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+
+    tapAndDrag.addPointer(downB);
+    pans.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.move(const Offset(45.0, 10.0)));
+    tester.route(pointer.up());
+    expect(events, <String>[
+      'verticalcancel',
+      'down#1',
+      'horizontaldragstart#1',
+      'horizontaldragupdate#1',
+      'horizontaldragend#1']);
+  });
+
+  testGesture('TapAndPanGestureRecognizer beats VerticalDragGestureRecognizer on a horizontal pan', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
+    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+      ..onStart = (DragStartDetails details) {
+        events.add('verticalstart');
+      }
+      ..onUpdate =  (DragUpdateDetails details) {
+        events.add('verticalupdate');
+      }
+      ..onEnd = (DragEndDetails details) {
+        events.add('verticalend');
+      }
+      ..onCancel = () {
+        events.add('verticalcancel');
+      };
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+
+    tapAndDrag.addPointer(downB);
+    pans.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.move(const Offset(45.0, 25.0)));
+    tester.route(pointer.up());
+    expect(events, <String>[
+      'verticalcancel',
+      'down#1',
+      'panstart#1',
+      'panupdate#1',
+      'panend#1']);
   });
 
   testGesture('Beats LongPressGestureRecognizer on a consecutive tap greater than one', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final LongPressGestureRecognizer longpress = LongPressGestureRecognizer()
       ..onLongPressStart = (LongPressStartDetails details) {
         events.add('longpressstart');
@@ -478,12 +671,14 @@ void main() {
       'down#1',
       'up#1',
       'down#2',
-      'dragstart#2',
-      'dragupdate#2',
-      'dragend#2']);
+      'panstart#2',
+      'panupdate#2',
+      'panend#2']);
   });
 
   testGesture('Beats TapGestureRecognizer when the pointer has not moved and this recognizer is the first in the arena', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final TapGestureRecognizer taps = TapGestureRecognizer()
       ..onTapDown = (TapDownDetails details) {
         events.add('tapdown');
@@ -505,6 +700,8 @@ void main() {
   });
 
   testGesture('Beats TapGestureRecognizer when the pointer has exceeded the slop tolerance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final TapGestureRecognizer taps = TapGestureRecognizer()
       ..onTapDown = (TapDownDetails details) {
         events.add('tapdown');
@@ -523,7 +720,7 @@ void main() {
     tester.route(move5);
     tester.route(up5);
     GestureBinding.instance.gestureArena.sweep(5);
-    expect(events, <String>['down#1', 'dragstart#1', 'dragend#1']);
+    expect(events, <String>['down#1', 'panstart#1', 'panend#1']);
 
     events.clear();
     tester.async.elapse(const Duration(milliseconds: 1000));
@@ -537,6 +734,8 @@ void main() {
   });
 
   testGesture('Ties with PanGestureRecognizer when pointer has not met sufficient global distance to be a drag', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     final PanGestureRecognizer pans = PanGestureRecognizer()
       ..onStart = (DragStartDetails details) {
         events.add('panstart');
@@ -562,13 +761,15 @@ void main() {
   });
 
   testGesture('Defaults to drag when pointer dragged past slop tolerance', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down5);
     tester.closeArena(5);
     tester.route(down5);
     tester.route(move5);
     tester.route(up5);
     GestureBinding.instance.gestureArena.sweep(5);
-    expect(events, <String>['down#1', 'dragstart#1', 'dragend#1']);
+    expect(events, <String>['down#1', 'panstart#1', 'panend#1']);
 
     events.clear();
     tester.async.elapse(const Duration(milliseconds: 1000));
@@ -581,6 +782,8 @@ void main() {
   });
 
   testGesture('Fires cancel and resets for PointerCancelEvent', (GestureTester tester) {
+    setUpTapAndPanGestureRecognizer();
+
     tapAndDrag.addPointer(down1);
     tester.closeArena(1);
     tester.route(down1);

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -494,10 +494,28 @@ void main() {
       'panend#1']);
   });
 
+  testGesture('TapAndHorizontalDragGestureRecognizer accepts drag on a pan when the arena has already been won by the primary pointer', (GestureTester tester) {
+    setUpTapAndHorizontalDragGestureRecognizer();
+
+    final TestPointer pointer = TestPointer(5);
+    final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
+
+    tapAndDrag.addPointer(downB);
+    tester.closeArena(5);
+    tester.route(downB);
+    tester.route(pointer.move(const Offset(25.0, 45.0)));
+    tester.route(pointer.up());
+    expect(events, <String>[
+      'down#1',
+      'horizontaldragstart#1',
+      'horizontaldragupdate#1',
+      'horizontaldragend#1']);
+  });
+
   testGesture('TapAndHorizontalDragGestureRecognizer loses to VerticalDragGestureRecognizer on a vertical drag', (GestureTester tester) {
     setUpTapAndHorizontalDragGestureRecognizer();
 
-    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+    final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer()
       ..onStart = (DragStartDetails details) {
         events.add('verticalstart');
       }
@@ -515,7 +533,7 @@ void main() {
     final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
 
     tapAndDrag.addPointer(downB);
-    pans.addPointer(downB);
+    verticalDrag.addPointer(downB);
     tester.closeArena(5);
     tester.route(downB);
     tester.route(pointer.move(const Offset(10.0, 45.0)));
@@ -530,7 +548,7 @@ void main() {
   testGesture('TapAndPanGestureRecognizer loses to VerticalDragGestureRecognizer on a vertical drag', (GestureTester tester) {
     setUpTapAndPanGestureRecognizer();
 
-    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+    final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer()
       ..onStart = (DragStartDetails details) {
         events.add('verticalstart');
       }
@@ -548,7 +566,7 @@ void main() {
     final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
 
     tapAndDrag.addPointer(downB);
-    pans.addPointer(downB);
+    verticalDrag.addPointer(downB);
     tester.closeArena(5);
     tester.route(downB);
     tester.route(pointer.move(const Offset(10.0, 45.0)));
@@ -563,7 +581,7 @@ void main() {
   testGesture('TapAndHorizontalDragGestureRecognizer beats VerticalDragGestureRecognizer on a horizontal drag', (GestureTester tester) {
     setUpTapAndHorizontalDragGestureRecognizer();
 
-    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+    final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer()
       ..onStart = (DragStartDetails details) {
         events.add('verticalstart');
       }
@@ -581,7 +599,7 @@ void main() {
     final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
 
     tapAndDrag.addPointer(downB);
-    pans.addPointer(downB);
+    verticalDrag.addPointer(downB);
     tester.closeArena(5);
     tester.route(downB);
     tester.route(pointer.move(const Offset(45.0, 10.0)));
@@ -597,7 +615,7 @@ void main() {
   testGesture('TapAndPanGestureRecognizer beats VerticalDragGestureRecognizer on a horizontal pan', (GestureTester tester) {
     setUpTapAndPanGestureRecognizer();
 
-    final VerticalDragGestureRecognizer pans = VerticalDragGestureRecognizer()
+    final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer()
       ..onStart = (DragStartDetails details) {
         events.add('verticalstart');
       }
@@ -615,7 +633,7 @@ void main() {
     final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
 
     tapAndDrag.addPointer(downB);
-    pans.addPointer(downB);
+    verticalDrag.addPointer(downB);
     tester.closeArena(5);
     tester.route(downB);
     tester.route(pointer.move(const Offset(45.0, 25.0)));

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -436,7 +436,8 @@ void main() {
   testGesture('Beats TapGestureRecognizer when mouse pointer moves past kPrecisePointerPanSlop', (GestureTester tester) {
     setUpTapAndPanGestureRecognizer();
 
-    // Regression test for https://github.com/flutter/flutter/issues/122141
+    // Regression test for https://github.com/flutter/flutter/issues/122141 and
+    // https://github.com/flutter/flutter/issues/102084
     final TapGestureRecognizer taps = TapGestureRecognizer()
       ..onTapDown = (TapDownDetails details) {
         events.add('tapdown');

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -16,11 +16,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late List<String> events;
-  late TapAndDragGestureRecognizer tapAndDrag;
+  late TapAndPanGestureRecognizer tapAndDrag;
 
   setUp(() {
     events = <String>[];
-    tapAndDrag = TapAndDragGestureRecognizer()
+    tapAndDrag = TapAndPanGestureRecognizer()
       ..dragStartBehavior = DragStartBehavior.down
       ..maxConsecutiveTap = 3
       ..onTapDown = (TapDragDownDetails details) {

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -404,36 +404,6 @@ void main() {
     expect(events, <String>['down#1', 'dragstart#1', 'dragupdate#1', 'dragend#1']);
   });
 
-  // testGesture('Recognizer loses when competing against a DragGestureRecognizer when the pointer travels minimum distance to be considered a drag', (GestureTester tester) {
-  //   final PanGestureRecognizer pans = PanGestureRecognizer()
-  //     ..onStart = (DragStartDetails details) {
-  //       events.add('panstart');
-  //     }
-  //     ..onUpdate =  (DragUpdateDetails details) {
-  //       events.add('panupdate');
-  //     }
-  //     ..onEnd = (DragEndDetails details) {
-  //       events.add('panend');
-  //     }
-  //     ..onCancel = () {
-  //       events.add('pancancel');
-  //     };
-
-  //   final TestPointer pointer = TestPointer(5);
-  //   final PointerDownEvent downB = pointer.down(const Offset(10.0, 10.0));
-  //   // When competing against another [DragGestureRecognizer], the [TapAndDragGestureRecognizer]
-  //   // will only win when it is the last recognizer in the arena.
-  //   tapAndDrag.addPointer(downB);
-  //   pans.addPointer(downB);
-  //   tester.closeArena(5);
-  //   tester.route(downB);
-  //   tester.route(pointer.move(const Offset(40.0, 45.0)));
-  //   tester.route(pointer.up());
-  //   expect(events, <String>[
-  //     'panstart',
-  //     'panend']);
-  // });
-
   testGesture('Recognizer declares self-victory in a non-empty arena when pointer travels minimum distance to be considered a drag', (GestureTester tester) {
     final PanGestureRecognizer pans = PanGestureRecognizer()
       ..onStart = (DragStartDetails details) {


### PR DESCRIPTION
This change does the following:
* Similar to other `DragGestureRecognizer`s in the framework, the `BaseTapAndDragGestureRecognizer` should declare victory immediately when it detects a drag.
* `BaseTapAndDragGestureRecognizer` becomes a sealed class.
* `BaseTapAndDragGestureRecognizer` declares victory immediately when the drag threshold is met (for the desired axis) or when we have won the arena for the primary pointer and the drag threshold is met on any axes.
* `TapAndHorizontalDragGestureRecognizer` accepts drags when movement on the x-axis passes the defined threshold.
* `TapAndPanGestureRecognizer` works how `TapAndDragGestureRecognizer` originally worked which was movement on the x and y axes.
* `TapAndDragGestureRecognizer` deprecated.
* Text selection on mobile platforms like iOS/Android/Fuchsia use `TapAndHorizontalDragGestureRecognizer` so they do not conflict with `VerticalDragGestureRecognizer`s that may be in a `Scrollable`.
* Text selection on desktop platforms like Linux/macOS/Windows use `TapAndPanGestureRecognizer`.

Fixes #122519
Fixes #122141

### Before fix

macOS|iOS|Android
--|--|--
<video src="https://user-images.githubusercontent.com/948037/228179483-c6393ddb-2410-4e12-8eef-474c123049ef.mov" />|<video src="https://user-images.githubusercontent.com/948037/228180665-79741006-579e-4bcb-bdc5-d2cf1ec3ae2a.mov" />|<video src="https://user-images.githubusercontent.com/948037/228180531-f9cd8882-44e1-45b6-a280-c6ec5be3accf.mov" />

### After fix

macOS|iOS|Android
--|--|--
<video src="https://user-images.githubusercontent.com/948037/228175951-a7de18b2-e2a3-4ccd-8cdf-8603e1994342.mov" />|<video src="https://user-images.githubusercontent.com/948037/228176384-597bd6ff-380d-43fc-b2d2-687085599044.mov" />|<video src="https://user-images.githubusercontent.com/948037/228177595-7f66a7b5-0c2a-4f28-aafe-54feb2f9116b.mov" />

Thanks @xu-baolin for his work and investigation on #122374 which some changes are incorporated into this PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.