### PR TITLE
DraggableScrollableSheet & NestedScrollView  should respect NeverScrollableScrollPhysics

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -781,7 +781,7 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
     ScrollPosition? oldPosition,
   ) {
     return _DraggableScrollableSheetScrollPosition(
-      physics: const AlwaysScrollableScrollPhysics().applyTo(physics),
+      physics: physics.applyTo(const AlwaysScrollableScrollPhysics()),
       context: context,
       oldPosition: oldPosition,
       getExtent: () => extent,

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1439,7 +1439,8 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
   }
 
   void updateCanDrag(double totalExtent) {
-    context.setCanDrag(totalExtent > (viewportDimension - maxScrollExtent) || minScrollExtent != maxScrollExtent);
+    context.setCanDrag(physics.allowUserScrolling &&
+        (totalExtent > (viewportDimension - maxScrollExtent) || minScrollExtent != maxScrollExtent));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -198,7 +198,7 @@ class ScrollPhysics {
 
   /// Whether the scrollable should let the user adjust the scroll offset, for
   /// example by dragging. If [allowUserScrolling] is false, the scrollable
-  /// will never allow the user scrolling.
+  /// will never allow user input to change the scroll position.
   ///
   /// By default, the user can manipulate the scroll offset if, and only if,
   /// there is actually content outside the viewport to reveal.
@@ -492,7 +492,7 @@ class ScrollPhysics {
   /// scroll position to fulfill such a request.
   bool get allowImplicitScrolling => true;
 
-  /// Whether a viewport is allowed the user scrolling.
+  /// Whether a viewport is allowed to change the scroll position as the result of user input.
   bool get allowUserScrolling => true;
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -197,7 +197,8 @@ class ScrollPhysics {
   }
 
   /// Whether the scrollable should let the user adjust the scroll offset, for
-  /// example by dragging.
+  /// example by dragging. If [allowUserScrolling] is false, the scrollable
+  /// will never allow the user scrolling.
   ///
   /// By default, the user can manipulate the scroll offset if, and only if,
   /// there is actually content outside the viewport to reveal.
@@ -206,6 +207,10 @@ class ScrollPhysics {
   /// reference to it to use later, as the values may update, may not update, or
   /// may update to reflect an entirely unrelated scrollable.
   bool shouldAcceptUserOffset(ScrollMetrics position) {
+    if (!allowUserScrolling) {
+      return false;
+    }
+
     if (parent == null) {
       return position.pixels != 0.0 || position.minScrollExtent != position.maxScrollExtent;
     }
@@ -486,6 +491,9 @@ class ScrollPhysics {
   /// whether the viewport associated with this object is allowed to change the
   /// scroll position to fulfill such a request.
   bool get allowImplicitScrolling => true;
+
+  /// Whether a viewport is allowed the user scrolling.
+  bool get allowUserScrolling => true;
 
   @override
   String toString() {
@@ -965,7 +973,7 @@ class NeverScrollableScrollPhysics extends ScrollPhysics {
   }
 
   @override
-  bool shouldAcceptUserOffset(ScrollMetrics position) => false;
+  bool get allowUserScrolling => false;
 
   @override
   bool get allowImplicitScrolling => false;

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -531,6 +531,47 @@ void main() {
     expect(point1.dy, greaterThan(point2.dy));
   });
 
+  testWidgets('NestedScrollViews respect NeverScrollableScrollPhysics', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/113753
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: NestedScrollView(
+            physics: const NeverScrollableScrollPhysics(),
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+              return <Widget>[
+                const SliverAppBar(
+                  floating: true,
+                  title: Text('AA'),
+                ),
+              ];
+            },
+            body: Container(),
+          ),
+        ),
+      ),
+    ));
+
+    expect(find.text('AA'), findsOneWidget);
+    final Offset point1 = tester.getCenter(find.text('AA'));
+
+    await tester.dragFrom(point1, const Offset(0.0, -200.0));
+    await tester.pump();
+
+    final Offset point2 = tester.getCenter(find.text(
+      'AA',
+      skipOffstage: false,
+    ));
+    expect(point1, point2);
+  });
+
   testWidgets('NestedScrollView and internal scrolling', (WidgetTester tester) async {
     debugDisableShadows = false;
     const List<String> tabs = <String>['Hello', 'World'];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/121021
Fixes https://github.com/flutter/flutter/issues/113753

#121021 was introduce by https://github.com/flutter/flutter/pull/109081

Adding a `ScrollPhysics.allowUserScrolling` to indicate whether the physics allowed the user scrolling.