### PR TITLE
Add customizable mouse cursor to `DataTable`

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -44,6 +44,7 @@ class DataColumn {
     this.tooltip,
     this.numeric = false,
     this.onSort,
+    this.mouseCursor,
   });
 
   /// The column heading.
@@ -85,6 +86,13 @@ class DataColumn {
   final DataColumnSortCallback? onSort;
 
   bool get _debugInteractive => onSort != null;
+
+  /// The cursor for a mouse pointer when it enters or is hovering over the
+  /// heading row.
+  ///
+  /// If this is null, then the value of [DataTableThemeData.headingCellCursor]
+  /// is used. If that's null, then [SystemMouseCursors.click] is used.
+  final MouseCursor? mouseCursor;
 }
 
 /// Row configuration and cell data for a [DataTable].
@@ -106,6 +114,7 @@ class DataRow {
     this.onSelectChanged,
     this.onLongPress,
     this.color,
+    this.mouseCursor,
     required this.cells,
   });
 
@@ -119,6 +128,7 @@ class DataRow {
     this.onSelectChanged,
     this.onLongPress,
     this.color,
+    this.mouseCursor,
     required this.cells,
   }) : key = ValueKey<int?>(index);
 
@@ -204,6 +214,16 @@ class DataRow {
   ///    match a component's state:
   ///    <https://material.io/design/interaction/states.html#anatomy>.
   final MaterialStateProperty<Color?>? color;
+
+  /// The cursor for a mouse pointer when it enters or is hovering over the
+  /// data row.
+  ///
+  /// If this is null, then the value of [DataTableThemeData.dataRowCursor]
+  /// is used. If that's null, then [MaterialStateMouseCursor.clickable] is used.
+  ///
+  /// See also:
+  ///  * [MaterialStateMouseCursor], which can be used to create a [MouseCursor].
+  final MaterialStateProperty<MouseCursor?>? mouseCursor;
 
   bool get _debugInteractive => onSelectChanged != null || cells.any((DataCell cell) => cell._debugInteractive);
 }
@@ -738,6 +758,7 @@ class DataTable extends StatelessWidget {
     required ValueChanged<bool?>? onCheckboxChanged,
     required MaterialStateProperty<Color?>? overlayColor,
     required bool tristate,
+    MouseCursor? rowMouseCursor,
   }) {
     final ThemeData themeData = Theme.of(context);
     final double effectiveHorizontalMargin = horizontalMargin
@@ -769,6 +790,7 @@ class DataTable extends StatelessWidget {
       contents = TableRowInkWell(
         onTap: onRowTap,
         overlayColor: overlayColor,
+        mouseCursor: rowMouseCursor,
         child: contents,
       );
     }
@@ -788,6 +810,7 @@ class DataTable extends StatelessWidget {
     required bool sorted,
     required bool ascending,
     required MaterialStateProperty<Color?>? overlayColor,
+    required MouseCursor? mouseCursor,
   }) {
     final ThemeData themeData = Theme.of(context);
     final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
@@ -838,6 +861,7 @@ class DataTable extends StatelessWidget {
     label = InkWell(
       onTap: onSort,
       overlayColor: overlayColor,
+      mouseCursor: mouseCursor,
       child: label,
     );
     return label;
@@ -858,6 +882,7 @@ class DataTable extends StatelessWidget {
     required GestureTapCancelCallback? onTapCancel,
     required MaterialStateProperty<Color?>? overlayColor,
     required GestureLongPressCallback? onRowLongPress,
+    required MouseCursor? mouseCursor,
   }) {
     final ThemeData themeData = Theme.of(context);
     final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
@@ -905,6 +930,7 @@ class DataTable extends StatelessWidget {
         onTapCancel: onTapCancel,
         onTapDown: onTapDown,
         overlayColor: overlayColor,
+        mouseCursor: mouseCursor,
         child: label,
       );
     } else if (onSelectChanged != null || onRowLongPress != null) {
@@ -912,6 +938,7 @@ class DataTable extends StatelessWidget {
         onTap: onSelectChanged,
         onLongPress: onRowLongPress,
         overlayColor: overlayColor,
+        mouseCursor: mouseCursor,
         child: label,
       );
     }
@@ -1014,12 +1041,19 @@ class DataTable extends StatelessWidget {
       );
       rowIndex = 1;
       for (final DataRow row in rows) {
+        final Set<MaterialState> states = <MaterialState>{
+          if (row.selected)
+            MaterialState.selected,
+          if (row.onSelectChanged == null)
+            MaterialState.disabled,
+        };
         tableRows[rowIndex].children[0] = _buildCheckbox(
           context: context,
           checked: row.selected,
           onRowTap: row.onSelectChanged == null ? null : () => row.onSelectChanged?.call(!row.selected),
           onCheckboxChanged: row.onSelectChanged,
           overlayColor: row.color ?? effectiveDataRowColor,
+          rowMouseCursor: row.mouseCursor?.resolve(states) ?? dataTableTheme.dataRowCursor?.resolve(states),
           tristate: false,
         );
         rowIndex += 1;
@@ -1067,9 +1101,16 @@ class DataTable extends StatelessWidget {
         sorted: dataColumnIndex == sortColumnIndex,
         ascending: sortAscending,
         overlayColor: effectiveHeadingRowColor,
+        mouseCursor: column.onSort != null ? column.mouseCursor ?? dataTableTheme.headingCellCursor : null,
       );
       rowIndex = 1;
       for (final DataRow row in rows) {
+        final Set<MaterialState> states = <MaterialState>{
+          if (row.selected)
+            MaterialState.selected,
+          if (row.onSelectChanged == null)
+            MaterialState.disabled,
+        };
         final DataCell cell = row.cells[dataColumnIndex];
         tableRows[rowIndex].children[displayColumnIndex] = _buildDataCell(
           context: context,
@@ -1086,6 +1127,7 @@ class DataTable extends StatelessWidget {
           onSelectChanged: row.onSelectChanged == null ? null : () => row.onSelectChanged?.call(!row.selected),
           overlayColor: row.color ?? effectiveDataRowColor,
           onRowLongPress: row.onLongPress,
+          mouseCursor: row.mouseCursor?.resolve(states) ?? dataTableTheme.dataRowCursor?.resolve(states),
         );
         rowIndex += 1;
       }
@@ -1138,6 +1180,7 @@ class TableRowInkWell extends InkResponse {
     super.onLongPress,
     super.onHighlightChanged,
     super.overlayColor,
+    super.mouseCursor,
   }) : super(
     containedInkWell: true,
     highlightShape: BoxShape.rectangle,

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -90,9 +90,16 @@ class DataColumn {
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// heading row.
   ///
+  /// [MaterialStateProperty.resolve] is used for the following [MaterialState]s:
+  ///
+  ///  * [MaterialState.disabled].
+  ///
   /// If this is null, then the value of [DataTableThemeData.headingCellCursor]
-  /// is used. If that's null, then [SystemMouseCursors.click] is used.
-  final MouseCursor? mouseCursor;
+  /// is used. If that's null, then [MaterialStateMouseCursor.clickable] is used.
+  ///
+  /// See also:
+  ///  * [MaterialStateMouseCursor], which can be used to create a [MouseCursor].
+  final MaterialStateProperty<MouseCursor?>? mouseCursor;
 }
 
 /// Row configuration and cell data for a [DataTable].
@@ -217,6 +224,10 @@ class DataRow {
 
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// data row.
+  ///
+  /// [MaterialStateProperty.resolve] is used for the following [MaterialState]s:
+  ///
+  ///  * [MaterialState.selected].
   ///
   /// If this is null, then the value of [DataTableThemeData.dataRowCursor]
   /// is used. If that's null, then [MaterialStateMouseCursor.clickable] is used.
@@ -930,7 +941,6 @@ class DataTable extends StatelessWidget {
         onTapCancel: onTapCancel,
         onTapDown: onTapDown,
         overlayColor: overlayColor,
-        mouseCursor: mouseCursor,
         child: label,
       );
     } else if (onSelectChanged != null || onRowLongPress != null) {
@@ -1044,8 +1054,6 @@ class DataTable extends StatelessWidget {
         final Set<MaterialState> states = <MaterialState>{
           if (row.selected)
             MaterialState.selected,
-          if (row.onSelectChanged == null)
-            MaterialState.disabled,
         };
         tableRows[rowIndex].children[0] = _buildCheckbox(
           context: context,
@@ -1091,6 +1099,10 @@ class DataTable extends StatelessWidget {
       } else {
         tableColumns[displayColumnIndex] = const IntrinsicColumnWidth();
       }
+      final Set<MaterialState> headerStates = <MaterialState>{
+        if (column.onSort == null)
+          MaterialState.disabled,
+      };
       tableRows[0].children[displayColumnIndex] = _buildHeadingCell(
         context: context,
         padding: padding,
@@ -1101,15 +1113,13 @@ class DataTable extends StatelessWidget {
         sorted: dataColumnIndex == sortColumnIndex,
         ascending: sortAscending,
         overlayColor: effectiveHeadingRowColor,
-        mouseCursor: column.onSort != null ? column.mouseCursor ?? dataTableTheme.headingCellCursor : null,
+        mouseCursor: column.mouseCursor?.resolve(headerStates) ?? dataTableTheme.headingCellCursor?.resolve(headerStates),
       );
       rowIndex = 1;
       for (final DataRow row in rows) {
         final Set<MaterialState> states = <MaterialState>{
           if (row.selected)
             MaterialState.selected,
-          if (row.onSelectChanged == null)
-            MaterialState.disabled,
         };
         final DataCell cell = row.cells[dataColumnIndex];
         tableRows[rowIndex].children[displayColumnIndex] = _buildDataCell(

--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -109,7 +109,7 @@ class DataTableThemeData with Diagnosticable {
   final double? checkboxHorizontalMargin;
 
   /// If specified, overrides the default value of [DataColumn.mouseCursor].
-  final MouseCursor? headingCellCursor;
+  final MaterialStateProperty<MouseCursor?>? headingCellCursor;
 
   /// If specified, overrides the default value of [DataRow.mouseCursor].
   final MaterialStateProperty<MouseCursor?>? dataRowCursor;
@@ -134,7 +134,7 @@ class DataTableThemeData with Diagnosticable {
     double? columnSpacing,
     double? dividerThickness,
     double? checkboxHorizontalMargin,
-    MouseCursor? headingCellCursor,
+    MaterialStateProperty<MouseCursor?>? headingCellCursor,
     MaterialStateProperty<MouseCursor?>? dataRowCursor,
   }) {
     return DataTableThemeData(
@@ -241,8 +241,8 @@ class DataTableThemeData with Diagnosticable {
     properties.add(DoubleProperty('columnSpacing', columnSpacing, defaultValue: null));
     properties.add(DoubleProperty('dividerThickness', dividerThickness, defaultValue: null));
     properties.add(DoubleProperty('checkboxHorizontalMargin', checkboxHorizontalMargin, defaultValue: null));
-    properties.add(DiagnosticsProperty<MouseCursor>('headingCellCursor', headingCellCursor, defaultValue: null));
-    properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('dataRowCursor', dataRowCursor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>?>('headingCellCursor', headingCellCursor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>?>('dataRowCursor', dataRowCursor, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -55,6 +55,8 @@ class DataTableThemeData with Diagnosticable {
     this.columnSpacing,
     this.dividerThickness,
     this.checkboxHorizontalMargin,
+    this.headingCellCursor,
+    this.dataRowCursor,
   }) : assert(dataRowMinHeight == null || dataRowMaxHeight == null || dataRowMaxHeight >= dataRowMinHeight),
        assert(dataRowHeight == null || (dataRowMinHeight == null && dataRowMaxHeight == null),
          'dataRowHeight ($dataRowHeight) must not be set if dataRowMinHeight ($dataRowMinHeight) or dataRowMaxHeight ($dataRowMaxHeight) are set.'),
@@ -106,6 +108,12 @@ class DataTableThemeData with Diagnosticable {
   /// {@macro flutter.material.dataTable.checkboxHorizontalMargin}
   final double? checkboxHorizontalMargin;
 
+  /// If specified, overrides the default value of [DataColumn.mouseCursor].
+  final MouseCursor? headingCellCursor;
+
+  /// If specified, overrides the default value of [DataRow.mouseCursor].
+  final MaterialStateProperty<MouseCursor?>? dataRowCursor;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   DataTableThemeData copyWith({
@@ -126,6 +134,8 @@ class DataTableThemeData with Diagnosticable {
     double? columnSpacing,
     double? dividerThickness,
     double? checkboxHorizontalMargin,
+    MouseCursor? headingCellCursor,
+    MaterialStateProperty<MouseCursor?>? dataRowCursor,
   }) {
     return DataTableThemeData(
       decoration: decoration ?? this.decoration,
@@ -141,6 +151,8 @@ class DataTableThemeData with Diagnosticable {
       columnSpacing: columnSpacing ?? this.columnSpacing,
       dividerThickness: dividerThickness ?? this.dividerThickness,
       checkboxHorizontalMargin: checkboxHorizontalMargin ?? this.checkboxHorizontalMargin,
+      headingCellCursor: headingCellCursor ?? this.headingCellCursor,
+      dataRowCursor: dataRowCursor ?? this.dataRowCursor,
     );
   }
 
@@ -166,6 +178,8 @@ class DataTableThemeData with Diagnosticable {
       columnSpacing: lerpDouble(a.columnSpacing, b.columnSpacing, t),
       dividerThickness: lerpDouble(a.dividerThickness, b.dividerThickness, t),
       checkboxHorizontalMargin: lerpDouble(a.checkboxHorizontalMargin, b.checkboxHorizontalMargin, t),
+      headingCellCursor: t < 0.5 ? a.headingCellCursor : b.headingCellCursor,
+      dataRowCursor: t < 0.5 ? a.dataRowCursor : b.dataRowCursor,
     );
   }
 
@@ -183,6 +197,8 @@ class DataTableThemeData with Diagnosticable {
     columnSpacing,
     dividerThickness,
     checkboxHorizontalMargin,
+    headingCellCursor,
+    dataRowCursor,
   );
 
   @override
@@ -205,7 +221,9 @@ class DataTableThemeData with Diagnosticable {
       && other.horizontalMargin == horizontalMargin
       && other.columnSpacing == columnSpacing
       && other.dividerThickness == dividerThickness
-      && other.checkboxHorizontalMargin == checkboxHorizontalMargin;
+      && other.checkboxHorizontalMargin == checkboxHorizontalMargin
+      && other.headingCellCursor == headingCellCursor
+      && other.dataRowCursor == dataRowCursor;
   }
 
   @override
@@ -223,6 +241,8 @@ class DataTableThemeData with Diagnosticable {
     properties.add(DoubleProperty('columnSpacing', columnSpacing, defaultValue: null));
     properties.add(DoubleProperty('dividerThickness', dividerThickness, defaultValue: null));
     properties.add(DoubleProperty('checkboxHorizontalMargin', checkboxHorizontalMargin, defaultValue: null));
+    properties.add(DiagnosticsProperty<MouseCursor>('headingCellCursor', headingCellCursor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('dataRowCursor', dataRowCursor, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -9,6 +9,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart' show Matrix3;
 
@@ -2071,5 +2072,149 @@ void main() {
 
     expect(() => createDataTable(dataRowHeight: 1.0, dataRowMinHeight: 2.0), throwsA(predicate((AssertionError e) =>
       e.toString().contains('dataRowHeight == null || (dataRowMinHeight == null && dataRowMaxHeight == null)'))));
+  });
+
+  testWidgets('DataRow cursor resolves MaterialStateMouseCursor correctly', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DataTable(
+            sortColumnIndex: 0,
+            columns: <DataColumn>[
+              DataColumn(
+                label: const Text('A'),
+                onSort: (int columnIndex, bool ascending) {},
+              ),
+              const DataColumn(label: Text('B')),
+            ],
+            rows: <DataRow>[
+              DataRow(
+                mouseCursor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                  if (states.contains(MaterialState.selected)) {
+                    return SystemMouseCursors.copy;
+                  }
+                  return SystemMouseCursors.forbidden;
+                }),
+                onSelectChanged: (bool? selected) {},
+                cells: const <DataCell>[
+                  DataCell(Text('Data 1')),
+                  DataCell(Text('Data 2')),
+                ],
+              ),
+              DataRow(
+                selected: true,
+                onSelectChanged: (bool? selected) {},
+                mouseCursor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                  if (states.contains(MaterialState.selected)) {
+                    return SystemMouseCursors.copy;
+                  }
+                  return SystemMouseCursors.forbidden;
+                }),
+                cells: const <DataCell>[
+                  DataCell(Text('Data 3')),
+                  DataCell(Text('Data 4')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.text('Data 1')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
+
+    await gesture.moveTo(tester.getCenter(find.text('Data 3')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.copy);
+  });
+
+  testWidgets("DataRow cursor doesn't update checkbox cursor", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DataTable(
+            sortColumnIndex: 0,
+            columns: <DataColumn>[
+              DataColumn(
+                label: const Text('A'),
+                onSort: (int columnIndex, bool ascending) {},
+              ),
+              const DataColumn(label: Text('B')),
+            ],
+            rows: <DataRow>[
+              DataRow(
+                onSelectChanged: (bool? selected) {},
+                mouseCursor: const MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.copy),
+                cells: const <DataCell>[
+                  DataCell(Text('Data')),
+                  DataCell(Text('Data 2')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.byType(Checkbox).last));
+    await tester.pump();
+
+    // Test that the checkbox cursor is not changed.
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.click);
+
+    await gesture.moveTo(tester.getCenter(find.text('Data')));
+    await tester.pump();
+
+    // Test that cursor is updated for the row.
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.copy);
+  });
+
+  testWidgets('Heading cell cursor can only updated if onSort is non-null', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DataTable(
+            sortColumnIndex: 0,
+            columns: <DataColumn>[
+              DataColumn(
+                mouseCursor: SystemMouseCursors.copy,
+                label: const Text('A'),
+                onSort: (int columnIndex, bool ascending) {},
+              ),
+              const DataColumn(
+                mouseCursor: SystemMouseCursors.copy,
+                label: Text('B'),
+              ),
+            ],
+            rows: <DataRow>[
+              DataRow(
+                onSelectChanged: (bool? selected) {},
+                cells: const <DataCell>[
+                  DataCell(Text('Data')),
+                  DataCell(Text('Data 2')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.text('A')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.copy);
+
+    await gesture.moveTo(tester.getCenter(find.text('B')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
   });
 }

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -32,6 +33,8 @@ void main() {
     expect(themeData.columnSpacing, null);
     expect(themeData.dividerThickness, null);
     expect(themeData.checkboxHorizontalMargin, null);
+    expect(themeData.headingCellCursor, null);
+    expect(themeData.dataRowCursor, null);
 
     const DataTableTheme theme = DataTableTheme(data: DataTableThemeData(), child: SizedBox());
     expect(theme.data.decoration, null);
@@ -47,6 +50,8 @@ void main() {
     expect(theme.data.columnSpacing, null);
     expect(theme.data.dividerThickness, null);
     expect(theme.data.checkboxHorizontalMargin, null);
+    expect(theme.data.headingCellCursor, null);
+    expect(theme.data.dataRowCursor, null);
   });
 
   testWidgets('Default DataTableThemeData debugFillProperties', (WidgetTester tester) async {
@@ -80,6 +85,8 @@ void main() {
       columnSpacing: 4.0,
       dividerThickness: 5.0,
       checkboxHorizontalMargin: 6.0,
+      headingCellCursor: SystemMouseCursors.grab,
+      dataRowCursor: const MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden),
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -99,6 +106,8 @@ void main() {
     expect(description[9], 'columnSpacing: 4.0');
     expect(description[10], 'dividerThickness: 5.0');
     expect(description[11], 'checkboxHorizontalMargin: 6.0');
+    expect(description[12], 'headingCellCursor: SystemMouseCursor(grab)');
+    expect(description[13], 'dataRowCursor: MaterialStatePropertyAll(SystemMouseCursor(forbidden))');
   });
 
   testWidgets('DataTable is themeable', (WidgetTester tester) async {
@@ -112,6 +121,8 @@ void main() {
     const double horizontalMargin = 3.0;
     const double columnSpacing = 4.0;
     const double dividerThickness = 5.0;
+    const MouseCursor headingCellCursor = SystemMouseCursors.grab;
+    const MaterialStateProperty<MouseCursor> dataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -128,11 +139,14 @@ void main() {
             horizontalMargin: horizontalMargin,
             columnSpacing: columnSpacing,
             dividerThickness: dividerThickness,
+            headingCellCursor: headingCellCursor,
+            dataRowCursor: dataRowCursor,
           ),
         ),
         home: Scaffold(
           body: DataTable(
             sortColumnIndex: 0,
+            showCheckboxColumn: false,
             columns: <DataColumn>[
               DataColumn(
                 label: const Text('A'),
@@ -140,11 +154,14 @@ void main() {
               ),
               const DataColumn(label: Text('B')),
             ],
-            rows: const <DataRow>[
-              DataRow(cells: <DataCell>[
-                DataCell(Text('Data')),
-                DataCell(Text('Data 2')),
-              ]),
+            rows: <DataRow>[
+              DataRow(
+                cells: const <DataCell>[
+                  DataCell(Text('Data')),
+                  DataCell(Text('Data 2')),
+                ],
+                onSelectChanged: (bool? value) { },
+              ),
             ],
           ),
         ),
@@ -167,6 +184,17 @@ void main() {
     expect(tester.getSize(_findFirstContainerFor('A')).height, headingRowHeight);
     expect(tester.getTopLeft(find.text('A')).dx, horizontalMargin);
     expect(tester.getTopLeft(find.text('Data 2')).dx - tester.getTopRight(find.text('Data')).dx, columnSpacing);
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.text('A')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.grab);
+
+    await gesture.moveTo(tester.getCenter(find.text('Data')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
   });
 
   testWidgets('DataTable is themeable - separate test for deprecated dataRowHeight', (WidgetTester tester) async {
@@ -214,6 +242,8 @@ void main() {
     const double themeHorizontalMargin = 2.0;
     const double themeColumnSpacing = 3.0;
     const double themeDividerThickness = 4.0;
+    const MouseCursor themeHeadingCellCursor = SystemMouseCursors.copy;
+    const MaterialStateProperty<MouseCursor> themeDataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.copy);
 
     const BoxDecoration decoration = BoxDecoration(color: Color(0xfffffff0));
     const MaterialStateProperty<Color> dataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
@@ -225,6 +255,8 @@ void main() {
     const double horizontalMargin = 3.0;
     const double columnSpacing = 4.0;
     const double dividerThickness = 5.0;
+    const MouseCursor headingCellCursor = SystemMouseCursors.forbidden;
+    const MaterialStateProperty<MouseCursor> dataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -241,10 +273,13 @@ void main() {
             horizontalMargin: themeHorizontalMargin,
             columnSpacing: themeColumnSpacing,
             dividerThickness: themeDividerThickness,
+            headingCellCursor: themeHeadingCellCursor,
+            dataRowCursor: themeDataRowCursor,
           ),
         ),
         home: Scaffold(
           body: DataTable(
+            showCheckboxColumn: false,
             decoration: decoration,
             dataRowColor: dataRowColor,
             dataRowMinHeight: minMaxDataRowHeight,
@@ -260,15 +295,20 @@ void main() {
             columns: <DataColumn>[
               DataColumn(
                 label: const Text('A'),
+                mouseCursor: headingCellCursor,
                 onSort: (int columnIndex, bool ascending) {},
               ),
               const DataColumn(label: Text('B')),
             ],
-            rows: const <DataRow>[
-              DataRow(cells: <DataCell>[
-                DataCell(Text('Data')),
-                DataCell(Text('Data 2')),
-              ]),
+            rows: <DataRow>[
+              DataRow(
+                mouseCursor: dataRowCursor,
+                onSelectChanged: (bool? selected) {},
+                cells: const <DataCell>[
+                  DataCell(Text('Data')),
+                  DataCell(Text('Data 2')),
+                ],
+              ),
             ],
           ),
         ),
@@ -291,6 +331,17 @@ void main() {
     expect(tester.getSize(_findFirstContainerFor('A')).height, headingRowHeight);
     expect(tester.getTopLeft(find.text('A')).dx, horizontalMargin);
     expect(tester.getTopLeft(find.text('Data 2')).dx - tester.getTopRight(find.text('Data')).dx, columnSpacing);
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.text('A')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), headingCellCursor);
+
+    await gesture.moveTo(tester.getCenter(find.text('Data')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), dataRowCursor.resolve(<MaterialState>{}));
   });
 
   testWidgets('DataTable properties are taken over the theme values - separate test for deprecated dataRowHeight', (WidgetTester tester) async {
@@ -340,6 +391,8 @@ void main() {
     const double globalThemeHorizontalMargin = 2.0;
     const double globalThemeColumnSpacing = 3.0;
     const double globalThemeDividerThickness = 4.0;
+    const MouseCursor globalHeadingCellCursor = SystemMouseCursors.allScroll;
+    const MaterialStateProperty<MouseCursor> globalDataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.allScroll);
 
     const BoxDecoration localThemeDecoration = BoxDecoration(color: Color(0xfffffff0));
     const MaterialStateProperty<Color> localThemeDataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
@@ -351,6 +404,8 @@ void main() {
     const double localThemeHorizontalMargin = 3.0;
     const double localThemeColumnSpacing = 4.0;
     const double localThemeDividerThickness = 5.0;
+    const MouseCursor localHeadingCellCursor = SystemMouseCursors.move;
+    const MaterialStateProperty<MouseCursor> localDataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.move);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -367,6 +422,8 @@ void main() {
             horizontalMargin: globalThemeHorizontalMargin,
             columnSpacing: globalThemeColumnSpacing,
             dividerThickness: globalThemeDividerThickness,
+            headingCellCursor: globalHeadingCellCursor,
+            dataRowCursor: globalDataRowCursor,
           ),
         ),
         home: Scaffold(
@@ -383,8 +440,11 @@ void main() {
               horizontalMargin: localThemeHorizontalMargin,
               columnSpacing: localThemeColumnSpacing,
               dividerThickness: localThemeDividerThickness,
+              headingCellCursor: localHeadingCellCursor,
+              dataRowCursor: localDataRowCursor,
             ),
             child: DataTable(
+              showCheckboxColumn: false,
               sortColumnIndex: 0,
               columns: <DataColumn>[
                 DataColumn(
@@ -393,11 +453,14 @@ void main() {
                 ),
                 const DataColumn(label: Text('B')),
               ],
-              rows: const <DataRow>[
-                DataRow(cells: <DataCell>[
-                  DataCell(Text('Data')),
-                  DataCell(Text('Data 2')),
-                ]),
+              rows: <DataRow>[
+                DataRow(
+                  onSelectChanged: (bool? selected) {},
+                  cells: const <DataCell>[
+                    DataCell(Text('Data')),
+                    DataCell(Text('Data 2')),
+                  ],
+                ),
               ],
             ),
           ),
@@ -421,6 +484,17 @@ void main() {
     expect(tester.getSize(_findFirstContainerFor('A')).height, localThemeHeadingRowHeight);
     expect(tester.getTopLeft(find.text('A')).dx, localThemeHorizontalMargin);
     expect(tester.getTopLeft(find.text('Data 2')).dx - tester.getTopRight(find.text('Data')).dx, localThemeColumnSpacing);
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: tester.getCenter(find.text('A')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), localHeadingCellCursor);
+
+    await gesture.moveTo(tester.getCenter(find.text('Data')));
+    await tester.pump();
+
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), localDataRowCursor.resolve(<MaterialState>{}));
   });
 
   testWidgets('Local DataTableTheme can override global DataTableTheme - separate test for deprecated dataRowHeight', (WidgetTester tester) async {
@@ -463,7 +537,6 @@ void main() {
     expect(tester.getSize(_findFirstContainerFor('Data')).height, localThemeDataRowHeight);
   });
 }
-
 
 BoxDecoration _tableRowBoxDecoration({required WidgetTester tester, required int index}) {
   final Table table = tester.widget(find.byType(Table));

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -85,7 +85,7 @@ void main() {
       columnSpacing: 4.0,
       dividerThickness: 5.0,
       checkboxHorizontalMargin: 6.0,
-      headingCellCursor: SystemMouseCursors.grab,
+      headingCellCursor: const MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.grab),
       dataRowCursor: const MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden),
     ).debugFillProperties(builder);
 
@@ -106,7 +106,7 @@ void main() {
     expect(description[9], 'columnSpacing: 4.0');
     expect(description[10], 'dividerThickness: 5.0');
     expect(description[11], 'checkboxHorizontalMargin: 6.0');
-    expect(description[12], 'headingCellCursor: SystemMouseCursor(grab)');
+    expect(description[12], 'headingCellCursor: MaterialStatePropertyAll(SystemMouseCursor(grab))');
     expect(description[13], 'dataRowCursor: MaterialStatePropertyAll(SystemMouseCursor(forbidden))');
   });
 
@@ -121,7 +121,7 @@ void main() {
     const double horizontalMargin = 3.0;
     const double columnSpacing = 4.0;
     const double dividerThickness = 5.0;
-    const MouseCursor headingCellCursor = SystemMouseCursors.grab;
+    const MaterialStateProperty<MouseCursor> headingCellCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.grab);
     const MaterialStateProperty<MouseCursor> dataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden);
 
     await tester.pumpWidget(
@@ -242,7 +242,7 @@ void main() {
     const double themeHorizontalMargin = 2.0;
     const double themeColumnSpacing = 3.0;
     const double themeDividerThickness = 4.0;
-    const MouseCursor themeHeadingCellCursor = SystemMouseCursors.copy;
+    const MaterialStateProperty<MouseCursor> themeHeadingCellCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.copy);
     const MaterialStateProperty<MouseCursor> themeDataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.copy);
 
     const BoxDecoration decoration = BoxDecoration(color: Color(0xfffffff0));
@@ -255,7 +255,7 @@ void main() {
     const double horizontalMargin = 3.0;
     const double columnSpacing = 4.0;
     const double dividerThickness = 5.0;
-    const MouseCursor headingCellCursor = SystemMouseCursors.forbidden;
+    const MaterialStateProperty<MouseCursor> headingCellCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden);
     const MaterialStateProperty<MouseCursor> dataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden);
 
     await tester.pumpWidget(
@@ -336,7 +336,7 @@ void main() {
     await gesture.addPointer(location: tester.getCenter(find.text('A')));
     await tester.pump();
 
-    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), headingCellCursor);
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), headingCellCursor.resolve(<MaterialState>{}));
 
     await gesture.moveTo(tester.getCenter(find.text('Data')));
     await tester.pump();
@@ -391,7 +391,7 @@ void main() {
     const double globalThemeHorizontalMargin = 2.0;
     const double globalThemeColumnSpacing = 3.0;
     const double globalThemeDividerThickness = 4.0;
-    const MouseCursor globalHeadingCellCursor = SystemMouseCursors.allScroll;
+    const MaterialStateProperty<MouseCursor> globalHeadingCellCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.allScroll);
     const MaterialStateProperty<MouseCursor> globalDataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.allScroll);
 
     const BoxDecoration localThemeDecoration = BoxDecoration(color: Color(0xfffffff0));
@@ -404,7 +404,7 @@ void main() {
     const double localThemeHorizontalMargin = 3.0;
     const double localThemeColumnSpacing = 4.0;
     const double localThemeDividerThickness = 5.0;
-    const MouseCursor localHeadingCellCursor = SystemMouseCursors.move;
+    const MaterialStateProperty<MouseCursor> localHeadingCellCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.move);
     const MaterialStateProperty<MouseCursor> localDataRowCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.move);
 
     await tester.pumpWidget(
@@ -489,7 +489,7 @@ void main() {
     await gesture.addPointer(location: tester.getCenter(find.text('A')));
     await tester.pump();
 
-    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), localHeadingCellCursor);
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), localHeadingCellCursor.resolve(<MaterialState>{}));
 
     await gesture.moveTo(tester.getCenter(find.text('Data')));
     await tester.pump();


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/123020

### Description
1. Add `mouseCursor` to the `DataColumn` for the header cell.
2. Add `mouseCursor` MaterialStateProperty to the `DataRow` for  the data row
3. Add `headingCellCursor` to customize the cursor in the header cell from `DataTableTheme`.
3. Add `dataRowCursor` to customize the cursor in the data row from `DataTableTheme`.


<details> 
<summary>code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(useMaterial3: true),
      home: const DataTableExample(),
    );
  }
}

class DataTableExample extends StatelessWidget {
  const DataTableExample({super.key});

  @override
  Widget build(BuildContext context) {
    final MaterialStateProperty<MouseCursor?> rowCursor =
        MaterialStateProperty.resolveWith<MouseCursor?>(
      (Set<MaterialState> states) {
        if (states.contains(MaterialState.disabled)) {
          return SystemMouseCursors.forbidden;
        }

        if (states.contains(MaterialState.selected)) {
          return SystemMouseCursors.copy;
        }
        return SystemMouseCursors.grab;
      },
    );

    return Scaffold(
      appBar: AppBar(
        title: const Text('DataTable'),
      ),
      body: DataTable(
        columns: <DataColumn>[
          DataColumn(
            label: const Expanded(
              child: Text(
                'Name',
              ),
            ),
            mouseCursor: MaterialStateProperty.resolveWith(
              (Set<MaterialState> states) {
                if (states.contains(MaterialState.disabled)) {
                  return SystemMouseCursors.forbidden;
                }
                return SystemMouseCursors.grab;
              },
            ),
            onSort: (int columnIndex, bool ascending) {},
          ),
          DataColumn(
            mouseCursor: MaterialStateProperty.resolveWith(
              (Set<MaterialState> states) {
                if (states.contains(MaterialState.disabled)) {
                  return SystemMouseCursors.forbidden;
                }
                return SystemMouseCursors.grab;
              },
            ),
            label: const Expanded(
              child: Text(
                'State',
              ),
            ),
          ),
        ],
        rows: <DataRow>[
          DataRow(
            mouseCursor: rowCursor,
            cells: const <DataCell>[
              DataCell(Text('Row')),
              DataCell(Text('disabled')),
            ],
          ),
          DataRow(
            mouseCursor: rowCursor,
            onSelectChanged: (bool? selected) {},
            cells: const <DataCell>[
              DataCell(Text('Row')),
              DataCell(Text('enabled')),
            ],
          ),
          DataRow(
            mouseCursor: rowCursor,
            selected: true,
            onSelectChanged: (bool? selected) {},
            cells: const <DataCell>[
              DataCell(Text('Row')),
              DataCell(Text('selected')),
            ],
          ),
        ],
      ),
    );
  }
}
``` 
	
</details>



https://user-images.githubusercontent.com/48603081/226934208-fcb1d9d9-69a9-4c03-9dca-27c70e817a02.mov






## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
