### PR TITLE
Use DeviceDiscoveryFilter correctly in ProxiedDevices.

### DIFF
--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -58,7 +58,7 @@ class ProxiedDevices extends DeviceDiscovery {
 
   @override
   Future<List<Device>> devices({DeviceDiscoveryFilter? filter}) async =>
-      _devices ?? await discoverDevices(filter: filter);
+      _filterDevices(_devices ?? await discoverDevices(), filter);
 
   @override
   Future<List<Device>> discoverDevices({
@@ -72,7 +72,14 @@ class ProxiedDevices extends DeviceDiscovery {
     ];
 
     _devices = devices;
-    return devices;
+    return _filterDevices(devices, filter);
+  }
+
+  Future<List<Device>> _filterDevices(List<Device> devices, DeviceDiscoveryFilter? filter) async {
+    if (filter == null) {
+      return devices;
+    }
+    return filter.filterDevices(devices);
   }
 
   @override


### PR DESCRIPTION
The device filtering is done on the client side and not the daemon side, so we should pass the device list through the filter if provided.

This fixes the issue introduced in #121359 when ProxiedDevices is used.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
