### PR TITLE
Provide an ApplicationPackage to the flutter_tools logs command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../application_package.dart';
 import '../base/common.dart';
 import '../base/io.dart';
 import '../device.dart';
@@ -50,7 +51,11 @@ class LogsCommand extends FlutterCommand {
       cachedDevice.clearLogs();
     }
 
-    final DeviceLogReader logReader = await cachedDevice.getLogReader();
+    final ApplicationPackage? app = await applicationPackages?.getPackageForPlatform(
+      await cachedDevice.targetPlatform,
+    );
+
+    final DeviceLogReader logReader = await cachedDevice.getLogReader(app: app);
 
     globals.printStatus('Showing $logReader logs:');
 


### PR DESCRIPTION
This is needed so that the platform's log reader can build filters that match the application's attributes.

Fixes https://github.com/flutter/flutter/issues/122727
