### PR TITLE
Enable prefer_mixin

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -173,7 +173,7 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
-    # - prefer_mixin # has false positives, see https://github.com/dart-lang/linter/issues/3018
+    - prefer_mixin
     # - prefer_null_aware_method_calls # "call()" is confusing to people new to the language since it's not documented anywhere
     - prefer_null_aware_operators
     - prefer_relative_imports

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -156,7 +156,8 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
 
 class ErrorHandlingFile
     extends ForwardingFileSystemEntity<File, io.File>
-    with ForwardingFile {
+    // TODO(goderbauer): Fix this ignore when https://github.com/google/file.dart/issues/209 is resolved.
+    with ForwardingFile { // ignore: prefer_mixin
   ErrorHandlingFile({
     required Platform platform,
     required this.fileSystem,
@@ -368,7 +369,8 @@ class ErrorHandlingFile
 
 class ErrorHandlingDirectory
     extends ForwardingFileSystemEntity<Directory, io.Directory>
-    with ForwardingDirectory<Directory> {
+    // TODO(goderbauer): Fix this ignore when https://github.com/google/file.dart/issues/209 is resolved.
+    with ForwardingDirectory<Directory> { // ignore: prefer_mixin
   ErrorHandlingDirectory({
     required Platform platform,
     required this.fileSystem,
@@ -504,7 +506,8 @@ class ErrorHandlingDirectory
 
 class ErrorHandlingLink
     extends ForwardingFileSystemEntity<Link, io.Link>
-    with ForwardingLink {
+    // TODO(goderbauer): Fix this ignore when https://github.com/google/file.dart/issues/209 is resolved.
+    with ForwardingLink { // ignore: prefer_mixin
   ErrorHandlingLink({
     required Platform platform,
     required this.fileSystem,

--- a/packages/flutter_tools/lib/src/base/multi_root_file_system.dart
+++ b/packages/flutter_tools/lib/src/base/multi_root_file_system.dart
@@ -209,7 +209,8 @@ abstract class MultiRootFileSystemEntity<T extends FileSystemEntity,
 }
 
 class MultiRootFile extends MultiRootFileSystemEntity<File, io.File>
-    with ForwardingFile {
+    // TODO(goderbauer): Fix this ignore when https://github.com/google/file.dart/issues/209 is resolved.
+    with ForwardingFile { // ignore: prefer_mixin
   MultiRootFile({
     required super.fileSystem,
     required super.delegate,
@@ -222,7 +223,8 @@ class MultiRootFile extends MultiRootFileSystemEntity<File, io.File>
 
 class MultiRootDirectory
     extends MultiRootFileSystemEntity<Directory, io.Directory>
-    with ForwardingDirectory<Directory> {
+    // TODO(goderbauer): Fix this ignore when https://github.com/google/file.dart/issues/209 is resolved.
+    with ForwardingDirectory<Directory> { // ignore: prefer_mixin
   MultiRootDirectory({
     required super.fileSystem,
     required super.delegate,
@@ -249,7 +251,8 @@ class MultiRootDirectory
 }
 
 class MultiRootLink extends MultiRootFileSystemEntity<Link, io.Link>
-    with ForwardingLink {
+    // TODO(goderbauer): Fix this ignore when https://github.com/google/file.dart/issues/209 is resolved.
+    with ForwardingLink { // ignore: prefer_mixin
   MultiRootLink({
     required super.fileSystem,
     required super.delegate,


### PR DESCRIPTION
Now that we have the mixin modifier, https://github.com/dart-lang/sdk/issues/58543 is no longer a blocker for this lint.

However, there are a handful of classes used as mixin from package:file, which has not been updated to use the mixin modifier yet. That work is tracked in https://github.com/google/file.dart/issues/209. I added ignores for those for the time being. 