### PR TITLE
Add documentation on how to use `dart-define` with `gradlew`

### DIFF
--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -222,8 +222,8 @@ physical):
 ```
 
 Note:
-If you want to use `--dart-define` with `gradlew` you have to `base64` encode
-all parameters, and pass them to gradle in a comma separated list:
+To use `--dart-define` with `gradlew` you must `base64` encode all parameters, 
+and pass them to gradle in a comma separated list:
 ```bash
 ./gradlew project:task -Pdart-defines="{base64(key=value)},[...]"
 ```

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -221,6 +221,13 @@ physical):
 ./gradlew app:connectedAndroidTest -Ptarget=`pwd`/../integration_test/foo_test.dart
 ```
 
+Note:
+If you want to use `--dart-define` with `gradlew` you have to `base64` encode
+all parameters, and pass them to gradle in a comma separated list:
+```bash
+./gradlew project:task -Pdart-defines="{base64(key=value)},[...]"
+```
+
 ## Firebase Test Lab
 
 If this is your first time testing with Firebase Test Lab, you'll need to follow

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -222,7 +222,7 @@ physical):
 ```
 
 Note:
-To use `--dart-define` with `gradlew` you must `base64` encode all parameters, 
+To use `--dart-define` with `gradlew` you must `base64` encode all parameters,
 and pass them to gradle in a comma separated list:
 ```bash
 ./gradlew project:task -Pdart-defines="{base64(key=value)},[...]"


### PR DESCRIPTION
Add documentation on how to use --dart-define command line arguments when building the app via gradlew.

Resolves #100292
Related: flutter/website#8417

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
