### PR TITLE
Migrate to ByteConversionSink to unblock engine roll

### DIFF
--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -98,7 +98,7 @@ Future<Uint8List> consolidateHttpClientResponseBytes(
   return completer.future;
 }
 
-class _OutputBuffer extends ByteConversionSinkBase {
+class _OutputBuffer extends ByteConversionSink {
   List<List<int>>? _chunks = <List<int>>[];
   int _contentLength = 0;
   Uint8List? _bytes;


### PR DESCRIPTION
See failure in https://github.com/flutter/flutter/pull/123249.