### PR TITLE
Remove 1745 decorative breaks

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -35,7 +35,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
     - always_specify_types
     # - always_use_package_imports # we do this commonly
     - annotate_overrides
@@ -64,8 +63,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are enough valid reasons to return `this` that this lint ends up with too many false positives
     - avoid_setters_without_getters
@@ -103,7 +100,6 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - enable_null_safety
     - eol_at_end_of_file
     - exhaustive_cases
     - file_names
@@ -201,6 +197,7 @@ linter:
     # - unawaited_futures # too many false positives, especially with the way AnimationController works
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
     # - unnecessary_final # conflicts with prefer_final_locals

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -115,7 +115,6 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
           opacity: (_controller.value * 2.0 - 1.0).abs(),
           child: child,
         );
-        break;
       case FilterType.rotateTransform:
         builder = (BuildContext context, Widget? child) => Transform(
           transform: Matrix4.rotationZ(_controller.value * 2.0 * pi),
@@ -123,7 +122,6 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
           filterQuality: FilterQuality.low,
           child: child,
         );
-        break;
       case FilterType.rotateFilter:
         builder = (BuildContext context, Widget? child) => ImageFiltered(
           imageFilter: ImageFilter.matrix((
@@ -134,7 +132,6 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
           ).storage),
           child: child,
         );
-        break;
     }
     return RepaintBoundary(
       child: AnimatedBuilder(

--- a/dev/benchmarks/macrobenchmarks/test_driver/large_image_changer_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/large_image_changer_test.dart
@@ -22,14 +22,12 @@ Future<void> main() async {
             await Future<void>.delayed(const Duration(seconds: 20));
           });
         }
-        break;
       case 'TargetPlatform.android':
         {
           // Just run for 20 seconds to collect memory usage. The widget itself
           // animates during this time.
           await Future<void>.delayed(const Duration(seconds: 20));
         }
-        break;
       default:
         throw UnsupportedError('Unsupported platform $targetPlatform');
     }

--- a/dev/benchmarks/platform_channels_benchmarks/lib/main.dart
+++ b/dev/benchmarks/platform_channels_benchmarks/lib/main.dart
@@ -16,31 +16,22 @@ List<Object?> _makeTestBuffer(int size) {
     switch (i % 9) {
       case 0:
         answer.add(1);
-        break;
       case 1:
         answer.add(math.pow(2, 65));
-        break;
       case 2:
         answer.add(1234.0);
-        break;
       case 3:
         answer.add(null);
-        break;
       case 4:
         answer.add(<int>[1234]);
-        break;
       case 5:
         answer.add(<String, int>{'hello': 1234});
-        break;
       case 6:
         answer.add('this is a test');
-        break;
       case 7:
         answer.add(true);
-        break;
       case 8:
         answer.add(Uint8List(64));
-        break;
     }
   }
   return answer;

--- a/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
@@ -94,19 +94,15 @@ class StockHomeState extends State<StockHome> {
         setState(() {
           _autorefresh = !_autorefresh;
         });
-        break;
       case _StockMenuItem.refresh:
         showDialog<void>(
           context: context,
           builder: (BuildContext context) => const _NotImplementedDialog(),
         );
-        break;
       case _StockMenuItem.speedUp:
         timeDilation /= 5.0;
-        break;
       case _StockMenuItem.speedDown:
         timeDilation *= 5.0;
-        break;
     }
   }
 

--- a/dev/benchmarks/test_apps/stocks/lib/stock_settings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_settings.dart
@@ -63,7 +63,6 @@ class StockSettingsState extends State<StockSettings> {
     switch (widget.configuration.stockMode) {
       case StockMode.optimistic:
         _handleOptimismChanged(false);
-        break;
       case StockMode.pessimistic:
         showDialog<bool>(
           context: context,
@@ -88,7 +87,6 @@ class StockSettingsState extends State<StockSettings> {
             );
           },
         ).then<void>(_handleOptimismChanged);
-        break;
     }
   }
 

--- a/dev/bots/analyze_snippet_code.dart
+++ b/dev/bots/analyze_snippet_code.dart
@@ -1148,7 +1148,6 @@ Future<void> _runInteractive({
         if (!busy) {
           rerun();
         }
-        break;
     }
   });
   Watcher(file.absolute.path).events.listen((_) => rerun());

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -113,7 +113,6 @@ Future<Command> startCommand(String executable, List<String> arguments, {
         switch (outputMode) {
           case OutputMode.print:
             print(line);
-            break;
           case OutputMode.capture:
             break;
         }
@@ -127,7 +126,6 @@ Future<Command> startCommand(String executable, List<String> arguments, {
         switch (outputMode) {
           case OutputMode.print:
             print(line);
-            break;
           case OutputMode.capture:
             break;
         }
@@ -188,7 +186,6 @@ Future<CommandResult> runCommand(String executable, List<String> arguments, {
       case OutputMode.capture:
         print(result.flattenedStdout);
         print(result.flattenedStderr);
-        break;
     }
     String allOutput;
     if (failureMessage == null) {

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -107,25 +107,18 @@ String _testTypeToIndexFile(ServiceWorkerTestType type) {
   switch (type) {
     case ServiceWorkerTestType.blockedServiceWorkers:
       indexFile = 'index_with_blocked_service_workers.html';
-      break;
     case ServiceWorkerTestType.withFlutterJs:
       indexFile = 'index_with_flutterjs.html';
-      break;
     case ServiceWorkerTestType.withoutFlutterJs:
       indexFile = 'index_without_flutterjs.html';
-      break;
     case ServiceWorkerTestType.withFlutterJsShort:
       indexFile = 'index_with_flutterjs_short.html';
-      break;
     case ServiceWorkerTestType.withFlutterJsEntrypointLoadedEvent:
       indexFile = 'index_with_flutterjs_entrypoint_loaded.html';
-      break;
     case ServiceWorkerTestType.withFlutterJsTrustedTypesOn:
       indexFile = 'index_with_flutterjs_el_tt_on.html';
-      break;
     case ServiceWorkerTestType.generatedEntrypoint:
       indexFile = 'generated_entrypoint.html';
-      break;
   }
   return indexFile;
 }

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -160,12 +160,10 @@ String getNewPrLink({
       candidateBranch = state.framework.candidateBranch;
       workingBranch = state.framework.workingBranch;
       repoLabel = 'Framework';
-      break;
     case 'engine':
       candidateBranch = state.engine.candidateBranch;
       workingBranch = state.engine.workingBranch;
       repoLabel = 'Engine';
-      break;
     default:
       throw ConductorException('Expected repoName to be one of flutter or engine but got $repoName.');
   }

--- a/dev/conductor/core/lib/src/next.dart
+++ b/dev/conductor/core/lib/src/next.dart
@@ -141,7 +141,6 @@ class NextContext extends Context {
         }
 
         await pushWorkingBranch(engine, state.engine);
-        break;
       case pb.ReleasePhase.CODESIGN_ENGINE_BINARIES:
         stdio.printStatus(<String>[
           'You must validate pre-submit CI for your engine PR, merge it, and codesign',
@@ -158,7 +157,6 @@ class NextContext extends Context {
             return;
           }
         }
-        break;
       case pb.ReleasePhase.APPLY_FRAMEWORK_CHERRYPICKS:
         final Remote engineUpstreamRemote = Remote(
             name: RemoteName.upstream,
@@ -251,7 +249,6 @@ class NextContext extends Context {
         }
 
         await pushWorkingBranch(framework, state.framework);
-        break;
       case pb.ReleasePhase.PUBLISH_VERSION:
         stdio.printStatus('Please ensure that you have merged your framework PR and that');
         stdio.printStatus('post-submit CI has finished successfully.\n');
@@ -292,7 +289,6 @@ class NextContext extends Context {
         }
         await framework.tag(frameworkHead, state.releaseVersion, frameworkUpstream.name);
         await engine.tag(engineHead, state.releaseVersion, engineUpstream.name);
-        break;
       case pb.ReleasePhase.PUBLISH_CHANNEL:
         final Remote upstream = Remote(
             name: RemoteName.upstream,
@@ -331,7 +327,6 @@ class NextContext extends Context {
             remote: state.framework.upstream.url,
             force: force,
         );
-        break;
       case pb.ReleasePhase.VERIFY_RELEASE:
         stdio.printStatus(
             'The current status of packaging builds can be seen at:\n'
@@ -346,7 +341,6 @@ class NextContext extends Context {
             return;
           }
         }
-        break;
       case pb.ReleasePhase.RELEASE_COMPLETED:
         throw ConductorException('This release is finished.');
     }

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -394,16 +394,12 @@ class StartContext extends Context {
           z: 0,
           type: VersionType.stable,
         );
-        break;
       case ReleaseType.STABLE_HOTFIX:
         nextVersion = Version.increment(lastVersion, 'z');
-        break;
       case ReleaseType.BETA_INITIAL:
         nextVersion = Version.fromCandidateBranch(candidateBranch);
-        break;
       case ReleaseType.BETA_HOTFIX:
         nextVersion = Version.increment(lastVersion, 'n');
-        break;
     }
     return nextVersion;
   }

--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -54,20 +54,16 @@ class Version {
         assert(m == null);
         assert(n == null);
         assert(commits == null);
-        break;
       case VersionType.development:
         assert(m != null);
         assert(n != null);
         assert(commits == null);
-        break;
       case VersionType.latest:
         assert(m != null);
         assert(n != null);
         assert(commits != null);
-        break;
       case VersionType.gitDescribe:
         assert(commits != null);
-        break;
     }
   }
 
@@ -182,19 +178,15 @@ class Version {
           nextM = 0;
           nextN = 0;
         }
-        break;
       case 'z':
         // Hotfix to stable release.
         assert(previousVersion.type == VersionType.stable);
         nextZ += 1;
-        break;
       case 'm':
         assert(false, "Do not increment 'm' via Version.increment, use instead Version.fromCandidateBranch()");
-        break;
       case 'n':
         // Hotfix to internal roll.
         nextN = nextN! + 1;
-        break;
       default:
         throw Exception('Unknown increment level $increment.');
     }

--- a/dev/devicelab/lib/framework/ab.dart
+++ b/dev/devicelab/lib/framework/ab.dart
@@ -114,14 +114,11 @@ class ABTest {
         switch (aligns[column]) {
           case FieldJustification.LEFT:
             value = value.padRight(len);
-            break;
           case FieldJustification.RIGHT:
             value = value.padLeft(len);
-            break;
           case FieldJustification.CENTER:
             value = value.padLeft((len + value.length) ~/2);
             value = value.padRight(len);
-            break;
         }
       }
       if (column > 0) {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -685,7 +685,6 @@ class StartupTest {
             '--target=$target',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
-          break;
         case DeviceOperatingSystem.androidArm:
           await flutter('build', options: <String>[
             'apk',
@@ -695,7 +694,6 @@ class StartupTest {
             '--target=$target',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
-          break;
         case DeviceOperatingSystem.androidArm64:
           await flutter('build', options: <String>[
             'apk',
@@ -705,7 +703,6 @@ class StartupTest {
             '--target=$target',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
-          break;
         case DeviceOperatingSystem.fake:
         case DeviceOperatingSystem.fuchsia:
         case DeviceOperatingSystem.linux:
@@ -720,7 +717,6 @@ class StartupTest {
           ]);
           final String buildRoot = path.join(testDirectory, 'build');
           applicationBinaryPath = _findDarwinAppInBuildDirectory(buildRoot);
-          break;
         case DeviceOperatingSystem.windows:
           await flutter('build', options: <String>[
             'windows',
@@ -737,7 +733,6 @@ class StartupTest {
             'Profile',
             '$basename.exe'
           );
-          break;
       }
 
       const int maxFailures = 3;
@@ -824,7 +819,6 @@ class DevtoolsStartupTest {
             '--target-platform=android-arm,android-arm64',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
-          break;
         case DeviceOperatingSystem.androidArm:
           await flutter('build', options: <String>[
             'apk',
@@ -833,7 +827,6 @@ class DevtoolsStartupTest {
             '--target-platform=android-arm',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
-          break;
         case DeviceOperatingSystem.androidArm64:
           await flutter('build', options: <String>[
             'apk',
@@ -842,7 +835,6 @@ class DevtoolsStartupTest {
             '--target-platform=android-arm64',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
-          break;
         case DeviceOperatingSystem.ios:
           await flutter('build', options: <String>[
             'ios',
@@ -850,7 +842,6 @@ class DevtoolsStartupTest {
             '--profile',
           ]);
           applicationBinaryPath = _findDarwinAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
-          break;
         case DeviceOperatingSystem.fake:
         case DeviceOperatingSystem.fuchsia:
         case DeviceOperatingSystem.linux:
@@ -1383,7 +1374,6 @@ class CompileTest {
           );
           metrics.addAll(sizeMetrics);
         }
-        break;
       case DeviceOperatingSystem.android:
       case DeviceOperatingSystem.androidArm:
         options.insert(0, 'apk');
@@ -1399,7 +1389,6 @@ class CompileTest {
         if (reportPackageContentSizes) {
           metrics.addAll(await getSizesFromApk(apkPath));
         }
-        break;
       case DeviceOperatingSystem.androidArm64:
         options.insert(0, 'apk');
         options.add('--target-platform=android-arm64');
@@ -1414,7 +1403,6 @@ class CompileTest {
         if (reportPackageContentSizes) {
           metrics.addAll(await getSizesFromApk(apkPath));
         }
-        break;
       case DeviceOperatingSystem.fake:
         throw Exception('Unsupported option for fake devices');
       case DeviceOperatingSystem.fuchsia:
@@ -1442,7 +1430,6 @@ class CompileTest {
         // rather a directory containing an .exe and .dll files.
         // The release size is set to the size of the produced .exe file
         releaseSizeInBytes = exe.lengthSync();
-        break;
     }
 
     metrics.addAll(<String, dynamic>{
@@ -1470,16 +1457,13 @@ class CompileTest {
     switch (deviceOperatingSystem) {
       case DeviceOperatingSystem.ios:
         options.insert(0, 'ios');
-        break;
       case DeviceOperatingSystem.android:
       case DeviceOperatingSystem.androidArm:
         options.insert(0, 'apk');
         options.add('--target-platform=android-arm');
-        break;
       case DeviceOperatingSystem.androidArm64:
         options.insert(0, 'apk');
         options.add('--target-platform=android-arm64');
-        break;
       case DeviceOperatingSystem.fake:
         throw Exception('Unsupported option for fake devices');
       case DeviceOperatingSystem.fuchsia:
@@ -1489,11 +1473,9 @@ class CompileTest {
       case DeviceOperatingSystem.macos:
         unawaited(stderr.flush());
         options.insert(0, 'macos');
-        break;
       case DeviceOperatingSystem.windows:
         unawaited(stderr.flush());
         options.insert(0, 'windows');
-        break;
     }
     watch.start();
     await flutter('build', options: options);
@@ -1521,7 +1503,6 @@ class CompileTest {
           'Flutter.framework',
           'Flutter',
         ));
-        break;
       case DeviceOperatingSystem.macos:
         frameworkDirectory = path.join(
           appPath,
@@ -1533,7 +1514,6 @@ class CompileTest {
           'FlutterMacOS.framework',
           'FlutterMacOS',
         )); // https://github.com/flutter/flutter/issues/70413
-        break;
       case DeviceOperatingSystem.android:
       case DeviceOperatingSystem.androidArm:
       case DeviceOperatingSystem.androidArm64:

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -262,7 +262,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
         ) != 0) {
           throw TaskResult.failure('Platform unit tests failed');
         }
-        break;
       case 'ios':
         await testWithNewIOSSimulator('TestNativeUnitTests', (String deviceId) async {
           if (!await runXcodeTests(
@@ -275,7 +274,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
             throw TaskResult.failure('Platform unit tests failed');
           }
         });
-        break;
       case 'linux':
         if (await exec(
           path.join(rootPath, 'build', 'linux', 'x64', 'release', 'plugins', 'plugintest', 'plugintest_test'),
@@ -284,7 +282,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
         ) != 0) {
           throw TaskResult.failure('Platform unit tests failed');
         }
-        break;
       case 'macos':
         if (!await runXcodeTests(
           platformDirectory: path.join(rootPath, 'macos'),
@@ -295,7 +292,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
         )) {
           throw TaskResult.failure('Platform unit tests failed');
         }
-        break;
       case 'windows':
         if (await exec(
           path.join(rootPath, 'build', 'windows', 'plugins', 'plugintest', 'Release', 'plugintest_test.exe'),
@@ -304,7 +300,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
         ) != 0) {
           throw TaskResult.failure('Platform unit tests failed');
         }
-        break;
     }
   }
 

--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -50,14 +50,12 @@ Widget builds: $_widgetBuilds''';
         _state = FrameState.slow;
         _icon = Icons.stop;
         channel.invokeMethod<void>('start', _flutterFrameRate ~/ 2);
-        break;
       case FrameState.slow:
         debugPrint('Stopping .5x speed test...');
         await channel.invokeMethod<void>('stop');
         await _summarizeStats();
         _icon = Icons.fast_forward;
         _state = FrameState.afterSlow;
-        break;
       case FrameState.afterSlow:
         debugPrint('Starting 2x speed test...');
         _widgetBuilds = 0;
@@ -65,20 +63,17 @@ Widget builds: $_widgetBuilds''';
         _state = FrameState.fast;
         _icon = Icons.stop;
         channel.invokeMethod<void>('start', (_flutterFrameRate * 2).toInt());
-        break;
       case FrameState.fast:
         debugPrint('Stopping 2x speed test...');
         await channel.invokeMethod<void>('stop');
         await _summarizeStats();
         _state = FrameState.afterFast;
         _icon = Icons.replay;
-        break;
       case FrameState.afterFast:
         debugPrint('Test complete.');
         _summary = 'Press play to start again';
         _state = FrameState.initial;
         _icon = Icons.play_arrow;
-        break;
     }
     setState(() {});
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/calculator/logic.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/calculator/logic.dart
@@ -155,22 +155,18 @@ class CalcExpression {
       case ExpressionState.Start:
         // Start a new number with digit.
         newToken = IntToken('$digit');
-        break;
       case ExpressionState.LeadingNeg:
         // Replace the leading neg with a negative number starting with digit.
         outList.removeLast();
         newToken = IntToken('-$digit');
-        break;
       case ExpressionState.Number:
         final ExpressionToken last = outList.removeLast()!;
         newToken = IntToken('${last.stringRep}$digit');
-        break;
       case ExpressionState.Point:
       case ExpressionState.NumberWithPoint:
         final ExpressionToken last = outList.removeLast()!;
         newState = ExpressionState.NumberWithPoint;
         newToken = FloatToken('${last.stringRep}$digit');
-        break;
       case ExpressionState.Result:
         // Cannot enter a number now
         return null;
@@ -188,13 +184,11 @@ class CalcExpression {
     switch (state) {
       case ExpressionState.Start:
         newToken = FloatToken('.');
-        break;
       case ExpressionState.LeadingNeg:
       case ExpressionState.Number:
         final ExpressionToken last = outList.removeLast()!;
         final String value = last.stringRep!;
         newToken = FloatToken('$value.');
-        break;
       case ExpressionState.Point:
       case ExpressionState.NumberWithPoint:
       case ExpressionState.Result:
@@ -292,10 +286,8 @@ class CalcExpression {
       switch (opToken.operation) {
         case Operation.Addition:
           currentTermValue += nextTermValue;
-          break;
         case Operation.Subtraction:
           currentTermValue -= nextTermValue;
-          break;
         case Operation.Multiplication:
         case Operation.Division:
           // Logic error.

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -603,11 +603,9 @@ class Tab2ConversationBubble extends StatelessWidget {
       case Tab2ConversationBubbleColor.gray:
         backgroundColor = CupertinoDynamicColor.resolve(CupertinoColors.systemFill, context);
         foregroundColor = CupertinoDynamicColor.resolve(CupertinoColors.label, context);
-        break;
       case Tab2ConversationBubbleColor.blue:
         backgroundColor = CupertinoTheme.of(context).primaryColor;
         foregroundColor = CupertinoColors.white;
-        break;
       case null:
         break;
     }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/banner_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/banner_demo.dart
@@ -34,13 +34,10 @@ class _BannerDemoState extends State<BannerDemo> {
           _displayBanner = true;
           _showMultipleActions = true;
           _showLeading = true;
-          break;
         case BannerDemoAction.showMultipleActions:
           _showMultipleActions = !_showMultipleActions;
-          break;
         case BannerDemoAction.showLeading:
           _showLeading = !_showLeading;
-          break;
       }
     });
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -382,13 +382,10 @@ class _CardsDemoState extends State<CardsDemo> {
             switch (destination.type) {
               case CardDemoType.standard:
                 child = TravelDestinationItem(destination: destination, shape: _shape);
-                break;
               case CardDemoType.tappable:
                 child = TappableTravelDestinationItem(destination: destination, shape: _shape);
-                break;
               case CardDemoType.selectable:
                 child = SelectableTravelDestinationItem(destination: destination, shape: _shape);
-                break;
             }
 
             return Container(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -68,19 +68,14 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
       switch (action) {
         case LeaveBehindDemoAction.reset:
           initListItems();
-          break;
         case LeaveBehindDemoAction.horizontalSwipe:
           _dismissDirection = DismissDirection.horizontal;
-          break;
         case LeaveBehindDemoAction.leftSwipe:
           _dismissDirection = DismissDirection.endToStart;
-          break;
         case LeaveBehindDemoAction.rightSwipe:
           _dismissDirection = DismissDirection.startToEnd;
-          break;
         case LeaveBehindDemoAction.confirmDismiss:
           _confirmDismiss = !_confirmDismiss;
-          break;
       }
     });
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/list_demo.dart
@@ -212,13 +212,10 @@ class _ListDemoState extends State<ListDemo> {
       case _MaterialListType.oneLine:
       case _MaterialListType.oneLineWithAvatar:
         itemTypeText = 'Single-line';
-        break;
       case _MaterialListType.twoLine:
         itemTypeText = 'Two-line';
-        break;
       case _MaterialListType.threeLine:
         itemTypeText = 'Three-line';
-        break;
       case null:
         break;
     }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -57,11 +57,9 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
           case AnimationStatus.dismissed:
           case AnimationStatus.forward:
             _controller.forward();
-            break;
           case AnimationStatus.reverse:
           case AnimationStatus.completed:
             _controller.reverse();
-            break;
         }
       }
     });

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
@@ -143,7 +143,6 @@ class _ListDemoState extends State<ReorderableListDemo> {
           subtitle: secondary,
           secondary: const Icon(Icons.drag_handle),
         );
-        break;
       case _ReorderableListType.horizontalAvatar:
       case _ReorderableListType.verticalAvatar:
         listTile = SizedBox(
@@ -155,12 +154,10 @@ class _ListDemoState extends State<ReorderableListDemo> {
             child: Text(item.value),
           ),
         );
-        break;
       case null:
         listTile = Container(
           key: Key(item.value),
         );
-        break;
     }
 
     return listTile;

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -86,26 +86,20 @@ class _CustomRangeThumbShape extends RangeSliderThumbShape {
         switch (thumb) {
           case Thumb.start:
             thumbPath = _rightTriangle(size, center);
-            break;
           case Thumb.end:
             thumbPath = _leftTriangle(size, center);
-            break;
           case null:
             break;
         }
-        break;
       case TextDirection.ltr:
         switch (thumb) {
           case Thumb.start:
             thumbPath = _leftTriangle(size, center);
-            break;
           case Thumb.end:
             thumbPath = _rightTriangle(size, center);
-            break;
           case null:
             break;
         }
-        break;
       case null:
         break;
     }

--- a/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
@@ -208,7 +208,6 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
           flutterViewEvents.removeLast();
         }
         setState(() {});
-        break;
     }
     return Future<dynamic>.value();
   }
@@ -222,7 +221,6 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
           embeddedViewEvents.removeLast();
         }
         setState(() {});
-        break;
     }
     return Future<dynamic>.value();
   }

--- a/dev/integration_tests/wide_gamut_test/lib/main.dart
+++ b/dev/integration_tests/wide_gamut_test/lib/main.dart
@@ -236,13 +236,10 @@ class _MyHomePageState extends State<MyHomePage> {
     switch (widget.setup) {
       case Setup.none:
         imageWidget = Container();
-        break;
       case Setup.image:
         imageWidget = Image.memory(base64Decode(_displayP3Logo));
-        break;
       case Setup.canvasSaveLayer:
         imageWidget = CustomPaint(painter: _SaveLayerDrawer(_image));
-        break;
       case Setup.blur:
         imageWidget = Stack(
           children: <Widget>[
@@ -258,7 +255,6 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: Image.memory(base64Decode(_displayP3Logo))),
           ],
         );
-        break;
     }
 
     return Scaffold(

--- a/dev/manual_tests/lib/card_collection.dart
+++ b/dev/manual_tests/lib/card_collection.dart
@@ -286,19 +286,15 @@ class CardCollectionState extends State<CardCollection> {
     switch (_dismissDirection) {
       case DismissDirection.horizontal:
         backgroundMessage = 'Swipe in either direction';
-        break;
       case DismissDirection.endToStart:
         backgroundMessage = 'Swipe left to dismiss';
-        break;
       case DismissDirection.startToEnd:
         backgroundMessage = 'Swipe right to dismiss';
-        break;
       case DismissDirection.vertical:
       case DismissDirection.up:
       case DismissDirection.down:
       case DismissDirection.none:
         backgroundMessage = 'Unsupported dismissDirection';
-        break;
     }
 
     // This icon is wrong in RTL.

--- a/dev/manual_tests/lib/material_arc.dart
+++ b/dev/manual_tests/lib/material_arc.dart
@@ -160,12 +160,10 @@ class _PointDemoState extends State<_PointDemo> {
         setState(() {
           _begin = _begin! + details.delta;
         });
-        break;
       case _DragTarget.end:
         setState(() {
           _end = _end! + details.delta;
         });
-        break;
     }
   }
 
@@ -322,12 +320,10 @@ class _RectangleDemoState extends State<_RectangleDemo> {
         setState(() {
           _begin = _begin?.shift(details.delta);
         });
-        break;
       case _DragTarget.end:
         setState(() {
           _end = _end?.shift(details.delta);
         });
-        break;
     }
   }
 

--- a/dev/manual_tests/lib/menu_anchor.dart
+++ b/dev/manual_tests/lib/menu_anchor.dart
@@ -481,13 +481,10 @@ class _TestMenusState extends State<_TestMenus> {
       switch (checkboxState) {
         case false:
           checkboxState = true;
-          break;
         case true:
           checkboxState = null;
-          break;
         case null:
           checkboxState = false;
-          break;
       }
     });
   }
@@ -506,10 +503,8 @@ class _TestMenusState extends State<_TestMenus> {
         case TestMenu.radioMenu2:
         case TestMenu.radioMenu3:
           shortcuts[item.shortcut!] = VoidCallbackIntent(() => _setRadio(item));
-          break;
         case TestMenu.subMenu1:
           shortcuts[item.shortcut!] = VoidCallbackIntent(() => _setCheck(item));
-          break;
         case TestMenu.mainMenu1:
         case TestMenu.mainMenu2:
         case TestMenu.mainMenu3:
@@ -529,7 +524,6 @@ class _TestMenusState extends State<_TestMenus> {
         case TestMenu.standaloneMenu1:
         case TestMenu.standaloneMenu2:
           shortcuts[item.shortcut!] = VoidCallbackIntent(() => _itemSelected(item));
-          break;
       }
     }
     _shortcutsEntry = ShortcutRegistry.of(context).addAll(shortcuts);

--- a/dev/manual_tests/lib/text.dart
+++ b/dev/manual_tests/lib/text.dart
@@ -171,7 +171,7 @@ class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
           return const TextStyle();
         case 1:
           style = const TextStyle();
-          break; // and mutate it below
+// and mutate it below
         default:
           return null;
       }
@@ -211,7 +211,6 @@ class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
           case 3:
             return value.withBlue(value.blue + _random.nextInt(10) - 5);
         }
-        break;
       case 1:
         return null;
     }
@@ -322,10 +321,8 @@ class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
       case 3:
       case 4:
         children.insert(_random.nextInt(children.length + 1), _createRandomTextSpan());
-        break;
       case 10:
         children = children.reversed.toList();
-        break;
       case 20:
         if (children.isEmpty) {
           break;
@@ -337,7 +334,6 @@ class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
         if (depthOf(children[index]) < 3) {
           children.removeAt(index);
         }
-        break;
     }
     if (children.isEmpty && _random.nextBool()) {
       return null;

--- a/dev/manual_tests/lib/text.dart
+++ b/dev/manual_tests/lib/text.dart
@@ -170,8 +170,7 @@ class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
         case 0:
           return const TextStyle();
         case 1:
-          style = const TextStyle();
-// and mutate it below
+          style = const TextStyle(); // is mutated below
         default:
           return null;
       }

--- a/dev/tools/localization/bin/gen_localizations.dart
+++ b/dev/tools/localization/bin/gen_localizations.dart
@@ -405,10 +405,8 @@ String generateType(Map<String, dynamic>? attributes) {
     switch (attributes['x-flutter-type'] as String?) {
       case 'icuShortTimePattern':
         type = 'TimeOfDayFormat';
-        break;
       case 'scriptCategory':
         type = 'ScriptCategory';
-        break;
     }
   }
   return type + (optional ? '?' : '');

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -71,12 +71,10 @@ class LocaleInfo implements Comparable<LocaleInfo> {
             case 'CN':
             case 'SG':
               scriptCode = 'Hans';
-              break;
             case 'TW':
             case 'HK':
             case 'MO':
               scriptCode = 'Hant';
-              break;
           }
           break;
         }
@@ -339,13 +337,10 @@ void precacheLanguageAndRegionTags() {
       switch (type) {
         case 'language':
           _languages[subtag] = description;
-          break;
         case 'region':
           _regions[subtag] = description;
-          break;
         case 'script':
           _scripts[subtag] = description;
-          break;
       }
     }
   }

--- a/dev/tools/vitool/lib/vitool.dart
+++ b/dev/tools/vitool/lib/vitool.dart
@@ -156,16 +156,12 @@ class PathCommandAnimation {
     switch (type) {
       case 'M':
         dartCommandClass = '_PathMoveTo';
-        break;
       case 'C':
         dartCommandClass = '_PathCubicTo';
-        break;
       case 'L':
         dartCommandClass = '_PathLineTo';
-        break;
       case 'Z':
         dartCommandClass = '_PathClose';
-        break;
       default:
         throw Exception('unsupported path command: $type');
     }

--- a/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
+++ b/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
@@ -80,10 +80,8 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                   curve: Curves.easeOut,
                 );
               }
-              break;
             case 1:
               showModal(context);
-              break;
           }
           setState(
             () {

--- a/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
@@ -178,22 +178,17 @@ class _MyCascadingMenuState extends State<MyCascadingMenu> {
           applicationName: 'MenuBar Sample',
           applicationVersion: '1.0.0',
         );
-        break;
       case MenuEntry.hideMessage:
       case MenuEntry.showMessage:
         showingMessage = !showingMessage;
-        break;
       case MenuEntry.colorMenu:
         break;
       case MenuEntry.colorRed:
         backgroundColor = Colors.red;
-        break;
       case MenuEntry.colorGreen:
         backgroundColor = Colors.green;
-        break;
       case MenuEntry.colorBlue:
         backgroundColor = Colors.blue;
-        break;
     }
   }
 }

--- a/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
@@ -169,22 +169,17 @@ class _MyContextMenuState extends State<MyContextMenu> {
           applicationName: 'MenuBar Sample',
           applicationVersion: '1.0.0',
         );
-        break;
       case MenuEntry.showMessage:
       case MenuEntry.hideMessage:
         showingMessage = !showingMessage;
-        break;
       case MenuEntry.colorMenu:
         break;
       case MenuEntry.colorRed:
         backgroundColor = Colors.red;
-        break;
       case MenuEntry.colorGreen:
         backgroundColor = Colors.green;
-        break;
       case MenuEntry.colorBlue:
         backgroundColor = Colors.blue;
-        break;
     }
   }
 

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -46,12 +46,10 @@ class _PlatformMenuBarExampleState extends State<PlatformMenuBarExample> {
           applicationName: 'MenuBar Sample',
           applicationVersion: '1.0.0',
         );
-        break;
       case MenuSelection.showMessage:
         setState(() {
           _showMessage = !_showMessage;
         });
-        break;
     }
   }
 

--- a/examples/api/lib/material/selectable_region/selectable_region.0.dart
+++ b/examples/api/lib/material/selectable_region/selectable_region.0.dart
@@ -185,15 +185,12 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
           _end = adjustedPoint;
         }
         result = SelectionUtils.getResultBasedOnRect(renderObjectRect, point);
-        break;
       case SelectionEventType.clear:
         _start = _end = null;
-        break;
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
         _start = Offset.zero;
         _end = Offset.infinite;
-        break;
       case SelectionEventType.granularlyExtendSelection:
         result = SelectionResult.end;
         final GranularlyExtendSelectionEvent extendSelectionEvent = event as GranularlyExtendSelectionEvent;
@@ -218,7 +215,6 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
           }
           _start = newOffset;
         }
-        break;
       case SelectionEventType.directionallyExtendSelection:
         result = SelectionResult.end;
         final DirectionallyExtendSelectionEvent extendSelectionEvent = event as DirectionallyExtendSelectionEvent;
@@ -240,7 +236,6 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
             } else {
               newOffset = Offset.infinite;
             }
-            break;
           case SelectionExtendDirection.nextLine:
           case SelectionExtendDirection.forward:
             forward = true;
@@ -254,7 +249,6 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
             } else {
               newOffset = Offset.zero;
             }
-            break;
         }
         if (extendSelectionEvent.isEnd) {
           if (newOffset == _end) {
@@ -267,7 +261,6 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
           }
           _start = newOffset;
         }
-        break;
     }
     _updateGeometry();
     return result;

--- a/examples/api/lib/widgets/async/stream_builder.0.dart
+++ b/examples/api/lib/widgets/async/stream_builder.0.dart
@@ -87,7 +87,6 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                       child: Text('Select a lot'),
                     ),
                   ];
-                  break;
                 case ConnectionState.waiting:
                   children = const <Widget>[
                     SizedBox(
@@ -100,7 +99,6 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                       child: Text('Awaiting bids...'),
                     ),
                   ];
-                  break;
                 case ConnectionState.active:
                   children = <Widget>[
                     const Icon(
@@ -113,7 +111,6 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                       child: Text('\$${snapshot.data}'),
                     ),
                   ];
-                  break;
                 case ConnectionState.done:
                   children = <Widget>[
                     const Icon(
@@ -126,7 +123,6 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                       child: Text('\$${snapshot.data} (closed)'),
                     ),
                   ];
-                  break;
               }
             }
 

--- a/examples/api/lib/widgets/basic/custom_multi_child_layout.0.dart
+++ b/examples/api/lib/widgets/basic/custom_multi_child_layout.0.dart
@@ -49,7 +49,6 @@ class _CascadeLayoutDelegate extends MultiChildLayoutDelegate {
     switch (textDirection) {
       case TextDirection.rtl:
         childPosition += Offset(size.width, 0);
-        break;
       case TextDirection.ltr:
         break;
     }
@@ -66,11 +65,9 @@ class _CascadeLayoutDelegate extends MultiChildLayoutDelegate {
         case TextDirection.rtl:
           positionChild(color, childPosition - Offset(currentSize.width, 0));
           childPosition += Offset(-currentSize.width, currentSize.height - overlap);
-          break;
         case TextDirection.ltr:
           positionChild(color, childPosition);
           childPosition += Offset(currentSize.width, currentSize.height - overlap);
-          break;
       }
     }
   }

--- a/examples/api/lib/widgets/navigator/navigator.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.0.dart
@@ -105,7 +105,6 @@ class SignUpPage extends StatelessWidget {
             // Assume CollectPersonalInfoPage collects personal info and then
             // navigates to 'signup/choose_credentials'.
             builder = (BuildContext context) => const CollectPersonalInfoPage();
-            break;
           case 'signup/choose_credentials':
             // Assume ChooseCredentialsPage collects new credentials and then
             // invokes 'onSignupComplete()'.
@@ -119,7 +118,6 @@ class SignUpPage extends StatelessWidget {
                     Navigator.of(context).pop();
                   },
                 );
-            break;
           default:
             throw Exception('Invalid route: ${settings.name}');
         }

--- a/examples/api/test/material/context_menu/editable_text_toolbar_builder.2_test.dart
+++ b/examples/api/test/material/context_menu/editable_text_toolbar_builder.2_test.dart
@@ -32,18 +32,14 @@ void main() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsAtLeastNWidgets(1));
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         expect(find.byType(TextSelectionToolbarTextButton), findsAtLeastNWidgets(1));
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.byType(DesktopTextSelectionToolbarButton), findsAtLeastNWidgets(1));
-        break;
       case TargetPlatform.macOS:
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsAtLeastNWidgets(1));
-        break;
     }
     expect(find.text('Copy'), findsNothing);
     expect(find.text('Cut'), findsNothing);

--- a/examples/api/test/material/page_transitions_theme/page_transitions_theme.0_test.dart
+++ b/examples/api/test/material/page_transitions_theme/page_transitions_theme.0_test.dart
@@ -23,18 +23,14 @@ void main() {
       switch (platform) {
         case TargetPlatform.iOS:
           expect(theme.builders[platform], isA<CupertinoPageTransitionsBuilder>());
-          break;
         case TargetPlatform.linux:
           expect(theme.builders[platform], isA<OpenUpwardsPageTransitionsBuilder>());
-          break;
         case TargetPlatform.macOS:
           expect(theme.builders[platform], isA<FadeUpwardsPageTransitionsBuilder>());
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(theme.builders[platform], isNull);
-          break;
       }
     }
 

--- a/examples/api/test/material/page_transitions_theme/page_transitions_theme.1_test.dart
+++ b/examples/api/test/material/page_transitions_theme/page_transitions_theme.1_test.dart
@@ -25,14 +25,12 @@ void main() {
           expect(theme.builders[platform], isA<ZoomPageTransitionsBuilder>());
           final ZoomPageTransitionsBuilder builder = theme.builders[platform]! as ZoomPageTransitionsBuilder;
           expect(builder.allowSnapshotting, isFalse);
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
         case TargetPlatform.linux:
         case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
           expect(theme.builders[platform], isNull);
-          break;
       }
     }
 

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -576,7 +576,6 @@ class AnimationController extends Animation<double>
           // pattern of an eternally repeating animation might cause an endless loop if it weren't delayed
           // for at least one frame.
           scale = 0.05;
-          break;
         case AnimationBehavior.preserve:
           break;
       }
@@ -696,7 +695,6 @@ class AnimationController extends Animation<double>
       switch (behavior) {
         case AnimationBehavior.normal:
           scale = 200.0; // This is arbitrary (it was chosen because it worked for the drawer widget).
-          break;
         case AnimationBehavior.preserve:
           break;
       }

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -424,13 +424,10 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
       case AnimationStatus.dismissed:
       case AnimationStatus.completed:
         _curveDirection = null;
-        break;
       case AnimationStatus.forward:
         _curveDirection ??= AnimationStatus.forward;
-        break;
       case AnimationStatus.reverse:
         _curveDirection ??= AnimationStatus.reverse;
-        break;
     }
   }
 
@@ -571,10 +568,8 @@ class TrainHoppingAnimation extends Animation<double>
       switch (_mode!) {
         case _TrainHoppingMode.minimize:
           hop = _nextTrain!.value <= _currentTrain!.value;
-          break;
         case _TrainHoppingMode.maximize:
           hop = _nextTrain!.value >= _currentTrain!.value;
-          break;
       }
       if (hop) {
         _currentTrain!

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -1041,20 +1041,15 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
         switch (level) {
           case CupertinoUserInterfaceLevelData.base:
             resolved = isHighContrastEnabled ? highContrastColor : color;
-            break;
           case CupertinoUserInterfaceLevelData.elevated:
             resolved = isHighContrastEnabled ? highContrastElevatedColor : elevatedColor;
-            break;
         }
-        break;
       case Brightness.dark:
         switch (level) {
           case CupertinoUserInterfaceLevelData.base:
             resolved = isHighContrastEnabled ? darkHighContrastColor : darkColor;
-            break;
           case CupertinoUserInterfaceLevelData.elevated:
             resolved = isHighContrastEnabled ? darkHighContrastElevatedColor : darkElevatedColor;
-            break;
         }
     }
 

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -564,7 +564,6 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
         }
         _lastOverlayEntry?.remove();
         _lastOverlayEntry = null;
-        break;
 
       case AnimationStatus.completed:
         setState(() {
@@ -580,7 +579,6 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
           _lastOverlayEntry = null;
           _openController.reset();
         });
-        break;
 
       case AnimationStatus.forward:
       case AnimationStatus.reverse:

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -428,7 +428,6 @@ class CupertinoDatePicker extends StatefulWidget {
             longestText = date;
           }
         }
-        break;
       case _PickerColumnType.hour:
         for (int i = 0; i < 24; i++) {
           final String hour = localizations.datePickerHour(i);
@@ -436,7 +435,6 @@ class CupertinoDatePicker extends StatefulWidget {
             longestText = hour;
           }
         }
-        break;
       case _PickerColumnType.minute:
         for (int i = 0; i < 60; i++) {
           final String minute = localizations.datePickerMinute(i);
@@ -444,13 +442,11 @@ class CupertinoDatePicker extends StatefulWidget {
             longestText = minute;
           }
         }
-        break;
       case _PickerColumnType.dayPeriod:
         longestText =
           localizations.anteMeridiemAbbreviation.length > localizations.postMeridiemAbbreviation.length
             ? localizations.anteMeridiemAbbreviation
             : localizations.postMeridiemAbbreviation;
-        break;
       case _PickerColumnType.dayOfMonth:
         int longestDayOfMonth = 1;
         for (int i = 1; i <=31; i++) {
@@ -468,7 +464,6 @@ class CupertinoDatePicker extends StatefulWidget {
             }
           }
         }
-        break;
       case _PickerColumnType.month:
         for (int i = 1; i <=12; i++) {
           final String month = localizations.datePickerMonth(i);
@@ -476,10 +471,8 @@ class CupertinoDatePicker extends StatefulWidget {
             longestText = month;
           }
         }
-        break;
       case _PickerColumnType.year:
         longestText = localizations.datePickerYear(2018);
-        break;
     }
 
     assert(longestText != '', 'column type is not appropriate');
@@ -1400,7 +1393,6 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
           estimatedColumnWidths[_PickerColumnType.dayOfMonth.index]!,
           estimatedColumnWidths[_PickerColumnType.year.index]!,
         ];
-        break;
       case DatePickerDateOrder.dmy:
         pickerBuilders = <_ColumnBuilder>[_buildDayPicker, _buildMonthPicker, _buildYearPicker];
         columnWidths = <double>[
@@ -1408,7 +1400,6 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
           estimatedColumnWidths[_PickerColumnType.month.index]!,
           estimatedColumnWidths[_PickerColumnType.year.index]!,
         ];
-        break;
       case DatePickerDateOrder.ymd:
         pickerBuilders = <_ColumnBuilder>[_buildYearPicker, _buildMonthPicker, _buildDayPicker];
         columnWidths = <double>[
@@ -1416,7 +1407,6 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
           estimatedColumnWidths[_PickerColumnType.month.index]!,
           estimatedColumnWidths[_PickerColumnType.dayOfMonth.index]!,
         ];
-        break;
       case DatePickerDateOrder.ydm:
         pickerBuilders = <_ColumnBuilder>[_buildYearPicker, _buildDayPicker, _buildMonthPicker];
         columnWidths = <double>[
@@ -1424,7 +1414,6 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
           estimatedColumnWidths[_PickerColumnType.dayOfMonth.index]!,
           estimatedColumnWidths[_PickerColumnType.month.index]!,
         ];
-        break;
     }
 
     final List<Widget> pickers = <Widget>[];
@@ -2099,7 +2088,6 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
                   _endSelectionOverlay,
               ),
             ];
-            break;
           case CupertinoTimerPickerMode.ms:
             final double secondLabelContentWidth = baseLabelContentWidth + secondLabelWidth;
             double secondColumnEndPadding =
@@ -2130,7 +2118,6 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
                   _endSelectionOverlay,
               ),
             ];
-            break;
           case CupertinoTimerPickerMode.hms:
             final double hourColumnEndPadding =
                 pickerColumnWidth - baseLabelContentWidth - hourLabelWidth - _kTimerPickerMinHorizontalPadding;
@@ -2162,7 +2149,6 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
                   _endSelectionOverlay,
               ),
             ];
-            break;
         }
         final CupertinoThemeData themeData = CupertinoTheme.of(context);
         return MediaQuery(

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -898,10 +898,8 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
     switch (slot) {
       case _AlertDialogSections.contentSection:
         renderObject.contentSection = child as RenderBox;
-        break;
       case _AlertDialogSections.actionsSection:
         renderObject.actionsSection = child as RenderBox;
-        break;
     }
   }
 }

--- a/packages/flutter/lib/src/cupertino/list_section.dart
+++ b/packages/flutter/lib/src/cupertino/list_section.dart
@@ -420,10 +420,8 @@ class CupertinoListSection extends StatelessWidget {
       switch (type) {
         case CupertinoListSectionType.insetGrouped:
           childrenGroupBorderRadius = _kDefaultInsetGroupedBorderRadius;
-          break;
         case CupertinoListSectionType.base:
           childrenGroupBorderRadius = BorderRadius.zero;
-          break;
       }
 
       // Refactored the decorate children group in one place to avoid repeating it

--- a/packages/flutter/lib/src/cupertino/list_tile.dart
+++ b/packages/flutter/lib/src/cupertino/list_tile.dart
@@ -292,10 +292,8 @@ class _CupertinoListTileState extends State<CupertinoListTile> {
       switch (widget._type) {
         case _CupertinoListTileType.base:
           padding = widget.subtitle == null ? _kPadding : _kPaddingWithSubtitle;
-          break;
         case _CupertinoListTileType.notched:
           padding = widget.leading == null ? _kNotchedPaddingWithoutLeading : _kNotchedPadding;
-          break;
       }
     }
 
@@ -331,10 +329,8 @@ class _CupertinoListTileState extends State<CupertinoListTile> {
     switch (widget._type) {
       case _CupertinoListTileType.base:
         minHeight = subtitle == null ? _kMinHeight : _kMinHeightWithSubtitle;
-        break;
       case _CupertinoListTileType.notched:
         minHeight = widget.leading == null ? _kNotchedMinHeightWithoutLeading : _kNotchedMinHeight;
-        break;
     }
 
     final Widget child = Container(

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -144,10 +144,8 @@ Widget _wrapWithBackground({
     switch (newBrightness) {
       case Brightness.dark:
         overlayStyle = SystemUiOverlayStyle.light;
-        break;
       case Brightness.light:
         overlayStyle = SystemUiOverlayStyle.dark;
-        break;
     }
     // [SystemUiOverlayStyle.light] and [SystemUiOverlayStyle.dark] set some system
     // navigation bar properties,
@@ -1544,7 +1542,6 @@ class _BackChevron extends StatelessWidget {
           transformHitTests: false,
           child: iconWidget,
         );
-        break;
       case TextDirection.ltr:
         break;
     }

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -237,14 +237,12 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
         hasSuitableHapticHardware = true;
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         hasSuitableHapticHardware = false;
-        break;
     }
     if (hasSuitableHapticHardware && index != _lastHapticIndex) {
       _lastHapticIndex = index;

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -533,7 +533,6 @@ class _CupertinoSliverRefreshControlState extends State<CupertinoSliverRefreshCo
         } else {
           nextState = RefreshIndicatorMode.inactive;
         }
-        break;
     }
 
     return nextState;

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -948,11 +948,9 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
       case TextDirection.rtl:
         start = offset.dx + configuration.size!.width;
         shadowDirection = 1;
-        break;
       case TextDirection.ltr:
         start = offset.dx;
         shadowDirection = -1;
-        break;
     }
 
     int bandColorIndex = 0;

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -188,10 +188,8 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
     switch (direction) {
       case Axis.vertical:
         _pressStartAxisPosition = localPosition.dy;
-        break;
       case Axis.horizontal:
         _pressStartAxisPosition = localPosition.dx;
-        break;
     }
   }
 
@@ -220,13 +218,11 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
           (localPosition.dy - _pressStartAxisPosition).abs() > 0) {
           HapticFeedback.mediumImpact();
         }
-        break;
       case Axis.horizontal:
         if (velocity.pixelsPerSecond.dx.abs() < 10 &&
           (localPosition.dx - _pressStartAxisPosition).abs() > 0) {
           HapticFeedback.mediumImpact();
         }
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -657,14 +657,12 @@ class _RenderSegmentedControl<T> extends RenderBox
           lastChild,
           firstChild,
         );
-        break;
       case TextDirection.ltr:
         _layoutRects(
           childAfter,
           firstChild,
           lastChild,
         );
-        break;
     }
 
     size = _computeOverallSizeFromChildSize(childSize);

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -456,10 +456,8 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
     switch (textDirection) {
       case TextDirection.rtl:
         visualPosition = 1.0 - _value;
-        break;
       case TextDirection.ltr:
         visualPosition = _value;
-        break;
     }
     return lerpDouble(_trackLeft + CupertinoThumbPainter.radius, _trackRight - CupertinoThumbPainter.radius, visualPosition)!;
   }
@@ -475,10 +473,8 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
       switch (textDirection) {
         case TextDirection.rtl:
           _currentDragValue -= valueDelta;
-          break;
         case TextDirection.ltr:
           _currentDragValue += valueDelta;
-          break;
       }
       onChanged!(_discretizedCurrentDragValue);
     }
@@ -522,12 +518,10 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
         visualPosition = 1.0 - _position.value;
         leftColor = _activeColor;
         rightColor = trackColor;
-        break;
       case TextDirection.ltr:
         visualPosition = _position.value;
         leftColor = trackColor;
         rightColor = _activeColor;
-        break;
     }
 
     final double trackCenter = offset.dy + size.height / 2.0;

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -498,7 +498,6 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
         break;
       case TextDirection.rtl:
         index = numOfChildren - 1 - index;
-        break;
     }
 
     return widget.children.keys.elementAt(index);
@@ -682,7 +681,6 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
         if (highlightedIndex != null) {
           highlightedIndex = index - 1 - highlightedIndex;
         }
-        break;
     }
 
     return UnconstrainedBox(

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -303,10 +303,8 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
       switch (Directionality.of(context)) {
         case TextDirection.rtl:
           _positionController.value -= delta;
-          break;
         case TextDirection.ltr:
           _positionController.value += delta;
-          break;
       }
     }
   }
@@ -325,7 +323,6 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
         HapticFeedback.lightImpact();
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -609,10 +606,8 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
     switch (textDirection) {
       case TextDirection.rtl:
         visualPosition = 1.0 - currentValue;
-        break;
       case TextDirection.ltr:
         visualPosition = currentValue;
-        break;
     }
 
     final Paint paint = Paint()

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1005,7 +1005,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
         if (cause == SelectionChangedCause.longPress) {
           _editableText.bringIntoView(selection.extent);
         }
-        break;
     }
 
     switch (defaultTargetPlatform) {
@@ -1019,7 +1018,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
         if (cause == SelectionChangedCause.drag) {
           _editableText.hideToolbar();
         }
-        break;
     }
   }
 
@@ -1186,7 +1184,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
         textSelectionControls ??= cupertinoTextSelectionHandleControls;
-        break;
 
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
@@ -1197,7 +1194,6 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
             _effectiveFocusNode.requestFocus();
           }
         };
-        break;
     }
 
     final bool enabled = widget.enabled ?? true;

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -587,13 +587,10 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
     switch (slot) {
       case _CupertinoTextSelectionToolbarItemsSlot.backButton:
         renderObject.backButton = child;
-        break;
       case _CupertinoTextSelectionToolbarItemsSlot.nextButton:
         renderObject.nextButton = child;
-        break;
       case _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled:
         renderObject.nextButtonDisabled = child;
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/cupertino/toggleable.dart
+++ b/packages/flutter/lib/src/cupertino/toggleable.dart
@@ -76,13 +76,10 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     switch (value) {
       case false:
         onChanged!(true);
-        break;
       case true:
         onChanged!(tristate ? null : false);
-        break;
       case null:
         onChanged!(false);
-        break;
     }
     context.findRenderObject()!.sendSemanticsEvent(const TapSemanticEvent());
   }

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -566,22 +566,16 @@ abstract class BindingBase {
             switch (parameters['value']) {
               case 'android':
                 debugDefaultTargetPlatformOverride = TargetPlatform.android;
-                break;
               case 'fuchsia':
                 debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
-                break;
               case 'iOS':
                 debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-                break;
               case 'linux':
                 debugDefaultTargetPlatformOverride = TargetPlatform.linux;
-                break;
               case 'macOS':
                 debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-                break;
               case 'windows':
                 debugDefaultTargetPlatformOverride = TargetPlatform.windows;
-                break;
               case 'default':
               default:
                 debugDefaultTargetPlatformOverride = null;
@@ -607,10 +601,8 @@ abstract class BindingBase {
             switch (parameters['value']) {
               case 'Brightness.light':
                 debugBrightnessOverride = ui.Brightness.light;
-                break;
               case 'Brightness.dark':
                 debugBrightnessOverride = ui.Brightness.dark;
-                break;
               default:
                 debugBrightnessOverride = null;
             }

--- a/packages/flutter/lib/src/foundation/consolidate_response.dart
+++ b/packages/flutter/lib/src/foundation/consolidate_response.dart
@@ -65,12 +65,10 @@ Future<Uint8List> consolidateHttpClientResponseBytes(
         // We need to un-compress the bytes as they come in.
         sink = gzip.decoder.startChunkedConversion(output);
       }
-      break;
     case HttpClientResponseCompressionState.decompressed:
       // response.contentLength will not match our bytes stream, so we declare
       // that we don't know the expected content length.
       expectedContentLength = null;
-      break;
     case HttpClientResponseCompressionState.notCompressed:
       // Fall-through.
       break;

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -907,13 +907,11 @@ class _PrefixedStringBuilder {
           }
           lastWordStart = index;
           mode = _WordWrapParseMode.inWord;
-          break;
         case _WordWrapParseMode.inWord: // looking for a good break point. Treat all text
           while ((index < message.length) && (message[index] != ' ' || noWrap(index))) {
             index += 1;
           }
           mode = _WordWrapParseMode.atBreak;
-          break;
         case _WordWrapParseMode.atBreak: // at start of break point
           if ((index - startForLengthCalculations > width) || (index == message.length)) {
             // we are over the width line, so break
@@ -953,7 +951,6 @@ class _PrefixedStringBuilder {
             // skip to the end of this break point
             mode = _WordWrapParseMode.inSpace;
           }
-          break;
       }
     }
   }

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -176,12 +176,10 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
               lineStart = currentPosition + 1;
               currentLineIndent += 1;
               state = _LicenseEntryWithLineBreaksParserState.beforeParagraph;
-              break;
             case '\t':
               lineStart = currentPosition + 1;
               currentLineIndent += 8;
               state = _LicenseEntryWithLineBreaksParserState.beforeParagraph;
-              break;
             case '\r':
             case '\n':
             case '\f':
@@ -197,7 +195,6 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
               currentParagraphIndentation = null;
               lineStart = currentPosition + 1;
               state = _LicenseEntryWithLineBreaksParserState.beforeParagraph;
-              break;
             case '[':
               // This is a bit of a hack for the LGPL 2.1, which does something like this:
               //
@@ -224,7 +221,6 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
               }
               state = _LicenseEntryWithLineBreaksParserState.inParagraph;
           }
-          break;
         case _LicenseEntryWithLineBreaksParserState.inParagraph:
           switch (text[currentPosition]) {
             case '\n':
@@ -233,7 +229,6 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
               currentLineIndent = 0;
               lineStart = currentPosition + 1;
               state = _LicenseEntryWithLineBreaksParserState.beforeParagraph;
-              break;
             case '\f':
               addLine();
               result.add(getParagraph());
@@ -242,11 +237,9 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
               currentParagraphIndentation = null;
               lineStart = currentPosition + 1;
               state = _LicenseEntryWithLineBreaksParserState.beforeParagraph;
-              break;
             default:
               state = _LicenseEntryWithLineBreaksParserState.inParagraph;
           }
-          break;
       }
       currentPosition += 1;
     }
@@ -255,11 +248,9 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
         if (lines.isNotEmpty) {
           result.add(getParagraph());
         }
-        break;
       case _LicenseEntryWithLineBreaksParserState.inParagraph:
         addLine();
         result.add(getParagraph());
-        break;
     }
     return result;
   }

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -136,13 +136,11 @@ Iterable<String> debugWordWrap(String message, int width, { String wrapIndent = 
         }
         lastWordStart = index;
         mode = _WordWrapParseMode.inWord;
-        break;
       case _WordWrapParseMode.inWord: // looking for a good break point
         while ((index < message.length) && (message[index] != ' ')) {
           index += 1;
         }
         mode = _WordWrapParseMode.atBreak;
-        break;
       case _WordWrapParseMode.atBreak: // at start of break point
         if ((index - startForLengthCalculations > width) || (index == message.length)) {
           // we are over the width line, so break
@@ -184,7 +182,6 @@ Iterable<String> debugWordWrap(String message, int width, { String wrapIndent = 
           // skip to the end of this break point
           mode = _WordWrapParseMode.inSpace;
         }
-        break;
     }
   }
 }

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -580,7 +580,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
             onLongPressUp == null) {
           return false;
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryLongPressDown == null &&
             onSecondaryLongPressCancel == null &&
@@ -591,7 +590,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
             onSecondaryLongPressUp == null) {
           return false;
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryLongPressDown == null &&
             onTertiaryLongPressCancel == null &&
@@ -602,7 +600,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
             onTertiaryLongPressUp == null) {
           return false;
         }
-        break;
       default:
         return false;
     }
@@ -669,17 +666,14 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onLongPressDown != null) {
           invokeCallback<void>('onLongPressDown', () => onLongPressDown!(details));
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryLongPressDown != null) {
           invokeCallback<void>('onSecondaryLongPressDown', () => onSecondaryLongPressDown!(details));
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryLongPressDown != null) {
           invokeCallback<void>('onTertiaryLongPressDown', () => onTertiaryLongPressDown!(details));
         }
-        break;
       default:
         assert(false, 'Unhandled button $_initialButtons');
     }
@@ -692,17 +686,14 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
           if (onLongPressCancel != null) {
             invokeCallback<void>('onLongPressCancel', onLongPressCancel!);
           }
-          break;
         case kSecondaryButton:
           if (onSecondaryLongPressCancel != null) {
             invokeCallback<void>('onSecondaryLongPressCancel', onSecondaryLongPressCancel!);
           }
-          break;
         case kTertiaryButton:
           if (onTertiaryLongPressCancel != null) {
             invokeCallback<void>('onTertiaryLongPressCancel', onTertiaryLongPressCancel!);
           }
-          break;
         default:
           assert(false, 'Unhandled button $_initialButtons');
       }
@@ -722,7 +713,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onLongPress != null) {
           invokeCallback<void>('onLongPress', onLongPress!);
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryLongPressStart != null) {
           final LongPressStartDetails details = LongPressStartDetails(
@@ -734,7 +724,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onSecondaryLongPress != null) {
           invokeCallback<void>('onSecondaryLongPress', onSecondaryLongPress!);
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryLongPressStart != null) {
           final LongPressStartDetails details = LongPressStartDetails(
@@ -746,7 +735,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onTertiaryLongPress != null) {
           invokeCallback<void>('onTertiaryLongPress', onTertiaryLongPress!);
         }
-        break;
       default:
         assert(false, 'Unhandled button $_initialButtons');
     }
@@ -764,17 +752,14 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onLongPressMoveUpdate != null) {
           invokeCallback<void>('onLongPressMoveUpdate', () => onLongPressMoveUpdate!(details));
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryLongPressMoveUpdate != null) {
           invokeCallback<void>('onSecondaryLongPressMoveUpdate', () => onSecondaryLongPressMoveUpdate!(details));
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryLongPressMoveUpdate != null) {
           invokeCallback<void>('onTertiaryLongPressMoveUpdate', () => onTertiaryLongPressMoveUpdate!(details));
         }
-        break;
       default:
         assert(false, 'Unhandled button $_initialButtons');
     }
@@ -800,7 +785,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onLongPressUp != null) {
           invokeCallback<void>('onLongPressUp', onLongPressUp!);
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryLongPressEnd != null) {
           invokeCallback<void>('onSecondaryLongPressEnd', () => onSecondaryLongPressEnd!(details));
@@ -808,7 +792,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onSecondaryLongPressUp != null) {
           invokeCallback<void>('onSecondaryLongPressUp', onSecondaryLongPressUp!);
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryLongPressEnd != null) {
           invokeCallback<void>('onTertiaryLongPressEnd', () => onTertiaryLongPressEnd!(details));
@@ -816,7 +799,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onTertiaryLongPressUp != null) {
           invokeCallback<void>('onTertiaryLongPressUp', onTertiaryLongPressUp!);
         }
-        break;
       default:
         assert(false, 'Unhandled button $_initialButtons');
     }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -411,10 +411,8 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
         case DragStartBehavior.start:
           _initialPosition = _initialPosition + delta;
           localUpdateDelta = Offset.zero;
-          break;
         case DragStartBehavior.down:
           localUpdateDelta = _getDeltaForDetails(delta.local);
-          break;
       }
       _pendingDragOffset = OffsetPair.zero;
       _lastPendingEventTimestamp = null;
@@ -460,11 +458,9 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
       case _DragState.possible:
         resolve(GestureDisposition.rejected);
         _checkCancel();
-        break;
 
       case _DragState.accepted:
         _checkEnd(pointer);
-        break;
     }
     _velocityTrackers.clear();
     _initialButtons = null;

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -762,15 +762,12 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     switch (_state) {
       case _ScaleState.possible:
         resolve(GestureDisposition.rejected);
-        break;
       case _ScaleState.ready:
         assert(false); // We should have not seen a pointer yet
-        break;
       case _ScaleState.accepted:
         break;
       case _ScaleState.started:
         assert(false); // We should be in the accepted state when user is done
-        break;
     }
     _state = _ScaleState.ready;
   }

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -593,7 +593,6 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
             onTapCancel == null) {
           return false;
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryTap == null &&
             onSecondaryTapDown == null &&
@@ -601,14 +600,12 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
             onSecondaryTapCancel == null) {
           return false;
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryTapDown == null &&
             onTertiaryTapUp == null &&
             onTertiaryTapCancel == null) {
           return false;
         }
-        break;
       default:
         return false;
     }
@@ -628,17 +625,14 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         if (onTapDown != null) {
           invokeCallback<void>('onTapDown', () => onTapDown!(details));
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryTapDown != null) {
           invokeCallback<void>('onSecondaryTapDown', () => onSecondaryTapDown!(details));
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryTapDown != null) {
           invokeCallback<void>('onTertiaryTapDown', () => onTertiaryTapDown!(details));
         }
-        break;
       default:
     }
   }
@@ -659,7 +653,6 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         if (onTap != null) {
           invokeCallback<void>('onTap', onTap!);
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryTapUp != null) {
           invokeCallback<void>('onSecondaryTapUp', () => onSecondaryTapUp!(details));
@@ -667,12 +660,10 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         if (onSecondaryTap != null) {
           invokeCallback<void>('onSecondaryTap', () => onSecondaryTap!());
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryTapUp != null) {
           invokeCallback<void>('onTertiaryTapUp', () => onTertiaryTapUp!(details));
         }
-        break;
       default:
     }
   }
@@ -686,17 +677,14 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
         if (onTapCancel != null) {
           invokeCallback<void>('${note}onTapCancel', onTapCancel!);
         }
-        break;
       case kSecondaryButton:
         if (onSecondaryTapCancel != null) {
           invokeCallback<void>('${note}onSecondaryTapCancel', onSecondaryTapCancel!);
         }
-        break;
       case kTertiaryButton:
         if (onTertiaryTapCancel != null) {
           invokeCallback<void>('${note}onTertiaryTapCancel', onTertiaryTapCancel!);
         }
-        break;
       default:
     }
   }

--- a/packages/flutter/lib/src/material/action_buttons.dart
+++ b/packages/flutter/lib/src/material/action_buttons.dart
@@ -105,14 +105,12 @@ class _ActionIcon extends StatelessWidget {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         semanticsLabel = getAndroidSemanticsLabel(MaterialLocalizations.of(context));
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         semanticsLabel = null;
-        break;
     }
 
     return Icon(data, semanticLabel: semanticsLabel);

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -766,10 +766,8 @@ class _AppBarState extends State<AppBar> {
         case AxisDirection.up:
           // Scroll view is reversed
           _scrolledUnder = metrics.extentAfter > 0;
-          break;
         case AxisDirection.down:
           _scrolledUnder = metrics.extentBefore > 0;
-          break;
         case AxisDirection.right:
         case AxisDirection.left:
           // Scrolled under is only supported in the vertical axis, and should
@@ -955,7 +953,6 @@ class _AppBarState extends State<AppBar> {
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           namesRoute = true;
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           break;
@@ -2121,10 +2118,8 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
     switch (variant) {
       case _ScrollUnderFlexibleVariant.medium:
         config = _MediumScrollUnderFlexibleConfig(context);
-        break;
       case _ScrollUnderFlexibleVariant.large:
         config = _LargeScrollUnderFlexibleConfig(context);
-        break;
     }
 
     late final Widget? collapsedTitle;

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -516,10 +516,8 @@ class _BottomNavigationTile extends StatelessWidget {
     switch (type) {
       case BottomNavigationBarType.fixed:
         size = 1;
-        break;
       case BottomNavigationBarType.shifting:
         size = (flex! * 1000.0).round();
-        break;
     }
 
     Widget result = InkResponse(
@@ -862,7 +860,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
                   _backgroundColor = circle.color;
                   circle.dispose();
                 });
-                break;
               case AnimationStatus.dismissed:
               case AnimationStatus.forward:
               case AnimationStatus.reverse:
@@ -890,7 +887,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           break;
         case BottomNavigationBarType.shifting:
           _pushCircle(widget.currentIndex);
-          break;
       }
       _controllers[oldWidget.currentIndex].reverse();
       _controllers[widget.currentIndex].forward();
@@ -928,10 +924,8 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     switch (themeData.brightness) {
       case Brightness.light:
         themeColor = themeData.colorScheme.primary;
-        break;
       case Brightness.dark:
         themeColor = themeData.colorScheme.secondary;
-        break;
     }
 
     final TextStyle effectiveSelectedLabelStyle =
@@ -979,7 +973,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ?? widget.fixedColor
             ?? themeColor,
         );
-        break;
       case BottomNavigationBarType.shifting:
         colorTween = ColorTween(
           begin: widget.unselectedItemColor
@@ -989,7 +982,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ?? bottomTheme.selectedItemColor
             ?? themeData.colorScheme.surface,
         );
-        break;
     }
 
     final ColorTween labelColorTween;
@@ -1006,7 +998,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ?? widget.fixedColor
             ?? themeColor,
         );
-        break;
       case BottomNavigationBarType.shifting:
         labelColorTween = ColorTween(
           begin: effectiveUnselectedLabelStyle.color
@@ -1018,7 +1009,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ?? bottomTheme.selectedItemColor
             ?? themeColor,
         );
-        break;
     }
 
     final ColorTween iconColorTween;
@@ -1035,7 +1025,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ?? widget.fixedColor
             ?? themeColor,
         );
-        break;
       case BottomNavigationBarType.shifting:
         iconColorTween = ColorTween(
           begin: effectiveUnselectedIconTheme.color
@@ -1047,7 +1036,6 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
             ?? bottomTheme.selectedItemColor
             ?? themeColor,
         );
-        break;
     }
 
     final List<Widget> tiles = <Widget>[];
@@ -1104,10 +1092,8 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     switch (_effectiveType) {
       case BottomNavigationBarType.fixed:
         backgroundColor = widget.backgroundColor ?? bottomTheme.backgroundColor;
-        break;
       case BottomNavigationBarType.shifting:
         backgroundColor = _backgroundColor;
-        break;
     }
 
     return Semantics(
@@ -1277,10 +1263,8 @@ class _RadialPainter extends CustomPainter {
       switch (textDirection) {
         case TextDirection.rtl:
           leftFraction = 1.0 - circle.horizontalLeadingOffset;
-          break;
         case TextDirection.ltr:
           leftFraction = circle.horizontalLeadingOffset;
-          break;
       }
       final Offset center = Offset(leftFraction * size.width, size.height / 2.0);
       final Tween<double> radiusTween = Tween<double>(

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -415,10 +415,8 @@ class _RawMaterialButtonState extends State<RawMaterialButton> with MaterialStat
         );
         assert(minSize.width >= 0.0);
         assert(minSize.height >= 0.0);
-        break;
       case MaterialTapTargetSize.shrinkWrap:
         minSize = Size.zero;
-        break;
     }
 
     return Semantics(

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -357,10 +357,8 @@ class _RenderButtonBarRow extends RenderFlex {
       switch (verticalDirection) {
         case VerticalDirection.down:
           child = firstChild;
-          break;
         case VerticalDirection.up:
           child = lastChild;
-          break;
       }
 
       while (child != null) {
@@ -380,44 +378,34 @@ class _RenderButtonBarRow extends RenderFlex {
               case MainAxisAlignment.center:
                 final double midpoint = (constraints.maxWidth - child.size.width) / 2.0;
                 childParentData.offset = Offset(midpoint, currentHeight);
-                break;
               case MainAxisAlignment.end:
                 childParentData.offset = Offset(constraints.maxWidth - child.size.width, currentHeight);
-                break;
               case MainAxisAlignment.spaceAround:
               case MainAxisAlignment.spaceBetween:
               case MainAxisAlignment.spaceEvenly:
               case MainAxisAlignment.start:
                 childParentData.offset = Offset(0, currentHeight);
-                break;
             }
-            break;
           case TextDirection.rtl:
             switch (mainAxisAlignment) {
               case MainAxisAlignment.center:
                 final double midpoint = constraints.maxWidth / 2.0 - child.size.width / 2.0;
                 childParentData.offset = Offset(midpoint, currentHeight);
-                break;
               case MainAxisAlignment.end:
                 childParentData.offset = Offset(0, currentHeight);
-                break;
               case MainAxisAlignment.spaceAround:
               case MainAxisAlignment.spaceBetween:
               case MainAxisAlignment.spaceEvenly:
               case MainAxisAlignment.start:
                 childParentData.offset = Offset(constraints.maxWidth - child.size.width, currentHeight);
-                break;
             }
-            break;
         }
         currentHeight += child.size.height;
         switch (verticalDirection) {
           case VerticalDirection.down:
             child = childParentData.nextSibling;
-            break;
           case VerticalDirection.up:
             child = childParentData.previousSibling;
-            break;
         }
 
         if (overflowButtonSpacing != null && child != null) {

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -419,10 +419,8 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
         );
         assert(minSize.width >= 0.0);
         assert(minSize.height >= 0.0);
-        break;
       case MaterialTapTargetSize.shrinkWrap:
         minSize = Size.zero;
-        break;
     }
 
     return Semantics(

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -201,7 +201,6 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         HapticFeedback.vibrate();
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         break;

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -425,10 +425,8 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
     switch (effectiveMaterialTapTargetSize) {
       case MaterialTapTargetSize.padded:
         size = const Size(kMinInteractiveDimension, kMinInteractiveDimension);
-        break;
       case MaterialTapTargetSize.shrinkWrap:
         size = const Size(kMinInteractiveDimension - 8.0, kMinInteractiveDimension - 8.0);
-        break;
     }
     size += effectiveVisualDensity.baseSizeAdjustment;
 

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -411,13 +411,10 @@ class CheckboxListTile extends StatelessWidget {
     switch (value) {
       case false:
         onChanged!(true);
-        break;
       case true:
         onChanged!(tristate ? null : false);
-        break;
       case null:
         onChanged!(false);
-        break;
     }
   }
 
@@ -445,12 +442,10 @@ class CheckboxListTile extends StatelessWidget {
       case ListTileControlAffinity.leading:
         leading = control;
         trailing = secondary;
-        break;
       case ListTileControlAffinity.trailing:
       case ListTileControlAffinity.platform:
         leading = secondary;
         trailing = control;
-        break;
     }
     final ThemeData theme = Theme.of(context);
     final CheckboxThemeData checkboxTheme = CheckboxTheme.of(context);

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1295,10 +1295,8 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
           minWidth: kMinInteractiveDimension + densityAdjustment.dx,
           minHeight: kMinInteractiveDimension + densityAdjustment.dy,
         );
-        break;
       case MaterialTapTargetSize.shrinkWrap:
         constraints = const BoxConstraints();
-        break;
     }
     result = _ChipRedirectingHitDetectionWidget(
       constraints: constraints,
@@ -1842,7 +1840,6 @@ class _RenderChip extends RenderBox with SlottedContainerRenderObjectMixin<_Chip
         } else {
           _pressRect = Rect.zero;
         }
-        break;
       case TextDirection.ltr:
         double start = left;
         if (theme.showCheckmark || theme.showAvatar) {
@@ -1875,7 +1872,6 @@ class _RenderChip extends RenderBox with SlottedContainerRenderObjectMixin<_Chip
         } else {
           _deleteButtonRect = Rect.zero;
         }
-        break;
     }
     // Center the label vertically.
     labelOffset = labelOffset +
@@ -1919,13 +1915,11 @@ class _RenderChip extends RenderBox with SlottedContainerRenderObjectMixin<_Chip
           begin: Colors.white.withAlpha(_kDisabledAlpha),
           end: Colors.white,
         );
-        break;
       case Brightness.dark:
         enableTween = ColorTween(
           begin: Colors.black.withAlpha(_kDisabledAlpha),
           end: Colors.black,
         );
-        break;
     }
     return enableTween.evaluate(enableAnimation)!;
   }
@@ -1938,10 +1932,8 @@ class _RenderChip extends RenderBox with SlottedContainerRenderObjectMixin<_Chip
       switch (theme.brightness) {
         case Brightness.light:
           paintColor = theme.showAvatar ? Colors.white : Colors.black.withAlpha(_kCheckmarkAlpha);
-          break;
         case Brightness.dark:
           paintColor = theme.showAvatar ? Colors.black : Colors.white.withAlpha(_kCheckmarkAlpha);
-          break;
       }
     }
 

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -207,19 +207,15 @@ class CircleAvatar extends StatelessWidget {
       switch (ThemeData.estimateBrightnessForColor(textStyle.color!)) {
         case Brightness.dark:
           effectiveBackgroundColor = theme.primaryColorLight;
-          break;
         case Brightness.light:
           effectiveBackgroundColor = theme.primaryColorDark;
-          break;
       }
     } else if (effectiveForegroundColor == null) {
       switch (ThemeData.estimateBrightnessForColor(backgroundColor!)) {
         case Brightness.dark:
           textStyle = textStyle.copyWith(color: theme.primaryColorLight);
-          break;
         case Brightness.light:
           textStyle = textStyle.copyWith(color: theme.primaryColorDark);
-          break;
       }
     }
     final double minDiameter = _minDiameter;

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -205,10 +205,8 @@ class ColorScheme with Diagnosticable {
     switch (brightness) {
       case Brightness.light:
         scheme = Scheme.light(seedColor.value);
-        break;
       case Brightness.dark:
         scheme = Scheme.dark(seedColor.value);
-        break;
     }
     return ColorScheme(
       primary: primary ?? Color(scheme.primary),
@@ -1067,10 +1065,8 @@ class ColorScheme with Diagnosticable {
     switch (brightness) {
       case Brightness.light:
         scheme = Scheme.light(baseColor.value);
-        break;
       case Brightness.dark:
         scheme = Scheme.dark(baseColor.value);
-        break;
     }
 
     return ColorScheme(primary: primary ?? Color(scheme.primary),

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -421,16 +421,13 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
           _autovalidateMode.value = AutovalidateMode.disabled;
           _entryMode.value = DatePickerEntryMode.input;
           _handleOnDatePickerModeChange();
-          break;
         case DatePickerEntryMode.input:
           _formKey.currentState!.save();
           _entryMode.value = DatePickerEntryMode.calendar;
            _handleOnDatePickerModeChange();
-          break;
         case DatePickerEntryMode.calendarOnly:
         case DatePickerEntryMode.inputOnly:
           assert(false, 'Can not change entry mode from _entryMode');
-          break;
       }
     });
   }
@@ -577,12 +574,10 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
           tooltip: localizations.inputDateModeButtonLabel,
           onPressed: _handleEntryModeToggle,
         );
-        break;
 
       case DatePickerEntryMode.calendarOnly:
         picker = calendarDatePicker();
         entryModeButton = null;
-        break;
 
       case DatePickerEntryMode.input:
         picker = inputDatePicker();
@@ -592,12 +587,10 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
           tooltip: localizations.calendarModeButtonLabel,
           onPressed: _handleEntryModeToggle,
         );
-        break;
 
       case DatePickerEntryMode.inputOnly:
         picker = inputDatePicker();
         entryModeButton = null;
-        break;
     }
 
     final Widget header = _DatePickerHeader(
@@ -1303,7 +1296,6 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
         case DatePickerEntryMode.calendar:
           _autoValidate.value = false;
           _entryMode.value = DatePickerEntryMode.input;
-          break;
 
         case DatePickerEntryMode.input:
         // Validate the range dates
@@ -1322,12 +1314,10 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
             _selectedEnd.value = null;
           }
           _entryMode.value = DatePickerEntryMode.calendar;
-          break;
 
         case DatePickerEntryMode.calendarOnly:
         case DatePickerEntryMode.inputOnly:
           assert(false, 'Can not change entry mode from $_entryMode');
-          break;
       }
     });
   }
@@ -1401,7 +1391,6 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
         shadowColor = datePickerTheme.rangePickerShadowColor ?? defaults.rangePickerShadowColor!;
         surfaceTintColor = datePickerTheme.rangePickerSurfaceTintColor ?? defaults.rangePickerSurfaceTintColor!;
         shape = datePickerTheme.rangePickerShape ?? defaults.rangePickerShape;
-        break;
 
       case DatePickerEntryMode.input:
       case DatePickerEntryMode.inputOnly:
@@ -1477,7 +1466,6 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
           : datePickerTheme.shape ?? dialogTheme.shape ?? defaults.shape;
 
         insetPadding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0);
-        break;
     }
 
     return Dialog(
@@ -1766,7 +1754,6 @@ class _CalendarDateRangePickerState extends State<_CalendarDateRangePicker> {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         HapticFeedback.vibrate();
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
@@ -2289,11 +2276,9 @@ class _MonthItemState extends State<_MonthItem> {
           case TraversalDirection.up:
           case TraversalDirection.left:
             policy = ScrollPositionAlignmentPolicy.keepVisibleAtStart;
-            break;
           case TraversalDirection.right:
           case TraversalDirection.down:
             policy = ScrollPositionAlignmentPolicy.keepVisibleAtEnd;
-            break;
         }
         Scrollable.ensureVisible(primaryFocus!.context!,
           duration: _monthScrollDuration,
@@ -2609,19 +2594,16 @@ class _HighlightPainter extends CustomPainter {
           textDirection == TextDirection.ltr ? rectRight : rectLeft,
           paint,
         );
-        break;
       case _HighlightPainterStyle.highlightLeading:
         canvas.drawRect(
           textDirection == TextDirection.ltr ? rectLeft : rectRight,
           paint,
         );
-        break;
       case _HighlightPainterStyle.highlightAll:
         canvas.drawRect(
           Rect.fromLTWH(0, 0, size.width, size.height),
           paint,
         );
-        break;
       case _HighlightPainterStyle.none:
         break;
     }

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -495,7 +495,6 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         case AnimationStatus.completed:
         case AnimationStatus.dismissed:
           _controller.value = widget.isDrawerOpen ? 1.0 : 0.0;
-          break;
         case AnimationStatus.forward:
         case AnimationStatus.reverse:
           break;
@@ -527,11 +526,9 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     switch (status) {
       case AnimationStatus.forward:
         _ensureHistoryEntry();
-        break;
       case AnimationStatus.reverse:
         _historyEntry?.remove();
         _historyEntry = null;
-        break;
       case AnimationStatus.dismissed:
         break;
       case AnimationStatus.completed:
@@ -581,15 +578,12 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         break;
       case DrawerAlignment.end:
         delta = -delta;
-        break;
     }
     switch (Directionality.of(context)) {
       case TextDirection.rtl:
         _controller.value -= delta;
-        break;
       case TextDirection.ltr:
         _controller.value += delta;
-        break;
     }
 
     final bool opened = _controller.value > 0.5;
@@ -610,17 +604,14 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
           break;
         case DrawerAlignment.end:
           visualVelocity = -visualVelocity;
-          break;
       }
       switch (Directionality.of(context)) {
         case TextDirection.rtl:
           _controller.fling(velocity: -visualVelocity);
           widget.drawerCallback?.call(visualVelocity < 0.0);
-          break;
         case TextDirection.ltr:
           _controller.fling(velocity: visualVelocity);
           widget.drawerCallback?.call(visualVelocity > 0.0);
-          break;
       }
     } else if (_controller.value < 0.5) {
       close();
@@ -682,12 +673,10 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         isDesktop = false;
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         isDesktop = true;
-        break;
     }
 
     double? dragAreaWidth = widget.edgeDragWidth;
@@ -697,11 +686,9 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         case TextDirection.ltr:
           dragAreaWidth = _kEdgeDragWidth +
             (drawerIsStart ? padding.left : padding.right);
-          break;
         case TextDirection.rtl:
           dragAreaWidth = _kEdgeDragWidth +
             (drawerIsStart ? padding.right : padding.left);
-          break;
       }
     }
 
@@ -727,14 +714,12 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
       switch (Theme.of(context).platform) {
         case TargetPlatform.android:
           platformHasBackButton = true;
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           platformHasBackButton = false;
-          break;
       }
 
       final Widget child = _DrawerControllerScope(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -120,10 +120,8 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     switch (FocusManager.instance.highlightMode) {
       case FocusHighlightMode.touch:
         inTraditionalMode = false;
-        break;
       case FocusHighlightMode.traditional:
         inTraditionalMode = true;
-        break;
     }
 
     if (focused && inTraditionalMode) {
@@ -377,10 +375,8 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     switch (textDirection!) {
       case TextDirection.rtl:
         left = clampDouble(buttonRect.right, 0.0, size.width) - childSize.width;
-        break;
       case TextDirection.ltr:
         left = clampDouble(buttonRect.left, 0.0, size.width - childSize.width);
-        break;
     }
 
     return Offset(left, menuLimits.top);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -366,12 +366,10 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         defaultStyle = MenuItemButton.styleFrom(
           padding: EdgeInsets.only(left: _kDefaultHorizontalPadding, right: padding),
         );
-        break;
       case TextDirection.ltr:
         defaultStyle = MenuItemButton.styleFrom(
           padding: EdgeInsets.only(left: padding, right: _kDefaultHorizontalPadding),
         );
-        break;
     }
 
     for (int i = 0; i < filteredEntries.length; i++) {

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -286,7 +286,6 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
             case TargetPlatform.iOS:
             case TargetPlatform.macOS:
               title = widget.title;
-              break;
             case TargetPlatform.android:
             case TargetPlatform.fuchsia:
             case TargetPlatform.linux:
@@ -295,7 +294,6 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
                 namesRoute: true,
                 child: widget.title,
               );
-              break;
           }
 
           // StretchMode.fadeTitle

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -559,13 +559,10 @@ class FloatingActionButton extends StatelessWidget {
     switch(_floatingActionButtonType) {
       case _FloatingActionButtonType.regular:
         sizeConstraints = floatingActionButtonTheme.sizeConstraints ?? defaults.sizeConstraints!;
-        break;
       case _FloatingActionButtonType.small:
         sizeConstraints = floatingActionButtonTheme.smallSizeConstraints ?? defaults.smallSizeConstraints!;
-        break;
       case _FloatingActionButtonType.large:
         sizeConstraints = floatingActionButtonTheme.largeSizeConstraints ?? defaults.largeSizeConstraints!;
-        break;
       case _FloatingActionButtonType.extended:
         sizeConstraints = floatingActionButtonTheme.extendedSizeConstraints ?? defaults.extendedSizeConstraints!;
         final double iconLabelSpacing = extendedIconLabelSpacing ?? floatingActionButtonTheme.extendedIconLabelSpacing ?? 8.0;
@@ -588,7 +585,6 @@ class FloatingActionButton extends StatelessWidget {
             ),
           ),
         );
-        break;
     }
 
     Widget result = RawMaterialButton(

--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -112,7 +112,6 @@ class InkHighlight extends InteractiveInkFeature {
     switch (_shape) {
       case BoxShape.circle:
         canvas.drawCircle(rect.center, _radius ?? Material.defaultSplashRadius, paint);
-        break;
       case BoxShape.rectangle:
         if (_borderRadius != BorderRadius.zero) {
           final RRect clipRRect = RRect.fromRectAndCorners(
@@ -124,7 +123,6 @@ class InkHighlight extends InteractiveInkFeature {
         } else {
           canvas.drawRect(rect, paint);
         }
-        break;
     }
     canvas.restore();
   }

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -920,12 +920,10 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     switch (type) {
       case _HighlightType.pressed:
         statesController.update(MaterialState.pressed, value);
-        break;
       case _HighlightType.hover:
         if (callOnHover) {
           statesController.update(MaterialState.hovered, value);
         }
-        break;
       case _HighlightType.focus:
         // see handleFocusUpdate()
         break;
@@ -947,13 +945,10 @@ class _InkResponseState extends State<_InkResponseStateWidget>
           switch (type) {
             case _HighlightType.pressed:
               resolvedOverlayColor = widget.highlightColor ?? theme.highlightColor;
-              break;
             case _HighlightType.focus:
               resolvedOverlayColor = widget.focusColor ?? theme.focusColor;
-              break;
             case _HighlightType.hover:
               resolvedOverlayColor = widget.hoverColor ?? theme.hoverColor;
-              break;
           }
         }
         final RenderBox referenceBox = context.findRenderObject()! as RenderBox;
@@ -982,12 +977,10 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     switch (type) {
       case _HighlightType.pressed:
         widget.onHighlightChanged?.call(value);
-        break;
       case _HighlightType.hover:
         if (callOnHover) {
           widget.onHover?.call(value);
         }
-        break;
       case _HighlightType.focus:
         break;
     }
@@ -1055,10 +1048,8 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     switch (FocusManager.instance.highlightMode) {
       case FocusHighlightMode.touch:
         showFocus = false;
-        break;
       case FocusHighlightMode.traditional:
         showFocus = _shouldShowFocus;
-        break;
     }
     updateHighlight(_HighlightType.focus, value: showFocus);
   }

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -529,12 +529,10 @@ class OutlineInputBorder extends InputBorder {
         case TextDirection.rtl:
           final Path path = _gapBorderPath(canvas, center, math.max(0.0, gapStart + gapPadding - extent), extent);
           canvas.drawPath(path, paint);
-          break;
 
         case TextDirection.ltr:
           final Path path = _gapBorderPath(canvas, center, math.max(0.0, gapStart - gapPadding), extent);
           canvas.drawPath(path, paint);
-          break;
       }
     }
   }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1364,10 +1364,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       switch (textDirection) {
         case TextDirection.rtl:
           x = 0.0;
-          break;
         case TextDirection.ltr:
           x = _boxSize(icon).width;
-          break;
        }
       _boxParentData(container).offset = Offset(x, 0.0);
     }
@@ -1395,10 +1393,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       switch (textDirection) {
         case TextDirection.rtl:
           x = overallWidth - icon!.size.width;
-          break;
         case TextDirection.ltr:
           x = 0.0;
-          break;
        }
       centerLayout(icon!, x);
     }
@@ -1482,7 +1478,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           if (counter != null) {
             baselineLayout(counter!, left);
           }
-          break;
         case TextDirection.ltr:
           if (helperError != null) {
             baselineLayout(helperError!, left + _boxSize(icon).width);
@@ -1490,7 +1485,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           if (counter != null) {
             baselineLayout(counter!, right - counter!.size.width);
           }
-          break;
       }
     }
 
@@ -1511,7 +1505,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
             _boxSize(container).width / 2.0 + floatWidth / 2.0,
             floatAlign);
 
-          break;
         case TextDirection.ltr:
           // The value of _InputBorderGap.start is relative to the origin of the
           // _BorderContainer which is inset by the icon's width. Although, when
@@ -1523,7 +1516,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           decoration.borderGap.start = lerpDouble(labelX - _boxSize(icon).width + offsetToPrefixIcon,
             _boxSize(container).width / 2.0 - floatWidth / 2.0,
             floatAlign);
-          break;
       }
       decoration.borderGap.extent = label!.size.width * _kFinalLabelScale;
     } else {
@@ -1576,14 +1568,12 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           if (prefixIcon != null && !decoration.alignLabelWithHint && isOutlineBorder) {
             floatStartX += material3 ? _boxSize(prefixIcon).width - contentPadding.left : 0.0;
           }
-          break;
         case TextDirection.ltr: // origin on the left
           startX = labelOffset.dx;
           floatStartX = startX;
           if (prefixIcon != null && !decoration.alignLabelWithHint && isOutlineBorder) {
             floatStartX += material3 ? -_boxSize(prefixIcon).width + contentPadding.left : 0.0;
           }
-          break;
       }
       final double floatEndX = lerpDouble(floatStartX, centeredFloatX, floatAlign)!;
       final double dx = lerpDouble(startX, floatEndX, t)!;

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -440,10 +440,8 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
       switch (widget.type) {
         case MaterialType.canvas:
           color = theme.canvasColor;
-          break;
         case MaterialType.card:
           color = theme.cardColor;
-          break;
         case MaterialType.button:
         case MaterialType.circle:
         case MaterialType.transparency:

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1262,13 +1262,10 @@ class CheckboxMenuButton extends StatelessWidget {
         switch (value) {
           case false:
             onChanged!.call(true);
-            break;
           case true:
             onChanged!.call(tristate ? null : false);
-            break;
           case null:
             onChanged!.call(false);
-            break;
         }
       },
       onHover: onHover,
@@ -1805,15 +1802,11 @@ class _SubmenuButtonState extends State<SubmenuButton> {
         switch (Directionality.of(context)) {
           case TextDirection.rtl:
             menuPaddingOffset += Offset(menuPadding.right, 0);
-            break;
           case TextDirection.ltr:
             menuPaddingOffset += Offset(-menuPadding.left, 0);
-            break;
         }
-        break;
       case Axis.vertical:
         menuPaddingOffset += Offset(0, -menuPadding.top);
-        break;
     }
 
     return MenuAnchor(
@@ -2021,14 +2014,12 @@ class _LocalizedShortcutLabeler {
       case TargetPlatform.macOS:
         // Use "⌃ ⇧ A" style on macOS and iOS.
         keySeparator = ' ';
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         // Use "Ctrl+Shift+A" style.
         keySeparator = '+';
-        break;
     }
     if (serialized.trigger != null) {
       final List<String> modifiers = <String>[];
@@ -2316,7 +2307,6 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
             if (_moveToParent(anchor)) {
               return;
             }
-            break;
           case Axis.vertical:
             if (firstItemIsFocused) {
               if (_moveToParent(anchor)) {
@@ -2326,23 +2316,18 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
             if (_moveToPrevious(anchor)) {
               return;
             }
-            break;
         }
-        break;
       case TraversalDirection.down:
         switch (orientation) {
           case Axis.horizontal:
             if (_moveToSubmenu(anchor)) {
               return;
             }
-            break;
           case Axis.vertical:
             if (_moveToNext(anchor)) {
               return;
             }
-            break;
         }
-        break;
       case TraversalDirection.left:
         switch (orientation) {
           case Axis.horizontal:
@@ -2351,14 +2336,11 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
                 if (_moveToNext(anchor)) {
                   return;
                 }
-                break;
               case TextDirection.ltr:
                 if (_moveToPrevious(anchor)) {
                   return;
                 }
-                break;
             }
-            break;
           case Axis.vertical:
             switch (Directionality.of(context)) {
               case TextDirection.rtl:
@@ -2371,14 +2353,12 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
                     return;
                   }
                 }
-                break;
               case TextDirection.ltr:
                 switch (anchor._parent!._orientation) {
                   case Axis.horizontal:
                     if (_moveToPreviousTopLevel(anchor)) {
                       return;
                     }
-                    break;
                   case Axis.vertical:
                     if (buttonIsFocused) {
                       if (_moveToPreviousTopLevel(anchor)) {
@@ -2389,13 +2369,9 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
                         return;
                       }
                     }
-                    break;
                 }
-                break;
             }
-            break;
         }
-        break;
       case TraversalDirection.right:
         switch (orientation) {
           case Axis.horizontal:
@@ -2404,14 +2380,11 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
                 if (_moveToPrevious(anchor)) {
                   return;
                 }
-                break;
               case TextDirection.ltr:
                 if (_moveToNext(anchor)) {
                   return;
                 }
-                break;
             }
-            break;
           case Axis.vertical:
             switch (Directionality.of(context)) {
               case TextDirection.rtl:
@@ -2420,14 +2393,11 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
                     if (_moveToPreviousTopLevel(anchor)) {
                       return;
                     }
-                    break;
                   case Axis.vertical:
                     if (_moveToParent(anchor)) {
                       return;
                     }
-                    break;
                 }
-                break;
               case TextDirection.ltr:
                 if (buttonIsFocused) {
                   if (_moveToSubmenu(anchor)) {
@@ -2438,11 +2408,8 @@ class _MenuDirectionalFocusAction extends DirectionalFocusAction {
                     return;
                   }
                 }
-                break;
             }
-            break;
         }
-        break;
     }
     super.invoke(intent);
   }
@@ -3113,10 +3080,8 @@ class _MenuLayout extends SingleChildLayoutDelegate {
         switch (textDirection) {
           case TextDirection.rtl:
             directionalOffset = Offset(-alignmentOffset.dx, alignmentOffset.dy);
-            break;
           case TextDirection.ltr:
             directionalOffset = alignmentOffset;
-            break;
         }
       } else {
         directionalOffset = alignmentOffset;
@@ -3127,7 +3092,6 @@ class _MenuLayout extends SingleChildLayoutDelegate {
       switch (textDirection) {
         case TextDirection.rtl:
           x -= childSize.width;
-          break;
         case TextDirection.ltr:
           break;
       }
@@ -3274,11 +3238,9 @@ class _MenuPanelState extends State<_MenuPanel> {
       case Axis.horizontal:
         themeStyle = MenuBarTheme.of(context).style;
         defaultStyle = _MenuBarDefaultsM3(context);
-        break;
       case Axis.vertical:
         themeStyle = MenuTheme.of(context).style;
         defaultStyle = _MenuDefaultsM3(context);
-        break;
     }
     final MenuStyle? widgetStyle = widget.menuStyle;
 
@@ -3422,11 +3384,9 @@ class _Submenu extends StatelessWidget {
       case Axis.horizontal:
         themeStyle = MenuBarTheme.of(context).style;
         defaultStyle = _MenuBarDefaultsM3(context);
-        break;
       case Axis.vertical:
         themeStyle = MenuTheme.of(context).style;
         defaultStyle = _MenuDefaultsM3(context);
-        break;
     }
     T? effectiveValue<T>(T? Function(MenuStyle? style) getProperty) {
       return getProperty(menuStyle) ?? getProperty(themeStyle) ?? getProperty(defaultStyle);

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -520,13 +520,10 @@ class _IndicatorInkWell extends InkResponse {
     switch (labelBehavior) {
       case NavigationDestinationLabelBehavior.alwaysShow:
         labelPadding = labelRect.height / 2;
-        break;
       case NavigationDestinationLabelBehavior.onlyShowSelected:
         labelPadding = selected ? labelRect.height / 2 : 0;
-        break;
       case NavigationDestinationLabelBehavior.alwaysHide:
         labelPadding = 0;
-        break;
     }
     final double indicatorOffsetX = referenceBox.size.width / 2;
     final double indicatorOffsetY = referenceBox.size.height / 2 - labelPadding;

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -665,7 +665,6 @@ class _RailDestination extends StatelessWidget {
             ),
           );
         }
-        break;
       case NavigationRailLabelType.selected:
         final double appearingAnimationValue = 1 - _positionAnimation.value;
         final double verticalPadding = lerpDouble(_verticalDestinationPaddingNoLabel, _verticalDestinationPaddingWithLabel, appearingAnimationValue)!;
@@ -717,7 +716,6 @@ class _RailDestination extends StatelessWidget {
             ),
           ),
         );
-        break;
       case NavigationRailLabelType.all:
         final double minHeight = material3 ? 0 : minWidth;
         final Widget topSpacing = SizedBox(height: material3 ? 0 : _verticalDestinationPaddingWithLabel);
@@ -752,7 +750,6 @@ class _RailDestination extends StatelessWidget {
             ],
           ),
         );
-        break;
     }
 
     final ColorScheme colors = Theme.of(context).colorScheme;

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -858,11 +858,9 @@ mixin _ZoomTransitionBase {
       case AnimationStatus.dismissed:
       case AnimationStatus.completed:
         controller.allowSnapshotting = false;
-        break;
       case AnimationStatus.forward:
       case AnimationStatus.reverse:
         controller.allowSnapshotting = useSnapshot;
-        break;
     }
   }
 }

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -425,7 +425,6 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
 ///     switch (result) {
 ///       case Commands.heroAndScholar:
 ///         setState(() { _heroAndScholar = !_heroAndScholar; });
-///         break;
 ///       case Commands.hurricaneCame:
 ///         // ...handle hurricane option
 ///         break;

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -719,10 +719,8 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
       switch (textDirection) {
         case TextDirection.rtl:
           x = size.width - position.right - childSize.width;
-          break;
         case TextDirection.ltr:
           x = position.left;
-          break;
       }
     }
     final Offset wantedPosition = Offset(x, y);
@@ -1245,10 +1243,8 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
     switch (popupMenuPosition) {
       case PopupMenuPosition.over:
         offset = widget.offset;
-        break;
       case PopupMenuPosition.under:
         offset = Offset(0.0, button.size.height - (widget.padding.vertical / 2)) + widget.offset;
-        break;
     }
     final RelativeRect position = RelativeRect.fromRect(
       Rect.fromPoints(

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -194,10 +194,8 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
       switch (textDirection) {
         case TextDirection.rtl:
           left = size.width - width - x;
-          break;
         case TextDirection.ltr:
           left = x;
-          break;
       }
       canvas.drawRect(Offset(left, 0.0) & Size(width, size.height), paint);
     }

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -378,10 +378,8 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
     switch (effectiveMaterialTapTargetSize) {
       case MaterialTapTargetSize.padded:
         size = const Size(kMinInteractiveDimension, kMinInteractiveDimension);
-        break;
       case MaterialTapTargetSize.shrinkWrap:
         size = const Size(kMinInteractiveDimension - 8.0, kMinInteractiveDimension - 8.0);
-        break;
     }
     size += effectiveVisualDensity.baseSizeAdjustment;
 

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -414,11 +414,9 @@ class RadioListTile<T> extends StatelessWidget {
       case ListTileControlAffinity.platform:
         leading = control;
         trailing = secondary;
-        break;
       case ListTileControlAffinity.trailing:
         leading = secondary;
         trailing = control;
-        break;
     }
     final ThemeData theme = Theme.of(context);
     final RadioThemeData radioThemeData = RadioTheme.of(context);

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -560,11 +560,9 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
         case TextDirection.ltr:
           towardsStart = dx < 0;
           towardsEnd = dx > 0;
-          break;
         case TextDirection.rtl:
           towardsStart = dx > 0;
           towardsEnd = dx < 0;
-          break;
       }
       if (towardsStart) {
         return Thumb.start;
@@ -1141,11 +1139,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       case Thumb.start:
         text = labels!.start;
         labelPainter = _startLabelPainter;
-        break;
       case Thumb.end:
         text = labels!.end;
         labelPainter = _endLabelPainter;
-        break;
     }
 
     if (labels != null) {
@@ -1402,11 +1398,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       case TextDirection.rtl:
         startVisualPosition = 1.0 - startValue;
         endVisualPosition = 1.0 - endValue;
-        break;
       case TextDirection.ltr:
         startVisualPosition = startValue;
         endVisualPosition = endValue;
-        break;
     }
 
     final Rect trackRect = _sliderTheme.rangeTrackShape!.getPreferredRect(
@@ -1589,11 +1583,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
         case TextDirection.ltr:
           innerOverflow += startOffset;
           innerOverflow -= endOffset;
-          break;
         case TextDirection.rtl:
           innerOverflow -= startOffset;
           innerOverflow += endOffset;
-          break;
       }
 
       _state.paintTopValueIndicator = (PaintingContext context, Offset offset) {
@@ -1706,11 +1698,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       case TextDirection.ltr:
         _startSemanticsNode!.rect = leftRect;
         _endSemanticsNode!.rect = rightRect;
-        break;
       case TextDirection.rtl:
         _startSemanticsNode!.rect = rightRect;
         _endSemanticsNode!.rect = leftRect;
-        break;
     }
 
     _startSemanticsNode!.updateWith(config: startSemanticsConfiguration);

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -355,11 +355,9 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       case AxisDirection.down:
       case AxisDirection.up:
         indicatorAtTopNow = true;
-        break;
       case AxisDirection.left:
       case AxisDirection.right:
         indicatorAtTopNow = null;
-        break;
     }
     if (indicatorAtTopNow != _isIndicatorAtTop) {
       if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
@@ -398,10 +396,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       switch (_mode) {
         case _RefreshIndicatorMode.armed:
           _show();
-          break;
         case _RefreshIndicatorMode.drag:
           _dismiss(_RefreshIndicatorMode.canceled);
-          break;
         case _RefreshIndicatorMode.canceled:
         case _RefreshIndicatorMode.done:
         case _RefreshIndicatorMode.refresh:
@@ -433,7 +429,6 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       case AxisDirection.down:
       case AxisDirection.up:
         _isIndicatorAtTop = true;
-        break;
       case AxisDirection.left:
       case AxisDirection.right:
         _isIndicatorAtTop = null;
@@ -471,10 +466,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     switch (_mode!) {
       case _RefreshIndicatorMode.done:
         await _scaleController.animateTo(1.0, duration: _kIndicatorScaleDuration);
-        break;
       case _RefreshIndicatorMode.canceled:
         await _positionController.animateTo(0.0, duration: _kIndicatorScaleDuration);
-        break;
       case _RefreshIndicatorMode.armed:
       case _RefreshIndicatorMode.drag:
       case _RefreshIndicatorMode.refresh:

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -448,7 +448,6 @@ class _ReorderableListViewState extends State<ReorderableListView> {
             listPadding = EdgeInsets.fromLTRB(widget.header != null ? 0 : padding.left, padding.top, widget.footer != null ? 0 : padding.right, padding.bottom);
             footerPadding = EdgeInsets.fromLTRB(0, padding.top, padding.right, padding.bottom);
           }
-          break;
         case Axis.vertical:
           if (widget.reverse) {
             headerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, padding.bottom);
@@ -459,7 +458,6 @@ class _ReorderableListViewState extends State<ReorderableListView> {
             listPadding = EdgeInsets.fromLTRB(padding.left, widget.header != null ? 0 : padding.top, padding.right, widget.footer != null ? 0 : padding.bottom);
             footerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, padding.bottom);
           }
-         break;
       }
     }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -360,14 +360,12 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
         if (_snackBars.isNotEmpty) {
           _snackBarController!.forward();
         }
-        break;
       case AnimationStatus.completed:
         setState(() {
           assert(_snackBarTimer == null);
           // build will create a new timer if necessary to dismiss the snackBar.
         });
         _updateScaffolds();
-        break;
       case AnimationStatus.forward:
         break;
       case AnimationStatus.reverse:
@@ -497,10 +495,8 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
         if (_materialBanners.isNotEmpty) {
           _materialBannerController!.forward();
         }
-        break;
       case AnimationStatus.completed:
         _updateScaffolds();
-        break;
       case AnimationStatus.forward:
         break;
       case AnimationStatus.reverse:
@@ -2927,7 +2923,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
           removeRightPadding: false,
           removeBottomPadding: true,
         );
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -312,14 +312,12 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
         idleColor = _useAndroidScrollbar
           ? Theme.of(context).highlightColor.withOpacity(1.0)
           : onSurface.withOpacity(0.1);
-        break;
       case Brightness.dark:
         dragColor = onSurface.withOpacity(0.75);
         hoverColor = onSurface.withOpacity(0.65);
         idleColor = _useAndroidScrollbar
           ? Theme.of(context).highlightColor.withOpacity(1.0)
           : onSurface.withOpacity(0.3);
-        break;
     }
 
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
@@ -403,14 +401,12 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
     switch (theme.platform) {
       case TargetPlatform.android:
         _useAndroidScrollbar = true;
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.linux:
       case TargetPlatform.fuchsia:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         _useAndroidScrollbar = false;
-        break;
     }
     super.didChangeDependencies();
   }

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -544,13 +544,11 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
           key: const ValueKey<_SearchBody>(_SearchBody.suggestions),
           child: widget.delegate.buildSuggestions(context),
         );
-        break;
       case _SearchBody.results:
         body = KeyedSubtree(
           key: const ValueKey<_SearchBody>(_SearchBody.results),
           child: widget.delegate.buildResults(context),
         );
-        break;
       case null:
         break;
     }
@@ -560,7 +558,6 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         routeName = '';
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -595,14 +595,12 @@ class _RenderSegmentedButton<T> extends RenderBox with
           lastChild,
           firstChild,
         );
-        break;
       case TextDirection.ltr:
         _layoutRects(
           childAfter,
           firstChild,
           lastChild,
         );
-        break;
     }
 
     size = _computeOverallSizeFromChildSize(childSize);
@@ -638,12 +636,10 @@ class _RenderSegmentedButton<T> extends RenderBox with
           segmentLeft = child == lastChild ? borderRect.left - borderOutset : childRect.left;
           segmentRight = child == firstChild ? borderRect.right + borderOutset : childRect.right;
           dividerPos = segmentRight;
-          break;
         case TextDirection.ltr:
           segmentLeft = child == firstChild ? borderRect.left - borderOutset : childRect.left;
           segmentRight = child == lastChild ? borderRect.right + borderOutset : childRect.right;
           dividerPos = segmentLeft;
-          break;
       }
       final Rect segmentClipRect = Rect.fromLTRB(
         segmentLeft, borderRect.top - borderOutset,

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -91,13 +91,11 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-          break;
       }
     }
     _state.widget.onTap?.call();
@@ -637,7 +635,6 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         selectionColor = selectionStyle.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
-        break;
 
       case TargetPlatform.macOS:
         final CupertinoThemeData cupertinoTheme = CupertinoTheme.of(context);
@@ -649,7 +646,6 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         selectionColor = selectionStyle.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -659,7 +655,6 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         cursorOpacityAnimates = false;
         cursorColor = widget.cursorColor ?? selectionStyle.cursorColor ?? theme.colorScheme.primary;
         selectionColor = selectionStyle.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
-        break;
 
       case TargetPlatform.linux:
       case TargetPlatform.windows:
@@ -669,7 +664,6 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         cursorOpacityAnimates = false;
         cursorColor = widget.cursorColor ?? selectionStyle.cursorColor ?? theme.colorScheme.primary;
         selectionColor = selectionStyle.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
-        break;
     }
 
     final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);

--- a/packages/flutter/lib/src/material/selection_area.dart
+++ b/packages/flutter/lib/src/material/selection_area.dart
@@ -126,17 +126,13 @@ class _SelectionAreaState extends State<SelectionArea> {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         controls ??= materialTextSelectionHandleControls;
-        break;
       case TargetPlatform.iOS:
         controls ??= cupertinoTextSelectionHandleControls;
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         controls ??= desktopTextSelectionHandleControls;
-        break;
       case TargetPlatform.macOS:
         controls ??= cupertinoDesktopTextSelectionHandleControls;
-        break;
     }
 
     return SelectableRegion(

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -648,28 +648,20 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         switch (textDirection) {
           case TextDirection.rtl:
             renderSlider.decreaseAction();
-            break;
           case TextDirection.ltr:
             renderSlider.increaseAction();
-            break;
         }
-        break;
       case _SliderAdjustmentType.left:
         switch (textDirection) {
           case TextDirection.rtl:
             renderSlider.increaseAction();
-            break;
           case TextDirection.ltr:
             renderSlider.decreaseAction();
-            break;
         }
-        break;
       case _SliderAdjustmentType.up:
         renderSlider.increaseAction();
-        break;
       case _SliderAdjustmentType.down:
         renderSlider.decreaseAction();
-        break;
     }
   }
 
@@ -836,17 +828,14 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
             focusNode.requestFocus();
           }
         };
-        break;
     }
 
     final Map<ShortcutActivator, Intent> shortcutMap;
     switch (MediaQuery.navigationModeOf(context)) {
       case NavigationMode.directional:
         shortcutMap = _directionalNavShortcutMap;
-        break;
       case NavigationMode.traditional:
         shortcutMap = _traditionalNavShortcutMap;
-        break;
     }
 
     final double textScaleFactor = theme.useMaterial3
@@ -1489,10 +1478,8 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       switch (textDirection) {
         case TextDirection.rtl:
           _currentDragValue -= valueDelta;
-          break;
         case TextDirection.ltr:
           _currentDragValue += valueDelta;
-          break;
       }
       onChanged!(_discretize(_currentDragValue));
     }
@@ -1566,11 +1553,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       case TextDirection.rtl:
         visualPosition = 1.0 - value;
         secondaryVisualPosition = (secondaryValue != null) ? (1.0 - secondaryValue) : null;
-        break;
       case TextDirection.ltr:
         visualPosition = value;
         secondaryVisualPosition = (secondaryValue != null) ? secondaryValue : null;
-        break;
     }
 
     final Rect trackRect = _sliderTheme.trackShape!.getPreferredRect(

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1585,11 +1585,9 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
       case TextDirection.ltr:
         leftTrackPaint = activePaint;
         rightTrackPaint = inactivePaint;
-        break;
       case TextDirection.rtl:
         leftTrackPaint = inactivePaint;
         rightTrackPaint = activePaint;
-        break;
     }
 
     final Rect trackRect = getPreferredRect(
@@ -1698,11 +1696,9 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
       case TextDirection.ltr:
         leftTrackPaint = activePaint;
         rightTrackPaint = inactivePaint;
-        break;
       case TextDirection.rtl:
         leftTrackPaint = inactivePaint;
         rightTrackPaint = activePaint;
-        break;
     }
 
     final Rect trackRect = getPreferredRect(
@@ -1863,11 +1859,9 @@ class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
       case TextDirection.ltr:
         leftThumbOffset = startThumbCenter;
         rightThumbOffset = endThumbCenter;
-        break;
       case TextDirection.rtl:
         leftThumbOffset = endThumbCenter;
         rightThumbOffset = startThumbCenter;
-        break;
     }
 
     final Rect trackRect = getPreferredRect(
@@ -1994,11 +1988,9 @@ class RoundedRectRangeSliderTrackShape extends RangeSliderTrackShape {
       case TextDirection.ltr:
         leftThumbOffset = startThumbCenter;
         rightThumbOffset = endThumbCenter;
-        break;
       case TextDirection.rtl:
         leftThumbOffset = endThumbCenter;
         rightThumbOffset = startThumbCenter;
-        break;
     }
     final Size thumbSize = sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete);
     final double thumbRadius = thumbSize.width / 2;
@@ -2116,12 +2108,10 @@ class RoundSliderTickMarkShape extends SliderTickMarkShape {
         final bool isTickMarkRightOfThumb = center.dx > thumbCenter.dx;
         begin = isTickMarkRightOfThumb ? sliderTheme.disabledInactiveTickMarkColor : sliderTheme.disabledActiveTickMarkColor;
         end = isTickMarkRightOfThumb ? sliderTheme.inactiveTickMarkColor : sliderTheme.activeTickMarkColor;
-        break;
       case TextDirection.rtl:
         final bool isTickMarkLeftOfThumb = center.dx < thumbCenter.dx;
         begin = isTickMarkLeftOfThumb ? sliderTheme.disabledInactiveTickMarkColor : sliderTheme.disabledActiveTickMarkColor;
         end = isTickMarkLeftOfThumb ? sliderTheme.inactiveTickMarkColor : sliderTheme.activeTickMarkColor;
-        break;
     }
     final Paint paint = Paint()..color = ColorTween(begin: begin, end: end).evaluate(enableAnimation)!;
 
@@ -2198,10 +2188,8 @@ class RoundRangeSliderTickMarkShape extends RangeSliderTickMarkShape {
     switch (textDirection) {
       case TextDirection.ltr:
         isBetweenThumbs = startThumbCenter.dx < center.dx && center.dx < endThumbCenter.dx;
-        break;
       case TextDirection.rtl:
         isBetweenThumbs = endThumbCenter.dx < center.dx && center.dx < startThumbCenter.dx;
-        break;
     }
     final Color? begin = isBetweenThumbs ? sliderTheme.disabledActiveTickMarkColor : sliderTheme.disabledInactiveTickMarkColor;
     final Color? end = isBetweenThumbs ? sliderTheme.activeTickMarkColor : sliderTheme.inactiveTickMarkColor;

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -485,10 +485,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     switch (Theme.of(context).brightness) {
       case Brightness.light:
         cancelColor = Colors.black54;
-        break;
       case Brightness.dark:
         cancelColor = Colors.white70;
-        break;
     }
 
     final ThemeData themeData = Theme.of(context);

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -753,10 +753,8 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
       switch (Directionality.of(context)) {
         case TextDirection.rtl:
           positionController.value -= delta;
-          break;
         case TextDirection.ltr:
           positionController.value += delta;
-          break;
       }
     }
   }
@@ -1279,10 +1277,8 @@ class _SwitchPainter extends ToggleablePainter {
     switch (textDirection) {
       case TextDirection.rtl:
         visualPosition = 1.0 - currentValue;
-        break;
       case TextDirection.ltr:
         visualPosition = currentValue;
-        break;
     }
     if (reaction.status == AnimationStatus.reverse && !_stopPressAnimation) {
       _stopPressAnimation = true;

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -537,7 +537,6 @@ class SwitchListTile extends StatelessWidget {
           splashRadius: splashRadius,
           overlayColor: overlayColor,
         );
-        break;
 
       case _SwitchListTileType.material:
         control = Switch(
@@ -570,12 +569,10 @@ class SwitchListTile extends StatelessWidget {
       case ListTileControlAffinity.leading:
         leading = control;
         trailing = secondary;
-        break;
       case ListTileControlAffinity.trailing:
       case ListTileControlAffinity.platform:
         leading = secondary;
         trailing = control;
-        break;
     }
 
     final ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -291,10 +291,8 @@ class _TabLabelBarRenderer extends RenderFlex {
     switch (textDirection!) {
       case TextDirection.rtl:
         xOffsets.insert(0, size.width);
-        break;
       case TextDirection.ltr:
         xOffsets.add(size.width);
-        break;
     }
     onPerformLayout(xOffsets, textDirection!, size.width);
   }
@@ -421,11 +419,9 @@ class _IndicatorPainter extends CustomPainter {
       case TextDirection.rtl:
         tabLeft = _currentTabOffsets![tabIndex + 1];
         tabRight = _currentTabOffsets![tabIndex];
-        break;
       case TextDirection.ltr:
         tabLeft = _currentTabOffsets![tabIndex];
         tabRight = _currentTabOffsets![tabIndex + 1];
-        break;
     }
 
     if (indicatorSize == TabBarIndicatorSize.label) {
@@ -1188,10 +1184,8 @@ class _TabBarState extends State<TabBar> {
       case TextDirection.rtl:
         paddingStart = widget.padding?.resolve(TextDirection.rtl).right ?? 0;
         tabCenter = _tabStripWidth - tabCenter;
-        break;
       case TextDirection.ltr:
         paddingStart = widget.padding?.resolve(TextDirection.ltr).left ?? 0;
-        break;
     }
 
     return clampDouble(tabCenter + paddingStart - viewportWidth / 2.0, minExtent, maxExtent);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -85,7 +85,6 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           Feedback.forLongPress(_state.context);
-          break;
       }
     }
   }
@@ -1136,7 +1135,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         if (cause == SelectionChangedCause.longPress) {
           _editableText?.bringIntoView(selection.extent);
         }
-        break;
     }
 
     switch (Theme.of(context).platform) {
@@ -1150,7 +1148,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         if (cause == SelectionChangedCause.drag) {
           _editableText?.hideToolbar();
         }
-        break;
     }
   }
 
@@ -1271,7 +1268,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         cursorRadius ??= const Radius.circular(2.0);
         cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
         autocorrectionTextRectColor = selectionColor;
-        break;
 
       case TargetPlatform.macOS:
         final CupertinoThemeData cupertinoTheme = CupertinoTheme.of(context);
@@ -1289,7 +1285,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
             _effectiveFocusNode.requestFocus();
           }
         };
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -1299,7 +1294,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         cursorOpacityAnimates = false;
         cursorColor = _hasError ? _errorColor : widget.cursorColor ?? selectionStyle.cursorColor ?? theme.colorScheme.primary;
         selectionColor = selectionStyle.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
-        break;
 
       case TargetPlatform.linux:
         forcePressEnabled = false;
@@ -1308,7 +1302,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         cursorOpacityAnimates = false;
         cursorColor = _hasError ? _errorColor : widget.cursorColor ?? selectionStyle.cursorColor ?? theme.colorScheme.primary;
         selectionColor = selectionStyle.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
-        break;
 
       case TargetPlatform.windows:
         forcePressEnabled = false;
@@ -1323,7 +1316,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
             _effectiveFocusNode.requestFocus();
           }
         };
-        break;
     }
 
     Widget child = RepaintBoundary(

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -439,12 +439,10 @@ class ThemeData with Diagnosticable {
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
         materialTapTargetSize ??= MaterialTapTargetSize.padded;
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
          materialTapTargetSize ??= MaterialTapTargetSize.shrinkWrap;
-        break;
     }
     pageTransitionsTheme ??= const PageTransitionsTheme();
     scrollbarTheme ??= const ScrollbarThemeData();

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -330,11 +330,9 @@ class _HourMinuteControl extends StatelessWidget {
       case TimePickerEntryMode.dial:
       case TimePickerEntryMode.dialOnly:
         height = defaultTheme.hourMinuteSize.height;
-        break;
       case TimePickerEntryMode.input:
       case TimePickerEntryMode.inputOnly:
         height = defaultTheme.hourMinuteInputSize.height;
-        break;
     }
 
     return SizedBox(
@@ -469,11 +467,9 @@ class _StringFragment extends StatelessWidget {
       case TimePickerEntryMode.dial:
       case TimePickerEntryMode.dialOnly:
         height = defaultTheme.hourMinuteSize.height;
-        break;
       case TimePickerEntryMode.input:
       case TimePickerEntryMode.inputOnly:
         height = defaultTheme.hourMinuteInputSize.height;
-        break;
     }
 
     return ExcludeSemantics(
@@ -561,7 +557,6 @@ class _DayPeriodControl extends StatelessWidget {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         _announceToAccessibility(context, MaterialLocalizations.of(context).anteMeridiemAbbreviation);
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         break;
@@ -580,7 +575,6 @@ class _DayPeriodControl extends StatelessWidget {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         _announceToAccessibility(context, MaterialLocalizations.of(context).postMeridiemAbbreviation);
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         break;
@@ -621,17 +615,13 @@ class _DayPeriodControl extends StatelessWidget {
         switch (orientation) {
           case Orientation.portrait:
             dayPeriodSize = defaultTheme.dayPeriodPortraitSize;
-            break;
           case Orientation.landscape:
             dayPeriodSize = defaultTheme.dayPeriodLandscapeSize;
-            break;
         }
-        break;
       case TimePickerEntryMode.input:
       case TimePickerEntryMode.inputOnly:
         orientation = Orientation.portrait;
         dayPeriodSize = defaultTheme.dayPeriodInputSize;
-        break;
     }
 
     final Widget result;
@@ -659,7 +649,6 @@ class _DayPeriodControl extends StatelessWidget {
             ),
           ),
         );
-        break;
       case Orientation.landscape:
         result = _DayPeriodInputPadding(
           minSize: dayPeriodSize,
@@ -683,7 +672,6 @@ class _DayPeriodControl extends StatelessWidget {
             ),
           ),
         );
-        break;
     }
     return result;
   }
@@ -861,14 +849,12 @@ class _RenderInputPadding extends RenderShiftedBox {
         } else {
           newPosition += const Offset(0, -1);
         }
-        break;
       case Orientation.landscape:
         if (position.dx > newPosition.dx) {
           newPosition += const Offset(1, 0);
         } else {
           newPosition += const Offset(-1, 0);
         }
-        break;
     }
 
     return result.addWithRawTransform(
@@ -1163,22 +1149,17 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     switch (widget.hourDialType) {
       case _HourDialType.twentyFourHour:
         hoursFactor = TimeOfDay.hoursPerDay;
-        break;
       case _HourDialType.twentyFourHourDoubleRing:
         hoursFactor = TimeOfDay.hoursPerPeriod;
-        break;
       case _HourDialType.twelveHour:
         hoursFactor = TimeOfDay.hoursPerPeriod;
-        break;
     }
     final double fraction;
     switch (widget.hourMinuteMode) {
       case _HourMinuteMode.hour:
         fraction = (time.hour / hoursFactor) % hoursFactor;
-        break;
       case _HourMinuteMode.minute:
         fraction = (time.minute / TimeOfDay.minutesPerHour) % TimeOfDay.minutesPerHour;
-        break;
     }
     return (math.pi / 2 - fraction * _kTwoPi) % _kTwoPi;
   }
@@ -1191,17 +1172,14 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
         switch (widget.hourDialType) {
           case _HourDialType.twentyFourHour:
             newHour = (fraction * TimeOfDay.hoursPerDay).round() % TimeOfDay.hoursPerDay;
-            break;
           case _HourDialType.twentyFourHourDoubleRing:
             newHour = (fraction * TimeOfDay.hoursPerPeriod).round() % TimeOfDay.hoursPerPeriod;
             if (radius < 0.5) {
               newHour = newHour + TimeOfDay.hoursPerPeriod;
             }
-            break;
           case _HourDialType.twelveHour:
             newHour = (fraction * TimeOfDay.hoursPerPeriod).round() % TimeOfDay.hoursPerPeriod;
             newHour = newHour + widget.selectedTime.periodOffset;
-            break;
         }
         return widget.selectedTime.replacing(hour: newHour);
       case _HourMinuteMode.minute:
@@ -1290,10 +1268,8 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
         case _HourDialType.twentyFourHour:
         case _HourDialType.twentyFourHourDoubleRing:
           _announceToAccessibility(context, localizations.formatDecimal(newTime.hour));
-          break;
         case _HourDialType.twelveHour:
           _announceToAccessibility(context, localizations.formatDecimal(newTime.hourOfPeriod));
-          break;
       }
       widget.onHourSelected?.call();
     } else {
@@ -1326,15 +1302,11 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
           case _HourDialType.twentyFourHour:
           case _HourDialType.twentyFourHourDoubleRing:
             time = TimeOfDay(hour: hour, minute: widget.selectedTime.minute);
-            break;
           case _HourDialType.twelveHour:
             time = getAmPmTime();
-            break;
         }
-        break;
       case _HourMinuteMode.minute:
         time = getAmPmTime();
-        break;
     }
     final double angle = _getThetaForTime(time);
     _thetaTween
@@ -1557,7 +1529,6 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
               selectedValue: selectedDialValue,
             );
             radiusValue = theme.useMaterial3 ? _radius.value : 1;
-            break;
           case _HourDialType.twelveHour:
             selectedDialValue = widget.selectedTime.hourOfPeriod;
             primaryLabels = _build12HourRing(
@@ -1569,9 +1540,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
               selectedValue: selectedDialValue,
             );
             radiusValue = 1;
-            break;
         }
-        break;
       case _HourMinuteMode.minute:
         selectedDialValue = widget.selectedTime.minute;
         primaryLabels = _buildMinutes(
@@ -1583,7 +1552,6 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
           selectedValue: selectedDialValue,
         );
         radiusValue = 1;
-        break;
     }
     painter?.dispose();
     painter = _DialPainter(
@@ -2263,10 +2231,8 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
         switch (_entryMode.value) {
           case TimePickerEntryMode.dial:
             _autovalidateMode.value = AutovalidateMode.disabled;
-            break;
           case TimePickerEntryMode.input:
             _formKey.currentState!.save();
-            break;
           case TimePickerEntryMode.dialOnly:
             break;
           case TimePickerEntryMode.inputOnly:
@@ -2282,14 +2248,11 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
     switch (_entryMode.value) {
       case TimePickerEntryMode.dial:
         _handleEntryModeChanged(TimePickerEntryMode.input);
-        break;
       case TimePickerEntryMode.input:
         _handleEntryModeChanged(TimePickerEntryMode.dial);
-        break;
       case TimePickerEntryMode.dialOnly:
       case TimePickerEntryMode.inputOnly:
         FlutterError('Can not change entry mode from $_entryMode');
-        break;
     }
   }
 
@@ -2335,11 +2298,9 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
           case TimeOfDayFormat.H_colon_mm:
             final _TimePickerDefaults defaultTheme = useMaterial3 ? _TimePickerDefaultsM3(context) : _TimePickerDefaultsM2(context);
             timePickerWidth = _kTimePickerMinInputSize.width - defaultTheme.dayPeriodPortraitSize.width - 12;
-            break;
           case TimeOfDayFormat.a_space_h_colon_mm:
           case TimeOfDayFormat.h_colon_mm_space_a:
             timePickerWidth = _kTimePickerMinInputSize.width - (useMaterial3 ? 32 : 0);
-            break;
         }
         return Size(timePickerWidth, _kTimePickerMinInputSize.height);
     }
@@ -2359,15 +2320,12 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
         switch (orientation) {
           case Orientation.portrait:
             timePickerSize = _kTimePickerPortraitSize;
-            break;
           case Orientation.landscape:
             timePickerSize = Size(
               _kTimePickerLandscapeSize.width * textScaleFactor,
               useMaterial3 ? _kTimePickerLandscapeSize.height : _kTimePickerLandscapeSizeM2.height
             );
-            break;
         }
-        break;
       case TimePickerEntryMode.input:
       case TimePickerEntryMode.inputOnly:
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
@@ -2380,14 +2338,11 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
           case TimeOfDayFormat.H_colon_mm:
             final _TimePickerDefaults defaultTheme = useMaterial3 ? _TimePickerDefaultsM3(context) : _TimePickerDefaultsM2(context);
             timePickerWidth = _kTimePickerInputSize.width - defaultTheme.dayPeriodPortraitSize.width - 12;
-            break;
           case TimeOfDayFormat.a_space_h_colon_mm:
           case TimeOfDayFormat.h_colon_mm_space_a:
             timePickerWidth = _kTimePickerInputSize.width - (useMaterial3 ? 32 : 0);
-            break;
         }
         timePickerSize = Size(timePickerWidth, _kTimePickerInputSize.height);
-        break;
     }
     return Size(timePickerSize.width, timePickerSize.height * textScaleFactor);
   }
@@ -2451,11 +2406,9 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
     switch (theme.materialTapTargetSize) {
       case MaterialTapTargetSize.padded:
         tapTargetSizeOffset = Offset.zero;
-        break;
       case MaterialTapTargetSize.shrinkWrap:
         // _dialogSize returns "padded" sizes.
         tapTargetSizeOffset = const Offset(0, -12);
-        break;
     }
     final Size dialogSize = _dialogSize(context, useMaterial3: theme.useMaterial3) + tapTargetSizeOffset;
     final Size minDialogSize = _minDialogSize(context, useMaterial3: theme.useMaterial3) + tapTargetSizeOffset;
@@ -2682,7 +2635,6 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
           HapticFeedback.vibrate();
           _vibrateTimer = null;
         });
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         break;
@@ -2703,16 +2655,13 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
       switch (widget.entryMode) {
         case TimePickerEntryMode.dial:
           newMode = TimePickerEntryMode.input;
-          break;
         case TimePickerEntryMode.input:
           _autofocusHour.value = false;
           _autofocusMinute.value = false;
           newMode = TimePickerEntryMode.dial;
-          break;
         case TimePickerEntryMode.dialOnly:
         case TimePickerEntryMode.inputOnly:
           FlutterError('Can not change entry mode from ${widget.entryMode}');
-          break;
       }
       _setEntryMode(newMode);
     });
@@ -2727,10 +2676,8 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
     switch (_hourMinuteMode.value) {
       case _HourMinuteMode.hour:
         _announceToAccessibility(context, localizations.timePickerHourModeAnnouncement);
-        break;
       case _HourMinuteMode.minute:
         _announceToAccessibility(context, localizations.timePickerMinuteModeAnnouncement);
-        break;
     }
     _lastModeAnnounced.value = _hourMinuteMode.value;
   }
@@ -2785,10 +2732,8 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
       case HourFormat.HH:
       case HourFormat.H:
         hourMode = theme.useMaterial3 ? _HourDialType.twentyFourHourDoubleRing : _HourDialType.twentyFourHour;
-        break;
       case HourFormat.h:
         hourMode = _HourDialType.twelveHour;
-        break;
     }
 
     final String helpText;
@@ -2804,17 +2749,13 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
         switch (orientation) {
           case Orientation.portrait:
             dialPadding = const EdgeInsets.only(left: 12, right: 12, top: 36);
-            break;
           case Orientation.landscape:
             switch (theme.materialTapTargetSize) {
               case MaterialTapTargetSize.padded:
                 dialPadding = const EdgeInsetsDirectional.only(start: 64);
-                break;
               case MaterialTapTargetSize.shrinkWrap:
                 dialPadding = const EdgeInsetsDirectional.only(start: 64);
-                break;
             }
-            break;
         }
         final Widget dial = Padding(
           padding: dialPadding,
@@ -2861,7 +2802,6 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
                 ),
               ],
             );
-            break;
           case Orientation.landscape:
             picker = Column(
               children: <Widget>[
@@ -2879,9 +2819,7 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
                 ),
               ],
             );
-            break;
         }
-        break;
       case TimePickerEntryMode.input:
       case TimePickerEntryMode.inputOnly:
         final String helpText =  widget.helpText ?? (theme.useMaterial3

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -718,10 +718,8 @@ class ToggleButtons extends StatelessWidget {
           }
           assert(minPaddingSize.width >= 0.0);
           assert(minPaddingSize.height >= 0.0);
-          break;
         case MaterialTapTargetSize.shrinkWrap:
           minPaddingSize = Size.zero;
-          break;
       }
 
       Widget button = _SelectToggleButton(
@@ -1188,19 +1186,15 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
       switch (textDirection) {
         case TextDirection.ltr:
           childParentData.offset = Offset(leadingBorderSide.width, borderSide.width);
-          break;
         case TextDirection.rtl:
           childParentData.offset = Offset(trailingBorderSide.width, borderSide.width);
-          break;
       }
     } else {
       switch (verticalDirection) {
         case VerticalDirection.down:
           childParentData.offset = Offset(borderSide.width, leadingBorderSide.width);
-          break;
         case VerticalDirection.up:
           childParentData.offset = Offset(borderSide.width, trailingBorderSide.width);
-          break;
       }
     }
   }
@@ -1354,7 +1348,6 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
               ..lineTo(outer.right - rrect.trRadiusX, rrect.bottom);
             context.canvas.drawPath(horizontalPaths, horizontalPaint);
           }
-          break;
         case TextDirection.rtl:
           if (isLastButton) {
             final Path leadingPath = Path();
@@ -1394,7 +1387,6 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
               ..lineTo(outer.left - rrect.tlRadiusX, rrect.bottom);
             context.canvas.drawPath(horizontalPaths, horizontalPaint);
           }
-          break;
       }
     } else {
       switch (verticalDirection) {
@@ -1437,7 +1429,6 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
               ..lineTo(rrect.right, outer.bottom);
             context.canvas.drawPath(paths, paint);
           }
-          break;
         case VerticalDirection.up:
           if (isLastButton) {
             final Path bottomPath = Path();
@@ -1477,7 +1468,6 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
               ..lineTo(rrect.right, outer.bottom - leadingBorderSide.width);
             context.canvas.drawPath(paths, paint);
           }
-          break;
       }
     }
   }

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -232,13 +232,10 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     switch (value) {
       case false:
         onChanged!(true);
-        break;
       case true:
         onChanged!(tristate ? null : false);
-        break;
       case null:
         onChanged!(false);
-        break;
     }
     context.findRenderObject()!.sendSemanticsEvent(const TapSemanticEvent());
   }

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -215,24 +215,19 @@ class Typography with Diagnosticable {
       case TargetPlatform.iOS:
         black ??= blackCupertino;
         white ??= whiteCupertino;
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         black ??= blackMountainView;
         white ??= whiteMountainView;
-        break;
       case TargetPlatform.windows:
         black ??= blackRedmond;
         white ??= whiteRedmond;
-        break;
       case TargetPlatform.macOS:
         black ??= blackRedwoodCity;
         white ??= whiteRedwoodCity;
-        break;
       case TargetPlatform.linux:
         black ??= blackHelsinki;
         white ??= whiteHelsinki;
-        break;
       case null:
         break;
     }

--- a/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/beveled_rectangle_border.dart
@@ -131,7 +131,6 @@ class BeveledRectangleBorder extends OutlinedBorder {
         final Path path = _getPath(adjustedRect)
           ..addPath(getInnerPath(rect, textDirection: textDirection), Offset.zero);
         canvas.drawPath(path, side.toPaint());
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -215,7 +215,6 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
     switch (type) {
       case 'fontsChange':
         _systemFonts.notifyListeners();
-        break;
     }
     return;
   }

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -285,18 +285,14 @@ class BorderSide with Diagnosticable {
     switch (a.style) {
       case BorderStyle.solid:
         colorA = a.color;
-        break;
       case BorderStyle.none:
         colorA = a.color.withAlpha(0x00);
-        break;
     }
     switch (b.style) {
       case BorderStyle.solid:
         colorB = b.color;
-        break;
       case BorderStyle.none:
         colorB = b.color.withAlpha(0x00);
-        break;
     }
     if (a.strokeAlign != b.strokeAlign) {
       return BorderSide(
@@ -927,7 +923,6 @@ void paintBorder(
         path.lineTo(rect.left + left.width, rect.top + top.width);
       }
       canvas.drawPath(path, paint);
-      break;
     case BorderStyle.none:
       break;
   }
@@ -946,7 +941,6 @@ void paintBorder(
         path.lineTo(rect.right - right.width, rect.top + top.width);
       }
       canvas.drawPath(path, paint);
-      break;
     case BorderStyle.none:
       break;
   }
@@ -965,7 +959,6 @@ void paintBorder(
         path.lineTo(rect.right - right.width, rect.bottom - bottom.width);
       }
       canvas.drawPath(path, paint);
-      break;
     case BorderStyle.none:
       break;
   }
@@ -984,7 +977,6 @@ void paintBorder(
         path.lineTo(rect.left + left.width, rect.bottom - bottom.width);
       }
       canvas.drawPath(path, paint);
-      break;
     case BorderStyle.none:
       break;
   }

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -525,14 +525,12 @@ class Border extends BoxBorder {
             case BoxShape.circle:
               assert(borderRadius == null, 'A borderRadius can only be given for rectangular boxes.');
               BoxBorder._paintUniformBorderWithCircle(canvas, rect, top);
-              break;
             case BoxShape.rectangle:
               if (borderRadius != null && borderRadius != BorderRadius.zero) {
                 BoxBorder._paintUniformBorderWithRadius(canvas, rect, top, borderRadius);
                 return;
               }
               BoxBorder._paintUniformBorderWithRectangle(canvas, rect, top);
-              break;
           }
           return;
       }
@@ -870,14 +868,12 @@ class BorderDirectional extends BoxBorder {
             case BoxShape.circle:
               assert(borderRadius == null, 'A borderRadius can only be given for rectangular boxes.');
               BoxBorder._paintUniformBorderWithCircle(canvas, rect, top);
-              break;
             case BoxShape.rectangle:
               if (borderRadius != null && borderRadius != BorderRadius.zero) {
                 BoxBorder._paintUniformBorderWithRadius(canvas, rect, top, borderRadius);
                 return;
               }
               BoxBorder._paintUniformBorderWithRectangle(canvas, rect, top);
-              break;
           }
           return;
       }
@@ -893,11 +889,9 @@ class BorderDirectional extends BoxBorder {
       case TextDirection.rtl:
         left = end;
         right = start;
-        break;
       case TextDirection.ltr:
         left = start;
         right = end;
-        break;
     }
     paintBorder(canvas, rect, top: top, left: left, bottom: bottom, right: right);
   }

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -423,14 +423,12 @@ class _BoxDecorationPainter extends BoxPainter {
         final Offset center = rect.center;
         final double radius = rect.shortestSide / 2.0;
         canvas.drawCircle(center, radius, paint);
-        break;
       case BoxShape.rectangle:
         if (_decoration.borderRadius == null || _decoration.borderRadius == BorderRadius.zero) {
           canvas.drawRect(rect, paint);
         } else {
           canvas.drawRRect(_decoration.borderRadius!.resolve(textDirection).toRRect(rect), paint);
         }
-        break;
     }
   }
 
@@ -465,12 +463,10 @@ class _BoxDecorationPainter extends BoxPainter {
         final double radius = rect.shortestSide / 2.0;
         final Rect square = Rect.fromCircle(center: center, radius: radius);
         clipPath = Path()..addOval(square);
-        break;
       case BoxShape.rectangle:
         if (_decoration.borderRadius != null) {
           clipPath = Path()..addRRect(_decoration.borderRadius!.resolve(configuration.textDirection).toRRect(rect));
         }
-        break;
     }
     _imagePainter!.paint(canvas, rect, clipPath, configuration);
   }

--- a/packages/flutter/lib/src/painting/box_fit.dart
+++ b/packages/flutter/lib/src/painting/box_fit.dart
@@ -148,7 +148,6 @@ FittedSizes applyBoxFit(BoxFit fit, Size inputSize, Size outputSize) {
     case BoxFit.fill:
       sourceSize = inputSize;
       destinationSize = outputSize;
-      break;
     case BoxFit.contain:
       sourceSize = inputSize;
       if (outputSize.width / outputSize.height > sourceSize.width / sourceSize.height) {
@@ -156,7 +155,6 @@ FittedSizes applyBoxFit(BoxFit fit, Size inputSize, Size outputSize) {
       } else {
         destinationSize = Size(outputSize.width, sourceSize.height * outputSize.width / sourceSize.width);
       }
-      break;
     case BoxFit.cover:
       if (outputSize.width / outputSize.height > inputSize.width / inputSize.height) {
         sourceSize = Size(inputSize.width, inputSize.width * outputSize.height / outputSize.width);
@@ -164,7 +162,6 @@ FittedSizes applyBoxFit(BoxFit fit, Size inputSize, Size outputSize) {
         sourceSize = Size(inputSize.height * outputSize.width / outputSize.height, inputSize.height);
       }
       destinationSize = outputSize;
-      break;
     case BoxFit.fitWidth:
       if (outputSize.width / outputSize.height > inputSize.width / inputSize.height) {
         // Like "cover"
@@ -175,7 +172,6 @@ FittedSizes applyBoxFit(BoxFit fit, Size inputSize, Size outputSize) {
         sourceSize = inputSize;
         destinationSize = Size(outputSize.width, sourceSize.height * outputSize.width / sourceSize.width);
       }
-      break;
     case BoxFit.fitHeight:
       if (outputSize.width / outputSize.height > inputSize.width / inputSize.height) {
         // Like "contain"
@@ -186,11 +182,9 @@ FittedSizes applyBoxFit(BoxFit fit, Size inputSize, Size outputSize) {
         sourceSize = Size(inputSize.height * outputSize.width / outputSize.height, inputSize.height);
         destinationSize = outputSize;
       }
-      break;
     case BoxFit.none:
       sourceSize = Size(math.min(inputSize.width, outputSize.width), math.min(inputSize.height, outputSize.height));
       destinationSize = sourceSize;
-      break;
     case BoxFit.scaleDown:
       sourceSize = inputSize;
       destinationSize = inputSize;
@@ -201,7 +195,6 @@ FittedSizes applyBoxFit(BoxFit fit, Size inputSize, Size outputSize) {
       if (destinationSize.width > outputSize.width) {
         destinationSize = Size(outputSize.width, outputSize.width / aspectRatio);
       }
-      break;
   }
   return FittedSizes(sourceSize, destinationSize);
 }

--- a/packages/flutter/lib/src/painting/clip.dart
+++ b/packages/flutter/lib/src/painting/clip.dart
@@ -16,14 +16,11 @@ abstract class ClipContext {
         break;
       case Clip.hardEdge:
         canvasClipCall(false);
-        break;
       case Clip.antiAlias:
         canvasClipCall(true);
-        break;
       case Clip.antiAliasWithSaveLayer:
         canvasClipCall(true);
         canvas.saveLayer(bounds, Paint());
-        break;
     }
     painter();
     if (clipBehavior == Clip.antiAliasWithSaveLayer) {

--- a/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
@@ -149,7 +149,6 @@ class ContinuousRectangleBorder extends OutlinedBorder {
           getOuterPath(rect, textDirection: textDirection),
           side.toPaint(),
         );
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -133,7 +133,6 @@ class RoundedRectangleBorder extends OutlinedBorder {
           final RRect outer = borderRect.inflate(side.strokeOutset);
           canvas.drawDRRect(outer, inner, paint);
         }
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -98,7 +98,6 @@ class ShapeDecoration extends Decoration {
         } else {
           shape = const CircleBorder();
         }
-        break;
       case BoxShape.rectangle:
         if (source.borderRadius != null) {
           assert(source.border == null || source.border!.isUniform);
@@ -109,7 +108,6 @@ class ShapeDecoration extends Decoration {
         } else {
           shape = source.border ?? const Border();
         }
-        break;
     }
     return ShapeDecoration(
       color: source.color,

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -915,10 +915,8 @@ class TextPainter {
           // the paragraph's width needs to be as close to the width of its
           // longest line as possible.
           newWidth = _applyFloatingPointHack(_paragraph!.longestLine);
-          break;
         case TextWidthBasis.parent:
           newWidth = maxIntrinsicWidth;
-          break;
       }
       newWidth = clampDouble(newWidth, minWidth, maxWidth);
       if (newWidth != _applyFloatingPointHack(_paragraph!.width)) {
@@ -1176,10 +1174,8 @@ class TextPainter {
     switch ((caretMetrics as _LineCaretMetrics).writingDirection) {
       case TextDirection.rtl:
         offset = Offset(caretMetrics.offset.dx - caretPrototype.width, caretMetrics.offset.dy);
-        break;
       case TextDirection.ltr:
         offset = caretMetrics.offset;
-        break;
     }
     // If offset.dx is outside of the advertised content area, then the associated
     // glyph cluster belongs to a trailing newline character. Ideally the behavior

--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -181,7 +181,6 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
         // Call markNeedsLayout in case the RenderObject isn't marked dirty
         // already, to resume interrupted resizing animation.
         markNeedsLayout();
-        break;
     }
   }
 
@@ -213,16 +212,12 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
     switch (_state) {
       case RenderAnimatedSizeState.start:
         _layoutStart();
-        break;
       case RenderAnimatedSizeState.stable:
         _layoutStable();
-        break;
       case RenderAnimatedSizeState.changed:
         _layoutChanged();
-        break;
       case RenderAnimatedSizeState.unstable:
         _layoutUnstable();
-        break;
     }
 
     size = constraints.constrain(_animatedSize!);
@@ -253,13 +248,11 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
         } else if (_controller.value == _controller.upperBound) {
           return constraints.constrain(childSize);
         }
-        break;
       case RenderAnimatedSizeState.unstable:
       case RenderAnimatedSizeState.changed:
         if (_sizeTween.end != childSize) {
           return constraints.constrain(childSize);
         }
-        break;
     }
 
     return constraints.constrain(_animatedSize!);

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -352,7 +352,6 @@ bool debugCheckHasBoundedAxis(Axis axis, BoxConstraints constraints) {
               'horizontal space in which to expand.',
             );
           }
-          break;
         case Axis.horizontal:
           if (!constraints.hasBoundedWidth) {
             throw FlutterError.fromParts(<DiagnosticsNode>[
@@ -382,7 +381,6 @@ bool debugCheckHasBoundedAxis(Axis axis, BoxConstraints constraints) {
               'vertical space in which to expand.',
             );
           }
-          break;
       }
     }
     return true;

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -234,10 +234,8 @@ mixin DebugOverflowIndicatorMixin on RenderObject {
     switch (overflows.length) {
       case 1:
         overflowText = overflows.first;
-        break;
       case 2:
         overflowText = '${overflows.first} and ${overflows.last}';
-        break;
       default:
         overflows[overflows.length - 1] = 'and ${overflows[overflows.length - 1]}';
         overflowText = overflows.join(', ');

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1811,7 +1811,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
           caretRect.width,
           caretRect.height,
         );
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -1825,7 +1824,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
           caretRect.width,
           caretHeight,
         );
-        break;
     }
 
     caretRect = caretRect.shift(_paintOffset);
@@ -2171,10 +2169,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
       case TextAffinity.upstream:
         // upstream affinity is effectively -1 in text position.
         effectiveOffset = position.offset - 1;
-        break;
       case TextAffinity.downstream:
         effectiveOffset = position.offset;
-        break;
     }
 
     // On iOS, select the previous word if there is a previous word, or select
@@ -2216,7 +2212,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
               extentOffset: position.offset,
             );
           }
-          break;
         case TargetPlatform.fuchsia:
         case TargetPlatform.macOS:
         case TargetPlatform.linux:
@@ -2268,14 +2263,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
             baselineOffset = child.getDistanceToBaseline(
               _placeholderSpans[childIndex].baseline!,
             );
-            break;
           case ui.PlaceholderAlignment.aboveBaseline:
           case ui.PlaceholderAlignment.belowBaseline:
           case ui.PlaceholderAlignment.bottom:
           case ui.PlaceholderAlignment.middle:
           case ui.PlaceholderAlignment.top:
             baselineOffset = null;
-            break;
         }
       } else {
         assert(_placeholderSpans[childIndex].alignment != ui.PlaceholderAlignment.baseline);
@@ -2356,13 +2349,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         _caretPrototype = Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight + 2);
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         _caretPrototype = Rect.fromLTWH(0.0, _kCaretHeightOffset, cursorWidth, cursorHeight - 2.0 * _kCaretHeightOffset);
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -439,7 +439,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       switch (direction) {
         case Axis.horizontal:
           assert(textDirection != null, 'Horizontal $runtimeType with multiple children has a null textDirection, so the layout order is undefined.');
-          break;
         case Axis.vertical:
           break;
       }
@@ -449,7 +448,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       switch (direction) {
         case Axis.horizontal:
           assert(textDirection != null, 'Horizontal $runtimeType with $mainAxisAlignment has a null textDirection, so the alignment cannot be resolved.');
-          break;
         case Axis.vertical:
           break;
       }
@@ -461,7 +459,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           break;
         case Axis.vertical:
           assert(textDirection != null, 'Vertical $runtimeType with $crossAxisAlignment has a null textDirection, so the alignment cannot be resolved.');
-          break;
       }
     }
     return true;
@@ -553,11 +550,9 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
             case Axis.horizontal:
               mainSize = child.getMaxIntrinsicWidth(double.infinity);
               crossSize = childSize(child, mainSize);
-              break;
             case Axis.vertical:
               mainSize = child.getMaxIntrinsicHeight(double.infinity);
               crossSize = childSize(child, mainSize);
-              break;
           }
           inflexibleSpace += mainSize;
           maxCrossSize = math.max(maxCrossSize, crossSize);
@@ -723,7 +718,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                   if (!node.constraints.hasBoundedWidth) {
                     node = null;
                   }
-                  break;
                 case Axis.vertical:
                   while (!node!.constraints.hasBoundedHeight && node.parent is RenderBox) {
                     node = node.parent! as RenderBox;
@@ -731,7 +725,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                   if (!node.constraints.hasBoundedHeight) {
                     node = null;
                   }
-                  break;
               }
               if (node != null) {
                 addendum.add(node.describeForError('The nearest ancestor providing an unbounded width constraint is'));
@@ -801,19 +794,15 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           switch (_direction) {
             case Axis.horizontal:
               innerConstraints = BoxConstraints.tightFor(height: constraints.maxHeight);
-              break;
             case Axis.vertical:
               innerConstraints = BoxConstraints.tightFor(width: constraints.maxWidth);
-              break;
           }
         } else {
           switch (_direction) {
             case Axis.horizontal:
               innerConstraints = BoxConstraints(maxHeight: constraints.maxHeight);
-              break;
             case Axis.vertical:
               innerConstraints = BoxConstraints(maxWidth: constraints.maxWidth);
-              break;
           }
         }
         final Size childSize = layoutChild(child, innerConstraints);
@@ -839,10 +828,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
             case FlexFit.tight:
               assert(maxChildExtent < double.infinity);
               minChildExtent = maxChildExtent;
-              break;
             case FlexFit.loose:
               minChildExtent = 0.0;
-              break;
           }
           final BoxConstraints innerConstraints;
           if (crossAxisAlignment == CrossAxisAlignment.stretch) {
@@ -854,7 +841,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                   minHeight: constraints.maxHeight,
                   maxHeight: constraints.maxHeight,
                 );
-                break;
               case Axis.vertical:
                 innerConstraints = BoxConstraints(
                   minWidth: constraints.maxWidth,
@@ -862,7 +848,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                   minHeight: minChildExtent,
                   maxHeight: maxChildExtent,
                 );
-                break;
             }
           } else {
             switch (_direction) {
@@ -872,14 +857,12 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                   maxWidth: maxChildExtent,
                   maxHeight: constraints.maxHeight,
                 );
-                break;
               case Axis.vertical:
                 innerConstraints = BoxConstraints(
                   maxWidth: constraints.maxWidth,
                   minHeight: minChildExtent,
                   maxHeight: maxChildExtent,
                 );
-                break;
             }
           }
           final Size childSize = layoutChild(child, innerConstraints);
@@ -961,12 +944,10 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         size = constraints.constrain(Size(actualSize, crossSize));
         actualSize = size.width;
         crossSize = size.height;
-        break;
       case Axis.vertical:
         size = constraints.constrain(Size(crossSize, actualSize));
         actualSize = size.height;
         crossSize = size.width;
-        break;
     }
     final double actualSizeDelta = actualSize - allocatedSize;
     _overflow = math.max(0.0, -actualSizeDelta);
@@ -983,27 +964,21 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       case MainAxisAlignment.start:
         leadingSpace = 0.0;
         betweenSpace = 0.0;
-        break;
       case MainAxisAlignment.end:
         leadingSpace = remainingSpace;
         betweenSpace = 0.0;
-        break;
       case MainAxisAlignment.center:
         leadingSpace = remainingSpace / 2.0;
         betweenSpace = 0.0;
-        break;
       case MainAxisAlignment.spaceBetween:
         leadingSpace = 0.0;
         betweenSpace = childCount > 1 ? remainingSpace / (childCount - 1) : 0.0;
-        break;
       case MainAxisAlignment.spaceAround:
         betweenSpace = childCount > 0 ? remainingSpace / childCount : 0.0;
         leadingSpace = betweenSpace / 2.0;
-        break;
       case MainAxisAlignment.spaceEvenly:
         betweenSpace = childCount > 0 ? remainingSpace / (childCount + 1) : 0.0;
         leadingSpace = betweenSpace;
-        break;
     }
 
     // Position elements
@@ -1019,13 +994,10 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
                                == (_crossAxisAlignment == CrossAxisAlignment.start)
                              ? 0.0
                              : crossSize - _getCrossSize(child.size);
-          break;
         case CrossAxisAlignment.center:
           childCrossPosition = crossSize / 2.0 - _getCrossSize(child.size) / 2.0;
-          break;
         case CrossAxisAlignment.stretch:
           childCrossPosition = 0.0;
-          break;
         case CrossAxisAlignment.baseline:
           if (_direction == Axis.horizontal) {
             assert(textBaseline != null);
@@ -1038,7 +1010,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           } else {
             childCrossPosition = 0.0;
           }
-          break;
       }
       if (flipMainAxis) {
         childMainPosition -= _getMainSize(child.size);
@@ -1046,10 +1017,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       switch (_direction) {
         case Axis.horizontal:
           childParentData.offset = Offset(childMainPosition, childCrossPosition);
-          break;
         case Axis.vertical:
           childParentData.offset = Offset(childCrossPosition, childMainPosition);
-          break;
       }
       if (flipMainAxis) {
         childMainPosition -= betweenSpace;
@@ -1117,10 +1086,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       switch (_direction) {
         case Axis.horizontal:
           overflowChildRect = Rect.fromLTWH(0.0, 0.0, size.width + _overflow, 0.0);
-          break;
         case Axis.vertical:
           overflowChildRect = Rect.fromLTWH(0.0, 0.0, 0.0, size.height + _overflow);
-          break;
       }
       paintOverflowIndicator(context, offset, Offset.zero & size, overflowChildRect, overflowHints: debugOverflowHints);
       return true;

--- a/packages/flutter/lib/src/rendering/list_body.dart
+++ b/packages/flutter/lib/src/rendering/list_body.dart
@@ -95,12 +95,10 @@ class RenderListBody extends RenderBox
           if (!constraints.hasBoundedWidth) {
             return true;
           }
-          break;
         case Axis.vertical:
           if (!constraints.hasBoundedHeight) {
             return true;
           }
-          break;
       }
       throw FlutterError.fromParts(<DiagnosticsNode>[
         ErrorSummary('RenderListBody must have unlimited space along its main axis.'),
@@ -121,12 +119,10 @@ class RenderListBody extends RenderBox
           if (constraints.hasBoundedHeight) {
             return true;
           }
-          break;
         case Axis.vertical:
           if (constraints.hasBoundedWidth) {
             return true;
           }
-          break;
       }
       // TODO(ianh): Detect if we're actually nested blocks and say something
       // more specific to the exact situation in that case, and don't mention
@@ -170,7 +166,6 @@ class RenderListBody extends RenderBox
           child = childParentData.nextSibling;
         }
         size = constraints.constrain(Size(mainAxisExtent, constraints.maxHeight));
-        break;
       case AxisDirection.left:
         final BoxConstraints innerConstraints = BoxConstraints.tightFor(height: constraints.maxHeight);
         while (child != null) {
@@ -190,7 +185,6 @@ class RenderListBody extends RenderBox
           child = childParentData.nextSibling;
         }
         size = constraints.constrain(Size(mainAxisExtent, constraints.maxHeight));
-        break;
       case AxisDirection.down:
         final BoxConstraints innerConstraints = BoxConstraints.tightFor(width: constraints.maxWidth);
         while (child != null) {
@@ -202,7 +196,6 @@ class RenderListBody extends RenderBox
           child = childParentData.nextSibling;
         }
         size = constraints.constrain(Size(constraints.maxWidth, mainAxisExtent));
-        break;
       case AxisDirection.up:
         final BoxConstraints innerConstraints = BoxConstraints.tightFor(width: constraints.maxWidth);
         while (child != null) {
@@ -222,7 +215,6 @@ class RenderListBody extends RenderBox
           child = childParentData.nextSibling;
         }
         size = constraints.constrain(Size(constraints.maxWidth, mainAxisExtent));
-        break;
     }
     assert(size.isFinite);
   }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -134,7 +134,6 @@ class RenderParagraph extends RenderBox
         _textPainter.text = value;
         _cachedCombinedSemanticsInfos = null;
         markNeedsSemanticsUpdate();
-        break;
       case RenderComparison.paint:
         _textPainter.text = value;
         _cachedAttributedLabels = null;
@@ -142,7 +141,6 @@ class RenderParagraph extends RenderBox
         _extractPlaceholderSpans(value);
         markNeedsPaint();
         markNeedsSemanticsUpdate();
-        break;
       case RenderComparison.layout:
         _textPainter.text = value;
         _overflowShader = null;
@@ -153,7 +151,6 @@ class RenderParagraph extends RenderBox
         _removeSelectionRegistrarSubscription();
         _disposeSelectableFragments();
         _updateSelectionRegistrarSubscription();
-        break;
     }
   }
 
@@ -690,14 +687,12 @@ class RenderParagraph extends RenderBox
             baselineOffset = child.getDistanceToBaseline(
               _placeholderSpans[childIndex].baseline!,
             );
-            break;
           case ui.PlaceholderAlignment.aboveBaseline:
           case ui.PlaceholderAlignment.belowBaseline:
           case ui.PlaceholderAlignment.bottom:
           case ui.PlaceholderAlignment.middle:
           case ui.PlaceholderAlignment.top:
             baselineOffset = null;
-            break;
         }
       } else {
         assert(_placeholderSpans[childIndex].alignment != ui.PlaceholderAlignment.baseline);
@@ -793,12 +788,10 @@ class RenderParagraph extends RenderBox
         case TextOverflow.visible:
           _needsClipping = false;
           _overflowShader = null;
-          break;
         case TextOverflow.clip:
         case TextOverflow.ellipsis:
           _needsClipping = true;
           _overflowShader = null;
-          break;
         case TextOverflow.fade:
           _needsClipping = true;
           final TextPainter fadeSizePainter = TextPainter(
@@ -813,11 +806,9 @@ class RenderParagraph extends RenderBox
               case TextDirection.rtl:
                 fadeEnd = 0.0;
                 fadeStart = fadeSizePainter.width;
-                break;
               case TextDirection.ltr:
                 fadeEnd = size.width;
                 fadeStart = fadeEnd - fadeSizePainter.width;
-                break;
             }
             _overflowShader = ui.Gradient.linear(
               Offset(fadeStart, 0.0),
@@ -834,7 +825,6 @@ class RenderParagraph extends RenderBox
             );
           }
           fadeSizePainter.dispose();
-          break;
       }
     } else {
       _needsClipping = false;
@@ -1402,17 +1392,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       case SelectionEventType.endEdgeUpdate:
         final SelectionEdgeUpdateEvent edgeUpdate = event as SelectionEdgeUpdateEvent;
         result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
-        break;
       case SelectionEventType.clear:
         result = _handleClearSelection();
-        break;
       case SelectionEventType.selectAll:
         result = _handleSelectAll();
-        break;
       case SelectionEventType.selectWord:
         final SelectWordSelectionEvent selectWord = event as SelectWordSelectionEvent;
         result = _handleSelectWord(selectWord.globalPosition);
-        break;
       case SelectionEventType.granularlyExtendSelection:
         final GranularlyExtendSelectionEvent granularlyExtendSelection = event as GranularlyExtendSelectionEvent;
         result = _handleGranularlyExtendSelection(
@@ -1420,7 +1406,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           granularlyExtendSelection.isEnd,
           granularlyExtendSelection.granularity,
         );
-        break;
       case SelectionEventType.directionallyExtendSelection:
         final DirectionallyExtendSelectionEvent directionallyExtendSelection = event as DirectionallyExtendSelectionEvent;
         result = _handleDirectionallyExtendSelection(
@@ -1428,7 +1413,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           directionallyExtendSelection.isEnd,
           directionallyExtendSelection.direction,
         );
-        break;
     }
 
     if (existingSelectionStart != _textSelectionStart ||
@@ -1567,7 +1551,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         );
         newPosition = moveResult.key;
         result = moveResult.value;
-        break;
       case SelectionExtendDirection.forward:
       case SelectionExtendDirection.backward:
         _textSelectionEnd ??= movement == SelectionExtendDirection.forward
@@ -1583,7 +1566,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         );
         newPosition = paragraph.getPositionForOffset(baselineOffsetInParagraphCoordinates);
         result = SelectionResult.end;
-        break;
     }
     if (isExtent) {
       _textSelectionEnd = newPosition;
@@ -1612,16 +1594,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         final String text = range.textInside(fullText);
         newPosition = _moveBeyondTextBoundaryAtDirection(targetedEdge, forward, CharacterBoundary(text));
         result = SelectionResult.end;
-        break;
       case TextGranularity.word:
         final TextBoundary textBoundary = paragraph._textPainter.wordBoundaries.moveByWordBoundary;
         newPosition = _moveBeyondTextBoundaryAtDirection(targetedEdge, forward, textBoundary);
         result = SelectionResult.end;
-        break;
       case TextGranularity.line:
         newPosition = _moveToTextBoundaryAtDirection(targetedEdge, forward, LineBoundary(this));
         result = SelectionResult.end;
-        break;
       case TextGranularity.document:
         final String text = range.textInside(fullText);
         newPosition = _moveBeyondTextBoundaryAtDirection(targetedEdge, forward, DocumentBoundary(text));
@@ -1632,7 +1611,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         } else {
           result = SelectionResult.end;
         }
-        break;
     }
 
     if (isExtent) {
@@ -1671,10 +1649,8 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           0,
           characterBoundary.getLeadingTextBoundaryAt(range.start + end.offset) ?? range.start,
         ) - 1;
-        break;
       case TextAffinity.downstream:
         caretOffset = end.offset;
-        break;
     }
     final int offset = forward
       ? textBoundary.getTrailingTextBoundaryAt(caretOffset) ?? range.end

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2768,7 +2768,6 @@ class RenderFittedBox extends RenderProxyBox {
           final BoxConstraints sizeConstraints = constraints.loosen();
           final Size unconstrainedSize = sizeConstraints.constrainSizeAndAttemptToPreserveAspectRatio(child!.size);
           size = constraints.constrain(unconstrainedSize);
-          break;
         case BoxFit.contain:
         case BoxFit.cover:
         case BoxFit.fill:
@@ -2776,7 +2775,6 @@ class RenderFittedBox extends RenderProxyBox {
         case BoxFit.fitWidth:
         case BoxFit.none:
           size = constraints.constrainSizeAndAttemptToPreserveAspectRatio(child!.size);
-          break;
       }
       _clearPaintData();
     } else {

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -819,7 +819,6 @@ class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugO
       switch (clipBehavior) {
         case Clip.none:
           paintOverflowIndicator(context, offset, _overflowContainerRect, _overflowChildRect);
-          break;
         case Clip.hardEdge:
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1452,13 +1452,11 @@ abstract class RenderSliver extends RenderObject {
       switch (direction) {
         case GrowthDirection.forward:
           dx1 = dx2 = dy1 = dy2 = d;
-          break;
         case GrowthDirection.reverse:
           temp = p0;
           p0 = p1;
           p1 = temp;
           dx1 = dx2 = dy1 = dy2 = -d;
-          break;
       }
       if (p0.dx == p1.dx) {
         dx2 = -dx2;
@@ -1517,7 +1515,6 @@ abstract class RenderSliver extends RenderObject {
               offset.translate(constraints.crossAxisExtent * 3.0 / 4.0, arrowExtent - padding),
               constraints.normalizedGrowthDirection,
             );
-            break;
           case Axis.horizontal:
             canvas.drawLine(
               offset,
@@ -1538,7 +1535,6 @@ abstract class RenderSliver extends RenderObject {
               offset.translate(arrowExtent - padding, constraints.crossAxisExtent * 3.0 / 4.0),
               constraints.normalizedGrowthDirection,
             );
-            break;
         }
       }
       return true;
@@ -1564,18 +1560,15 @@ mixin RenderSliverHelpers implements RenderSliver {
       case AxisDirection.up:
       case AxisDirection.left:
         rightWayUp = false;
-        break;
       case AxisDirection.down:
       case AxisDirection.right:
         rightWayUp = true;
-        break;
     }
     switch (constraints.growthDirection) {
       case GrowthDirection.forward:
         break;
       case GrowthDirection.reverse:
         rightWayUp = !rightWayUp;
-        break;
     }
     return rightWayUp;
   }
@@ -1606,7 +1599,6 @@ mixin RenderSliverHelpers implements RenderSliver {
         }
         paintOffset = Offset(delta, crossAxisDelta);
         transformedPosition = Offset(absolutePosition, absoluteCrossAxisPosition);
-        break;
       case Axis.vertical:
         if (!rightWayUp) {
           absolutePosition = child.size.height - absolutePosition;
@@ -1614,7 +1606,6 @@ mixin RenderSliverHelpers implements RenderSliver {
         }
         paintOffset = Offset(crossAxisDelta, delta);
         transformedPosition = Offset(absoluteCrossAxisPosition, absolutePosition);
-        break;
     }
     return result.addWithOutOfBandPosition(
       paintOffset: paintOffset,
@@ -1643,13 +1634,11 @@ mixin RenderSliverHelpers implements RenderSliver {
           delta = geometry!.paintExtent - child.size.width - delta;
         }
         transform.translate(delta, crossAxisDelta);
-        break;
       case Axis.vertical:
         if (!rightWayUp) {
           delta = geometry!.paintExtent - child.size.height - delta;
         }
         transform.translate(crossAxisDelta, delta);
-        break;
     }
   }
 }
@@ -1691,16 +1680,12 @@ abstract class RenderSliverSingleBoxAdapter extends RenderSliver with RenderObje
     switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
       case AxisDirection.up:
         childParentData.paintOffset = Offset(0.0, -(geometry.scrollExtent - (geometry.paintExtent + constraints.scrollOffset)));
-        break;
       case AxisDirection.right:
         childParentData.paintOffset = Offset(-constraints.scrollOffset, 0.0);
-        break;
       case AxisDirection.down:
         childParentData.paintOffset = Offset(0.0, -constraints.scrollOffset);
-        break;
       case AxisDirection.left:
         childParentData.paintOffset = Offset(-(geometry.scrollExtent - (geometry.paintExtent + constraints.scrollOffset)), 0.0);
-        break;
     }
   }
 
@@ -1764,10 +1749,8 @@ class RenderSliverToBoxAdapter extends RenderSliverSingleBoxAdapter {
     switch (constraints.axis) {
       case Axis.horizontal:
         childExtent = child!.size.width;
-        break;
       case Axis.vertical:
         childExtent = child!.size.height;
-        break;
     }
     final double paintedChildSize = calculatePaintOffset(constraints, from: 0.0, to: childExtent);
     final double cacheExtent = calculateCacheOffset(constraints, from: 0.0, to: childExtent);

--- a/packages/flutter/lib/src/rendering/sliver_fill.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fill.dart
@@ -144,10 +144,8 @@ class RenderSliverFillRemaining extends RenderSliverSingleBoxAdapter {
       switch (constraints.axis) {
         case Axis.horizontal:
           childExtent = child!.getMaxIntrinsicWidth(constraints.crossAxisExtent);
-          break;
         case Axis.vertical:
           childExtent = child!.getMaxIntrinsicHeight(constraints.crossAxisExtent);
-          break;
       }
 
       // If the childExtent is greater than the computed extent, we want to use
@@ -221,10 +219,8 @@ class RenderSliverFillRemainingAndOverscroll extends RenderSliverSingleBoxAdapte
       switch (constraints.axis) {
         case Axis.horizontal:
           childExtent = child!.getMaxIntrinsicWidth(constraints.crossAxisExtent);
-          break;
         case Axis.vertical:
           childExtent = child!.getMaxIntrinsicHeight(constraints.crossAxisExtent);
-          break;
       }
 
       // If the childExtent is greater than the computed extent, we want to use

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -615,25 +615,21 @@ abstract class RenderSliverMultiBoxAdaptor extends RenderSliver
         crossAxisUnit = const Offset(1.0, 0.0);
         originOffset = offset + Offset(0.0, geometry!.paintExtent);
         addExtent = true;
-        break;
       case AxisDirection.right:
         mainAxisUnit = const Offset(1.0, 0.0);
         crossAxisUnit = const Offset(0.0, 1.0);
         originOffset = offset;
         addExtent = false;
-        break;
       case AxisDirection.down:
         mainAxisUnit = const Offset(0.0, 1.0);
         crossAxisUnit = const Offset(1.0, 0.0);
         originOffset = offset;
         addExtent = false;
-        break;
       case AxisDirection.left:
         mainAxisUnit = const Offset(-1.0, 0.0);
         crossAxisUnit = const Offset(0.0, 1.0);
         originOffset = offset + Offset(geometry!.paintExtent, 0.0);
         addExtent = true;
-        break;
     }
     RenderBox? child = firstChild;
     while (child != null) {

--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -194,16 +194,12 @@ abstract class RenderSliverEdgeInsetsPadding extends RenderSliver with RenderObj
     switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
       case AxisDirection.up:
         childParentData.paintOffset = Offset(resolvedPadding!.left, calculatePaintOffset(constraints, from: resolvedPadding!.bottom + childLayoutGeometry.scrollExtent, to: resolvedPadding!.bottom + childLayoutGeometry.scrollExtent + resolvedPadding!.top));
-        break;
       case AxisDirection.right:
         childParentData.paintOffset = Offset(calculatePaintOffset(constraints, from: 0.0, to: resolvedPadding!.left), resolvedPadding!.top);
-        break;
       case AxisDirection.down:
         childParentData.paintOffset = Offset(resolvedPadding!.left, calculatePaintOffset(constraints, from: 0.0, to: resolvedPadding!.top));
-        break;
       case AxisDirection.left:
         childParentData.paintOffset = Offset(calculatePaintOffset(constraints, from: resolvedPadding!.right + childLayoutGeometry.scrollExtent, to: resolvedPadding!.right + childLayoutGeometry.scrollExtent + resolvedPadding!.left), resolvedPadding!.top);
-        break;
     }
     assert(beforePadding == this.beforePadding);
     assert(afterPadding == this.afterPadding);

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -301,16 +301,12 @@ abstract class RenderSliverPersistentHeader extends RenderSliver with RenderObje
       switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
         case AxisDirection.up:
           offset += Offset(0.0, geometry!.paintExtent - childMainAxisPosition(child!) - childExtent);
-          break;
         case AxisDirection.down:
           offset += Offset(0.0, childMainAxisPosition(child!));
-          break;
         case AxisDirection.left:
           offset += Offset(geometry!.paintExtent - childMainAxisPosition(child!) - childExtent, 0.0);
-          break;
         case AxisDirection.right:
           offset += Offset(childMainAxisPosition(child!), 0.0);
-          break;
       }
       context.paintChild(child!, offset);
     }
@@ -454,16 +450,12 @@ abstract class RenderSliverPinnedPersistentHeader extends RenderSliverPersistent
     switch (applyGrowthDirectionToAxisDirection(constraints.axisDirection, constraints.growthDirection)) {
       case AxisDirection.up:
         newRect = _trim(localBounds, bottom: childExtent);
-        break;
       case AxisDirection.right:
         newRect = _trim(localBounds, left: 0);
-        break;
       case AxisDirection.down:
         newRect = _trim(localBounds, top: 0);
-        break;
       case AxisDirection.left:
         newRect = _trim(localBounds, right: childExtent);
-        break;
     }
 
     super.showOnScreen(
@@ -723,19 +715,15 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
       case AxisDirection.up:
         targetExtent = childExtent - (childBounds?.top ?? 0);
         targetRect = _trim(childBounds, bottom: childExtent);
-        break;
       case AxisDirection.right:
         targetExtent = childBounds?.right ?? childExtent;
         targetRect = _trim(childBounds, left: 0);
-        break;
       case AxisDirection.down:
         targetExtent = childBounds?.bottom ?? childExtent;
         targetRect = _trim(childBounds, top: 0);
-        break;
       case AxisDirection.left:
         targetExtent = childExtent - (childBounds?.left ?? 0);
         targetRect = _trim(childBounds, right: childExtent);
-        break;
     }
 
     // A stretch header can have a bigger childExtent than maxExtent.

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -76,11 +76,9 @@ class RelativeRect {
       case TextDirection.rtl:
         left = end;
         right = start;
-        break;
       case TextDirection.ltr:
         left = start;
         right = end;
-        break;
     }
 
     return RelativeRect.fromLTRB(left, top, right, bottom);
@@ -566,13 +564,10 @@ class RenderStack extends RenderBox
     switch (fit) {
       case StackFit.loose:
         nonPositionedConstraints = constraints.loosen();
-        break;
       case StackFit.expand:
         nonPositionedConstraints = BoxConstraints.tight(constraints.biggest);
-        break;
       case StackFit.passthrough:
         nonPositionedConstraints = constraints;
-        break;
     }
 
     RenderBox? child = firstChild;

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1059,7 +1059,6 @@ class RenderTable extends RenderBox {
             case TableCellVerticalAlignment.bottom:
               final Size childSize = child.getDryLayout(BoxConstraints.tightFor(width: widths[x]));
               rowHeight = math.max(rowHeight, childSize.height);
-              break;
             case TableCellVerticalAlignment.fill:
               break;
           }
@@ -1093,7 +1092,6 @@ class RenderTable extends RenderBox {
         }
         _columnLefts = positions.reversed;
         _tableWidth = positions.first + widths.first;
-        break;
       case TextDirection.ltr:
         positions[0] = 0.0;
         for (int x = 1; x < columns; x += 1) {
@@ -1101,7 +1099,6 @@ class RenderTable extends RenderBox {
         }
         _columnLefts = positions;
         _tableWidth = positions.last + widths.last;
-        break;
     }
     _rowTops.clear();
     _baselineDistance = null;
@@ -1135,13 +1132,11 @@ class RenderTable extends RenderBox {
                 rowHeight = math.max(rowHeight, child.size.height);
                 childParentData.offset = Offset(positions[x], rowTop);
               }
-              break;
             case TableCellVerticalAlignment.top:
             case TableCellVerticalAlignment.middle:
             case TableCellVerticalAlignment.bottom:
               child.layout(BoxConstraints.tightFor(width: widths[x]), parentUsesSize: true);
               rowHeight = math.max(rowHeight, child.size.height);
-              break;
             case TableCellVerticalAlignment.fill:
               break;
           }
@@ -1161,20 +1156,15 @@ class RenderTable extends RenderBox {
           switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
             case TableCellVerticalAlignment.baseline:
               childParentData.offset = Offset(positions[x], rowTop + beforeBaselineDistance - baselines[x]);
-              break;
             case TableCellVerticalAlignment.top:
               childParentData.offset = Offset(positions[x], rowTop);
-              break;
             case TableCellVerticalAlignment.middle:
               childParentData.offset = Offset(positions[x], rowTop + (rowHeight - child.size.height) / 2.0);
-              break;
             case TableCellVerticalAlignment.bottom:
               childParentData.offset = Offset(positions[x], rowTop + rowHeight - child.size.height);
-              break;
             case TableCellVerticalAlignment.fill:
               child.layout(BoxConstraints.tightFor(width: widths[x], height: rowHeight));
               childParentData.offset = Offset(positions[x], rowTop);
-              break;
           }
         }
       }

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -227,7 +227,6 @@ class TableBorder {
               path.lineTo(rect.left + x, rect.bottom);
             }
             canvas.drawPath(path, paint);
-            break;
           case BorderStyle.none:
             break;
         }
@@ -246,7 +245,6 @@ class TableBorder {
               path.lineTo(rect.right, rect.top + y);
             }
             canvas.drawPath(path, paint);
-            break;
           case BorderStyle.none:
             break;
         }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -306,7 +306,6 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         lowerOverlayStyle = layer!.find<SystemUiOverlayStyle>(bottom);
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
       case TargetPlatform.linux:

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -625,16 +625,12 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     switch (applyGrowthDirectionToAxisDirection(axisDirection, child.constraints.growthDirection)) {
       case AxisDirection.down:
         top += overlapCorrection;
-        break;
       case AxisDirection.up:
         bottom -= overlapCorrection;
-        break;
       case AxisDirection.right:
         left += overlapCorrection;
-        break;
       case AxisDirection.left:
         right -= overlapCorrection;
-        break;
     }
     return Rect.fromLTRB(left, top, right, bottom);
   }
@@ -715,10 +711,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
         switch (axis) {
           case Axis.vertical:
             size = Size(child.constraints.crossAxisExtent, child.geometry!.layoutExtent);
-            break;
           case Axis.horizontal:
             size = Size(child.geometry!.layoutExtent, child.constraints.crossAxisExtent);
-            break;
         }
         canvas.drawRect(((offset + paintOffsetOf(child)) & size).deflate(0.5), paint);
         child = childAfter(child);
@@ -734,11 +728,9 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       case Axis.vertical:
         mainAxisPosition = position.dy;
         crossAxisPosition = position.dx;
-        break;
       case Axis.horizontal:
         mainAxisPosition = position.dx;
         crossAxisPosition = position.dy;
-        break;
     }
     final SliverHitTestResult sliverResult = SliverHitTestResult.wrap(result);
     for (final RenderSliver child in childrenInHitTestOrder) {
@@ -822,10 +814,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       switch (axis) {
         case Axis.horizontal:
           pivotExtent = pivot.size.width;
-          break;
         case Axis.vertical:
           pivotExtent = pivot.size.height;
-          break;
       }
       rect ??= target.paintBounds;
       rectLocal = MatrixUtils.transformRect(target.getTransformTo(pivot), rect);
@@ -845,14 +835,12 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
               targetSliver.geometry!.scrollExtent,
               targetSliver.constraints.crossAxisExtent,
             );
-            break;
           case Axis.vertical:
             rect = Rect.fromLTWH(
               0, 0,
               targetSliver.constraints.crossAxisExtent,
               targetSliver.geometry!.scrollExtent,
             );
-            break;
         }
       }
       rectLocal = rect;
@@ -871,19 +859,15 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
       case AxisDirection.up:
         leadingScrollOffset += pivotExtent - rectLocal.bottom;
         targetMainAxisExtent = rectLocal.height;
-        break;
       case AxisDirection.right:
         leadingScrollOffset += rectLocal.left;
         targetMainAxisExtent = rectLocal.width;
-        break;
       case AxisDirection.down:
         leadingScrollOffset += rectLocal.top;
         targetMainAxisExtent = rectLocal.height;
-        break;
       case AxisDirection.left:
         leadingScrollOffset += pivotExtent - rectLocal.right;
         targetMainAxisExtent = rectLocal.width;
-        break;
     }
 
     // So far leadingScrollOffset is the scroll offset of `rect` in the `child`
@@ -910,7 +894,6 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
           return RevealedOffset(offset: double.infinity, rect: targetRect);
         }
         leadingScrollOffset -= extentOfPinnedSlivers;
-        break;
       case GrowthDirection.reverse:
         if (isPinned && alignment >= 1) {
           return RevealedOffset(offset: double.negativeInfinity, rect: targetRect);
@@ -921,22 +904,17 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
         switch (axis) {
           case Axis.vertical:
             leadingScrollOffset -= targetRect.height;
-            break;
           case Axis.horizontal:
             leadingScrollOffset -= targetRect.width;
-            break;
         }
-        break;
     }
 
     final double mainAxisExtent;
     switch (axis) {
       case Axis.horizontal:
         mainAxisExtent = size.width - extentOfPinnedSlivers;
-        break;
       case Axis.vertical:
         mainAxisExtent = size.height - extentOfPinnedSlivers;
-        break;
     }
 
     final double targetOffset = leadingScrollOffset - (mainAxisExtent - targetMainAxisExtent) * alignment;
@@ -945,16 +923,12 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     switch (axisDirection) {
       case AxisDirection.down:
         targetRect = targetRect.translate(0.0, offsetDifference);
-        break;
       case AxisDirection.right:
         targetRect = targetRect.translate(offsetDifference, 0.0);
-        break;
       case AxisDirection.up:
         targetRect = targetRect.translate(0.0, -offsetDifference);
-        break;
       case AxisDirection.left:
         targetRect = targetRect.translate(-offsetDifference, 0.0);
-        break;
     }
 
     return RevealedOffset(offset: targetOffset, rect: targetRect);
@@ -1407,10 +1381,8 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     switch (axis) {
       case Axis.vertical:
         offset.applyViewportDimension(size.height);
-        break;
       case Axis.horizontal:
         offset.applyViewportDimension(size.width);
-        break;
     }
 
     if (center == null) {
@@ -1429,11 +1401,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
       case Axis.vertical:
         mainAxisExtent = size.height;
         crossAxisExtent = size.width;
-        break;
       case Axis.horizontal:
         mainAxisExtent = size.width;
         crossAxisExtent = size.height;
-        break;
     }
 
     final double centerOffsetAdjustment = center!.centerOffsetAdjustment;
@@ -1500,10 +1470,8 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     switch (cacheExtentStyle) {
       case CacheExtentStyle.pixel:
         _calculatedCacheExtent = cacheExtent;
-        break;
       case CacheExtentStyle.viewport:
         _calculatedCacheExtent = mainAxisExtent * _cacheExtent;
-        break;
     }
 
     final double fullCacheExtent = mainAxisExtent + 2 * _calculatedCacheExtent!;
@@ -1557,10 +1525,8 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
     switch (growthDirection) {
       case GrowthDirection.forward:
         _maxScrollExtent += childLayoutGeometry.scrollExtent;
-        break;
       case GrowthDirection.reverse:
         _minScrollExtent -= childLayoutGeometry.scrollExtent;
-        break;
     }
     if (childLayoutGeometry.hasVisualOverflow) {
       _hasVisualOverflow = true;
@@ -1806,7 +1772,6 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
               'unlimited amount of horizontal space in which to expand.',
             );
           }
-          break;
         case Axis.horizontal:
           if (!constraints.hasBoundedHeight) {
             throw FlutterError(
@@ -1817,7 +1782,6 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
               'unlimited amount of vertical space in which to expand.',
             );
           }
-          break;
       }
       return true;
     }());
@@ -1833,10 +1797,8 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
       switch (axis) {
         case Axis.vertical:
           size = Size(constraints.maxWidth, constraints.minHeight);
-          break;
         case Axis.horizontal:
           size = Size(constraints.minWidth, constraints.maxHeight);
-          break;
       }
       offset.applyViewportDimension(0.0);
       _maxScrollExtent = 0.0;
@@ -1854,11 +1816,9 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
       case Axis.vertical:
         mainAxisExtent = constraints.maxHeight;
         crossAxisExtent = constraints.maxWidth;
-        break;
       case Axis.horizontal:
         mainAxisExtent = constraints.maxWidth;
         crossAxisExtent = constraints.maxHeight;
-        break;
     }
 
     double correction;
@@ -1871,10 +1831,8 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
         switch (axis) {
           case Axis.vertical:
             effectiveExtent = constraints.constrainHeight(_shrinkWrapExtent);
-            break;
           case Axis.horizontal:
             effectiveExtent = constraints.constrainWidth(_shrinkWrapExtent);
-            break;
         }
         final bool didAcceptViewportDimension = offset.applyViewportDimension(effectiveExtent);
         final bool didAcceptContentDimension = offset.applyContentDimensions(0.0, math.max(0.0, _maxScrollExtent - effectiveExtent));
@@ -1886,10 +1844,8 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     switch (axis) {
       case Axis.vertical:
         size = constraints.constrainDimensions(crossAxisExtent, effectiveExtent);
-        break;
       case Axis.horizontal:
         size = constraints.constrainDimensions(effectiveExtent, crossAxisExtent);
-        break;
     }
   }
 
@@ -1913,10 +1869,8 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     switch (cacheExtentStyle) {
       case CacheExtentStyle.pixel:
         _calculatedCacheExtent = cacheExtent;
-        break;
       case CacheExtentStyle.viewport:
         _calculatedCacheExtent = mainAxisExtent * _cacheExtent;
-        break;
     }
 
     return layoutChildSequence(

--- a/packages/flutter/lib/src/rendering/wrap.dart
+++ b/packages/flutter/lib/src/rendering/wrap.dart
@@ -344,7 +344,6 @@ class RenderWrap extends RenderBox
       switch (direction) {
         case Axis.horizontal:
           assert(textDirection != null, 'Horizontal $runtimeType with multiple children has a null textDirection, so the layout order is undefined.');
-          break;
         case Axis.vertical:
           break;
       }
@@ -353,7 +352,6 @@ class RenderWrap extends RenderBox
       switch (direction) {
         case Axis.horizontal:
           assert(textDirection != null, 'Horizontal $runtimeType with alignment $alignment has a null textDirection, so the alignment cannot be resolved.');
-          break;
         case Axis.vertical:
           break;
       }
@@ -364,7 +362,6 @@ class RenderWrap extends RenderBox
           break;
         case Axis.vertical:
           assert(textDirection != null, 'Vertical $runtimeType with runAlignment $runAlignment has a null textDirection, so the alignment cannot be resolved.');
-          break;
       }
     }
     if (crossAxisAlignment == WrapCrossAlignment.start || crossAxisAlignment == WrapCrossAlignment.end) {
@@ -373,7 +370,6 @@ class RenderWrap extends RenderBox
           break;
         case Axis.vertical:
           assert(textDirection != null, 'Vertical $runtimeType with crossAxisAlignment $crossAxisAlignment has a null textDirection, so the alignment cannot be resolved.');
-          break;
       }
     }
     return true;
@@ -508,11 +504,9 @@ class RenderWrap extends RenderBox
       case Axis.horizontal:
         childConstraints = BoxConstraints(maxWidth: constraints.maxWidth);
         mainAxisLimit = constraints.maxWidth;
-        break;
       case Axis.vertical:
         childConstraints = BoxConstraints(maxHeight: constraints.maxHeight);
         mainAxisLimit = constraints.maxHeight;
-        break;
     }
 
     double mainAxisExtent = 0.0;
@@ -576,7 +570,6 @@ class RenderWrap extends RenderBox
         if (verticalDirection == VerticalDirection.up) {
           flipCrossAxis = true;
         }
-        break;
       case Axis.vertical:
         childConstraints = BoxConstraints(maxHeight: constraints.maxHeight);
         mainAxisLimit = constraints.maxHeight;
@@ -586,7 +579,6 @@ class RenderWrap extends RenderBox
         if (textDirection == TextDirection.rtl) {
           flipCrossAxis = true;
         }
-        break;
     }
     final double spacing = this.spacing;
     final double runSpacing = this.runSpacing;
@@ -641,12 +633,10 @@ class RenderWrap extends RenderBox
         size = constraints.constrain(Size(mainAxisExtent, crossAxisExtent));
         containerMainAxisExtent = size.width;
         containerCrossAxisExtent = size.height;
-        break;
       case Axis.vertical:
         size = constraints.constrain(Size(crossAxisExtent, mainAxisExtent));
         containerMainAxisExtent = size.height;
         containerCrossAxisExtent = size.width;
-        break;
     }
 
     _hasVisualOverflow = containerMainAxisExtent < mainAxisExtent || containerCrossAxisExtent < crossAxisExtent;
@@ -659,21 +649,16 @@ class RenderWrap extends RenderBox
         break;
       case WrapAlignment.end:
         runLeadingSpace = crossAxisFreeSpace;
-        break;
       case WrapAlignment.center:
         runLeadingSpace = crossAxisFreeSpace / 2.0;
-        break;
       case WrapAlignment.spaceBetween:
         runBetweenSpace = runCount > 1 ? crossAxisFreeSpace / (runCount - 1) : 0.0;
-        break;
       case WrapAlignment.spaceAround:
         runBetweenSpace = crossAxisFreeSpace / runCount;
         runLeadingSpace = runBetweenSpace / 2.0;
-        break;
       case WrapAlignment.spaceEvenly:
         runBetweenSpace = crossAxisFreeSpace / (runCount + 1);
         runLeadingSpace = runBetweenSpace;
-        break;
     }
 
     runBetweenSpace += runSpacing;
@@ -695,21 +680,16 @@ class RenderWrap extends RenderBox
           break;
         case WrapAlignment.end:
           childLeadingSpace = mainAxisFreeSpace;
-          break;
         case WrapAlignment.center:
           childLeadingSpace = mainAxisFreeSpace / 2.0;
-          break;
         case WrapAlignment.spaceBetween:
           childBetweenSpace = childCount > 1 ? mainAxisFreeSpace / (childCount - 1) : 0.0;
-          break;
         case WrapAlignment.spaceAround:
           childBetweenSpace = mainAxisFreeSpace / childCount;
           childLeadingSpace = childBetweenSpace / 2.0;
-          break;
         case WrapAlignment.spaceEvenly:
           childBetweenSpace = mainAxisFreeSpace / (childCount + 1);
           childLeadingSpace = childBetweenSpace;
-          break;
       }
 
       childBetweenSpace += spacing;

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -390,11 +390,9 @@ mixin SchedulerBinding on BindingBase {
       case AppLifecycleState.resumed:
       case AppLifecycleState.inactive:
         _setFramesEnabledState(true);
-        break;
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:
         _setFramesEnabledState(false);
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4741,10 +4741,8 @@ AttributedString _concatAttributedString({
     switch (otherTextDirection) {
       case TextDirection.rtl:
         otherAttributedString = AttributedString(Unicode.RLE) + otherAttributedString + AttributedString(Unicode.PDF);
-        break;
       case TextDirection.ltr:
         otherAttributedString = AttributedString(Unicode.LRE) + otherAttributedString + AttributedString(Unicode.PDF);
-        break;
     }
   }
   if (thisAttributedString.string.isEmpty) {

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -149,7 +149,6 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
     switch (type) {
       case 'memoryPressure':
         handleMemoryPressure();
-        break;
     }
     return;
   }
@@ -272,7 +271,6 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
         if (_systemUiChangeCallback != null) {
           await _systemUiChangeCallback!(args[0] as bool);
         }
-        break;
       case 'System.requestAppExit':
         return <String, dynamic>{'response': (await handleRequestAppExit()).name};
     }

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -78,7 +78,6 @@ class PlatformViewsService {
         if (_focusCallbacks.containsKey(id)) {
           _focusCallbacks[id]!();
         }
-        break;
       default:
         throw UnimplementedError("${call.method} was invoked but isn't implemented by PlatformViewsService");
     }
@@ -625,19 +624,14 @@ class _AndroidMotionEventConverter {
       case PointerDeviceKind.touch:
       case PointerDeviceKind.trackpad:
         toolType = AndroidPointerProperties.kToolTypeFinger;
-        break;
       case PointerDeviceKind.mouse:
         toolType = AndroidPointerProperties.kToolTypeMouse;
-        break;
       case PointerDeviceKind.stylus:
         toolType = AndroidPointerProperties.kToolTypeStylus;
-        break;
       case PointerDeviceKind.invertedStylus:
         toolType = AndroidPointerProperties.kToolTypeEraser;
-        break;
       case PointerDeviceKind.unknown:
         toolType = AndroidPointerProperties.kToolTypeUnknown;
-        break;
     }
     return AndroidPointerProperties(id: pointerId, toolType: toolType);
   }

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -330,7 +330,6 @@ abstract class RawKeyEvent with Diagnosticable {
           if (message.containsKey('character')) {
             character = message['character'] as String?;
           }
-          break;
         case 'fuchsia':
           final int codePoint = message['codePoint'] as int? ?? 0;
           data = RawKeyEventDataFuchsia(
@@ -341,7 +340,6 @@ abstract class RawKeyEvent with Diagnosticable {
           if (codePoint != 0) {
             character = String.fromCharCode(codePoint);
           }
-          break;
         case 'macos':
           data = RawKeyEventDataMacOs(
             characters: message['characters'] as String? ?? '',
@@ -351,7 +349,6 @@ abstract class RawKeyEvent with Diagnosticable {
             specifiedLogicalKey: message['specifiedLogicalKey'] as int?,
           );
           character = message['characters'] as String?;
-          break;
         case 'ios':
           data = RawKeyEventDataIos(
             characters: message['characters'] as String? ?? '',
@@ -359,7 +356,6 @@ abstract class RawKeyEvent with Diagnosticable {
             keyCode: message['keyCode'] as int? ?? 0,
             modifiers: message['modifiers'] as int? ?? 0,
           );
-          break;
         case 'linux':
           final int unicodeScalarValues = message['unicodeScalarValues'] as int? ?? 0;
           data = RawKeyEventDataLinux(
@@ -374,7 +370,6 @@ abstract class RawKeyEvent with Diagnosticable {
           if (unicodeScalarValues != 0) {
             character = String.fromCharCode(unicodeScalarValues);
           }
-          break;
         case 'windows':
           final int characterCodePoint = message['characterCodePoint'] as int? ?? 0;
           data = RawKeyEventDataWindows(
@@ -386,10 +381,8 @@ abstract class RawKeyEvent with Diagnosticable {
           if (characterCodePoint != 0) {
             character = String.fromCharCode(characterCodePoint);
           }
-          break;
         case 'web':
           data = dataFromWeb();
-          break;
         default:
           /// This exception would only be hit on platforms that haven't yet
           /// implemented raw key events, but will only be triggered if the

--- a/packages/flutter/lib/src/services/raw_keyboard_ios.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_ios.dart
@@ -162,19 +162,14 @@ class RawKeyEventDataIos extends RawKeyEventData {
     switch (key) {
       case ModifierKey.controlModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierControl, modifierLeftControl, modifierRightControl);
-        break;
       case ModifierKey.shiftModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierShift, modifierLeftShift, modifierRightShift);
-        break;
       case ModifierKey.altModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierOption, modifierLeftOption, modifierRightOption);
-        break;
       case ModifierKey.metaModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierCommand, modifierLeftCommand, modifierRightCommand);
-        break;
       case ModifierKey.capsLockModifier:
         result = independentModifier & modifierCapsLock != 0;
-        break;
     // On iOS, the function modifier bit is set for any function key, like F1,
     // F2, etc., but the meaning of ModifierKey.modifierFunction in Flutter is
     // that of the Fn modifier key, so there's no good way to emulate that on
@@ -185,7 +180,6 @@ class RawKeyEventDataIos extends RawKeyEventData {
       case ModifierKey.scrollLockModifier:
         // These modifier masks are not used in iOS keyboards.
         result = false;
-        break;
     }
     assert(!result || getModifierSide(key) != null, "$runtimeType thinks that a modifier is pressed, but can't figure out what side it's on.");
     return result;

--- a/packages/flutter/lib/src/services/raw_keyboard_linux.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_linux.dart
@@ -279,25 +279,19 @@ class GLFWKeyHelper implements KeyHelper {
       case shiftLeftKeyCode:
       case shiftRightKeyCode:
         modifierChange = modifierShift;
-        break;
       case controlLeftKeyCode:
       case controlRightKeyCode:
         modifierChange = modifierControl;
-        break;
       case altLeftKeyCode:
       case altRightKeyCode:
         modifierChange = modifierAlt;
-        break;
       case metaLeftKeyCode:
       case metaRightKeyCode:
         modifierChange = modifierMeta;
-        break;
       case capsLockKeyCode:
         modifierChange = modifierCapsLock;
-        break;
       case numLockKeyCode:
         modifierChange = modifierNumericPad;
-        break;
       default:
         break;
     }
@@ -422,26 +416,20 @@ class GtkKeyHelper implements KeyHelper {
       case shiftLeftKeyCode:
       case shiftRightKeyCode:
         modifierChange = modifierShift;
-        break;
       case controlLeftKeyCode:
       case controlRightKeyCode:
         modifierChange = modifierControl;
-        break;
       case altLeftKeyCode:
       case altRightKeyCode:
         modifierChange = modifierMod1;
-        break;
       case metaLeftKeyCode:
       case metaRightKeyCode:
         modifierChange = modifierMeta;
-        break;
       case capsLockKeyCode:
       case shiftLockKeyCode:
         modifierChange = modifierCapsLock;
-        break;
       case numLockKeyCode:
         modifierChange = modifierMod2;
-        break;
       default:
         break;
     }

--- a/packages/flutter/lib/src/services/raw_keyboard_macos.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_macos.dart
@@ -164,19 +164,14 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
     switch (key) {
       case ModifierKey.controlModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierControl, modifierLeftControl, modifierRightControl);
-        break;
       case ModifierKey.shiftModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierShift, modifierLeftShift, modifierRightShift);
-        break;
       case ModifierKey.altModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierOption, modifierLeftOption, modifierRightOption);
-        break;
       case ModifierKey.metaModifier:
         result = _isLeftRightModifierPressed(side, independentModifier & modifierCommand, modifierLeftCommand, modifierRightCommand);
-        break;
       case ModifierKey.capsLockModifier:
         result = independentModifier & modifierCapsLock != 0;
-        break;
     // On macOS, the function modifier bit is set for any function key, like F1,
     // F2, etc., but the meaning of ModifierKey.modifierFunction in Flutter is
     // that of the Fn modifier key, so there's no good way to emulate that on
@@ -187,7 +182,6 @@ class RawKeyEventDataMacOs extends RawKeyEventData {
       case ModifierKey.scrollLockModifier:
         // These modifier masks are not used in macOS keyboards.
         result = false;
-        break;
     }
     assert(!result || getModifierSide(key) != null, "$runtimeType thinks that a modifier is pressed, but can't figure out what side it's on.");
     return result;

--- a/packages/flutter/lib/src/services/raw_keyboard_windows.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard_windows.dart
@@ -122,32 +122,24 @@ class RawKeyEventDataWindows extends RawKeyEventData {
     switch (key) {
       case ModifierKey.controlModifier:
         result = _isLeftRightModifierPressed(side, modifierControl, modifierLeftControl, modifierRightControl);
-        break;
       case ModifierKey.shiftModifier:
         result = _isLeftRightModifierPressed(side, modifierShift, modifierLeftShift, modifierRightShift);
-        break;
       case ModifierKey.altModifier:
         result = _isLeftRightModifierPressed(side, modifierAlt, modifierLeftAlt, modifierRightAlt);
-        break;
       case ModifierKey.metaModifier:
         // Windows does not provide an "any" key for win key press.
         result = _isLeftRightModifierPressed(side, modifierLeftMeta | modifierRightMeta , modifierLeftMeta, modifierRightMeta);
-        break;
       case ModifierKey.capsLockModifier:
         result = modifiers & modifierCaps != 0;
-        break;
       case ModifierKey.scrollLockModifier:
         result = modifiers & modifierScrollLock != 0;
-        break;
       case ModifierKey.numLockModifier:
         result = modifiers & modifierNumLock != 0;
-        break;
       // The OS does not expose the Fn key to the drivers, it doesn't generate a key message.
       case ModifierKey.functionModifier:
       case ModifierKey.symbolModifier:
         // These modifier masks are not used in Windows keyboards.
         result = false;
-        break;
     }
     assert(!result || getModifierSide(key) != null, "$runtimeType thinks that a modifier is pressed, but can't figure out what side it's on.");
     return result;

--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -306,7 +306,6 @@ class RestorationManager extends ChangeNotifier {
     switch (call.method) {
       case 'push':
         _parseAndHandleRestorationUpdateFromEngine(call.arguments as Map<Object?, Object?>);
-        break;
       default:
         throw UnimplementedError("${call.method} was invoked but isn't implemented by $runtimeType");
     }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1843,7 +1843,6 @@ class TextInput {
       case 'TextInputClient.updateEditingState':
         final TextEditingValue value = TextEditingValue.fromJSON(args[1] as Map<String, dynamic>);
         TextInput._instance._updateEditingValue(value, exclude: _PlatformTextInputControl.instance);
-        break;
       case 'TextInputClient.updateEditingStateWithDeltas':
         assert(_currentConnection!._client is DeltaTextInputClient, 'You must be using a DeltaTextInputClient if TextInputConfiguration.enableDeltaModel is set to true');
         final List<TextEditingDelta> deltas = <TextEditingDelta>[];
@@ -1856,7 +1855,6 @@ class TextInput {
         }
 
         (_currentConnection!._client as DeltaTextInputClient).updateEditingValueWithDeltas(deltas);
-        break;
       case 'TextInputClient.performAction':
         if (args[1] as String == 'TextInputAction.commitContent') {
           final KeyboardInsertedContent content = KeyboardInsertedContent.fromJson(args[2] as Map<String, dynamic>);
@@ -1864,11 +1862,9 @@ class TextInput {
         } else {
           _currentConnection!._client.performAction(_toTextInputAction(args[1] as String));
         }
-        break;
       case 'TextInputClient.performSelectors':
         final List<String> selectors = (args[1] as List<dynamic>).cast<String>();
         selectors.forEach(_currentConnection!._client.performSelector);
-        break;
       case 'TextInputClient.performPrivateCommand':
         final Map<String, dynamic> firstArg = args[1] as Map<String, dynamic>;
         _currentConnection!._client.performPrivateCommand(
@@ -1877,28 +1873,21 @@ class TextInput {
               ? <String, dynamic>{}
               : firstArg['data'] as Map<String, dynamic>,
         );
-        break;
       case 'TextInputClient.updateFloatingCursor':
         _currentConnection!._client.updateFloatingCursor(_toTextPoint(
           _toTextCursorAction(args[1] as String),
           args[2] as Map<String, dynamic>,
         ));
-        break;
       case 'TextInputClient.onConnectionClosed':
         _currentConnection!._client.connectionClosed();
-        break;
       case 'TextInputClient.showAutocorrectionPromptRect':
         _currentConnection!._client.showAutocorrectionPromptRect(args[1] as int, args[2] as int);
-        break;
       case 'TextInputClient.showToolbar':
         _currentConnection!._client.showToolbar();
-        break;
       case 'TextInputClient.insertTextPlaceholder':
         _currentConnection!._client.insertTextPlaceholder(Size((args[1] as num).toDouble(), (args[2] as num).toDouble()));
-        break;
       case 'TextInputClient.removeTextPlaceholder':
         _currentConnection!._client.removeTextPlaceholder();
-        break;
       default:
         throw MissingPluginException();
     }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1196,10 +1196,8 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
       switch (FocusManager.instance.highlightMode) {
         case FocusHighlightMode.touch:
           _canShowHighlight = false;
-          break;
         case FocusHighlightMode.traditional:
           _canShowHighlight = true;
-          break;
       }
     });
   }

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -306,10 +306,8 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
       switch (widget.crossFadeState) {
         case CrossFadeState.showFirst:
           _controller.reverse();
-          break;
         case CrossFadeState.showSecond:
           _controller.forward();
-          break;
       }
     }
   }

--- a/packages/flutter/lib/src/widgets/autofill.dart
+++ b/packages/flutter/lib/src/widgets/autofill.dart
@@ -234,10 +234,8 @@ class AutofillGroupState extends State<AutofillGroup> with AutofillScopeMixin {
     switch (widget.onDisposeAction) {
       case AutofillContextAction.cancel:
         TextInput.finishAutofillContext(shouldSave: false);
-        break;
       case AutofillContextAction.commit:
         TextInput.finishAutofillContext();
-        break;
     }
   }
 }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4141,11 +4141,9 @@ class Positioned extends ParentDataWidget<StackParentData> {
       case TextDirection.rtl:
         left = end;
         right = start;
-        break;
       case TextDirection.ltr:
         left = start;
         right = end;
-        break;
     }
     return Positioned(
       key: key,

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -96,10 +96,8 @@ class DecoratedBox extends SingleChildRenderObjectWidget {
     switch (position) {
       case DecorationPosition.background:
         label = 'bg';
-        break;
       case DecorationPosition.foreground:
         label = 'fg';
-        break;
     }
     properties.add(EnumProperty<DecorationPosition>('position', position, level: DiagnosticLevel.hidden));
     properties.add(DiagnosticsProperty<Decoration>(label, decoration));

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -390,19 +390,16 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       case DismissDirection.horizontal:
       case DismissDirection.vertical:
         _dragExtent += delta;
-        break;
 
       case DismissDirection.up:
         if (_dragExtent + delta < 0) {
           _dragExtent += delta;
         }
-        break;
 
       case DismissDirection.down:
         if (_dragExtent + delta > 0) {
           _dragExtent += delta;
         }
-        break;
 
       case DismissDirection.endToStart:
         switch (Directionality.of(context)) {
@@ -410,14 +407,11 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
             if (_dragExtent + delta > 0) {
               _dragExtent += delta;
             }
-            break;
           case TextDirection.ltr:
             if (_dragExtent + delta < 0) {
               _dragExtent += delta;
             }
-            break;
         }
-        break;
 
       case DismissDirection.startToEnd:
         switch (Directionality.of(context)) {
@@ -425,18 +419,14 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
             if (_dragExtent + delta < 0) {
               _dragExtent += delta;
             }
-            break;
           case TextDirection.ltr:
             if (_dragExtent + delta > 0) {
               _dragExtent += delta;
             }
-            break;
         }
-        break;
 
       case DismissDirection.none:
         _dragExtent = 0;
-        break;
     }
     if (oldDragExtent.sign != _dragExtent.sign) {
       setState(() {
@@ -526,13 +516,11 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
         }
         _dragExtent = flingVelocity.sign;
         _moveController!.fling(velocity: flingVelocity.abs() * _kFlingVelocityScale);
-        break;
       case _FlingGestureKind.reverse:
         assert(_dragExtent != 0.0);
         assert(!_moveController!.isDismissed);
         _dragExtent = flingVelocity.sign;
         _moveController!.fling(velocity: -flingVelocity.abs() * _kFlingVelocityScale);
-        break;
       case _FlingGestureKind.none:
         if (!_moveController!.isDismissed) { // we already know it's not completed, we check that above
           if (_moveController!.value > (widget.dismissThresholds[_dismissDirection] ?? _kDismissThreshold)) {
@@ -541,7 +529,6 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
             _moveController!.reverse();
           }
         }
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/dual_transition_builder.dart
+++ b/packages/flutter/lib/src/widgets/dual_transition_builder.dart
@@ -163,12 +163,10 @@ class _DualTransitionBuilderState extends State<DualTransitionBuilder> {
       case AnimationStatus.forward:
         _forwardAnimation.parent = widget.animation;
         _reverseAnimation.parent = kAlwaysDismissedAnimation;
-        break;
       case AnimationStatus.reverse:
       case AnimationStatus.completed:
         _forwardAnimation.parent = kAlwaysCompleteAnimation;
         _reverseAnimation.parent = ReverseAnimation(widget.animation);
-        break;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1923,7 +1923,6 @@ class EditableText extends StatefulWidget {
           if (keyboardType != null) {
             return keyboardType;
           }
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
@@ -2238,7 +2237,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             ),
             SelectionChangedCause.toolbar,
           );
-          break;
       }
     }
     clipboardStatus.update();
@@ -2340,7 +2338,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           bringIntoView(textEditingValue.selection.extent);
-          break;
         case TargetPlatform.macOS:
         case TargetPlatform.iOS:
           break;
@@ -2842,7 +2839,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         if (!_isMultiline) {
           _finalizeEditing(action, shouldUnfocus: true);
         }
-        break;
       case TextInputAction.done:
       case TextInputAction.go:
       case TextInputAction.next:
@@ -2850,7 +2846,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       case TextInputAction.search:
       case TextInputAction.send:
         _finalizeEditing(action, shouldUnfocus: true);
-        break;
       case TextInputAction.continueAction:
       case TextInputAction.emergencyCall:
       case TextInputAction.join:
@@ -2860,7 +2855,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         // Finalize editing, but don't give up focus because this keyboard
         // action does not imply the user is done inputting information.
         _finalizeEditing(action, shouldUnfocus: false);
-        break;
     }
   }
 
@@ -2917,7 +2911,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _lastBoundedOffset = _startCaretRect!.center - _floatingCursorOffset;
         _lastTextPosition = currentTextPosition;
         renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
-        break;
       case FloatingCursorDragState.Update:
         final Offset centeredPoint = point.offset! - _pointOffsetOrigin!;
         final Offset rawCursorOffset = _startCaretRect!.center + centeredPoint - _floatingCursorOffset;
@@ -2925,7 +2918,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _lastBoundedOffset = renderEditable.calculateBoundedFloatingCursorOffset(rawCursorOffset);
         _lastTextPosition = renderEditable.getPositionForPoint(renderEditable.localToGlobal(_lastBoundedOffset! + _floatingCursorOffset));
         renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
-        break;
       case FloatingCursorDragState.End:
         // Resume cursor blinking.
         _startCursorBlink();
@@ -2934,7 +2926,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           _floatingCursorResetController!.value = 0.0;
           _floatingCursorResetController!.animateTo(1.0, duration: _floatingCursorResetTime, curve: Curves.decelerate);
         }
-        break;
     }
   }
 
@@ -2994,13 +2985,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           case TextInputAction.emergencyCall:
           case TextInputAction.newline:
             widget.focusNode.unfocus();
-            break;
           case TextInputAction.next:
             widget.focusNode.nextFocus();
-            break;
           case TextInputAction.previous:
             widget.focusNode.previousFocus();
-            break;
         }
       }
     }
@@ -3363,12 +3351,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       case SelectionChangedCause.tap:
       case SelectionChangedCause.toolbar:
         requestKeyboard();
-        break;
       case SelectionChangedCause.keyboard:
         if (_hasFocus) {
           requestKeyboard();
         }
-        break;
     }
     if (widget.selectionControls == null && widget.contextMenuBuilder == null) {
       _selectionOverlay?.dispose();
@@ -3620,7 +3606,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             cause == SelectionChangedCause.drag) {
           bringIntoView(newSelection.extent);
         }
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
       case TargetPlatform.fuchsia:
@@ -3632,7 +3617,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             bringIntoView(newSelection.extent);
           }
         }
-        break;
     }
   }
 
@@ -4211,10 +4195,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         // boundary, and do this instead:
         // final int graphemeStart = CharacterRange.at(string, extent.offset).stringBeforeLength - 1;
         caretOffset = math.max(0, extent.offset - 1);
-        break;
       case TextAffinity.downstream:
         caretOffset = extent.offset;
-        break;
     }
     // The line boundary range does not include some control characters
     // (most notably, Line Feed), in which case there's
@@ -4436,22 +4418,18 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
             if (kIsWeb) {
               widget.focusNode.unfocus();
             }
-            break;
           case ui.PointerDeviceKind.mouse:
           case ui.PointerDeviceKind.stylus:
           case ui.PointerDeviceKind.invertedStylus:
           case ui.PointerDeviceKind.unknown:
             widget.focusNode.unfocus();
-            break;
           case ui.PointerDeviceKind.trackpad:
             throw UnimplementedError('Unexpected pointer down event for trackpad');
         }
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         widget.focusNode.unfocus();
-        break;
     }
   }
 
@@ -4533,7 +4511,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                     if (!widget.controller.value.composing.isCollapsed) {
                       return false;
                     }
-                    break;
                   case TargetPlatform.android:
                     // Gboard on Android puts non-CJK words in composing regions. Coalesce
                     // composing text in order to allow the saving of partial words in that

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -90,7 +90,6 @@ KeyEventResult combineKeyEventResults(Iterable<KeyEventResult> results) {
         return KeyEventResult.handled;
       case KeyEventResult.skipRemainingHandlers:
         hasSkipRemainingHandlers = true;
-        break;
       case KeyEventResult.ignored:
         break;
     }
@@ -885,7 +884,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
           scope = scope.enclosingScope ?? _manager?.rootScope;
         }
         scope._doRequestFocus(findFirstFocus: false);
-        break;
       case UnfocusDisposition.previouslyFocusedChild:
         // Select the most recent focused child from the nearest focusable scope
         // and focus that. If there isn't one, focus the scope itself.
@@ -897,7 +895,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
           scope = scope.enclosingScope ?? _manager?.rootScope;
         }
         scope._doRequestFocus(findFirstFocus: true);
-        break;
     }
     assert(_focusDebug(() => 'Unfocused node:', () => <Object>['primary focus was $this', 'next focus will be ${_manager?._markedForFocus}']));
   }
@@ -1769,13 +1766,11 @@ class _HighlightModeManager {
       case PointerDeviceKind.invertedStylus:
         _lastInteractionWasTouch = true;
         expectedMode = FocusHighlightMode.touch;
-        break;
       case PointerDeviceKind.mouse:
       case PointerDeviceKind.trackpad:
       case PointerDeviceKind.unknown:
         _lastInteractionWasTouch = false;
         expectedMode = FocusHighlightMode.traditional;
-        break;
     }
     if (expectedMode != highlightMode) {
       updateMode();
@@ -1818,11 +1813,9 @@ class _HighlightModeManager {
         case KeyEventResult.handled:
           assert(_focusDebug(() => 'Node $node handled key event $message.'));
           handled = true;
-          break;
         case KeyEventResult.skipRemainingHandlers:
           assert(_focusDebug(() => 'Node $node stopped key event propagation: $message.'));
           handled = false;
-          break;
       }
       // Only KeyEventResult.ignored will continue the for loop. All other
       // options will stop the event propagation.
@@ -1853,13 +1846,10 @@ class _HighlightModeManager {
         } else {
           newMode = FocusHighlightMode.traditional;
         }
-        break;
       case FocusHighlightStrategy.alwaysTouch:
         newMode = FocusHighlightMode.touch;
-        break;
       case FocusHighlightStrategy.alwaysTraditional:
         newMode = FocusHighlightMode.traditional;
-        break;
     }
     // We can't just compare newMode with _highlightMode here, since
     // _highlightMode could be null, so we want to compare with the return value

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -702,10 +702,8 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     switch (direction) {
       case TraversalDirection.left:
         filtered = nodes.where((FocusNode node) => node.rect != target && node.rect.center.dx <= target.left);
-        break;
       case TraversalDirection.right:
         filtered = nodes.where((FocusNode node) => node.rect != target && node.rect.center.dx >= target.right);
-        break;
       case TraversalDirection.up:
       case TraversalDirection.down:
         throw ArgumentError('Invalid direction $direction');
@@ -729,10 +727,8 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     switch (direction) {
       case TraversalDirection.up:
         filtered = nodes.where((FocusNode node) => node.rect != target && node.rect.center.dy <= target.top);
-        break;
       case TraversalDirection.down:
         filtered = nodes.where((FocusNode node) => node.rect != target && node.rect.center.dy >= target.bottom);
-        break;
       case TraversalDirection.left:
       case TraversalDirection.right:
         throw ArgumentError('Invalid direction $direction');
@@ -771,11 +767,9 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
           case TraversalDirection.up:
           case TraversalDirection.left:
             alignmentPolicy = ScrollPositionAlignmentPolicy.keepVisibleAtStart;
-            break;
           case TraversalDirection.right:
           case TraversalDirection.down:
             alignmentPolicy = ScrollPositionAlignmentPolicy.keepVisibleAtEnd;
-            break;
         }
         _focusAndEnsureVisible(
           lastNode,
@@ -792,15 +786,12 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
             case TraversalDirection.right:
               // Reset the policy data if we change directions.
               invalidateScopeData(nearestScope);
-              break;
             case TraversalDirection.up:
             case TraversalDirection.down:
               if (popOrInvalidate(direction)) {
                 return true;
               }
-              break;
           }
-          break;
         case TraversalDirection.left:
         case TraversalDirection.right:
           switch (policyData.history.first.direction) {
@@ -809,12 +800,10 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
               if (popOrInvalidate(direction)) {
                 return true;
               }
-              break;
             case TraversalDirection.up:
             case TraversalDirection.down:
               // Reset the policy data if we change directions.
               invalidateScopeData(nearestScope);
-              break;
           }
       }
     }
@@ -865,14 +854,12 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
             firstFocus,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
           );
-          break;
         case TraversalDirection.right:
         case TraversalDirection.down:
           _focusAndEnsureVisible(
             firstFocus,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
           );
-          break;
       }
       return true;
     }
@@ -908,7 +895,6 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         // closest to the center line horizontally, and if any are the same
         // distance horizontally, pick the closest one of those vertically.
         found = _sortClosestEdgesByDistancePreferHorizontal(focusedChild.rect.center, eligibleNodes).first;
-        break;
       case TraversalDirection.right:
       case TraversalDirection.left:
         Iterable<FocusNode> eligibleNodes = _sortAndFilterHorizontally(direction, focusedChild.rect, nearestScope.traversalDescendants);
@@ -935,7 +921,6 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         // closest to the center line vertically, and if any are the same
         // distance vertically, pick the closest one of those horizontally.
         found = _sortClosestEdgesByDistancePreferVertical(focusedChild.rect.center, eligibleNodes).first;
-        break;
     }
     if (found != null) {
       _pushPolicyData(direction, nearestScope, focusedChild);
@@ -946,14 +931,12 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
             found,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
           );
-          break;
         case TraversalDirection.down:
         case TraversalDirection.right:
           _focusAndEnsureVisible(
             found,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
           );
-          break;
       }
       return true;
     }

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -183,12 +183,10 @@ class FormState extends State<Form> {
     switch (widget.autovalidateMode) {
       case AutovalidateMode.always:
         _validate();
-        break;
       case AutovalidateMode.onUserInteraction:
         if (_hasInteractedByUser) {
           _validate();
         }
-        break;
       case AutovalidateMode.disabled:
         break;
     }
@@ -495,12 +493,10 @@ class FormFieldState<T> extends State<FormField<T>> with RestorationMixin {
       switch (widget.autovalidateMode) {
         case AutovalidateMode.always:
           _validate();
-          break;
         case AutovalidateMode.onUserInteraction:
           if (_hasInteractedByUser.value) {
             _validate();
           }
-          break;
         case AutovalidateMode.disabled:
           break;
       }

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -664,11 +664,9 @@ class _HeroFlight {
       case HeroFlightDirection.pop:
         _proxyAnimation.parent = ReverseAnimation(manifest.animation);
         shouldIncludeChildInPlaceholder = false;
-        break;
       case HeroFlightDirection.push:
         _proxyAnimation.parent = manifest.animation;
         shouldIncludeChildInPlaceholder = true;
-        break;
     }
 
     heroRectTween = manifest.createHeroRectTween(begin: manifest.fromHeroLocation, end: manifest.toHeroLocation);
@@ -861,12 +859,10 @@ class HeroController extends NavigatorObserver {
           if (from.animation!.value == 0.0) {
             return;
           }
-          break;
         case HeroFlightDirection.push:
           if (to.animation!.value == 1.0) {
             return;
           }
-          break;
       }
 
       // For pop transitions driven by a user gesture: if the "to" page has

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -294,7 +294,6 @@ class Icon extends StatelessWidget {
             transformHitTests: false,
             child: iconWidget,
           );
-          break;
         case TextDirection.ltr:
           break;
       }

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -368,7 +368,6 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
       switch (status) {
         case AnimationStatus.completed:
           widget.onEnd?.call();
-          break;
         case AnimationStatus.dismissed:
         case AnimationStatus.forward:
         case AnimationStatus.reverse:

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -611,16 +611,12 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       switch(widget.panAxis){
         case PanAxis.horizontal:
           alignedTranslation = _alignAxis(translation, Axis.horizontal);
-          break;
         case PanAxis.vertical:
           alignedTranslation = _alignAxis(translation, Axis.vertical);
-          break;
         case PanAxis.aligned:
           alignedTranslation = _alignAxis(translation, _currentAxis!);
-          break;
         case PanAxis.free:
           alignedTranslation = translation;
-          break;
       }
     } else {
       alignedTranslation = translation;
@@ -863,7 +859,6 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         if (_round(_referenceFocalPoint!) != _round(focalPointSceneCheck)) {
           _referenceFocalPoint = focalPointSceneCheck;
         }
-        break;
 
       case _GestureType.rotate:
         if (details.rotation == 0.0) {
@@ -877,7 +872,6 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
           details.localFocalPoint,
         );
         _currentRotation = desiredRotation;
-        break;
 
       case _GestureType.pan:
         assert(_referenceFocalPoint != null);
@@ -899,7 +893,6 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         _referenceFocalPoint = _transformationController!.toScene(
           details.localFocalPoint,
         );
-        break;
     }
     widget.onInteractionUpdate?.call(details);
   }

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -1350,92 +1350,74 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
             if (data.size != oldWidget.data.size) {
               return true;
             }
-            break;
           case _MediaQueryAspect.orientation:
             if (data.orientation != oldWidget.data.orientation) {
               return true;
             }
-            break;
           case _MediaQueryAspect.devicePixelRatio:
             if (data.devicePixelRatio != oldWidget.data.devicePixelRatio) {
               return true;
             }
-            break;
           case _MediaQueryAspect.textScaleFactor:
             if (data.textScaleFactor != oldWidget.data.textScaleFactor) {
               return true;
             }
-            break;
           case _MediaQueryAspect.platformBrightness:
             if (data.platformBrightness != oldWidget.data.platformBrightness) {
               return true;
             }
-            break;
           case _MediaQueryAspect.padding:
             if (data.padding != oldWidget.data.padding) {
               return true;
             }
-            break;
           case _MediaQueryAspect.viewInsets:
             if (data.viewInsets != oldWidget.data.viewInsets) {
               return true;
             }
-            break;
           case _MediaQueryAspect.systemGestureInsets:
             if (data.systemGestureInsets != oldWidget.data.systemGestureInsets) {
               return true;
             }
-            break;
           case _MediaQueryAspect.viewPadding:
             if (data.viewPadding != oldWidget.data.viewPadding) {
               return true;
             }
-            break;
           case _MediaQueryAspect.alwaysUse24HourFormat:
             if (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat) {
               return true;
             }
-            break;
           case _MediaQueryAspect.accessibleNavigation:
             if (data.accessibleNavigation != oldWidget.data.accessibleNavigation) {
               return true;
             }
-            break;
           case _MediaQueryAspect.invertColors:
             if (data.invertColors != oldWidget.data.invertColors) {
               return true;
             }
-            break;
           case _MediaQueryAspect.highContrast:
             if (data.highContrast != oldWidget.data.highContrast) {
               return true;
             }
-            break;
           case _MediaQueryAspect.disableAnimations:
             if (data.disableAnimations != oldWidget.data.disableAnimations) {
               return true;
             }
-            break;
           case _MediaQueryAspect.boldText:
             if (data.boldText != oldWidget.data.boldText) {
               return true;
             }
-            break;
           case _MediaQueryAspect.navigationMode:
             if (data.navigationMode != oldWidget.data.navigationMode) {
               return true;
             }
-            break;
           case _MediaQueryAspect.gestureSettings:
             if (data.gestureSettings != oldWidget.data.gestureSettings) {
               return true;
             }
-            break;
           case _MediaQueryAspect.displayFeatures:
             if (data.displayFeatures != oldWidget.data.displayFeatures) {
               return true;
             }
-            break;
         }
       }
     }

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -212,12 +212,10 @@ class ModalBarrier extends StatelessWidget {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         platformSupportsDismissingBarrier = false;
-        break;
       case TargetPlatform.android:
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         platformSupportsDismissingBarrier = true;
-        break;
     }
     final bool semanticsDismissible = dismissible && platformSupportsDismissingBarrier;
     final bool modalBarrierSemanticsDismissible = barrierSemanticsDismissible ?? semanticsDismissible;

--- a/packages/flutter/lib/src/widgets/navigation_toolbar.dart
+++ b/packages/flutter/lib/src/widgets/navigation_toolbar.dart
@@ -113,10 +113,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
       switch (textDirection) {
         case TextDirection.rtl:
           leadingX = size.width - leadingWidth;
-          break;
         case TextDirection.ltr:
           leadingX = 0.0;
-          break;
       }
       positionChild(_ToolbarSlot.leading, Offset(leadingX, 0.0));
     }
@@ -128,10 +126,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
       switch (textDirection) {
         case TextDirection.rtl:
           trailingX = 0.0;
-          break;
         case TextDirection.ltr:
           trailingX = size.width - trailingSize.width;
-          break;
       }
       final double trailingY = (size.height - trailingSize.height) / 2.0;
       trailingWidth = trailingSize.width;
@@ -161,10 +157,8 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
       switch (textDirection) {
         case TextDirection.rtl:
           middleX = size.width - middleSize.width - middleStart;
-          break;
         case TextDirection.ltr:
           middleX = middleStart;
-          break;
       }
 
       positionChild(_ToolbarSlot.middle, Offset(middleX, middleY));

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3944,7 +3944,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
             assert(entry.currentState == _RouteLifecycle.idle);
             continue;
           }
-          break;
         case _RouteLifecycle.push:
         case _RouteLifecycle.pushReplace:
         case _RouteLifecycle.replace:
@@ -3961,13 +3960,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           if (entry.currentState == _RouteLifecycle.idle) {
             continue;
           }
-          break;
         case _RouteLifecycle.pushing: // Will exit this state when animation completes.
           if (!seenTopActiveRoute && poppedRoute != null) {
             entry.handleDidPopNext(poppedRoute);
           }
           seenTopActiveRoute = true;
-          break;
         case _RouteLifecycle.idle:
           if (!seenTopActiveRoute && poppedRoute != null) {
             entry.handleDidPopNext(poppedRoute);
@@ -3976,7 +3973,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           // This route is idle, so we are allowed to remove subsequent (earlier)
           // routes that are waiting to be removed silently:
           canRemoveOrAdd = true;
-          break;
         case _RouteLifecycle.pop:
           if (!entry.handlePop(
                 navigator: this,
@@ -4000,7 +3996,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           }
           assert(entry.currentState == _RouteLifecycle.popping);
           canRemoveOrAdd = true;
-          break;
         case _RouteLifecycle.popping:
           // Will exit this state when animation completes.
           break;
@@ -4032,11 +4027,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           // Delay disposal until didChangeNext/didChangePrevious have been sent.
           toBeDisposed.add(_history.removeAt(index));
           entry = next;
-          break;
         case _RouteLifecycle.disposed:
         case _RouteLifecycle.staging:
           assert(false);
-          break;
       }
       index -= 1;
       next = entry;

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1635,7 +1635,6 @@ class SliverOverlapAbsorberHandle extends ChangeNotifier {
     switch (_writers) {
       case 0:
         extra = ', orphan';
-        break;
       case 1:
         // normal case
         break;
@@ -1942,13 +1941,11 @@ class RenderSliverOverlapInjector extends RenderSliver {
             start = Offset(x, offset.dy);
             end = Offset(x, offset.dy + geometry!.paintExtent);
             delta = Offset(constraints.crossAxisExtent / 5.0, 0.0);
-            break;
           case Axis.horizontal:
             final double y = offset.dy + constraints.crossAxisExtent / 2.0;
             start = Offset(offset.dx, y);
             end = Offset(offset.dy + geometry!.paintExtent, y);
             delta = Offset(0.0, constraints.crossAxisExtent / 5.0);
-            break;
         }
         for (int index = -2; index <= 2; index += 1) {
           paintZigZag(

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -497,13 +497,10 @@ class _RenderOverflowBar extends RenderBox
         switch (overflowAlignment) {
           case OverflowBarAlignment.start:
             x = rtl ? constraints.maxWidth - child.size.width : 0;
-            break;
           case OverflowBarAlignment.center:
             x = (constraints.maxWidth - child.size.width) / 2;
-            break;
           case OverflowBarAlignment.end:
             x = rtl ? 0 : constraints.maxWidth - child.size.width;
-            break;
         }
         childParentData.offset = Offset(x, y);
         y += child.size.height + overflowSpacing;
@@ -522,29 +519,22 @@ class _RenderOverflowBar extends RenderBox
       switch (alignment) {
         case null:
           x = rtl ? size.width - firstChildWidth : 0;
-          break;
         case MainAxisAlignment.start:
           x = rtl ? size.width - firstChildWidth : 0;
-          break;
         case MainAxisAlignment.center:
           final double halfRemainingWidth = (size.width - actualWidth) / 2;
           x = rtl ? size.width - halfRemainingWidth - firstChildWidth : halfRemainingWidth;
-          break;
         case MainAxisAlignment.end:
           x = rtl ? actualWidth - firstChildWidth : size.width - actualWidth;
-          break;
         case MainAxisAlignment.spaceBetween:
           layoutSpacing = (size.width - childrenWidth) / (childCount - 1);
           x = rtl ? size.width - firstChildWidth : 0;
-          break;
         case MainAxisAlignment.spaceAround:
           layoutSpacing = childCount > 0 ? (size.width - childrenWidth) / childCount : 0;
           x = rtl ? size.width - layoutSpacing / 2 - firstChildWidth : layoutSpacing / 2;
-          break;
         case MainAxisAlignment.spaceEvenly:
           layoutSpacing = (size.width - childrenWidth) / (childCount + 1);
           x = rtl ? size.width - layoutSpacing - firstChildWidth : layoutSpacing;
-          break;
       }
 
       while (child != null) {

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -255,10 +255,8 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
             switch (notification.metrics.axis) {
               case Axis.horizontal:
                 controller!.pull(notification.overscroll.abs(), size.width, clampDouble(position.dy, 0.0, size.height), size.height);
-                break;
               case Axis.vertical:
                 controller!.pull(notification.overscroll.abs(), size.height, clampDouble(position.dx, 0.0, size.width), size.width);
-                break;
             }
           }
         }
@@ -467,11 +465,9 @@ class _GlowController extends ChangeNotifier {
     switch (_state) {
       case _GlowState.absorb:
         _recede(_recedeTime);
-        break;
       case _GlowState.recede:
         _state = _GlowState.idle;
         _pullDistance = 0.0;
-        break;
       case _GlowState.pull:
       case _GlowState.idle:
         break;
@@ -562,28 +558,24 @@ class _GlowingOverscrollIndicatorPainter extends CustomPainter {
     switch (applyGrowthDirectionToAxisDirection(axisDirection, growthDirection)) {
       case AxisDirection.up:
         controller.paint(canvas, size);
-        break;
       case AxisDirection.down:
         canvas.save();
         canvas.translate(0.0, size.height);
         canvas.scale(1.0, -1.0);
         controller.paint(canvas, size);
         canvas.restore();
-        break;
       case AxisDirection.left:
         canvas.save();
         canvas.rotate(piOver2);
         canvas.scale(1.0, -1.0);
         controller.paint(canvas, Size(size.height, size.width));
         canvas.restore();
-        break;
       case AxisDirection.right:
         canvas.save();
         canvas.translate(size.width, 0.0);
         canvas.rotate(piOver2);
         controller.paint(canvas, Size(size.height, size.width));
         canvas.restore();
-        break;
     }
   }
 
@@ -800,11 +792,9 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
             case Axis.horizontal:
               x += stretch;
               mainAxisSize = size.width;
-              break;
             case Axis.vertical:
               y += stretch;
               mainAxisSize = size.height;
-              break;
           }
 
           final AlignmentGeometry alignment = _getAlignmentForAxisDirection(
@@ -933,11 +923,9 @@ class _StretchController extends ChangeNotifier {
     switch (_state) {
       case _StretchState.absorb:
         _recede(_stretchDuration);
-        break;
       case _StretchState.recede:
         _state = _StretchState.idle;
         _pullDistance = 0.0;
-        break;
       case _StretchState.pull:
       case _StretchState.idle:
         break;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -232,7 +232,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         }
         _performanceModeRequestHandle?.dispose();
         _performanceModeRequestHandle = null;
-        break;
       case AnimationStatus.forward:
       case AnimationStatus.reverse:
         if (overlayEntries.isNotEmpty) {
@@ -241,7 +240,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         _performanceModeRequestHandle ??=
           SchedulerBinding.instance
             .requestPerformanceMode(ui.DartPerformanceMode.latency);
-        break;
       case AnimationStatus.dismissed:
         // We might still be an active route if a subclass is controlling the
         // transition and hits the dismissed status. For example, the iOS
@@ -253,7 +251,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
           _performanceModeRequestHandle?.dispose();
           _performanceModeRequestHandle = null;
         }
-        break;
     }
   }
 
@@ -371,7 +368,6 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
                   _trainHoppingListenerRemover!();
                   _trainHoppingListenerRemover = null;
                 }
-                break;
               case AnimationStatus.forward:
               case AnimationStatus.reverse:
                 break;

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -743,10 +743,8 @@ class BouncingScrollPhysics extends ScrollPhysics {
       switch (decelerationRate) {
         case ScrollDecelerationRate.fast:
           constantDeceleration = 1400;
-          break;
         case ScrollDecelerationRate.normal:
           constantDeceleration = 0;
-          break;
       }
       return BouncingScrollSimulation(
         spring: spring,

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -643,19 +643,15 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
       case AxisDirection.up:
         forward = SemanticsAction.scrollDown;
         backward = SemanticsAction.scrollUp;
-        break;
       case AxisDirection.right:
         forward = SemanticsAction.scrollLeft;
         backward = SemanticsAction.scrollRight;
-        break;
       case AxisDirection.down:
         forward = SemanticsAction.scrollUp;
         backward = SemanticsAction.scrollDown;
-        break;
       case AxisDirection.left:
         forward = SemanticsAction.scrollRight;
         backward = SemanticsAction.scrollLeft;
-        break;
     }
 
     final Set<SemanticsAction> actions = <SemanticsAction>{};
@@ -710,19 +706,16 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     switch (alignmentPolicy) {
       case ScrollPositionAlignmentPolicy.explicit:
         target = clampDouble(viewport.getOffsetToReveal(object, alignment, rect: targetRect).offset, minScrollExtent, maxScrollExtent);
-        break;
       case ScrollPositionAlignmentPolicy.keepVisibleAtEnd:
         target = clampDouble(viewport.getOffsetToReveal(object, 1.0, rect: targetRect).offset, minScrollExtent, maxScrollExtent);
         if (target < pixels) {
           target = pixels;
         }
-        break;
       case ScrollPositionAlignmentPolicy.keepVisibleAtStart:
         target = clampDouble(viewport.getOffsetToReveal(object, 0.0, rect: targetRect).offset, minScrollExtent, maxScrollExtent);
         if (target > pixels) {
           target = pixels;
         }
-        break;
     }
 
     if (target == pixels) {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -675,7 +675,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
               },
             ),
           };
-          break;
         case Axis.horizontal:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
@@ -697,7 +696,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
               },
             ),
           };
-          break;
       }
     }
     _lastCanDrag = value;
@@ -809,7 +807,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         delta = flipAxes
           ? event.scrollDelta.dy
           : event.scrollDelta.dx;
-        break;
       case Axis.vertical:
         delta = flipAxes
           ? event.scrollDelta.dx
@@ -1328,26 +1325,21 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       case SelectionEventType.startEdgeUpdate:
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
         ensureChildUpdated(selectable);
-        break;
       case SelectionEventType.endEdgeUpdate:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
         ensureChildUpdated(selectable);
-        break;
       case SelectionEventType.granularlyExtendSelection:
       case SelectionEventType.directionallyExtendSelection:
         ensureChildUpdated(selectable);
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
-        break;
       case SelectionEventType.clear:
         _selectableEndEdgeUpdateRecords.remove(selectable);
         _selectableStartEdgeUpdateRecords.remove(selectable);
-        break;
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
-        break;
     }
     return super.dispatchSelectionEventToChild(selectable, event);
   }

--- a/packages/flutter/lib/src/widgets/scrollable_helpers.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_helpers.dart
@@ -264,7 +264,6 @@ class EdgeDraggingAutoScroller {
           final double overDrag = math.min(viewportStart - proxyStart, overDragMax);
           newOffset = math.min(scrollable.position.maxScrollExtent, scrollable.position.pixels + overDrag);
         }
-        break;
       case AxisDirection.right:
       case AxisDirection.down:
         if (proxyStart < viewportStart && scrollable.position.pixels > scrollable.position.minScrollExtent) {
@@ -274,7 +273,6 @@ class EdgeDraggingAutoScroller {
           final double overDrag = math.min(proxyEnd - viewportEnd, overDragMax);
           newOffset = math.min(scrollable.position.maxScrollExtent, scrollable.position.pixels + overDrag);
         }
-        break;
     }
 
     if (newOffset == null || (newOffset - scrollable.position.pixels).abs() < 1.0) {

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -567,7 +567,6 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         trackOffset = Offset(x - crossAxisMargin, _leadingTrackMainAxisOffset);
         borderStart = trackOffset + Offset(trackSize.width, 0.0);
         borderEnd = Offset(trackOffset.dx + trackSize.width, trackOffset.dy + _trackExtent);
-        break;
       case ScrollbarOrientation.right:
         thumbSize = Size(thickness, _thumbExtent);
         trackSize = Size(thickness + 2 * crossAxisMargin, _trackExtent);
@@ -576,7 +575,6 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         trackOffset = Offset(x - crossAxisMargin, _leadingTrackMainAxisOffset);
         borderStart = trackOffset;
         borderEnd = Offset(trackOffset.dx, trackOffset.dy + _trackExtent);
-        break;
       case ScrollbarOrientation.top:
         thumbSize = Size(_thumbExtent, thickness);
         trackSize = Size(_trackExtent, thickness + 2 * crossAxisMargin);
@@ -585,7 +583,6 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         trackOffset = Offset(_leadingTrackMainAxisOffset, y - crossAxisMargin);
         borderStart = trackOffset + Offset(0.0, trackSize.height);
         borderEnd = Offset(trackOffset.dx + _trackExtent, trackOffset.dy + trackSize.height);
-        break;
       case ScrollbarOrientation.bottom:
         thumbSize = Size(_thumbExtent, thickness);
         trackSize = Size(_trackExtent, thickness + 2 * crossAxisMargin);
@@ -594,7 +591,6 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         trackOffset = Offset(_leadingTrackMainAxisOffset, y - crossAxisMargin);
         borderStart = trackOffset;
         borderEnd = Offset(trackOffset.dx + _trackExtent, trackOffset.dy);
-        break;
     }
 
     // Whether we paint or not, calculating these rects allows us to hit test
@@ -1687,19 +1683,15 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       case AxisDirection.up:
         primaryDeltaFromDragStart = _startDragScrollbarAxisOffset!.dy - updatedOffset.dy;
         primaryDeltaFromLastDragUpdate = _lastDragUpdateOffset!.dy - updatedOffset.dy;
-        break;
       case AxisDirection.right:
         primaryDeltaFromDragStart = updatedOffset.dx -_startDragScrollbarAxisOffset!.dx;
         primaryDeltaFromLastDragUpdate = updatedOffset.dx -_lastDragUpdateOffset!.dx;
-        break;
       case AxisDirection.down:
         primaryDeltaFromDragStart = updatedOffset.dy -_startDragScrollbarAxisOffset!.dy;
         primaryDeltaFromLastDragUpdate = updatedOffset.dy -_lastDragUpdateOffset!.dy;
-        break;
       case AxisDirection.left:
         primaryDeltaFromDragStart = _startDragScrollbarAxisOffset!.dx - updatedOffset.dx;
         primaryDeltaFromLastDragUpdate = _lastDragUpdateOffset!.dx - updatedOffset.dx;
-        break;
     }
 
     // Convert primaryDelta, the amount that the scrollbar moved since the last
@@ -1725,7 +1717,6 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
           newPosition = clampDouble(newPosition, position.minScrollExtent, position.maxScrollExtent);
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.android:
           // We can only drag the scrollbar into overscroll on mobile
@@ -1850,7 +1841,6 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
         } else {
           scrollDirection = AxisDirection.up;
         }
-        break;
       case AxisDirection.left:
       case AxisDirection.right:
         if (details.localPosition.dx > scrollbarPainter._thumbOffset) {
@@ -2153,7 +2143,6 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
                       if (enableGestures) {
                         handleHoverExit(event);
                       }
-                      break;
                     case PointerDeviceKind.stylus:
                     case PointerDeviceKind.invertedStylus:
                     case PointerDeviceKind.unknown:
@@ -2168,7 +2157,6 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
                       if (enableGestures) {
                         handleHover(event);
                       }
-                      break;
                     case PointerDeviceKind.stylus:
                     case PointerDeviceKind.invertedStylus:
                     case PointerDeviceKind.unknown:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -402,10 +402,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case SelectionStatus.uncollapsed:
       case SelectionStatus.collapsed:
         selection = const TextSelection(baseOffset: 0, extentOffset: 1);
-        break;
       case SelectionStatus.none:
         selection = const TextSelection.collapsed(offset: 1);
-        break;
     }
     textEditingValue = TextEditingValue(text: '__', selection: selection);
     if (_hasSelectionOverlayGeometry) {
@@ -1000,15 +998,12 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
             _clearSelection();
-            break;
           case TargetPlatform.iOS:
             hideToolbar(false);
-            break;
           case TargetPlatform.linux:
           case TargetPlatform.macOS:
           case TargetPlatform.windows:
             hideToolbar();
-            break;
         }
       },
       onSelectAll: () {
@@ -1017,13 +1012,11 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.iOS:
           case TargetPlatform.fuchsia:
             selectAll(SelectionChangedCause.toolbar);
-            break;
           case TargetPlatform.linux:
           case TargetPlatform.macOS:
           case TargetPlatform.windows:
             selectAll();
             hideToolbar();
-            break;
         }
       },
     );
@@ -1381,15 +1374,12 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
       case SelectionEventType.startEdgeUpdate:
         _hasReceivedStartEvent.add(selectable);
         ensureChildUpdated(selectable);
-        break;
       case SelectionEventType.endEdgeUpdate:
         _hasReceivedEndEvent.add(selectable);
         ensureChildUpdated(selectable);
-        break;
       case SelectionEventType.clear:
         _hasReceivedStartEvent.remove(selectable);
         _hasReceivedEndEvent.remove(selectable);
-        break;
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
         break;
@@ -1398,7 +1388,6 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
         _hasReceivedStartEvent.add(selectable);
         _hasReceivedEndEvent.add(selectable);
         ensureChildUpdated(selectable);
-        break;
     }
     return super.dispatchSelectionEventToChild(selectable, event);
   }
@@ -1960,11 +1949,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         case SelectionExtendDirection.previousLine:
         case SelectionExtendDirection.backward:
           currentSelectionStartIndex = currentSelectionEndIndex = selectables.length;
-          break;
         case SelectionExtendDirection.nextLine:
         case SelectionExtendDirection.forward:
         currentSelectionStartIndex = currentSelectionEndIndex = 0;
-          break;
       }
     }
     int targetIndex = event.isEnd ? currentSelectionEndIndex : currentSelectionStartIndex;
@@ -1982,7 +1969,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             assert(result == SelectionResult.end);
           }
         }
-        break;
       case SelectionExtendDirection.nextLine:
         assert(result == SelectionResult.end || result == SelectionResult.next);
         if (result == SelectionResult.next) {
@@ -1995,11 +1981,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             assert(result == SelectionResult.end);
           }
         }
-        break;
       case SelectionExtendDirection.forward:
       case SelectionExtendDirection.backward:
         assert(result == SelectionResult.end);
-        break;
     }
     if (event.isEnd) {
       currentSelectionEndIndex = targetIndex;
@@ -2033,27 +2017,21 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       case SelectionEventType.endEdgeUpdate:
         _extendSelectionInProgress = false;
         result = handleSelectionEdgeUpdate(event as SelectionEdgeUpdateEvent);
-        break;
       case SelectionEventType.clear:
         _extendSelectionInProgress = false;
         result = handleClearSelection(event as ClearSelectionEvent);
-        break;
       case SelectionEventType.selectAll:
         _extendSelectionInProgress = false;
         result = handleSelectAll(event as SelectAllSelectionEvent);
-        break;
       case SelectionEventType.selectWord:
         _extendSelectionInProgress = false;
         result = handleSelectWord(event as SelectWordSelectionEvent);
-        break;
       case SelectionEventType.granularlyExtendSelection:
         _extendSelectionInProgress = true;
         result = handleGranularlyExtendSelection(event as GranularlyExtendSelectionEvent);
-        break;
       case SelectionEventType.directionallyExtendSelection:
         _extendSelectionInProgress = true;
         result = handleDirectionallyExtendSelection(event as DirectionallyExtendSelectionEvent);
-        break;
     }
     _isHandlingSelectionEvent = false;
     _updateSelectionGeometry();
@@ -2112,12 +2090,10 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         case SelectionResult.next:
         case SelectionResult.none:
           newIndex = index;
-          break;
         case SelectionResult.end:
           newIndex = index;
           result = SelectionResult.end;
           hasFoundEdgeIndex = true;
-          break;
         case SelectionResult.previous:
           hasFoundEdgeIndex = true;
           if (index == 0) {
@@ -2125,12 +2101,10 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             result = SelectionResult.previous;
           }
           result ??= SelectionResult.end;
-          break;
         case SelectionResult.pending:
           newIndex = index;
           result = SelectionResult.pending;
           hasFoundEdgeIndex = true;
-          break;
       }
     }
 
@@ -2184,7 +2158,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         case SelectionResult.pending:
         case SelectionResult.none:
           finalResult = currentSelectableResult;
-          break;
         case SelectionResult.next:
           if (forward == false) {
             newIndex += 1;
@@ -2195,7 +2168,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             forward = true;
             newIndex += 1;
           }
-          break;
         case SelectionResult.previous:
           if (forward ?? false) {
             newIndex -= 1;
@@ -2206,7 +2178,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             forward = false;
             newIndex -= 1;
           }
-          break;
       }
     }
     if (isEnd) {

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -308,10 +308,8 @@ class _SemanticsDebuggerPainter extends CustomPainter {
         switch (data.textDirection!) {
           case TextDirection.rtl:
             effectivelabel = '${Unicode.RLI}$tooltipAndLabel${Unicode.PDF}';
-            break;
           case TextDirection.ltr:
             effectivelabel = tooltipAndLabel;
-            break;
         }
       }
       if (annotations.isEmpty) {

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -611,22 +611,18 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
         mainAxisExtent = size.height;
         leadingScrollOffset = contentSize.height - bounds.bottom;
         targetMainAxisExtent = bounds.height;
-        break;
       case AxisDirection.right:
         mainAxisExtent = size.width;
         leadingScrollOffset = bounds.left;
         targetMainAxisExtent = bounds.width;
-        break;
       case AxisDirection.down:
         mainAxisExtent = size.height;
         leadingScrollOffset = bounds.top;
         targetMainAxisExtent = bounds.height;
-        break;
       case AxisDirection.left:
         mainAxisExtent = size.width;
         leadingScrollOffset = contentSize.width - bounds.right;
         targetMainAxisExtent = bounds.width;
-        break;
     }
 
     final double targetOffset = leadingScrollOffset - (mainAxisExtent - targetMainAxisExtent) * alignment;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1928,10 +1928,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       switch (renderObject.constraints.axis) {
         case Axis.horizontal:
           itemExtent = child.renderObject!.paintBounds.width;
-          break;
         case Axis.vertical:
           itemExtent = child.renderObject!.paintBounds.height;
-          break;
       }
 
       return parentData.layoutOffset != null &&

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -146,10 +146,8 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
     switch (constraints.axis) {
       case Axis.horizontal:
         _resolvedPadding = EdgeInsets.symmetric(horizontal: paddingValue);
-        break;
       case Axis.vertical:
         _resolvedPadding = EdgeInsets.symmetric(vertical: paddingValue);
-        break;
     }
 
     return;

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -903,7 +903,6 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
               onCancel == null) {
             return false;
           }
-          break;
         default:
           return false;
       }
@@ -971,7 +970,6 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
       case _DragState.ready:
         _checkCancel();
         resolve(GestureDisposition.rejected);
-        break;
 
       case _DragState.possible:
         if (_pastSlopTolerance) {
@@ -994,13 +992,11 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
             _checkTapUp(currentUp!);
           }
         }
-        break;
 
       case _DragState.accepted:
         // For the case when the pointer has been accepted as a drag.
         // Meaning [_checkTapDown] and [_checkDragStart] have already ran.
         _checkDragEnd();
-        break;
     }
 
     _stopDeadlineTimer();

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -734,7 +734,6 @@ class TextSelectionOverlay {
         if (position.offset <= _selection.start) {
           return; // Don't allow order swapping.
         }
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -746,7 +745,6 @@ class TextSelectionOverlay {
         if (newSelection.baseOffset >= newSelection.extentOffset) {
           return; // Don't allow order swapping.
         }
-        break;
     }
 
     _handleSelectionHandleChanged(newSelection);
@@ -830,7 +828,6 @@ class TextSelectionOverlay {
         if (newSelection.extentOffset >= _selection.end) {
           return; // Don't allow order swapping.
         }
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -842,7 +839,6 @@ class TextSelectionOverlay {
         if (newSelection.baseOffset >= newSelection.extentOffset) {
           return; // Don't allow order swapping.
         }
-        break;
     }
 
     _selectionOverlay.updateMagnifier(_buildMagnifier(
@@ -1162,7 +1158,6 @@ class SelectionOverlay {
         switch(defaultTargetPlatform) {
           case TargetPlatform.android:
             HapticFeedback.selectionClick();
-            break;
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:
           case TargetPlatform.linux:
@@ -2072,7 +2067,6 @@ class TextSelectionGestureDetectorBuilder {
         // then the selection moves to the closest word edge, instead of a
         // precise position.
         renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         if (isShiftPressedValid) {
@@ -2080,7 +2074,6 @@ class TextSelectionGestureDetectorBuilder {
           return;
         }
         renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-        break;
     }
   }
 
@@ -2152,7 +2145,6 @@ class TextSelectionGestureDetectorBuilder {
         case TargetPlatform.windows:
           editableText.hideToolbar();
           // On desktop platforms the selection is set on tap down.
-          break;
         case TargetPlatform.android:
           editableText.hideToolbar();
           editableText.showSpellCheckSuggestionsToolbar();
@@ -2161,7 +2153,6 @@ class TextSelectionGestureDetectorBuilder {
             return;
           }
           renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-          break;
         case TargetPlatform.fuchsia:
           editableText.hideToolbar();
           if (isShiftPressedValid) {
@@ -2169,7 +2160,6 @@ class TextSelectionGestureDetectorBuilder {
             return;
           }
           renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-          break;
         case TargetPlatform.iOS:
           if (isShiftPressedValid) {
             // On iOS, a shift-tapped unfocused field expands from 0, not from
@@ -2191,7 +2181,6 @@ class TextSelectionGestureDetectorBuilder {
             case PointerDeviceKind.invertedStylus:
               // Precise devices should place the cursor at a precise position.
               renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-              break;
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
               // Toggle the toolbar if the `previousSelection` is collapsed, the tap is on the selection, the
@@ -2220,9 +2209,7 @@ class TextSelectionGestureDetectorBuilder {
                   editableText.hideToolbar(false);
                 }
               }
-              break;
           }
-          break;
       }
     }
   }
@@ -2257,20 +2244,17 @@ class TextSelectionGestureDetectorBuilder {
             from: details.globalPosition,
             cause: SelectionChangedCause.longPress,
           );
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           renderEditable.selectWord(cause: SelectionChangedCause.longPress);
-          break;
       }
 
       switch (defaultTargetPlatform) {
         case TargetPlatform.android:
         case TargetPlatform.iOS:
           editableText.showMagnifier(details.globalPosition);
-          break;
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
@@ -2311,7 +2295,6 @@ class TextSelectionGestureDetectorBuilder {
             from: details.globalPosition,
             cause: SelectionChangedCause.longPress,
           );
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
@@ -2321,14 +2304,12 @@ class TextSelectionGestureDetectorBuilder {
             to: details.globalPosition,
             cause: SelectionChangedCause.longPress,
           );
-          break;
       }
 
       switch (defaultTargetPlatform) {
         case TargetPlatform.android:
         case TargetPlatform.iOS:
           editableText.showMagnifier(details.globalPosition);
-          break;
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
@@ -2352,7 +2333,6 @@ class TextSelectionGestureDetectorBuilder {
       case TargetPlatform.android:
       case TargetPlatform.iOS:
         editableText.hideMagnifier();
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
@@ -2384,7 +2364,6 @@ class TextSelectionGestureDetectorBuilder {
           editableText.hideToolbar();
           editableText.showToolbar();
         }
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -2393,7 +2372,6 @@ class TextSelectionGestureDetectorBuilder {
           renderEditable.selectPosition(cause: SelectionChangedCause.tap);
         }
         editableText.toggleToolbar();
-        break;
     }
   }
 
@@ -2469,13 +2447,11 @@ class TextSelectionGestureDetectorBuilder {
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           _expandSelection(details.globalPosition, SelectionChangedCause.drag);
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           _extendSelection(details.globalPosition, SelectionChangedCause.drag);
-          break;
       }
     } else {
       switch (defaultTargetPlatform) {
@@ -2491,7 +2467,6 @@ class TextSelectionGestureDetectorBuilder {
                 from: details.globalPosition,
                 cause: SelectionChangedCause.drag,
               );
-              break;
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
               // For Android, Fucshia, and iOS platforms, a touch drag
@@ -2502,11 +2477,9 @@ class TextSelectionGestureDetectorBuilder {
                   cause: SelectionChangedCause.drag,
                 );
               }
-              break;
             case null:
               break;
           }
-          break;
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
@@ -2514,7 +2487,6 @@ class TextSelectionGestureDetectorBuilder {
             from: details.globalPosition,
             cause: SelectionChangedCause.drag,
           );
-          break;
       }
     }
   }
@@ -2587,7 +2559,6 @@ class TextSelectionGestureDetectorBuilder {
                   cause: SelectionChangedCause.drag,
                 );
               }
-              break;
             case null:
               break;
           }
@@ -2615,7 +2586,6 @@ class TextSelectionGestureDetectorBuilder {
                   cause: SelectionChangedCause.drag,
                 );
               }
-              break;
             case null:
               break;
           }
@@ -3048,7 +3018,6 @@ class ClipboardStatusNotifier extends ValueNotifier<ClipboardStatus> with Widget
     switch (state) {
       case AppLifecycleState.resumed:
         update();
-        break;
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -296,11 +296,9 @@ class ScaleTransition extends AnimatedWidget {
       case AnimationStatus.dismissed:
       case AnimationStatus.completed:
         useFilterQuality = false;
-        break;
       case AnimationStatus.forward:
       case AnimationStatus.reverse:
         useFilterQuality = true;
-        break;
     }
     return Transform.scale(
       scale: scale.value,
@@ -379,11 +377,9 @@ class RotationTransition extends AnimatedWidget {
       case AnimationStatus.dismissed:
       case AnimationStatus.completed:
         useFilterQuality = false;
-        break;
       case AnimationStatus.forward:
       case AnimationStatus.reverse:
         useFilterQuality = true;
-        break;
     }
     return Transform.rotate(
       angle: turns.value * math.pi * 2.0,

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -196,10 +196,8 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
     switch(direction) {
       case UndoDirection.undo:
         undo();
-        break;
       case UndoDirection.redo:
         redo();
-        break;
     }
   }
 

--- a/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
@@ -59,13 +59,11 @@ void main() {
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoTextSelectionToolbar), findsOneWidget);
         expect(find.byType(CupertinoDesktopTextSelectionToolbar), findsNothing);
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.byType(CupertinoTextSelectionToolbar), findsNothing);
         expect(find.byType(CupertinoDesktopTextSelectionToolbar), findsOneWidget);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(),
@@ -144,12 +142,10 @@ void main() {
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsOneWidget);
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
@@ -185,12 +181,10 @@ void main() {
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsNWidgets(4));
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNWidgets(4));
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
@@ -231,13 +225,11 @@ void main() {
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsOneWidget);
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(),

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -451,7 +451,6 @@ void main() {
       case TargetPlatform.iOS:
         // Does not throw if we aren't using it.
         defaultBehavior.buildScrollbar(capturedContext, child, details);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
@@ -464,7 +463,6 @@ void main() {
                 'description', contains('details.controller != null')),
           ),
         );
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2069,13 +2069,11 @@ void main() {
           case TargetPlatform.macOS:
           case TargetPlatform.iOS:
             expect(find.byType(CupertinoButton), findsNWidgets(3));
-            break;
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.linux:
           case TargetPlatform.windows:
             expect(find.byType(CupertinoButton), findsNWidgets(4));
-            break;
         }
       }
     },
@@ -2321,13 +2319,11 @@ void main() {
           case TargetPlatform.macOS:
           case TargetPlatform.iOS:
             matchToolbarButtons = findsNWidgets(3);
-            break;
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.linux:
           case TargetPlatform.windows:
             matchToolbarButtons = findsNWidgets(4);
-            break;
         }
       }
       expect(find.byType(CupertinoButton), matchToolbarButtons);
@@ -3422,13 +3418,11 @@ void main() {
         case TargetPlatform.macOS:
         case TargetPlatform.iOS:
           matchToolbarButtons = findsNWidgets(3);
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           matchToolbarButtons = findsNWidgets(4);
-          break;
       }
     }
     expect(find.byType(CupertinoButton), matchToolbarButtons);
@@ -4909,14 +4903,12 @@ void main() {
           // On Apple platforms, dragging the base handle makes it the extent.
           expect(controller.selection.baseOffset, testValue.length);
           expect(controller.selection.extentOffset, toOffset);
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(controller.selection.baseOffset, toOffset);
           expect(controller.selection.extentOffset, testValue.length);
-          break;
       }
 
       // The scroll area of text field should not move.
@@ -6596,7 +6588,6 @@ void main() {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 0);
-        break;
 
       // Other platforms start from the previous selection.
       case TargetPlatform.android:
@@ -6604,7 +6595,6 @@ void main() {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 35);
-        break;
     }
     expect(controller.selection.extentOffset, 20);
   }, variant: TargetPlatformVariant.all());
@@ -7075,7 +7065,6 @@ void main() {
         expect(find.text('Cut'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Paste'), findsOneWidget);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -7085,7 +7074,6 @@ void main() {
         expect(find.text('Cut'), findsNothing);
         expect(find.text('Copy'), findsNothing);
         expect(find.text('Paste'), findsOneWidget);
-        break;
     }
 
     // Right click the first word.
@@ -7101,7 +7089,6 @@ void main() {
         expect(find.text('Cut'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Paste'), findsOneWidget);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -7111,7 +7098,6 @@ void main() {
         expect(find.text('Cut'), findsNothing);
         expect(find.text('Copy'), findsNothing);
         expect(find.text('Paste'), findsNothing);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(),

--- a/packages/flutter/test/cupertino/theme_test.dart
+++ b/packages/flutter/test/cupertino/theme_test.dart
@@ -229,10 +229,8 @@ void main() {
     switch (currentBrightness) {
       case Brightness.light:
         expect(componentColor, isSameColorAs(expectedDynamicColor.color));
-        break;
       case Brightness.dark:
         expect(componentColor, isSameColorAs(expectedDynamicColor.darkColor));
-        break;
     }
   }
 

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -902,10 +902,8 @@ void main() {
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         expect(find.byType(CupertinoScrollbar), findsNothing);
-        break;
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoScrollbar), findsOneWidget);
-        break;
       case null:
         break;
     }
@@ -962,10 +960,8 @@ void main() {
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         expect(find.byType(CupertinoScrollbar), findsNothing);
-        break;
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoScrollbar), findsOneWidget);
-        break;
       case null:
         break;
     }

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -57,19 +57,16 @@ void main() {
         expect(find.byType(CupertinoTextSelectionToolbar), findsNothing);
         expect(find.byType(DesktopTextSelectionToolbar), findsNothing);
         expect(find.byType(CupertinoDesktopTextSelectionToolbar), findsNothing);
-        break;
       case TargetPlatform.iOS:
         expect(find.byType(TextSelectionToolbar), findsNothing);
         expect(find.byType(CupertinoTextSelectionToolbar), findsOneWidget);
         expect(find.byType(DesktopTextSelectionToolbar), findsNothing);
         expect(find.byType(CupertinoDesktopTextSelectionToolbar), findsNothing);
-        break;
       case TargetPlatform.macOS:
         expect(find.byType(TextSelectionToolbar), findsNothing);
         expect(find.byType(CupertinoTextSelectionToolbar), findsNothing);
         expect(find.byType(DesktopTextSelectionToolbar), findsNothing);
         expect(find.byType(CupertinoDesktopTextSelectionToolbar), findsOneWidget);
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
@@ -77,7 +74,6 @@ void main() {
         expect(find.byType(CupertinoTextSelectionToolbar), findsNothing);
         expect(find.byType(DesktopTextSelectionToolbar), findsOneWidget);
         expect(find.byType(CupertinoDesktopTextSelectionToolbar), findsNothing);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(),
@@ -158,17 +154,13 @@ void main() {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         expect(find.byType(TextSelectionToolbarTextButton), findsOneWidget);
-        break;
       case TargetPlatform.iOS:
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsOneWidget);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.byType(DesktopTextSelectionToolbarButton), findsOneWidget);
-        break;
       case TargetPlatform.macOS:
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
@@ -207,20 +199,16 @@ void main() {
       case TargetPlatform.fuchsia:
         expect(find.text('Select all'), findsOneWidget);
         expect(find.byType(TextSelectionToolbarTextButton), findsNWidgets(4));
-        break;
       case TargetPlatform.iOS:
         expect(find.text('Select All'), findsOneWidget);
         expect(find.byType(CupertinoTextSelectionToolbarButton), findsNWidgets(4));
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(find.text('Select all'), findsOneWidget);
         expect(find.byType(DesktopTextSelectionToolbarButton), findsNWidgets(4));
-        break;
       case TargetPlatform.macOS:
         expect(find.text('Select All'), findsOneWidget);
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNWidgets(4));
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
@@ -291,10 +279,8 @@ void main() {
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-          break;
         case TargetPlatform.macOS:
           expect(buttonTypes, isNot(contains(ContextMenuButtonType.selectAll)));
-          break;
       }
 
       // With text and selection.
@@ -316,11 +302,9 @@ void main() {
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           expect(buttonTypes, isNot(contains(ContextMenuButtonType.selectAll)));
-          break;
       }
     },
       variant: TargetPlatformVariant.all(),
@@ -365,26 +349,22 @@ void main() {
           expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
           expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
           expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-          break;
         case TargetPlatform.iOS:
           expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
           expect(find.byType(CupertinoTextSelectionToolbarButton), findsOneWidget);
           expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
           expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-          break;
         case TargetPlatform.macOS:
           expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
           expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
           expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
           expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
-          break;
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
           expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
           expect(find.byType(DesktopTextSelectionToolbarButton), findsOneWidget);
           expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
-          break;
       }
     },
       variant: TargetPlatformVariant.all(),

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1482,7 +1482,6 @@ void main() {
       case TargetPlatform.iOS:
         // Does not throw if we aren't using it.
         defaultBehavior.buildScrollbar(capturedContext, child, details);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
@@ -1495,7 +1494,6 @@ void main() {
               'description', contains('details.controller != null')),
           ),
         );
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 
@@ -1534,7 +1532,6 @@ void main() {
         // Does not throw if we aren't using it.
         // Horizontal axis gets no scrollbars for all platforms.
         defaultBehavior.buildScrollbar(capturedContext, child, details);
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 }

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -201,7 +201,6 @@ void main() {
     switch(defaultTargetPlatform) {
       case TargetPlatform.android:
         expectedLabel = 'Back';
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
       case TargetPlatform.linux:
@@ -245,7 +244,6 @@ void main() {
     switch(defaultTargetPlatform) {
       case TargetPlatform.android:
         expectedLabel = 'Close';
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
       case TargetPlatform.linux:

--- a/packages/flutter/test/material/drawer_button_test.dart
+++ b/packages/flutter/test/material/drawer_button_test.dart
@@ -150,7 +150,6 @@ void main() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         expectedLabel = 'Open navigation menu';
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
       case TargetPlatform.linux:
@@ -208,7 +207,6 @@ void main() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         expectedLabel = 'Open navigation menu';
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
       case TargetPlatform.linux:

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -841,12 +841,10 @@ void main() {
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         isMobile = true;
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         isMobile = false;
-        break;
     }
     int expectedCount = isMobile ? 0 : 1;
 

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -728,10 +728,8 @@ void main() {
               buttonBox.localToGlobal(buttonBox.size.bottomRight(Offset.zero)),
               equals(itemBox.localToGlobal(itemBox.size.bottomRight(Offset.zero))),
             );
-            break;
           case TextDirection.ltr:
             expect(buttonBox.localToGlobal(Offset.zero), equals(itemBox.localToGlobal(Offset.zero)));
-            break;
         }
         expect(buttonBox.size.height, equals(itemBox.size.height));
       }

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -1742,11 +1742,9 @@ class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation
       case TextDirection.rtl:
         final double startPadding = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.right;
         fabX = scaffoldGeometry.scaffoldSize.width - scaffoldGeometry.floatingActionButtonSize.width - startPadding;
-        break;
       case TextDirection.ltr:
         final double startPadding = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.left;
         fabX = startPadding;
-        break;
     }
     final double fabY = scaffoldGeometry.contentTop - (scaffoldGeometry.floatingActionButtonSize.height / 2.0);
     return Offset(fabX, fabY);

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -1870,7 +1870,6 @@ void main() {
           expect(mnemonic2.data, equals('Alt+C'));
           mnemonic3 = tester.widget(findMnemonic(TestMenu.subSubMenu113.label));
           expect(mnemonic3.data, equals('Meta+D'));
-          break;
         case TargetPlatform.windows:
           mnemonic0 = tester.widget(findMnemonic(TestMenu.subSubMenu110.label));
           expect(mnemonic0.data, equals('Ctrl+A'));
@@ -1880,7 +1879,6 @@ void main() {
           expect(mnemonic2.data, equals('Alt+C'));
           mnemonic3 = tester.widget(findMnemonic(TestMenu.subSubMenu113.label));
           expect(mnemonic3.data, equals('Win+D'));
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           mnemonic0 = tester.widget(findMnemonic(TestMenu.subSubMenu110.label));
@@ -1891,7 +1889,6 @@ void main() {
           expect(mnemonic2.data, equals('⌥ C'));
           mnemonic3 = tester.widget(findMnemonic(TestMenu.subSubMenu113.label));
           expect(mnemonic3.data, equals('⌘ D'));
-          break;
       }
 
       await tester.pumpWidget(
@@ -2414,7 +2411,6 @@ void main() {
           expectedAlt = 'Alt';
           expectedShift = 'Shift';
           expectedSeparator = '+';
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           expectedCtrl = '⌃';
@@ -2422,7 +2418,6 @@ void main() {
           expectedAlt = '⌥';
           expectedShift = '⇧';
           expectedSeparator = ' ';
-          break;
       }
 
       const SingleActivator allModifiers = SingleActivator(

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -23,7 +23,6 @@ void main() {
             isNotNull,
             reason: 'theme builder for $platform is null',
           );
-          break;
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
@@ -32,7 +31,6 @@ void main() {
             isNull,
             reason: 'theme builder for $platform is not null',
           );
-          break;
       }
     }
   });

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -737,7 +737,6 @@ void main() {
                   expect(newRect.left, lessThan(rect.left));
                 }
               }
-              break;
             case TextDirection.ltr:
               expect(newRect.left, rect.left);
               if (doneHorizontally) {
@@ -749,7 +748,6 @@ void main() {
                   expect(newRect.right, greaterThan(rect.right));
                 }
               }
-              break;
           }
           rect = newRect;
         } while (tester.binding.hasScheduledFrame);
@@ -781,7 +779,6 @@ void main() {
               }
               expect(newRect.top, rect.top);
               expect(newRect.bottom, greaterThan(rect.bottom));
-              break;
             case 1:
               if (newRect.top == rect.top) {
                 verticalStage = 2;
@@ -790,11 +787,9 @@ void main() {
               }
               expect(newRect.top, lessThan(rect.top));
               expect(newRect.bottom, rect.bottom);
-              break;
             case 2:
               expect(newRect.bottom, rect.bottom);
               expect(newRect.top, rect.top);
-              break;
             default:
               assert(false);
           }
@@ -810,7 +805,6 @@ void main() {
                   expect(newRect.left, lessThan(rect.left));
                 }
               }
-              break;
             case TextDirection.ltr:
               expect(newRect.left, rect.left);
               if (doneHorizontally) {
@@ -822,7 +816,6 @@ void main() {
                   expect(newRect.right, greaterThan(rect.right));
                 }
               }
-              break;
           }
           rect = newRect;
         } while (tester.binding.hasScheduledFrame);

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -28,17 +28,13 @@ void main() {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         expect(region.selectionControls, materialTextSelectionHandleControls);
-        break;
       case TargetPlatform.iOS:
         expect(region.selectionControls, cupertinoTextSelectionHandleControls);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(region.selectionControls, desktopTextSelectionHandleControls);
-        break;
       case TargetPlatform.macOS:
         expect(region.selectionControls, cupertinoDesktopTextSelectionHandleControls);
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2708,28 +2708,22 @@ Map<DismissDirection, List<Offset>> _getDragGesturesOfDismissDirections(double s
     switch (val) {
       case DismissDirection.down:
         dragGestures[val] = <Offset>[const Offset(0.0, 50.0)]; // drag to bottom gesture
-        break;
       case DismissDirection.up:
         dragGestures[val] = <Offset>[const Offset(0.0, -50.0)]; // drag to top gesture
-        break;
       case DismissDirection.vertical:
         dragGestures[val] = <Offset>[
           const Offset(0.0, 50.0), // drag to bottom gesture
           const Offset(0.0, -50.0), // drag to top gesture
         ];
-        break;
       case DismissDirection.startToEnd:
         dragGestures[val] = <Offset>[Offset(scaffoldWidth, 0.0)]; // drag to right gesture
-        break;
       case DismissDirection.endToStart:
         dragGestures[val] = <Offset>[Offset(-scaffoldWidth, 0.0)]; // drag to left gesture
-        break;
       case DismissDirection.horizontal:
         dragGestures[val] = <Offset>[
           Offset(scaffoldWidth, 0.0), // drag to right gesture
           Offset(-scaffoldWidth, 0.0), // drag to left gesture
         ];
-        break;
       case DismissDirection.none:
         break;
     }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2394,14 +2394,12 @@ void main() {
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 11);
         expect(controller.selection.extentOffset, 2);
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 2);
         expect(controller.selection.extentOffset, 11);
-        break;
     }
 
     // Drag the left handle 2 letters to the left again.
@@ -2424,14 +2422,12 @@ void main() {
         // The left handle was already the extent, and it remains so.
         expect(controller.selection.baseOffset, 11);
         expect(controller.selection.extentOffset, 0);
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 0);
         expect(controller.selection.extentOffset, 11);
-        break;
     }
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
@@ -2503,14 +2499,12 @@ void main() {
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 11);
         expect(controller.selection.extentOffset, 2);
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 2);
         expect(controller.selection.extentOffset, 11);
-        break;
     }
 
     // Drag the left handle 2 letters to the left again.
@@ -2533,14 +2527,12 @@ void main() {
         // The left handle was already the extent, and it remains so.
         expect(controller.selection.baseOffset, 11);
         expect(controller.selection.extentOffset, 0);
-        break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 0);
         expect(controller.selection.extentOffset, 11);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
@@ -2620,14 +2612,12 @@ void main() {
           // On Apple platforms, dragging the base handle makes it the extent.
           expect(controller.selection.baseOffset, testValue.length);
           expect(controller.selection.extentOffset, toOffset);
-          break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
           expect(controller.selection.baseOffset, toOffset);
           expect(controller.selection.extentOffset, testValue.length);
-          break;
       }
 
       // The scroll area of text field should not move.
@@ -12151,10 +12141,8 @@ void main() {
         switch (methodCall.method) {
           case 'Clipboard.getData':
             calledGetData = true;
-            break;
           case 'Clipboard.hasStrings':
             calledHasStrings = true;
-            break;
           default:
             break;
         }
@@ -13054,7 +13042,6 @@ void main() {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 0);
-        break;
 
       // Other platforms start from the previous selection.
       case TargetPlatform.android:
@@ -13062,7 +13049,6 @@ void main() {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 35);
-        break;
     }
     expect(controller.selection.extentOffset, 20);
   }, variant: TargetPlatformVariant.all());
@@ -13527,7 +13513,6 @@ void main() {
         expect(find.text('Cut'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Paste'), findsOneWidget);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -13538,7 +13523,6 @@ void main() {
         expect(find.text('Copy'), findsNothing);
         expect(find.text('Paste'), findsOneWidget);
         expect(find.text('Select all'), findsOneWidget);
-        break;
     }
 
     // Right click the first word.
@@ -13554,7 +13538,6 @@ void main() {
         expect(find.text('Cut'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Paste'), findsOneWidget);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -13565,7 +13548,6 @@ void main() {
         expect(find.text('Copy'), findsNothing);
         expect(find.text('Paste'), findsNothing);
         expect(find.text('Select all'), findsNothing);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(),
@@ -14295,21 +14277,17 @@ void main() {
               case TargetPlatform.android:
               case TargetPlatform.fuchsia:
                 expect(focusNode.hasPrimaryFocus, equals(!kIsWeb));
-                break;
               case TargetPlatform.linux:
               case TargetPlatform.macOS:
               case TargetPlatform.windows:
                 expect(focusNode.hasPrimaryFocus, isFalse);
-                break;
             }
-            break;
           case PointerDeviceKind.mouse:
           case PointerDeviceKind.stylus:
           case PointerDeviceKind.invertedStylus:
           case PointerDeviceKind.trackpad:
           case PointerDeviceKind.unknown:
             expect(focusNode.hasPrimaryFocus, isFalse);
-            break;
         }
       }, variant: TargetPlatformVariant.all());
     }

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1104,7 +1104,6 @@ void main() {
         expect(find.text('Cut'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Paste'), findsOneWidget);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -1115,7 +1114,6 @@ void main() {
         expect(find.text('Copy'), findsNothing);
         expect(find.text('Paste'), findsOneWidget);
         expect(find.text('Select all'), findsOneWidget);
-        break;
     }
 
     // Right click the first word.
@@ -1131,7 +1129,6 @@ void main() {
         expect(find.text('Cut'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Paste'), findsOneWidget);
-        break;
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -1142,7 +1139,6 @@ void main() {
         expect(find.text('Copy'), findsNothing);
         expect(find.text('Paste'), findsNothing);
         expect(find.text('Select all'), findsNothing);
-        break;
     }
   },
     variant: TargetPlatformVariant.all(),

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -90,12 +90,10 @@ void main() {
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
         expect(themeData.materialTapTargetSize, MaterialTapTargetSize.padded);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         expect(themeData.materialTapTargetSize, MaterialTapTargetSize.shrinkWrap);
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 
@@ -434,7 +432,6 @@ void main() {
         } else {
           expect(theme.splashFactory, equals(InkSparkle.splashFactory));
         }
-        break;
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -464,7 +461,6 @@ void main() {
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(VisualDensity.adaptivePlatformDensity, equals(VisualDensity.standard));
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
@@ -479,7 +475,6 @@ void main() {
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(themeData.visualDensity, equals(VisualDensity.standard));
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -27,12 +27,10 @@ void main() {
         selectTimeString = 'SELECT TIME';
         enterTimeString = 'ENTER TIME';
         cancelString = 'CANCEL';
-        break;
       case MaterialType.material3:
         selectTimeString = 'Select time';
         enterTimeString = 'Enter time';
         cancelString = 'Cancel';
-        break;
     }
 
     group('Dial (${materialType.name})', () {
@@ -413,7 +411,6 @@ void main() {
             // ignore: avoid_dynamic_calls
             expect(selectedLabels.map<String>((dynamic tp) => tp.painter.text.text as String), labels00To22);
           });
-          break;
         case MaterialType.material3:
           testWidgets('Dialog size - dial mode', (WidgetTester tester) async {
             addTearDown(tester.view.reset);
@@ -519,7 +516,6 @@ void main() {
             // ignore: avoid_dynamic_calls
             expect(selectedLabels.map<bool>((dynamic tp) => tp.inner as bool), inner0To23);
           });
-          break;
       }
 
       testWidgets('when change orientation, should reflect in render objects', (WidgetTester tester) async {
@@ -752,13 +748,11 @@ void main() {
             expect(tester.getBottomRight(find.text(okString)).dx, 644);
             expect(tester.getBottomLeft(find.text(okString)).dx, 616);
             expect(tester.getBottomRight(find.text(cancelString)).dx, 582);
-            break;
           case MaterialType.material3:
             expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(138, 129)));
             expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(292.0, 143.0)));
             expect(tester.getBottomLeft(find.text(okString)).dx, 616);
             expect(tester.getBottomRight(find.text(cancelString)).dx, 578);
-            break;
         }
 
         await tester.tap(find.text(okString));
@@ -775,14 +769,12 @@ void main() {
             expect(tester.getBottomLeft(find.text(okString)).dx, 156);
             expect(tester.getBottomRight(find.text(okString)).dx, 184);
             expect(tester.getBottomLeft(find.text(cancelString)).dx, 218);
-            break;
           case MaterialType.material3:
             expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(508, 129)));
             expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(662, 143)));
             expect(tester.getBottomLeft(find.text(okString)).dx, 156);
             expect(tester.getBottomRight(find.text(okString)).dx, 184);
             expect(tester.getBottomLeft(find.text(cancelString)).dx, 222);
-            break;
         }
 
         await tester.tap(find.text(okString));

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -451,7 +451,6 @@ void main() {
                 ),
               ),
             );
-            break;
           case null:
             box = RenderConstraintsTransformBox(
               alignment: Alignment.center,
@@ -464,7 +463,6 @@ void main() {
                 ),
               ),
             );
-            break;
         }
         layout(box, constraints: const BoxConstraints(), phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
         context.paintChild(box, Offset.zero);
@@ -474,12 +472,10 @@ void main() {
           case null:
           case Clip.none:
             expect(hadErrors, isTrue, reason: 'Should have had overflow errors for $clip');
-            break;
           case Clip.hardEdge:
           case Clip.antiAlias:
           case Clip.antiAliasWithSaveLayer:
             expect(hadErrors, isFalse, reason: 'Should not have had overflow errors for $clip');
-            break;
         }
         hadErrors = false;
       }
@@ -727,7 +723,6 @@ void main() {
             child: box200x200,
             clipBehavior: clip!,
           );
-          break;
         case null:
           box = RenderConstraintsTransformBox(
             constraintsTransform: ConstraintsTransformBox.unconstrained,
@@ -735,19 +730,16 @@ void main() {
             textDirection: TextDirection.ltr,
             child: box200x200,
           );
-          break;
       }
       layout(box, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
       switch (clip) {
         case null:
         case Clip.none:
           expect(hadErrors, isTrue, reason: 'Should have had overflow errors for $clip');
-          break;
         case Clip.hardEdge:
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:
           expect(hadErrors, isFalse, reason: 'Should not have had overflow errors for $clip');
-          break;
       }
       hadErrors = false;
       context.paintChild(box, Offset.zero);

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -77,7 +77,6 @@ void main() {
             selection: const TextSelection(baseOffset: 0, extentOffset: 0),
             clipBehavior: clip!,
           );
-          break;
         case null:
           editable = RenderEditable(
             text: TextSpan(text: longString),
@@ -88,7 +87,6 @@ void main() {
             textSelectionDelegate: _FakeEditableTextState(),
             selection: const TextSelection(baseOffset: 0, extentOffset: 0),
           );
-          break;
       }
       layout(editable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectNoFlutterErrors);
       context.paintChild(editable, Offset.zero);

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -70,10 +70,8 @@ void main() {
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:
           flex = RenderFlex(direction: Axis.vertical, children: <RenderBox>[box200x200], clipBehavior: clip!);
-          break;
         case null:
           flex = RenderFlex(direction: Axis.vertical, children: <RenderBox>[box200x200]);
-          break;
       }
       layout(flex, constraints: viewport, phase: EnginePhase.composite, onErrors: () {
         absorbOverflowedErrors();

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -545,10 +545,8 @@ void main() {
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:
           box = RenderFittedBox(child: box200x200, fit: BoxFit.none, clipBehavior: clip!);
-          break;
         case null:
           box = RenderFittedBox(child: box200x200, fit: BoxFit.none);
-          break;
       }
       layout(box, constraints: viewport, phase: EnginePhase.composite, onErrors: expectNoFlutterErrors);
       box.paint(context, Offset.zero);

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -80,13 +80,11 @@ void main() {
             children: <RenderBox>[child],
             clipBehavior: clip!,
           );
-          break;
         case null:
           stack = RenderStack(
             textDirection: TextDirection.ltr,
             children: <RenderBox>[child],
           );
-          break;
       }
       { // Make sure that the child is positioned so the stack will consider it as overflowed.
         final StackParentData parentData = child.parentData! as StackParentData;

--- a/packages/flutter/test/rendering/wrap_test.dart
+++ b/packages/flutter/test/rendering/wrap_test.dart
@@ -216,10 +216,8 @@ void main() {
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:
           wrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200], clipBehavior: clip!);
-          break;
         case null:
           wrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200]);
-          break;
       }
       layout(wrap, constraints: viewport, phase: EnginePhase.composite, onErrors: expectNoFlutterErrors);
       context.paintChild(wrap, Offset.zero);

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -619,12 +619,10 @@ void main() {
             startsWith('A RenderConstraintsTransformBox overflowed'),
             reason: 'for clip = $clip',
           );
-          break;
         case Clip.hardEdge:
         case Clip.antiAlias:
         case Clip.antiAliasWithSaveLayer:
           expect(tester.takeException(), isNull, reason: 'for clip = $clip');
-          break;
       }
     }
   });

--- a/packages/flutter/test/widgets/clipboard_utils.dart
+++ b/packages/flutter/test/widgets/clipboard_utils.dart
@@ -28,7 +28,6 @@ class MockClipboard {
         return <String, bool>{'value': text != null && text.isNotEmpty};
       case 'Clipboard.setData':
         clipboardData = methodCall.arguments;
-        break;
     }
     return null;
   }

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -377,16 +377,13 @@ void _defineTests() {
         case SemanticsAction.moveCursorBackwardByWord:
         case SemanticsAction.moveCursorForwardByWord:
           semanticsOwner.performAction(expectedId, action, true);
-          break;
         case SemanticsAction.setSelection:
           semanticsOwner.performAction(expectedId, action, <String, int>{
             'base': 4,
             'extent': 5,
           });
-          break;
         case SemanticsAction.setText:
           semanticsOwner.performAction(expectedId, action, 'text');
-          break;
         case SemanticsAction.copy:
         case SemanticsAction.customAction:
         case SemanticsAction.cut:
@@ -404,7 +401,6 @@ void _defineTests() {
         case SemanticsAction.showOnScreen:
         case SemanticsAction.tap:
           semanticsOwner.performAction(expectedId, action);
-          break;
       }
       expect(performedActions.length, expectedLength);
       expect(performedActions.last, action);

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -98,23 +98,19 @@ Future<void> dismissElement(WidgetTester tester, Finder finder, { required AxisD
       // edge and outside the Dismissible event listener's bounds.
       downLocation = tester.getTopRight(finder) + const Offset(-0.1, 0.0);
       upLocation = tester.getTopLeft(finder) + const Offset(-0.1, 0.0);
-      break;
     case AxisDirection.right:
       // we do the same thing here to keep the test symmetric
       downLocation = tester.getTopLeft(finder) + const Offset(0.1, 0.0);
       upLocation = tester.getTopRight(finder) + const Offset(0.1, 0.0);
-      break;
     case AxisDirection.up:
       // getBottomLeft() returns a point that's just below itemWidget's bottom
       // edge and outside the Dismissible event listener's bounds.
       downLocation = tester.getBottomLeft(finder) + const Offset(0.0, -0.1);
       upLocation = tester.getTopLeft(finder) + const Offset(0.0, -0.1);
-      break;
     case AxisDirection.down:
       // again with doing the same here for symmetry
       downLocation = tester.getTopLeft(finder) + const Offset(0.1, 0.0);
       upLocation = tester.getBottomLeft(finder) + const Offset(0.1, 0.0);
-      break;
   }
 
   final TestGesture gesture = await tester.startGesture(downLocation);
@@ -127,16 +123,12 @@ Future<void> dragElement(WidgetTester tester, Finder finder, { required AxisDire
   switch (gestureDirection) {
     case AxisDirection.left:
       delta = Offset(-amount, 0.0);
-      break;
     case AxisDirection.right:
       delta = Offset(amount, 0.0);
-      break;
     case AxisDirection.up:
       delta = Offset(0.0, -amount);
-      break;
     case AxisDirection.down:
       delta = Offset(0.0, amount);
-      break;
   }
   await tester.drag(finder, delta);
 }
@@ -146,16 +138,12 @@ Future<void> flingElement(WidgetTester tester, Finder finder, { required AxisDir
   switch (gestureDirection) {
     case AxisDirection.left:
       delta = const Offset(-300.0, 0.0);
-      break;
     case AxisDirection.right:
       delta = const Offset(300.0, 0.0);
-      break;
     case AxisDirection.up:
       delta = const Offset(0.0, -300.0);
-      break;
     case AxisDirection.down:
       delta = const Offset(0.0, 300.0);
-      break;
   }
   await tester.fling(finder, delta, 1000.0, initialOffset: delta * initialOffsetFactor);
 }
@@ -229,16 +217,12 @@ Future<void> rollbackElement(WidgetTester tester, Finder finder, { required Axis
   switch (gestureDirection) {
     case AxisDirection.left:
       delta = const Offset(-30.0, 0.0);
-      break;
     case AxisDirection.right:
       delta = const Offset(30.0, 0.0);
-      break;
     case AxisDirection.up:
       delta = const Offset(0.0, -30.0);
-      break;
     case AxisDirection.down:
       delta = const Offset(0.0, 30.0);
-      break;
   }
   await tester.fling(finder, delta, 1000.0, initialOffset: delta * initialOffsetFactor);
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5946,7 +5946,6 @@ void main() {
                 0 + kMinInteractiveDimension,
               ),
             );
-            break;
           case HandlePositionInViewport.rightEdge:
             expect(
               pos,
@@ -5955,7 +5954,6 @@ void main() {
                 viewport.width + kMinInteractiveDimension,
               ),
             );
-            break;
           case HandlePositionInViewport.within:
             expect(
               pos,
@@ -5964,7 +5962,6 @@ void main() {
                 viewport.width + kMinInteractiveDimension,
               ),
             );
-            break;
         }
       }
       expect(state.selectionOverlay!.handlesAreVisible, isTrue);
@@ -6391,7 +6388,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Mac and iOS expand by line.
       case TargetPlatform.iOS:
@@ -6407,7 +6403,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
 
     // Select All
@@ -6565,7 +6560,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
       // On macOS/iOS expand selection.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
@@ -6579,7 +6573,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
 
     // Move to start again.
@@ -7370,7 +7363,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // These platforms go to the line start/end.
       case TargetPlatform.linux:
@@ -7384,7 +7376,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
 
     expect(controller.text, equals(testText), reason: 'on $platform');
@@ -7412,7 +7403,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // These platforms go to the line start/end.
       case TargetPlatform.linux:
@@ -7427,7 +7417,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
     expect(controller.text, equals(testText), reason: 'on $platform');
   },
@@ -7521,7 +7510,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // These platforms go to the line start/end.
       case TargetPlatform.linux:
@@ -7535,7 +7523,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
 
     expect(controller.text, equals(testText), reason: 'on $platform');
@@ -7563,7 +7550,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Linux does nothing at a wordwrap with subsequent presses.
       case TargetPlatform.linux:
@@ -7576,7 +7562,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Windows jumps to the previous wordwrapped line.
       case TargetPlatform.windows:
@@ -7589,7 +7574,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
@@ -7682,7 +7666,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // These platforms go to the line start/end.
       case TargetPlatform.linux:
@@ -7697,7 +7680,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
     expect(controller.text, equals(testText), reason: 'on $platform');
 
@@ -7724,7 +7706,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Linux does nothing at a wordwrap with subsequent presses.
       case TargetPlatform.linux:
@@ -7738,7 +7719,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Windows jumps to the next wordwrapped line.
       case TargetPlatform.windows:
@@ -7752,7 +7732,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
@@ -7875,7 +7854,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Linux extends to the line start/end.
       case TargetPlatform.linux:
@@ -7900,7 +7878,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Windows expands to the line start/end.
       case TargetPlatform.windows:
@@ -7924,7 +7901,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Mac and iOS go to the start/end of the document.
       case TargetPlatform.iOS:
@@ -7950,7 +7926,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
@@ -8214,7 +8189,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Mac and iOS select to the start of the document.
       case TargetPlatform.iOS:
@@ -8229,7 +8203,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // These platforms select to the line start.
       case TargetPlatform.linux:
@@ -8244,7 +8217,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
 
     expect(controller.text, equals(testText), reason: 'on $platform');
@@ -8271,7 +8243,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Mac and iOS select to the start of the document.
       case TargetPlatform.iOS:
@@ -8286,7 +8257,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Linux does nothing at a wordwrap with subsequent presses.
       case TargetPlatform.linux:
@@ -8300,7 +8270,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Windows jumps to the previous wordwrapped line.
       case TargetPlatform.windows:
@@ -8314,7 +8283,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
@@ -8406,7 +8374,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Mac and iOS select to the end of the document.
       case TargetPlatform.iOS:
@@ -8421,7 +8388,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // These platforms select to the line end.
       case TargetPlatform.linux:
@@ -8437,7 +8403,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
     expect(controller.text, equals(testText), reason: 'on $platform');
 
@@ -8463,7 +8428,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Mac and iOS stay at the end of the document.
       case TargetPlatform.iOS:
@@ -8478,7 +8442,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Linux does nothing at a wordwrap with subsequent presses.
       case TargetPlatform.linux:
@@ -8493,7 +8456,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
 
       // Windows jumps to the previous wordwrapped line.
       case TargetPlatform.windows:
@@ -8508,7 +8470,6 @@ void main() {
           ),
           reason: 'on $platform',
         );
-        break;
     }
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
@@ -9049,7 +9010,6 @@ void main() {
                 0 + kMinInteractiveDimension,
               ),
             );
-            break;
           case HandlePositionInViewport.rightEdge:
             expect(
               pos,
@@ -9058,7 +9018,6 @@ void main() {
                 viewport.width + kMinInteractiveDimension,
               ),
             );
-            break;
           case HandlePositionInViewport.within:
             expect(
               pos,
@@ -9067,7 +9026,6 @@ void main() {
                 viewport.width + kMinInteractiveDimension,
               ),
             );
-            break;
         }
       }
       expect(state.selectionOverlay!.handlesAreVisible, isTrue);
@@ -11650,14 +11608,12 @@ void main() {
       case TargetPlatform.windows:
         expect(controller.selection.baseOffset, 17);
         expect(controller.selection.extentOffset, 15);
-        break;
 
       // Mac and iOS expand by line.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 15);
         expect(controller.selection.extentOffset, 24);
-        break;
     }
 
     // Set the caret to the end of a line.
@@ -13866,7 +13822,6 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
               selection: TextSelection.collapsed(offset: 6),
             ),
           );
-          break;
         // Composing changes are ignored on all other platforms.
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
@@ -13880,7 +13835,6 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
               selection: TextSelection.collapsed(offset: 4),
             ),
           );
-          break;
       }
       await sendUndo(tester);
       expect(
@@ -13925,7 +13879,6 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
               selection: TextSelection.collapsed(offset: 6),
             ),
           );
-          break;
         // Composing changes are ignored on all other platforms.
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
@@ -13939,7 +13892,6 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
               selection: TextSelection.collapsed(offset: 4),
             ),
           );
-          break;
       }
       await sendRedo(tester);
       expect(

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1107,12 +1107,10 @@ void main() {
         case TargetPlatform.android:
         case TargetPlatform.iOS:
           expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.touch));
-          break;
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
         case TargetPlatform.windows:
           expect(FocusManager.instance.highlightMode, equals(FocusHighlightMode.traditional));
-          break;
       }
     }, variant: TargetPlatformVariant.all());
 

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -43,25 +43,18 @@ class TestAssetBundle extends CachingAssetBundle {
     switch (key) {
       case 'AssetManifest.bin':
         data = manifest;
-        break;
       case 'assets/image.png':
         data = testByteData(1.0);
-        break;
       case 'assets/1.0x/image.png':
         data = testByteData(10.0); // see "...with a main asset and a 1.0x asset"
-        break;
       case 'assets/1.5x/image.png':
         data = testByteData(1.5);
-        break;
       case 'assets/2.0x/image.png':
         data = testByteData(2.0);
-        break;
       case 'assets/3.0x/image.png':
         data = testByteData(3.0);
-        break;
       case 'assets/4.0x/image.png':
         data = testByteData(4.0);
-        break;
     }
     return SynchronousFuture<ByteData>(data);
   }

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1105,7 +1105,6 @@ void main() {
         switch(clip) {
           case Clip.none:
             expect(renderObject.describeApproximatePaintClip(child), null);
-            break;
           case Clip.hardEdge:
           case Clip.antiAlias:
           case Clip.antiAliasWithSaveLayer:
@@ -1113,7 +1112,6 @@ void main() {
               renderObject.describeApproximatePaintClip(child),
               const Rect.fromLTRB(0, 0, 800, 600),
             );
-            break;
         }
       });
       expect(visited, true);

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -32,10 +32,8 @@ void main() {
         } else {
           axisDirection = reverse ? AxisDirection.left : AxisDirection.right;
         }
-        break;
       case Axis.vertical:
         axisDirection = reverse ? AxisDirection.up : AxisDirection.down;
-        break;
     }
 
     return Directionality(

--- a/packages/flutter/test/widgets/scroll_behavior_test.dart
+++ b/packages/flutter/test/widgets/scroll_behavior_test.dart
@@ -59,7 +59,6 @@ void main() {
       case TargetPlatform.iOS:
         // Does not throw if we aren't using it.
         defaultBehavior.buildScrollbar(capturedContext, child, details);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
@@ -72,7 +71,6 @@ void main() {
               'description', contains('details.controller != null')),
           ),
         );
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -251,11 +251,9 @@ void main() {
                   ? size.width - rect.right
                   : rect.left,
               );
-              break;
             case AxisDirection.left:
             case AxisDirection.right:
               expect(margin, size.height - rect.bottom);
-              break;
           }
         }
       }
@@ -298,25 +296,21 @@ void main() {
           expect(rect.top, 0);
           expect(rect.right, _kThickness);
           expect(rect.bottom, _kMinThumbExtent);
-          break;
         case ScrollbarOrientation.right:
           expect(rect.left, 600 - _kThickness);
           expect(rect.top, 0);
           expect(rect.right, 600);
           expect(rect.bottom, _kMinThumbExtent);
-          break;
         case ScrollbarOrientation.top:
           expect(rect.left, 0);
           expect(rect.top, 0);
           expect(rect.right, _kMinThumbExtent);
           expect(rect.bottom, _kThickness);
-          break;
         case ScrollbarOrientation.bottom:
           expect(rect.left, 0);
           expect(rect.top, 23 - _kThickness);
           expect(rect.right, _kMinThumbExtent);
           expect(rect.bottom, 23);
-          break;
       }
     }
   });

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -378,14 +378,12 @@ void main() {
           log.last,
           isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.selectionClick'),
         );
-        break;
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         expect(log, isEmpty);
-        break;
     }
     await gesture.up();
   }, variant: TargetPlatformVariant.all());
@@ -1261,12 +1259,10 @@ void main() {
         case TargetPlatform.windows:
           alt = false;
           control = true;
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           alt = true;
           control = false;
-          break;
       }
 
       // Ho[w ar]e you?
@@ -1371,12 +1367,10 @@ void main() {
         case TargetPlatform.windows:
           meta = false;
           alt = true;
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           meta = true;
           alt = false;
-          break;
       }
 
       // Ho[w ar]e you?
@@ -1462,12 +1456,10 @@ void main() {
         case TargetPlatform.windows:
           meta = false;
           alt = true;
-          break;
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
           meta = true;
           alt = false;
-          break;
       }
 
       // Ho[w ar]e you?
@@ -1749,17 +1741,14 @@ void main() {
         expect(regionState.selectionOverlay, isNull);
         expect(regionState.selectionOverlay?.startHandleLayerLink, isNull);
         expect(regionState.selectionOverlay?.endHandleLayerLink, isNull);
-        break;
       case TargetPlatform.iOS:
         expect(regionState.selectionOverlay, isNotNull);
         expect(regionState.selectionOverlay?.startHandleLayerLink, isNotNull);
         expect(regionState.selectionOverlay?.endHandleLayerLink, isNotNull);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
         expect(regionState.selectionOverlay, isNotNull);
-        break;
     }
   },
     skip: kIsWeb, // [intended]
@@ -1805,7 +1794,6 @@ void main() {
         expect(regionState.selectionOverlay, isNotNull);
         expect(regionState.selectionOverlay?.startHandleLayerLink, isNotNull);
         expect(regionState.selectionOverlay?.endHandleLayerLink, isNotNull);
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -329,13 +329,11 @@ void main() {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(value, equals(0.65));
-        break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         expect(value, equals(0.70));
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -546,16 +546,13 @@ void main() {
         case SemanticsAction.moveCursorBackwardByCharacter:
         case SemanticsAction.moveCursorForwardByCharacter:
           semanticsOwner.performAction(expectedId, action, true);
-          break;
         case SemanticsAction.setSelection:
           semanticsOwner.performAction(expectedId, action, <dynamic, dynamic>{
             'base': 4,
             'extent': 5,
           });
-          break;
         case SemanticsAction.setText:
           semanticsOwner.performAction(expectedId, action, 'text');
-          break;
         case SemanticsAction.copy:
         case SemanticsAction.customAction:
         case SemanticsAction.cut:
@@ -575,7 +572,6 @@ void main() {
         case SemanticsAction.showOnScreen:
         case SemanticsAction.tap:
           semanticsOwner.performAction(expectedId, action);
-          break;
       }
       expect(performedActions.length, expectedLength);
       expect(performedActions.last, action);

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -593,7 +593,6 @@ void main() {
       case TargetPlatform.iOS:
         expect(renderEditable.selectWordEdgeCalled, isTrue);
         expect(renderEditable.lastCause, SelectionChangedCause.tap);
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -601,7 +600,6 @@ void main() {
       case TargetPlatform.windows:
         expect(renderEditable.selectPositionAtCalled, isTrue);
         expect(renderEditable.lastCause, SelectionChangedCause.tap);
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 
@@ -626,7 +624,6 @@ void main() {
       case TargetPlatform.iOS:
         expect(renderEditable.selectWordEdgeCalled, isFalse);
         expect(state.toggleToolbarCalled, isTrue);
-        break;
       case TargetPlatform.macOS:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -634,7 +631,6 @@ void main() {
       case TargetPlatform.windows:
         expect(renderEditable.selectPositionAtCalled, isTrue);
         expect(renderEditable.lastCause, SelectionChangedCause.tap);
-        break;
     }
   }, variant: TargetPlatformVariant.all());
 

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -337,19 +337,14 @@ mixin CommandHandlerFactory {
     switch (getOffsetCommand.offsetType) {
       case OffsetType.topLeft:
         localPoint = Offset.zero;
-        break;
       case OffsetType.topRight:
         localPoint = box.size.topRight(Offset.zero);
-        break;
       case OffsetType.bottomLeft:
         localPoint = box.size.bottomLeft(Offset.zero);
-        break;
       case OffsetType.bottomRight:
         localPoint = box.size.bottomRight(Offset.zero);
-        break;
       case OffsetType.center:
         localPoint = box.size.center(Offset.zero);
-        break;
     }
     final Offset globalPoint = box.localToGlobal(localPoint);
     return GetOffsetResult(dx: globalPoint.dx, dy: globalPoint.dy);
@@ -363,10 +358,8 @@ mixin CommandHandlerFactory {
     switch (diagnosticsCommand.diagnosticsType) {
       case DiagnosticsType.renderObject:
         diagnosticsNode = element.renderObject!.toDiagnosticsNode();
-        break;
       case DiagnosticsType.widget:
         diagnosticsNode = element.toDiagnosticsNode();
-        break;
     }
     return DiagnosticsTreeResult(diagnosticsNode.toJsonMap(DiagnosticsSerializationDelegate(
       subtreeDepth: diagnosticsCommand.subtreeDepth,

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1814,7 +1814,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
           _handleViewNeedsPaint();
         }
         super.handlePointerEvent(event);
-        break;
       case TestBindingEventSource.device:
         if (shouldPropagateDevicePointerEvents) {
           super.handlePointerEvent(event);
@@ -1829,7 +1828,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
             () => super.handlePointerEvent(localEvent)
           );
         }
-        break;
     }
   }
 
@@ -1838,7 +1836,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     switch (pointerEventSource) {
       case TestBindingEventSource.test:
         super.dispatchEvent(event, hitTestResult);
-        break;
       case TestBindingEventSource.device:
         assert(hitTestResult != null || event is PointerAddedEvent || event is PointerRemovedEvent);
         if (shouldPropagateDevicePointerEvents) {
@@ -1849,7 +1846,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         if (hitTestResult != null) {
           deviceEventDispatcher!.dispatchEvent(event, hitTestResult);
         }
-        break;
     }
   }
 

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1599,16 +1599,12 @@ abstract class WidgetController {
       switch (widget<Scrollable>(scrollable!).axisDirection) {
         case AxisDirection.up:
           moveStep = Offset(0, delta);
-          break;
         case AxisDirection.down:
           moveStep = Offset(0, -delta);
-          break;
         case AxisDirection.left:
           moveStep = Offset(delta, 0);
-          break;
         case AxisDirection.right:
           moveStep = Offset(-delta, 0);
-          break;
       }
       await dragUntilVisible(
         finder,

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -80,22 +80,16 @@ class KeyEventSimulator {
     switch (platform) {
       case 'android':
         map = kAndroidToPhysicalKey;
-        break;
       case 'fuchsia':
         map = kFuchsiaToPhysicalKey;
-        break;
       case 'macos':
         map = kMacOsToPhysicalKey;
-        break;
       case 'ios':
         map = kIosToPhysicalKey;
-        break;
       case 'linux':
         map = kLinuxToPhysicalKey;
-        break;
       case 'windows':
         map = kWindowsToPhysicalKey;
-        break;
       case 'web':
         // web doesn't have int type code
         return -1;
@@ -122,10 +116,8 @@ class KeyEventSimulator {
       switch (platform) {
         case 'android':
           map = kAndroidToLogicalKey;
-          break;
         case 'fuchsia':
           map = kFuchsiaToLogicalKey;
-          break;
         case 'macos':
         // macOS doesn't do key codes, just scan codes.
           return -1;
@@ -137,10 +129,8 @@ class KeyEventSimulator {
           return -1;
         case 'linux':
           map = kGlfwToLogicalKey;
-          break;
         case 'windows':
           map = kWindowsToLogicalKey;
-          break;
       }
       int? keyCode;
       for (final int code in map.keys) {
@@ -212,25 +202,18 @@ class KeyEventSimulator {
       switch (platform) {
         case 'android':
           map = kAndroidToPhysicalKey;
-          break;
         case 'fuchsia':
           map = kFuchsiaToPhysicalKey;
-          break;
         case 'macos':
           map = kMacOsToPhysicalKey;
-          break;
         case 'ios':
           map = kIosToPhysicalKey;
-          break;
         case 'linux':
           map = kLinuxToPhysicalKey;
-          break;
         case 'web':
           map = kWebToPhysicalKey;
-          break;
         case 'windows':
           map = kWindowsToPhysicalKey;
-          break;
       }
     }
     PhysicalKeyboardKey? result;
@@ -291,21 +274,18 @@ class KeyEventSimulator {
         }
         result['scanCode'] = scanCode;
         result['metaState'] = _getAndroidModifierFlags(key, isDown);
-        break;
       case 'fuchsia':
         result['hidUsage'] = physicalKey.usbHidUsage;
         if (resultCharacter.isNotEmpty) {
           result['codePoint'] = resultCharacter.codeUnitAt(0);
         }
         result['modifiers'] = _getFuchsiaModifierFlags(key, isDown);
-        break;
       case 'linux':
         result['toolkit'] = 'glfw';
         result['keyCode'] = keyCode;
         result['scanCode'] = scanCode;
         result['modifiers'] = _getGlfwModifierFlags(key, isDown);
         result['unicodeScalarValues'] = resultCharacter.isNotEmpty ? resultCharacter.codeUnitAt(0) : 0;
-        break;
       case 'macos':
         result['keyCode'] = scanCode;
         if (resultCharacter.isNotEmpty) {
@@ -313,13 +293,11 @@ class KeyEventSimulator {
           result['charactersIgnoringModifiers'] = resultCharacter;
         }
         result['modifiers'] = _getMacOsModifierFlags(key, isDown);
-        break;
       case 'ios':
         result['keyCode'] = scanCode;
         result['characters'] = resultCharacter;
         result['charactersIgnoringModifiers'] = resultCharacter;
         result['modifiers'] = _getIOSModifierFlags(key, isDown);
-        break;
       case 'windows':
         result['keyCode'] = keyCode;
         result['scanCode'] = scanCode;
@@ -327,10 +305,8 @@ class KeyEventSimulator {
           result['characterCodePoint'] = resultCharacter.codeUnitAt(0);
         }
         result['modifiers'] = _getWindowsModifierFlags(key, isDown);
-        break;
       case 'web':
         assignWeb();
-        break;
     }
     return result;
   }

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -29,14 +29,12 @@ class TestPointer {
     switch (kind) {
       case PointerDeviceKind.mouse:
         _device = device ?? 1;
-        break;
       case PointerDeviceKind.stylus:
       case PointerDeviceKind.invertedStylus:
       case PointerDeviceKind.touch:
       case PointerDeviceKind.trackpad:
       case PointerDeviceKind.unknown:
         _device = device ?? 0;
-        break;
     }
   }
 
@@ -105,12 +103,10 @@ class TestPointer {
       case PointerDownEvent:
         assert(!isDown);
         _isDown = true;
-        break;
       case PointerUpEvent:
       case PointerCancelEvent:
         assert(isDown);
         _isDown = false;
-        break;
       default:
         break;
     }

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -129,29 +129,23 @@ class TestTextInput {
         final List<dynamic> arguments = methodCall.arguments as List<dynamic>;
         _client = arguments[0] as int;
         setClientArgs = arguments[1] as Map<String, dynamic>;
-        break;
       case 'TextInput.updateConfig':
         setClientArgs = methodCall.arguments as Map<String, dynamic>;
-        break;
       case 'TextInput.clearClient':
         _client = null;
         _isVisible = false;
         _keyHandler = null;
         onCleared?.call();
-        break;
       case 'TextInput.setEditingState':
         editingState = methodCall.arguments as Map<String, dynamic>;
-        break;
       case 'TextInput.show':
         _isVisible = true;
         if (!kIsWeb && defaultTargetPlatform == TargetPlatform.macOS) {
           _keyHandler ??= MacOSTestTextInputKeyHandler(_client ?? -1);
         }
-        break;
       case 'TextInput.hide':
         _isVisible = false;
         _keyHandler = null;
-        break;
     }
   }
 

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -49,17 +49,14 @@ class Context {
     switch (subCommand) {
       case 'build':
         buildApp();
-        break;
       case 'thin':
         // No-op, thinning is handled during the bundle asset assemble build target.
         break;
       case 'embed':
         embedFlutterFrameworks();
-        break;
       case 'embed_and_thin':
         // Thinning is handled during the bundle asset assemble build target, so just embed.
         embedFlutterFrameworks();
-        break;
       case 'test_vm_service_bonjour_service':
         // Exposed for integration testing only.
         addVmServiceBonjourService();

--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -552,16 +552,12 @@ class AndroidDevice extends Device {
     switch (devicePlatform) {
       case TargetPlatform.android_arm:
         androidArch = AndroidArch.armeabi_v7a;
-        break;
       case TargetPlatform.android_arm64:
         androidArch = AndroidArch.arm64_v8a;
-        break;
       case TargetPlatform.android_x64:
         androidArch = AndroidArch.x86_64;
-        break;
       case TargetPlatform.android_x86:
         androidArch = AndroidArch.x86;
-        break;
       case TargetPlatform.android:
       case TargetPlatform.darwin:
       case TargetPlatform.fuchsia_arm64:
@@ -949,25 +945,18 @@ AndroidMemoryInfo parseMeminfoDump(String input) {
       switch (key) {
         case AndroidMemoryInfo._kJavaHeapKey:
           androidMemoryInfo.javaHeap = value;
-          break;
         case AndroidMemoryInfo._kNativeHeapKey:
           androidMemoryInfo.nativeHeap = value;
-          break;
         case AndroidMemoryInfo._kCodeKey:
           androidMemoryInfo.code = value;
-          break;
         case AndroidMemoryInfo._kStackKey:
           androidMemoryInfo.stack = value;
-          break;
         case AndroidMemoryInfo._kGraphicsKey:
           androidMemoryInfo.graphics = value;
-          break;
         case AndroidMemoryInfo._kPrivateOtherKey:
           androidMemoryInfo.privateOther = value;
-          break;
         case AndroidMemoryInfo._kSystemKey:
           androidMemoryInfo.system = value;
-          break;
       }
   });
   return androidMemoryInfo;

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -316,7 +316,6 @@ class AndroidLicenseValidator extends DoctorValidator {
     switch (await licensesAccepted) {
       case LicensesAccepted.all:
         messages.add(ValidationMessage(_userMessages.androidLicensesAll));
-        break;
       case LicensesAccepted.some:
         messages.add(ValidationMessage.hint(_userMessages.androidLicensesSome));
         return ValidationResult(ValidationType.partial, messages, statusInfo: sdkVersionText);

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -327,7 +327,6 @@ class ApkManifestData {
           case 'A':
             currentElement
                 .addChild(_Attribute.fromLine(line, currentElement));
-            break;
           case 'E':
             final _Element element = _Element.fromLine(line, currentElement);
             currentElement.addChild(element);

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -743,7 +743,6 @@ void _handlePosixException(Exception e, String? message, int errorCode, String? 
         '$message. The target device is full.'
         '\n$e\n'
         'Free up space and try again.';
-      break;
     case eperm:
     case eacces:
       final StringBuffer errorBuffer = StringBuffer();
@@ -758,7 +757,6 @@ void _handlePosixException(Exception e, String? message, int errorCode, String? 
         errorBuffer.writeln(posixPermissionSuggestion);
       }
       errorMessage = errorBuffer.toString();
-      break;
     default:
       // Caller must rethrow the exception.
       break;
@@ -799,31 +797,26 @@ void _handleWindowsException(Exception e, String? message, int errorCode) {
         '$message. The flutter tool cannot access the file or directory.\n'
         'Please ensure that the SDK and/or project is installed in a location '
         'that has read/write permissions for the current user.';
-      break;
     case kDeviceFull:
       errorMessage =
         '$message. The target device is full.'
         '\n$e\n'
         'Free up space and try again.';
-      break;
     case kUserMappedSectionOpened:
       errorMessage =
         '$message. The file is being used by another program.'
         '\n$e\n'
         'Do you have an antivirus program running? '
         'Try disabling your antivirus program and try again.';
-      break;
     case kFatalDeviceHardwareError:
       errorMessage =
         '$message. There is a problem with the device driver '
         'that this file or directory is stored on.';
-      break;
     case kDeviceDoesNotExist:
       errorMessage =
         '$message. The device was not found.'
         '\n$e\n'
         'Verify the device is mounted and try again.';
-      break;
     default:
       // Caller must rethrow the exception.
       break;

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -1065,19 +1065,15 @@ class VerboseLogger extends DelegatingLogger {
         if (stackTrace != null) {
           super.printError(indent + stackTrace.toString().replaceAll('\n', '\n$indent'));
         }
-        break;
       case _LogType.warning:
         super.printWarning(prefix + terminal.bolden(indentMessage));
-        break;
       case _LogType.status:
         super.printStatus(prefix + terminal.bolden(indentMessage));
-        break;
       case _LogType.trace:
         // This seems wrong, since there is a 'printTrace' to call on the
         // superclass, but it's actually the entire point of this logger: to
         // make things more verbose than they normally would be.
         super.printStatus(prefix + indentMessage);
-        break;
     }
   }
 

--- a/packages/flutter_tools/lib/src/build_system/file_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_store.dart
@@ -191,12 +191,10 @@ class FileStore {
         for (final File file in files) {
           _hashFile(file, dirty);
         }
-        break;
       case FileStoreStrategy.timestamp:
         for (final File file in files) {
           _checkModification(file, dirty);
         }
-        break;
     }
     return dirty;
   }

--- a/packages/flutter_tools/lib/src/build_system/source.dart
+++ b/packages/flutter_tools/lib/src/build_system/source.dart
@@ -101,24 +101,19 @@ class SourceVisitor implements ResolvedFiles {
       case Environment.kProjectDirectory:
         segments.addAll(
           environment.fileSystem.path.split(environment.projectDir.resolveSymbolicLinksSync()));
-        break;
       case Environment.kBuildDirectory:
         segments.addAll(environment.fileSystem.path.split(
           environment.buildDir.resolveSymbolicLinksSync()));
-        break;
       case Environment.kCacheDirectory:
         segments.addAll(
           environment.fileSystem.path.split(environment.cacheDir.resolveSymbolicLinksSync()));
-        break;
       case Environment.kFlutterRootDirectory:
         // flutter root will not contain a symbolic link.
         segments.addAll(
           environment.fileSystem.path.split(environment.flutterRootDir.absolute.path));
-        break;
       case Environment.kOutputDirectory:
         segments.addAll(
           environment.fileSystem.path.split(environment.outputDir.resolveSymbolicLinksSync()));
-        break;
       default:
         throw InvalidPatternException(pattern);
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -129,7 +129,6 @@ Future<Depfile> copyAssets(
                 outputPath: file.path,
                 relativePath: entry.key,
               );
-              break;
             case AssetKind.shader:
               doCopy = !await shaderCompiler.compileShader(
                 input: content.file as File,
@@ -137,13 +136,11 @@ Future<Depfile> copyAssets(
                 target: shaderTarget,
                 json: targetPlatform == TargetPlatform.web_javascript,
               );
-              break;
             case AssetKind.model:
               doCopy = !await sceneImporter.importScene(
                 input: content.file as File,
                 outputPath: file.path,
               );
-              break;
           }
           if (doCopy) {
             await (content.file as File).copy(file.path);

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -196,7 +196,6 @@ class KernelSnapshot extends Target {
       case TargetPlatform.windows_x64:
       case TargetPlatform.linux_x64:
         forceLinkPlatform = true;
-        break;
       case TargetPlatform.android:
       case TargetPlatform.android_arm:
       case TargetPlatform.android_arm64:
@@ -209,7 +208,6 @@ class KernelSnapshot extends Target {
       case TargetPlatform.tester:
       case TargetPlatform.web_javascript:
         forceLinkPlatform = false;
-        break;
     }
 
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(

--- a/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
@@ -56,7 +56,6 @@ class DevelopmentShaderCompiler {
     switch (platform) {
       case TargetPlatform.ios:
         _shaderTarget = ShaderTarget.impelleriOS;
-        break;
       case TargetPlatform.android_arm64:
       case TargetPlatform.android_x64:
       case TargetPlatform.android_x86:
@@ -65,7 +64,6 @@ class DevelopmentShaderCompiler {
         _shaderTarget = impellerStatus == ImpellerStatus.enabled
           ? ShaderTarget.impellerAndroid
           : ShaderTarget.sksl;
-        break;
       case TargetPlatform.darwin:
       case TargetPlatform.linux_x64:
       case TargetPlatform.linux_arm64:
@@ -75,12 +73,10 @@ class DevelopmentShaderCompiler {
       case TargetPlatform.tester:
         assert(impellerStatus != ImpellerStatus.enabled);
         _shaderTarget = ShaderTarget.sksl;
-        break;
       case TargetPlatform.web_javascript:
         assert(impellerStatus != ImpellerStatus.enabled);
         _shaderTarget = ShaderTarget.sksl;
         _jsonMode = true;
-        break;
       case null:
         return;
     }

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -194,13 +194,11 @@ Future<void> writeBundle(
                 target: ShaderTarget.sksl, // TODO(zanderso): configure impeller target when enabled.
                 json: targetPlatform == TargetPlatform.web_javascript,
               );
-              break;
             case AssetKind.model:
               doCopy = !await sceneImporter.importScene(
                 input: input,
                 outputPath: file.path,
               );
-              break;
           }
           if (doCopy) {
             input.copySync(file.path);

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -100,18 +100,15 @@ class BuildBundleCommand extends BuildSubCommand {
         if (!featureFlags.isMacOSEnabled) {
           throwToolExit('macOS is not a supported target platform.');
         }
-        break;
       case TargetPlatform.windows_x64:
         if (!featureFlags.isWindowsEnabled) {
           throwToolExit('Windows is not a supported target platform.');
         }
-        break;
       case TargetPlatform.linux_x64:
       case TargetPlatform.linux_arm64:
         if (!featureFlags.isLinuxEnabled) {
           throwToolExit('Linux is not a supported target platform.');
         }
-        break;
       case TargetPlatform.android:
       case TargetPlatform.android_arm:
       case TargetPlatform.android_arm64:

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -356,7 +356,6 @@ class CreateCommand extends CreateBase {
           projectType: template,
         );
         pubContext = PubContext.create;
-        break;
       case FlutterProjectType.skeleton:
         generatedFileCount += await generateApp(
           <String>['skeleton'],
@@ -367,7 +366,6 @@ class CreateCommand extends CreateBase {
           generateMetadata: false,
         );
         pubContext = PubContext.create;
-        break;
       case FlutterProjectType.module:
         generatedFileCount += await _generateModule(
           relativeDir,
@@ -376,7 +374,6 @@ class CreateCommand extends CreateBase {
           printStatusWhenWriting: !creatingNewProject,
         );
         pubContext = PubContext.create;
-        break;
       case FlutterProjectType.package:
         generatedFileCount += await _generatePackage(
           relativeDir,
@@ -385,7 +382,6 @@ class CreateCommand extends CreateBase {
           printStatusWhenWriting: !creatingNewProject,
         );
         pubContext = PubContext.createPackage;
-        break;
       case FlutterProjectType.plugin:
         generatedFileCount += await _generateMethodChannelPlugin(
           relativeDir,
@@ -395,7 +391,6 @@ class CreateCommand extends CreateBase {
           projectType: template,
         );
         pubContext = PubContext.createPlugin;
-        break;
       case FlutterProjectType.ffiPlugin:
         generatedFileCount += await _generateFfiPlugin(
           relativeDir,
@@ -405,7 +400,6 @@ class CreateCommand extends CreateBase {
           projectType: template,
         );
         pubContext = PubContext.createPlugin;
-        break;
     }
 
     if (boolArg('pub')) {

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -83,7 +83,6 @@ class ScreenshotCommand extends FlutterCommand {
         if (!device!.supportsScreenshot) {
           throwToolExit('Screenshot not supported for ${device!.name}.');
         }
-        break;
       default:
         if (vmServiceUrl == null) {
           throwToolExit('VM Service URI must be specified for screenshot type $screenshotType');
@@ -111,13 +110,10 @@ class ScreenshotCommand extends FlutterCommand {
     switch (stringArg(_kType)) {
       case _kDeviceType:
         await runScreenshot(outputFile);
-        break;
       case _kSkiaType:
         success = await runSkia(outputFile);
-        break;
       case _kRasterizerType:
         success = await runRasterizer(outputFile);
-        break;
     }
 
     return success ? FlutterCommandResult.success()

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -954,7 +954,6 @@ class PubspecYaml {
               endOfDirectDependencies = output.length;
             }
             endOfDevDependencies = output.length;
-            break;
           case Section.builders:
           case Section.dependencyOverrides:
           case Section.header:
@@ -964,7 +963,6 @@ class PubspecYaml {
             if (data.lockLine != null) {
               output.add(data.lockLine!);
             }
-            break;
         }
       } else {
         // Not a header, not a dependency, just pass that through unmodified.
@@ -1377,12 +1375,10 @@ class PubspecDependency extends PubspecLine {
       case DependencyKind.unknown:
       case DependencyKind.overridden:
         assert(kind != DependencyKind.unknown);
-        break;
       case DependencyKind.normal:
         if (!kManuallyPinnedDependencies.containsKey(name)) {
           dependencies.writeln('  $name: $versionToUse');
         }
-        break;
       case DependencyKind.path:
         if (_lockIsOverride) {
           dependencies.writeln('  $name: $versionToUse');
@@ -1392,7 +1388,6 @@ class PubspecDependency extends PubspecLine {
           dependencies.writeln('  $name:');
           dependencies.writeln('    path: $_lockTarget');
         }
-        break;
       case DependencyKind.sdk:
         if (_lockIsOverride) {
           dependencies.writeln('  $name: $versionToUse');
@@ -1402,7 +1397,6 @@ class PubspecDependency extends PubspecLine {
           dependencies.writeln('  $name:');
           dependencies.writeln('    sdk: $_lockTarget');
         }
-        break;
       case DependencyKind.git:
         if (_lockIsOverride) {
           dependencies.writeln('  $name: $versionToUse');
@@ -1412,7 +1406,6 @@ class PubspecDependency extends PubspecLine {
           dependencies.writeln('  $name:');
           dependencies.writeln(lockLine);
         }
-        break;
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/validate_project.dart
+++ b/packages/flutter_tools/lib/src/commands/validate_project.dart
@@ -102,17 +102,13 @@ class ValidateProject {
     switch(result.status) {
       case StatusProjectValidator.error:
         icon = '[✗]';
-        break;
       case StatusProjectValidator.info:
       case StatusProjectValidator.success:
         icon = '[✓]';
-        break;
       case StatusProjectValidator.warning:
         icon = '[!]';
-        break;
       case StatusProjectValidator.crash:
         icon = '[☠]';
-        break;
     }
 
     return '$icon $result';

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -144,10 +144,8 @@ class StdoutHandler {
       switch (message[0]) {
         case '+':
           sources.add(Uri.parse(message.substring(1)));
-          break;
         case '-':
           sources.remove(Uri.parse(message.substring(1)));
-          break;
         default:
           _logger.printTrace('Unexpected prefix for $message uri - ignoring');
       }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -173,14 +173,12 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
         final bool isFullRestart = request.command == 'hotRestart';
         await _performRestart(isFullRestart, args?.args['reason'] as String?);
         sendResponse(null);
-        break;
 
       // Handle requests (from the client) that provide responses to reverse-requests
       // that we forwarded from `flutter run --machine`.
       case 'flutter.sendForwardedRequestResponse':
         _handleForwardedResponse(args);
         sendResponse(null);
-        break;
 
       default:
         await super.customRequest(request, args, sendResponse);
@@ -196,12 +194,9 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
         switch (event.extensionKind) {
           case 'Flutter.ServiceExtensionStateChanged':
             _sendServiceExtensionStateChanged(event.extensionData);
-            break;
           case 'Flutter.Error':
             _handleFlutterErrorEvent(event.extensionData);
-            break;
         }
-        break;
     }
   }
 
@@ -457,16 +452,12 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     switch (event) {
       case 'daemon.connected':
         _handleDaemonConnected(params);
-        break;
       case 'app.debugPort':
         _handleDebugPort(params);
-        break;
       case 'app.start':
         _handleAppStart(params);
-        break;
       case 'app.started':
         _handleAppStarted();
-        break;
     }
 
     if (_eventsToForwardToClient.contains(event)) {

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -671,7 +671,6 @@ class DevFS {
                 shaderPathsToEvict.add(archivePath);
               }
             });
-            break;
           case AssetKind.model:
             if (sceneImporter == null) {
               break;
@@ -689,7 +688,6 @@ class DevFS {
                 scenePathsToEvict.add(archivePath);
               }
             });
-            break;
           case AssetKind.regular:
           case AssetKind.font:
           case null:

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -294,19 +294,14 @@ class Doctor {
         case ValidationType.crash:
           lineBuffer.write('the doctor check crashed without a result.');
           sawACrash = true;
-          break;
         case ValidationType.missing:
           lineBuffer.write('is not installed.');
-          break;
         case ValidationType.partial:
           lineBuffer.write('is partially installed; more components are available.');
-          break;
         case ValidationType.notAvailable:
           lineBuffer.write('is not available.');
-          break;
         case ValidationType.success:
           lineBuffer.write('is fully installed.');
-          break;
       }
 
       if (result.statusInfo != null) {
@@ -392,15 +387,12 @@ class Doctor {
         case ValidationType.crash:
           doctorResult = false;
           issues += 1;
-          break;
         case ValidationType.missing:
           doctorResult = false;
           issues += 1;
-          break;
         case ValidationType.partial:
         case ValidationType.notAvailable:
           issues += 1;
-          break;
         case ValidationType.success:
           break;
       }

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -120,17 +120,14 @@ class GroupedValidator extends DoctorValidator {
           if (mergedType == ValidationType.missing) {
             mergedType = ValidationType.partial;
           }
-          break;
         case ValidationType.notAvailable:
         case ValidationType.partial:
           mergedType = ValidationType.partial;
-          break;
         case ValidationType.crash:
         case ValidationType.missing:
           if (mergedType == ValidationType.success) {
             mergedType = ValidationType.partial;
           }
-          break;
       }
       mergedMessages.addAll(result.messages);
     }

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -479,7 +479,6 @@ bool _validate(Object? manifest, Logger logger) {
           if (kvp.value is! String) {
             errors.add('Expected "${kvp.key}" to be a string, but got ${kvp.value}.');
           }
-          break;
         case 'flutter':
           if (kvp.value == null) {
             continue;
@@ -489,7 +488,6 @@ bool _validate(Object? manifest, Logger logger) {
           } else {
             _validateFlutter(kvp.value as YamlMap?, errors);
           }
-          break;
         default:
         // additionalProperties are allowed.
           break;
@@ -522,7 +520,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         if (yamlValue is! bool) {
           errors.add('Expected "$yamlKey" to be a bool, but got $yamlValue (${yamlValue.runtimeType}).');
         }
-        break;
       case 'assets':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
@@ -533,7 +530,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-        break;
       case 'shaders':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
@@ -544,7 +540,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-        break;
       case 'models':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
@@ -555,7 +550,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
             'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
           );
         }
-        break;
       case 'fonts':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
@@ -568,7 +562,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         } else {
           _validateFonts(yamlValue, errors);
         }
-        break;
       case 'licenses':
         if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list of files, but got $yamlValue (${yamlValue.runtimeType})');
@@ -581,7 +574,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         } else {
           _validateListType<String>(yamlValue, errors, '"$yamlKey"', 'files');
         }
-        break;
       case 'module':
         if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
@@ -597,7 +589,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         if (yamlValue['iosBundleIdentifier'] != null && yamlValue['iosBundleIdentifier'] is! String) {
           errors.add('The "iosBundleIdentifier" section must be a string if set.');
         }
-        break;
       case 'plugin':
         if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
@@ -605,12 +596,10 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         }
         final List<String> pluginErrors = Plugin.validatePluginYaml(yamlValue);
         errors.addAll(pluginErrors);
-        break;
       case 'generate':
         break;
       case 'deferred-components':
         _validateDeferredComponents(kvp, errors);
-        break;
       default:
         errors.add('Unexpected child "$yamlKey" found under "flutter".');
         break;
@@ -698,17 +687,14 @@ void _validateFonts(YamlList fonts, List<String> errors) {
             if (kvp.value is! String) {
               errors.add('Expected font asset ${kvp.value} ((${kvp.value.runtimeType})) to be a string.');
             }
-            break;
           case 'weight':
             if (!fontWeights.contains(kvp.value)) {
               errors.add('Invalid value ${kvp.value} ((${kvp.value.runtimeType})) for font -> weight.');
             }
-            break;
           case 'style':
             if (kvp.value != 'normal' && kvp.value != 'italic') {
               errors.add('Invalid value ${kvp.value} ((${kvp.value.runtimeType})) for font -> style.');
             }
-            break;
           default:
             errors.add('Unexpected key $fontKey ((${kvp.value.runtimeType})) under font.');
             break;

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -424,7 +424,6 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
         );
       }
       templateContent = _androidPluginRegistryTemplateNewEmbedding;
-      break;
     case AndroidEmbeddingVersion.v1:
       globals.printWarning(
         'This app is using a deprecated version of the Android embedding.\n'
@@ -444,7 +443,6 @@ Future<void> _writeAndroidPluginRegistrant(FlutterProject project, List<Plugin> 
         }
       }
       templateContent = _androidPluginRegistryTemplateOldEmbedding;
-      break;
   }
   globals.printTrace('Generating $registryPath');
   _renderTemplateToFile(

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -683,10 +683,8 @@ _XCResultIssueHandlingResult _handleXCResultIssue({required XCResultIssue issue,
   switch (issue.type) {
     case XCResultIssueType.error:
       logger.printError(issueSummary);
-      break;
     case XCResultIssueType.warning:
       logger.printWarning(issueSummary);
-      break;
   }
 
   final String? message = issue.message;

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -72,12 +72,10 @@ class LocaleInfo implements Comparable<LocaleInfo> {
             case 'CN':
             case 'SG':
               scriptCode = 'Hans';
-              break;
             case 'TW':
             case 'HK':
             case 'MO':
               scriptCode = 'Hant';
-              break;
           }
           break;
         }
@@ -202,13 +200,10 @@ void precacheLanguageAndRegionTags() {
       switch (type) {
         case 'language':
           _languages[subtag] = description;
-          break;
         case 'region':
           _regions[subtag] = description;
-          break;
         case 'script':
           _scripts[subtag] = description;
-          break;
       }
     }
   }

--- a/packages/flutter_tools/lib/src/localizations/message_parser.dart
+++ b/packages/flutter_tools/lib/src/localizations/message_parser.dart
@@ -308,13 +308,10 @@ class Parser {
           switch(tokenStr) {
             case 'plural':
               matchedType = ST.plural;
-              break;
             case 'select':
               matchedType = ST.select;
-              break;
             case 'other':
               matchedType = ST.other;
-              break;
           }
           tokens.add(Node(matchedType!, startIndex, value: match.group(0)));
           startIndex = match.end;
@@ -374,13 +371,10 @@ class Parser {
             // Theoretically, we can never get here.
             throw L10nException('ICU Syntax Error.');
           }
-          break;
         case ST.placeholderExpr:
           parseAndConstructNode(ST.placeholderExpr, 0);
-          break;
         case ST.pluralExpr:
           parseAndConstructNode(ST.pluralExpr, 0);
-          break;
         case ST.pluralParts:
           if (tokens.isNotEmpty && (
               tokens[0].type == ST.identifier ||
@@ -392,7 +386,6 @@ class Parser {
           } else {
             parseAndConstructNode(ST.pluralParts, 1);
           }
-          break;
         case ST.pluralPart:
           if (tokens.isNotEmpty && tokens[0].type == ST.identifier) {
             parseAndConstructNode(ST.pluralPart, 0);
@@ -409,10 +402,8 @@ class Parser {
               tokens[0].positionInMessage,
             );
           }
-          break;
         case ST.selectExpr:
           parseAndConstructNode(ST.selectExpr, 0);
-          break;
         case ST.selectParts:
           if (tokens.isNotEmpty && (
             tokens[0].type == ST.identifier ||
@@ -423,7 +414,6 @@ class Parser {
           } else {
             parseAndConstructNode(ST.selectParts, 1);
           }
-          break;
         case ST.selectPart:
           if (tokens.isNotEmpty && tokens[0].type == ST.identifier) {
             parseAndConstructNode(ST.selectPart, 0);
@@ -440,7 +430,6 @@ class Parser {
               tokens[0].positionInMessage
             );
           }
-          break;
         // At this point, we are only handling terminal symbols.
         // ignore: no_default_cases
         default:
@@ -530,7 +519,6 @@ class Parser {
           node = node.children[1];
         }
         syntaxTree.children = children;
-        break;
       // ignore: no_default_cases
       default:
         node.children.forEach(compress);
@@ -568,7 +556,6 @@ class Parser {
             );
           }
         }
-        break;
       case ST.selectParts:
         if (children.every((Node node) => node.children[0].type != ST.other)) {
           throw L10nParserException(
@@ -579,7 +566,6 @@ class Parser {
             syntaxTree.positionInMessage,
           );
         }
-        break;
       // ignore: no_default_cases
       default:
         break;

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -198,7 +198,6 @@ class CocoaPods {
           'To upgrade $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
-        break;
       case CocoaPodsStatus.belowMinimumVersion:
         _logger.printWarning(
           'Warning: CocoaPods minimum required version $cocoaPodsMinimumVersion or greater not installed. Skipping pod install.\n'
@@ -214,7 +213,6 @@ class CocoaPods {
           'To upgrade $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
-        break;
       case CocoaPodsStatus.recommended:
         break;
     }

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -480,7 +480,6 @@ class MDnsVmServiceDiscovery {
           'under System Preferences > Network > iPhone USB. '
           'See https://github.com/flutter/flutter/issues/46698 for details.'
         );
-        break;
       case TargetPlatform.android:
       case TargetPlatform.android_arm:
       case TargetPlatform.android_arm64:
@@ -495,7 +494,6 @@ class MDnsVmServiceDiscovery {
       case TargetPlatform.web_javascript:
       case TargetPlatform.windows_x64:
         _logger.printTrace('No interface with an ipv4 link local address was found.');
-        break;
     }
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1394,25 +1394,18 @@ String _describePausedIsolates(int pausedIsolatesFound, String serviceEventKind)
   switch (serviceEventKind) {
     case vm_service.EventKind.kPauseStart:
       message.write('paused (probably due to --start-paused)');
-      break;
     case vm_service.EventKind.kPauseExit:
       message.write('paused because ${ plural ? 'they have' : 'it has' } terminated');
-      break;
     case vm_service.EventKind.kPauseBreakpoint:
       message.write('paused in the debugger on a breakpoint');
-      break;
     case vm_service.EventKind.kPauseInterrupted:
       message.write('paused due in the debugger');
-      break;
     case vm_service.EventKind.kPauseException:
       message.write('paused in the debugger after an exception was thrown');
-      break;
     case vm_service.EventKind.kPausePostRequest:
       message.write('paused');
-      break;
     case '':
       message.write('paused for various reasons');
-      break;
     default:
       message.write('paused');
   }

--- a/packages/flutter_tools/lib/src/sksl_writer.dart
+++ b/packages/flutter_tools/lib/src/sksl_writer.dart
@@ -44,7 +44,6 @@ Future<String?> sharedSkSlWriter(Device device, Map<String, Object?>? data, {
     case TargetPlatform.android_x64:
     case TargetPlatform.android_x86:
       targetPlatform = TargetPlatform.android;
-      break;
     case TargetPlatform.android:
     case TargetPlatform.darwin:
     case TargetPlatform.ios:

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -378,10 +378,8 @@ class FlutterWebPlatform extends PlatformPlugin {
     switch (extension) {
       case '.js':
         contentType = 'text/javascript';
-        break;
       case '.wasm':
         contentType = 'application/wasm';
-        break;
       default:
         final String error = 'Failed to determine Content-Type for "${request.url.path}".';
         _logger.printError(error);
@@ -787,12 +785,10 @@ class BrowserManager {
           break;
         case 'restart':
           _onRestartController.add(null);
-          break;
         case 'resume':
           if (_pauseCompleter != null) {
             _pauseCompleter!.complete();
           }
-          break;
         default:
         // Unreachable.
           assert(false);

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -961,11 +961,9 @@ class VersionFreshnessValidator {
     switch (remoteVersionStatus) {
       case VersionCheckResult.newVersionAvailable:
         updateMessage = _newVersionAvailableMessage;
-        break;
       case VersionCheckResult.versionIsCurrent:
       case VersionCheckResult.unknown:
         updateMessage = versionOutOfDateMessage(frameworkAge);
-        break;
     }
 
     logger.printBox(updateMessage);

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1423,19 +1423,16 @@ TerminalHandler setUpTerminalHandler(List<FakeVmServiceRequest> requests, {
         ..isRunningDebug = true
         ..isRunningProfile = false
         ..isRunningRelease = false;
-      break;
     case BuildMode.profile:
       residentRunner
         ..isRunningDebug = false
         ..isRunningProfile = true
         ..isRunningRelease = false;
-      break;
     case BuildMode.release:
       residentRunner
         ..isRunningDebug = false
         ..isRunningProfile = false
         ..isRunningRelease = true;
-      break;
   }
   return TerminalHandler(
     residentRunner,

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -52,7 +52,6 @@ String getFlutterRoot() {
   switch (platform.script.scheme) {
     case 'file':
       scriptUri = platform.script;
-      break;
     case 'data':
       final RegExp flutterTools = RegExp(r'(file://[^"]*[/\\]flutter_tools[/\\][^"]+\.dart)', multiLine: true);
       final Match? match = flutterTools.firstMatch(Uri.decodeFull(platform.script.path));
@@ -60,7 +59,6 @@ String getFlutterRoot() {
         throw invalidScript();
       }
       scriptUri = Uri.parse(match.group(1)!);
-      break;
     default:
       throw invalidScript();
   }

--- a/packages/integration_test/lib/_callback_io.dart
+++ b/packages/integration_test/lib/_callback_io.dart
@@ -41,10 +41,8 @@ class IOCallbackManager implements CallbackManager {
                   data: testRunner.reportData,
                 ).toJson(),
         };
-        break;
       case 'get_health':
         response = <String, String>{'status': 'ok'};
-        break;
       default:
         throw UnimplementedError('$command is not implemented');
     }
@@ -109,7 +107,6 @@ class IOCallbackManager implements CallbackManager {
     switch (call.method) {
       case 'scheduleFrame':
         PlatformDispatcher.instance.scheduleFrame();
-        break;
     }
     return null;
   }

--- a/packages/integration_test/lib/_callback_web.dart
+++ b/packages/integration_test/lib/_callback_web.dart
@@ -91,7 +91,6 @@ class WebCallbackManager implements CallbackManager {
             : _requestDataWithMessage(params['message']!, testRunner);
       case 'get_health':
         response = <String, String>{'status': 'ok'};
-        break;
       default:
         throw UnimplementedError('$command is not implemented');
     }
@@ -119,14 +118,12 @@ class WebCallbackManager implements CallbackManager {
           response = <String, String>{
             'message': Response.webDriverCommand(data: data).toJson(),
           };
-          break;
         case WebDriverCommandType.noop:
           final Map<String, dynamic> data = <String, dynamic>{};
           data.addAll(WebDriverCommand.typeToMap(WebDriverCommandType.noop));
           response = <String, String>{
             'message': Response.webDriverCommand(data: data).toJson(),
           };
-          break;
         case WebDriverCommandType.ack:
           throw UnimplementedError('${command.type} is not implemented');
       }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

In Dart 3, the `break` statement is optional in switch/case. This PR removes them and enforces that with a lint. It also removes all lints that are no longer valid with Dart 3.

Further reading: https://github.com/dart-lang/language/blob/master/accepted/future-releases/0546-patterns/feature-specification.md#implicit-break