### PR TITLE
Added ExpansionTileController

### DIFF
--- a/examples/api/lib/material/expansion_tile/expansion_tile.1.dart
+++ b/examples/api/lib/material/expansion_tile/expansion_tile.1.dart
@@ -27,19 +27,54 @@ class _ExpansionTileControllerAppState extends State<ExpansionTileControllerApp>
       theme: ThemeData(useMaterial3: true),
       home: Scaffold(
         appBar: AppBar(title: const Text('ExpansionTileController Example')),
-        body: ExpansionTile(
-          controller: controller,
-          title: const Text('ExpansionTile'),
+        body: Column(
           children: <Widget>[
-            Container(
-              padding: const EdgeInsets.all(24),
-              alignment: Alignment.center,
-              child: ElevatedButton(
-                child: const Text('Collapse This Tile'),
-                onPressed: () {
+            // A controller has been provided to the ExpansionTile because it's
+            // going to be accessed from a component that is not within the
+            // tile's BuildContext.
+            ExpansionTile(
+              controller: controller,
+              title: const Text('ExpansionTile with explicit controller.'),
+              children: <Widget>[
+                Container(
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.all(24),
+                  child: const Text('ExpansionTile Contents'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              child: const Text('Expand/Collapse the Tile Above'),
+              onPressed: () {
+                if (controller.isExpanded) {
                   controller.collapse();
-                },
-              ),
+                } else {
+                  controller.expand();
+                }
+              },
+            ),
+            const SizedBox(height: 48),
+            // A controller has not been provided to the ExpansionTile because
+            // the automatically created one can be retrieved via the tile's BuildContext.
+            ExpansionTile(
+              title: const Text('ExpansionTile with implicit controller.'),
+              children: <Widget>[
+                Builder(
+                  builder: (BuildContext context) {
+                    return Container(
+                      padding: const EdgeInsets.all(24),
+                      alignment: Alignment.center,
+                      child: ElevatedButton(
+                        child: const Text('Collapse This Tile'),
+                        onPressed: () {
+                          return ExpansionTileController.of(context).collapse();
+                        },
+                      ),
+                    );
+                  },
+                ),
+              ],
             ),
           ],
         ),

--- a/examples/api/lib/material/expansion_tile/expansion_tile.1.dart
+++ b/examples/api/lib/material/expansion_tile/expansion_tile.1.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for [ExpansionTile] and [ExpansionTileController]
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const ExpansionTileControllerApp());
+}
+
+class ExpansionTileControllerApp extends StatefulWidget {
+  const ExpansionTileControllerApp({ super.key });
+
+  @override
+  State<ExpansionTileControllerApp> createState() => _ExpansionTileControllerAppState();
+}
+
+class _ExpansionTileControllerAppState extends State<ExpansionTileControllerApp> {
+  final ExpansionTileController controller = ExpansionTileController();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Code Sample for ExpansionTileController.',
+      theme: ThemeData(useMaterial3: true),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('ExpansionTileController Example')),
+        body: ExpansionTile(
+          controller: controller,
+          title: const Text('ExpansionTile'),
+          children: <Widget>[
+            Container(
+              padding: const EdgeInsets.all(24),
+              alignment: Alignment.center,
+              child: ElevatedButton(
+                child: const Text('Collapse This Tile'),
+                onPressed: () {
+                  controller.collapse();
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/test/material/expansion_tile/expansion_tile.1_test.dart
+++ b/examples/api/test/material/expansion_tile/expansion_tile.1_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/expansion_tile/expansion_tile.1.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -12,14 +11,19 @@ void main() {
       const example.ExpansionTileControllerApp(),
     );
 
-    expect(find.byType(ExpansionTile), findsOneWidget);
-
+    expect(find.text('ExpansionTile Contents'), findsNothing);
     expect(find.text('Collapse This Tile'), findsNothing);
 
-    await tester.tap(find.text('ExpansionTile'));
+    await tester.tap(find.text('Expand/Collapse the Tile Above'));
+    await tester.pumpAndSettle();
+    expect(find.text('ExpansionTile Contents'), findsOneWidget);
+    await tester.tap(find.text('Expand/Collapse the Tile Above'));
+    await tester.pumpAndSettle();
+    expect(find.text('ExpansionTile Contents'), findsNothing);
+
+    await tester.tap(find.text('ExpansionTile with implicit controller.'));
     await tester.pumpAndSettle();
     expect(find.text('Collapse This Tile'), findsOneWidget);
-
     await tester.tap(find.text('Collapse This Tile'));
     await tester.pumpAndSettle();
     expect(find.text('Collapse This Tile'), findsNothing);

--- a/examples/api/test/material/expansion_tile/expansion_tile.1_test.dart
+++ b/examples/api/test/material/expansion_tile/expansion_tile.1_test.dart
@@ -1,0 +1,27 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/expansion_tile/expansion_tile.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('When expansion tiles are expanded tile numbers are revealed', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ExpansionTileControllerApp(),
+    );
+
+    expect(find.byType(ExpansionTile), findsOneWidget);
+
+    expect(find.text('Collapse This Tile'), findsNothing);
+
+    await tester.tap(find.text('ExpansionTile'));
+    await tester.pumpAndSettle();
+    expect(find.text('Collapse This Tile'), findsOneWidget);
+
+    await tester.tap(find.text('Collapse This Tile'));
+    await tester.pumpAndSettle();
+    expect(find.text('Collapse This Tile'), findsNothing);
+  });
+}

--- a/examples/api/test/material/expansion_tile/expansion_tile.1_test.dart
+++ b/examples/api/test/material/expansion_tile/expansion_tile.1_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_api_samples/material/expansion_tile/expansion_tile.1.dar
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('When expansion tiles are expanded tile numbers are revealed', (WidgetTester tester) async {
+  testWidgets('Test the basics of ExpansionTileControllerApp', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.ExpansionTileControllerApp(),
     );

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -113,7 +113,7 @@ class ExpansionTileController {
   /// Typical usage of the [ExpansionTileController.of] function is to call it from within the
   /// `build` method of a descendant of an [ExpansionTile].
   ///
-  /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.of.1.dart **
+  /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.1.dart **
   /// {@end-tool}
   ///
   /// {@tool dartpad}
@@ -125,7 +125,7 @@ class ExpansionTileController {
   /// to provide a new scope with a [BuildContext] that is "under" the
   /// [ExpansionTile]:
   ///
-  /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.of.1.dart **
+  /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.1.dart **
   /// {@end-tool}
   ///
   /// A more efficient solution is to split your build function into several

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -76,8 +76,8 @@ class ExpansionTileController {
 
   /// Collapses the [ExpansionTile] that was built with this controller.
   ///
-  /// Normally the tile is collapsed automatically when the user tap on the header.
-  /// It can be useful sometime to trigger the collapse programmatically due
+  /// Normally the tile is collapsed automatically when the user taps on the header.
+  /// It can be useful sometimes to trigger the collapse programmatically due
   /// to some external changes.
   ///
   /// If the tile is already in the collapsed state (see [isExpanded]), calling
@@ -110,7 +110,7 @@ class ExpansionTileController {
   /// To return null if there is no [ExpansionTile] use [maybeOf] instead.
   ///
   /// {@tool dartpad}
-  /// Typical usage of the [ExpansionTile.of] function is to call it from within the
+  /// Typical usage of the [ExpansionTileController.of] function is to call it from within the
   /// `build` method of a descendant of an [ExpansionTile].
   ///
   /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.of.1.dart **
@@ -132,7 +132,7 @@ class ExpansionTileController {
   /// widgets. This introduces a new context from which you can obtain the
   /// [ExpansionTileController]. In this solution, you would have an outer widget that creates
   /// the [ExpansionTile] populated by instances of your new inner widgets, and then
-  /// in these inner widgets you would use [ExpansionTile.of].
+  /// in these inner widgets you would use [ExpansionTileController.of].
   static ExpansionTileController of(BuildContext context) {
     final _ExpansionTileState? result = context.findAncestorStateOfType<_ExpansionTileState>();
     if (result != null) {
@@ -143,24 +143,24 @@ class ExpansionTileController {
         'ExpansionTileController.of() called with a context that does not contain a ExpansionTile.',
       ),
       ErrorDescription(
-        'No ExpansionTile ancestor could be found starting from the context that was passed to ExpansionTile.of(). '
+        'No ExpansionTile ancestor could be found starting from the context that was passed to ExpansionTileController.of(). '
         'This usually happens when the context provided is from the same StatefulWidget as that '
         'whose build function actually creates the ExpansionTile widget being sought.',
       ),
       ErrorHint(
         'There are several ways to avoid this problem. The simplest is to use a Builder to get a '
         'context that is "under" the ExpansionTile. For an example of this, please see the '
-        'documentation for ExpansionTile.of():\n'
+        'documentation for ExpansionTileController.of():\n'
         '  https://api.flutter.dev/flutter/material/ExpansionTile/of.html',
       ),
       ErrorHint(
         'A more efficient solution is to split your build function into several widgets. This '
         'introduces a new context from which you can obtain the ExpansionTile. In this solution, '
         'you would have an outer widget that creates the ExpansionTile populated by instances of '
-        'your new inner widgets, and then in these inner widgets you would use ExpansionTile.of().\n'
+        'your new inner widgets, and then in these inner widgets you would use ExpansionTileController.of().\n'
         'An other solution is assign a GlobalKey to the ExpansionTile, '
         'then use the key.currentState property to obtain the ExpansionTile rather than '
-        'using the ExpansionTile.of() function.',
+        'using the ExpansionTileController.of() function.',
       ),
       context.describeElement('The context used was'),
     ]);
@@ -255,7 +255,6 @@ class ExpansionTile extends StatefulWidget {
        'CrossAxisAlignment.baseline is not supported since the expanded children '
            'are aligned in a column, not a row. Try to use another constant.',
        );
-
 
   /// A widget to display before the title.
   ///

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -113,26 +113,23 @@ class ExpansionTileController {
   /// Typical usage of the [ExpansionTileController.of] function is to call it from within the
   /// `build` method of a descendant of an [ExpansionTile].
   ///
-  /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.1.dart **
-  /// {@end-tool}
-  ///
-  /// {@tool dartpad}
-  /// When the [ExpansionTile] is actually created in the same `build` function as the
-  /// , the
-  /// `context` argument to the `build` function can't be used to find the
-  /// [ExpansionTileController] (since it's "above" the widget being returned in the widget
-  /// tree). In such cases, the following technique with a [Builder] can be used
-  /// to provide a new scope with a [BuildContext] that is "under" the
-  /// [ExpansionTile]:
+  /// When the [ExpansionTile] is actually created in the same `build`
+  /// function as the callback that refers to the controller, then the
+  /// `context` argument to the `build` function can't be used to find
+  /// the [ExpansionTileController] (since it's "above" the widget
+  /// being returned in the widget tree). In cases like that you can
+  /// add a [Builder] widget, which provides a new scope with a
+  /// [BuildContext] that is "under" the [ExpansionTile]:
   ///
   /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.1.dart **
   /// {@end-tool}
   ///
-  /// A more efficient solution is to split your build function into several
-  /// widgets. This introduces a new context from which you can obtain the
-  /// [ExpansionTileController]. In this solution, you would have an outer widget that creates
-  /// the [ExpansionTile] populated by instances of your new inner widgets, and then
-  /// in these inner widgets you would use [ExpansionTileController.of].
+  /// A more efficient solution is to split your build function into
+  /// several widgets. This introduces a new context from which you
+  /// can obtain the [ExpansionTileController]. With this approach you
+  /// would have an outer widget that creates the [ExpansionTile]
+  /// populated by instances of your new inner widgets, and then in
+  /// these inner widgets you would use [ExpansionTileController.of].
   static ExpansionTileController of(BuildContext context) {
     final _ExpansionTileState? result = context.findAncestorStateOfType<_ExpansionTileState>();
     if (result != null) {
@@ -181,7 +178,6 @@ class ExpansionTileController {
     return context.findAncestorStateOfType<_ExpansionTileState>()?._tileController;
   }
 }
-
 
 /// A single-line [ListTile] with an expansion arrow icon that expands or collapses
 /// the tile to reveal or hide the [children].

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -793,4 +793,55 @@ void main() {
     await tester.pump();
     expect(tester.hasRunningAnimations, isFalse);
   });
+
+  testWidgets('Call to ExpansionTileController.of()', (WidgetTester tester) async {
+    final GlobalKey titleKey = GlobalKey();
+    final GlobalKey childKey = GlobalKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: ExpansionTile(
+          initiallyExpanded: true,
+          title: Text('Title', key: titleKey),
+          children: <Widget>[
+            Text('Child 0', key: childKey),
+          ],
+        ),
+      ),
+    ));
+
+    final ExpansionTileController controller1 = ExpansionTileController.of(childKey.currentContext!);
+    expect(controller1.isExpanded, isTrue);
+
+    final ExpansionTileController controller2 = ExpansionTileController.of(titleKey.currentContext!);
+    expect(controller2.isExpanded, isTrue);
+
+    expect(controller1, controller2);
+  });
+
+  testWidgets('Call to ExpansionTile.maybeOf()', (WidgetTester tester) async {
+    final GlobalKey titleKey = GlobalKey();
+    final GlobalKey nonDescendantKey = GlobalKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Column(
+          children: <Widget>[
+            ExpansionTile(
+              title: Text('Title', key: titleKey),
+              children: const <Widget>[
+                Text('Child 0'),
+              ],
+            ),
+            Text('Non descendant', key: nonDescendantKey),
+          ],
+        ),
+      ),
+    ));
+
+    final ExpansionTileController? controller1 = ExpansionTileController.maybeOf(titleKey.currentContext!);
+    expect(controller1, isNotNull);
+    expect(controller1?.isExpanded, isFalse);
+
+    final ExpansionTileController? controller2 = ExpansionTileController.maybeOf(nonDescendantKey.currentContext!);
+    expect(controller2, isNull);
+  });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -729,4 +729,68 @@ void main() {
       expect(getTextColor(), theme.colorScheme.primary);
     });
   });
+
+  testWidgets('ExpansionTileController isExpanded, expand() and collapse()', (WidgetTester tester) async {
+    final ExpansionTileController controller = ExpansionTileController();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: ExpansionTile(
+          controller: controller,
+          title: const Text('Title'),
+          children: const <Widget>[
+            Text('Child 0'),
+          ],
+        ),
+      ),
+    ));
+
+    expect(find.text('Child 0'), findsNothing);
+    expect(controller.isExpanded, isFalse);
+    controller.expand();
+    expect(controller.isExpanded, isTrue);
+    await tester.pumpAndSettle();
+    expect(find.text('Child 0'), findsOneWidget);
+    expect(controller.isExpanded, isTrue);
+    controller.collapse();
+    expect(controller.isExpanded, isFalse);
+    await tester.pumpAndSettle();
+    expect(find.text('Child 0'), findsNothing);
+  });
+
+  testWidgets('Calling ExpansionTileController.expand/collapsed has no effect if it is already expanded/collapsed', (WidgetTester tester) async {
+    final ExpansionTileController controller = ExpansionTileController();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: ExpansionTile(
+          controller: controller,
+          title: const Text('Title'),
+          initiallyExpanded: true,
+          children: const <Widget>[
+            Text('Child 0'),
+          ],
+        ),
+      ),
+    ));
+
+    expect(find.text('Child 0'), findsOneWidget);
+    expect(controller.isExpanded, isTrue);
+    controller.expand();
+    expect(controller.isExpanded, isTrue);
+    await tester.pump();
+    expect(tester.hasRunningAnimations, isFalse);
+    expect(find.text('Child 0'), findsOneWidget);
+    controller.collapse();
+    expect(controller.isExpanded, isFalse);
+    await tester.pump();
+    expect(tester.hasRunningAnimations, isTrue);
+    await tester.pumpAndSettle();
+    expect(controller.isExpanded, isFalse);
+    expect(find.text('Child 0'), findsNothing);
+    controller.collapse();
+    expect(controller.isExpanded, isFalse);
+    await tester.pump();
+    expect(tester.hasRunningAnimations, isFalse);
+  });
 }


### PR DESCRIPTION
Supports programmatically expanding or collapsing an ExpansionTile.

Most of the work for this PR was completed by @xvrh in https://github.com/flutter/flutter/pull/107038. 

Fixes https://github.com/flutter/flutter/issues/60387

Here's an example:
```dart
class MyApp extends StatefulWidget {
  const MyApp({super.key});

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  final ExpansionTileController controller = ExpansionTileController();

  @override
  Widget build(BuildContext context) {
    return Column(
      children: <Widget>[
        ExpansionTile(
          controller: controller,
          title: const Text('Collapsible menu'),
          children: const <Widget>[
            Text('Menu'),
          ],
        ),
        ElevatedButton(
          onPressed: () {
            if (controller.isExpanded) {
              controller.collapse();
            } else {
              controller.expand();
            }
          },
          child: const Text('TOGGLE MENU'),
        )
      ],
    );
  }
}
```