### PR TITLE
Fix SliverGridRegularTileLayout.computeMaxScrollOffset for 0 children

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -225,6 +225,11 @@ class SliverGridRegularTileLayout extends SliverGridLayout {
 
   @override
   double computeMaxScrollOffset(int childCount) {
+    if (childCount == 0) {
+      // There are no children in the grid. The max scroll offset should be
+      // zero.
+      return 0.0;
+    }
     final int mainAxisCount = ((childCount - 1) ~/ crossAxisCount) + 1;
     final double mainAxisSpacing = mainAxisStride - childMainAxisExtent;
     return mainAxisStride * mainAxisCount - mainAxisSpacing;

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -1294,6 +1294,55 @@ void main() {
     expect(firstTapped, 0);
     expect(secondTapped, 1);
   });
+
+  testWidgets('SliverGridRegularTileLayout.computeMaxScrollOffset handles 0 children', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/59663
+    final ScrollController controller = ScrollController();
+
+    // SliverGridDelegateWithFixedCrossAxisCount
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverGrid.builder(
+              itemCount: 0,
+              itemBuilder: (_, __) => Container(),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 1,
+                mainAxisSpacing: 10,
+                childAspectRatio: 2.1,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    // Verify correct scroll extent
+    expect(controller.position.maxScrollExtent, 0.0);
+
+    // SliverGridDelegateWithMaxCrossAxisExtent
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            SliverGrid.builder(
+              itemCount: 0,
+              itemBuilder: (_, __) => Container(),
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 30,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    // Verify correct scroll extent
+    expect(controller.position.maxScrollExtent, 0.0);
+  });
 }
 
 bool isRight(Offset a, Offset b) => b.dx > a.dx;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/59663

SliverGridRegularTileLayout.computeMaxScrollOffset did not account for a child count of 0.
This would either produce a crash or report the wrong value.

---

```dart
SliverGrid.builder(
  itemCount: 0,
  itemBuilder: (_, __) => Container(),
  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
    crossAxisCount: 1,
    mainAxisSpacing: 10,
    childAspectRatio: 2.1,
  ),
),
```

This case would  cause a crash from a negative scroll extent. 💀 

```dart
SliverGrid.builder(
  itemCount: 0,
  itemBuilder: (_, __) => Container(),
  gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
    maxCrossAxisExtent: 30,
  ),
),
```

This would just report the wrong value > 0. 🙃 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
