### PR TITLE
Use Web resources CDN in service_worker_test by default

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -107,25 +107,18 @@ String _testTypeToIndexFile(ServiceWorkerTestType type) {
   switch (type) {
     case ServiceWorkerTestType.blockedServiceWorkers:
       indexFile = 'index_with_blocked_service_workers.html';
-      break;
     case ServiceWorkerTestType.withFlutterJs:
       indexFile = 'index_with_flutterjs.html';
-      break;
     case ServiceWorkerTestType.withoutFlutterJs:
       indexFile = 'index_without_flutterjs.html';
-      break;
     case ServiceWorkerTestType.withFlutterJsShort:
       indexFile = 'index_with_flutterjs_short.html';
-      break;
     case ServiceWorkerTestType.withFlutterJsEntrypointLoadedEvent:
       indexFile = 'index_with_flutterjs_entrypoint_loaded.html';
-      break;
     case ServiceWorkerTestType.withFlutterJsTrustedTypesOn:
       indexFile = 'index_with_flutterjs_el_tt_on.html';
-      break;
     case ServiceWorkerTestType.generatedEntrypoint:
       indexFile = 'generated_entrypoint.html';
-      break;
   }
   return indexFile;
 }

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -107,18 +107,25 @@ String _testTypeToIndexFile(ServiceWorkerTestType type) {
   switch (type) {
     case ServiceWorkerTestType.blockedServiceWorkers:
       indexFile = 'index_with_blocked_service_workers.html';
+      break;
     case ServiceWorkerTestType.withFlutterJs:
       indexFile = 'index_with_flutterjs.html';
+      break;
     case ServiceWorkerTestType.withoutFlutterJs:
       indexFile = 'index_without_flutterjs.html';
+      break;
     case ServiceWorkerTestType.withFlutterJsShort:
       indexFile = 'index_with_flutterjs_short.html';
+      break;
     case ServiceWorkerTestType.withFlutterJsEntrypointLoadedEvent:
       indexFile = 'index_with_flutterjs_entrypoint_loaded.html';
+      break;
     case ServiceWorkerTestType.withFlutterJsTrustedTypesOn:
       indexFile = 'index_with_flutterjs_el_tt_on.html';
+      break;
     case ServiceWorkerTestType.generatedEntrypoint:
       indexFile = 'generated_entrypoint.html';
+      break;
   }
   return indexFile;
 }
@@ -140,7 +147,7 @@ Future<void> _rebuildApp({ required int version, required ServiceWorkerTestType 
   );
   await runCommand(
     _flutter,
-    <String>['build', 'web', '--profile', '-t', target],
+    <String>['build', 'web', '--web-resources-cdn', '--profile', '-t', target],
     workingDirectory: _testAppDirectory,
     environment: <String, String>{
       'FLUTTER_WEB': 'true',


### PR DESCRIPTION
Use CDN CanvasKit resources for service worker test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
