### PR TITLE
Update dartdoc to 6.2.1.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 6.2.0
+    "$DART" pub global activate dartdoc 6.2.1
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
Bump dartdoc to 6.2.1.  In particular, this includes improved support for class modifiers and will avoid a crash when interacting with the new (not yet landed) analyzer change https://dart-review.googlesource.com/c/sdk/+/290614.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v6.2.1

Part of #118837.
