### PR TITLE
Fix warning in `flutter create`d project ("package attribute is deprecated" in AndroidManifest)

### DIFF
--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.yourcompany.complexLayout"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/complex_layout/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/complex_layout/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.complexLayout">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.yourcompany.microbenchmarks"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    namespace "com.yourcompany.microbenchmarks"
+    namespace "com.example.macrobenchmarks"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.macrobenchmarks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.yourcompany.microbenchmarks"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.microbenchmarks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -13,6 +13,7 @@ android {
         }
     }
 
+    namespace "dev.flutter.multipleflutters"
     compileSdkVersion 31
 
     compileOptions {

--- a/dev/benchmarks/multiple_flutters/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/multiple_flutters/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.flutter.multipleflutters">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".App"

--- a/dev/benchmarks/multiple_flutters/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/multiple_flutters/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "dev.benchmarks.platform_views_layout"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/platform_views_layout/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/platform_views_layout/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.benchmarks.platform_views_layout">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "dev.benchmarks.platform_views_layout_hybrid_composition"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.benchmarks.platform_views_layout_hybrid_composition">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "io.flutter.examples.stocks"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/benchmarks/test_apps/stocks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/test_apps/stocks/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.stocks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -30,6 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.channels"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/dev/integration_tests/channels/android/app/src/debug/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/debug/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.channels">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.channels">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="channels"
         android:name="${applicationName}"

--- a/dev/integration_tests/channels/android/app/src/profile/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/profile/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.channels">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/dev/integration_tests/deferred_components_test/android/app/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/app/build.gradle
@@ -36,6 +36,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "io.flutter.integration.deferred_components_test"
     compileSdkVersion flutter.compileSdkVersion
 
     sourceSets {

--- a/dev/integration_tests/deferred_components_test/android/app/src/debug/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/app/src/debug/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.integration.deferred_components_test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.integration.deferred_components_test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- ${applicationName} is used by the Flutter tool to select the Application
          class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide

--- a/dev/integration_tests/deferred_components_test/android/component1/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/component1/build.gradle
@@ -23,6 +23,7 @@ if (flutterVersionName == null) {
 apply plugin: "com.android.dynamic-feature"
 
 android {
+    namespace "io.flutter.integration.deferred_components_test.component1"
     compileSdkVersion 31
 
     sourceSets {

--- a/dev/integration_tests/deferred_components_test/android/component1/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/component1/src/main/AndroidManifest.xml
@@ -3,8 +3,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:dist="http://schemas.android.com/apk/distribution"
-    package="io.flutter.integration.deferred_components_test.component1">
+    xmlns:dist="http://schemas.android.com/apk/distribution">
 
     <dist:module
         dist:instant="false"

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.yourcompany.flavors"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/integration_tests/flavors/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/flavors/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.flavors">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -40,6 +40,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "io.flutter.demo.gallery"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/integration_tests/flutter_gallery/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/flutter_gallery/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.demo.gallery">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/dev/integration_tests/spell_check/android/app/build.gradle
+++ b/dev/integration_tests/spell_check/android/app/build.gradle
@@ -30,6 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.spell_check"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/dev/integration_tests/spell_check/android/app/src/debug/AndroidManifest.xml
+++ b/dev/integration_tests/spell_check/android/app/src/debug/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.spell_check">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/dev/integration_tests/spell_check/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/spell_check/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.spell_check">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="spell_check"
         android:name="${applicationName}"

--- a/dev/integration_tests/spell_check/android/app/src/profile/AndroidManifest.xml
+++ b/dev/integration_tests/spell_check/android/app/src/profile/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.spell_check">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.yourcompany.integration_ui"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.yourcompany.integration_ui">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/api/android/app/build.gradle
+++ b/examples/api/android/app/build.gradle
@@ -30,6 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "dev.flutter.flutter_api_samples"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/api/android/app/src/debug/AndroidManifest.xml
+++ b/examples/api/android/app/src/debug/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.flutter.flutter_api_samples">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/examples/api/android/app/src/main/AndroidManifest.xml
+++ b/examples/api/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.flutter.flutter_api_samples">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="@string/app_name"
         android:name="androidx.multidex.MultiDexApplication"

--- a/examples/api/android/app/src/profile/AndroidManifest.xml
+++ b/examples/api/android/app/src/profile/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.flutter.flutter_api_samples">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.view"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/flutter_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter_view/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.view">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically, flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "io.flutter.examples.hello_world"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/hello_world/android/app/src/main/AndroidManifest.xml
+++ b/examples/hello_world/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.hello_world">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.image_list"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/image_list/android/app/src/main/AndroidManifest.xml
+++ b/examples/image_list/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.image_list">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "io.flutter.examples.Layers"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/layers/android/app/src/main/AndroidManifest.xml
+++ b/examples/layers/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.Layers">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.platformchannel"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/platform_channel/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.platformchannel">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "io.flutter.examples.platform_view"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/examples/platform_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_view/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.examples.platform_view">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "{{androidIdentifier}}"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "{{androidIdentifier}}"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{androidIdentifier}}">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{androidIdentifier}}">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:label="{{projectName}}"
         android:name="${applicationName}"

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/profile/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/profile/AndroidManifest.xml.tmpl
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{androidIdentifier}}">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.


### PR DESCRIPTION
This PR resolves #123302

Learn more:
- [Android Developers | Configure the app module](https://developer.android.com/studio/build/configure-app-module#set-namespace)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
