### PR TITLE
Implement SystemChrome.getPreferredOrientations

### DIFF
--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -381,6 +381,14 @@ abstract final class SystemChrome {
       'SystemChrome.setPreferredOrientations',
       _stringify(orientations),
     );
+    _preferredOrientations = orientations;
+  }
+
+  /// Returns the list of device orientations as they were requested in [setPreferredOrientations].
+  /// 
+  /// Returns null, if the [setPreferredOrientations] was never called.
+  static List<DeviceOrientation>? getPreferredOrientations() {
+    return _preferredOrientations;
   }
 
   /// Specifies the description of the current state of the application as it
@@ -575,4 +583,7 @@ abstract final class SystemChrome {
   @visibleForTesting
   static SystemUiOverlayStyle? get latestStyle => _latestStyle;
   static SystemUiOverlayStyle? _latestStyle;
+
+  /// The last device preferred orientations that were set using [SystemChrome.setSystemUIOverlayStyle].
+  static List<DeviceOrientation>? _preferredOrientations;
 }

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -385,7 +385,7 @@ abstract final class SystemChrome {
   }
 
   /// Returns the list of device orientations as they were requested in [setPreferredOrientations].
-  /// 
+  ///
   /// Returns null, if the [setPreferredOrientations] was never called.
   static List<DeviceOrientation>? getPreferredOrientations() {
     return _preferredOrientations;

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -67,6 +67,48 @@ void main() {
     ));
   });
 
+  test('getPreferredOrientations control test', () async {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
+      return null;
+    });
+
+    expect(SystemChrome.getPreferredOrientations(), null);
+
+    List<DeviceOrientation> preferredOrientations = <DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+    ];
+    await SystemChrome.setPreferredOrientations(preferredOrientations);
+    expect(SystemChrome.getPreferredOrientations(), preferredOrientations);
+
+    preferredOrientations = <DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.landscapeRight,
+    ];
+    await SystemChrome.setPreferredOrientations(preferredOrientations);
+    expect(SystemChrome.getPreferredOrientations(), preferredOrientations);
+
+    preferredOrientations = <DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+      DeviceOrientation.landscapeRight,
+    ];
+    await SystemChrome.setPreferredOrientations(preferredOrientations);
+    expect(SystemChrome.getPreferredOrientations(), preferredOrientations);
+
+    preferredOrientations = <DeviceOrientation>[
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+      DeviceOrientation.landscapeRight,
+      DeviceOrientation.landscapeLeft,
+    ];
+    await SystemChrome.setPreferredOrientations(preferredOrientations);
+    expect(SystemChrome.getPreferredOrientations(), preferredOrientations);
+
+    preferredOrientations = <DeviceOrientation>[];
+    await SystemChrome.setPreferredOrientations(preferredOrientations);
+    expect(SystemChrome.getPreferredOrientations(), preferredOrientations);
+  });
+
   test('setPreferredOrientations control test', () async {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -68,11 +68,9 @@ void main() {
   });
 
   test('getPreferredOrientations control test', () async {
-    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
       return null;
     });
-
-    expect(SystemChrome.getPreferredOrientations(), null);
 
     List<DeviceOrientation> preferredOrientations = <DeviceOrientation>[
       DeviceOrientation.portraitUp,


### PR DESCRIPTION
Implement SystemChrome.getPreferredOrientations as requested in #95719. The main idea is to store requested orientations on the framework side, so it would return exactly the same list as the user has set.

Fixes #95719

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

