### PR TITLE
Add `borderRadius` to LinearProgressIndicator

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -153,7 +153,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
   final double? value;
   final double animationValue;
   final TextDirection textDirection;
-  final BorderRadius indicatorBorderRadius;
+  final BorderRadiusGeometry indicatorBorderRadius;
 
   // The indeterminate progress animation displays two lines whose leading (head)
   // and trailing (tail) endpoints are defined by the following four curves.
@@ -201,21 +201,23 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 
       final Rect rect = Offset(left, 0.0) & Size(width, size.height);
       if (indicatorBorderRadius != BorderRadius.zero) {
-        // When the indicator has a determinate value, we override the start
-        // border radius to be zero, so that the radius is only applied to the
-        // trailing edge of the indicator.
-        final BorderRadius borderRadius;
-        if (value == null || indicatorBorderRadius == BorderRadius.zero) {
-          borderRadius = indicatorBorderRadius;
-        } else {
-          switch (textDirection) {
-            case TextDirection.rtl:
-              borderRadius = indicatorBorderRadius.copyWith(topRight: Radius.zero, bottomRight: Radius.zero);
-            case TextDirection.ltr:
-              borderRadius = indicatorBorderRadius.copyWith(topLeft: Radius.zero, bottomLeft: Radius.zero);
-          }
+        RRect rrect = indicatorBorderRadius.resolve(textDirection).toRRect(rect);
+        if (value != null) {
+          // When the indicator has a determinate value, we override the start
+          // border radius to be zero, so that the radius is only applied to the
+          // trailing edge of the indicator.
+          rrect = RRect.fromLTRBAndCorners(
+            rect.left,
+            rect.top,
+            rect.right,
+            rect.bottom,
+            bottomRight: rrect.brRadius,
+            topRight: rrect.trRadius,
+            // bottomLeft: Radius.zero, (default value)
+            // topLeft: Radius.zero, (default value)
+          );
         }
-        canvas.drawRRect(borderRadius.toRRect(rect), paint);
+        canvas.drawRRect(rrect, paint);
       } else {
         canvas.drawRect(rect, paint);
       }
@@ -333,7 +335,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// The border radius of the indicator.
   ///
   /// By default it is [BorderRadius.zero], which produces a rectangular indicator.
-  final BorderRadius indicatorBorderRadius;
+  final BorderRadiusGeometry indicatorBorderRadius;
 
   @override
   State<LinearProgressIndicator> createState() => _LinearProgressIndicatorState();

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -211,10 +211,10 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
             rect.top,
             rect.right,
             rect.bottom,
-            bottomRight: rrect.brRadius,
-            topRight: rrect.trRadius,
-            // bottomLeft: Radius.zero, (default value)
-            // topLeft: Radius.zero, (default value)
+            bottomRight: (textDirection == TextDirection.ltr) ? rrect.brRadius : Radius.zero,
+            topRight: (textDirection == TextDirection.ltr) ? rrect.trRadius : Radius.zero,
+            bottomLeft: (textDirection == TextDirection.rtl) ? rrect.blRadius : Radius.zero,
+            topLeft: (textDirection == TextDirection.rtl) ? rrect.tlRadius : Radius.zero,
           );
         }
         canvas.drawRRect(rrect, paint);

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -201,22 +201,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 
       final Rect rect = Offset(left, 0.0) & Size(width, size.height);
       if (indicatorBorderRadius != BorderRadius.zero) {
-        RRect rrect = indicatorBorderRadius.resolve(textDirection).toRRect(rect);
-        if (value != null) {
-          // When the indicator has a determinate value, we override the start
-          // border radius to be zero, so that the radius is only applied to the
-          // trailing edge of the indicator.
-          rrect = RRect.fromLTRBAndCorners(
-            rect.left,
-            rect.top,
-            rect.right,
-            rect.bottom,
-            bottomRight: (textDirection == TextDirection.ltr) ? rrect.brRadius : Radius.zero,
-            topRight: (textDirection == TextDirection.ltr) ? rrect.trRadius : Radius.zero,
-            bottomLeft: (textDirection == TextDirection.rtl) ? rrect.blRadius : Radius.zero,
-            topLeft: (textDirection == TextDirection.rtl) ? rrect.tlRadius : Radius.zero,
-          );
-        }
+        final RRect rrect = indicatorBorderRadius.resolve(textDirection).toRRect(rect);
         canvas.drawRRect(rrect, paint);
       } else {
         canvas.drawRect(rect, paint);
@@ -303,8 +288,7 @@ class LinearProgressIndicator extends ProgressIndicator {
     this.minHeight,
     super.semanticsLabel,
     super.semanticsValue,
-    this.outerBorderRadius = BorderRadius.zero,
-    this.indicatorBorderRadius = BorderRadius.zero,
+    this.borderRadius = BorderRadius.zero,
   }) : assert(minHeight == null || minHeight > 0);
 
   /// {@template flutter.material.LinearProgressIndicator.trackColor}
@@ -327,27 +311,11 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// {@endtemplate}
   final double? minHeight;
 
-  /// The border radius of the background shape.
+  /// The border radius of both the indicator and the track.
   ///
-  /// This covers the entire widget, including the indicator.
-  /// By default it is [BorderRadius.zero], which produces a rectangular shape.
-  final BorderRadiusGeometry outerBorderRadius;
-
-  /// The border radius of the indicator.
-  ///
-  /// When TextDirection is set to [TextDirection.ltr], [BorderRadius.topLeft]
-  /// and [BorderRadius.bottomLeft] are overriten to be [Radius.zero], so that
-  /// the indicator always fill the starting position. Therefore, setting
-  /// [indicatorBorderRadius] to BorderRadius.circular(10) will produce a
-  /// rounded indicator with radius 10 at the end with a sharp edge at the
-  /// start.
-  ///
-  /// When TextDirection is set to [TextDirection.rtl], [BorderRadius.topRight]
-  /// and [BorderRadius.bottomRight] are overriten to be [Radius.zero], as that becomes
-  /// the starting position.
-  ///
-  /// By default it is [BorderRadius.zero], which produces a rectangular indicator.
-  final BorderRadiusGeometry indicatorBorderRadius;
+  /// By default it is [BorderRadius.zero], which produces a rectangular shape
+  /// with a rectangular indicator.
+  final BorderRadiusGeometry borderRadius;
 
   @override
   State<LinearProgressIndicator> createState() => _LinearProgressIndicatorState();
@@ -400,12 +368,13 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
     return widget._buildSemanticsWrapper(
       context: context,
       child: Container(
-        clipBehavior: (widget.outerBorderRadius != BorderRadius.zero)
+        // Clip is only needed with indeterminate progress indicators
+        clipBehavior: (widget.borderRadius != BorderRadius.zero && widget.value == null)
             ? Clip.antiAlias
             : Clip.none,
         decoration: ShapeDecoration(
           color: trackColor,
-          shape: RoundedRectangleBorder(borderRadius: widget.outerBorderRadius),
+          shape: RoundedRectangleBorder(borderRadius: widget.borderRadius),
         ),
         constraints: BoxConstraints(
           minWidth: double.infinity,
@@ -418,7 +387,7 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
             value: widget.value, // may be null
             animationValue: animationValue, // ignored if widget.value is not null
             textDirection: textDirection,
-            indicatorBorderRadius: widget.indicatorBorderRadius,
+            indicatorBorderRadius: widget.borderRadius,
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -335,14 +335,14 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// The border radius of the indicator.
   ///
   /// When TextDirection is set to [TextDirection.ltr], [BorderRadius.topLeft]
-  /// and [BorderRadius.leftBottom] are overriten to be [Radius.zero], so that
+  /// and [BorderRadius.bottomLeft] are overriten to be [Radius.zero], so that
   /// the indicator always fill the starting position. Therefore, setting
-  /// [indicatorBorderRadius] to [BorderRadius.circular(10)] will produce a
+  /// [indicatorBorderRadius] to BorderRadius.circular(10) will produce a
   /// rounded indicator with radius 10 at the end with a sharp edge at the
   /// start.
   ///
   /// When TextDirection is set to [TextDirection.rtl], [BorderRadius.topRight]
-  /// and [BorderRadius.rightBottom] are overriten to be [Radius.zero], as that becomes
+  /// and [BorderRadius.bottomRight] are overriten to be [Radius.zero], as that becomes
   /// the starting position.
   ///
   /// By default it is [BorderRadius.zero], which produces a rectangular indicator.

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -201,9 +201,9 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 
       final Rect rect = Offset(left, 0.0) & Size(width, size.height);
       if (indicatorBorderRadius != BorderRadius.zero) {
-        // When the indicator has a value, we override the start border radius
-        // to be zero, so that the radius is only applied to the trailing edge
-        // of the indicator.
+        // When the indicator has a determinate value, we override the start
+        // border radius to be zero, so that the radius is only applied to the
+        // trailing edge of the indicator.
         final BorderRadius borderRadius;
         if (value == null || indicatorBorderRadius == BorderRadius.zero) {
           borderRadius = indicatorBorderRadius;
@@ -301,7 +301,7 @@ class LinearProgressIndicator extends ProgressIndicator {
     this.minHeight,
     super.semanticsLabel,
     super.semanticsValue,
-    this.shape = const RoundedRectangleBorder(),
+    this.outerBorderRadius = BorderRadius.zero,
     this.indicatorBorderRadius = BorderRadius.zero,
   }) : assert(minHeight == null || minHeight > 0);
 
@@ -325,15 +325,10 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// {@endtemplate}
   final double? minHeight;
 
-  /// The physical shape of the widget, as well as its border.
+  /// The border radius of the widget.
   ///
-  /// By default it is [RoundedRectangleBorder], which produces a rectangular
-  /// widget without a border.
-  ///
-  /// See also:
-  ///
-  ///  * [StadiumBorder], which produces a rounded rectangle with semi-circular ends.
-  final ShapeBorder shape;
+  /// By default it is [BorderRadius.zero], which produces a rectangular shape.
+  final BorderRadius outerBorderRadius;
 
   /// The border radius of the indicator.
   ///
@@ -391,10 +386,12 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
     return widget._buildSemanticsWrapper(
       context: context,
       child: Container(
-        clipBehavior: Clip.antiAlias,
+        clipBehavior: (widget.outerBorderRadius != BorderRadius.zero)
+            ? Clip.antiAlias
+            : Clip.none,
         decoration: ShapeDecoration(
           color: trackColor,
-          shape: widget.shape,
+          shape: RoundedRectangleBorder(borderRadius: widget.outerBorderRadius),
         ),
         constraints: BoxConstraints(
           minWidth: double.infinity,

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -328,7 +328,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// The border radius of the widget.
   ///
   /// By default it is [BorderRadius.zero], which produces a rectangular shape.
-  final BorderRadius outerBorderRadius;
+  final BorderRadiusGeometry outerBorderRadius;
 
   /// The border radius of the indicator.
   ///

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -327,8 +327,9 @@ class LinearProgressIndicator extends ProgressIndicator {
   /// {@endtemplate}
   final double? minHeight;
 
-  /// The border radius of the widget.
+  /// The border radius of the background shape.
   ///
+  /// This covers the entire widget, including the indicator.
   /// By default it is [BorderRadius.zero], which produces a rectangular shape.
   final BorderRadiusGeometry outerBorderRadius;
 

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -334,6 +334,17 @@ class LinearProgressIndicator extends ProgressIndicator {
 
   /// The border radius of the indicator.
   ///
+  /// When TextDirection is set to [TextDirection.ltr], [BorderRadius.topLeft]
+  /// and [BorderRadius.leftBottom] are overriten to be [Radius.zero], so that
+  /// the indicator always fill the starting position. Therefore, setting
+  /// [indicatorBorderRadius] to [BorderRadius.circular(10)] will produce a
+  /// rounded indicator with radius 10 at the end with a sharp edge at the
+  /// start.
+  ///
+  /// When TextDirection is set to [TextDirection.rtl], [BorderRadius.topRight]
+  /// and [BorderRadius.rightBottom] are overriten to be [Radius.zero], as that becomes
+  /// the starting position.
+  ///
   /// By default it is [BorderRadius.zero], which produces a rectangular indicator.
   final BorderRadiusGeometry indicatorBorderRadius;
 

--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -120,7 +120,7 @@ class ShapeDecoration extends Decoration {
 
   @override
   Path getClipPath(Rect rect, TextDirection textDirection) {
-    return shape.getInnerPath(rect, textDirection: textDirection);
+    return shape.getOuterPath(rect, textDirection: textDirection);
   }
 
   /// The color to fill in the background of the shape.

--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -120,7 +120,7 @@ class ShapeDecoration extends Decoration {
 
   @override
   Path getClipPath(Rect rect, TextDirection textDirection) {
-    return shape.getOuterPath(rect, textDirection: textDirection);
+    return shape.getInnerPath(rect, textDirection: textDirection);
   }
 
   /// The color to fill in the background of the shape.

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -465,6 +465,38 @@ void main() {
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeCap: StrokeCap.round));
   });
 
+  testWidgets('LinearProgressIndicator with indicatorBorderRadius', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Theme(
+        data: theme,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 100.0,
+              height: 4.0,
+              child: LinearProgressIndicator(
+                value: 0.25,
+                indicatorBorderRadius: BorderRadius.all(Radius.circular(10)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(
+        find.byType(LinearProgressIndicator),
+        paints
+        ..rrect(
+          rrect: RRect.fromLTRBAndCorners(0.0, 0.0, 25.0, 4.0,
+            topRight: const Radius.circular(10.0),
+            bottomRight: const Radius.circular(10.0),
+          ),
+        ),
+    );
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
   testWidgets('CircularProgressIndicator paint colors', (WidgetTester tester) async {
     const Color green = Color(0xFF00FF00);
     const Color blue = Color(0xFF0000FF);

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -477,8 +477,7 @@ void main() {
               height: 4.0,
               child: LinearProgressIndicator(
                 value: 0.25,
-                outerBorderRadius: BorderRadius.all(Radius.circular(20)),
-                indicatorBorderRadius: BorderRadius.all(Radius.circular(10)),
+                borderRadius: BorderRadius.all(Radius.circular(10)),
               ),
             ),
           ),
@@ -489,12 +488,12 @@ void main() {
         find.byType(LinearProgressIndicator),
         paints
         ..rrect(
-          rrect: RRect.fromLTRBR(0.0, 0.0, 100.0, 4.0, const Radius.circular(20.0)),
+          rrect: RRect.fromLTRBR(0.0, 0.0, 100.0, 4.0, const Radius.circular(10.0)),
         )
         ..rrect(
-          rrect: RRect.fromLTRBAndCorners(0.0, 0.0, 25.0, 4.0,
-            topRight: const Radius.circular(10.0),
-            bottomRight: const Radius.circular(10.0),
+          rrect: RRect.fromRectAndRadius(
+            const Rect.fromLTRB(0.0, 0.0, 25.0, 4.0),
+            const Radius.circular(10.0),
           ),
         ),
     );

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -477,6 +477,7 @@ void main() {
               height: 4.0,
               child: LinearProgressIndicator(
                 value: 0.25,
+                outerBorderRadius: BorderRadius.all(Radius.circular(20)),
                 indicatorBorderRadius: BorderRadius.all(Radius.circular(10)),
               ),
             ),
@@ -487,6 +488,9 @@ void main() {
     expect(
         find.byType(LinearProgressIndicator),
         paints
+        ..rrect(
+          rrect: RRect.fromLTRBR(0.0, 0.0, 100.0, 4.0, const Radius.circular(20.0)),
+        )
         ..rrect(
           rrect: RRect.fromLTRBAndCorners(0.0, 0.0, 25.0, 4.0,
             topRight: const Radius.circular(10.0),


### PR DESCRIPTION
Split from https://github.com/flutter/flutter/pull/122664 so it gets easier to review, as this is now unrelated to the `preferRound`. I'm one step from adding a width attribute, lol.

<img width="474" alt="image" src="https://user-images.githubusercontent.com/351125/226083798-71e529e9-4ae9-41de-a500-0412b989a273.png">

cc @Piinks