### PR TITLE
Make InkInteractiveFeature customBorder updatable

### DIFF
--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -44,14 +44,14 @@ class InkHighlight extends InteractiveInkFeature {
     BoxShape shape = BoxShape.rectangle,
     double? radius,
     BorderRadius? borderRadius,
-    ShapeBorder? customBorder,
+    super.customBorder,
     RectCallback? rectCallback,
     super.onRemoved,
     Duration fadeDuration = _kDefaultHighlightFadeDuration,
   }) : _shape = shape,
        _radius = radius,
        _borderRadius = borderRadius ?? BorderRadius.zero,
-       _customBorder = customBorder,
+
        _textDirection = textDirection,
        _rectCallback = rectCallback {
     _alphaController = AnimationController(duration: fadeDuration, vsync: controller.vsync)
@@ -69,7 +69,6 @@ class InkHighlight extends InteractiveInkFeature {
   final BoxShape _shape;
   final double? _radius;
   final BorderRadius _borderRadius;
-  final ShapeBorder? _customBorder;
   final RectCallback? _rectCallback;
   final TextDirection _textDirection;
 
@@ -106,8 +105,8 @@ class InkHighlight extends InteractiveInkFeature {
 
   void _paintHighlight(Canvas canvas, Rect rect, Paint paint) {
     canvas.save();
-    if (_customBorder != null) {
-      canvas.clipPath(_customBorder!.getOuterPath(rect, textDirection: _textDirection));
+    if (customBorder != null) {
+      canvas.clipPath(customBorder!.getOuterPath(rect, textDirection: _textDirection));
     }
     switch (_shape) {
       case BoxShape.circle:

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -116,12 +116,11 @@ class InkRipple extends InteractiveInkFeature {
     bool containedInkWell = false,
     RectCallback? rectCallback,
     BorderRadius? borderRadius,
-    ShapeBorder? customBorder,
+    super.customBorder,
     double? radius,
     super.onRemoved,
   }) : _position = position,
        _borderRadius = borderRadius ?? BorderRadius.zero,
-       _customBorder = customBorder,
        _textDirection = textDirection,
        _targetRadius = radius ?? _getTargetRadius(referenceBox, containedInkWell, rectCallback, position),
        _clipCallback = _getClipCallback(referenceBox, containedInkWell, rectCallback),
@@ -166,7 +165,6 @@ class InkRipple extends InteractiveInkFeature {
 
   final Offset _position;
   final BorderRadius _borderRadius;
-  final ShapeBorder? _customBorder;
   final double _targetRadius;
   final RectCallback? _clipCallback;
   final TextDirection _textDirection;
@@ -245,7 +243,7 @@ class InkRipple extends InteractiveInkFeature {
       center: center,
       textDirection: _textDirection,
       radius: _radius.value,
-      customBorder: _customBorder,
+      customBorder: customBorder,
       borderRadius: _borderRadius,
       clipCallback: _clipCallback,
     );

--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -106,7 +106,7 @@ class InkSparkle extends InteractiveInkFeature {
     bool containedInkWell = true,
     RectCallback? rectCallback,
     BorderRadius? borderRadius,
-    ShapeBorder? customBorder,
+    super.customBorder,
     double? radius,
     super.onRemoved,
     double? turbulenceSeed,
@@ -114,7 +114,6 @@ class InkSparkle extends InteractiveInkFeature {
        _color = color,
        _position = position,
        _borderRadius = borderRadius ?? BorderRadius.zero,
-       _customBorder = customBorder,
        _textDirection = textDirection,
        _targetRadius = (radius ?? _getTargetRadius(
                                     referenceBox,
@@ -236,7 +235,6 @@ class InkSparkle extends InteractiveInkFeature {
   final Color _color;
   final Offset _position;
   final BorderRadius _borderRadius;
-  final ShapeBorder? _customBorder;
   final double _targetRadius;
   final RectCallback? _clipCallback;
   final TextDirection _textDirection;
@@ -292,7 +290,7 @@ class InkSparkle extends InteractiveInkFeature {
         canvas: canvas,
         clipCallback: _clipCallback!,
         textDirection: _textDirection,
-        customBorder: _customBorder,
+        customBorder: customBorder,
         borderRadius: _borderRadius,
       );
     }

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -122,12 +122,11 @@ class InkSplash extends InteractiveInkFeature {
     bool containedInkWell = false,
     RectCallback? rectCallback,
     BorderRadius? borderRadius,
-    ShapeBorder? customBorder,
+    super.customBorder,
     double? radius,
     super.onRemoved,
   }) : _position = position,
        _borderRadius = borderRadius ?? BorderRadius.zero,
-       _customBorder = customBorder,
        _targetRadius = radius ?? _getTargetRadius(referenceBox, containedInkWell, rectCallback, position!),
        _clipCallback = _getClipCallback(referenceBox, containedInkWell, rectCallback),
        _repositionToReferenceBox = !containedInkWell,
@@ -153,7 +152,6 @@ class InkSplash extends InteractiveInkFeature {
 
   final Offset? _position;
   final BorderRadius _borderRadius;
-  final ShapeBorder? _customBorder;
   final double _targetRadius;
   final RectCallback? _clipCallback;
   final bool _repositionToReferenceBox;
@@ -211,7 +209,7 @@ class InkSplash extends InteractiveInkFeature {
       center: center!,
       textDirection: _textDirection,
       radius: _radius.value,
-      customBorder: _customBorder,
+      customBorder: customBorder,
       borderRadius: _borderRadius,
       clipCallback: _clipCallback,
     );


### PR DESCRIPTION
## Description

This PR makes splashes and highlights customBorder propertie updatable.

<details>
<summary>Video captures using the following code sample</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData.dark(
        useMaterial3: true,
      ),
      home: Scaffold(
        body: Center(
          child: FilledButton(
            style: ButtonStyle(
              fixedSize: MaterialStateProperty.all(const Size(100, 100)),
              shape: MaterialStateProperty.resolveWith(
                (states) => RoundedRectangleBorder(
                  borderRadius: BorderRadius.circular(
                    states.contains(MaterialState.pressed) ? 20 : 50,
                  ),
                ),
              ),
            ),
            child: const Text('Button'),
            onPressed: () {},
          ),
        ),
      ),
    );
  }
}
```
</details> 

### Before (Button's splash is drawn according to the initial border)

https://user-images.githubusercontent.com/840911/227986443-92464a66-5066-416d-962c-83c8e6b23848.mov


### After (Button's splash is updated according to the new border)

https://user-images.githubusercontent.com/840911/227986489-d17c5f83-722c-4571-89ee-64f4e99d9960.mov


## Related Issue

Fixes https://github.com/flutter/flutter/issues/121626

## Tests

Adds 1 test.
