### PR TITLE
Fix velocity_tracker_test.dart

### DIFF
--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -19,19 +19,19 @@ bool _checkVelocity(Velocity actual, Offset expected) {
 
 void main() {
   const List<Offset> expected = <Offset>[
-    Offset(219.5762939453125, 1304.6705322265625),
-    Offset(355.6900939941406, 967.1700439453125),
-    Offset(12.651158332824707, -36.9227180480957),
-    Offset(714.1383056640625, -2561.540283203125),
-    Offset(-19.658065795898438, -2910.080322265625),
-    Offset(646.8700561523438, 2976.982421875),
-    Offset(396.6878967285156, 2106.204833984375),
-    Offset(298.3150634765625, -3660.821044921875),
-    Offset(-1.7460877895355225, -3288.16162109375),
-    Offset(384.6415710449219, -2645.6484375),
-    Offset(176.3752899169922, 2711.24609375),
-    Offset(396.9254455566406, 4280.640625),
-    Offset(-71.51288604736328, 3716.74560546875),
+    Offset(219.59280094228163, 1304.701682306001),
+    Offset(355.71046950050845, 967.2112857054104),
+    Offset(12.657970884022308, -36.90447839251946),
+    Offset(714.1399654786744, -2561.534447931869),
+    Offset(-19.668121066218564, -2910.105747052462),
+    Offset(646.8690114934209, 2976.977762577527),
+    Offset(396.6988447819592, 2106.225572911095),
+    Offset(298.31594440044495, -3660.8315955215294),
+    Offset(-1.7334232785165882, -3288.13174127454),
+    Offset(384.6361280392334, -2645.6612524779835),
+    Offset(176.37900397918557, 2711.2542876273264),
+    Offset(396.9328560260098, 4280.651578291764),
+    Offset(-71.51939428321249, 3716.7385187526947),
   ];
 
   test('Velocity tracker gives expected results', () {
@@ -42,7 +42,7 @@ void main() {
         tracker.addPosition(event.timeStamp, event.position);
       }
       if (event is PointerUpEvent) {
-        _checkVelocity(tracker.getVelocity(), expected[i]);
+        expect(_checkVelocity(tracker.getVelocity(), expected[i]), isTrue);
         i += 1;
       }
     }
@@ -68,7 +68,7 @@ void main() {
         tracker.addPosition(event.timeStamp, event.position);
       }
       if (event is PointerUpEvent) {
-        _checkVelocity(tracker.getVelocity(), const Offset(649.5, 3890.3));
+        expect(_checkVelocity(tracker.getVelocity(), const Offset(649.5, 3890.3)), isTrue);
       }
     }
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/22460.

The test never verified that the velocity actually matched expectations because the return value of `_checkVelocity` was just ignored. Because of this, the recored expectations were also slightly outdated.