### PR TITLE
[macOS] platform_channel sample style cleanups

### DIFF
--- a/examples/platform_channel/macos/Runner/MainFlutterWindow.swift
+++ b/examples/platform_channel/macos/Runner/MainFlutterWindow.swift
@@ -5,22 +5,6 @@
 import Cocoa
 import FlutterMacOS
 
-enum ChannelName {
-  static let battery = "samples.flutter.io/battery"
-  static let charging = "samples.flutter.io/charging"
-}
-
-enum BatteryState {
-  static let charging = "charging"
-  static let discharging = "discharging"
-  static let unavailable = "UNAVAILABLE"
-}
-
-enum ErrorCode {
-  static let noBattery = "NO_BATTERY"
-  static let unavailable = "UNAVAILABLE"
-}
-
 class MainFlutterWindow: NSWindow {
   private let powerSource = PowerSource()
   private let stateChangeHandler = PowerSourceStateChangeHandler()
@@ -36,7 +20,7 @@ class MainFlutterWindow: NSWindow {
     // Register battery method channel.
     let registrar = flutterViewController.registrar(forPlugin: "BatteryLevel")
     let batteryChannel = FlutterMethodChannel(
-      name: ChannelName.battery,
+      name: "samples.flutter.io/battery",
       binaryMessenger: registrar.messenger)
     batteryChannel.setMethodCallHandler { [powerSource = self.powerSource] (call, result) in
       switch call.method {
@@ -44,7 +28,7 @@ class MainFlutterWindow: NSWindow {
         guard powerSource.hasBattery() else {
           result(
             FlutterError(
-              code: ErrorCode.noBattery,
+              code: "NO_BATTERY",
               message: "Device does not have a battery",
               details: nil))
           return
@@ -52,7 +36,7 @@ class MainFlutterWindow: NSWindow {
         guard let level = powerSource.getCurrentCapacity() else {
           result(
             FlutterError(
-              code: ErrorCode.unavailable,
+              code: "UNAVAILABLE",
               message: "Battery info unavailable",
               details: nil))
           return
@@ -65,7 +49,7 @@ class MainFlutterWindow: NSWindow {
 
     // Register charging event channel.
     let chargingChannel = FlutterEventChannel(
-      name: ChannelName.charging,
+      name: "samples.flutter.io/charging",
       binaryMessenger: registrar.messenger)
     chargingChannel.setStreamHandler(self)
 
@@ -79,11 +63,11 @@ class MainFlutterWindow: NSWindow {
     if let sink = self.eventSink {
       switch self.powerSource.getPowerState() {
       case .ac:
-        sink(BatteryState.charging)
+        sink("charging")
       case .battery:
-        sink(BatteryState.discharging)
+        sink("discharging")
       case .unknown:
-        sink(BatteryState.unavailable)
+        sink("UNAVAILABLE")
       }
     }
   }

--- a/examples/platform_channel/macos/Runner/MainFlutterWindow.swift
+++ b/examples/platform_channel/macos/Runner/MainFlutterWindow.swift
@@ -5,37 +5,54 @@
 import Cocoa
 import FlutterMacOS
 
-class MainFlutterWindow: NSWindow, FlutterStreamHandler, PowerSourceStateChangeDelegate {
+enum ChannelName {
+  static let battery = "samples.flutter.io/battery"
+  static let charging = "samples.flutter.io/charging"
+}
+
+enum BatteryState {
+  static let charging = "charging"
+  static let discharging = "discharging"
+  static let unavailable = "UNAVAILABLE"
+}
+
+enum ErrorCode {
+  static let noBattery = "NO_BATTERY"
+  static let unavailable = "UNAVAILABLE"
+}
+
+class MainFlutterWindow: NSWindow {
   private let powerSource = PowerSource()
-  private let stateChangeSource = PowerSourceStateChangeHandler()
+  private let stateChangeHandler = PowerSourceStateChangeHandler()
   private var eventSink: FlutterEventSink?
 
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController.init()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
+    self.displayIfNeeded()
     self.setFrame(windowFrame, display: true)
 
     // Register battery method channel.
     let registrar = flutterViewController.registrar(forPlugin: "BatteryLevel")
     let batteryChannel = FlutterMethodChannel(
-      name: "samples.flutter.io/battery",
+      name: ChannelName.battery,
       binaryMessenger: registrar.messenger)
-    batteryChannel.setMethodCallHandler({ [weak self] (call, result) in
+    batteryChannel.setMethodCallHandler { [powerSource = self.powerSource] (call, result) in
       switch call.method {
       case "getBatteryLevel":
-        if self?.powerSource.hasBattery() == false {
-          result(FlutterError(
-            code: "NO_BATTERY",
-            message: "Device does not have a battery",
-            details: nil))
-          return
-        }
-        let level = self?.powerSource.getCurrentCapacity()
-        if level == -1 {
+        guard powerSource.hasBattery() else {
           result(
             FlutterError(
-              code: "UNAVAILABLE",
+              code: ErrorCode.noBattery,
+              message: "Device does not have a battery",
+              details: nil))
+          return
+        }
+        guard let level = powerSource.getCurrentCapacity() else {
+          result(
+            FlutterError(
+              code: ErrorCode.unavailable,
               message: "Battery info unavailable",
               details: nil))
           return
@@ -44,11 +61,11 @@ class MainFlutterWindow: NSWindow, FlutterStreamHandler, PowerSourceStateChangeD
       default:
         result(FlutterMethodNotImplemented)
       }
-    })
+    }
 
     // Register charging event channel.
     let chargingChannel = FlutterEventChannel(
-      name: "samples.flutter.io/charging",
+      name: ChannelName.charging,
       binaryMessenger: registrar.messenger)
     chargingChannel.setStreamHandler(self)
 
@@ -57,36 +74,40 @@ class MainFlutterWindow: NSWindow, FlutterStreamHandler, PowerSourceStateChangeD
     super.awakeFromNib()
   }
 
+  /// Emit a power status event to the registered event sink.
+  func emitPowerStatusEvent() {
+    if let sink = self.eventSink {
+      switch self.powerSource.getPowerState() {
+      case .ac:
+        sink(BatteryState.charging)
+      case .battery:
+        sink(BatteryState.discharging)
+      case .unknown:
+        sink(BatteryState.unavailable)
+      }
+    }
+  }
+}
+
+extension MainFlutterWindow: FlutterStreamHandler {
   func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink)
     -> FlutterError?
   {
     self.eventSink = events
     self.emitPowerStatusEvent()
-    self.stateChangeSource.delegate = self
+    self.stateChangeHandler.delegate = self
     return nil
   }
 
   func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    self.stateChangeSource.delegate = nil
+    self.stateChangeHandler.delegate = nil
     self.eventSink = nil
     return nil
   }
+}
 
-  func onPowerSourceStateChanged() {
+extension MainFlutterWindow: PowerSourceStateChangeDelegate {
+  func didChangePowerSourceState() {
     self.emitPowerStatusEvent()
   }
-
-  func emitPowerStatusEvent() {
-    if let sink = self.eventSink {
-      switch self.powerSource.getPowerState() {
-      case .ac:
-        sink("charging")
-      case .battery:
-        sink("discharging")
-      case .unknown:
-        sink("UNAVAILABLE")
-      }
-    }
-  }
-
 }

--- a/examples/platform_channel/macos/Runner/PowerSource.swift
+++ b/examples/platform_channel/macos/Runner/PowerSource.swift
@@ -13,8 +13,12 @@ enum PowerState {
 
 /// A convenience wrapper for an IOKit power source.
 final class PowerSource {
-  private let info = IOPSCopyPowerSourcesInfo().takeRetainedValue()
-  private lazy var sources = IOPSCopyPowerSourcesList(info).takeRetainedValue() as Array
+  let info = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+  let sources: Array<CFTypeRef>
+
+  init() {
+    sources = IOPSCopyPowerSourcesList(info).takeRetainedValue() as Array
+  }
 
   func hasBattery() -> Bool {
     return !sources.isEmpty

--- a/examples/platform_channel/macos/Runner/PowerSource.swift
+++ b/examples/platform_channel/macos/Runner/PowerSource.swift
@@ -12,9 +12,9 @@ enum PowerState {
 }
 
 /// A convenience wrapper for an IOKit power source.
-class PowerSource {
-  let info = IOPSCopyPowerSourcesInfo().takeRetainedValue()
-  lazy var sources = IOPSCopyPowerSourcesList(info).takeRetainedValue() as Array
+final class PowerSource {
+  private let info = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+  private lazy var sources = IOPSCopyPowerSourcesList(info).takeRetainedValue() as Array
 
   func hasBattery() -> Bool {
     return !sources.isEmpty
@@ -22,7 +22,7 @@ class PowerSource {
 
   /// Returns the current power source capacity. Apple-defined power sources will return this value
   /// as a percentage.
-  func getCurrentCapacity() -> Int {
+  func getCurrentCapacity() -> Int? {
     if let source = sources.first {
       let description =
         IOPSGetPowerSourceDescription(info, source).takeUnretainedValue() as! [String: AnyObject]
@@ -30,7 +30,7 @@ class PowerSource {
         return level
       }
     }
-    return -1
+    return nil
   }
 
   /// Returns whether the device is drawing battery power or connected to an external power source.
@@ -54,11 +54,11 @@ class PowerSource {
 }
 
 protocol PowerSourceStateChangeDelegate: AnyObject {
-  func onPowerSourceStateChanged()
+  func didChangePowerSourceState()
 }
 
 /// A listener for system power source state change events. Notifies the delegate on each event.
-class PowerSourceStateChangeHandler {
+final class PowerSourceStateChangeHandler {
   private var runLoopSource: CFRunLoopSource?
   weak var delegate: PowerSourceStateChangeDelegate?
 
@@ -66,10 +66,10 @@ class PowerSourceStateChangeHandler {
     let context = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
     self.runLoopSource = IOPSNotificationCreateRunLoopSource(
       { (context: UnsafeMutableRawPointer?) in
-        let weakSelf = Unmanaged<PowerSourceStateChangeHandler>.fromOpaque(
+        let unownedSelf = Unmanaged<PowerSourceStateChangeHandler>.fromOpaque(
           UnsafeRawPointer(context!)
         ).takeUnretainedValue()
-        weakSelf.delegate?.onPowerSourceStateChanged()
+        unownedSelf.delegate?.didChangePowerSourceState()
       }, context
     ).takeRetainedValue()
     CFRunLoopAddSource(CFRunLoopGetCurrent(), self.runLoopSource, .defaultMode)


### PR DESCRIPTION
Applies a few Swift style cleanups to the macOS platform_channel sample.

Also adds ChannelName, BatteryState, ErrorCode enums to bring the example a bit closer to the iOS Swift example. Will follow up with a patch that applies relevant style fixes to the iOS Swift example.

No test changes since app semantics have not changed.

Issue: https://github.com/flutter/flutter/issues/79204

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
