### PR TITLE
[macOS] Eliminate explicit main window init()

### DIFF
--- a/dev/benchmarks/complex_layout/macos/Runner/MainFlutterWindow.swift
+++ b/dev/benchmarks/complex_layout/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/dev/benchmarks/macrobenchmarks/macos/Runner/MainFlutterWindow.swift
+++ b/dev/benchmarks/macrobenchmarks/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/dev/integration_tests/channels/macos/Runner/MainFlutterWindow.swift
+++ b/dev/integration_tests/channels/macos/Runner/MainFlutterWindow.swift
@@ -60,7 +60,7 @@ class ExtendedReaderWriter: FlutterStandardReaderWriter {
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/dev/integration_tests/flavors/macos/Runner/MainFlutterWindow.swift
+++ b/dev/integration_tests/flavors/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/dev/integration_tests/flutter_gallery/macos/Runner/MainFlutterWindow.swift
+++ b/dev/integration_tests/flutter_gallery/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/dev/integration_tests/ui/macos/Runner/MainFlutterWindow.swift
+++ b/dev/integration_tests/ui/macos/Runner/MainFlutterWindow.swift
@@ -13,7 +13,7 @@ extension NSWindow {
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/dev/manual_tests/macos/Runner/MainFlutterWindow.swift
+++ b/dev/manual_tests/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/examples/api/macos/Runner/MainFlutterWindow.swift
+++ b/examples/api/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/examples/hello_world/macos/Runner/MainFlutterWindow.swift
+++ b/examples/hello_world/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/examples/image_list/macos/Runner/MainFlutterWindow.swift
+++ b/examples/image_list/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/examples/layers/macos/Runner/MainFlutterWindow.swift
+++ b/examples/layers/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/examples/platform_channel/macos/Runner/MainFlutterWindow.swift
+++ b/examples/platform_channel/macos/Runner/MainFlutterWindow.swift
@@ -11,7 +11,7 @@ class MainFlutterWindow: NSWindow, FlutterStreamHandler, PowerSourceStateChangeD
   private var eventSink: FlutterEventSink?
 
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/examples/platform_view/macos/Runner/MainFlutterWindow.swift
+++ b/examples/platform_view/macos/Runner/MainFlutterWindow.swift
@@ -13,7 +13,7 @@ import FlutterMacOS
 */
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/MainFlutterWindow.swift
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/MainFlutterWindow.swift
@@ -3,7 +3,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)


### PR DESCRIPTION
The style guide actively recommends against calling .init().
See: https://google.github.io/swift/#initializers-1

No additional tests since this is purely a style change with no semantic effect.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
