### PR TITLE
Revert "Fix divider width in scrollable `TabBar` for  Material 3 and add `dividerHeight` parameter"

### DIFF
--- a/dev/tools/gen_defaults/lib/tabs_template.dart
+++ b/dev/tools/gen_defaults/lib/tabs_template.dart
@@ -21,9 +21,6 @@ class _${blockName}PrimaryDefaultsM3 extends TabBarTheme {
   late final TextTheme _textTheme = Theme.of(context).textTheme;
 
   @override
-  double? get dividerHeight => ${tokens['md.comp.primary-navigation-tab.divider.height']};
-
-  @override
   Color? get dividerColor => ${componentColor("md.comp.primary-navigation-tab.divider")};
 
   @override
@@ -83,9 +80,6 @@ class _${blockName}SecondaryDefaultsM3 extends TabBarTheme {
 
   @override
   Color? get dividerColor => ${componentColor("md.comp.secondary-navigation-tab.divider")};
-
-  @override
-  double? get dividerHeight => ${tokens['md.comp.primary-navigation-tab.divider.height']};
 
   @override
   Color? get indicatorColor => ${componentColor("md.comp.primary-navigation-tab.active-indicator")};

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -32,7 +32,6 @@ class TabBarTheme with Diagnosticable {
     this.indicatorColor,
     this.indicatorSize,
     this.dividerColor,
-    this.dividerHeight,
     this.labelColor,
     this.labelPadding,
     this.labelStyle,
@@ -54,9 +53,6 @@ class TabBarTheme with Diagnosticable {
 
   /// Overrides the default value for [TabBar.dividerColor].
   final Color? dividerColor;
-
-  /// Overrides the default value for [TabBar.dividerHeight].
-  final double? dividerHeight;
 
   /// Overrides the default value for [TabBar.labelColor].
   ///
@@ -101,7 +97,6 @@ class TabBarTheme with Diagnosticable {
     Color? indicatorColor,
     TabBarIndicatorSize? indicatorSize,
     Color? dividerColor,
-    double? dividerHeight,
     Color? labelColor,
     EdgeInsetsGeometry? labelPadding,
     TextStyle? labelStyle,
@@ -116,7 +111,6 @@ class TabBarTheme with Diagnosticable {
       indicatorColor: indicatorColor ?? this.indicatorColor,
       indicatorSize: indicatorSize ?? this.indicatorSize,
       dividerColor: dividerColor ?? this.dividerColor,
-      dividerHeight: dividerHeight ?? this.dividerHeight,
       labelColor: labelColor ?? this.labelColor,
       labelPadding: labelPadding ?? this.labelPadding,
       labelStyle: labelStyle ?? this.labelStyle,
@@ -147,7 +141,6 @@ class TabBarTheme with Diagnosticable {
       indicatorColor: Color.lerp(a.indicatorColor, b.indicatorColor, t),
       indicatorSize: t < 0.5 ? a.indicatorSize : b.indicatorSize,
       dividerColor: Color.lerp(a.dividerColor, b.dividerColor, t),
-      dividerHeight: t < 0.5 ? a.dividerHeight : b.dividerHeight,
       labelColor: Color.lerp(a.labelColor, b.labelColor, t),
       labelPadding: EdgeInsetsGeometry.lerp(a.labelPadding, b.labelPadding, t),
       labelStyle: TextStyle.lerp(a.labelStyle, b.labelStyle, t),
@@ -165,7 +158,6 @@ class TabBarTheme with Diagnosticable {
     indicatorColor,
     indicatorSize,
     dividerColor,
-    dividerHeight,
     labelColor,
     labelPadding,
     labelStyle,
@@ -189,7 +181,6 @@ class TabBarTheme with Diagnosticable {
         && other.indicatorColor == indicatorColor
         && other.indicatorSize == indicatorSize
         && other.dividerColor == dividerColor
-        && other.dividerHeight == dividerHeight
         && other.labelColor == labelColor
         && other.labelPadding == labelPadding
         && other.labelStyle == labelStyle

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -109,8 +109,7 @@ class _UnderlinePainter extends BoxPainter {
     if (borderRadius != null) {
       paint = Paint()..color = decoration.borderSide.color;
       final Rect indicator = decoration._indicatorRectFor(rect, textDirection)
-        .inflate(decoration.borderSide.width / 4.0)
-        .shift(Offset(0.0, -decoration.borderSide.width / 2.0));
+        .inflate(decoration.borderSide.width / 4.0);
       final RRect rrect = RRect.fromRectAndCorners(
         indicator,
         topLeft: borderRadius!.topLeft,

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -126,30 +126,27 @@ void main() {
     final Rect tabTwoRect = tester.getRect(find.byKey(_sizedTabs[1].key!));
 
     // Verify tabOne coordinates.
-    final double tabOneLeft = (tabBar.width
-      - (tabOneRect.width + tabTwoRect.width) - kTabLabelPadding.horizontal) / 2;
-    expect(tabOneRect.left, equals(tabOneLeft));
+    expect(tabOneRect.left, equals(kTabLabelPadding.left));
     expect(tabOneRect.top, equals(kTabLabelPadding.top));
     expect(tabOneRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
 
     // Verify tabTwo coordinates.
-    final double tabTwoRight = tabBar.width
-      - (tabBar.width - (tabOneRect.width + tabTwoRect.width) - kTabLabelPadding.horizontal) / 2;
-    expect(tabTwoRect.right, equals(tabTwoRight));
+    expect(tabTwoRect.right, equals(tabBar.width - kTabLabelPadding.right));
     expect(tabTwoRect.top, equals(kTabLabelPadding.top));
     expect(tabTwoRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
 
     // Verify tabOne and tabTwo is separated by right padding of tabOne and left padding of tabTwo.
     expect(tabOneRect.right, equals(tabTwoRect.left - kTabLabelPadding.left - kTabLabelPadding.right));
 
-    // Test default divider color.
-    final Divider divider = tester.widget<Divider>(find.byType(Divider));
-    expect(divider.color, equals(theme.colorScheme.surfaceVariant));
-    expect(divider.thickness, 1.0);
-
-    // Test default indicator color.
+    // Verify divider color and indicator color.
     final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
-    expect(tabBarBox, paints..rrect(color: theme.colorScheme.primary));
+    expect(
+      tabBarBox,
+      paints
+        ..line(color: theme.colorScheme.surfaceVariant)
+        // Indicator is a rrect in the primary tab bar.
+        ..rrect(color: theme.colorScheme.primary),
+    );
   });
 
   testWidgets('Tab bar defaults (secondary)', (WidgetTester tester) async {
@@ -180,30 +177,27 @@ void main() {
     final Rect tabTwoRect = tester.getRect(find.byKey(_sizedTabs[1].key!));
 
     // Verify tabOne coordinates.
-    final double tabOneLeft = (tabBar.width
-      - (tabOneRect.width + tabTwoRect.width) - kTabLabelPadding.horizontal) / 2;
-    expect(tabOneRect.left, equals(tabOneLeft));
+    expect(tabOneRect.left, equals(kTabLabelPadding.left));
     expect(tabOneRect.top, equals(kTabLabelPadding.top));
     expect(tabOneRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
 
     // Verify tabTwo coordinates.
-    final double tabTwoRight = tabBar.width
-      - (tabBar.width - (tabOneRect.width + tabTwoRect.width) - kTabLabelPadding.horizontal) / 2;
-    expect(tabTwoRect.right, equals(tabTwoRight));
+    expect(tabTwoRect.right, equals(tabBar.width - kTabLabelPadding.right));
     expect(tabTwoRect.top, equals(kTabLabelPadding.top));
     expect(tabTwoRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
 
     // Verify tabOne and tabTwo is separated by right padding of tabOne and left padding of tabTwo.
     expect(tabOneRect.right, equals(tabTwoRect.left - kTabLabelPadding.left - kTabLabelPadding.right));
 
-    // Test default divider color.
-    final Divider divider = tester.widget<Divider>(find.byType(Divider));
-    expect(divider.color, equals(theme.colorScheme.surfaceVariant));
-    expect(divider.thickness, 1.0);
-
-    // Test default indicator color.
+    // Verify divider color and indicator color.
     final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
-    expect(tabBarBox, paints..line(color: theme.colorScheme.primary));
+    expect(
+      tabBarBox,
+      paints
+        ..line(color: theme.colorScheme.surfaceVariant)
+        // Indicator is a line in the secondary tab bar.
+        ..line(color: theme.colorScheme.primary),
+    );
   });
 
   testWidgets('Tab bar theme overrides label color (selected)', (WidgetTester tester) async {
@@ -384,21 +378,21 @@ void main() {
     expect(iconRenderObject.text.style!.color, equals(unselectedLabelColor));
   });
 
-  testWidgets('Tab bar default tab indicator size (primary)', (WidgetTester tester) async {
+  testWidgets('Tab bar default tab indicator size', (WidgetTester tester) async {
     await tester.pumpWidget(buildTabBar(useMaterial3: true, isScrollable: true));
 
     await expectLater(
       find.byKey(_painterKey),
-      matchesGoldenFile('tab_bar_primary.default.tab_indicator_size.png'),
+      matchesGoldenFile('tab_bar.default.tab_indicator_size.png'),
     );
   });
 
-  testWidgets('Tab bar default tab indicator size (secondary)', (WidgetTester tester) async {
-    await tester.pumpWidget(buildTabBar(secondaryTabBar: true, useMaterial3: true, isScrollable: true));
+  testWidgets('Tab bar default tab indicator size', (WidgetTester tester) async {
+    await tester.pumpWidget(buildTabBar(useMaterial3: true, isScrollable: true));
 
     await expectLater(
       find.byKey(_painterKey),
-      matchesGoldenFile('tab_bar_secondary.default.tab_indicator_size.png'),
+      matchesGoldenFile('tab_bar.default.tab_indicator_size.png'),
     );
   });
 
@@ -468,74 +462,6 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.beveled_rect_indicator.png'),
     );
-  });
-
-  testWidgets('TabBar divider can use TabBarTheme.dividerColor & TabBarTheme.dividerHeight', (WidgetTester tester) async {
-    const Color dividerColor = Colors.yellow;
-    const double dividerHeight = 10.0;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(
-          useMaterial3: true,
-          tabBarTheme: const TabBarTheme(
-            dividerColor: dividerColor,
-            dividerHeight: dividerHeight,
-          ),
-        ),
-        home: Scaffold(
-          appBar: AppBar(
-            bottom: TabBar(
-              controller: TabController(length: 3, vsync: const TestVSync()),
-              tabs: const <Widget>[
-                Tab(text: 'Tab 1'),
-                Tab(text: 'Tab 2'),
-                Tab(text: 'Tab 3'),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-
-    final Divider divider = tester.widget<Divider>(find.byType(Divider));
-    expect(divider.color, equals(dividerColor));
-    expect(divider.thickness, dividerHeight);
-  });
-
-  testWidgets('dividerColor & dividerHeight overrides TabBarTheme.dividerColor', (WidgetTester tester) async {
-    const Color dividerColor = Colors.amber;
-    const double dividerHeight = 8.0;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(
-          useMaterial3: true,
-          tabBarTheme: const TabBarTheme(
-            dividerColor: Colors.pink,
-            dividerHeight: 5.0,
-          ),
-        ),
-        home: Scaffold(
-          appBar: AppBar(
-            bottom: TabBar(
-              dividerColor: dividerColor,
-              dividerHeight: dividerHeight,
-              controller: TabController(length: 3, vsync: const TestVSync()),
-              tabs: const <Widget>[
-                Tab(text: 'Tab 1'),
-                Tab(text: 'Tab 2'),
-                Tab(text: 'Tab 3'),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-
-    final Divider divider = tester.widget<Divider>(find.byType(Divider));
-    expect(divider.color, equals(dividerColor));
-    expect(divider.thickness, dividerHeight);
   });
 
   group('Material 2', () {

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -5778,6 +5778,36 @@ void main() {
         labelColor.withAlpha(0xB2) // 70% alpha,
       );
     });
+
+    testWidgets('Material3 - TabBar inherits the dividerColor of TabBarTheme', (WidgetTester tester) async {
+      const Color dividerColor = Colors.yellow;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            useMaterial3: true,
+            tabBarTheme: const TabBarTheme(dividerColor: dividerColor),
+          ),
+          home: Scaffold(
+            appBar: AppBar(
+              bottom: TabBar(
+                controller: TabController(length: 3, vsync: const TestVSync()),
+                tabs: const <Widget>[
+                  Tab(text: 'Tab 1'),
+                  Tab(text: 'Tab 2'),
+                  Tab(text: 'Tab 3'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Test painter's divider color.
+      final CustomPaint paint = tester.widget<CustomPaint>(find.byType(CustomPaint).last);
+      // ignore: avoid_dynamic_calls
+      expect((paint.painter as dynamic).dividerColor, dividerColor);
+    });
   });
 }
 


### PR DESCRIPTION
Reverts flutter/flutter#123127

This broke many customer tests, most are ok, but some look unexpected.

FYI @TahaTesser 