### PR TITLE
Match iOS Longpress behavior with native

### DIFF
--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1591,6 +1591,7 @@ void main() {
         home: Column(
           children: <Widget>[
             CupertinoTextField(
+              autofocus: true,
               controller: controller,
               toolbarOptions: const ToolbarOptions(copy: true),
             ),
@@ -1598,6 +1599,9 @@ void main() {
         ),
       ),
     );
+
+    // This extra pump is so autofocus can propagate to renderEditable.
+    await tester.pump();
 
     // Long press to put the cursor after the "w".
     const int index = 3;
@@ -2060,11 +2064,15 @@ void main() {
         CupertinoApp(
           home: Center(
             child: CupertinoTextField(
+              autofocus: true,
               controller: controller,
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       // Long press to put the cursor after the "w".
       const int index = 3;
@@ -2830,11 +2838,15 @@ void main() {
         CupertinoApp(
           home: Center(
             child: CupertinoTextField(
+              autofocus: true,
               controller: controller,
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
@@ -2870,11 +2882,15 @@ void main() {
         CupertinoApp(
           home: Center(
             child: CupertinoTextField(
+              autofocus: true,
               controller: controller,
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
@@ -2971,7 +2987,7 @@ void main() {
   );
 
   testWidgets(
-    'long press drag moves the cursor under the drag and shows toolbar on lift on Apple platforms',
+    'long press drag on a focused TextField moves the cursor under the drag and shows toolbar on lift on Apple platforms',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
@@ -2980,11 +2996,15 @@ void main() {
         CupertinoApp(
           home: Center(
             child: CupertinoTextField(
+              autofocus: true,
               controller: controller,
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
 
@@ -3135,11 +3155,15 @@ void main() {
       CupertinoApp(
         home: Center(
           child: CupertinoTextField(
+            autofocus: true,
             controller: controller,
           ),
         ),
       ),
     );
+
+    // This extra pump is so autofocus can propagate to renderEditable.
+    await tester.pump();
 
     final RenderEditable renderEditable = tester.renderObject<RenderEditable>(
       find.byElementPredicate((Element element) => element.renderObject is RenderEditable).last,
@@ -3289,11 +3313,15 @@ void main() {
         CupertinoApp(
           home: Center(
             child: CupertinoTextField(
+              autofocus: true,
               controller: controller,
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       // Use a position higher than wPos to avoid tapping the context menu on
       // desktop.
@@ -7313,6 +7341,7 @@ void main() {
               child: Column(
                 children: <Widget>[
                   CupertinoTextField(
+                    autofocus: true,
                     key: const Key('field0'),
                     controller: controller,
                     style: const TextStyle(height: 4, color: ui.Color.fromARGB(100, 0, 0, 0)),
@@ -7328,6 +7357,9 @@ void main() {
         ),
       ),
     );
+
+    // This extra pump is so autofocus can propagate to renderEditable.
+    await tester.pump();
 
     final Offset textFieldStart = tester.getTopLeft(find.byKey(const Key('field0')));
 
@@ -7363,6 +7395,7 @@ void main() {
               child: Column(
                 children: <Widget>[
                   CupertinoTextField(
+                    autofocus: true,
                     key: const Key('field0'),
                     controller: controller,
                     style: const TextStyle(height: 4, color: ui.Color.fromARGB(100, 0, 0, 0)),
@@ -7377,6 +7410,9 @@ void main() {
         ),
       ),
     );
+
+    // This extra pump is so autofocus can propagate to renderEditable.
+    await tester.pump();
 
     final Offset textFieldStart = tester.getTopLeft(find.byKey(const Key('field0')));
 

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -200,12 +200,16 @@ void main() {
               data: const MediaQueryData(size: Size(800.0, 600.0)),
               child: Center(
                 child: CupertinoTextField(
+                  autofocus: true,
                   controller: controller,
                 ),
               ),
             ),
           ),
       ));
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       // Initially, the menu isn't shown at all.
       expect(find.text('Cut'), findsNothing);
@@ -432,12 +436,16 @@ void main() {
               data: const MediaQueryData(size: Size(800.0, 600.0)),
               child: Center(
                 child: CupertinoTextField(
+                  autofocus: true,
                   controller: controller,
                 ),
               ),
             ),
           ),
       ));
+
+      // This extra pump is so autofocus can propagate to renderEditable.
+      await tester.pump();
 
       // Initially, the menu isn't shown at all.
       expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
@@ -546,6 +554,7 @@ void main() {
                 data: const MediaQueryData(size: Size(800.0, 600.0)),
                 child: Center(
                   child: CupertinoTextField(
+                    autofocus: true,
                     padding: const EdgeInsets.all(8.0),
                     controller: controller,
                     maxLines: 2,
@@ -554,6 +563,9 @@ void main() {
               ),
             ),
         ));
+
+        // This extra pump is so autofocus can propagate to renderEditable.
+        await tester.pump();
 
         // Initially, the menu isn't shown at all.
         expect(find.text('Cut'), findsNothing);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -10717,7 +10717,51 @@ void main() {
   );
 
   testWidgets(
-    'long press moves cursor to the exact long press position and shows toolbar',
+    'long press moves cursor to the exact long press position and shows toolbar when the field is focused',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(
+                autofocus: true,
+                controller: controller,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // This extra pump allows the selection set by autofocus to propagate to
+      // the RenderEditable.
+      await tester.pump();
+
+      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+
+      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pumpAndSettle();
+
+      // Collapsed cursor for iOS long press.
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 3),
+      );
+
+      // Collapsed toolbar shows 2 buttons.
+      final int buttons = defaultTargetPlatform == TargetPlatform.iOS ? 2 : 1;
+      expect(
+        find.byType(CupertinoButton),
+        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(buttons),
+      );
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
+  );
+
+  testWidgets(
+    'long press that starts on an unfocused TextField selects the word at the exact long press position and shows toolbar',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
@@ -10742,14 +10786,13 @@ void main() {
       // Collapsed cursor for iOS long press.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 3),
+        const TextSelection(baseOffset: 0, extentOffset: 7),
       );
 
-      // Collapsed toolbar shows 2 buttons.
-      final int buttons = defaultTargetPlatform == TargetPlatform.iOS ? 2 : 1;
+      // Collapsed toolbar shows 3 buttons.
       expect(
         find.byType(CupertinoButton),
-        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(buttons),
+        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(3),
       );
     },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
@@ -10800,12 +10843,16 @@ void main() {
           home: Material(
             child: Center(
               child: TextField(
+                autofocus: true,
                 controller: controller,
               ),
             ),
           ),
         ),
       );
+      
+      // This extra pump is so autofocus can propogate to renderEditable.
+      await tester.pump();
 
       final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
@@ -10910,7 +10957,7 @@ void main() {
   );
 
   testWidgets(
-    'long press drag moves the cursor under the drag and shows toolbar on lift',
+    'long press drag on a focused TextField moves the cursor under the drag and shows toolbar on lift',
     (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
@@ -10920,12 +10967,16 @@ void main() {
           home: Material(
             child: Center(
               child: TextField(
+                autofocus: true,
                 controller: controller,
               ),
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propogate to renderEditable.
+      await tester.pump();
 
       final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
 
@@ -10976,6 +11027,77 @@ void main() {
       expect(
         find.byType(CupertinoButton),
         isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(buttons),
+      );
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
+  );
+
+  testWidgets(
+    'long press drag on an unfocused TextField selects word-by-word and shows toolbar on lift',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(
+        text: 'Atwater Peel Sherbrooke Bonaventure',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextField(
+                controller: controller,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+
+      final TestGesture gesture =
+          await tester.startGesture(textfieldStart + const Offset(50.0, 9.0));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // Long press on iOS shows collapsed selection cursor.
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 7),
+      );
+      // Cursor move doesn't trigger a toolbar initially.
+      expect(find.byType(CupertinoButton), findsNothing);
+
+      await gesture.moveBy(const Offset(100, 0));
+      await tester.pump();
+
+      // The selection position is now moved with the drag.
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 12),
+      );
+      // Still no toolbar.
+      expect(find.byType(CupertinoButton), findsNothing);
+
+      await gesture.moveBy(const Offset(100, 0));
+      await tester.pump();
+
+      // The selection position is now moved with the drag.
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 23),
+      );
+      // Still no toolbar.
+      expect(find.byType(CupertinoButton), findsNothing);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // The selection isn't affected by the gesture lift.
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 23),
+      );
+      // The toolbar now shows up.
+      expect(
+        find.byType(CupertinoButton),
+        isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(3),
       );
     },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
@@ -11069,7 +11191,7 @@ void main() {
     expect(firstCharEndpoint[0].point.dx, moreOrLessEquals(-257.0, epsilon: 1));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows }));
 
-  testWidgets('long press drag can edge scroll on Apple platforms', (WidgetTester tester) async {
+  testWidgets('long press drag can edge scroll on Apple platforms - unfocused TextField', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
     );
@@ -11084,6 +11206,98 @@ void main() {
         ),
       ),
     );
+
+    final RenderEditable renderEditable = findRenderEditable(tester);
+
+    List<TextSelectionPoint> lastCharEndpoint = renderEditable.getEndpointsForSelection(
+      const TextSelection.collapsed(offset: 66), // Last character's position.
+    );
+
+    expect(lastCharEndpoint.length, 1);
+    // Just testing the test and making sure that the last character is off
+    // the right side of the screen.
+    expect(lastCharEndpoint[0].point.dx, 1056);
+
+    final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+
+    final TestGesture gesture =
+        await tester.startGesture(textfieldStart);
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 0, extentOffset: 7, affinity: TextAffinity.upstream),
+    );
+    expect(find.byType(CupertinoButton), findsNothing);
+
+    await gesture.moveBy(const Offset(900, 5));
+    // To the edge of the screen basically.
+    await tester.pump();
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 0, extentOffset: 59),
+    );
+    // Keep moving out.
+    await gesture.moveBy(const Offset(1, 0));
+    await tester.pump();
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 0, extentOffset: 66),
+    );
+    await gesture.moveBy(const Offset(1, 0));
+    await tester.pump();
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 0, extentOffset: 66, affinity: TextAffinity.upstream),
+    ); // We're at the edge now.
+    expect(find.byType(CupertinoButton), findsNothing);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // The selection isn't affected by the gesture lift.
+    expect(
+      controller.selection,
+      const TextSelection(baseOffset: 0, extentOffset: 66, affinity: TextAffinity.upstream),
+    );
+    // The toolbar now shows up.
+    expect(find.byType(CupertinoButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(3));
+
+    lastCharEndpoint = renderEditable.getEndpointsForSelection(
+      const TextSelection.collapsed(offset: 66), // Last character's position.
+    );
+
+    expect(lastCharEndpoint.length, 1);
+    // The last character is now on screen near the right edge.
+    expect(lastCharEndpoint[0].point.dx, moreOrLessEquals(798, epsilon: 1));
+
+    final List<TextSelectionPoint> firstCharEndpoint = renderEditable.getEndpointsForSelection(
+      const TextSelection.collapsed(offset: 0), // First character's position.
+    );
+    expect(firstCharEndpoint.length, 1);
+    // The first character is now offscreen to the left.
+    expect(firstCharEndpoint[0].point.dx, moreOrLessEquals(-257.0, epsilon: 1));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+
+  testWidgets('long press drag can edge scroll on Apple platforms - focused TextField', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextField(
+              autofocus: true,
+              controller: controller,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // This extra pump is so autofocus can propogate to renderEditable.
+    await tester.pump();
 
     final RenderEditable renderEditable = findRenderEditable(tester);
 
@@ -11309,6 +11523,7 @@ void main() {
         home: Material(
           child: Center(
             child: TextField(
+              autofocus: true,
               maxLines: 2,
               controller: controller,
             ),
@@ -11316,6 +11531,9 @@ void main() {
         ),
       ),
     );
+
+    // This extra pump is so autofocus can propogate to renderEditable.
+    await tester.pump();
 
     // Just testing the test and making sure that the last character is outside
     // the bottom of the field.
@@ -11595,12 +11813,16 @@ void main() {
           home: Material(
             child: Center(
               child: TextField(
+                autofocus: true,
                 controller: controller,
               ),
             ),
           ),
         ),
       );
+
+      // This extra pump is so autofocus can propogate to renderEditable.
+      await tester.pump();
 
       // The second tap is slightly higher to avoid tapping the context menu on
       // desktop.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -10850,7 +10850,7 @@ void main() {
           ),
         ),
       );
-      
+
       // This extra pump is so autofocus can propogate to renderEditable.
       await tester.pump();
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -460,8 +460,12 @@ void main() {
     expect(dragEndCount, 1);
   });
 
-  testWidgets('test TextSelectionGestureDetectorBuilder long press on Apple Platforms', (WidgetTester tester) async {
+  testWidgets('test TextSelectionGestureDetectorBuilder long press on Apple Platforms - focused renderEditable', (WidgetTester tester) async {
     await pumpTextSelectionGestureDetectorBuilder(tester);
+    final FakeEditableTextState state = tester.state(find.byType(FakeEditableText));
+    final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
+    renderEditable.hasFocus = true;
+
     final TestGesture gesture = await tester.startGesture(
       const Offset(200.0, 200.0),
       pointer: 0,
@@ -470,12 +474,28 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
 
-    final FakeEditableTextState state = tester.state(find.byType(FakeEditableText));
-    final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
     expect(state.showToolbarCalled, isTrue);
     expect(renderEditable.selectPositionAtCalled, isTrue);
     expect(renderEditable.lastCause, SelectionChangedCause.longPress);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+
+  testWidgets('test TextSelectionGestureDetectorBuilder long press on iOS - renderEditable not focused', (WidgetTester tester) async {
+    await pumpTextSelectionGestureDetectorBuilder(tester);
+    final FakeEditableTextState state = tester.state(find.byType(FakeEditableText));
+    final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
+
+    final TestGesture gesture = await tester.startGesture(
+      const Offset(200.0, 200.0),
+      pointer: 0,
+    );
+    await tester.pump(const Duration(seconds: 2));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(state.showToolbarCalled, isTrue);
+    expect(renderEditable.selectWordCalled, isTrue);
+    expect(renderEditable.lastCause, SelectionChangedCause.longPress);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
 
   testWidgets('test TextSelectionGestureDetectorBuilder long press on non-Apple Platforms', (WidgetTester tester) async {
     await pumpTextSelectionGestureDetectorBuilder(tester);


### PR DESCRIPTION
This change adds the ability to long press to select word-by-word when the long press starts on an unfocused TextField. Behavior when TextField is focused remains the same (moves the cursor).

Fixes #35010

https://user-images.githubusercontent.com/948037/228342240-627f7cba-5d57-4f05-8a79-6b37dc15c668.MP4

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.