### PR TITLE
Update the copy icon in snippets and samples to use the standard one

### DIFF
--- a/dev/snippets/config/skeletons/sample.html
+++ b/dev/snippets/config/skeletons/sample.html
@@ -14,7 +14,7 @@
   <div class="copyable-container">
     <button class="copy-button-overlay copy-button" title="Copy to clipboard"
       onclick="copyTextToClipboard(longSnippet{{serial}});">
-      <i class="material-icons copy-image">assignment</i>
+      <i class="material-icons copy-image">content_copy</i>
     </button>
     <pre id="longSnippet{{serial}}"
       class="language-{{language}}"><code class="language-{{language}}">{{app}}</code></pre>

--- a/dev/snippets/config/skeletons/snippet.html
+++ b/dev/snippets/config/skeletons/snippet.html
@@ -10,7 +10,7 @@
   <div class="copyable-container">
     <button class="copy-button-overlay copy-button" title="Copy to clipboard"
       onclick="copyTextToClipboard(findSiblingWithId(this, 'sample-code'));">
-      <i class="material-icons copy-image">assignment</i>
+      <i class="material-icons copy-image">content_copy</i>
     </button>
     <pre class="language-{{language}}" id="sample-code"><code class="language-{{language}}">{{code}}</code></pre>
   </div>


### PR DESCRIPTION
## Description

This updates the copy icon for copying sample code to use `content_copy` instead of `assignment`.
Before:
<img width="369" alt="223876418-2470c4c5-abfc-4511-9762-1fd0b6e05903" src="https://user-images.githubusercontent.com/8867023/228396142-450125ee-d8cf-4ede-8545-5920eb0da99d.png">

After:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/8867023/228395959-8531704a-77aa-43af-9dcf-7456bb2ed090.png">


## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/122246

## Tests
 - No tests needed.