### PR TITLE
Modify flutter_tests dart:io mocks to support Dart 3.0

### DIFF
--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -514,7 +514,7 @@ class _MockHttpResponse implements HttpClientResponse {
 }
 
 /// A mocked [HttpHeaders] that ignores all writes.
-class _MockHttpHeaders extends HttpHeaders {
+class _MockHttpHeaders implements HttpHeaders {
   @override
   List<String>? operator [](String name) => <String>[];
 
@@ -522,13 +522,40 @@ class _MockHttpHeaders extends HttpHeaders {
   void add(String name, Object value, {bool preserveHeaderCase = false}) { }
 
   @override
+  late bool chunkedTransferEncoding;
+
+  @override
   void clear() { }
+
+  @override
+  int contentLength = -1;
+
+  @override
+  ContentType? contentType;
+
+  @override
+  DateTime? date;
+
+  @override
+  DateTime? expires;
 
   @override
   void forEach(void Function(String name, List<String> values) f) { }
 
   @override
+  String? host;
+
+  @override
+  DateTime? ifModifiedSince;
+
+  @override
   void noFolding(String name) { }
+
+  @override
+  late bool persistentConnection;
+
+  @override
+  int? port;
 
   @override
   void remove(String name, Object value) { }

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -206,9 +206,18 @@ class _MockHttpClient implements HttpClient {
 }
 
 /// A mocked [HttpClientRequest] which always returns a [_MockHttpClientResponse].
-class _MockHttpRequest extends HttpClientRequest {
+class _MockHttpRequest implements HttpClientRequest {
+  @override
+  bool bufferOutput = true;
+
+  @override
+  int contentLength = -1;
+
   @override
   late Encoding encoding;
+
+  @override
+  bool followRedirects = true;
 
   @override
   final HttpHeaders headers = _MockHttpHeaders();
@@ -247,7 +256,13 @@ class _MockHttpRequest extends HttpClientRequest {
   }
 
   @override
+  int maxRedirects = 5;
+
+  @override
   String get method => '';
+
+  @override
+  bool persistentConnection = true;
 
   @override
   Uri get uri => Uri();

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -457,7 +457,7 @@ class _FakeHttpClientResponse extends Stream<List<int>> implements HttpClientRes
   int get statusCode => _response.statusCode;
 }
 
-class _FakeHttpHeaders extends HttpHeaders {
+class _FakeHttpHeaders implements HttpHeaders {
   _FakeHttpHeaders(this._backingData);
 
   final Map<String, List<String>> _backingData;
@@ -472,12 +472,30 @@ class _FakeHttpHeaders extends HttpHeaders {
   }
 
   @override
+  late bool chunkedTransferEncoding;
+
+  @override
   void clear() {
     _backingData.clear();
   }
 
   @override
+  int contentLength = -1;
+
+  @override
+  ContentType? contentType;
+
+  @override
+  DateTime? date;
+
+  @override
+  DateTime? expires;
+
+  @override
   void forEach(void Function(String name, List<String> values) action) { }
+
+  @override
+  String? host;
 
   @override
   void noFolding(String name) {  }
@@ -501,4 +519,13 @@ class _FakeHttpHeaders extends HttpHeaders {
   String? value(String name) {
     return _backingData[name]?.join('; ');
   }
+
+  @override
+  DateTime? ifModifiedSince;
+
+  @override
+  late bool persistentConnection;
+
+  @override
+  int? port;
 }


### PR DESCRIPTION
Changes some `dart:io` subclasses from `extends` to `implements` to be forwards-compatible with `dart:io` classes that will become `interface`s in Dart 3.

See https://github.com/flutter/flutter/issues/123711

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
