### PR TITLE
Revert "Workaround for exhaustivness bug in dart2js (#123242)"

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -444,9 +444,6 @@ abstract class FocusTraversalPolicy with Diagnosticable {
         case TraversalEdgeBehavior.closedLoop:
           _focusAndEnsureVisible(sortedNodes.first, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd);
           return true;
-        // TODO(goderbauer): Remove this hack once exhaustiveness bug is fixed, https://github.com/flutter/flutter/issues/123243.
-        default: // ignore: no_default_cases
-          throw UnsupportedError('unreachable');
       }
     }
     if (!forward && focusedChild == sortedNodes.first) {
@@ -457,9 +454,6 @@ abstract class FocusTraversalPolicy with Diagnosticable {
         case TraversalEdgeBehavior.closedLoop:
           _focusAndEnsureVisible(sortedNodes.last, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart);
           return true;
-        // TODO(goderbauer): Remove this hack once exhaustiveness bug is fixed, https://github.com/flutter/flutter/issues/123243.
-        default: // ignore: no_default_cases
-          throw UnsupportedError('unreachable');
       }
     }
 


### PR DESCRIPTION
This reverts commit f68a676353eddab637f95019a5e1a8b85721c944.

Fixes https://github.com/flutter/flutter/issues/123243.

The dart version with the fix has long been rolled into google3 and I verified that one of the troublesome targets in google3 is now working just fine without this work around. Time to remove it and pay back some tech debt!