### PR TITLE
Remove the networked image from the example for `FittedBox`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
     "editor.formatOnSave": false,
     "editor.formatOnType": false,
 
-    "html.format.enable": false
+    "html.format.enable": false,
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
 }

--- a/examples/api/lib/widgets/basic/fitted_box.0.dart
+++ b/examples/api/lib/widgets/basic/fitted_box.0.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flutter code sample for [FittedBox].
-
 import 'package:flutter/material.dart';
+
+/// Flutter code sample for [FittedBox].
 
 void main() => runApp(const FittedBoxApp());
 
@@ -32,12 +32,12 @@ class FittedBoxExample extends StatelessWidget {
     return Container(
       height: 400,
       width: 300,
-      color: Colors.red,
-      child: FittedBox(
+      color: Colors.blue,
+      child: const FittedBox(
+        // TRY THIS: Try changing the fit types to see how they change the way
+        // the placeholder fits into the container.
         fit: BoxFit.fill,
-        child: Image.network(
-          'https://flutter.github.io/assets-for-api-docs/assets/widgets/owl-2.jpg',
-        ),
+        child: Placeholder(),
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1701,17 +1701,18 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
 /// {@youtube 560 315 https://www.youtube.com/watch?v=T4Uehk3_wlY}
 ///
 /// {@tool dartpad}
-/// In this example, the image is stretched to fill the entire [Container], which would
-/// not happen normally without using FittedBox.
+/// In this example, the [Placeholder] is stretched to fill the entire
+/// [Container]. Try changing the fit types to see the effect on the layout of
+/// the [Placeholder].
 ///
 /// ** See code in examples/api/lib/widgets/basic/fitted_box.0.dart **
 /// {@end-tool}
 ///
 /// See also:
 ///
-///  * [Transform], which applies an arbitrary transform to its child widget at
-///    paint time.
-///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
+/// * [Transform], which applies an arbitrary transform to its child widget at
+///   paint time.
+/// * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
 class FittedBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that scales and positions its child within itself according to [fit].
   ///


### PR DESCRIPTION
## Description

This removes the `Image.network` from the example, since that causes a race condition in the test, and an image isn't necessary for the example, it works just was well (maybe better) with a `Placeholder` widget that shows how the fitted box affects the layout.

## Related
- Caused a revert of the Dart roll because of the racy test: https://github.com/flutter/engine/pull/40767

## Tests
 - No change to the tests because the example test doesn't cover the content of the widget drawn.