### PR TITLE
Setup channels during IntegrationTest registration on iOS

### DIFF
--- a/packages/integration_test/example/ios/RunnerTests/RunnerTests.m
+++ b/packages/integration_test/example/ios/RunnerTests/RunnerTests.m
@@ -39,10 +39,6 @@ INTEGRATION_TEST_IOS_RUNNER(RunnerTests)
 
 @implementation FakeIntegrationTestPlugin
 @synthesize testResults;
-
-- (void)setupChannels:(id<FlutterBinaryMessenger>)binaryMessenger {
-}
-
 @end
 
 #pragma mark - Behavior tests

--- a/packages/integration_test/ios/Classes/FLTIntegrationTestRunner.m
+++ b/packages/integration_test/ios/Classes/FLTIntegrationTestRunner.m
@@ -26,13 +26,6 @@
 
 - (void)testIntegrationTestWithResults:(NS_NOESCAPE FLTIntegrationTestResults)testResult {
   IntegrationTestPlugin *integrationTestPlugin = self.integrationTestPlugin;
-  UIViewController *rootViewController = UIApplication.sharedApplication.delegate.window.rootViewController;
-  if (![rootViewController isKindOfClass:[FlutterViewController class]]) {
-    testResult(NSSelectorFromString(@"testSetup"), NO, @"rootViewController was not expected FlutterViewController");
-  }
-  FlutterViewController *flutterViewController = (FlutterViewController *)rootViewController;
-  [integrationTestPlugin setupChannels:flutterViewController.engine.binaryMessenger];
-
   // Spin the runloop.
   while (!integrationTestPlugin.testResults) {
     [NSRunLoop.currentRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];

--- a/packages/integration_test/ios/Classes/IntegrationTestPlugin.h
+++ b/packages/integration_test/ios/Classes/IntegrationTestPlugin.h
@@ -22,9 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, readonly) NSDictionary<NSString *, UIImage *> *capturedScreenshotsByName;
 
 /** Fetches the singleton instance of the plugin. */
-+ (IntegrationTestPlugin *)instance;
-
-- (void)setupChannels:(id<FlutterBinaryMessenger>)binaryMessenger;
++ (instancetype)instance;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/packages/integration_test/ios/Classes/IntegrationTestPlugin.m
+++ b/packages/integration_test/ios/Classes/IntegrationTestPlugin.m
@@ -25,7 +25,7 @@ static NSString *const kMethodRevertImage = @"revertFlutterImage";
   NSMutableDictionary<NSString *, UIImage *> *_capturedScreenshotsByName;
 }
 
-+ (IntegrationTestPlugin *)instance {
++ (instancetype)instance {
   static dispatch_once_t onceToken;
   static IntegrationTestPlugin *sInstance;
   dispatch_once(&onceToken, ^{
@@ -45,19 +45,9 @@ static NSString *const kMethodRevertImage = @"revertFlutterImage";
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-  // No initialization happens here because of the way XCTest loads the testing
-  // bundles.  Setup on static variables can be disregarded when a new static
-  // instance of IntegrationTestPlugin is allocated when the bundle is reloaded.
-  // See also: https://github.com/flutter/plugins/pull/2465
-}
-
-- (void)setupChannels:(id<FlutterBinaryMessenger>)binaryMessenger {
-  FlutterMethodChannel *channel =
-  [FlutterMethodChannel methodChannelWithName:kIntegrationTestPluginChannel
-                              binaryMessenger:binaryMessenger];
-  [channel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
-    [self handleMethodCall:call result:result];
-  }];
+  FlutterMethodChannel *channel = [FlutterMethodChannel methodChannelWithName:kIntegrationTestPluginChannel
+                                                              binaryMessenger:registrar.messenger];
+  [registrar addMethodCallDelegate:[self instance] channel:channel];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {


### PR DESCRIPTION
Allow iOS integration_tests to run from `flutter drive` and not just Xcode.

From https://github.com/flutter/flutter/issues/91668#issuecomment-1454200234
> I wasn't able to get the originally reported stuck runloop from #48601 to reproduce, even when I totally reverted [flutter/plugins#2465](https://github.com/flutter/plugins/pull/2465). I also validated [flutter/plugins#2514](https://github.com/flutter/plugins/pull/2514) passes when it's reverted.
> 
> Talked to @gaaclarke and we suspect some precondition for the original bug have been resolved... somewhere. This code was moved from flutter/plugins to the SDK, making bisecting this tricky, and probably not worth it if I can't reproduce it from Xcode or the command line at all with either a static or dynamic linked integration_test. So let's try re-adding the `+registerWithRegistrar` channel setup removed in #48601.

Reverts https://github.com/flutter/plugins/pull/2465 (not a clean revert but essentially the same thing).

Fixes https://github.com/flutter/flutter/issues/91668
Closes https://github.com/flutter/flutter/pull/116539

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
