### PR TITLE
M3 DatePicker landscape header text style is now TextTheme.headlineSmall

### DIFF
--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1156,36 +1156,6 @@ void main() {
     });
   });
 
-  group('Landscape input-only date picker headers use headlineSmall', () {
-    // Regression test for https://github.com/flutter/flutter/issues/122056
-
-    // Common screen size roughly based on a Pixel 1
-    const Size kCommonScreenSizePortrait = Size(1070, 1770);
-    const Size kCommonScreenSizeLandscape = Size(1770, 1070);
-
-    Future<void> showPicker(WidgetTester tester, Size size) async {
-      addTearDown(tester.view.reset);
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      initialEntryMode = DatePickerEntryMode.input;
-      await prepareDatePicker(tester, (Future<DateTime?> date) async { }, useMaterial3: true);
-    }
-
-    testWidgets('portrait', (WidgetTester tester) async {
-      await showPicker(tester, kCommonScreenSizePortrait);
-      expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 32);
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-    });
-
-    testWidgets('landscape', (WidgetTester tester) async {
-      await showPicker(tester, kCommonScreenSizeLandscape);
-      expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 24);
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-    });
-  });
-
   group('showDatePicker avoids overlapping display features', () {
     testWidgets('positioning with anchorPoint', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1387,6 +1387,34 @@ void main() {
       expect(find.byType(TextField), findsNothing);
     });
   });
+
+  group('Landscape input-only date picker headers use headlineSmall', () {
+    // Regression test for https://github.com/flutter/flutter/issues/122056
+
+    // Common screen size roughly based on a Pixel 1
+    const Size kCommonScreenSizePortrait = Size(1070, 1770);
+    const Size kCommonScreenSizeLandscape = Size(1770, 1070);
+
+    Future<void> showPicker(WidgetTester tester, Size size) async {
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = size;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        await tester.tap(find.byIcon(Icons.edit_outlined));
+        await tester.pumpAndSettle();
+      },
+      useMaterial3: true);
+    }
+
+    testWidgets('portrait', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizePortrait);
+      expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 32);
+    });
+
+    testWidgets('landscape', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizeLandscape);
+      expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 24);
+    });
+  });
 }
 
 class _RestorableDatePickerDialogTestWidget extends StatefulWidget {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1432,11 +1432,8 @@ void main() {
       addTearDown(tester.view.reset);
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
-      await prepareDatePicker(tester, (Future<DateTime?> date) async {
-        await tester.tap(find.byIcon(Icons.edit_outlined));
-        await tester.pumpAndSettle();
-      },
-      useMaterial3: true);
+      initialEntryMode = DatePickerEntryMode.input;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async { }, useMaterial3: true);
     }
 
     testWidgets('portrait', (WidgetTester tester) async {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1156,6 +1156,39 @@ void main() {
     });
   });
 
+  group('Landscape input-only date picker headers use headlineSmall', () {
+    // Regression test for https://github.com/flutter/flutter/issues/122056
+
+    // Common screen size roughly based on a Pixel 1
+    const Size kCommonScreenSizePortrait = Size(1070, 1770);
+    const Size kCommonScreenSizeLandscape = Size(1770, 1070);
+
+    Future<void> showPicker(WidgetTester tester, Size size) async {
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        await tester.tap(find.byIcon(Icons.edit_outlined));
+        await tester.pumpAndSettle();
+      },
+      useMaterial3: true);
+    }
+
+    testWidgets('portrait', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizePortrait);
+      expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 32);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('landscape', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizeLandscape);
+      expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 24);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    });
+  });
+
   group('showDatePicker avoids overlapping display features', () {
     testWidgets('positioning with anchorPoint', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -1409,14 +1442,14 @@ void main() {
     testWidgets('portrait', (WidgetTester tester) async {
       await showPicker(tester, kCommonScreenSizePortrait);
       expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 32);
-      await tester.tap('Cancel');
+      await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
     });
 
     testWidgets('landscape', (WidgetTester tester) async {
       await showPicker(tester, kCommonScreenSizeLandscape);
       expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 24);
-      await tester.tap('Cancel');
+      await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
     });
   });

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1398,6 +1398,7 @@ void main() {
     Future<void> showPicker(WidgetTester tester, Size size) async {
       addTearDown(tester.view.reset);
       tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         await tester.tap(find.byIcon(Icons.edit_outlined));
         await tester.pumpAndSettle();

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1167,11 +1167,8 @@ void main() {
       addTearDown(tester.view.reset);
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
-      await prepareDatePicker(tester, (Future<DateTime?> date) async {
-        await tester.tap(find.byIcon(Icons.edit_outlined));
-        await tester.pumpAndSettle();
-      },
-      useMaterial3: true);
+      initialEntryMode = DatePickerEntryMode.input;
+      await prepareDatePicker(tester, (Future<DateTime?> date) async { }, useMaterial3: true);
     }
 
     testWidgets('portrait', (WidgetTester tester) async {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1409,11 +1409,15 @@ void main() {
     testWidgets('portrait', (WidgetTester tester) async {
       await showPicker(tester, kCommonScreenSizePortrait);
       expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 32);
+      await tester.tap('Cancel');
+      await tester.pumpAndSettle();
     });
 
     testWidgets('landscape', (WidgetTester tester) async {
       await showPicker(tester, kCommonScreenSizeLandscape);
       expect(tester.widget<Text>(find.text('Fri, Jan 15')).style?.fontSize, 24);
+      await tester.tap('Cancel');
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -108,6 +108,39 @@ void main() {
     await callback(range);
   }
 
+  group('Landscape input-only date picker headers use headlineSmall', () {
+    // Regression test for https://github.com/flutter/flutter/issues/122056
+
+    // Common screen size roughly based on a Pixel 1
+    const Size kCommonScreenSizePortrait = Size(1070, 1770);
+    const Size kCommonScreenSizeLandscape = Size(1770, 1070);
+
+    Future<void> showPicker(WidgetTester tester, Size size) async {
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      await preparePicker(tester, (Future<DateTimeRange?> range) async {
+        await tester.tap(find.byIcon(Icons.edit_outlined));
+        await tester.pumpAndSettle();
+      },
+      useMaterial3: true);
+    }
+
+    testWidgets('portrait', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizePortrait);
+      expect(tester.widget<Text>(find.text('Jan 15 – Jan 25, 2016')).style?.fontSize, 32);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('landscape', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizeLandscape);
+      expect(tester.widget<Text>(find.text('Jan 15 – Jan 25, 2016')).style?.fontSize, 24);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+    });
+  });
+
   testWidgets('Save and help text is used', (WidgetTester tester) async {
     helpText = 'help';
     saveText = 'make it so';
@@ -1157,35 +1190,6 @@ void main() {
       expect(picker.keyboardType, keyboardType ?? TextInputType.datetime);
     });
   }
-
-  group('Landscape input-only date picker headers use headlineSmall', () {
-    // Regression test for https://github.com/flutter/flutter/issues/122056
-
-    // Common screen size roughly based on a Pixel 1
-    const Size kCommonScreenSizePortrait = Size(1070, 1770);
-    const Size kCommonScreenSizeLandscape = Size(1770, 1070);
-
-    Future<void> showPicker(WidgetTester tester, Size size) async {
-      addTearDown(tester.view.reset);
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      await preparePicker(tester, (Future<DateTimeRange?> range) async {
-        await tester.tap(find.byIcon(Icons.edit_outlined));
-        await tester.pumpAndSettle();
-      },
-      useMaterial3: true);
-    }
-
-    testWidgets('portrait', (WidgetTester tester) async {
-      await showPicker(tester, kCommonScreenSizePortrait);
-      expect(tester.widget<Text>(find.text('Jan 15 – Jan 25, 2016')).style?.fontSize, 32);
-    });
-
-    testWidgets('landscape', (WidgetTester tester) async {
-      await showPicker(tester, kCommonScreenSizeLandscape);
-      expect(tester.widget<Text>(find.text('Jan 15 – Jan 25, 2016')).style?.fontSize, 24);
-    });
-  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1157,6 +1157,34 @@ void main() {
       expect(picker.keyboardType, keyboardType ?? TextInputType.datetime);
     });
   }
+
+  group('Landscape input-only date picker headers use headlineSmall', () {
+    // Regression test for https://github.com/flutter/flutter/issues/122056
+
+    // Common screen size roughly based on a Pixel 1
+    const Size kCommonScreenSizePortrait = Size(1070, 1770);
+    const Size kCommonScreenSizeLandscape = Size(1770, 1070);
+
+    Future<void> showPicker(WidgetTester tester, Size size) async {
+      addTearDown(tester.view.reset);
+      tester.view.physicalSize = size;
+      await preparePicker(tester, (Future<DateTimeRange?> range) async {
+        await tester.tap(find.byIcon(Icons.edit_outlined));
+        await tester.pumpAndSettle();
+      },
+      useMaterial3: true);
+    }
+
+    testWidgets('portrait', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizePortrait);
+      expect(tester.widget<Text>(find.text('Jan 15 – Jan 25, 2016')).style?.fontSize, 32);
+    });
+
+    testWidgets('landscape', (WidgetTester tester) async {
+      await showPicker(tester, kCommonScreenSizeLandscape);
+      expect(tester.widget<Text>(find.text('Jan 15 – Jan 25, 2016')).style?.fontSize, 24);
+    });
+  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1168,6 +1168,7 @@ void main() {
     Future<void> showPicker(WidgetTester tester, Size size) async {
       addTearDown(tester.view.reset);
       tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
       await preparePicker(tester, (Future<DateTimeRange?> range) async {
         await tester.tap(find.byIcon(Icons.edit_outlined));
         await tester.pumpAndSettle();

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -119,11 +119,8 @@ void main() {
       addTearDown(tester.view.reset);
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
-      await preparePicker(tester, (Future<DateTimeRange?> range) async {
-        await tester.tap(find.byIcon(Icons.edit_outlined));
-        await tester.pumpAndSettle();
-      },
-      useMaterial3: true);
+      initialEntryMode = DatePickerEntryMode.input;
+      await preparePicker(tester, (Future<DateTimeRange?> range) async { }, useMaterial3: true);
     }
 
     testWidgets('portrait', (WidgetTester tester) async {


### PR DESCRIPTION
Using the same header title text style as M2 did for the input (not calendar) date pickers for landscape mode. There's not nearly enough room for the M3 default - TextTheme.headlineLarge - in the landscape header once the soft keyboard has appeared. 

Fixes https://github.com/flutter/flutter/issues/122056