### PR TITLE
Invalidate the `WebStaticAssets` target if the web sdk changes.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -494,8 +494,8 @@ class WebReleaseBundle extends Target {
 /// Static assets provided by the Flutter SDK that do not change, such as
 /// CanvasKit.
 ///
-/// These assets can be cached forever and are only invalidated when the
-/// Flutter SDK is upgraded to a new version.
+/// These assets can be cached until a new version of the flutter web sdk is
+/// downloaded.
 class WebBuiltInAssets extends Target {
   const WebBuiltInAssets(this.fileSystem, {required this.isWasm});
 
@@ -512,7 +512,9 @@ class WebBuiltInAssets extends Target {
   List<String> get depfiles => const <String>[];
 
   @override
-  List<Source> get inputs => const <Source>[];
+  List<Source> get inputs => const <Source>[
+    const Source.hostArtifact(HostArtifact.flutterWebSdk),
+  ];
 
   @override
   List<Source> get outputs => const <Source>[];

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -513,7 +513,7 @@ class WebBuiltInAssets extends Target {
 
   @override
   List<Source> get inputs => const <Source>[
-    const Source.hostArtifact(HostArtifact.flutterWebSdk),
+    Source.hostArtifact(HostArtifact.flutterWebSdk),
   ];
 
   @override

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -946,4 +946,26 @@ void main() {
       .childFile('canvaskit.wasm')
       .existsSync(), true);
   }));
+
+  test('wasm copies over canvaskit again if the web sdk changes', () => testbed.run(() async {
+    final File canvasKitInput = globals.fs.file('bin/cache/flutter_web_sdk/canvaskit/canvaskit.wasm')
+      ..createSync(recursive: true);
+    canvasKitInput.writeAsStringSync('foo', flush: true);
+
+    await WebBuiltInAssets(globals.fs, isWasm: true).build(environment);
+
+    final File canvasKitOutputBefore = environment.outputDir.childDirectory('canvaskit')
+      .childFile('canvaskit.wasm');
+    expect(canvasKitOutputBefore.existsSync(), true);
+    expect(canvasKitOutputBefore.readAsStringSync(), 'foo');
+
+    canvasKitInput.writeAsStringSync('bar', flush: true);
+
+    await WebBuiltInAssets(globals.fs, isWasm: true).build(environment);
+
+    final File canvasKitOutputAfter = environment.outputDir.childDirectory('canvaskit')
+      .childFile('canvaskit.wasm');
+    expect(canvasKitOutputAfter.existsSync(), true);
+    expect(canvasKitOutputAfter.readAsStringSync(), 'bar');
+  }));
 }


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/123737

Since we're copying over local canvaskit, we need to invalidate it if the web sdk changes. So we need to specify the web sdk as an input artifact to this target.
