### PR TITLE
Fix bottom app bar height and end-contained fab location

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -194,9 +194,12 @@ class _BottomAppBarState extends State<BottomAppBar> {
     final Color effectiveColor = isMaterial3 ? color : ElevationOverlay.applyOverlay(context, color, elevation);
     final Color shadowColor = widget.shadowColor ?? babTheme.shadowColor ?? defaults.shadowColor!;
 
-    final Widget child = Padding(
-      padding: widget.padding ?? babTheme.padding ?? (isMaterial3 ? const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0) : EdgeInsets.zero),
-      child: widget.child,
+    final Widget child = SizedBox(
+      height: height,
+      child: Padding(
+        padding: widget.padding ?? babTheme.padding ?? (isMaterial3 ? const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0) : EdgeInsets.zero),
+        child: widget.child,
+      ),
     );
 
     final Material material = Material(
@@ -209,16 +212,14 @@ class _BottomAppBarState extends State<BottomAppBar> {
       child: SafeArea(child: child),
     );
 
-    final PhysicalShape physicalShape = PhysicalShape(
+    return PhysicalShape(
       clipper: clipper,
       elevation: elevation,
       shadowColor: shadowColor,
       color: effectiveColor,
       clipBehavior: widget.clipBehavior,
       child: material,
-     );
-
-    return SizedBox(height: height, child: physicalShape);
+    );
   }
 }
 

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -633,7 +633,7 @@ mixin FabContainedOffsetY on StandardFabLocation {
 
     double safeMargin;
     if (contentMargin > bottomViewPadding + fabHeight) {
-      // If contentMargin is higher than bottomMinInset enough to display the
+      // If contentMargin is higher than bottomViewPadding enough to display the
       // FAB without clipping, don't provide a margin
       safeMargin = 0.0;
     } else {

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -630,10 +630,9 @@ mixin FabContainedOffsetY on StandardFabLocation {
     final double contentMargin = scaffoldGeometry.scaffoldSize.height - contentBottom;
     final double bottomViewPadding = scaffoldGeometry.minViewPadding.bottom;
     final double fabHeight = scaffoldGeometry.floatingActionButtonSize.height;
-    final double bottomMinInset = scaffoldGeometry.minInsets.bottom;
 
-    double safeMargin = 0.0;
-    if (contentMargin > bottomMinInset + fabHeight / 2.0) {
+    double safeMargin;
+    if (contentMargin > bottomViewPadding + fabHeight) {
       // If contentMargin is higher than bottomMinInset enough to display the
       // FAB without clipping, don't provide a margin
       safeMargin = 0.0;
@@ -641,9 +640,14 @@ mixin FabContainedOffsetY on StandardFabLocation {
       safeMargin = bottomViewPadding;
     }
 
-    final double fabY = contentBottom - fabHeight / 2.0 - safeMargin;
+    // This is to compute the distance between the content bottom to the top edge
+    // of the floating action button. This can be negative if content margin is
+    // too small.
+    final double contentBottomToFabTop = (contentMargin - bottomViewPadding - fabHeight) / 2.0;
+    final double fabY = contentBottom + contentBottomToFabTop;
     final double maxFabY = scaffoldGeometry.scaffoldSize.height - fabHeight - safeMargin;
-    return math.min(maxFabY, fabY + contentMargin / 2);
+
+    return math.min(maxFabY, fabY);
   }
 }
 

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -11,8 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'material_state_mixin_test.dart';
-
 void main() {
   testWidgets('no overlap with floating action button', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'material_state_mixin_test.dart';
+
 void main() {
   testWidgets('no overlap with floating action button', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -615,6 +617,44 @@ void main() {
 
     physicalShape = tester.widget(find.byType(PhysicalShape).at(0));
     expect(physicalShape.clipper.toString(), 'ShapeBorderClipper');
+  });
+
+  testWidgets('BottomAppBar adds bottom padding to height', (WidgetTester tester) async {
+    const double bottomPadding = 35.0;
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(bottom: bottomPadding),
+          viewPadding: EdgeInsets.only(bottom: bottomPadding),
+        ),
+        child: MaterialApp(
+          theme: ThemeData(useMaterial3: true),
+          home: Scaffold(
+            floatingActionButtonLocation: FloatingActionButtonLocation.endContained,
+            floatingActionButton: FloatingActionButton(onPressed: () { }),
+            bottomNavigationBar: BottomAppBar(
+              child: IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      )
+    );
+
+    final Rect bottomAppBar = tester.getRect(find.byType(BottomAppBar));
+    final Rect iconButton = tester.getRect(find.widgetWithIcon(IconButton, Icons.search));
+    final Rect fab = tester.getRect(find.byType(FloatingActionButton));
+
+    // The height of the bottom app bar should be its height(default is 80.0) + bottom safe area height.
+    expect(bottomAppBar.height, 80.0 + bottomPadding);
+
+    // The vertical position of the icon button and fab should be center of the area excluding the bottom padding.
+    final double barCenter = bottomAppBar.topLeft.dy + (bottomAppBar.height - bottomPadding) / 2;
+    expect(iconButton.center.dy, barCenter);
+    expect(fab.center.dy, barCenter);
   });
 }
 


### PR DESCRIPTION
Fixes: #119526.

This PR is to fix the `SafeArea` issue for the `BottomAppBar`. When `MediaQuery.of(context).padding.bottom` is not 0.0(such as on iOS platforms), the height of the `BottomAppBar` should add the bottom padding, so that the items on the bar can show correct shapes and positions. So to fix this, we should put the `SizedBox` inside of `SafeArea`, instead of the original way(The `SizedBox` is outside of the `SafeArea`).

The calculation of `FloatingActionButtonLocation.endContained` is also updated in this PR to respect the non-SafeArea(bottom padding).

After the fix:
<img width="250" alt="Screenshot 2023-03-29 at 7 53 15 PM" src="https://user-images.githubusercontent.com/36861262/228716153-6bd26678-565d-4ebe-8687-59e54050d06f.png">


Before the fix:
<img width="250" alt="Screenshot 2023-03-29 at 7 46 53 PM" src="https://user-images.githubusercontent.com/36861262/228716201-1e0987f2-193c-445c-b793-8f9f42e7434d.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.