### PR TITLE
Fix EditableText misplaces caret when selection is invalid

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3709,6 +3709,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _updateRemoteEditingValueIfNeeded();
     _startOrStopCursorTimerIfNeeded();
     _updateOrDisposeSelectionOverlayIfNeeded();
+    if (_hasFocus && !_value.selection.isValid) {
+      // If this field is focused and the selection is invalid, place the cursor at
+      // the end. Does not rely on _handleFocusChanged because it makes selection
+      // handles visible on Android.
+      widget.controller.selection = TextSelection.collapsed(offset: _value.text.length);
+    }
     // TODO(abarth): Teach RenderEditable about ValueNotifier<TextEditingValue>
     // to avoid this setState().
     setState(() { /* We use widget.controller.value in build(). */ });

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3706,15 +3706,18 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   void _didChangeTextEditingValue() {
-    _updateRemoteEditingValueIfNeeded();
-    _startOrStopCursorTimerIfNeeded();
-    _updateOrDisposeSelectionOverlayIfNeeded();
     if (_hasFocus && !_value.selection.isValid) {
       // If this field is focused and the selection is invalid, place the cursor at
       // the end. Does not rely on _handleFocusChanged because it makes selection
       // handles visible on Android.
-      widget.controller.selection = TextSelection.collapsed(offset: _value.text.length);
+      // Unregister as a listener to the text controller while making the change.
+      widget.controller.removeListener(_didChangeTextEditingValue);
+      widget.controller.selection = _adjustedSelectionWhenFocused()!;
+      widget.controller.addListener(_didChangeTextEditingValue);
     }
+    _updateRemoteEditingValueIfNeeded();
+    _startOrStopCursorTimerIfNeeded();
+    _updateOrDisposeSelectionOverlayIfNeeded();
     // TODO(abarth): Teach RenderEditable about ValueNotifier<TextEditingValue>
     // to avoid this setState().
     setState(() { /* We use widget.controller.value in build(). */ });
@@ -3732,27 +3735,33 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       if (!widget.readOnly) {
         _scheduleShowCaretOnScreen(withAnimation: true);
       }
-      final bool shouldSelectAll = widget.selectionEnabled && kIsWeb
-          && !_isMultiline && !_nextFocusChangeIsInternal;
-      if (shouldSelectAll) {
-        // On native web, single line <input> tags select all when receiving
-        // focus.
-        _handleSelectionChanged(
-          TextSelection(
-            baseOffset: 0,
-            extentOffset: _value.text.length,
-          ),
-          null,
-        );
-      } else if (!_value.selection.isValid) {
-        // Place cursor at the end if the selection is invalid when we receive focus.
-        _handleSelectionChanged(TextSelection.collapsed(offset: _value.text.length), null);
+      final TextSelection? updatedSelection = _adjustedSelectionWhenFocused();
+      if (updatedSelection != null) {
+        _handleSelectionChanged(updatedSelection, null);
       }
     } else {
       WidgetsBinding.instance.removeObserver(this);
       setState(() { _currentPromptRectRange = null; });
     }
     updateKeepAlive();
+  }
+
+  TextSelection? _adjustedSelectionWhenFocused() {
+    TextSelection? selection;
+    final bool shouldSelectAll = widget.selectionEnabled && kIsWeb
+        && !_isMultiline && !_nextFocusChangeIsInternal;
+    if (shouldSelectAll) {
+      // On native web, single line <input> tags select all when receiving
+      // focus.
+      selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _value.text.length,
+      );
+    } else if (!_value.selection.isValid) {
+      // Place cursor at the end if the selection is invalid when we receive focus.
+      selection = TextSelection.collapsed(offset: _value.text.length);
+    }
+    return selection;
   }
 
   void _compositeCallback(Layer layer) {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -6744,8 +6744,8 @@ void main() {
     variant: KeySimulatorTransitModeVariant.all()
   );
 
-  // Regressing test for https://github.com/flutter/flutter/issues/78219
-  testWidgets('Paste does not crash when the section is inValid', (WidgetTester tester) async {
+  // Regression test for https://github.com/flutter/flutter/issues/78219
+  testWidgets('Paste does not crash after calling TextController.text setter', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
     final TextEditingController controller = TextEditingController();
     final TextField textField = TextField(
@@ -6778,7 +6778,7 @@ void main() {
     await tester.tap(find.byType(TextField));
     await tester.pumpAndSettle();
 
-    // This setter will set `selection` invalid.
+    // Clear the text.
     controller.text = '';
 
     // Paste clipboardContent to the text field.
@@ -6790,10 +6790,12 @@ void main() {
     await tester.sendKeyUpEvent(LogicalKeyboardKey.controlRight);
     await tester.pumpAndSettle();
 
-    // Do nothing.
-    expect(find.text(clipboardContent), findsNothing);
-    expect(controller.selection, const TextSelection.collapsed(offset: -1));
-  }, variant: KeySimulatorTransitModeVariant.all());
+    // Clipboard content is correctly pasted.
+    expect(find.text(clipboardContent), findsOneWidget);
+  },
+    skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
+    variant: KeySimulatorTransitModeVariant.all(),
+  );
 
   testWidgets('Cut test', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -90,33 +90,37 @@ void main() {
     );
   }
 
+  // Should we remove this test, because if this PR is approved it won't be possible
+  // to have an invalid selection for the controller if it is attached to a focused
+  // TextField.
   testWidgets(
     'Movement/Deletion shortcuts do nothing when the selection is invalid',
     (WidgetTester tester) async {
-      await tester.pumpWidget(buildEditableText());
-      controller.text = testText;
-      controller.selection = const TextSelection.collapsed(offset: -1);
-      await tester.pump();
 
-      const List<LogicalKeyboardKey> triggers = <LogicalKeyboardKey>[
-        LogicalKeyboardKey.backspace,
-        LogicalKeyboardKey.delete,
-        LogicalKeyboardKey.arrowLeft,
-        LogicalKeyboardKey.arrowRight,
-        LogicalKeyboardKey.arrowUp,
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.pageUp,
-        LogicalKeyboardKey.pageDown,
-        LogicalKeyboardKey.home,
-        LogicalKeyboardKey.end,
-      ];
+      // await tester.pumpWidget(buildEditableText());
+      // controller.text = testText;
+      // controller.selection = const TextSelection.collapsed(offset: -1);
+      // await tester.pump();
 
-      for (final SingleActivator activator in triggers.expand(allModifierVariants)) {
-        await sendKeyCombination(tester, activator);
-        await tester.pump();
-        expect(controller.text, testText, reason: activator.toString());
-        expect(controller.selection, const TextSelection.collapsed(offset: -1), reason: activator.toString());
-      }
+      // const List<LogicalKeyboardKey> triggers = <LogicalKeyboardKey>[
+      //   LogicalKeyboardKey.backspace,
+      //   LogicalKeyboardKey.delete,
+      //   LogicalKeyboardKey.arrowLeft,
+      //   LogicalKeyboardKey.arrowRight,
+      //   LogicalKeyboardKey.arrowUp,
+      //   LogicalKeyboardKey.arrowDown,
+      //   LogicalKeyboardKey.pageUp,
+      //   LogicalKeyboardKey.pageDown,
+      //   LogicalKeyboardKey.home,
+      //   LogicalKeyboardKey.end,
+      // ];
+
+      // for (final SingleActivator activator in triggers.expand(allModifierVariants)) {
+      //   await sendKeyCombination(tester, activator);
+      //   await tester.pump();
+      //   expect(controller.text, testText, reason: activator.toString());
+      //   expect(controller.selection, const TextSelection.collapsed(offset: -1), reason: activator.toString());
+      // }
     },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
     variant: TargetPlatformVariant.all(),

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -90,42 +90,6 @@ void main() {
     );
   }
 
-  // Should we remove this test, because if this PR is approved it won't be possible
-  // to have an invalid selection for the controller if it is attached to a focused
-  // TextField.
-  testWidgets(
-    'Movement/Deletion shortcuts do nothing when the selection is invalid',
-    (WidgetTester tester) async {
-
-      // await tester.pumpWidget(buildEditableText());
-      // controller.text = testText;
-      // controller.selection = const TextSelection.collapsed(offset: -1);
-      // await tester.pump();
-
-      // const List<LogicalKeyboardKey> triggers = <LogicalKeyboardKey>[
-      //   LogicalKeyboardKey.backspace,
-      //   LogicalKeyboardKey.delete,
-      //   LogicalKeyboardKey.arrowLeft,
-      //   LogicalKeyboardKey.arrowRight,
-      //   LogicalKeyboardKey.arrowUp,
-      //   LogicalKeyboardKey.arrowDown,
-      //   LogicalKeyboardKey.pageUp,
-      //   LogicalKeyboardKey.pageDown,
-      //   LogicalKeyboardKey.home,
-      //   LogicalKeyboardKey.end,
-      // ];
-
-      // for (final SingleActivator activator in triggers.expand(allModifierVariants)) {
-      //   await sendKeyCombination(tester, activator);
-      //   await tester.pump();
-      //   expect(controller.text, testText, reason: activator.toString());
-      //   expect(controller.selection, const TextSelection.collapsed(offset: -1), reason: activator.toString());
-      // }
-    },
-    skip: kIsWeb, // [intended] on web these keys are handled by the browser.
-    variant: TargetPlatformVariant.all(),
-  );
-
   group('Common text editing shortcuts: ',
     () {
       final TargetPlatformVariant allExceptApple = TargetPlatformVariant.all(excluding: <TargetPlatform>{TargetPlatform.macOS, TargetPlatform.iOS});

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -15522,6 +15522,64 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
       );
     });
 
+    testWidgets('Selection is updated when the field has focus and the new selection is invalid', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/120631.
+      final TextEditingController controller = TextEditingController();
+      controller.text = 'Text';
+      final FocusNode focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            key: ValueKey<String>(controller.text),
+            controller: controller,
+            focusNode: focusNode,
+            style: Typography.material2018().black.titleMedium!,
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      expect(focusNode.hasFocus, isFalse);
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: -1),
+      );
+
+      // Tab to focus the field.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isTrue);
+      expect(
+        controller.selection,
+        kIsWeb
+          ? TextSelection(
+              baseOffset: 0,
+              extentOffset: controller.text.length,
+            )
+          : TextSelection.collapsed(
+              offset: controller.text.length,
+            ),
+      );
+
+      // Update text with an invalid selection.
+      controller.text = 'Updated';
+
+      expect(focusNode.hasFocus, isTrue);
+      expect(
+        controller.selection,
+        kIsWeb
+          ? TextSelection(
+              baseOffset: 0,
+              extentOffset: controller.text.length,
+            )
+          : TextSelection.collapsed(
+              offset: controller.text.length,
+            ),
+      );
+    });
+
     testWidgets('when having focus stolen between frames on web', (WidgetTester tester) async {
       final TextEditingController controller1 = TextEditingController();
       controller1.text = 'Text1';

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -15577,9 +15577,10 @@ testWidgets('Floating cursor ending with selection', (WidgetTester tester) async
             ),
       );
 
-      // Update text with an invalid selection.
+      // Update text without specifying the selection.
       controller.text = 'Updated';
 
+      // As the TextField is focused the selection should be automatically adjusted.
       expect(focusNode.hasFocus, isTrue);
       expect(
         controller.selection,

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -621,10 +621,12 @@ void main() {
         expect(paragraph1.selections.isEmpty, isTrue);
         expect(paragraph2.selections.isEmpty, isTrue);
 
-        // Reset selection and focus selectable region.
-        controller.selection = const TextSelection.collapsed(offset: -1);
+        // Focus selectable region.
         selectableRegionFocus.requestFocus();
         await tester.pump();
+
+        // Reset controller selection once the TextField is unfocused.
+        controller.selection = const TextSelection.collapsed(offset: -1);
 
         // Make sure keyboard select all will be handled by selectable region now.
         await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, control: true));
@@ -672,10 +674,12 @@ void main() {
         expect(paragraph1.selections.isEmpty, isTrue);
         expect(paragraph2.selections.isEmpty, isTrue);
 
-        // Reset selection and focus selectable region.
-        controller.selection = const TextSelection.collapsed(offset: -1);
+        // Focus selectable region.
         selectableRegionFocus.requestFocus();
         await tester.pump();
+
+        // Reset controller selection once the TextField is unfocused.
+        controller.selection = const TextSelection.collapsed(offset: -1);
 
         // Make sure keyboard select all will be handled by selectable region now.
         await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, meta: true));


### PR DESCRIPTION
## Description

`EditableTextState._handleFocusChanged` adjusts the selection when a text field is focused. But if the selection becomes invalid (for instance after setting TextController.text) on an already focused field the position won’t be adjusted. The issue can be very visible when `TextField.textAlign` is set to `TextAlign.center` (video using the Android emulator):

https://user-images.githubusercontent.com/840911/228870859-6f6707b6-0b20-4701-9a5a-2eb921dff4f9.mp4

<details><summary>Code sample for the repro</summary>

```dart
import 'package:flutter/material.dart';
import 'package:flutter/services.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  final TextEditingController textController = TextEditingController();

  MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: Scaffold(
        body: Center(
          child: Row(children: [
            SizedBox(
                width: 60,
                child: TextField(
                  controller: textController,
                  textAlign: TextAlign.center,
                )),
            TextButton(
              child: const Text("Reset text", style: TextStyle(color: Colors.red)),
              onPressed: () {
                textController.text = "0";
              },
            ),
          ]),
        ),
      ),
    );
  }
}

```
</details> 

## Implementation

AFAIK, there are several ways to fix this issue:
1. Not showing the caret when the selection is invalid. This is described in https://github.com/flutter/flutter/issues/79495. Unfortunately a PR for it was reverted (see https://github.com/flutter/flutter/pull/79607) due to a Google internal test failure.

2. Changing the selection to a valid one when TextController selection is invalid and the field is focused. this is the solution implemented in this PR. It breaks several tests which expect that the selection stays invalid.

3. Adding an assert to throw a detailed error message. The impact on existing tests will probably be worth than with solution 2 because for some of these tests It might be difficult to make them complied with this new requirement (for solution 2, tests can be updated by updating some `expect` calls).


## Related Issue

Fixes https://github.com/flutter/flutter/issues/120631

## Tests

Adds 1 test.
Will need to update several existing tests if becoming a real PR.
