### PR TITLE
Add KeepAliveHandle.removeKeepAlive method to replace release()

### DIFF
--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -325,10 +325,21 @@ class KeepAliveHandle extends ChangeNotifier {
   /// This method does not call [dispose]. When the handle is not needed
   /// anymore, it must be [dispose]d regardless of whether notifying listeners.
   @Deprecated(
-    'Use dispose instead. '
+    'Use dispose and/or removeKeepAlive instead. '
     'This feature was deprecated after v3.3.0-0.0.pre.',
   )
   void release() {
+    notifyListeners();
+  }
+
+  /// Trigger the listeners to indicate that the widget
+  /// no longer needs to be kept alive.
+  /// A widget can be marked as needing to be kept alive again with
+  /// [KeepAliveNotification.dispatch].
+  ///
+  /// *This method does not call [dispose].* When the handle is not needed
+  /// anymore, it must be [dispose]d regardless of whether notifying listeners.
+  void removeKeepAlive() {
     notifyListeners();
   }
 

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -46,6 +46,7 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
   // widget must be the same across frames.
   late Widget _child;
   bool _keepingAlive = false;
+  bool _disposed = false;
 
   @override
   void initState() {
@@ -68,6 +69,7 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
 
   @override
   void dispose() {
+    _disposed = true;
     if (_handles != null) {
       for (final Listenable handle in _handles!.keys) {
         handle.removeListener(_handles![handle]!);
@@ -146,7 +148,7 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
   VoidCallback _createCallback(Listenable handle) {
     return () {
       assert(() {
-        if (!mounted) {
+        if (_disposed) {
           throw FlutterError(
             'AutomaticKeepAlive handle triggered after AutomaticKeepAlive was disposed.\n'
             'Widgets should always trigger their KeepAliveNotification handle when they are '

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -16,33 +16,33 @@ class Leaf extends StatefulWidget {
 
 class _LeafState extends State<Leaf> {
   bool _keepAlive = false;
-  KeepAliveHandle? _handle;
+  final _handle = KeepAliveHandle();
 
   @override
   void deactivate() {
-    _handle?.release();
-    _handle = null;
+    _handle.removeKeepAlive();
     super.deactivate();
   }
 
   void setKeepAlive(bool value) {
     _keepAlive = value;
     if (_keepAlive) {
-      if (_handle == null) {
-        _handle = KeepAliveHandle();
-        KeepAliveNotification(_handle!).dispatch(context);
-      }
+      KeepAliveNotification(_handle).dispatch(context);
     } else {
-      _handle?.release();
-      _handle = null;
+      _handle.removeKeepAlive();
     }
   }
 
   @override
+  void dispose() {
+    _handle.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (_keepAlive && _handle == null) {
-      _handle = KeepAliveHandle();
-      KeepAliveNotification(_handle!).dispatch(context);
+    if (_keepAlive) {
+      KeepAliveNotification(_handle).dispatch(context);
     }
     return widget.child;
   }

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -16,36 +16,33 @@ class Leaf extends StatefulWidget {
 
 class _LeafState extends State<Leaf> {
   bool _keepAlive = false;
-  KeepAliveHandle? _handle;
-
-  @override
-  void deactivate() {
-    _handle?.removeKeepAlive();
-    super.deactivate();
-  }
+  final KeepAliveHandle _handle = KeepAliveHandle();
 
   void setKeepAlive(bool value) {
     _keepAlive = value;
     if (_keepAlive) {
-      _handle ??= KeepAliveHandle();
-      KeepAliveNotification(_handle!).dispatch(context);
+      KeepAliveNotification(_handle).dispatch(context);
     } else {
-      _handle?.removeKeepAlive();
+      _handle.removeKeepAlive();
     }
   }
 
   @override
+  void deactivate() {
+    _handle.removeKeepAlive();
+    super.deactivate();
+  }
+
+  @override
   void dispose() {
-    _handle?.dispose();
-    _handle = null;
+    _handle.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     if (_keepAlive) {
-      _handle ??= KeepAliveHandle();
-      KeepAliveNotification(_handle!).dispatch(context);
+      KeepAliveNotification(_handle).dispatch(context);
     }
     return widget.child;
   }

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -16,7 +16,7 @@ class Leaf extends StatefulWidget {
 
 class _LeafState extends State<Leaf> {
   bool _keepAlive = false;
-  final _handle = KeepAliveHandle();
+  final KeepAliveHandle _handle = KeepAliveHandle();
 
   @override
   void deactivate() {

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -16,33 +16,36 @@ class Leaf extends StatefulWidget {
 
 class _LeafState extends State<Leaf> {
   bool _keepAlive = false;
-  final KeepAliveHandle _handle = KeepAliveHandle();
+  KeepAliveHandle? _handle;
 
   @override
   void deactivate() {
-    _handle.removeKeepAlive();
+    _handle?.removeKeepAlive();
     super.deactivate();
   }
 
   void setKeepAlive(bool value) {
     _keepAlive = value;
     if (_keepAlive) {
-      KeepAliveNotification(_handle).dispatch(context);
+      _handle ??= KeepAliveHandle();
+      KeepAliveNotification(_handle!).dispatch(context);
     } else {
-      _handle.removeKeepAlive();
+      _handle?.removeKeepAlive();
     }
   }
 
   @override
   void dispose() {
-    _handle.dispose();
+    _handle?.dispose();
+    _handle = null;
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     if (_keepAlive) {
-      KeepAliveNotification(_handle).dispatch(context);
+      _handle ??= KeepAliveHandle();
+      KeepAliveNotification(_handle!).dispatch(context);
     }
     return widget.child;
   }


### PR DESCRIPTION
In 3.3.0, `KeepAliveHandle.release()` was deprecated (see #108384).
However, in many situations, it makes sense to just create a single `KeepAliveHandle` for the entire lifecycle of an `Element`, and then just `dispose()` it once when the applicable `Element` is disposed. Then, in `deactivate`, simply call `release` (or an equivalently named method) on the `KeepAliveHandle`. This is the intended behavior as documented at https://api.flutter.dev/flutter/widgets/KeepAliveNotification-class.html and https://api.flutter.dev/flutter/widgets/KeepAliveHandle-class.html.

Fixes #123712 by adding in a `removeKeepAlive` method that is more clear than `release`.
