### PR TITLE
Hyperlink dart docs around BinaryMessenger deprecations

### DIFF
--- a/packages/flutter_test/lib/src/deprecated.dart
+++ b/packages/flutter_test/lib/src/deprecated.dart
@@ -6,7 +6,6 @@ import 'package:flutter/services.dart';
 
 import 'binding.dart';
 
-// TODO(ianh): Once https://github.com/dart-lang/dartdoc/issues/2033 is fixed, update the hyperlinks marked HYPERLINK below.
 // TODO(ianh): Once cocoon and other customer_tests are migrated, deprecate these transitional APIs
 
 /// Shim to support the obsolete [setMockMessageHandler] and
@@ -19,8 +18,7 @@ import 'binding.dart';
 /// `tester.binding.defaultBinaryMessenger.setMockMessageHandler` directly. This
 /// more accurately represents the actual method invocation.
 extension TestBinaryMessengerExtension on BinaryMessenger {
-  /// Shim for `TestDefaultBinaryMessenger.setMockMessageHandler`.
-  // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  /// Shim for [TestDefaultBinaryMessenger.setMockMessageHandler].
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.setMockMessageHandler or '
   //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler instead. '
@@ -30,8 +28,7 @@ extension TestBinaryMessengerExtension on BinaryMessenger {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(channel, handler);
   }
 
-  /// Shim for `TestDefaultBinaryMessenger.checkMockMessageHandler`.
-  // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  /// Shim for [TestDefaultBinaryMessenger.checkMockMessageHandler].
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.checkMockMessageHandler or '
   //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler instead.'
@@ -51,8 +48,7 @@ extension TestBinaryMessengerExtension on BinaryMessenger {
 /// `tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler`
 /// directly. This more accurately represents the actual method invocation.
 extension TestBasicMessageChannelExtension<T> on BasicMessageChannel<T> {
-  /// Shim for `TestDefaultBinaryMessenger.setMockDecodedMessageHandler`.
-  // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  /// Shim for [TestDefaultBinaryMessenger.setMockDecodedMessageHandler].
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler or '
   //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler instead. '
@@ -62,8 +58,7 @@ extension TestBasicMessageChannelExtension<T> on BasicMessageChannel<T> {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<T>(this, handler);
   }
 
-  /// Shim for `TestDefaultBinaryMessenger.checkMockMessageHandler`.
-  // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  /// Shim for [TestDefaultBinaryMessenger.checkMockMessageHandler].
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.checkMockMessageHandler or '
   //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler instead. '
@@ -84,8 +79,7 @@ extension TestBasicMessageChannelExtension<T> on BasicMessageChannel<T> {
 /// `tester.binding.defaultBinaryMessenger.setMockMethodCallHandler` directly.
 /// This more accurately represents the actual method invocation.
 extension TestMethodChannelExtension on MethodChannel {
-  /// Shim for `TestDefaultBinaryMessenger.setMockMethodCallHandler`.
-  // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  /// Shim for [TestDefaultBinaryMessenger.setMockMethodCallHandler].
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or '
   //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. '
@@ -95,8 +89,7 @@ extension TestMethodChannelExtension on MethodChannel {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(this, handler);
   }
 
-  /// Shim for `TestDefaultBinaryMessenger.checkMockMessageHandler`.
-  // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  /// Shim for [TestDefaultBinaryMessenger.checkMockMessageHandler].
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.checkMockMessageHandler or '
   //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler instead. '


### PR DESCRIPTION
The underlying issue (https://github.com/dart-lang/dartdoc/issues/2033) is marked as fixed.