### PR TITLE
Prevent bots/analyze.dart crashing on circular dependencies

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1772,7 +1772,11 @@ Future<void> _checkConsumerDependencies() async {
 
       final List<String> currentDependencies = (currentPackage['dependencies']! as List<Object?>).cast<String>();
       for (final String dependency in currentDependencies) {
-        workset.add(dependencyTree[dependency]!);
+        // Don't add dependencies we've already seen or we will get stuck
+        // forever if there are any circular references.
+        if (!dependencies.contains(dependency)) {
+          workset.add(dependencyTree[dependency]!);
+        }
       }
     }
   }

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1774,6 +1774,9 @@ Future<void> _checkConsumerDependencies() async {
       for (final String dependency in currentDependencies) {
         // Don't add dependencies we've already seen or we will get stuck
         // forever if there are any circular references.
+        // TODO(dantup): Consider failing gracefully with the names of the
+        //  packages once the cycle between test_api and matcher is resolved.
+        //  https://github.com/dart-lang/test/issues/1979
         if (!dependencies.contains(dependency)) {
           workset.add(dependencyTree[dependency]!);
         }


### PR DESCRIPTION
The bot rolling packages is failing here:

https://github.com/flutter/flutter/pull/123350#issuecomment-1490722596.

> Exhausted heap space, trying to allocate 34359738384 bytes.
> Unhandled exception:
> Out of Memory

It appears that there's a circular dependency between `test_api` and `matcher` which this script gets stuck following until it runs out of memory.

This change preferences adding packages that have already been added, and prevents the crash in my local machine.