### PR TITLE
`SemanticsFlag`/`SemanticsAction` cleanup (part 2)

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -669,7 +669,7 @@ class SemanticsData with Diagnosticable {
     properties.add(DoubleProperty('elevation', elevation, defaultValue: 0.0));
     properties.add(DoubleProperty('thickness', thickness, defaultValue: 0.0));
     final List<String> actionSummary = <String>[
-      for (final SemanticsAction action in SemanticsAction.values.values)
+      for (final SemanticsAction action in SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList)
         if ((actions & action.index) != 0)
           describeEnum(action),
     ];
@@ -680,7 +680,7 @@ class SemanticsData with Diagnosticable {
     properties.add(IterableProperty<String?>('customActions', customSemanticsActionSummary, ifEmpty: null));
 
     final List<String> flagSummary = <String>[
-      for (final SemanticsFlag flag in SemanticsFlag.values.values)
+      for (final SemanticsFlag flag in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList)
         if ((flags & flag.index) != 0)
           describeEnum(flag),
     ];
@@ -2755,7 +2755,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       .toList();
     properties.add(IterableProperty<String>('actions', actions, ifEmpty: null));
     properties.add(IterableProperty<String?>('customActions', customSemanticsActions, ifEmpty: null));
-    final List<String> flags = SemanticsFlag.values.values.where((SemanticsFlag flag) => hasFlag(flag)).map((SemanticsFlag flag) => flag.toString().substring('SemanticsFlag.'.length)).toList();
+    final List<String> flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.where((SemanticsFlag flag) => hasFlag(flag)).map((SemanticsFlag flag) => flag.toString().substring('SemanticsFlag.'.length)).toList();
     properties.add(IterableProperty<String>('flags', flags, ifEmpty: null));
     properties.add(FlagProperty('isInvisible', value: isInvisible, ifTrue: 'invisible'));
     properties.add(FlagProperty('isHidden', value: hasFlag(SemanticsFlag.isHidden), ifTrue: 'HIDDEN'));

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -669,6 +669,7 @@ class SemanticsData with Diagnosticable {
     properties.add(DoubleProperty('elevation', elevation, defaultValue: 0.0));
     properties.add(DoubleProperty('thickness', thickness, defaultValue: 0.0));
     final List<String> actionSummary = <String>[
+      // ignore: deprecated_member_use
       for (final SemanticsAction action in SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList)
         if ((actions & action.index) != 0)
           describeEnum(action),
@@ -680,6 +681,7 @@ class SemanticsData with Diagnosticable {
     properties.add(IterableProperty<String?>('customActions', customSemanticsActionSummary, ifEmpty: null));
 
     final List<String> flagSummary = <String>[
+      // ignore: deprecated_member_use
       for (final SemanticsFlag flag in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList)
         if ((flags & flag.index) != 0)
           describeEnum(flag),
@@ -2755,6 +2757,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
       .toList();
     properties.add(IterableProperty<String>('actions', actions, ifEmpty: null));
     properties.add(IterableProperty<String?>('customActions', customSemanticsActions, ifEmpty: null));
+    // ignore: deprecated_member_use
     final List<String> flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.where((SemanticsFlag flag) => hasFlag(flag)).map((SemanticsFlag flag) => flag.toString().substring('SemanticsFlag.'.length)).toList();
     properties.add(IterableProperty<String>('flags', flags, ifEmpty: null));
     properties.add(FlagProperty('isInvisible', value: isInvisible, ifTrue: 'invisible'));

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -346,7 +346,7 @@ void _defineTests() {
         ),
       ),
     ));
-    final Set<SemanticsAction> allActions = SemanticsAction.values.values.toSet()
+    final Set<SemanticsAction> allActions = SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList.toSet()
       ..remove(SemanticsAction.customAction) // customAction is not user-exposed.
       ..remove(SemanticsAction.showOnScreen); // showOnScreen is not user-exposed
 
@@ -444,7 +444,7 @@ void _defineTests() {
         ),
       ),
     ));
-    List<SemanticsFlag> flags = SemanticsFlag.values.values.toList();
+    List<SemanticsFlag> flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.toList();
     // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
     // therefore it has to be removed.
     flags
@@ -498,7 +498,7 @@ void _defineTests() {
         ),
       ),
     ));
-    flags = SemanticsFlag.values.values.toList();
+    flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.toList();
     // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
     // therefore it has to be removed.
     flags

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -346,6 +346,7 @@ void _defineTests() {
         ),
       ),
     ));
+    // ignore: deprecated_member_use
     final Set<SemanticsAction> allActions = SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList.toSet()
       ..remove(SemanticsAction.customAction) // customAction is not user-exposed.
       ..remove(SemanticsAction.showOnScreen); // showOnScreen is not user-exposed
@@ -444,6 +445,7 @@ void _defineTests() {
         ),
       ),
     ));
+    // ignore: deprecated_member_use
     List<SemanticsFlag> flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.toList();
     // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
     // therefore it has to be removed.
@@ -498,6 +500,7 @@ void _defineTests() {
         ),
       ),
     ));
+    // ignore: deprecated_member_use
     flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.toList();
     // [SemanticsFlag.hasImplicitScrolling] isn't part of [SemanticsProperties]
     // therefore it has to be removed.

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -520,7 +520,7 @@ void main() {
       ),
     );
 
-    final Set<SemanticsAction> allActions = SemanticsAction.values.values.toSet()
+    final Set<SemanticsAction> allActions = SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList.toSet()
       ..remove(SemanticsAction.moveCursorForwardByWord)
       ..remove(SemanticsAction.moveCursorBackwardByWord)
       ..remove(SemanticsAction.customAction) // customAction is not user-exposed.
@@ -612,7 +612,7 @@ void main() {
           liveRegion: true,
         ),
     );
-    final List<SemanticsFlag> flags = SemanticsFlag.values.values.toList();
+    final List<SemanticsFlag> flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.toList();
     flags
       ..remove(SemanticsFlag.hasToggledState)
       ..remove(SemanticsFlag.isToggled)

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -520,6 +520,7 @@ void main() {
       ),
     );
 
+    // ignore: deprecated_member_use
     final Set<SemanticsAction> allActions = SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList.toSet()
       ..remove(SemanticsAction.moveCursorForwardByWord)
       ..remove(SemanticsAction.moveCursorBackwardByWord)
@@ -612,6 +613,7 @@ void main() {
           liveRegion: true,
         ),
     );
+    // ignore: deprecated_member_use
     final List<SemanticsFlag> flags = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList.toList();
     flags
       ..remove(SemanticsFlag.hasToggledState)

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -633,7 +633,7 @@ class SemanticsTester {
   static String _flagsToSemanticsFlagExpression(dynamic flags) {
     Iterable<SemanticsFlag> list;
     if (flags is int) {
-      list = SemanticsFlag.values.values
+      list = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList
           .where((SemanticsFlag flag) => (flag.index & flags) != 0);
     } else {
       list = flags as List<SemanticsFlag>;
@@ -648,7 +648,7 @@ class SemanticsTester {
   static String _actionsToSemanticsActionExpression(dynamic actions) {
     Iterable<SemanticsAction> list;
     if (actions is int) {
-      list = SemanticsAction.values.values
+      list = SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList
           .where((SemanticsAction action) => (action.index & actions) != 0);
     } else {
       list = actions as List<SemanticsAction>;

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -633,6 +633,7 @@ class SemanticsTester {
   static String _flagsToSemanticsFlagExpression(dynamic flags) {
     Iterable<SemanticsFlag> list;
     if (flags is int) {
+      // ignore: deprecated_member_use
       list = SemanticsFlag.doNotUseWillBeDeletedWithoutWarningValuesAsList
           .where((SemanticsFlag flag) => (flag.index & flags) != 0);
     } else {
@@ -648,6 +649,7 @@ class SemanticsTester {
   static String _actionsToSemanticsActionExpression(dynamic actions) {
     Iterable<SemanticsAction> list;
     if (actions is int) {
+      // ignore: deprecated_member_use
       list = SemanticsAction.doNotUseWillBeDeletedWithoutWarningValuesAsList
           .where((SemanticsAction action) => (action.index & actions) != 0);
     } else {

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -613,10 +613,10 @@ void main() {
       int actions = 0;
       int flags = 0;
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
-      for (final int index in SemanticsAction.values.keys) {
+      for (final int index in SemanticsAction.doNotUseWillBeDeletedWithoutWarningKeys) {
         actions |= index;
       }
-      for (final int index in SemanticsFlag.values.keys) {
+      for (final int index in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningKeys) {
         flags |= index;
       }
       final SemanticsData data = SemanticsData(
@@ -895,10 +895,10 @@ void main() {
       int actions = 0;
       int flags = 0;
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
-      for (final int index in SemanticsAction.values.keys) {
+      for (final int index in SemanticsAction.doNotUseWillBeDeletedWithoutWarningKeys) {
         actions |= index;
       }
-      for (final int index in SemanticsFlag.values.keys) {
+      for (final int index in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningKeys) {
         flags |= index;
       }
       final SemanticsData data = SemanticsData(
@@ -1081,10 +1081,10 @@ void main() {
     testWidgets('only matches given flags and actions', (WidgetTester tester) async {
       int allActions = 0;
       int allFlags = 0;
-      for (final int index in SemanticsAction.values.keys) {
+      for (final int index in SemanticsAction.doNotUseWillBeDeletedWithoutWarningKeys) {
         allActions |= index;
       }
-      for (final int index in SemanticsFlag.values.keys) {
+      for (final int index in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningKeys) {
         allFlags |= index;
       }
       final SemanticsData emptyData = SemanticsData(

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -613,9 +613,11 @@ void main() {
       int actions = 0;
       int flags = 0;
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
+      // ignore: deprecated_member_use
       for (final int index in SemanticsAction.doNotUseWillBeDeletedWithoutWarningKeys) {
         actions |= index;
       }
+      // ignore: deprecated_member_use
       for (final int index in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningKeys) {
         flags |= index;
       }
@@ -895,9 +897,11 @@ void main() {
       int actions = 0;
       int flags = 0;
       const CustomSemanticsAction action = CustomSemanticsAction(label: 'test');
+      // ignore: deprecated_member_use
       for (final int index in SemanticsAction.doNotUseWillBeDeletedWithoutWarningKeys) {
         actions |= index;
       }
+      // ignore: deprecated_member_use
       for (final int index in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningKeys) {
         flags |= index;
       }
@@ -1081,9 +1085,11 @@ void main() {
     testWidgets('only matches given flags and actions', (WidgetTester tester) async {
       int allActions = 0;
       int allFlags = 0;
+      // ignore: deprecated_member_use
       for (final int index in SemanticsAction.doNotUseWillBeDeletedWithoutWarningKeys) {
         allActions |= index;
       }
+      // ignore: deprecated_member_use
       for (final int index in SemanticsFlag.doNotUseWillBeDeletedWithoutWarningKeys) {
         allFlags |= index;
       }


### PR DESCRIPTION
Part 2 of https://github.com/flutter/flutter/issues/123346
Migrate their usages into temporary properties.