### PR TITLE
Fix menu width issue for `DropdownMenu`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -19,6 +19,7 @@ import 'menu_anchor.dart';
 import 'menu_style.dart';
 import 'text_field.dart';
 import 'theme.dart';
+import 'theme_data.dart';
 
 
 // Navigation shortcuts to move the selected menu items up or down.
@@ -535,10 +536,10 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
             );
 
             return _DropdownMenuBody(
-              key: _anchorKey,
               width: widget.width,
               children: <Widget>[
                 TextField(
+                  key: _anchorKey,
                   mouseCursor: effectiveMouseCursor,
                   canRequestFocus: canRequestFocus(),
                   enableInteractiveSelection: canRequestFocus(),
@@ -607,7 +608,6 @@ class _ArrowDownIntent extends Intent {
 
 class _DropdownMenuBody extends MultiChildRenderObjectWidget {
   const _DropdownMenuBody({
-    super.key,
     super.children,
     this.width,
   });
@@ -826,6 +826,7 @@ class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
     return const MenuStyle(
       minimumSize: MaterialStatePropertyAll<Size>(Size(_kMinimumWidth, 0.0)),
       maximumSize: MaterialStatePropertyAll<Size>(Size.infinite),
+      visualDensity: VisualDensity.standard,
     );
   }
 

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1058,6 +1058,58 @@ void main() {
     await gesture.moveTo(tester.getCenter(textFieldFinder));
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.click);
   });
+
+  testWidgets('The menu has the same width as the input field in ListView', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/123631
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListView(
+          children: <Widget>[
+            DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    final Rect textInput = tester.getRect(find.byType(TextField));
+
+    await tester.tap(find.byType(TextField));
+    await tester.pumpAndSettle();
+
+    final Finder findMenu = find.byWidgetPredicate((Widget widget) {
+      return widget.runtimeType.toString() == '_MenuPanel';
+    });
+    final Rect menu = tester.getRect(findMenu);
+    expect(textInput.width, menu.width);
+
+    await tester.pumpWidget(Container());
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListView(
+          children: <Widget>[
+            DropdownMenu<TestMenu>(
+              width: 200,
+              dropdownMenuEntries: menuChildren,
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    final Rect textInput1 = tester.getRect(find.byType(TextField));
+
+    await tester.tap(find.byType(TextField));
+    await tester.pumpAndSettle();
+
+    final Finder findMenu1 = find.byWidgetPredicate((Widget widget) {
+      return widget.runtimeType.toString() == '_MenuPanel';
+    });
+    final Rect menu1 = tester.getRect(findMenu1);
+    expect(textInput1.width, 200);
+    expect(menu1.width, 200);
+  });
 }
 
 enum TestMenu {


### PR DESCRIPTION
Fixes: #123631.

This PR is to fix the menu width. It should be the same width as the input field.

Borrow the same example that shows in the issue description:)
<img width="300" alt="Screenshot 2023-03-30 at 3 26 55 PM" src="https://user-images.githubusercontent.com/36861262/228977450-46fe990b-c652-49d9-8aae-aa86eebf1e51.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
