### PR TITLE
Fix surface-size state leak in material/paginated_data_table_test (framework shuffle-all 3/n)

### DIFF
--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -845,6 +838,7 @@ void main() {
 
   testWidgets('PaginatedDataTable with optional column checkbox', (WidgetTester tester) async {
     await binding.setSurfaceSize(const Size(800, 800));
+    addTearDown(() => binding.setSurfaceSize(null));
 
     Widget buildTable(bool checkbox) => MaterialApp(
       home: PaginatedDataTable(
@@ -1004,6 +998,7 @@ void main() {
 
   testWidgets('PaginatedDataTable arrowHeadColor set properly', (WidgetTester tester) async {
     await binding.setSurfaceSize(const Size(800, 800));
+    addTearDown(() => binding.setSurfaceSize(null));
     const Color arrowHeadColor = Color(0xFFE53935);
 
     await tester.pumpWidget(

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -505,6 +505,17 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// then flushes microtasks.
   ///
   /// Set to null to use the default surface size.
+  ///
+  /// To avoid affecting other tests by leaking state, a test that
+  /// uses this method should always reset the surface size to the default.
+  /// For example, using `addTearDown`:
+  /// ```dart
+  ///   await binding.setSurfaceSize(someSize);
+  ///   addTearDown(() => binding.setSurfaceSize(null));
+  /// ```
+  ///
+  /// See also [TestFlutterView.physicalSize], which has a similar effect.
+  // TODO(pdblasi-google): Deprecate this. https://github.com/flutter/flutter/issues/123881
   Future<void> setSurfaceSize(Size? size) {
     return TestAsyncUtils.guard<void>(() async {
       assert(inTest);


### PR DESCRIPTION
Fixes part of #85160. This comes after #123751 and #123806 as part of removing `no-shuffle` tags from all tests in the framework.

The tests in this file had a state leak because although many of them were scrupulously resetting the surface size, two tests were missing that step:
* "PaginatedDataTable with optional column checkbox"
* "PaginatedDataTable arrowHeadColor set properly"

We could add a line `addTearDown(() => binding.setSurfaceSize(null));` to those two tests.  But it seems like we'll inevitably keep having bugs of this form — and so will any other `flutter_test` users that use this `setSurfaceSize` feature — unless the feature arranges to automatically either check that the state got reset, or just reset it.

And then once we're automatically detecting that the state wasn't reset, it doesn't seem like there's anything to be gained by making the author of the individual test take care of it.  This isn't a situation where there's any ambiguity about how to handle the reset, or where the un-reset data could be a sign of a broader bug; the thing the test author would do is always to just reset the state to the default anyway.  So take care of it automatically.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
