### PR TITLE
Un-deprecate KeepAliveHandle.release()

### DIFF
--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -326,10 +326,6 @@ class KeepAliveHandle extends ChangeNotifier {
   ///
   /// This method does not call [dispose]. When the handle is not needed
   /// anymore, it must be [dispose]d regardless of whether notifying listeners.
-  @Deprecated(
-    'Use dispose instead. '
-    'This feature was deprecated after v3.3.0-0.0.pre.',
-  )
   void release() {
     notifyListeners();
   }
@@ -359,19 +355,7 @@ class KeepAliveHandle extends ChangeNotifier {
 ///  * [KeepAliveNotification], the notifications sent by this mixin.
 @optionalTypeArgs
 mixin AutomaticKeepAliveClientMixin<T extends StatefulWidget> on State<T> {
-  KeepAliveHandle? _keepAliveHandle;
-
-  void _ensureKeepAlive() {
-    assert(_keepAliveHandle == null);
-    _keepAliveHandle = KeepAliveHandle();
-    KeepAliveNotification(_keepAliveHandle!).dispatch(context);
-  }
-
-  void _releaseKeepAlive() {
-    // Dispose and release do not imply each other.
-    _keepAliveHandle!.dispose();
-    _keepAliveHandle = null;
-  }
+  final KeepAliveHandle _keepAliveHandle = KeepAliveHandle();
 
   /// Whether the current instance should be kept alive.
   ///
@@ -385,38 +369,28 @@ mixin AutomaticKeepAliveClientMixin<T extends StatefulWidget> on State<T> {
   @protected
   void updateKeepAlive() {
     if (wantKeepAlive) {
-      if (_keepAliveHandle == null) {
-        _ensureKeepAlive();
-      }
+      KeepAliveNotification(_keepAliveHandle).dispatch(context);
     } else {
-      if (_keepAliveHandle != null) {
-        _releaseKeepAlive();
-      }
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    if (wantKeepAlive) {
-      _ensureKeepAlive();
+      _keepAliveHandle.release();
     }
   }
 
   @override
   void deactivate() {
-    if (_keepAliveHandle != null) {
-      _releaseKeepAlive();
-    }
+    _keepAliveHandle.release();
     super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    _keepAliveHandle.dispose();
+    super.dispose();
   }
 
   @mustCallSuper
   @override
   Widget build(BuildContext context) {
-    if (wantKeepAlive && _keepAliveHandle == null) {
-      _ensureKeepAlive();
-    }
+    updateKeepAlive();
     return const _NullWidget();
   }
 }

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -16,33 +16,33 @@ class Leaf extends StatefulWidget {
 
 class _LeafState extends State<Leaf> {
   bool _keepAlive = false;
-  KeepAliveHandle? _handle;
+  final KeepAliveHandle _handle = KeepAliveHandle();
 
   @override
   void deactivate() {
-    _handle?.release();
-    _handle = null;
+    _handle.release();
     super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    _handle.dispose();
+    super.dispose();
   }
 
   void setKeepAlive(bool value) {
     _keepAlive = value;
     if (_keepAlive) {
-      if (_handle == null) {
-        _handle = KeepAliveHandle();
-        KeepAliveNotification(_handle!).dispatch(context);
-      }
+      KeepAliveNotification(_handle).dispatch(context);
     } else {
-      _handle?.release();
-      _handle = null;
+      _handle.release();
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_keepAlive && _handle == null) {
-      _handle = KeepAliveHandle();
-      KeepAliveNotification(_handle!).dispatch(context);
+    if (_keepAlive) {
+      KeepAliveNotification(_handle).dispatch(context);
     }
     return widget.child;
   }


### PR DESCRIPTION
In 3.3.0, `KeepAliveHandle.release()` was deprecated (see #108384).
However, in many situations, it makes sense to just create a single `KeepAliveHandle` for the entire lifecycle of an `Element`, and then just `dispose()` it once when the applicable `Element` is disposed. Then, in `deactivate`, simply call `release` (or an equivalently named method) on the `KeepAliveHandle`. This is the intended behavior as documented at https://api.flutter.dev/flutter/widgets/KeepAliveNotification-class.html and https://api.flutter.dev/flutter/widgets/KeepAliveHandle-class.html.

Fixes #123712 by adding in a `removeKeepAlive` method that is more clear than `release`.
