### PR TITLE
Use BlendMode.dst when drawing vertices in the Transformations demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -181,7 +181,7 @@ class BoardPainter extends CustomPainter {
         board!.selected == boardPoint ? 0.2 : 1.0,
       );
       final Vertices vertices = board!.getVerticesForBoardPoint(boardPoint, color);
-      canvas.drawVertices(vertices, BlendMode.color, Paint());
+      canvas.drawVertices(vertices, BlendMode.dst, Paint());
       vertices.dispose();
     }
 


### PR DESCRIPTION
Flutter is building Skia using a flag that overrides other blend modes in SkCanvas::drawVertices with BlendMode.dst.  Apps should not rely on this behavior, which is not currently implemented in Impeller.

See https://github.com/flutter/flutter/issues/123834
