### PR TITLE
Remove Finder extended attributes in build target before code signing iOS frameworks

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -9,8 +9,10 @@ import '../../base/build.dart';
 import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
+import '../../base/process.dart';
 import '../../build_info.dart';
 import '../../globals.dart' as globals;
+import '../../ios/mac.dart';
 import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../../reporting/reporting.dart';
@@ -296,7 +298,7 @@ abstract class UnpackIOS extends Target {
     if (buildMode == BuildMode.release) {
       _bitcodeStripFramework(environment, frameworkBinaryPath);
     }
-    _signFramework(environment, frameworkBinaryPath, buildMode);
+    await _signFramework(environment, frameworkBinary, buildMode);
   }
 
   void _copyFramework(Environment environment, String sdkRoot) {
@@ -463,7 +465,7 @@ abstract class IosAssetBundle extends Target {
     }
     final BuildMode buildMode = getBuildModeForName(environmentBuildMode);
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
-    final String frameworkBinaryPath = frameworkDirectory.childFile('App').path;
+    final File frameworkBinary = frameworkDirectory.childFile('App');
     final Directory assetDirectory = frameworkDirectory.childDirectory('flutter_assets');
     frameworkDirectory.createSync(recursive: true);
     assetDirectory.createSync();
@@ -474,7 +476,7 @@ abstract class IosAssetBundle extends Target {
       environment.buildDir
         .childDirectory('App.framework')
         .childFile('App')
-        .copySync(frameworkBinaryPath);
+        .copySync(frameworkBinary.path);
 
       final String vmSnapshotData = environment.artifacts.getArtifactPath(Artifact.vmSnapshotData, mode: BuildMode.debug);
       final String isolateSnapshotData = environment.artifacts.getArtifactPath(Artifact.isolateSnapshotData, mode: BuildMode.debug);
@@ -486,7 +488,7 @@ abstract class IosAssetBundle extends Target {
           .copySync(assetDirectory.childFile('isolate_snapshot_data').path);
     } else {
       environment.buildDir.childDirectory('App.framework').childFile('App')
-        .copySync(frameworkBinaryPath);
+        .copySync(frameworkBinary.path);
     }
 
     // Copy the dSYM
@@ -539,7 +541,7 @@ abstract class IosAssetBundle extends Target {
       .childDirectory('App.framework')
       .childFile('Info.plist').path);
 
-    _signFramework(environment, frameworkBinaryPath, buildMode);
+    await _signFramework(environment, frameworkBinary, buildMode);
   }
 }
 
@@ -692,10 +694,16 @@ Future<void> _createStubAppFramework(File outputFile, Environment environment,
     }
   }
 
-  _signFramework(environment, outputFile.path, BuildMode.debug);
+  await _signFramework(environment, outputFile, BuildMode.debug);
 }
 
-void _signFramework(Environment environment, String binaryPath, BuildMode buildMode) {
+Future<void> _signFramework(Environment environment, File binary, BuildMode buildMode) async {
+  await removeFinderExtendedAttributes(
+    binary,
+    ProcessUtils(processManager: environment.processManager, logger: environment.logger),
+    environment.logger,
+  );
+
   String? codesignIdentity = environment.defines[kCodesignIdentity];
   if (codesignIdentity == null || codesignIdentity.isEmpty) {
     codesignIdentity = '-';
@@ -709,13 +717,13 @@ void _signFramework(Environment environment, String binaryPath, BuildMode buildM
       // Mimic Xcode's timestamp codesigning behavior on non-release binaries.
       '--timestamp=none',
     ],
-    binaryPath,
+    binary.path,
   ]);
   if (result.exitCode != 0) {
     final String stdout = (result.stdout as String).trim();
     final String stderr = (result.stderr as String).trim();
     final StringBuffer output = StringBuffer();
-    output.writeln('Failed to codesign $binaryPath with identity $codesignIdentity.');
+    output.writeln('Failed to codesign ${binary.path} with identity $codesignIdentity.');
     if (stdout.isNotEmpty) {
       output.writeln(stdout);
     }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import '../artifacts.dart';
@@ -493,8 +492,7 @@ Future<XcodeBuildResult> buildXcodeProject({
 
 /// Extended attributes applied by Finder can cause code signing errors. Remove them.
 /// https://developer.apple.com/library/archive/qa/qa1940/_index.html
-@visibleForTesting
-Future<void> removeFinderExtendedAttributes(Directory projectDirectory, ProcessUtils processUtils, Logger logger) async {
+Future<void> removeFinderExtendedAttributes(FileSystemEntity projectDirectory, ProcessUtils processUtils, Logger logger) async {
   final bool success = await processUtils.exitsHappy(
     <String>[
       'xattr',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -105,6 +105,13 @@ void main() {
         appFrameworkPath,
       ]),
       FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        appFrameworkPath,
+      ]),
+      FakeCommand(command: <String>[
         'codesign',
         '--force',
         '--sign',
@@ -139,6 +146,13 @@ void main() {
             '.tmp_rand0', 'flutter_tools_stub_source.rand0', 'debug_app.cc')),
         ..._kSharedConfig,
         '-o',
+        appFrameworkPath,
+      ]),
+      FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
         appFrameworkPath,
       ]),
       FakeCommand(command: <String>[
@@ -195,7 +209,14 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommand(
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        frameworkDirectoryBinary.path,
+      ]),
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -204,7 +225,7 @@ void main() {
         '--timestamp=none',
         frameworkDirectoryBinary.path,
       ]),
-    );
+    ]);
 
     await const DebugIosApplicationBundle().build(environment);
     expect(processManager, hasNoRemainingExpectations);
@@ -268,6 +289,13 @@ void main() {
         '--include=/./shader_lib',
       ]),
       FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        frameworkDirectoryBinary.path,
+      ]),
+      FakeCommand(command: <String>[
         'codesign',
         '--force',
         '--sign',
@@ -323,7 +351,14 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommand(
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        frameworkDirectoryBinary.path,
+      ]),
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -331,7 +366,7 @@ void main() {
         'ABC123',
         frameworkDirectoryBinary.path,
       ]),
-    );
+    ]);
 
     await const ReleaseIosApplicationBundle().build(environment);
     expect(processManager, hasNoRemainingExpectations);
@@ -371,7 +406,14 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommand(
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        frameworkDirectoryBinary.path,
+      ]),
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -379,7 +421,7 @@ void main() {
         '-',
         frameworkDirectoryBinary.path,
       ]),
-    );
+    ]);
 
     await const ReleaseIosApplicationBundle().build(environment);
     expect(usage.events, contains(const TestUsageEvent('assemble', 'ios-archive', label: 'success')));
@@ -466,6 +508,7 @@ void main() {
     late FakeCommand copyPhysicalFrameworkCommand;
     late FakeCommand lipoCommandNonFatResult;
     late FakeCommand lipoVerifyArm64Command;
+    late FakeCommand xattrCommand;
     late FakeCommand adHocCodesignCommand;
 
     setUp(() {
@@ -493,6 +536,14 @@ void main() {
         binary.path,
         '-verify_arch',
         'arm64',
+      ]);
+
+      xattrCommand = FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        binary.path,
       ]);
 
       adHocCodesignCommand = FakeCommand(command: <String>[
@@ -538,6 +589,7 @@ void main() {
           '-verify_arch',
           'x86_64',
         ]),
+        xattrCommand,
         adHocCodesignCommand,
       ]);
       await const DebugUnpackIOS().build(environment);
@@ -684,6 +736,7 @@ void main() {
         copyPhysicalFrameworkCommand,
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
+        xattrCommand,
         adHocCodesignCommand,
       ]);
       await const DebugUnpackIOS().build(environment);
@@ -733,6 +786,7 @@ void main() {
           'armv7',
           binary.path,
         ]),
+        xattrCommand,
         adHocCodesignCommand,
       ]);
 
@@ -810,6 +864,7 @@ void main() {
         copyPhysicalFrameworkCommand,
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
+        xattrCommand,
         adHocCodesignCommand,
       ]);
       await const DebugUnpackIOS().build(environment);
@@ -838,6 +893,7 @@ void main() {
         copyPhysicalFrameworkCommand,
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
+        xattrCommand,
         FakeCommand(command: <String>[
             'codesign',
             '--force',
@@ -885,6 +941,7 @@ void main() {
         copyPhysicalFrameworkCommand,
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
+        xattrCommand,
         FakeCommand(command: <String>[
           'codesign',
           '--force',


### PR DESCRIPTION
Remove disallowed Finder extended attributes right before codesigning instead of at the beginning of the `flutter` build command.  This should work when running from Xcode as well.

Apple's docs: https://developer.apple.com/library/archive/qa/qa1940/_index.html
See where this was attempted in the `flutter` command: https://github.com/flutter/flutter/pull/81342

Related to https://github.com/flutter/flutter/issues/123583 though there's some evidence it won't fix it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
