### PR TITLE
Remove default text animation

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -467,8 +467,9 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
     );
     Widget? contents = widget.child;
     if (contents != null) {
-      contents = DefaultTextStyle(
+      contents = AnimatedDefaultTextStyle(
         style: widget.textStyle ?? Theme.of(context).textTheme.bodyMedium!,
+        duration: Duration.zero,
         child: contents,
       );
     }

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -467,9 +467,8 @@ class _MaterialState extends State<Material> with TickerProviderStateMixin {
     );
     Widget? contents = widget.child;
     if (contents != null) {
-      contents = AnimatedDefaultTextStyle(
+      contents = DefaultTextStyle(
         style: widget.textStyle ?? Theme.of(context).textTheme.bodyMedium!,
-        duration: widget.animationDuration,
         child: contents,
       );
     }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -540,7 +540,7 @@ void main() {
     //     this case, it's at t=1.0 of the theme animation, so this is also the
     //     frame in which the theme animation ends.
     //  3. End all the other animations.
-    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 1);
     expect(Theme.of(tester.element(find.text('HELLO'))).platform, TargetPlatform.android);
     final Offset helloPosition3 = tester.getCenter(find.text('HELLO'));
     expect(helloPosition3, helloPosition2);


### PR DESCRIPTION
This PR removes the default text animation that is caused with any widget that makes use of text. This issue extends to the use case where Text would still animate even after a ```AnimatedTheme``` widget is provided with a duration of 0.

<details>
<summary>Before (theme switch example): </summary>

https://user-images.githubusercontent.com/73116038/229247597-799506f4-935b-400d-80e1-7f6c360f2cbb.mp4

</details>

<details>
<summary>After (theme switch example): </summary>

https://user-images.githubusercontent.com/73116038/229247601-c497814a-bb06-4e4c-89a0-5c332a30b094.mp4

</details>

<details>
<summary>Before (MenuBar example)</summary>

https://user-images.githubusercontent.com/73116038/229261277-8da26727-b829-4d37-989a-f51796941dec.mp4

</details>

<details>
<summary>After (MenuBar example)</summary>

https://user-images.githubusercontent.com/73116038/229248335-d068d6d0-4ff6-47bb-bb76-f02a6b7119e8.mp4

</details>


<details>
<summary>Repro code (theme switcher): </summary>

```
import 'package:flutter/material.dart';
import 'package:provider/provider.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return ChangeNotifierProvider(
      create: (_) => ThemeProvider(false),
      child: Builder(
        builder: (context) {
          final themeProvider = Provider.of<ThemeProvider>(context);
          return MaterialApp(
            theme: lightTheme,
            darkTheme: darkTheme,
            themeMode: themeProvider.currentThemeMode,
            home: const HomeScreen(),
            builder: (BuildContext context, Widget? child) {
              return AnimatedTheme(
                data: themeProvider.currentThemeMode == ThemeMode.dark
                    ? darkTheme
                    : lightTheme,
                duration: const Duration(milliseconds: 1000),
                //curve: Curves.easeInOut,
                child: child!,
              );
            },
          );
        },
      ),
    );
  }
}

class HomeScreen extends StatelessWidget {
  const HomeScreen({super.key});

  @override
  Widget build(BuildContext context) {
    final themeProvider = Provider.of<ThemeProvider>(context);

    return Scaffold(
      appBar: AppBar(
        title: const Text('Light/Dark Theme Switcher'),
      ),
      body: Column(
        children: [
          const Text("Hello World"),
          Center(
            child: ElevatedButton(
              onPressed: () {
                themeProvider.toggleTheme();
              },
              child: const Text('Toggle Theme'),
            ),
          ),
        ],
      ),
    );
  }
}

class ThemeProvider extends ChangeNotifier {
  late ThemeMode _currentThemeMode;

  ThemeProvider(bool isDarkMode) {
    _currentThemeMode = isDarkMode ? ThemeMode.dark : ThemeMode.light;
  }

  ThemeMode get currentThemeMode => _currentThemeMode;

  void toggleTheme() {
    _currentThemeMode =
        _currentThemeMode == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
    notifyListeners();
  }
}

final ThemeData lightTheme = ThemeData.light().copyWith();

final ThemeData darkTheme = ThemeData.dark().copyWith();

```

</details>


I'm not too familiar with this area of the codebase, and am honestly surprised that text still animates on theme switches after the ```AnimatedDefaultTextStyle``` is replaced with ```DefaultTextStyle```. Also still needs tests :)

Fixes #123615 