### PR TITLE
Add CallbackShortcuts example

### DIFF
--- a/examples/api/lib/widgets/shortcuts/callback_shortcuts.0.dart
+++ b/examples/api/lib/widgets/shortcuts/callback_shortcuts.0.dart
@@ -2,40 +2,37 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flutter code sample for [CallbackShortcuts].
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-void main() => runApp(const MyApp());
+/// Flutter code sample for [CallbackShortcuts].
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+void main() => runApp(const CallbackShortcutsApp());
 
-  static const String _title = 'Flutter Code Sample';
+class CallbackShortcutsApp extends StatelessWidget {
+  const CallbackShortcutsApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
+        appBar: AppBar(title: const Text('CallbackShortcuts Sample')),
         body: const Center(
-          child: MyStatefulWidget(),
+          child: CallbackShortcutsExample(),
         ),
       ),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({super.key});
+class CallbackShortcutsExample extends StatefulWidget {
+  const CallbackShortcutsExample({super.key});
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<CallbackShortcutsExample> createState() => _CallbackShortcutsExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _CallbackShortcutsExampleState extends State<CallbackShortcutsExample> {
   int count = 0;
 
   @override
@@ -53,9 +50,8 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
         autofocus: true,
         child: Column(
           children: <Widget>[
-            const Text('Add to the counter by pressing the up arrow key'),
-            const Text(
-                'Subtract from the counter by pressing the down arrow key'),
+            const Text('Press the up arrow key to add to the counter'),
+            const Text('Press the down arrow key to subtract from the counter'),
             Text('count: $count'),
           ],
         ),

--- a/examples/api/lib/widgets/shortcuts/callback_shortcuts.0.dart
+++ b/examples/api/lib/widgets/shortcuts/callback_shortcuts.0.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for [CallbackShortcuts].
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const Center(
+          child: MyStatefulWidget(),
+        ),
+      ),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({super.key});
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.arrowUp): () {
+          setState(() => count = count + 1);
+        },
+        const SingleActivator(LogicalKeyboardKey.arrowDown): () {
+          setState(() => count = count - 1);
+        },
+      },
+      child: Focus(
+        autofocus: true,
+        child: Column(
+          children: <Widget>[
+            const Text('Add to the counter by pressing the up arrow key'),
+            const Text(
+                'Subtract from the counter by pressing the down arrow key'),
+            Text('count: $count'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/test/widgets/shortcuts/callback_shortcuts.0.dart
+++ b/examples/api/test/widgets/shortcuts/callback_shortcuts.0.dart
@@ -1,0 +1,29 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_api_samples/widgets/shortcuts/callback_shortcuts.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('WidgetsApp test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.CallbackShortcutsApp(),
+    );
+
+    expect(find.text('count: 0'), findsOneWidget);
+
+    // Increment the counter.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+
+    expect(find.text('count: 1'), findsOneWidget);
+
+    // Decrement the counter.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+
+    expect(find.text('count: 0'), findsOneWidget);
+  });
+}

--- a/examples/api/test/widgets/shortcuts/callback_shortcuts.0.dart
+++ b/examples/api/test/widgets/shortcuts/callback_shortcuts.0.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/widgets/shortcuts/callback_shortcuts.0.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('WidgetsApp test', (WidgetTester tester) async {
+  testWidgets('CallbackShortcutsApp increments and decrements', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.CallbackShortcutsApp(),
     );

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1057,6 +1057,13 @@ class _ShortcutsState extends State<Shortcuts> {
 /// deletion intent may be to delete a character in a text input, or to delete
 /// a file in a file menu.
 ///
+/// {@tool dartpad}
+/// This example uses the [CallbackShortcuts] widget to add and subtract
+/// from a counter when the up or down arrow keys are pressed.
+///
+/// ** See code in examples/api/lib/widgets/shortcuts/callback_shortcuts.0.dart **
+/// {@end-tool}
+///
 /// [Shortcuts] and [CallbackShortcuts] can both be used in the same app. As
 /// with any key handling widget, if this widget handles a key event then
 /// widgets above it in the focus chain will not receive the event. This means


### PR DESCRIPTION
This code sample mirrors the corresponding `Shortcuts` code sample: https://github.com/flutter/flutter/blob/c2219e86b134d62c975801e74afc3dcf8bfd219e/examples/api/lib/widgets/shortcuts/shortcuts.0.dart

This is my first time adding a code sample, let me know if I did anything wrong!

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
