### PR TITLE
Make tester.startGesture less async, for better stack traces

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1133,6 +1133,19 @@ abstract class WidgetController {
     return result;
   }
 
+  TestGesture _createGesture({
+    int? pointer,
+    required PointerDeviceKind kind,
+    required int buttons,
+  }) {
+    return TestGesture(
+      dispatcher: sendEventToBinding,
+      kind: kind,
+      pointer: pointer ?? _getNextPointer(),
+      buttons: buttons,
+    );
+  }
+
   /// Creates gesture and returns the [TestGesture] object which you can use
   /// to continue the gesture using calls on the [TestGesture] object.
   ///
@@ -1143,12 +1156,7 @@ abstract class WidgetController {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int buttons = kPrimaryButton,
   }) async {
-    return TestGesture(
-      dispatcher: sendEventToBinding,
-      kind: kind,
-      pointer: pointer ?? _getNextPointer(),
-      buttons: buttons,
-    );
+    return _createGesture(pointer: pointer, kind: kind, buttons: buttons);
   }
 
   /// Creates a gesture with an initial appropriate starting gesture at a
@@ -1172,11 +1180,7 @@ abstract class WidgetController {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int buttons = kPrimaryButton,
   }) async {
-    final TestGesture result = await createGesture(
-      pointer: pointer,
-      kind: kind,
-      buttons: buttons,
-    );
+    final TestGesture result = _createGesture(pointer: pointer, kind: kind, buttons: buttons);
     if (kind == PointerDeviceKind.trackpad) {
       await result.panZoomStart(downLocation);
     } else {


### PR DESCRIPTION
Toward #85160.

When tests interfere with each other over gestures, debugging the problem can get confusing.  One reason is that the stack traces are obscured by asynchrony, in a way that turns out to have an easy fix.  This PR makes that fix.

---

For example, here's a stack trace I encountered when debugging one of the state leaks in `widgets/draggable_test.dart`:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following assertion was thrown running a test:
Pointer of PointerDownEvent#21bfd(position: Offset(400.0, 72.0), pointer: 7, kind: touch, buttons:
1, down: true) unexpectedly has a HitTestResult associated with it.
'package:flutter/src/gestures/binding.dart':
Failed assertion: line 369 pos 14: '!_hitTests.containsKey(event.pointer)'

Either the assertion indicates an error in the framework itself, or we should provide substantially
more information in this error message to help you determine and fix the underlying cause.
In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=2_bug.md

When the exception was thrown, this was the stack:
#2      GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:369:14)
#3      GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:363:5)
#4      TestWidgetsFlutterBinding.handlePointerEventForSource.<anonymous closure> (package:flutter_test/src/binding.dart:614:42)
#5      TestWidgetsFlutterBinding.withPointerEventSource (package:flutter_test/src/binding.dart:624:11)
#6      TestWidgetsFlutterBinding.handlePointerEventForSource (package:flutter_test/src/binding.dart:614:5)
#7      WidgetTester.sendEventToBinding.<anonymous closure> (package:flutter_test/src/widget_tester.dart:849:15)
#10     TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:68:41)
#11     WidgetTester.sendEventToBinding (package:flutter_test/src/widget_tester.dart:848:27)
#12     TestGesture.down.<anonymous closure> (package:flutter_test/src/test_pointer.dart:456:25)
#15     TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:68:41)
#16     TestGesture.down (package:flutter_test/src/test_pointer.dart:455:27)
#17     WidgetController.startGesture (package:flutter_test/src/controller.dart:1183:20)
<asynchronous suspension>
<asynchronous suspension>
(elided 7 frames from class _AssertionError, dart:async, and package:stack_trace)

The test description was:
  Drag and drop - dragging over button
════════════════════════════════════════════════════════════════════════════════════════════════════
```

That test, "Drag and drop - dragging over button", is 90 lines long.  So the first thing one wants to know to debug it is where in the test the error occurred — what steps have already happened to get us to the state where the assertion detected a problem, and what step we were on that triggered the assert.

And unfortunately this stack trace doesn't tell us that; it doesn't contain any frames from the test.  The outermost frame is in `WidgetController.startGesture`, inside the `flutter_test` library.

The test does call that method, though — on line 451 and line 467.  So one might guess that one of those calls triggered the failure.

That turns out to be the wrong track.

After applying this PR, here's the stack trace from the same debugging attempt:
```
When the exception was thrown, this was the stack:
#2      GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:369:14)
#3      GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:363:5)
#4      TestWidgetsFlutterBinding.handlePointerEventForSource.<anonymous closure> (package:flutter_test/src/binding.dart:614:42)
#5      TestWidgetsFlutterBinding.withPointerEventSource (package:flutter_test/src/binding.dart:624:11)
#6      TestWidgetsFlutterBinding.handlePointerEventForSource (package:flutter_test/src/binding.dart:614:5)
#7      WidgetTester.sendEventToBinding.<anonymous closure> (package:flutter_test/src/widget_tester.dart:849:15)
#10     TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:68:41)
#11     WidgetTester.sendEventToBinding (package:flutter_test/src/widget_tester.dart:848:27)
#12     TestGesture.down.<anonymous closure> (package:flutter_test/src/test_pointer.dart:456:25)
#15     TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:68:41)
#16     TestGesture.down (package:flutter_test/src/test_pointer.dart:455:27)
#17     WidgetController.startGesture (package:flutter_test/src/controller.dart:1187:20)
#18     WidgetController.tapAt.<anonymous closure> (package:flutter_test/src/controller.dart:560:41)
#21     TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:68:41)
#22     WidgetController.tapAt (package:flutter_test/src/controller.dart:559:27)
#23     WidgetController.tap (package:flutter_test/src/controller.dart:554:12)
#24     main.<anonymous closure> (file:///home/greg/n/flutter/flutter/packages/flutter/test/widgets/draggable_test.dart:476:18)
<asynchronous suspension>
<asynchronous suspension>
(elided 9 frames from class _AssertionError, dart:async, and package:stack_trace)
```

This immediately tells us the error is happening on line 476 of the test file.  That's several steps later than the `tester.startGesture` calls; it's instead a call to `tester.tap`.  The `startGesture` call on the stack was an internal one.

With that information in hand, we avoid some fruitless paths of debugging, and can instead go straight to investigating why that particular `tap` call found itself in this situation.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
