### PR TITLE
[NavigationDrawer] adds padding property in NavigationDrawer Widget

### DIFF
--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -61,6 +61,7 @@ class NavigationDrawer extends StatelessWidget {
     this.indicatorShape,
     this.onDestinationSelected,
     this.selectedIndex = 0,
+    this.padding = const EdgeInsets.symmetric(horizontal: 12.0),
   });
 
   /// The background color of the [Material] that holds the [NavigationDrawer]'s
@@ -124,6 +125,9 @@ class NavigationDrawer extends StatelessWidget {
   /// Upon updating [selectedIndex], the [NavigationDrawer] will be rebuilt.
   final ValueChanged<int>? onDestinationSelected;
 
+  /// padding of drawer items
+  final EdgeInsetsGeometry padding;
+
   @override
   Widget build(BuildContext context) {
     final int totalNumberOfDestinations =
@@ -141,6 +145,7 @@ class NavigationDrawer extends StatelessWidget {
             selectedAnimation: animation,
             indicatorColor: indicatorColor,
             indicatorShape: indicatorShape,
+            padding: padding,
             onTap: () {
               if (onDestinationSelected != null) {
                 onDestinationSelected!(index);
@@ -321,7 +326,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
     final NavigationDrawerThemeData defaults = _NavigationDrawerDefaultsM3(context);
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      padding: info.padding,
       child: _NavigationDestinationSemantics(
         child: SizedBox(
           height: navigationDrawerTheme.tileHeight ?? defaults.tileHeight,
@@ -455,6 +460,7 @@ class _NavigationDrawerDestinationInfo extends InheritedWidget {
     required this.indicatorShape,
     required this.onTap,
     required super.child,
+    required this.padding,
   });
 
   /// Which destination index is this in the navigation drawer.
@@ -513,6 +519,9 @@ class _NavigationDrawerDestinationInfo extends InheritedWidget {
   /// This is computed by calling [NavigationDrawer.onDestinationSelected]
   /// with [index] passed in.
   final VoidCallback onTap;
+
+  /// padding of drawer items
+  final EdgeInsetsGeometry padding;
 
   /// Returns a non null [_NavigationDrawerDestinationInfo].
   ///

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -61,7 +61,7 @@ class NavigationDrawer extends StatelessWidget {
     this.indicatorShape,
     this.onDestinationSelected,
     this.selectedIndex = 0,
-    this.padding = const EdgeInsets.symmetric(horizontal: 12.0),
+    this.tilePadding = const EdgeInsets.symmetric(horizontal: 12.0),
   });
 
   /// The background color of the [Material] that holds the [NavigationDrawer]'s
@@ -128,7 +128,7 @@ class NavigationDrawer extends StatelessWidget {
   /// Defines the padding for [NavigationDrawerDestination] widgets (Drawer items).
   ///
   /// Defaults to `EdgeInsets.symmetric(horizontal: 12.0)`.
-  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry tilePadding;
 
   @override
   Widget build(BuildContext context) {
@@ -147,7 +147,7 @@ class NavigationDrawer extends StatelessWidget {
             selectedAnimation: animation,
             indicatorColor: indicatorColor,
             indicatorShape: indicatorShape,
-            padding: padding,
+            tilePadding: tilePadding,
             onTap: () {
               if (onDestinationSelected != null) {
                 onDestinationSelected!(index);
@@ -328,7 +328,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
     final NavigationDrawerThemeData defaults = _NavigationDrawerDefaultsM3(context);
 
     return Padding(
-      padding: info.padding,
+      padding: info.tilePadding,
       child: _NavigationDestinationSemantics(
         child: SizedBox(
           height: navigationDrawerTheme.tileHeight ?? defaults.tileHeight,
@@ -462,7 +462,7 @@ class _NavigationDrawerDestinationInfo extends InheritedWidget {
     required this.indicatorShape,
     required this.onTap,
     required super.child,
-    required this.padding,
+    required this.tilePadding,
   });
 
   /// Which destination index is this in the navigation drawer.
@@ -525,7 +525,7 @@ class _NavigationDrawerDestinationInfo extends InheritedWidget {
   /// Defines the padding for [NavigationDrawerDestination] widgets (Drawer items).
   ///
   /// Defaults to `EdgeInsets.symmetric(horizontal: 12.0)`.
-  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry tilePadding;
 
   /// Returns a non null [_NavigationDrawerDestinationInfo].
   ///

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -125,7 +125,9 @@ class NavigationDrawer extends StatelessWidget {
   /// Upon updating [selectedIndex], the [NavigationDrawer] will be rebuilt.
   final ValueChanged<int>? onDestinationSelected;
 
-  /// padding of drawer items
+  /// Defines the padding for [NavigationDrawerDestination] widgets (Drawer items).
+  ///
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 12.0)`.
   final EdgeInsetsGeometry padding;
 
   @override
@@ -520,7 +522,9 @@ class _NavigationDrawerDestinationInfo extends InheritedWidget {
   /// with [index] passed in.
   final VoidCallback onTap;
 
-  /// padding of drawer items
+  /// Defines the padding for [NavigationDrawerDestination] widgets (Drawer items).
+  ///
+  /// Defaults to `EdgeInsets.symmetric(horizontal: 12.0)`.
   final EdgeInsetsGeometry padding;
 
   /// Returns a non null [_NavigationDrawerDestinationInfo].

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -360,6 +360,29 @@ void main() {
     // Test that InkWell for hover, focus and pressed use custom shape.
     expect(_getInkWell(tester)?.customBorder, shape);
   });
+
+  testWidgets('NavigationDrawer.padding defaults to EdgeInsets.symmetric(horizontal: 12.0)', (WidgetTester tester) async {
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    widgetSetup(tester, 3000, viewHeight: 3000);
+    final Widget widget = _buildWidget(
+      scaffoldKey,
+      NavigationDrawer(
+        children: const <Widget>[
+          NavigationDrawerDestination(
+            icon: Icon(Icons.ac_unit),
+            label: Text('AC'),
+          ),
+        ],
+        onDestinationSelected: (int i) {},
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+    scaffoldKey.currentState!.openDrawer();
+    await tester.pump();
+    final NavigationDrawer drawer = tester.widget(find.byType(NavigationDrawer));
+    expect(drawer.padding, const EdgeInsets.symmetric(horizontal: 12.0));
+  });
 }
 
 Widget _buildWidget(GlobalKey<ScaffoldState> scaffoldKey, Widget child) {

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -361,7 +361,7 @@ void main() {
     expect(_getInkWell(tester)?.customBorder, shape);
   });
 
-  testWidgets('NavigationDrawer.padding defaults to EdgeInsets.symmetric(horizontal: 12.0)', (WidgetTester tester) async {
+  testWidgets('NavigationDrawer.tilePadding defaults to EdgeInsets.symmetric(horizontal: 12.0)', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     widgetSetup(tester, 3000, viewHeight: 3000);
     final Widget widget = _buildWidget(
@@ -378,10 +378,10 @@ void main() {
     );
 
     await tester.pumpWidget(widget);
-    scaffoldKey.currentState!.openDrawer();
+    scaffoldKey.currentState?.openDrawer();
     await tester.pump();
     final NavigationDrawer drawer = tester.widget(find.byType(NavigationDrawer));
-    expect(drawer.padding, const EdgeInsets.symmetric(horizontal: 12.0));
+    expect(drawer.tilePadding, const EdgeInsets.symmetric(horizontal: 12.0));
   });
 }
 


### PR DESCRIPTION
Adds `tilePadding` property to `NavigationDrawer` Widget.

Fixes: #121662

| Without adding `tilePadding` in NavigationDrawer | With `tilePadding: EdgeInsets.all(16)` in NavigationDrawer |
| --- | --- |
| ![photo_2023-04-02_15-03-56](https://user-images.githubusercontent.com/13456345/229344718-9070c0c0-9c71-4436-9953-d258367951e9.jpg) | ![photo_2023-04-02_15-04-00](https://user-images.githubusercontent.com/13456345/229344717-0768f9d5-6a55-4c2f-918e-53f2423bb959.jpg) |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
