### PR TITLE
Update `ThemeData`'s factory method documents

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -850,7 +850,7 @@ class ThemeData with Diagnosticable {
     );
   }
 
-  /// A default light blue theme.
+  /// A default light theme.
   ///
   /// This theme does not contain text geometry. Instead, it is expected that
   /// this theme is localized using text geometry using [ThemeData.localize].
@@ -859,7 +859,7 @@ class ThemeData with Diagnosticable {
     useMaterial3: useMaterial3,
   );
 
-  /// A default dark theme with a teal secondary [ColorScheme] color.
+  /// A default dark theme.
   ///
   /// This theme does not contain text geometry. Instead, it is expected that
   /// this theme is localized using text geometry using [ThemeData.localize].


### PR DESCRIPTION
Catch up document. As Material 3 actually use a purple theme.

https://github.com/flutter/flutter/blob/d8cbaf62615497fdb1e51167d0eb306a2d7b7bcf/packages/flutter/lib/src/material/theme_data.dart#L2777-L2856
