### PR TITLE
Add readlink -f flag to CocoaPods script to workaround Xcode 14.3 issue

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -28,6 +28,7 @@ Future<void> processPodsIfNeeded(
     paths: <String>[
       xcodeProject.xcodeProjectInfoFile.path,
       xcodeProject.podfile.path,
+      xcodeProject.podRunnerFrameworksScript.path, // for CocoaPodsScriptReadlink migration.
       globals.fs.path.join(
         Cache.flutterRoot!,
         'packages',

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -28,7 +28,6 @@ Future<void> processPodsIfNeeded(
     paths: <String>[
       xcodeProject.xcodeProjectInfoFile.path,
       xcodeProject.podfile.path,
-      xcodeProject.podRunnerFrameworksScript.path, // for CocoaPodsScriptReadlink migration.
       globals.fs.path.join(
         Cache.flutterRoot!,
         'packages',

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -13,10 +13,12 @@ import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
+import '../base/project_migrator.dart';
 import '../base/version.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../ios/xcodeproj.dart';
+import '../migrations/cocoapods_script_symlink.dart';
 import '../reporting/reporting.dart';
 import '../xcode_project.dart';
 
@@ -166,6 +168,13 @@ class CocoaPods {
         throwToolExit('CocoaPods not installed or not in valid state.');
       }
       await _runPodInstall(xcodeProject, buildMode);
+
+      // This migrator works around a CocoaPods bug, and should be run after `pod install` is run.
+      final ProjectMigration postPodMigration = ProjectMigration(<ProjectMigrator>[
+        CocoaPodsScriptReadlink(xcodeProject, _xcodeProjectInterpreter, _logger),
+      ]);
+      postPodMigration.run();
+
       podsProcessed = true;
     }
     return podsProcessed;

--- a/packages/flutter_tools/lib/src/migrations/cocoapods_script_symlink.dart
+++ b/packages/flutter_tools/lib/src/migrations/cocoapods_script_symlink.dart
@@ -1,0 +1,52 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../base/file_system.dart';
+import '../base/project_migrator.dart';
+import '../base/version.dart';
+import '../ios/xcodeproj.dart';
+import '../xcode_project.dart';
+
+// Xcode 14.3 changed the readlink symlink behavior to be relative from the script working directory, instead of the
+// relative path of the symlink. The -f flag returns the original "--canonicalize" behavior the CocoaPods script relies on.
+// This has been fixed upstream in CocoaPods, but migrate a copy of their workaround so users don't need to update.
+//
+// See https://github.com/flutter/flutter/issues/123890#issuecomment-1494825976.
+class CocoaPodsScriptReadlink extends ProjectMigrator {
+  CocoaPodsScriptReadlink(
+    XcodeBasedProject project,
+    XcodeProjectInterpreter xcodeProjectInterpreter,
+    super.logger,
+  )   : _podRunnerFrameworksScript = project.podRunnerFrameworksScript,
+        _xcodeProjectInterpreter = xcodeProjectInterpreter;
+
+  final File _podRunnerFrameworksScript;
+  final XcodeProjectInterpreter _xcodeProjectInterpreter;
+
+  @override
+  void migrate() {
+    if (!_podRunnerFrameworksScript.existsSync()) {
+      logger.printTrace('CocoaPods Pods-Runner-frameworks.sh script not found, skipping "readlink -f" workaround.');
+      return;
+    }
+
+    final Version? version = _xcodeProjectInterpreter.version;
+
+    // Skip if Xcode not installed or less than 14.3 with readlink behavior change, skip this migration.
+    if (version == null || version < Version(14, 3, 0)) {
+      logger.printTrace('Detected Xcode version is $version, below 14.3, skipping "readlink -f" workaround.');
+      return;
+    }
+
+    processFileLines(_podRunnerFrameworksScript);
+  }
+
+  @override
+  String? migrateLine(String line) {
+    const String originalReadLinkLine = r'source="$(readlink "${source}")"';
+    const String replacementReadLinkLine = r'source="$(readlink -f "${source}")"';
+
+    return line.replaceAll(originalReadLinkLine, replacementReadLinkLine);
+  }
+}

--- a/packages/flutter_tools/lib/src/migrations/cocoapods_script_symlink.dart
+++ b/packages/flutter_tools/lib/src/migrations/cocoapods_script_symlink.dart
@@ -33,7 +33,7 @@ class CocoaPodsScriptReadlink extends ProjectMigrator {
 
     final Version? version = _xcodeProjectInterpreter.version;
 
-    // Skip if Xcode not installed or less than 14.3 with readlink behavior change, skip this migration.
+    // If Xcode not installed or less than 14.3 with readlink behavior change, skip this migration.
     if (version == null || version < Version(14, 3, 0)) {
       logger.printTrace('Detected Xcode version is $version, below 14.3, skipping "readlink -f" workaround.');
       return;

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -89,6 +89,13 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform  {
 
   /// The CocoaPods 'Manifest.lock'.
   File get podManifestLock => hostAppRoot.childDirectory('Pods').childFile('Manifest.lock');
+
+  /// The CocoaPods generated 'Pods-Runner-frameworks.sh'.
+  File get podRunnerFrameworksScript => hostAppRoot
+      .childDirectory('Pods')
+      .childDirectory('Target Support Files')
+      .childDirectory('Pods-Runner')
+      .childFile('Pods-Runner-frameworks.sh');
 }
 
 /// Represents the iOS sub-project of a Flutter project.

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -6,6 +6,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/project_migrator.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/ios/migrations/host_app_info_plist_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/ios_deployment_target_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/project_base_configuration_migration.dart';
@@ -13,6 +14,8 @@ import 'package:flutter_tools/src/ios/migrations/project_build_location_migratio
 import 'package:flutter_tools/src/ios/migrations/remove_bitcode_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/remove_framework_link_and_embedding_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/xcode_build_system_migration.dart';
+import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/migrations/cocoapods_script_symlink.dart';
 import 'package:flutter_tools/src/migrations/xcode_project_object_version_migration.dart';
 import 'package:flutter_tools/src/migrations/xcode_script_build_phase_migration.dart';
 import 'package:flutter_tools/src/migrations/xcode_thin_binary_build_phase_input_paths_migration.dart';
@@ -21,6 +24,7 @@ import 'package:flutter_tools/src/xcode_project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
 
 void main () {
   group('iOS migration', () {
@@ -901,6 +905,104 @@ platform :ios, '11.0'
         expect('Disabling deprecated bitcode Xcode build setting'.allMatches(testLogger.warningText).length, 1);
       });
     });
+
+    group('CocoaPods script readlink', () {
+      late MemoryFileSystem memoryFileSystem;
+      late BufferLogger testLogger;
+      late FakeIosProject project;
+      late File podRunnerFrameworksScript;
+      late ProcessManager processManager;
+      late XcodeProjectInterpreter xcode143ProjectInterpreter;
+
+      setUp(() {
+        memoryFileSystem = MemoryFileSystem();
+        podRunnerFrameworksScript = memoryFileSystem.file('Pods-Runner-frameworks.sh');
+        testLogger = BufferLogger.test();
+        project = FakeIosProject();
+        processManager = FakeProcessManager.any();
+        xcode143ProjectInterpreter = XcodeProjectInterpreter.test(processManager: processManager, version: Version(14, 3, 0));
+        project.podRunnerFrameworksScript = podRunnerFrameworksScript;
+      });
+
+      testWithoutContext('skipped if files are missing', () {
+        final CocoaPodsScriptReadlink iosProjectMigration = CocoaPodsScriptReadlink(
+          project,
+          xcode143ProjectInterpreter,
+          testLogger,
+        );
+        iosProjectMigration.migrate();
+        expect(podRunnerFrameworksScript.existsSync(), isFalse);
+
+        expect(testLogger.traceText, contains('CocoaPods Pods-Runner-frameworks.sh script not found'));
+        expect(testLogger.statusText, isEmpty);
+      });
+
+      testWithoutContext('skipped if nothing to upgrade', () {
+        const String contents = r'''
+  if [ -L "${source}" ]; then
+    echo "Symlinked..."
+    source="$(readlink -f "${source}")"
+  fi''';
+        podRunnerFrameworksScript.writeAsStringSync(contents);
+
+        final CocoaPodsScriptReadlink iosProjectMigration = CocoaPodsScriptReadlink(
+          project,
+          xcode143ProjectInterpreter,
+          testLogger,
+        );
+        iosProjectMigration.migrate();
+        expect(podRunnerFrameworksScript.existsSync(), isTrue);
+        expect(testLogger.traceText, isEmpty);
+        expect(testLogger.statusText, isEmpty);
+      });
+
+      testWithoutContext('skipped if Xcode version below 14.3', () {
+        const String contents = r'''
+  if [ -L "${source}" ]; then
+    echo "Symlinked..."
+    source="$(readlink "${source}")"
+  fi''';
+        podRunnerFrameworksScript.writeAsStringSync(contents);
+
+        final XcodeProjectInterpreter xcode142ProjectInterpreter = XcodeProjectInterpreter.test(
+          processManager: processManager,
+          version: Version(14, 2, 0),
+        );
+
+        final CocoaPodsScriptReadlink iosProjectMigration = CocoaPodsScriptReadlink(
+          project,
+          xcode142ProjectInterpreter,
+          testLogger,
+        );
+        iosProjectMigration.migrate();
+        expect(podRunnerFrameworksScript.existsSync(), isTrue);
+        expect(testLogger.traceText, contains('Detected Xcode version is 14.2.0, below 14.3, skipping "readlink -f" workaround'));
+        expect(testLogger.statusText, isEmpty);
+      });
+
+      testWithoutContext('Xcode project is migrated', () {
+        const String contents = r'''
+  if [ -L "${source}" ]; then
+    echo "Symlinked..."
+    source="$(readlink "${source}")"
+  fi''';
+        podRunnerFrameworksScript.writeAsStringSync(contents);
+
+        final CocoaPodsScriptReadlink iosProjectMigration = CocoaPodsScriptReadlink(
+          project,
+          xcode143ProjectInterpreter,
+          testLogger,
+        );
+        iosProjectMigration.migrate();
+        expect(podRunnerFrameworksScript.readAsStringSync(), r'''
+  if [ -L "${source}" ]; then
+    echo "Symlinked..."
+    source="$(readlink -f "${source}")"
+  fi
+''');
+        expect(testLogger.statusText, contains('Upgrading Pods-Runner-frameworks.sh'));
+      });
+    });
   });
 
   group('update Xcode script build phase', () {
@@ -1134,6 +1236,9 @@ class FakeIosProject extends Fake implements IosProject {
 
   @override
   File podfile = MemoryFileSystem.test().file('Podfile');
+
+  @override
+  File podRunnerFrameworksScript = MemoryFileSystem.test().file('podRunnerFrameworksScript');
 }
 
 class FakeIOSMigrator extends ProjectMigrator {


### PR DESCRIPTION
Xcode 14.3 (released March 30, 2023) changed the [`readlink`](https://linux.die.net/man/1/readlink) symlink behavior to be relative from the script working directory, instead of the relative path of the symlink.  A CocoaPods script generated as `source="$(readlink "${source}")"` but with the new behavior should be `source="$(readlink -f "${source}")"`.   CocoaPods updated their script at https://github.com/CocoaPods/CocoaPods/pull/11828, but hasn't yet released it.  


This caused a failure when archiving/`flutter build ipa`ing iOS or macOS Flutter apps (build seems to succeed):
```
    Symlinked...
    rsync --delete -av --filter P .*.?????? --links --filter "- CVS/" --filter
    "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter
    "- PrivateHeaders" --filter "- Modules"
    "../../../IntermediateBuildFilesPath/UninstalledProducts/iphoneos/url_launch
    er_ios.framework"
    "/Users/m/Library/Developer/Xcode/DerivedData/Runner-gnengnkipgqsumexkv
    wkdczgvrst/Build/Intermediates.noindex/ArchiveIntermediates/Runner/Installat
    ionBuildProductsLocation/Applications/Runner.app/Frameworks"
    building file list ... rsync: link_stat
```

Add a migrator to copy the CocoaPods workaround and update the generated CocoaPods script so that users don't need to update CocoaPods when they update to Xcode 14.3.  Only run the migrator when Xcode >=14.3.

Confirmed on this PR:
- iOS apps can be archived successfully on Xcode 14.3
- macOS apps can be archived successfully on Xcode 14.3
- the migrator doesn't run on 14.2
- the migration only runs once on 14.3
- after run once, subsequent runs do not kick off a new `pod install`
- manually running `pod install` again after the migration does restore the old behavior, but running `flutter build`/`run` again will re-run the migrator.

Fixes https://github.com/flutter/flutter/issues/123890

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
