### PR TITLE
Fix `clipBehavior` for `Drawer` with shape and add `clipBehavior` property.

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -240,9 +240,9 @@ class Drawer extends StatelessWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// The [clipBehavior] argument is used the clip shape of the drawer.
+  /// The [clipBehavior] argument specifies how to clip the drawer's [shape].
   ///
-  /// If the drawer has a shape, it defaults to [Clip.hardEdge]. Otherwise,
+  /// If the drawer has a [shape], it defaults to [Clip.hardEdge]. Otherwise,
   /// defaults to [Clip.none].
   final Clip? clipBehavior;
 

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -153,6 +153,7 @@ class Drawer extends StatelessWidget {
     this.width,
     this.child,
     this.semanticLabel,
+    this.clipBehavior,
   }) : assert(elevation == null || elevation >= 0.0);
 
   /// Sets the color of the [Material] that holds all of the [Drawer]'s
@@ -237,6 +238,14 @@ class Drawer extends StatelessWidget {
   ///    value is used.
   final String? semanticLabel;
 
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// The [clipBehavior] argument is used the clip shape of the drawer.
+  ///
+  /// If the drawer has a shape, it defaults to [Clip.hardEdge]. Otherwise,
+  /// defaults to [Clip.none].
+  final Clip? clipBehavior;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
@@ -255,6 +264,9 @@ class Drawer extends StatelessWidget {
     final bool useMaterial3 = Theme.of(context).useMaterial3;
     final bool isDrawerStart = DrawerController.maybeOf(context)?.alignment != DrawerAlignment.end;
     final DrawerThemeData defaults= useMaterial3 ? _DrawerDefaultsM3(context): _DrawerDefaultsM2(context);
+    final ShapeBorder? effectiveShape = shape ?? (isDrawerStart
+      ? (drawerTheme.shape ?? defaults.shape)
+      : (drawerTheme.endShape ?? defaults.endShape));
     return Semantics(
       scopesRoute: true,
       namesRoute: true,
@@ -267,9 +279,8 @@ class Drawer extends StatelessWidget {
           elevation: elevation ?? drawerTheme.elevation ?? defaults.elevation!,
           shadowColor: shadowColor ?? drawerTheme.shadowColor ?? defaults.shadowColor,
           surfaceTintColor: surfaceTintColor ?? drawerTheme.surfaceTintColor ?? defaults.surfaceTintColor,
-          shape: shape ?? (isDrawerStart
-            ? (drawerTheme.shape ?? defaults.shape)
-            : (drawerTheme.endShape ?? defaults.endShape)),
+          shape: effectiveShape,
+          clipBehavior: effectiveShape != null ? (clipBehavior ?? Clip.hardEdge) : Clip.none,
           child: child,
         ),
       ),

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -688,6 +688,57 @@ void main() {
     );
   });
 
+  testWidgets('Drawer clip behavior', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: const Scaffold(
+          drawer: Drawer(),
+        ),
+      ),
+    );
+
+    final Finder drawerMaterial = find.descendant(
+      of: find.byType(Drawer),
+      matching: find.byType(Material),
+    );
+
+    final ScaffoldState state = tester.firstState(find.byType(Scaffold));
+
+    // Open the drawer.
+    state.openDrawer();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    // Test default clip behavior.
+    Material material = tester.widget<Material>(drawerMaterial);
+    expect(material.clipBehavior, Clip.hardEdge);
+
+    state.closeDrawer();
+    await tester.pumpAndSettle();
+
+    // Provide a custom clip behavior.
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: const Scaffold(
+          drawer: Drawer(
+            clipBehavior: Clip.antiAlias,
+          ),
+        ),
+      ),
+    );
+
+    // Open the drawer again.
+    state.openDrawer();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    // Clip behavior is now updated.
+    material = tester.widget<Material>(drawerMaterial);
+    expect(material.clipBehavior, Clip.antiAlias);
+  });
+
   group('Material 2', () {
     // Tests that are only relevant for Material 2. Once ThemeData.useMaterial3
     // is turned on by default, these tests can be removed.
@@ -731,6 +782,58 @@ void main() {
       // Test the end drawer shape.
       material = tester.widget<Material>(drawerMaterial);
       expect(material.shape, null);
+    });
+
+    testWidgets('Drawer clip behavior', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: const Scaffold(
+            drawer: Drawer(),
+          ),
+        ),
+      );
+
+      final Finder drawerMaterial = find.descendant(
+        of: find.byType(Drawer),
+        matching: find.byType(Material),
+      );
+
+      final ScaffoldState state = tester.firstState(find.byType(Scaffold));
+
+      // Open the drawer.
+      state.openDrawer();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // Test default clip behavior.
+      Material material = tester.widget<Material>(drawerMaterial);
+      expect(material.clipBehavior, Clip.none);
+
+      state.closeDrawer();
+      await tester.pumpAndSettle();
+
+      // Provide a shape and custom clip behavior.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: const Scaffold(
+            drawer: Drawer(
+              clipBehavior: Clip.hardEdge,
+              shape: RoundedRectangleBorder(),
+            ),
+          ),
+        ),
+      );
+
+      // Open the drawer again.
+      state.openDrawer();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      // Clip behavior is now updated.
+      material = tester.widget<Material>(drawerMaterial);
+      expect(material.clipBehavior, Clip.hardEdge);
     });
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/123863

<details> 
<summary>code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(useMaterial3: true),
      home: const DrawerExample(),
    );
  }
}

class DrawerExample extends StatelessWidget {
  const DrawerExample({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      drawer: const Drawer(
        child: Column(
          children: <Widget>[
            ListTile(
              tileColor: Colors.white,
              title: Text('Drawer'),
            )
          ],
        ),
      ),
      endDrawer: const NavigationDrawer(
        children: <Widget>[
          NavigationDrawerDestination(
            icon: Icon(Icons.favorite_rounded),
            label: Text('Favorite'),
          ),
        ],
      ),
      appBar: AppBar(
        title: const Text('Sample'),
      ),
    );
  }
}

```  
	
</details>

###  Before
![Screenshot 2023-04-04 at 10 40 15](https://user-images.githubusercontent.com/48603081/229723234-14184749-495f-42dc-960d-2a38cb5d43ba.png)




### After

![Screenshot 2023-04-04 at 10 45 08](https://user-images.githubusercontent.com/48603081/229723411-26689430-4f05-49fc-b1d9-18c8a0fd5cf7.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
