### PR TITLE
Make flutter_adapter_test more resilient to pub output

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -60,14 +60,18 @@ void main() {
 
       final String output = _uniqueOutputLines(outputEvents);
 
-      expectLines(output, <Object>[
+      expectLines(
+        output,
+        <Object>[
         'Launching $relativeMainPath on Flutter test device in debug mode...',
-        startsWith('Connecting to VM Service at'),
-        'topLevelFunction',
-        'Application finished.',
-        '',
-        startsWith('Exited'),
-      ]);
+          startsWith('Connecting to VM Service at'),
+          'topLevelFunction',
+          'Application finished.',
+          '',
+          startsWith('Exited'),
+        ],
+        allowExtras: true,
+      );
     });
 
     testWithoutContext('logs to client when sendLogsToClient=true', () async {
@@ -125,13 +129,17 @@ void main() {
 
       final String output = _uniqueOutputLines(outputEvents);
 
-      expectLines(output, <Object>[
-        'Launching $relativeMainPath on Flutter test device in debug mode...',
-        'topLevelFunction',
-        'Application finished.',
-        '',
-        startsWith('Exited'),
-      ]);
+      expectLines(
+        output,
+        <Object>[
+          'Launching $relativeMainPath on Flutter test device in debug mode...',
+          'topLevelFunction',
+          'Application finished.',
+          '',
+          startsWith('Exited'),
+        ],
+        allowExtras: true,
+      );
 
       // If we're running with an out-of-process debug adapter, ensure that its
       // own process shuts down after we terminated.
@@ -246,6 +254,7 @@ void main() {
             startsWith('Reloaded'),
             'topLevelFunction',
           ],
+          allowExtras: true,
       );
 
       await dap.client.terminate();
@@ -320,6 +329,7 @@ void main() {
             startsWith('Restarted application'),
             'topLevelFunction',
           ],
+          allowExtras: true,
       );
 
       await dap.client.terminate();


### PR DESCRIPTION
Makes test more resilient by allowing extra lines instead of exact matching all lines.

Fixes https://github.com/flutter/flutter/issues/124128.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
