### PR TITLE
[InputDatePickerFormField] adds acceptEmptyDate to InputDatePickerFormField Widget

### DIFF
--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -135,7 +135,7 @@ class InputDatePickerFormField extends StatefulWidget {
   ///
   /// Defaults to false.
   ///
-  /// If true, [errorFormatText] is not shown when entered date is empty.
+  /// If true, [errorFormatText] is not shown when the date input field is empty.
   final bool acceptEmptyDate;
 
   @override

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -135,7 +135,7 @@ class InputDatePickerFormField extends StatefulWidget {
   ///
   /// Defaults to false.
   ///
-  /// If true, [errorFormatText] is shown when entered date is empty.
+  /// If true, [errorFormatText] is not shown when entered date is empty.
   final bool acceptEmptyDate;
 
   @override

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -58,6 +58,7 @@ class InputDatePickerFormField extends StatefulWidget {
     this.fieldLabelText,
     this.keyboardType,
     this.autofocus = false,
+    this.acceptEmptyDate = false,
   }) : initialDate = initialDate != null ? DateUtils.dateOnly(initialDate) : null,
        firstDate = DateUtils.dateOnly(firstDate),
        lastDate = DateUtils.dateOnly(lastDate) {
@@ -129,6 +130,13 @@ class InputDatePickerFormField extends StatefulWidget {
 
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
+
+  /// Determines if an empty date would show [errorFormatText] or not.
+  ///
+  /// Defaults to false.
+  ///
+  /// If true, [errorFormatText] is shown when entered date is empty.
+  final bool acceptEmptyDate;
 
   @override
   State<InputDatePickerFormField> createState() => _InputDatePickerFormFieldState();
@@ -206,6 +214,9 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   }
 
   String? _validateDate(String? text) {
+    if ((text == null || text.isEmpty) && widget.acceptEmptyDate) {
+      return null;
+    }
     final DateTime? date = _parseDate(text);
     if (date == null) {
       return widget.errorFormatText ?? MaterialLocalizations.of(context).invalidDateFormatLabel;

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -49,6 +49,7 @@ void main() {
     Key? formKey,
     ThemeData? theme,
     Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
+    bool acceptEmptyDate = false,
   }) {
     return MaterialApp(
       theme: theme ?? ThemeData.from(colorScheme: const ColorScheme.light()),
@@ -69,6 +70,7 @@ void main() {
             fieldHintText: fieldHintText,
             fieldLabelText: fieldLabelText,
             autofocus: autofocus,
+            acceptEmptyDate: acceptEmptyDate,
           ),
         ),
       ),
@@ -344,6 +346,35 @@ void main() {
           localizationsDelegates: delegates,
         )
       );
+    });
+
+    testWidgets('when an empty date is entered and acceptEmptyDate is true, then errorFormatText is not shown', (WidgetTester tester) async {
+      final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+      const String errorFormatText = 'That is not a date.';
+      await tester.pumpWidget(inputDatePickerField(
+        errorFormatText: errorFormatText,
+        formKey: formKey,
+        acceptEmptyDate: true,
+      ));
+      await tester.enterText(find.byType(TextField), '');
+      await tester.pumpAndSettle();
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      expect(find.text(errorFormatText), findsNothing);
+    });
+
+    testWidgets('when an empty date is entered and acceptEmptyDate is false, then errorFormatText is shown', (WidgetTester tester) async {
+      final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+      const String errorFormatText = 'That is not a date.';
+      await tester.pumpWidget(inputDatePickerField(
+        errorFormatText: errorFormatText,
+        formKey: formKey,
+      ));
+      await tester.enterText(find.byType(TextField), '');
+      await tester.pumpAndSettle();
+      formKey.currentState!.validate();
+      await tester.pumpAndSettle();
+      expect(find.text(errorFormatText), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Adds `acceptEmptyDate` property to `InputDatePickerFormField`.

Fixes: #117511

| `acceptEmptyDate` is **false** | `acceptEmptyDate` is **true** |
| --- | ---|
| ![acceptemptydate_false](https://user-images.githubusercontent.com/13456345/229893658-280ecdee-d509-4579-b53c-9d8d485c61b4.gif) | ![acceptemptydate__true](https://user-images.githubusercontent.com/13456345/229895144-115e71bd-e5bb-4653-8db2-9f57dd8262aa.gif) |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
