### PR TITLE
Make `UnderlineInputBorder` consistent

### DIFF
--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -244,9 +244,49 @@ class UnderlineInputBorder extends InputBorder {
     TextDirection? textDirection,
   }) {
     if (borderRadius.bottomLeft != Radius.zero || borderRadius.bottomRight != Radius.zero) {
-      canvas.clipPath(getOuterPath(rect, textDirection: textDirection));
+      _drawMultipleWidth(canvas, borderRadius.toRRect(rect), borderSide);
+    } else {
+      canvas.drawLine(rect.bottomLeft, rect.bottomRight, borderSide.toPaint());
     }
-    canvas.drawLine(rect.bottomLeft, rect.bottomRight, borderSide.toPaint());
+  }
+
+  void _drawMultipleWidth(Canvas canvas, RRect borderRect, BorderSide bottom) {
+    final Paint paint = Paint()..color = bottom.color;
+
+    final RRect inner = _inflateRRect(
+      borderRect,
+      EdgeInsets.fromLTRB(0, 0, 0, bottom.width * (1 - (1 + bottom.strokeAlign) / 2)));
+
+    final RRect outer = _deflateRRect(
+        borderRect,
+        EdgeInsets.fromLTRB(0, 0, 0, bottom.width * (1 + bottom.strokeAlign) / 2));
+    canvas.drawDRRect(outer, inner, paint);
+  }
+
+  static RRect _inflateRRect(RRect rect, EdgeInsets insets) {
+    return RRect.fromLTRBAndCorners(
+      rect.left - insets.left,
+      rect.top - insets.top,
+      rect.right + insets.right,
+      rect.bottom + insets.bottom,
+      topLeft: (rect.tlRadius + Radius.elliptical(insets.left, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      topRight: (rect.trRadius + Radius.elliptical(insets.right, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomRight: (rect.brRadius + Radius.elliptical(insets.right, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomLeft: (rect.blRadius + Radius.elliptical(insets.left, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+    );
+  }
+
+  static RRect _deflateRRect(RRect rect, EdgeInsets insets) {
+    return RRect.fromLTRBAndCorners(
+      rect.left + insets.left,
+      rect.top + insets.top,
+      rect.right - insets.right,
+      rect.bottom - insets.bottom,
+      topLeft: (rect.tlRadius - Radius.elliptical(insets.left, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      topRight: (rect.trRadius - Radius.elliptical(insets.right, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomRight: (rect.brRadius - Radius.elliptical(insets.right, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomLeft:(rect.blRadius - Radius.elliptical(insets.left, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -250,10 +250,12 @@ class UnderlineInputBorder extends InputBorder {
         bottomRight: borderRadius.bottomRight.clamp(maximum: Radius.circular(rect.height / 2)),
       );
 
+      // We set the strokeAlign to center, so the behavior is consistent with
+      // drawLine and with the historical behavior of this border.
       BoxBorder.paintNonUniformBorder(canvas, rect,
           textDirection: textDirection,
           borderRadius: updatedBorderRadius,
-          bottom: borderSide,
+          bottom: borderSide.copyWith(strokeAlign: BorderSide.strokeAlignCenter),
           color: borderSide.color);
     } else {
       canvas.drawLine(rect.bottomLeft, rect.bottomRight, borderSide.toPaint());

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -244,49 +244,20 @@ class UnderlineInputBorder extends InputBorder {
     TextDirection? textDirection,
   }) {
     if (borderRadius.bottomLeft != Radius.zero || borderRadius.bottomRight != Radius.zero) {
-      _drawMultipleWidth(canvas, borderRadius.toRRect(rect), borderSide);
+      // This prevents the border from leaking the color due to anti-aliasing rounding errors.
+      final BorderRadius updatedBorderRadius = BorderRadius.only(
+        bottomLeft: borderRadius.bottomLeft.clamp(maximum: Radius.circular(rect.height / 2)),
+        bottomRight: borderRadius.bottomRight.clamp(maximum: Radius.circular(rect.height / 2)),
+      );
+
+      BoxBorder.paintNonUniformBorder(canvas, rect,
+          textDirection: textDirection,
+          borderRadius: updatedBorderRadius,
+          bottom: borderSide,
+          color: borderSide.color);
     } else {
       canvas.drawLine(rect.bottomLeft, rect.bottomRight, borderSide.toPaint());
     }
-  }
-
-  void _drawMultipleWidth(Canvas canvas, RRect borderRect, BorderSide bottom) {
-    final Paint paint = Paint()..color = bottom.color;
-
-    final RRect inner = _inflateRRect(
-      borderRect,
-      EdgeInsets.fromLTRB(0, 0, 0, bottom.width * (1 - (1 + bottom.strokeAlign) / 2)));
-
-    final RRect outer = _deflateRRect(
-        borderRect,
-        EdgeInsets.fromLTRB(0, 0, 0, bottom.width * (1 + bottom.strokeAlign) / 2));
-    canvas.drawDRRect(outer, inner, paint);
-  }
-
-  static RRect _inflateRRect(RRect rect, EdgeInsets insets) {
-    return RRect.fromLTRBAndCorners(
-      rect.left - insets.left,
-      rect.top - insets.top,
-      rect.right + insets.right,
-      rect.bottom + insets.bottom,
-      topLeft: (rect.tlRadius + Radius.elliptical(insets.left, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      topRight: (rect.trRadius + Radius.elliptical(insets.right, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      bottomRight: (rect.brRadius + Radius.elliptical(insets.right, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      bottomLeft: (rect.blRadius + Radius.elliptical(insets.left, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-    );
-  }
-
-  static RRect _deflateRRect(RRect rect, EdgeInsets insets) {
-    return RRect.fromLTRBAndCorners(
-      rect.left + insets.left,
-      rect.top + insets.top,
-      rect.right - insets.right,
-      rect.bottom - insets.bottom,
-      topLeft: (rect.tlRadius - Radius.elliptical(insets.left, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      topRight: (rect.trRadius - Radius.elliptical(insets.right, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      bottomRight: (rect.brRadius - Radius.elliptical(insets.right, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      bottomLeft:(rect.blRadius - Radius.elliptical(insets.left, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-    );
   }
 
   @override

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6934,4 +6934,25 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
       expect(decoration.isCollapsed, true);
     });
   });
+
+  testWidgets('InputDecorator2 fillColor is clipped by border', (WidgetTester tester) async {
+    const Rect canvasRect = Rect.fromLTWH(0, 0, 100, 100);
+      const UnderlineInputBorder border = UnderlineInputBorder(
+        borderRadius: BorderRadius.all(Radius.circular(12.0)),
+      );
+
+      // Fill is the border's outer path, a rounded rectangle
+      expect(
+          (Canvas canvas) => border.paint(canvas, canvasRect),
+          paints
+            ..drrect(
+            inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 101.0,
+                topLeft: const Radius.circular(12.0),
+                topRight: const Radius.circular(12.0),
+                bottomRight: const Radius.elliptical(12.0, 13.0),
+                bottomLeft: const Radius.elliptical(12.0, 13.0)),
+            outer: RRect.fromLTRBR(0.0, 0.0, 100.0, 100.0, const Radius.circular(12.0)),
+          ),
+      );
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5000,14 +5000,15 @@ void runAllTests({ required bool useMaterial3 }) {
     final RenderBox box = tester.renderObject(find.byType(InputDecorator));
 
     // Fill is the border's outer path, a rounded rectangle
-    expect(box, paints..path(
+    expect(box, paints
+    ..drrect(
       style: PaintingStyle.fill,
-      color: const Color(0xFF00FF00),
-      includes: <Offset>[const Offset(800.0/2.0, 56/2.0)],
-      excludes: <Offset>[
-        const Offset(1.0, 56.0 - 6.0), // bottom left
-        const Offset(800 - 1.0, 56.0 - 6.0), // bottom right
-      ],
+      inner: RRect.fromLTRBAndCorners(0.0, 0.0, 800.0, 47.5,
+          bottomRight: const Radius.elliptical(12.0, 11.5),
+          bottomLeft: const Radius.elliptical(12.0, 11.5)),
+      outer: RRect.fromLTRBAndCorners(0.0, 0.0, 800.0, 48.5,
+          bottomRight: const Radius.elliptical(12.0, 12.5),
+          bottomLeft: const Radius.elliptical(12.0, 12.5)),
     ));
   });
 
@@ -6935,7 +6936,7 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
     });
   });
 
-  testWidgets('InputDecorator fillColor is clipped by border', (WidgetTester tester) async {
+  testWidgets('UnderlineInputBorder clips top border to prevent anti-aliasing glitches', (WidgetTester tester) async {
     const Rect canvasRect = Rect.fromLTWH(0, 0, 100, 100);
     const UnderlineInputBorder border = UnderlineInputBorder(
       borderRadius: BorderRadius.all(Radius.circular(12.0)),
@@ -6944,12 +6945,12 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
       (Canvas canvas) => border.paint(canvas, canvasRect),
       paints
         ..drrect(
-          outer: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 100.0,
-                bottomRight: const Radius.circular(12.0),
-                bottomLeft: const Radius.circular(12.0)),
-          inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 99.0,
-                bottomRight: const Radius.elliptical(12.0, 11.0),
-                bottomLeft: const Radius.elliptical(12.0, 11.0)),
+          outer: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 100.5,
+                bottomRight: const Radius.elliptical(12.0, 12.5),
+                bottomLeft: const Radius.elliptical(12.0, 12.5)),
+          inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 99.5,
+                bottomRight: const Radius.elliptical(12.0, 11.5),
+                bottomLeft: const Radius.elliptical(12.0, 11.5)),
         ),
     );
 
@@ -6960,12 +6961,12 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
       (Canvas canvas) => border2.paint(canvas, canvasRect),
       paints
         ..drrect(
-          outer: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 100.0,
-                bottomRight: const Radius.circular(50.0),
-                bottomLeft: const Radius.circular(50.0)),
-          inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 99.0,
-                bottomRight: const Radius.elliptical(50.0, 49.0),
-                bottomLeft: const Radius.elliptical(50.0, 49.0)),
+          outer: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 100.5,
+                bottomRight: const Radius.elliptical(50.0, 50.5),
+                bottomLeft: const Radius.elliptical(50.0, 50.5)),
+          inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 99.5,
+                bottomRight: const Radius.elliptical(50.0, 49.5),
+                bottomLeft: const Radius.elliptical(50.0, 49.5)),
         ),
       reason: 'clamp is expected',
     );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6935,24 +6935,39 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
     });
   });
 
-  testWidgets('InputDecorator2 fillColor is clipped by border', (WidgetTester tester) async {
+  testWidgets('InputDecorator fillColor is clipped by border', (WidgetTester tester) async {
     const Rect canvasRect = Rect.fromLTWH(0, 0, 100, 100);
-      const UnderlineInputBorder border = UnderlineInputBorder(
-        borderRadius: BorderRadius.all(Radius.circular(12.0)),
-      );
+    const UnderlineInputBorder border = UnderlineInputBorder(
+      borderRadius: BorderRadius.all(Radius.circular(12.0)),
+    );
+    expect(
+      (Canvas canvas) => border.paint(canvas, canvasRect),
+      paints
+        ..drrect(
+          outer: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 100.0,
+                bottomRight: const Radius.circular(12.0),
+                bottomLeft: const Radius.circular(12.0)),
+          inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 99.0,
+                bottomRight: const Radius.elliptical(12.0, 11.0),
+                bottomLeft: const Radius.elliptical(12.0, 11.0)),
+        ),
+    );
 
-      // Fill is the border's outer path, a rounded rectangle
-      expect(
-          (Canvas canvas) => border.paint(canvas, canvasRect),
-          paints
-            ..drrect(
-            inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 101.0,
-                topLeft: const Radius.circular(12.0),
-                topRight: const Radius.circular(12.0),
-                bottomRight: const Radius.elliptical(12.0, 13.0),
-                bottomLeft: const Radius.elliptical(12.0, 13.0)),
-            outer: RRect.fromLTRBR(0.0, 0.0, 100.0, 100.0, const Radius.circular(12.0)),
-          ),
-      );
+    const UnderlineInputBorder border2 = UnderlineInputBorder(
+      borderRadius: BorderRadius.all(Radius.circular(60.0)),
+    );
+    expect(
+      (Canvas canvas) => border2.paint(canvas, canvasRect),
+      paints
+        ..drrect(
+          outer: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 100.0,
+                bottomRight: const Radius.circular(50.0),
+                bottomLeft: const Radius.circular(50.0)),
+          inner: RRect.fromLTRBAndCorners(0.0, 0.0, 100.0, 99.0,
+                bottomRight: const Radius.elliptical(50.0, 49.0),
+                bottomLeft: const Radius.elliptical(50.0, 49.0)),
+        ),
+      reason: 'clamp is expected',
+    );
   });
 }


### PR DESCRIPTION
This was easy to implement. I like the result, I think `borderRadius.zero` -> `borderRadius.circular` makes a nice transition, and many places (like macOS) use an effect similar to this PR, while Google doesn't use anywhere (yet). I'm curious if it is going to break goldens or google testing.

<img width="954" alt="ttt" src="https://user-images.githubusercontent.com/351125/229918871-9f2ab851-6b41-44f5-80b9-c7928a8c0014.png">

What do you think? cc @HansMuller @gspencergoog. Is this something you want, should I ask the community, or do you prefer the current one?

Side effects:
- This makes strokeAlign work with `UnderlineInputBorder` (TODO: fix `drawLine` when borderRadius is zero).
- This is faster than the current implementation (clip is slow on Skia). 🚀 
- We could just call `BoxBorder._paintNonUniformBorder` (if it weren't private). Single LOC implementation.
- Web does this by default:
![image](https://user-images.githubusercontent.com/351125/233448671-90ce62ff-be91-40ca-8007-e82b57f3272e.png)
- Apparently no tests fail and most usages around (via code search) seem to be without a borderRadius.