### PR TITLE
Fix a memory leak in `AutomaticKeepAlive`

### DIFF
--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -144,7 +144,8 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
   }
 
   VoidCallback _createCallback(Listenable handle) {
-    return () {
+    late final VoidCallback callback;
+    return callback = () {
       assert(() {
         if (!mounted) {
           throw FlutterError(
@@ -157,6 +158,7 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
         return true;
       }());
       _handles!.remove(handle);
+      handle.removeListener(callback);
       if (_handles!.isEmpty) {
         if (SchedulerBinding.instance.schedulerPhase.index < SchedulerPhase.persistentCallbacks.index) {
           // Build/layout haven't started yet so let's just schedule this for

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -557,6 +557,26 @@ void main() {
 
     expect(alternate.children.length, 1);
   });
+
+  testWidgets('Keep alive Listenable has its listener removed once called', (WidgetTester tester) async {
+    final LeakCheckerHandle handle = LeakCheckerHandle();
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView.builder(
+        itemCount: 1,
+        itemBuilder: (BuildContext context, int index) {
+          return const KeepAliveListenableLeakChecker(key: GlobalObjectKey<_KeepAliveListenableLeakCheckerState>(0));
+        },
+      ),
+    ));
+    final _KeepAliveListenableLeakCheckerState state = const GlobalObjectKey<_KeepAliveListenableLeakCheckerState>(0).currentState!;
+
+    expect(handle.hasListeners, false);
+    state.dispatch(handle);
+    expect(handle.hasListeners, true);
+    handle.notifyListeners();
+    expect(handle.hasListeners, false);
+  });
 }
 
 class _AlwaysKeepAlive extends StatefulWidget {
@@ -632,4 +652,35 @@ class RenderSliverMultiBoxAdaptorAlt extends RenderSliver with
 
   @override
   void performLayout() { }
+}
+
+class LeakCheckerHandle with ChangeNotifier {
+  @override
+  bool get hasListeners => super.hasListeners;
+}
+
+class KeepAliveListenableLeakChecker extends StatefulWidget {
+  const KeepAliveListenableLeakChecker({super.key});
+
+  @override
+  State<KeepAliveListenableLeakChecker> createState() => _KeepAliveListenableLeakCheckerState();
+}
+
+class _KeepAliveListenableLeakCheckerState extends State<KeepAliveListenableLeakChecker> {
+  final LeakCheckerHandle _handle = LeakCheckerHandle();
+
+  @override
+  void deactivate() {
+    _handle.dispose();
+    super.deactivate();
+  }
+
+  void dispatch(Listenable handle) {
+    KeepAliveNotification(handle).dispatch(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
 }

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -667,14 +667,6 @@ class KeepAliveListenableLeakChecker extends StatefulWidget {
 }
 
 class _KeepAliveListenableLeakCheckerState extends State<KeepAliveListenableLeakChecker> {
-  final LeakCheckerHandle _handle = LeakCheckerHandle();
-
-  @override
-  void deactivate() {
-    _handle.dispose();
-    super.deactivate();
-  }
-
   void dispatch(Listenable handle) {
     KeepAliveNotification(handle).dispatch(context);
   }


### PR DESCRIPTION
Previously, if a KeepAliveHandle outlived an AutomaticKeepAlive (e.g., switching locations in the tree), it'd cause a memory leak by holding onto the AutomaticKeepAlive. This PR fixes that leak by calling `removeListener` once the listener is fired. See more: https://github.com/flutter/flutter/pull/123864#issuecomment-1493365197

This PR was spun off of #123864.

CC @dnfield @Piinks 