### PR TITLE
Allow multiple KeepAliveNotifications from the same KeepAliveHandle

### DIFF
--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -287,9 +287,8 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
 /// [KeepAliveNotification] is not immediately sent, then the widget risks being
 /// garbage collected while it wants to be kept alive.
 ///
-/// It is an error to use the same [handle] in two [KeepAliveNotification]s
-/// within the same [AutomaticKeepAlive] without triggering that [handle] before
-/// the second notification is sent.
+/// It is acceptable to provide the same [handle] to multiple
+/// [KeepAliveNotification]s without needing to trigger the [handle] inbetween.
 ///
 /// For a more convenient way to interact with [AutomaticKeepAlive] widgets,
 /// consider using [AutomaticKeepAliveClientMixin], which uses

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -79,9 +79,11 @@ class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {
   bool _addClient(KeepAliveNotification notification) {
     final Listenable handle = notification.handle;
     _handles ??= <Listenable, VoidCallback>{};
-    assert(!_handles!.containsKey(handle));
-    _handles![handle] = _createCallback(handle);
-    handle.addListener(_handles![handle]!);
+    if (!_handles!.containsKey(handle)) {
+      _handles![handle] = _createCallback(handle);
+      handle.addListener(_handles![handle]!);
+    }
+
     if (!_keepingAlive) {
       _keepingAlive = true;
       final ParentDataElement<KeepAliveParentDataMixin>? childElement = _getChildElement();

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -577,6 +577,18 @@ void main() {
     handle.notifyListeners();
     expect(handle.hasListeners, false);
   });
+
+  testWidgets('Dispatching multiple KeepAliveNotifications does not throw', (WidgetTester tester) async {
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ListView.builder(
+        itemCount: 1,
+        itemBuilder: (BuildContext context, int index) {
+          return const MultiKeepAliveNotificationDispatchWidget();
+        },
+      ),
+    ));
+  });
 }
 
 class _AlwaysKeepAlive extends StatefulWidget {
@@ -673,6 +685,30 @@ class _KeepAliveListenableLeakCheckerState extends State<KeepAliveListenableLeak
 
   @override
   Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}
+
+class MultiKeepAliveNotificationDispatchWidget extends StatefulWidget {
+  const MultiKeepAliveNotificationDispatchWidget({super.key});
+
+  @override
+  State<MultiKeepAliveNotificationDispatchWidget> createState() => _MultiKeepAliveNotificationDispatchWidgetState();
+}
+
+class _MultiKeepAliveNotificationDispatchWidgetState extends State<MultiKeepAliveNotificationDispatchWidget> {
+  final KeepAliveHandle _handle = KeepAliveHandle();
+
+  @override
+  void deactivate() {
+    _handle.dispose();
+    super.deactivate();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    KeepAliveNotification(_handle).dispatch(context);
+    KeepAliveNotification(_handle).dispatch(context);
     return const Placeholder();
   }
 }


### PR DESCRIPTION
Previously, dispatching multiple `KeepAliveNotification`s would break an assert. However, the assert was faulty because this behavior should be allowed based on the documentation (i.e., should be able to dispatch a notification whenever you want a keep alive, perhaps once every build).

This PR was spun off of #123864.

CC @dnfield @Piinks