### PR TITLE
TextSelectionHandleControls deprecation deletion timeframe

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3256,12 +3256,11 @@ enum ClipboardStatus {
   notPasteable,
 }
 
+// TODO(justinmc): Deprecate this after TextSelectionControls.buildToolbar is
+// deleted, when users should migrate back to TextSelectionControls.buildHandle.
+// See https://github.com/flutter/flutter/pull/124262
 /// [TextSelectionControls] that specifically do not manage the toolbar in order
 /// to leave that to [EditableText.contextMenuBuilder].
-@Deprecated(
-  'Use `TextSelectionControls`. '
-  'This feature was deprecated after v3.9.0-21.0.pre.',
-)
 mixin TextSelectionHandleControls on TextSelectionControls {
   @override
   Widget buildToolbar(

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3260,7 +3260,7 @@ enum ClipboardStatus {
 /// to leave that to [EditableText.contextMenuBuilder].
 @Deprecated(
   'Use `TextSelectionControls`. '
-  'This feature was deprecated after v3.3.0-0.5.pre.',
+  'This feature was deprecated after v3.9.0-21.0.pre.',
 )
 mixin TextSelectionHandleControls on TextSelectionControls {
   @override


### PR DESCRIPTION
This came out of [this discussion](https://github.com/flutter/flutter/pull/123827#discussion_r1156544790) on another PR.  This PR executes "Option 2" in my list of options.

Currently, TextSelectionControls.buildToolbar and TextSelectionHandleControls have the same deprecation version, which implies that they will both be deleted at the same time.  This creates a problematic migration for users:

  1. Receive a deprecation warning.  Migrate from `TextSelectionControls.buildToolbar to `EditableText.buildContextMenu` and from `TextSelectionControls.buildHandle` to `TextSelectionHandleControls.buildHandle`.
  2. Receive a sudden breakage when `TextSelectionHandleControls` is deleted, and have to migrate immediately back to `TextSelectionControls.buildHandle`.

Instead, I've bumped the deprecation version so that the deletion happens in two stages.  This results in a two-stage migration process and avoids the sudden breaking change:

  1. (Same as before) Receive a deprecation warning.  Migrate from `TextSelectionControls.buildToolbar` to `EditableText.buildContextMenu` and from `TextSelectionControls.buildHandle` to `TextSelectionHandleControls.buildHandle`.
  2. Receive another deprecation warning when `TextSelectionControls.buildToolbar` is removed.  Migrate from `TextSelectionHandleControls.buildToolbar` back to `TextSelectionControls.buildToolbar`.
  3. `TextSelectionHandleControls` is removed safely.