### PR TITLE
[web] - fix text editing integration tests for new DOM structure

### DIFF
--- a/dev/integration_tests/web_e2e_tests/lib/common.dart
+++ b/dev/integration_tests/web_e2e_tests/lib/common.dart
@@ -25,6 +25,13 @@ List<Node> findElements(String selector) {
     );
   }
 
+  // TODO(htoor3): Remove shadowRoot selectors once DOM structure PR is merged.
+  final Element? flutterView = document.querySelector('flutter-view');
+
+  if(flutterView != null){
+    return flutterView.querySelectorAll(selector);
+  }
+
   final ShadowRoot? shadowRoot = glassPane.shadowRoot;
   return shadowRoot != null
     ? shadowRoot.querySelectorAll(selector)


### PR DESCRIPTION
Before we can merge the DOM structure changes, we need to merge this backwards-compatible fix in so the tests don't break. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
