### PR TITLE
Revert "flutter tool: make FlutterOptions abstract final"

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -97,7 +97,7 @@ class FlutterCommandResult {
 }
 
 /// Common flutter command line options.
-abstract final class FlutterOptions {
+class FlutterOptions {
   static const String kExtraFrontEndOptions = 'extra-front-end-options';
   static const String kExtraGenSnapshotOptions = 'extra-gen-snapshot-options';
   static const String kEnableExperiment = 'enable-experiment';


### PR DESCRIPTION
Reverts flutter/flutter#124178

Not sure whether this change or https://github.com/flutter/flutter/pull/124165 has turned the tree red, so reverting both.