### PR TITLE
Revert "flutter tool: log dart2wasm vs dart2js as appropriate during build"

### DIFF
--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -119,11 +119,7 @@ class WebBuilder {
     } finally {
       status.stop();
     }
-    _flutterUsage.sendTiming(
-      'build',
-      isWasm ? 'dart2wasm' : 'dart2js',
-      Duration(milliseconds: sw.elapsedMilliseconds),
-    );
+    _flutterUsage.sendTiming('build', 'dart2js', Duration(milliseconds: sw.elapsedMilliseconds));
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
@@ -78,7 +78,7 @@ void main() {
     // Sends timing event.
     final TestTimingEvent timingEvent = testUsage.timings.single;
     expect(timingEvent.category, 'build');
-    expect(timingEvent.variableName, 'dart2wasm');
+    expect(timingEvent.variableName, 'dart2js');
   });
 
   testUsingContext('WebBuilder throws tool exit on failure', () async {


### PR DESCRIPTION
Reverts flutter/flutter#124165

Not sure whether this or https://github.com/flutter/flutter/pull/124178 turned the tree red so reverting both.

https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20module_host_with_custom_build_test/12399/overview