### PR TITLE
Update re-thrown error for incompatible Java/Gradle versions to include migration guide

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -687,22 +687,12 @@ final GradleHandledError incompatibleJavaAndGradleVersionsHandler = GradleHandle
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
-    final File gradlePropertiesFile = project.directory
-        .childDirectory('android')
-        .childDirectory('gradle')
-        .childDirectory('wrapper')
-        .childFile('gradle-wrapper.properties');
     // TODO(reidbaker): Replace URL with constant defined in
     // https://github.com/flutter/flutter/pull/123916.
     globals.printBox(
       "${globals.logger.terminal.warningMark} Your project's Gradle version "
       'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
-      'To fix this issue, first, check the Java version used by Flutter by '
-      'running `flutter doctor --verbose`.\n\n'
-      'Then, update the Gradle version specified in ${gradlePropertiesFile.path} '
-      'to be compatible with that Java version. '
-      'See the link below for more information on compatible Java/Gradle versions:\n'
-      'https://docs.gradle.org/current/userguide/compatibility.html#java\n\n',
+      'To fix this issue, consult the migration guide at docs.flutter.devgo/android-android-gradle-error.',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -692,7 +692,7 @@ final GradleHandledError incompatibleJavaAndGradleVersionsHandler = GradleHandle
     globals.printBox(
       "${globals.logger.terminal.warningMark} Your project's Gradle version "
       'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
-      'To fix this issue, consult the migration guide at docs.flutter.dev/go/android-android-gradle-error.',
+      'To fix this issue, consult the migration guide at docs.flutter.dev/go/android-java-gradle-error.',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -692,7 +692,7 @@ final GradleHandledError incompatibleJavaAndGradleVersionsHandler = GradleHandle
     globals.printBox(
       "${globals.logger.terminal.warningMark} Your project's Gradle version "
       'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
-      'To fix this issue, consult the migration guide at docs.flutter.devgo/android-android-gradle-error.',
+      'To fix this issue, consult the migration guide at docs.flutter.dev/go/android-android-gradle-error.',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1330,7 +1330,7 @@ Could not compile build file '…/example/android/build.gradle'.
 
       // Ensure the error notes the incompatible Gradle/AGP/Java versions and links to related resources.
       expect(testLogger.statusText, contains('Gradle version is incompatible with the Java version'));
-      expect(testLogger.statusText, contains('docs.flutter.dev/go/android-android-gradle-error'));
+      expect(testLogger.statusText, contains('docs.flutter.dev/go/android-java-gradle-error'));
     }, overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
       Platform: () => fakePlatform('android'),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1330,7 +1330,7 @@ Could not compile build file '…/example/android/build.gradle'.
 
       // Ensure the error notes the incompatible Gradle/AGP/Java versions and links to related resources.
       expect(testLogger.statusText, contains('Gradle version is incompatible with the Java version'));
-      expect(testLogger.statusText, contains('https://docs.gradle.org/current/userguide/compatibility.html#java'));
+      expect(testLogger.statusText, contains('docs.flutter.devgo/android-android-gradle-error'));
     }, overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
       Platform: () => fakePlatform('android'),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1330,7 +1330,7 @@ Could not compile build file '…/example/android/build.gradle'.
 
       // Ensure the error notes the incompatible Gradle/AGP/Java versions and links to related resources.
       expect(testLogger.statusText, contains('Gradle version is incompatible with the Java version'));
-      expect(testLogger.statusText, contains('docs.flutter.devgo/android-android-gradle-error'));
+      expect(testLogger.statusText, contains('docs.flutter.dev/go/android-android-gradle-error'));
     }, overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
       Platform: () => fakePlatform('android'),


### PR DESCRIPTION
Updates error message concerning incompatible Java/Gradle versions to reference migration guide that will be created in https://github.com/flutter/website/pull/8501.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
