### PR TITLE
Adaptive alert dialog

### DIFF
--- a/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
+++ b/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       // Try this: set the platform to platform.android and see the difference
-      theme: ThemeData(platform: TargetPlatform.iOS),
+      theme: ThemeData(platform: TargetPlatform.iOS, useMaterial3: true),
       home: Scaffold(
         appBar: AppBar(title: const Text('AlertDialog Sample')),
         body: const Center(

--- a/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
+++ b/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
@@ -1,0 +1,76 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for [AlertDialog].
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      // Try this: set the platform to platform.android and see the difference
+      theme: ThemeData(platform: TargetPlatform.iOS),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('AlertDialog Sample')),
+        body: const Center(
+          child: AdaptiveDialogExample(),
+        ),
+      ),
+    );
+  }
+}
+
+class AdaptiveDialogExample extends StatelessWidget {
+  const AdaptiveDialogExample({super.key});
+
+  Widget adaptiveAction({
+    required BuildContext context,
+    required VoidCallback onPressed,
+    required Widget child
+  }) {
+    final ThemeData theme = Theme.of(context);
+    switch (theme.platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return TextButton(onPressed: onPressed, child: child);
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return CupertinoDialogAction(onPressed: onPressed, child: child);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () => showAdaptiveDialog<String>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog.adaptive(
+          title: const Text('AlertDialog Title'),
+          content: const Text('AlertDialog description'),
+          actions: <Widget>[
+            adaptiveAction(
+              context: context,
+              onPressed: () => Navigator.pop(context, 'Cancel'),
+              child: const Text('Cancel'),
+            ),
+            adaptiveAction(
+              context: context,
+              onPressed: () => Navigator.pop(context, 'OK'),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ),
+      child: const Text('Show Dialog'),
+    );
+  }
+}

--- a/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
+++ b/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // Try this: set the platform to platform.android and see the difference
+      // Try this: set the platform to TargetPlatform.android and see the difference
       theme: ThemeData(platform: TargetPlatform.iOS, useMaterial3: true),
       home: Scaffold(
         appBar: AppBar(title: const Text('AlertDialog Sample')),

--- a/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
+++ b/examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flutter code sample for [AlertDialog].
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+/// Flutter code sample for [AlertDialog].
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+void main() => runApp(const AdaptiveAlertDialogApp());
+
+class AdaptiveAlertDialogApp extends StatelessWidget {
+  const AdaptiveAlertDialogApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/test/material/dialog/adaptive_alert_dialog.0_test.dart
+++ b/examples/api/test/material/dialog/adaptive_alert_dialog.0_test.dart
@@ -12,7 +12,7 @@ void main() {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
-          body: example.MyApp(),
+          body: example.AdaptiveAlertDialogApp(),
         ),
       ),
     );

--- a/examples/api/test/material/dialog/adaptive_alert_dialog.0_test.dart
+++ b/examples/api/test/material/dialog/adaptive_alert_dialog.0_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/dialog/adaptive_alert_dialog.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Show Adaptive Alert dialog', (WidgetTester tester) async {
+    const String dialogTitle = 'AlertDialog Title';
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: example.MyApp(),
+        ),
+      ),
+    );
+
+    expect(find.text(dialogTitle), findsNothing);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Show Dialog'));
+    await tester.pumpAndSettle();
+    expect(find.text(dialogTitle), findsOneWidget);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.text(dialogTitle), findsNothing);
+  });
+}

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -411,6 +411,17 @@ class AlertDialog extends StatelessWidget {
   /// are ignored: [title], [content], and [actions].
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
+  ///
+  /// {@tool dartpad}
+  /// This demo shows a [TextButton] which when pressed, calls [showAdaptiveDialog].
+  /// When called, this method displays an adaptive dialog above the current
+  /// contents of the app, with different behaviors depending on target platform.
+  ///
+  /// [CupertinoDialogAction] is conditionally used as the child to show more
+  /// platform specific design.
+  ///
+  /// ** See code in examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart **
+  /// {@end-tool}
   const AlertDialog.adaptive({
     super.key,
     this.icon,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -730,9 +730,6 @@ class AlertDialog extends StatelessWidget {
   ///    section when it is long.
   final ScrollController? actionScrollController;
 
-  ScrollController get _effectiveActionScrollController =>
-    actionScrollController ?? ScrollController();
-
   /// {@macro flutter.material.dialog.insetAnimationDuration}
   ///
   /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -397,7 +397,20 @@ class AlertDialog extends StatelessWidget {
     this.scrollable = false,
   }) : _dialogType = _DialogType.material;
 
-  /// Adaptive alert dialog
+  /// Creates an adaptive [AlertDialog] based on whether the target platform is
+  /// iOS or macOS, following Material design's
+  /// [Cross-platform guidelines](https://material.io/design/platform-guidance/cross-platform-adaptation.html).
+  ///
+  /// On iOS and macOS, this constructor creates a [CupertinoAlertDialog]. On
+  /// other platforms, this creates a Material design [AlertDialog].
+  ///
+  /// Typically passed as a child of [showAdaptiveDialog], which will display
+  /// the alert differently based on platform.
+  ///
+  /// If a [CupertinoAlertDialog] is created, all but the following parameters
+  /// are ignored: [title], [content], and [actions].
+  ///
+  /// The target platform is based on the current [Theme]: [ThemeData.platform].
   const AlertDialog.adaptive({
     super.key,
     this.icon,
@@ -1363,7 +1376,14 @@ Future<T?> showDialog<T>({
   ));
 }
 
-/// Displays an adaptive dialog.
+/// Displays either a Material or Cupertino dialog depending on platform.
+///
+/// On most platforms this function will act the same as [showDialog], except
+/// for iOS and macOS, in which case it will act the same as
+/// [showCupertinoDialog].
+///
+/// On Cupertino platforms, [barrierColor], [useSafeArea], and
+/// [traversalEdgeBehavior] are ignored.
 Future<T?> showAdaptiveDialog<T>({
   required BuildContext context,
   required WidgetBuilder builder,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -411,8 +411,8 @@ class AlertDialog extends StatelessWidget {
   /// Typically passed as a child of [showAdaptiveDialog], which will display
   /// the alert differently based on platform.
   ///
-  /// If a [CupertinoAlertDialog] is created, all parameters are ignored except
-  /// for: [title], [content], [actions], [scrollController],
+  /// If a [CupertinoAlertDialog] is created only these parameters are used:
+  /// [title], [content], [actions], [scrollController],
   /// [actionScrollController], [insetAnimationDuration], and
   /// [insetAnimationCurve]. If a material [AlertDialog] is created,
   /// [scrollController], [actionScrollController], [insetAnimationDuration],

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -411,12 +411,12 @@ class AlertDialog extends StatelessWidget {
   /// Typically passed as a child of [showAdaptiveDialog], which will display
   /// the alert differently based on platform.
   ///
-  /// If a [CupertinoAlertDialog] is created, all but the following parameters
-  /// are ignored: [title], [content], [actions], [scrollController],
+  /// If a [CupertinoAlertDialog] is created, all parameters are ignored except
+  /// for: [title], [content], [actions], [scrollController],
   /// [actionScrollController], [insetAnimationDuration], and
-  /// [insetAnimationCurve]. If a [AlertDialog] is created, [scrollController],
-  /// [actionScrollController], [insetAnimationDuration], and
-  /// [insetAnimationCurve] are ignored.
+  /// [insetAnimationCurve]. If a material [AlertDialog] is created,
+  /// [scrollController], [actionScrollController], [insetAnimationDuration],
+  /// and [insetAnimationCurve] are ignored.
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
   ///

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -4,8 +4,8 @@
 
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show clampDouble;
-import 'package:flutter/widgets.dart';
 
 import 'color_scheme.dart';
 import 'colors.dart';
@@ -23,6 +23,8 @@ import 'theme_data.dart';
 // late BuildContext context;
 
 const EdgeInsets _defaultInsetPadding = EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
+
+enum _DialogType {material, adaptive }
 
 /// A Material Design dialog.
 ///
@@ -393,7 +395,38 @@ class AlertDialog extends StatelessWidget {
     this.shape,
     this.alignment,
     this.scrollable = false,
-  });
+  }) : _dialogType = _DialogType.material;
+
+  /// Adaptive alert dialog
+  const AlertDialog.adaptive({
+    super.key,
+    this.icon,
+    this.iconPadding,
+    this.iconColor,
+    this.title,
+    this.titlePadding,
+    this.titleTextStyle,
+    this.content,
+    this.contentPadding,
+    this.contentTextStyle,
+    this.actions,
+    this.actionsPadding,
+    this.actionsAlignment,
+    this.actionsOverflowAlignment,
+    this.actionsOverflowDirection,
+    this.actionsOverflowButtonSpacing,
+    this.buttonPadding,
+    this.backgroundColor,
+    this.elevation,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.semanticLabel,
+    this.insetPadding = _defaultInsetPadding,
+    this.clipBehavior = Clip.none,
+    this.shape,
+    this.alignment,
+    this.scrollable = false,
+  }) : _dialogType = _DialogType.adaptive;
 
   /// An optional icon to display at the top of the dialog.
   ///
@@ -634,10 +667,32 @@ class AlertDialog extends StatelessWidget {
   /// button bar.
   final bool scrollable;
 
+  final _DialogType _dialogType;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = Theme.of(context);
+    switch (_dialogType) {
+      case _DialogType.material:
+        break;
+
+      case _DialogType.adaptive:
+        switch(theme.platform) {
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+            break;
+          case TargetPlatform.iOS:
+          case TargetPlatform.macOS:
+            return CupertinoAlertDialog(
+              title: title,
+              content: content,
+              actions: actions ?? <Widget>[],
+            );
+        }
+    }
     final DialogTheme dialogTheme = DialogTheme.of(context);
     final DialogTheme defaults = theme.useMaterial3 ? _DialogDefaultsM3(context) : _DialogDefaultsM2(context);
 
@@ -1306,6 +1361,51 @@ Future<T?> showDialog<T>({
     anchorPoint: anchorPoint,
     traversalEdgeBehavior: traversalEdgeBehavior ?? TraversalEdgeBehavior.closedLoop,
   ));
+}
+
+/// Displays an adaptive dialog.
+Future<T?> showAdaptiveDialog<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool? barrierDismissible,
+  Color? barrierColor = Colors.black54,
+  String? barrierLabel,
+  bool useSafeArea = true,
+  bool useRootNavigator = true,
+  RouteSettings? routeSettings,
+  Offset? anchorPoint,
+  TraversalEdgeBehavior? traversalEdgeBehavior,
+}) {
+  final ThemeData theme = Theme.of(context);
+  switch (theme.platform) {
+    case TargetPlatform.android:
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.linux:
+    case TargetPlatform.windows:
+      return showDialog<T>(
+        context: context,
+        builder: builder,
+        barrierDismissible: barrierDismissible ?? true,
+        barrierColor: barrierColor,
+        barrierLabel: barrierLabel,
+        useSafeArea: useSafeArea,
+        useRootNavigator: useRootNavigator,
+        routeSettings: routeSettings,
+        anchorPoint: anchorPoint,
+        traversalEdgeBehavior: traversalEdgeBehavior,
+      );
+    case TargetPlatform.iOS:
+    case TargetPlatform.macOS:
+      return showCupertinoDialog<T>(
+        context: context,
+        builder: builder,
+        barrierDismissible: barrierDismissible ?? false,
+        barrierLabel: barrierLabel,
+        useRootNavigator: useRootNavigator,
+        anchorPoint: anchorPoint,
+        routeSettings: routeSettings,
+      );
+  }
 }
 
 bool _debugIsActive(BuildContext context) {

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -395,7 +395,11 @@ class AlertDialog extends StatelessWidget {
     this.shape,
     this.alignment,
     this.scrollable = false,
-  }) : _dialogType = _DialogType.material;
+  }) : _dialogType = _DialogType.material,
+       scrollController = null,
+       actionScrollController = null,
+       insetAnimationDuration = const Duration(milliseconds: 100),
+       insetAnimationCurve = Curves.decelerate;
 
   /// Creates an adaptive [AlertDialog] based on whether the target platform is
   /// iOS or macOS, following Material design's
@@ -408,7 +412,11 @@ class AlertDialog extends StatelessWidget {
   /// the alert differently based on platform.
   ///
   /// If a [CupertinoAlertDialog] is created, all but the following parameters
-  /// are ignored: [title], [content], and [actions].
+  /// are ignored: [title], [content], [actions], [scrollController],
+  /// [actionScrollController], [insetAnimationDuration], and
+  /// [insetAnimationCurve]. If a [AlertDialog] is created, [scrollController],
+  /// [actionScrollController], [insetAnimationDuration], and
+  /// [insetAnimationCurve] are ignored.
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
   ///
@@ -450,6 +458,10 @@ class AlertDialog extends StatelessWidget {
     this.shape,
     this.alignment,
     this.scrollable = false,
+    this.scrollController,
+    this.actionScrollController,
+    this.insetAnimationDuration = const Duration(milliseconds: 100),
+    this.insetAnimationCurve = Curves.decelerate,
   }) : _dialogType = _DialogType.adaptive;
 
   /// An optional icon to display at the top of the dialog.
@@ -691,6 +703,46 @@ class AlertDialog extends StatelessWidget {
   /// button bar.
   final bool scrollable;
 
+  /// A scroll controller that can be used to control the scrolling of the
+  /// [content] in the dialog.
+  ///
+  /// Defaults to null, and is typically not needed, since most alert messages
+  /// are short.
+  ///
+  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
+  ///
+  /// See also:
+  ///
+  ///  * [actionScrollController], which can be used for controlling the actions
+  ///    section when there are many actions.
+  final ScrollController? scrollController;
+
+  /// A scroll controller that can be used to control the scrolling of the
+  /// actions in the dialog.
+  ///
+  /// Defaults to null, and is typically not needed.
+  ///
+  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
+  ///
+  /// See also:
+  ///
+  ///  * [scrollController], which can be used for controlling the [content]
+  ///    section when it is long.
+  final ScrollController? actionScrollController;
+
+  ScrollController get _effectiveActionScrollController =>
+    actionScrollController ?? ScrollController();
+
+  /// {@macro flutter.material.dialog.insetAnimationDuration}
+  ///
+  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
+  final Duration insetAnimationDuration;
+
+  /// {@macro flutter.material.dialog.insetAnimationCurve}
+  ///
+  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
+  final Curve insetAnimationCurve;
+
   final _DialogType _dialogType;
 
   @override
@@ -714,6 +766,10 @@ class AlertDialog extends StatelessWidget {
               title: title,
               content: content,
               actions: actions ?? <Widget>[],
+              scrollController: scrollController,
+              actionScrollController: actionScrollController,
+              insetAnimationDuration: insetAnimationDuration,
+              insetAnimationCurve: insetAnimationCurve,
             );
         }
     }

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -24,8 +24,6 @@ import 'theme_data.dart';
 
 const EdgeInsets _defaultInsetPadding = EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
 
-enum _DialogType {material, adaptive }
-
 /// A Material Design dialog.
 ///
 /// This dialog widget does not have any opinion about the contents of the
@@ -395,11 +393,7 @@ class AlertDialog extends StatelessWidget {
     this.shape,
     this.alignment,
     this.scrollable = false,
-  }) : _dialogType = _DialogType.material,
-       scrollController = null,
-       actionScrollController = null,
-       insetAnimationDuration = const Duration(milliseconds: 100),
-       insetAnimationCurve = Curves.decelerate;
+  });
 
   /// Creates an adaptive [AlertDialog] based on whether the target platform is
   /// iOS or macOS, following Material design's
@@ -430,39 +424,39 @@ class AlertDialog extends StatelessWidget {
   ///
   /// ** See code in examples/api/lib/material/dialog/adaptive_alert_dialog.0.dart **
   /// {@end-tool}
-  const AlertDialog.adaptive({
-    super.key,
-    this.icon,
-    this.iconPadding,
-    this.iconColor,
-    this.title,
-    this.titlePadding,
-    this.titleTextStyle,
-    this.content,
-    this.contentPadding,
-    this.contentTextStyle,
-    this.actions,
-    this.actionsPadding,
-    this.actionsAlignment,
-    this.actionsOverflowAlignment,
-    this.actionsOverflowDirection,
-    this.actionsOverflowButtonSpacing,
-    this.buttonPadding,
-    this.backgroundColor,
-    this.elevation,
-    this.shadowColor,
-    this.surfaceTintColor,
-    this.semanticLabel,
-    this.insetPadding = _defaultInsetPadding,
-    this.clipBehavior = Clip.none,
-    this.shape,
-    this.alignment,
-    this.scrollable = false,
-    this.scrollController,
-    this.actionScrollController,
-    this.insetAnimationDuration = const Duration(milliseconds: 100),
-    this.insetAnimationCurve = Curves.decelerate,
-  }) : _dialogType = _DialogType.adaptive;
+  const factory AlertDialog.adaptive({
+    Key? key,
+    Widget? icon,
+    EdgeInsetsGeometry? iconPadding,
+    Color? iconColor,
+    Widget? title,
+    EdgeInsetsGeometry? titlePadding,
+    TextStyle? titleTextStyle,
+    Widget? content,
+    EdgeInsetsGeometry? contentPadding,
+    TextStyle? contentTextStyle,
+    List<Widget>? actions,
+    EdgeInsetsGeometry? actionsPadding,
+    MainAxisAlignment? actionsAlignment,
+    OverflowBarAlignment? actionsOverflowAlignment,
+    VerticalDirection? actionsOverflowDirection,
+    double? actionsOverflowButtonSpacing,
+    EdgeInsetsGeometry? buttonPadding,
+    Color? backgroundColor,
+    double? elevation,
+    Color? shadowColor,
+    Color? surfaceTintColor,
+    String? semanticLabel,
+    EdgeInsets insetPadding,
+    Clip clipBehavior,
+    ShapeBorder? shape,
+    AlignmentGeometry? alignment,
+    bool scrollable,
+    ScrollController? scrollController,
+    ScrollController? actionScrollController,
+    Duration insetAnimationDuration,
+    Curve insetAnimationCurve,
+  }) = _AdaptiveAlertDialog;
 
   /// An optional icon to display at the top of the dialog.
   ///
@@ -703,73 +697,11 @@ class AlertDialog extends StatelessWidget {
   /// button bar.
   final bool scrollable;
 
-  /// A scroll controller that can be used to control the scrolling of the
-  /// [content] in the dialog.
-  ///
-  /// Defaults to null, and is typically not needed, since most alert messages
-  /// are short.
-  ///
-  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
-  ///
-  /// See also:
-  ///
-  ///  * [actionScrollController], which can be used for controlling the actions
-  ///    section when there are many actions.
-  final ScrollController? scrollController;
-
-  /// A scroll controller that can be used to control the scrolling of the
-  /// actions in the dialog.
-  ///
-  /// Defaults to null, and is typically not needed.
-  ///
-  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
-  ///
-  /// See also:
-  ///
-  ///  * [scrollController], which can be used for controlling the [content]
-  ///    section when it is long.
-  final ScrollController? actionScrollController;
-
-  /// {@macro flutter.material.dialog.insetAnimationDuration}
-  ///
-  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
-  final Duration insetAnimationDuration;
-
-  /// {@macro flutter.material.dialog.insetAnimationCurve}
-  ///
-  /// Only used when [AlertDialog.adaptive] resolves to an iOS platform.
-  final Curve insetAnimationCurve;
-
-  final _DialogType _dialogType;
-
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = Theme.of(context);
-    switch (_dialogType) {
-      case _DialogType.material:
-        break;
 
-      case _DialogType.adaptive:
-        switch(theme.platform) {
-          case TargetPlatform.android:
-          case TargetPlatform.fuchsia:
-          case TargetPlatform.linux:
-          case TargetPlatform.windows:
-            break;
-          case TargetPlatform.iOS:
-          case TargetPlatform.macOS:
-            return CupertinoAlertDialog(
-              title: title,
-              content: content,
-              actions: actions ?? <Widget>[],
-              scrollController: scrollController,
-              actionScrollController: actionScrollController,
-              insetAnimationDuration: insetAnimationDuration,
-              insetAnimationCurve: insetAnimationCurve,
-            );
-        }
-    }
     final DialogTheme dialogTheme = DialogTheme.of(context);
     final DialogTheme defaults = theme.useMaterial3 ? _DialogDefaultsM3(context) : _DialogDefaultsM2(context);
 
@@ -952,6 +884,71 @@ class AlertDialog extends StatelessWidget {
       alignment: alignment,
       child: dialogChild,
     );
+  }
+}
+
+class _AdaptiveAlertDialog extends AlertDialog {
+  const _AdaptiveAlertDialog({
+    super.key,
+    super.icon,
+    super.iconPadding,
+    super.iconColor,
+    super.title,
+    super.titlePadding,
+    super.titleTextStyle,
+    super.content,
+    super.contentPadding,
+    super.contentTextStyle,
+    super.actions,
+    super.actionsPadding,
+    super.actionsAlignment,
+    super.actionsOverflowAlignment,
+    super.actionsOverflowDirection,
+    super.actionsOverflowButtonSpacing,
+    super.buttonPadding,
+    super.backgroundColor,
+    super.elevation,
+    super.shadowColor,
+    super.surfaceTintColor,
+    super.semanticLabel,
+    super.insetPadding = _defaultInsetPadding,
+    super.clipBehavior = Clip.none,
+    super.shape,
+    super.alignment,
+    super.scrollable = false,
+    this.scrollController,
+    this.actionScrollController,
+    this.insetAnimationDuration = const Duration(milliseconds: 100),
+    this.insetAnimationCurve = Curves.decelerate,
+  });
+
+  final ScrollController? scrollController;
+  final ScrollController? actionScrollController;
+  final Duration insetAnimationDuration;
+  final Curve insetAnimationCurve;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    switch(theme.platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        break;
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return CupertinoAlertDialog(
+          title: title,
+          content: content,
+          actions: actions ?? <Widget>[],
+          scrollController: scrollController,
+          actionScrollController: actionScrollController,
+          insetAnimationDuration: insetAnimationDuration,
+          insetAnimationCurve: insetAnimationCurve,
+        );
+    }
+    return super.build(context);
   }
 }
 

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -2668,8 +2668,8 @@ void main() {
       ),
       actions: <Widget>[
         TextButton(
-            onPressed: () {},
-            child: const Text('OK'),
+          onPressed: () {},
+          child: const Text('OK'),
         ),
       ],
     );

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -2701,7 +2701,7 @@ void main() {
     }
   });
 
-  testWidgets('showAdaptiveDialog should have the right behavior', (WidgetTester tester) async {
+  testWidgets('showAdaptiveDialog should not allow dismiss on barrier on iOS by default', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(platform: TargetPlatform.iOS),
@@ -2759,7 +2759,6 @@ void main() {
 
     await tester.pumpAndSettle(const Duration(seconds: 1));
     expect(find.text('Dialog2'), findsOneWidget);
-
   });
 
   testWidgets('Uses open focus traversal when overridden', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -2656,6 +2657,109 @@ void main() {
     expect(await previousFocus(), true);
     expect(okNode.hasFocus, true);
     expect(cancelNode.hasFocus, false);
+  });
+
+  testWidgets('Adaptive AlertDialog shows correct widget on each platform', (WidgetTester tester) async {
+    final AlertDialog dialog = AlertDialog.adaptive(
+      content: Container(
+        height: 5000.0,
+        width: 300.0,
+        color: Colors.green[500],
+      ),
+      actions: <Widget>[
+        TextButton(
+            onPressed: () {},
+            child: const Text('OK'),
+        ),
+      ],
+    );
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS, TargetPlatform.macOS ]) {
+      await tester.pumpWidget(_buildAppWithDialog(dialog, theme: ThemeData(platform: platform)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoAlertDialog), findsOneWidget);
+
+      await tester.tapAt(const Offset(10.0, 10.0));
+      await tester.pumpAndSettle();
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows ]) {
+      await tester.pumpWidget(_buildAppWithDialog(dialog, theme: ThemeData(platform: platform)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoAlertDialog), findsNothing);
+
+      await tester.tapAt(const Offset(10.0, 10.0));
+      await tester.pumpAndSettle();
+    }
+  });
+
+  testWidgets('showAdaptiveDialog should have the right behavior', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.iOS),
+        home: const Material(
+          child: Center(
+            child: ElevatedButton(
+              onPressed: null,
+              child: Text('Go'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final BuildContext context = tester.element(find.text('Go'));
+
+    showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return Container(
+          width: 100.0,
+          height: 100.0,
+          alignment: Alignment.center,
+          child: const Text('Dialog1'),
+        );
+      },
+    );
+
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(find.text('Dialog1'), findsOneWidget);
+
+    // Tap on the barrier.
+    await tester.tapAt(const Offset(10.0, 10.0));
+
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(find.text('Dialog1'), findsNothing);
+
+    showAdaptiveDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return Container(
+          width: 100.0,
+          height: 100.0,
+          alignment: Alignment.center,
+          child: const Text('Dialog2'),
+        );
+      },
+    );
+
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(find.text('Dialog2'), findsOneWidget);
+
+    // Tap on the barrier, which shouldn't do anything this time.
+    await tester.tapAt(const Offset(10.0, 10.0));
+
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(find.text('Dialog2'), findsOneWidget);
+
   });
 
   testWidgets('Uses open focus traversal when overridden', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #102811. Adds an adaptive constructor to AlertDialog, along with the adaptive function showAdaptiveDialog.

<img width="357" alt="Screenshot 2023-04-06 at 10 40 18 AM" src="https://user-images.githubusercontent.com/58190796/230455412-31100922-cfc5-4252-b8c6-6f076353f29e.png">
<img width="350" alt="Screenshot 2023-04-06 at 10 42 50 AM" src="https://user-images.githubusercontent.com/58190796/230455454-363dd37e-c44e-4aca-b6a0-cfa1d959f606.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
