### PR TITLE
Adds `dart_fix` support to `flutter_test`

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -927,7 +927,7 @@ Future<void> _runFrameworkTests() async {
     }
   }
 
-  Future<void> runFixTests() async {
+  Future<void> runFixTests(String package) async {
     final List<String> args = <String>[
       'fix',
       '--compare-to-golden',
@@ -935,7 +935,7 @@ Future<void> _runFrameworkTests() async {
     await runCommand(
       dart,
       args,
-      workingDirectory: path.join(flutterRoot, 'packages', 'flutter', 'test_fixes'),
+      workingDirectory: path.join(flutterRoot, 'packages', package, 'test_fixes'),
     );
   }
 
@@ -965,7 +965,8 @@ Future<void> _runFrameworkTests() async {
   Future<void> runSlow() async {
     printProgress('${green}Running slow package tests$reset for directories other than packages/flutter');
     await runTracingTests();
-    await runFixTests();
+    await runFixTests('flutter');
+    await runFixTests('flutter_test');
     await runPrivateTests();
   }
 

--- a/packages/flutter/lib/fix_data/README.md
+++ b/packages/flutter/lib/fix_data/README.md
@@ -5,7 +5,7 @@ define the [`dart fix` framework](https://dart.dev/tools/dart-fix) refactorings
 used by the Flutter framework.
 
 The number of fix rules defined in a file should not exceed 50 for better
-maintainability. Searching for `title:` is a given `.yaml` file will account
+maintainability. Searching for `title:` in a given `.yaml` file will account
 for the number of fixes. Splitting out fix rules should be done by class.
 
 When adding a new `.yaml` file, make a copy of `fix_template.yaml`. If the new

--- a/packages/flutter_test/analysis_options.yaml
+++ b/packages/flutter_test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+
+analyzer:
+  exclude:
+    - "test_fixes/**"

--- a/packages/flutter_test/lib/fix_data/README.md
+++ b/packages/flutter_test/lib/fix_data/README.md
@@ -1,0 +1,46 @@
+## Directory contents
+
+The `.yaml` files in these directories are used to
+define the [`dart fix` framework](https://dart.dev/tools/dart-fix) refactorings
+used by the Flutter framework.
+
+The number of fix rules defined in a file should not exceed 50 for better
+maintainability. Searching for `title:` is a given `.yaml` file will account
+for the number of fixes. Splitting out fix rules should be done by class.
+
+When adding a new `.yaml` file, make a copy of `template.yaml`. If the new
+file is not for generic library fixes (`fix_material.yaml`), ensure it is
+enclosed in an appropriate library directory (`fix_data/fix_material`), and
+named after the class. Fix files outside of generic libraries should represent
+individual classes (`fix_data/fix_material/fix_app_bar.yaml`).
+
+See the flutter/packages/flutter_test/test_fixes directory for the tests that
+validate these fix rules.
+
+To run these tests locally, execute this command in the
+flutter/packages/flutter_test/test_fixes directory.
+```sh
+dart fix --compare-to-golden
+```
+
+For more documentation about Data Driven Fixes, see
+https://dart.dev/go/data-driven-fixes#test-folder.
+
+To learn more about how fixes are authored in package:flutter_test, see
+https://github.com/flutter/flutter/wiki/Data-driven-Fixes
+
+## When making structural changes to this directory
+
+The tests in this directory are also invoked from external
+repositories. Specifically, the CI system for the dart-lang/sdk repo
+runs these tests in order to ensure that changes to the dart fix file
+format do not break Flutter.
+
+See [tools/bots/flutter/analyze_flutter_flutter.sh](https://github.com/dart-lang/sdk/blob/main/tools/bots/flutter/analyze_flutter_flutter.sh)
+for where the flutter fix tests are invoked for the dart repo.
+
+See [dev/bots/test.dart](https://github.com/flutter/flutter/blob/master/dev/bots/test.dart)
+for where the flutter fix tests are invoked for the flutter/flutter repo.
+
+When possible, please coordinate changes to this directory that might affect the
+`analyze_flutter_flutter.sh` script.

--- a/packages/flutter_test/lib/fix_data/README.md
+++ b/packages/flutter_test/lib/fix_data/README.md
@@ -2,17 +2,16 @@
 
 The `.yaml` files in these directories are used to
 define the [`dart fix` framework](https://dart.dev/tools/dart-fix) refactorings
-used by the Flutter framework.
+used by `flutter_test`.
 
 The number of fix rules defined in a file should not exceed 50 for better
-maintainability. Searching for `title:` is a given `.yaml` file will account
+maintainability. Searching for `title:` in a given `.yaml` file will account
 for the number of fixes. Splitting out fix rules should be done by class.
 
-When adding a new `.yaml` file, make a copy of `template.yaml`. If the new
-file is not for generic library fixes (`fix_material.yaml`), ensure it is
-enclosed in an appropriate library directory (`fix_data/fix_material`), and
-named after the class. Fix files outside of generic libraries should represent
-individual classes (`fix_data/fix_material/fix_app_bar.yaml`).
+When adding a new `.yaml` file, make a copy of `template.yaml`. Each file should
+be for a single class and named `fix_<class>.yaml`. To make sure each file is
+grouped with related classes, a `fix_<filename>` folder will contain all of the
+fix files for the individual classes.
 
 See the flutter/packages/flutter_test/test_fixes directory for the tests that
 validate these fix rules.

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_animation_sheet_builder.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_animation_sheet_builder.yaml
@@ -16,14 +16,14 @@
 # For documentation about this file format, see
 # https://dart.dev/go/data-driven-fixes.
 
-# * Fixes in this file are for AnimationSheetBuilder from the flutter_test/animation_sheet library. *
+# * Fixes in this file are for AnimationSheetBuilder from the flutter_test/animation_sheet.dart file. *
 
 version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/83337
   # The related deprecation for `sheetSize` doesn't have a fix because there
   # isn't an alternative API, it's being removed completely.
-  - title: 'Use collate instead'
+  - title: 'Migrate to collate'
     date: 2023-03-29
     element:
       uris: [ 'flutter_test.dart' ]

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_animation_sheet_builder.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_animation_sheet_builder.yaml
@@ -1,0 +1,42 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/test_fixes/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for AnimationSheetBuilder from the flutter_test/animation_sheet library. *
+
+version: 1
+transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/83337
+  # The related deprecation for `sheetSize` doesn't have a fix because there
+  # isn't an alternative API, it's being removed completely.
+  - title: 'Use collate instead'
+    date: 2023-03-29
+    element:
+      uris: [ 'flutter_test.dart' ]
+      method: 'display'
+      inClass: 'AnimationSheetBuilder'
+    changes:
+      - kind: 'rename'
+        newName: 'collate'
+      - kind: 'removeParameter'
+        name: 'key'
+      - kind: 'addParameter'
+        index: 0
+        name: 'cellsPerRow'
+        style: 'required_positional'
+        argumentValue:
+          expression: '1'

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_automated_test_widgets_flutter_binding.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_automated_test_widgets_flutter_binding.yaml
@@ -1,0 +1,32 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/test_fixes/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for AutomatedTestWidgetsFlutterBinding from the flutter_test/binding library. *
+
+version: 1
+transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/89952
+  - title: "Don't use timeout parameter"
+    date: 2023-03-30
+    element:
+      uris: [ 'flutter_test.dart' ]
+      method: 'runTest'
+      inClass: 'AutomatedTestWidgetsFlutterBinding'
+    changes:
+      - kind: 'removeParameter'
+        name: 'timeout'

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_automated_test_widgets_flutter_binding.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_automated_test_widgets_flutter_binding.yaml
@@ -16,12 +16,12 @@
 # For documentation about this file format, see
 # https://dart.dev/go/data-driven-fixes.
 
-# * Fixes in this file are for AutomatedTestWidgetsFlutterBinding from the flutter_test/binding library. *
+# * Fixes in this file are for AutomatedTestWidgetsFlutterBinding from the flutter_test/binding.dart file. *
 
 version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/89952
-  - title: "Don't use timeout parameter"
+  - title: "Remove timeout"
     date: 2023-03-30
     element:
       uris: [ 'flutter_test.dart' ]

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_live_test_widgets_flutter_binding.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_live_test_widgets_flutter_binding.yaml
@@ -1,0 +1,32 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/test_fixes/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for LiveTestWidgetsFlutterBinding from the flutter_test/binding library. *
+
+version: 1
+transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/89952
+  - title: "Don't use timeout parameter"
+    date: 2023-03-30
+    element:
+      uris: [ 'flutter_test.dart' ]
+      method: 'runTest'
+      inClass: 'LiveTestWidgetsFlutterBinding'
+    changes:
+      - kind: 'removeParameter'
+        name: 'timeout'

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_live_test_widgets_flutter_binding.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_live_test_widgets_flutter_binding.yaml
@@ -16,12 +16,12 @@
 # For documentation about this file format, see
 # https://dart.dev/go/data-driven-fixes.
 
-# * Fixes in this file are for LiveTestWidgetsFlutterBinding from the flutter_test/binding library. *
+# * Fixes in this file are for LiveTestWidgetsFlutterBinding from the flutter_test/binding.dart file. *
 
 version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/89952
-  - title: "Don't use timeout parameter"
+  - title: "Remove timeout"
     date: 2023-03-30
     element:
       uris: [ 'flutter_test.dart' ]

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_test_widgets_flutter_binding.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_test_widgets_flutter_binding.yaml
@@ -1,0 +1,45 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/test_fixes/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for TestWidgetsFlutterBinding from the flutter_test/binding library. *
+
+version: 1
+transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/89952
+  - title: "Don't use timeout parameter"
+    date: 2023-03-30
+    element:
+      uris: [ 'flutter_test.dart' ]
+      method: 'runTest'
+      inClass: 'TestWidgetsFlutterBinding'
+    changes:
+      - kind: 'removeParameter'
+        name: 'timeout'
+
+  # Changes made in https://github.com/flutter/flutter/pull/89952
+  # The related deprecation for `addTime` doesn't have a fix as the method is
+  # being removed completely.
+  - title: "Don't use additionalTime parameter"
+    date: 2023-03-30
+    element:
+      uris: [ 'flutter_test.dart' ]
+      method: 'runAsync'
+      inClass: 'TestWidgetsFlutterBinding'
+    changes:
+      - kind: 'removeParameter'
+        name: 'additionalTime'

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_test_widgets_flutter_binding.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_binding/fix_test_widgets_flutter_binding.yaml
@@ -16,12 +16,12 @@
 # For documentation about this file format, see
 # https://dart.dev/go/data-driven-fixes.
 
-# * Fixes in this file are for TestWidgetsFlutterBinding from the flutter_test/binding library. *
+# * Fixes in this file are for TestWidgetsFlutterBinding from the flutter_test/binding.dart file. *
 
 version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/89952
-  - title: "Don't use timeout parameter"
+  - title: "Remove timeout"
     date: 2023-03-30
     element:
       uris: [ 'flutter_test.dart' ]
@@ -34,7 +34,7 @@ transforms:
   # Changes made in https://github.com/flutter/flutter/pull/89952
   # The related deprecation for `addTime` doesn't have a fix as the method is
   # being removed completely.
-  - title: "Don't use additionalTime parameter"
+  - title: "Remove additionalTime"
     date: 2023-03-30
     element:
       uris: [ 'flutter_test.dart' ]

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_widget_tester.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_widget_tester.yaml
@@ -16,12 +16,12 @@
 # For documentation about this file format, see
 # https://dart.dev/go/data-driven-fixes.
 
-# * Fixes in this file are for the flutter_test/widget_tester library. *
+# * Fixes in this file are for the flutter_test/widget_tester.dart file. *
 
 version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/89952
-  - title: "Don't use initialTimeout"
+  - title: "Migrate to timeout"
     date: 2023-03-30
     element:
       uris: [ 'flutter_test.dart' ]

--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_widget_tester.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_widget_tester.yaml
@@ -1,0 +1,51 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/test_fixes/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for the flutter_test/widget_tester library. *
+
+version: 1
+transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/89952
+  - title: "Don't use initialTimeout"
+    date: 2023-03-30
+    element:
+      uris: [ 'flutter_test.dart' ]
+      function: 'testWidgets'
+    oneOf:
+      - if: "initialTimeout != '' && timeout == ''"
+        changes:
+          - kind: 'addParameter'
+            index: 3
+            name: 'timeout'
+            style: optional_named
+            argumentValue:
+              expression: 'Timeout({% initialTimeout %})'
+              requiredIf: "initialTimeout != '' && timeout == ''"
+          - kind: 'removeParameter'
+            name: 'initialTimeout'
+      - if: "initialTimeout != '' && timeout != ''"
+        changes:
+          - kind: 'removeParameter'
+            name: 'initialTimeout'
+    variables:
+      initialTimeout:
+        kind: 'fragment'
+        value: 'arguments[initialTimeout]'
+      timeout:
+        kind: 'fragment'
+        value: 'arguments[timeout]'

--- a/packages/flutter_test/lib/fix_data/template.yaml
+++ b/packages/flutter_test/lib/fix_data/template.yaml
@@ -1,0 +1,25 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/lib/fix_data/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are [for CLASS] from the <XXX> library. *
+
+# Uncomment version & transforms, and follow with fixes.
+# version: 1
+# transforms:
+
+# Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -759,6 +759,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       'This parameter has no effect. Use the `timeout` parameter on `testWidgets` instead. '
       'This feature was deprecated after v2.6.0-1.0.pre.'
     )
+    // TODO(pdblasi-google): Do not remove until https://github.com/flutter/flutter/issues/124346
+    // is complete, as this removal will cascade into `integration_test`
     Duration? timeout,
   });
 
@@ -1430,6 +1432,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       'This parameter has no effect. Use the `timeout` parameter on `testWidgets` instead. '
       'This feature was deprecated after v2.6.0-1.0.pre.'
     )
+    // TODO(pdblasi-google): Do not remove until https://github.com/flutter/flutter/issues/124346
+    // is complete, as this removal will cascade into `integration_test`
     Duration? timeout,
   }) {
     assert(!inTest);
@@ -1927,6 +1931,8 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       'This parameter has no effect. Use the `timeout` parameter on `testWidgets` instead. '
       'This feature was deprecated after v2.6.0-1.0.pre.'
     )
+    // TODO(pdblasi-google): Do not remove until https://github.com/flutter/flutter/issues/124346
+    // is complete, as this removal will cascade into `integration_test`
     Duration? timeout,
   }) {
     assert(!inTest);

--- a/packages/flutter_test/test_fixes/analysis_options.yaml
+++ b/packages/flutter_test/test_fixes/analysis_options.yaml
@@ -1,0 +1,1 @@
+# This ensures that parent analysis options do not accidentally break the fix tests.

--- a/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart
@@ -10,17 +10,13 @@ void main() {
     final AnimationSheetBuilder animationSheet =
         AnimationSheetBuilder(frameSize: const Size(48, 24));
 
-    await tester.pumpFrames(
-      animationSheet.record(const CircularProgressIndicator()),
-      const Duration(seconds: 1),
-    );
-
     // This line will remain unchanged as there is no replacement for the
     // `sheetSize` API.
     tester.binding.setSurfaceSize(animationSheet.sheetSize());
 
-    // This line will replace the call to `display` with a call to `collate`
+    // These lines will replace the calls to `display` with a call to `collate`
     // but will still have a build error.
+    // Changes made in https://github.com/flutter/flutter/pull/83337
     final Widget display = await animationSheet.display();
     final Widget display2 = await animationSheet.display(key: UniqueKey());
   });

--- a/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart
@@ -1,0 +1,27 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('test', (WidgetTester tester) async {
+    final AnimationSheetBuilder animationSheet =
+        AnimationSheetBuilder(frameSize: const Size(48, 24));
+
+    await tester.pumpFrames(
+      animationSheet.record(const CircularProgressIndicator()),
+      const Duration(seconds: 1),
+    );
+
+    // This line will remain unchanged as there is no replacement for the
+    // `sheetSize` API.
+    tester.binding.setSurfaceSize(animationSheet.sheetSize());
+
+    // This line will replace the call to `display` with a call to `collate`
+    // but will still have a build error.
+    final Widget display = await animationSheet.display();
+    final Widget display2 = await animationSheet.display(key: UniqueKey());
+  });
+}

--- a/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart.expect
@@ -1,0 +1,27 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('test', (WidgetTester tester) async {
+    final AnimationSheetBuilder animationSheet =
+        AnimationSheetBuilder(frameSize: const Size(48, 24));
+
+    await tester.pumpFrames(
+      animationSheet.record(const CircularProgressIndicator()),
+      const Duration(seconds: 1),
+    );
+
+    // This line will remain unchanged as there is no replacement for the
+    // `sheetSize` API.
+    tester.binding.setSurfaceSize(animationSheet.sheetSize());
+
+    // This line will replace the call to `display` with a call to `collate`
+    // but will still have a build error.
+    final Widget display = await animationSheet.collate(1);
+    final Widget display2 = await animationSheet.collate(1);
+  });
+}

--- a/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/animation_sheet_builder.dart.expect
@@ -10,17 +10,13 @@ void main() {
     final AnimationSheetBuilder animationSheet =
         AnimationSheetBuilder(frameSize: const Size(48, 24));
 
-    await tester.pumpFrames(
-      animationSheet.record(const CircularProgressIndicator()),
-      const Duration(seconds: 1),
-    );
-
     // This line will remain unchanged as there is no replacement for the
     // `sheetSize` API.
     tester.binding.setSurfaceSize(animationSheet.sheetSize());
 
-    // This line will replace the call to `display` with a call to `collate`
+    // These lines will replace the calls to `display` with a call to `collate`
     // but will still have a build error.
+    // Changes made in https://github.com/flutter/flutter/pull/83337
     final Widget display = await animationSheet.collate(1);
     final Widget display2 = await animationSheet.collate(1);
   });

--- a/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart
@@ -1,0 +1,18 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final binding = AutomatedTestWidgetsFlutterBinding.ensureInitialized();
+  binding.runTest(
+    () async {
+      expect(true, isTrue);
+    },
+    () { },
+    // This timeout will be removed and not replaced since there is no
+    // equivalent API at this layer.
+    timeout: Duration(minutes: 30),
+  );
+}

--- a/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart
@@ -7,12 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final binding = AutomatedTestWidgetsFlutterBinding.ensureInitialized();
   binding.runTest(
-    () async {
-      expect(true, isTrue);
-    },
+    () async { },
     () { },
-    // This timeout will be removed and not replaced since there is no
-    // equivalent API at this layer.
+    // Changes made in https://github.com/flutter/flutter/pull/89952
     timeout: Duration(minutes: 30),
   );
 }

--- a/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart.expect
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final binding = AutomatedTestWidgetsFlutterBinding.ensureInitialized();
+  binding.runTest(
+    () async {
+      expect(true, isTrue);
+    },
+    () { },
+  );
+}

--- a/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/automated_test_widgets_flutter_binding.dart.expect
@@ -7,9 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final binding = AutomatedTestWidgetsFlutterBinding.ensureInitialized();
   binding.runTest(
-    () async {
-      expect(true, isTrue);
-    },
+    () async { },
     () { },
   );
 }

--- a/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart
@@ -1,0 +1,18 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final binding = LiveTestWidgetsFlutterBinding.ensureInitialized();
+  binding.runTest(
+    () async {
+      expect(true, isTrue);
+    },
+    () { },
+    // This timeout will be removed and not replaced since there is no
+    // equivalent API at this layer.
+    timeout: Duration(minutes: 30),
+  );
+}

--- a/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart
@@ -7,12 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final binding = LiveTestWidgetsFlutterBinding.ensureInitialized();
   binding.runTest(
-    () async {
-      expect(true, isTrue);
-    },
+    () async { },
     () { },
-    // This timeout will be removed and not replaced since there is no
-    // equivalent API at this layer.
+    // Changes made in https://github.com/flutter/flutter/pull/89952
     timeout: Duration(minutes: 30),
   );
 }

--- a/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart.expect
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final binding = LiveTestWidgetsFlutterBinding.ensureInitialized();
+  binding.runTest(
+    () async {
+      expect(true, isTrue);
+    },
+    () { },
+  );
+}

--- a/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/live_test_widgets_flutter_binding.dart.expect
@@ -7,9 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final binding = LiveTestWidgetsFlutterBinding.ensureInitialized();
   binding.runTest(
-    () async {
-      expect(true, isTrue);
-    },
+    () async { },
     () { },
   );
 }

--- a/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart
@@ -1,0 +1,62 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:clock/src/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  TestWidgetsFlutterBinding binding = FakeTestWidgetsFlutterBinding();
+  binding.runTest(
+    () async {
+      // This will be unchanged as there is no equivalent API.
+      binding.addTime(Duration(seconds: 30));
+
+      await binding.runAsync(
+        () async {},
+        // The `additionalTime` parameter will be removed
+        additionalTime: Duration(seconds: 25),
+      );
+    },
+    () { },
+    // This timeout will be removed and not replaced since there is no
+    // equivalent API at this layer.
+    timeout: Duration(minutes: 30),
+  );
+}
+
+class FakeTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
+  @override
+  Clock get clock => throw UnimplementedError();
+
+  @override
+  Timeout get defaultTestTimeout => throw UnimplementedError();
+
+  @override
+  Future<void> delayed(Duration duration) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool get inTest => throw UnimplementedError();
+
+  @override
+  int get microtaskCount => throw UnimplementedError();
+
+  @override
+  Future<void> pump([Duration? duration, EnginePhase newPhase = EnginePhase.sendSemanticsUpdate]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<T?> runAsync<T>(Future<T> Function() callback, {Duration additionalTime = const Duration(milliseconds: 1000)}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> runTest(Future<void> Function() testBody, VoidCallback invariantTester, {String description = '', Duration? timeout}) {
+    throw UnimplementedError();
+  }
+}

--- a/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart
@@ -8,7 +8,7 @@ import 'package:clock/src/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  TestWidgetsFlutterBinding binding = FakeTestWidgetsFlutterBinding();
+  TestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding.ensureInitialized();
   binding.runTest(
     () async {
       // This will be unchanged as there is no equivalent API.
@@ -16,7 +16,7 @@ void main() async {
 
       await binding.runAsync(
         () async {},
-        // The `additionalTime` parameter will be removed
+        // Changes made in https://github.com/flutter/flutter/pull/89952
         additionalTime: Duration(seconds: 25),
       );
     },
@@ -25,38 +25,4 @@ void main() async {
     // equivalent API at this layer.
     timeout: Duration(minutes: 30),
   );
-}
-
-class FakeTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
-  @override
-  Clock get clock => throw UnimplementedError();
-
-  @override
-  Timeout get defaultTestTimeout => throw UnimplementedError();
-
-  @override
-  Future<void> delayed(Duration duration) {
-    throw UnimplementedError();
-  }
-
-  @override
-  bool get inTest => throw UnimplementedError();
-
-  @override
-  int get microtaskCount => throw UnimplementedError();
-
-  @override
-  Future<void> pump([Duration? duration, EnginePhase newPhase = EnginePhase.sendSemanticsUpdate]) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<T?> runAsync<T>(Future<T> Function() callback, {Duration additionalTime = const Duration(milliseconds: 1000)}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> runTest(Future<void> Function() testBody, VoidCallback invariantTester, {String description = '', Duration? timeout}) {
-    throw UnimplementedError();
-  }
 }

--- a/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart.expect
@@ -2,13 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
-import 'package:clock/src/clock.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  TestWidgetsFlutterBinding binding = FakeTestWidgetsFlutterBinding();
+  TestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding.ensureInitialized();
   binding.runTest(
     () async {
       // This will be unchanged as there is no equivalent API.
@@ -20,38 +17,4 @@ void main() async {
     },
     () { },
   );
-}
-
-class FakeTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
-  @override
-  Clock get clock => throw UnimplementedError();
-
-  @override
-  Timeout get defaultTestTimeout => throw UnimplementedError();
-
-  @override
-  Future<void> delayed(Duration duration) {
-    throw UnimplementedError();
-  }
-
-  @override
-  bool get inTest => throw UnimplementedError();
-
-  @override
-  int get microtaskCount => throw UnimplementedError();
-
-  @override
-  Future<void> pump([Duration? duration, EnginePhase newPhase = EnginePhase.sendSemanticsUpdate]) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<T?> runAsync<T>(Future<T> Function() callback, {Duration additionalTime = const Duration(milliseconds: 1000)}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> runTest(Future<void> Function() testBody, VoidCallback invariantTester, {String description = '', Duration? timeout}) {
-    throw UnimplementedError();
-  }
 }

--- a/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/binding/test_widgets_flutter_binding.dart.expect
@@ -1,0 +1,57 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:clock/src/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() async {
+  TestWidgetsFlutterBinding binding = FakeTestWidgetsFlutterBinding();
+  binding.runTest(
+    () async {
+      // This will be unchanged as there is no equivalent API.
+      binding.addTime(Duration(seconds: 30));
+
+      await binding.runAsync(
+        () async {},
+      );
+    },
+    () { },
+  );
+}
+
+class FakeTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
+  @override
+  Clock get clock => throw UnimplementedError();
+
+  @override
+  Timeout get defaultTestTimeout => throw UnimplementedError();
+
+  @override
+  Future<void> delayed(Duration duration) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool get inTest => throw UnimplementedError();
+
+  @override
+  int get microtaskCount => throw UnimplementedError();
+
+  @override
+  Future<void> pump([Duration? duration, EnginePhase newPhase = EnginePhase.sendSemanticsUpdate]) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<T?> runAsync<T>(Future<T> Function() callback, {Duration additionalTime = const Duration(milliseconds: 1000)}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> runTest(Future<void> Function() testBody, VoidCallback invariantTester, {String description = '', Duration? timeout}) {
+    throw UnimplementedError();
+  }
+}

--- a/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart
@@ -7,15 +7,18 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('test', (WidgetTester tester) async {
     // This call will be unchanged
+    // Changes made in https://github.com/flutter/flutter/pull/89952
   }, timeout: Timeout(Duration(hours: 1)));
 
   testWidgets('test', (WidgetTester tester) async {
     // The `timeout` will remain unchanged, but `initialTimeout` will be removed
+    // Changes made in https://github.com/flutter/flutter/pull/89952
   },
   timeout: Timeout(Duration(minutes: 45)),
   initialTimeout: Duration(minutes: 30));
 
   testWidgets('test', (WidgetTester tester) async {
     // initialTimeout will be wrapped in a Timeout and changed to `timeout`
+    // Changes made in https://github.com/flutter/flutter/pull/89952
   }, initialTimeout: Duration(seconds: 30));
 }

--- a/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('test', (WidgetTester tester) async {
+    // This call will be unchanged
+  }, timeout: Timeout(Duration(hours: 1)));
+
+  testWidgets('test', (WidgetTester tester) async {
+    // The `timeout` will remain unchanged, but `initialTimeout` will be removed
+  },
+  timeout: Timeout(Duration(minutes: 45)),
+  initialTimeout: Duration(minutes: 30));
+
+  testWidgets('test', (WidgetTester tester) async {
+    // initialTimeout will be wrapped in a Timeout and changed to `timeout`
+  }, initialTimeout: Duration(seconds: 30));
+}

--- a/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart.expect
@@ -1,0 +1,20 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('test', (WidgetTester tester) async {
+    // This call will be unchanged
+  }, timeout: Timeout(Duration(hours: 1)));
+
+  testWidgets('test', (WidgetTester tester) async {
+    // The `timeout` will remain unchanged, but `initialTimeout` will be removed
+  },
+  timeout: Timeout(Duration(minutes: 45)));
+
+  testWidgets('test', (WidgetTester tester) async {
+    // initialTimeout will be wrapped in a Timeout and changed to `timeout`
+  }, timeout: Timeout(Duration(seconds: 30)));
+}

--- a/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/widget_tester.dart.expect
@@ -7,14 +7,17 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('test', (WidgetTester tester) async {
     // This call will be unchanged
+    // Changes made in https://github.com/flutter/flutter/pull/89952
   }, timeout: Timeout(Duration(hours: 1)));
 
   testWidgets('test', (WidgetTester tester) async {
     // The `timeout` will remain unchanged, but `initialTimeout` will be removed
+    // Changes made in https://github.com/flutter/flutter/pull/89952
   },
   timeout: Timeout(Duration(minutes: 45)));
 
   testWidgets('test', (WidgetTester tester) async {
     // initialTimeout will be wrapped in a Timeout and changed to `timeout`
+    // Changes made in https://github.com/flutter/flutter/pull/89952
   }, timeout: Timeout(Duration(seconds: 30)));
 }


### PR DESCRIPTION
* Adds fixes for the first round of deprecations listed in #122323
* Adds tests for all new fixes
* Adds a note for the `runTest(timeout)` deprecations to prevent them from being removed before `integration_test` also has `dart fix` support

Resolves #123154

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
