### PR TITLE
Force plugin transitive dependencies to an ARC compatible version

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -347,12 +347,19 @@ public class $pluginClass: NSObject, FlutterPlugin {
     if (!podspecContent.contains(versionString)) {
       throw TaskResult.failure('Update this test to match plugin minimum $target deployment version');
     }
-    podspecContent = podspecContent.replaceFirst(
-      versionString,
-      target == 'ios'
-          ? "s.platform = :ios, '10.0'"
-          : "s.platform = :osx, '10.8'"
-    );
+    // Add transitive dependency on AppAuth 1.6 targeting iOS 8 and macOS 10.9, which no longer builds in Xcode
+    // to test the version is forced higher and builds.
+    const String iosContent = '''
+s.platform = :ios, '10.0'
+s.dependency 'AppAuth', '1.6.0'
+''';
+
+    const String macosContent = '''
+s.platform = :osx, '10.8'
+s.dependency 'AppAuth', '1.6.0'
+''';
+
+    podspecContent = podspecContent.replaceFirst(versionString, target == 'ios' ? iosContent : macosContent);
     podspec.writeAsStringSync(podspecContent, flush: true);
   }
 
@@ -372,7 +379,8 @@ public class $pluginClass: NSObject, FlutterPlugin {
         // but the range of supported deployment target versions is 9.0 to 14.0.99.
         //
         // (or "The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET'"...)
-        if (buildOutput.contains('the range of supported deployment target versions')) {
+        if (buildOutput.contains('is set to 10.0, but the range of supported deployment target versions') ||
+            buildOutput.contains('is set to 10.8, but the range of supported deployment target versions')) {
           throw TaskResult.failure('Minimum plugin version warning present');
         }
 
@@ -390,15 +398,23 @@ public class $pluginClass: NSObject, FlutterPlugin {
             if (podsProjectContent.contains('IPHONEOS_DEPLOYMENT_TARGET = 10')) {
               throw TaskResult.failure('Plugin build setting IPHONEOS_DEPLOYMENT_TARGET not removed');
             }
+            // Transitive dependency AppAuth targeting too-low 8.0 was not fixed.
+            if (podsProjectContent.contains('IPHONEOS_DEPLOYMENT_TARGET = 8')) {
+              throw TaskResult.failure('Transitive dependency build setting IPHONEOS_DEPLOYMENT_TARGET=8 not removed');
+            }
             if (!podsProjectContent.contains(r'"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "$(inherited) i386";')) {
               throw TaskResult.failure(r'EXCLUDED_ARCHS is not "$(inherited) i386"');
             }
-          }
-
-          // Same for macOS deployment target, but 10.8.
-          // The plugintest target should not have MACOSX_DEPLOYMENT_TARGET set.
-          if (target == 'macos' && podsProjectContent.contains('MACOSX_DEPLOYMENT_TARGET = 10.8')) {
-            throw TaskResult.failure('Plugin build setting MACOSX_DEPLOYMENT_TARGET not removed');
+          } else if (target == 'macos') {
+            // Same for macOS deployment target, but 10.8.
+            // The plugintest target should not have MACOSX_DEPLOYMENT_TARGET set.
+            if (podsProjectContent.contains('MACOSX_DEPLOYMENT_TARGET = 10.8')) {
+              throw TaskResult.failure('Plugin build setting MACOSX_DEPLOYMENT_TARGET not removed');
+            }
+            // Transitive dependency AppAuth targeting too-low 10.9 was not fixed.
+            if (podsProjectContent.contains('MACOSX_DEPLOYMENT_TARGET = 10.9')) {
+              throw TaskResult.failure('Transitive dependency build setting MACOSX_DEPLOYMENT_TARGET=10.9 not removed');
+            }
           }
         }
       }

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -34,6 +34,9 @@ def flutter_additional_ios_build_settings(target)
   # [target.deployment_target] is a [String] formatted as "8.0".
   inherit_deployment_target = target.deployment_target[/\d+/].to_i < 11
 
+  # ARC code targeting iOS 8 does not build on Xcode 14.3.
+  force_to_arc_supported_min = target.deployment_target[/\d+/].to_i < 9
+
   # This podhelper script is at $FLUTTER_ROOT/packages/flutter_tools/bin.
   # Add search paths from $FLUTTER_ROOT/bin/cache/artifacts/engine.
   artifacts_dir = File.join('..', '..', '..', '..', 'bin', 'cache', 'artifacts', 'engine')
@@ -61,6 +64,9 @@ def flutter_additional_ios_build_settings(target)
       build_configuration.build_settings['CODE_SIGNING_IDENTITY'] = '-'
       build_configuration.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = '-'
     end
+
+    # ARC code targeting iOS 8 does not build on Xcode 14.3. Force to at least iOS 9.
+    build_configuration.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0' if force_to_arc_supported_min
 
     # Skip other updates if it's not a Flutter plugin (transitive dependency).
     next unless target.dependencies.any? { |dependency| dependency.name == 'Flutter' }
@@ -99,11 +105,13 @@ end
 def flutter_additional_macos_build_settings(target)
   return unless target.platform_name == :osx
 
-  # Return if it's not a Flutter plugin (transitive dependency).
-  return unless target.dependencies.any? { |dependency| dependency.name == 'FlutterMacOS' }
-
   # [target.deployment_target] is a [String] formatted as "10.8".
   deployment_target_major, deployment_target_minor = target.deployment_target.match(/(\d+).?(\d*)/).captures
+
+  # ARC code targeting macOS 10.10 does not build on Xcode 14.3.
+  force_to_arc_supported_min = !target.deployment_target.blank? &&
+                                  (deployment_target_major.to_i < 10) ||
+                                  (deployment_target_major.to_i == 10 && deployment_target_minor.to_i < 11)
 
   # Suppress warning when pod supports a version lower than the minimum supported by the latest stable version of Xcode (currently 10.14).
   # This warning is harmless but confusing--it's not a bad thing for dependencies to support a lower version.
@@ -123,6 +131,12 @@ def flutter_additional_macos_build_settings(target)
   end
 
   target.build_configurations.each do |build_configuration|
+    # ARC code targeting macOS 10.10 does not build on Xcode 14.3. Force to at least macOS 10.11.
+    build_configuration.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.11' if force_to_arc_supported_min
+
+    # Skip other updates if it's not a Flutter plugin (transitive dependency).
+    next unless target.dependencies.any? { |dependency| dependency.name == 'FlutterMacOS' }
+
     # Profile can't be derived from the CocoaPods build configuration. Use release framework (for linking only).
     configuration_engine_dir = build_configuration.type == :debug ? debug_framework_dir : release_framework_dir
     build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS'] = "\"#{configuration_engine_dir}\" $(inherited)"


### PR DESCRIPTION
Xcode 14.3 (released March 30, 2023) stopped building automatic reference counted (ARC) code targeting < iOS 9 or < macOS 10.11 by removing a `libarclite_*` library from the toolchain that was needed to link for these older targets.

Flutter was already forcing Flutter plugins to the same minimum version as the app, but wasn't doing so for the plugins's transitive dependencies.  In particular, some Firebase plugins depend on pods targeting lower versions.

Force transitive dependencies to a minimum version of at least iOS 9 or macOS 10.11. 

https://ci.chromium.org/p/flutter/builders/try/Mac%20plugin_test_ios/16683
https://ci.chromium.org/p/flutter/builders/try/Mac%20plugin_test_macos/3136

Fixes https://github.com/flutter/flutter/issues/124340

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
