### PR TITLE
Fix InkWell ripple visible on right click when not expected

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1214,17 +1214,26 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   }
 
   bool isWidgetEnabled(_InkResponseStateWidget widget) {
+    return _primaryButtonEnabled(widget) || _secondaryButtonEnabled(widget);
+  }
+
+  bool _primaryButtonEnabled(_InkResponseStateWidget widget) {
     return widget.onTap != null
       || widget.onDoubleTap != null
       || widget.onLongPress != null
       || widget.onTapUp != null
-      || widget.onTapDown != null
-      || widget.onSecondaryTap != null
+      || widget.onTapDown != null;
+  }
+
+  bool _secondaryButtonEnabled(_InkResponseStateWidget widget) {
+    return widget.onSecondaryTap != null
       || widget.onSecondaryTapUp != null
       || widget.onSecondaryTapDown != null;
   }
 
   bool get enabled => isWidgetEnabled(widget);
+  bool get primaryButtonEnabled => _primaryButtonEnabled(widget);
+  bool get secondaryButtonEnabled => _secondaryButtonEnabled(widget);
 
   void handleMouseEnter(PointerEnterEvent event) {
     _hovering = true;
@@ -1305,16 +1314,16 @@ class _InkResponseState extends State<_InkResponseStateWidget>
               onTap: widget.excludeFromSemantics || widget.onTap == null ? null : simulateTap,
               onLongPress: widget.excludeFromSemantics || widget.onLongPress == null ? null : simulateLongPress,
               child: GestureDetector(
-                onTapDown: enabled ? handleTapDown : null,
-                onTapUp: enabled ? handleTapUp : null,
-                onTap: enabled ? handleTap : null,
-                onTapCancel: enabled ? handleTapCancel : null,
+                onTapDown: primaryButtonEnabled ? handleTapDown : null,
+                onTapUp: primaryButtonEnabled ? handleTapUp : null,
+                onTap: primaryButtonEnabled ? handleTap : null,
+                onTapCancel: primaryButtonEnabled ? handleTapCancel : null,
                 onDoubleTap: widget.onDoubleTap != null ? handleDoubleTap : null,
                 onLongPress: widget.onLongPress != null ? handleLongPress : null,
-                onSecondaryTapDown: enabled ? handleSecondaryTapDown : null,
-                onSecondaryTapUp: enabled ? handleSecondaryTapUp: null,
-                onSecondaryTap: enabled ? handleSecondaryTap : null,
-                onSecondaryTapCancel: enabled ? handleSecondaryTapCancel : null,
+                onSecondaryTapDown: secondaryButtonEnabled ? handleSecondaryTapDown : null,
+                onSecondaryTapUp: secondaryButtonEnabled ? handleSecondaryTapUp: null,
+                onSecondaryTap: secondaryButtonEnabled ? handleSecondaryTap : null,
+                onSecondaryTapCancel: secondaryButtonEnabled ? handleSecondaryTapCancel : null,
                 behavior: HitTestBehavior.opaque,
                 excludeFromSemantics: true,
                 child: widget.child,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -1232,8 +1232,8 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   }
 
   bool get enabled => isWidgetEnabled(widget);
-  bool get primaryButtonEnabled => _primaryButtonEnabled(widget);
-  bool get secondaryButtonEnabled => _secondaryButtonEnabled(widget);
+  bool get _primaryEnabled => _primaryButtonEnabled(widget);
+  bool get _secondaryEnabled => _secondaryButtonEnabled(widget);
 
   void handleMouseEnter(PointerEnterEvent event) {
     _hovering = true;
@@ -1314,16 +1314,16 @@ class _InkResponseState extends State<_InkResponseStateWidget>
               onTap: widget.excludeFromSemantics || widget.onTap == null ? null : simulateTap,
               onLongPress: widget.excludeFromSemantics || widget.onLongPress == null ? null : simulateLongPress,
               child: GestureDetector(
-                onTapDown: primaryButtonEnabled ? handleTapDown : null,
-                onTapUp: primaryButtonEnabled ? handleTapUp : null,
-                onTap: primaryButtonEnabled ? handleTap : null,
-                onTapCancel: primaryButtonEnabled ? handleTapCancel : null,
+                onTapDown: _primaryEnabled ? handleTapDown : null,
+                onTapUp: _primaryEnabled ? handleTapUp : null,
+                onTap: _primaryEnabled ? handleTap : null,
+                onTapCancel: _primaryEnabled ? handleTapCancel : null,
                 onDoubleTap: widget.onDoubleTap != null ? handleDoubleTap : null,
                 onLongPress: widget.onLongPress != null ? handleLongPress : null,
-                onSecondaryTapDown: secondaryButtonEnabled ? handleSecondaryTapDown : null,
-                onSecondaryTapUp: secondaryButtonEnabled ? handleSecondaryTapUp: null,
-                onSecondaryTap: secondaryButtonEnabled ? handleSecondaryTap : null,
-                onSecondaryTapCancel: secondaryButtonEnabled ? handleSecondaryTapCancel : null,
+                onSecondaryTapDown: _secondaryEnabled ? handleSecondaryTapDown : null,
+                onSecondaryTapUp: _secondaryEnabled ? handleSecondaryTapUp: null,
+                onSecondaryTap: _secondaryEnabled ? handleSecondaryTap : null,
+                onSecondaryTapCancel: _secondaryEnabled ? handleSecondaryTapCancel : null,
                 behavior: HitTestBehavior.opaque,
                 excludeFromSemantics: true,
                 child: widget.child,

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -2137,4 +2137,30 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
 
     expect(log, equals(<String>['secondary-tap-down', 'secondary-tap-cancel']));
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/124328.
+  testWidgets('InkWell secondary tap should not draw a splash when no secondary callbacks are defined', (WidgetTester tester) async {
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: Center(
+          child: InkWell(
+            onTap: () {},
+          ),
+        ),
+      ),
+    ));
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getRect(find.byType(InkWell)).center,
+      buttons: kSecondaryButton,
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    // No splash should be painted.
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
+
+    await gesture.up();
+  });
 }


### PR DESCRIPTION
## Description

This PR removes the splash effect when no secondary button callbacks are defined. 

`InkWell` defines several useful callbacks related to the secondary button.
When no secondary button callbacks are defined the splash effect should not be visible.

## Implementation choice

This PR does not remove the splash effect when at least one of the secondary button callbacks is defined (this behavior was proposed in https://github.com/flutter/flutter/pull/119058#pullrequestreview-1269813844).

Maybe we should consider if showing a splash effect for the secondary button is an expected behavior (and decide to remove it or make it configurable) ? A possible use case is an InkWell which defines both primary button callbacks and secondary button callbacks, where the primary button is used to execute an action and the secondary button to show a popup menu, in this case, it might be a better UX choice to not show the splash effect for the secondary button.
@Renzo-Olivares @justinmc 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/124328

## Tests

Adds 1 test.