### PR TITLE
Mark analyzer_benchmark as unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -189,7 +189,6 @@ targets:
   - name: Linux analyzer_benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # Newly switched to a vm bot: https://github.com/flutter/flutter/issues/124065
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/124065

The test is passing consistently for >50 runs: https://ci.chromium.org/p/flutter/builders/staging/Linux%20analyzer_benchmark?limit=50