### PR TITLE
Reland Refactor reorderable list semantics

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -10,6 +10,7 @@ import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
 import 'inherited_theme.dart';
+import 'localizations.dart';
 import 'media_query.dart';
 import 'overlay.dart';
 import 'scroll_controller.dart';
@@ -928,6 +929,63 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       key: _ReorderableItemGlobalKey(child.key!, index, this),
       index: index,
       capturedThemes: InheritedTheme.capture(from: context, to: overlay.context),
+      child: _wrapWithSemantics(child, index),
+    );
+  }
+
+  Widget _wrapWithSemantics(Widget child, int index) {
+    void reorder(int startIndex, int endIndex) {
+      if (startIndex != endIndex) {
+        widget.onReorder(startIndex, endIndex);
+      }
+    }
+
+    // First, determine which semantics actions apply.
+    final Map<CustomSemanticsAction, VoidCallback> semanticsActions = <CustomSemanticsAction, VoidCallback>{};
+
+    // Create the appropriate semantics actions.
+    void moveToStart() => reorder(index, 0);
+    void moveToEnd() => reorder(index, widget.itemCount);
+    void moveBefore() => reorder(index, index - 1);
+    // To move after, go to index+2 because it is moved to the space
+    // before index+2, which is after the space at index+1.
+    void moveAfter() => reorder(index, index + 2);
+
+    final WidgetsLocalizations localizations = WidgetsLocalizations.of(context);
+    final bool isHorizontal = _scrollDirection == Axis.horizontal;
+    // If the item can move to before its current position in the list.
+    if (index > 0) {
+      semanticsActions[CustomSemanticsAction(label: localizations.reorderItemToStart)] = moveToStart;
+      String reorderItemBefore = localizations.reorderItemUp;
+      if (isHorizontal) {
+        reorderItemBefore = Directionality.of(context) == TextDirection.ltr
+            ? localizations.reorderItemLeft
+            : localizations.reorderItemRight;
+      }
+      semanticsActions[CustomSemanticsAction(label: reorderItemBefore)] = moveBefore;
+    }
+
+    // If the item can move to after its current position in the list.
+    if (index < widget.itemCount - 1) {
+      String reorderItemAfter = localizations.reorderItemDown;
+      if (isHorizontal) {
+        reorderItemAfter = Directionality.of(context) == TextDirection.ltr
+            ? localizations.reorderItemRight
+            : localizations.reorderItemLeft;
+      }
+      semanticsActions[CustomSemanticsAction(label: reorderItemAfter)] = moveAfter;
+      semanticsActions[CustomSemanticsAction(label: localizations.reorderItemToEnd)] = moveToEnd;
+    }
+
+    // Pass toWrap with a GlobalKey into the item so that when it
+    // gets dragged, the accessibility framework can preserve the selected
+    // state of the dragging item.
+    //
+    // Also apply the relevant custom accessibility actions for moving the item
+    // up, down, to the start, and to the end of the list.
+    return Semantics(
+      container: true,
+      customSemanticsActions: semanticsActions,
       child: child,
     );
   }

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -673,8 +673,23 @@ void main() {
           // Get the switch tile's semantics:
           final SemanticsNode semanticsNode = tester.getSemantics(find.byKey(const Key('Switch tile')));
 
-          // Check for properties of both SwitchTile semantics and the ReorderableListView custom semantics actions.
+          // Check for ReorderableListView custom semantics actions.
           expect(semanticsNode, matchesSemantics(
+            customActions: const <CustomSemanticsAction>[
+              CustomSemanticsAction(label: 'Move up'),
+              CustomSemanticsAction(label: 'Move down'),
+              CustomSemanticsAction(label: 'Move to the end'),
+              CustomSemanticsAction(label: 'Move to the start'),
+            ],
+          ));
+
+          // Check for properties of SwitchTile semantics.
+          late SemanticsNode child;
+          semanticsNode.visitChildren((SemanticsNode node) {
+            child = node;
+            return false;
+          });
+          expect(child, matchesSemantics(
             hasToggledState: true,
             isToggled: true,
             isEnabled: true,
@@ -682,12 +697,6 @@ void main() {
             hasEnabledState: true,
             label: 'Switch tile',
             hasTapAction: true,
-            customActions: const <CustomSemanticsAction>[
-              CustomSemanticsAction(label: 'Move up'),
-              CustomSemanticsAction(label: 'Move down'),
-              CustomSemanticsAction(label: 'Move to the end'),
-              CustomSemanticsAction(label: 'Move to the start'),
-            ],
           ));
           handle.dispose();
         });
@@ -1644,7 +1653,7 @@ void main() {
         DefaultMaterialLocalizations.delegate,
         DefaultWidgetsLocalizations.delegate,
       ],
-      child:SizedBox(
+      child: SizedBox(
         width: 100.0,
         height: 100.0,
         child: Directionality(


### PR DESCRIPTION
Previous pr was reverted due to internal customer extends the materialLocalization with a special english translation for a certain ethnic group

This pr revert the localization breaking change so that the internal customer can migrate

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
