### PR TITLE
relayout active ListWheelScrollView children every performLayout

### DIFF
--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -763,8 +763,9 @@ class RenderListWheelViewport
 
     // Relayout all active children.
     RenderBox? child = firstChild;
+    int index = currentFirstIndex;
     while (child != null) {
-      child.layout(childConstraints, parentUsesSize: true);
+      _layoutChild(child, childConstraints, index++);
       child = childAfter(child);
     }
 

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -605,23 +605,24 @@ void main() {
       expect(viewport.childCount, 13);
     });
 
-    testWidgets('all active children are layout again during performLayout', (WidgetTester tester) async {
-      Future<void> buildWidget(double width) async => tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: ListWheelScrollView(
-            itemExtent: 100.0,
-            children: <Widget>[
-              SizedBox(
-                width: width,
-                child: const Center(
-                  child: Text('blah'),
+    testWidgets('Active children are laid out with correct offset', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/123497
+      Future<void> buildWidget(double width) async {
+        return tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: ListWheelScrollView(
+              itemExtent: 100.0,
+              children: <Widget>[
+                SizedBox(
+                  width: width,
+                  child: const Center(child: Text('blah')),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
-      );
+        );
+      }
 
       double getSizedBoxWidth() => tester.getSize(find.byType(SizedBox)).width;
       double getSizedBoxCenterX() => tester.getCenter(find.byType(SizedBox)).dx;

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -604,6 +604,40 @@ void main() {
       // centered.
       expect(viewport.childCount, 13);
     });
+
+    testWidgets('all active children are layout again during performLayout', (WidgetTester tester) async {
+      Future<void> buildWidget(double width) async => tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            itemExtent: 100.0,
+            children: <Widget>[
+              SizedBox(
+                width: width,
+                child: const Center(
+                  child: Text('blah'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      double getSizedBoxWidth() => tester.getSize(find.byType(SizedBox)).width;
+      double getSizedBoxCenterX() => tester.getCenter(find.byType(SizedBox)).dx;
+
+      await buildWidget(200.0);
+      expect(getSizedBoxWidth(), 200.0);
+      expect(getSizedBoxCenterX(), 400.0);
+
+      await buildWidget(100.0);
+      expect(getSizedBoxWidth(), 100.0);
+      expect(getSizedBoxCenterX(), 400.0);
+
+      await buildWidget(300.0);
+      expect(getSizedBoxWidth(), 300.0);
+      expect(getSizedBoxCenterX(), 400.0);
+    });
   });
 
   group('pre-transform viewport', () {


### PR DESCRIPTION
during performLayout, active children's constraints were updated, but they weren't laid out again w.r.t their parent (ListWheelScrollView).

Fixes #123497

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
