### PR TITLE
BottomAppBar doc: Fix doc about surfaceTintColor

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -127,11 +127,17 @@ class BottomAppBar extends StatefulWidget {
   /// Not used if [shape] is null.
   final double notchMargin;
 
-  /// The color used as an overlay on [color] to indicate elevation.
+  /// A custom color for the Material 3 surface-tint elevation effect.
   ///
-  /// If this is null, no overlay will be applied. Otherwise the
-  /// color will be composited on top of [color] with an opacity related
-  /// to [elevation] and used to paint the background of the [BottomAppBar].
+  /// In Material 3, a "surface tint" with an opacity related to [elevation]
+  /// will be applied to the [BottomAppBar]'s background.
+  /// Use this property to override the default color of that tint.
+  ///
+  /// If this property is null, then [BottomAppBarTheme.surfaceTintColor]
+  /// of [ThemeData.bottomAppBarTheme] is used.
+  /// If that is also null, [ColorScheme.surfaceTint] is used.
+  ///
+  /// Ignored if [ThemeData.useMaterial3] is false.
   ///
   /// The default is null.
   ///


### PR DESCRIPTION
Fixes #124535
Fixes #124536

The new text mentions that `surfaceTintColor` is ignored in Material 2 (fixing #124536) and correctly says what the surface tint color will be when `surfaceTintColor` is null, fixing #124535.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
