### PR TITLE
Instantiate HardwareKeyboard with an initial pressed state

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -66,10 +66,21 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
   late final KeyEventManager _keyEventManager;
 
   void _initKeyboard() {
-    _keyboard = HardwareKeyboard();
+    _keyboard = HardwareKeyboard(pressedKeys: _readInitialPressedKeys());
     _keyEventManager = KeyEventManager(_keyboard, RawKeyboard.instance);
     platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
     SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
+  }
+
+  Map<PhysicalKeyboardKey, LogicalKeyboardKey> _readInitialPressedKeys() {
+    final Map<PhysicalKeyboardKey, LogicalKeyboardKey> initialPressedKeys = <PhysicalKeyboardKey, LogicalKeyboardKey>{};
+    final List<int> keys = instance.platformDispatcher.initialKeyboardState;
+    for (int i = 0; i < keys.length; i = i + 2) {
+      final PhysicalKeyboardKey physical = PhysicalKeyboardKey(keys[i]);
+      final LogicalKeyboardKey logical = LogicalKeyboardKey(keys[i+1]);
+      initialPressedKeys[physical] = logical;
+    }
+    return initialPressedKeys;
   }
 
   /// The default instance of [BinaryMessenger].

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -41,6 +41,13 @@ $license2
 ''';
 
 class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
+  TestBinding() : platformDispatcher = TestPlatformDispatcher(
+    platformDispatcher: PlatformDispatcher.instance,
+  )..initialKeyboardStateTestValue = <int>[1, 2, 3, 4];
+
+  @override
+  final TestPlatformDispatcher platformDispatcher;
+
   @override
   TestDefaultBinaryMessenger get defaultBinaryMessenger => super.defaultBinaryMessenger as TestDefaultBinaryMessenger;
 
@@ -144,5 +151,17 @@ void main() {
     expect(receivedReply, isTrue);
     expect(result, isNotNull);
     expect(result!['response'], equals('exit'));
+  });
+
+  test('initInstances synchronizes keyboard state', () async {
+    final Set<PhysicalKeyboardKey> physicalKeys = HardwareKeyboard.instance.physicalKeysPressed;
+    final Set<LogicalKeyboardKey> logicalKeys = HardwareKeyboard.instance.logicalKeysPressed;
+
+    expect(physicalKeys.length, 2);
+    expect(logicalKeys.length, 2);
+    expect(physicalKeys.first, const PhysicalKeyboardKey(1));
+    expect(logicalKeys.first, const LogicalKeyboardKey(2));
+    expect(physicalKeys.last, const PhysicalKeyboardKey(3));
+    expect(logicalKeys.last, const LogicalKeyboardKey(4));
   });
 }

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -233,6 +233,14 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   }
 
   @override
+  List<int> get initialKeyboardState => _initialKeyboardStateTestValue;
+  List<int> _initialKeyboardStateTestValue = <int>[];
+  /// Sets a faked initial keyboard state for testing.
+  set initialKeyboardStateTestValue(List<int> state) { // ignore: avoid_setters_without_getters
+    _initialKeyboardStateTestValue = state;
+  }
+
+  @override
   double get textScaleFactor => _textScaleFactorTestValue ?? _platformDispatcher.textScaleFactor;
   double? _textScaleFactorTestValue;
   /// Hides the real text scale factor and reports the given


### PR DESCRIPTION
## Description

This draft PR updates `HardwareKeyboard` to make it possible to instantiate it with an initial keyboard state which will be initialized by the engine.

This PR relies on the following engine change: https://github.com/flutter/engine/pull/41073

This work is not yet done, these drafts PR are meant to validate the proposed approach.

## Related Issue

Framework side implementation for https://github.com/flutter/flutter/issues/87391

## Tests

Adds 1 test.
More tests to add once this is validated.
