### PR TITLE
SelectionContainer's listeners can remove itself during listener call…

### DIFF
--- a/examples/api/test/material/context_menu/selectable_region_toolbar_builder.0_test.dart
+++ b/examples/api/test/material/context_menu/selectable_region_toolbar_builder.0_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(BrowserContextMenu.enabled, !kIsWeb);
 
     // Allow the selection overlay geometry to be created.
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1507,7 +1507,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   void _scheduleSelectableUpdate() {
     if (!_scheduledSelectableUpdate) {
       _scheduledSelectableUpdate = true;
-      SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+      SchedulerBinding.instance.scheduleFrameCallback((Duration timeStamp) {
         if (!_scheduledSelectableUpdate) {
           return;
         }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1477,7 +1477,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   Selectable? _endHandleLayerOwner;
 
   bool _isHandlingSelectionEvent = false;
-  bool _scheduledSelectableUpdate = false;
+  int? _scheduledSelectableUpdateCallbackId;
   bool _selectionInProgress = false;
   Set<Selectable> _additions = <Selectable>{};
 
@@ -1505,16 +1505,13 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   }
 
   void _scheduleSelectableUpdate() {
-    if (!_scheduledSelectableUpdate) {
-      _scheduledSelectableUpdate = true;
-      SchedulerBinding.instance.scheduleFrameCallback((Duration timeStamp) {
-        if (!_scheduledSelectableUpdate) {
-          return;
-        }
-        _scheduledSelectableUpdate = false;
-        _updateSelectables();
-      });
-    }
+    _scheduledSelectableUpdateCallbackId ??= SchedulerBinding.instance.scheduleFrameCallback((Duration timeStamp) {
+      if (_scheduledSelectableUpdateCallbackId == null) {
+        return;
+      }
+      _scheduledSelectableUpdateCallbackId = null;
+      _updateSelectables();
+    });
   }
 
   void _updateSelectables() {
@@ -2045,7 +2042,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       selectable.removeListener(_handleSelectableGeometryChange);
     }
     selectables = const <Selectable>[];
-    _scheduledSelectableUpdate = false;
+    if (_scheduledSelectableUpdateCallbackId != null) {
+      SchedulerBinding.instance.cancelFrameCallbackWithId(_scheduledSelectableUpdateCallbackId!);
+    }
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -133,7 +133,8 @@ class _SelectionContainerState extends State<SelectionContainer> with Selectable
         _listeners.forEach(widget.delegate!.addListener);
       }
       if (oldWidget.delegate?.value != widget.delegate?.value) {
-        for (final VoidCallback listener in _listeners) {
+        // Avoid concurrent modification.
+        for (final VoidCallback listener in _listeners.toList(growable: false)) {
           listener();
         }
       }

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -47,6 +47,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
 
@@ -80,6 +81,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
     expect(find.byKey(key), findsNothing);
@@ -151,6 +153,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
     final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 7)); // at the 'a'
     addTearDown(gesture.removePointer);

--- a/packages/flutter/test/widgets/default_colors_test.dart
+++ b/packages/flutter/test/widgets/default_colors_test.dart
@@ -93,6 +93,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
     await _expectColors(
       tester,
       find.byType(Align),

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -47,6 +47,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
@@ -85,6 +86,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
@@ -118,6 +120,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
@@ -171,6 +174,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
@@ -210,6 +214,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     controller.jumpTo(4000);
     await tester.pumpAndSettle();
@@ -258,6 +263,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
@@ -305,6 +311,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pumpAndSettle();
 
     controller.jumpTo(2080);
     await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1935,6 +1935,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
 
       final SelectableRegionState state =
           tester.state<SelectableRegionState>(find.byType(SelectableRegion));

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -48,6 +48,7 @@ void main() {
             ),
           )
       );
+      await tester.pumpAndSettle();
 
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0), kind: PointerDeviceKind.mouse);
@@ -121,6 +122,8 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
+
       final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(spy)));
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
@@ -241,6 +244,7 @@ void main() {
             ),
           )
       );
+      await tester.pumpAndSettle();
 
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0), kind: PointerDeviceKind.mouse);
@@ -260,6 +264,7 @@ void main() {
             ),
           )
       );
+      await tester.pumpAndSettle();
 
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       renderSelectionSpy.events.clear();
@@ -284,6 +289,7 @@ void main() {
             ),
           )
       );
+      await tester.pumpAndSettle();
 
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       renderSelectionSpy.events.clear();
@@ -315,6 +321,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
 
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       renderSelectionSpy.events.clear();
@@ -348,6 +355,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 6)); // at the 'r'
@@ -708,6 +716,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       focusNode.requestFocus();
 
       // keyboard select all.
@@ -897,6 +906,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 6)); // at the 'r'
       addTearDown(gesture.removePointer);
@@ -928,6 +938,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
 
       final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 7)); // at the 'a'
@@ -964,6 +975,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 7)); // at the 'a'
       addTearDown(gesture.removePointer);
@@ -998,6 +1010,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 7)); // at the 'h'
       addTearDown(gesture.removePointer);
@@ -1039,6 +1052,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 7)); // at the 'h'
       addTearDown(gesture.removePointer);
@@ -1075,6 +1089,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 7)); // at the 'h'
       addTearDown(gesture.removePointer);
@@ -1111,6 +1126,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 7)); // at the 'h'
       addTearDown(gesture.removePointer);
@@ -1146,6 +1162,7 @@ void main() {
           ),
         ),
       );
+      await tester.pumpAndSettle();
       final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 7)); // at the 'h'
       addTearDown(gesture.removePointer);
@@ -1621,6 +1638,7 @@ void main() {
             ),
           ),
         );
+        await tester.pumpAndSettle();
 
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
             find.descendant(
@@ -1676,6 +1694,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
     final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 6)); // at the 'r'
@@ -1723,6 +1742,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
     await tester.longPressAt(textOffsetToPosition(paragraph1, 6)); // at the 'r'
@@ -1776,6 +1796,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
     await tester.longPressAt(textOffsetToPosition(paragraph1, 6)); // at the 'r'
@@ -1830,6 +1851,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
 

--- a/packages/flutter/test/widgets/selection_container_test.dart
+++ b/packages/flutter/test/widgets/selection_container_test.dart
@@ -37,6 +37,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
     expect(registrar.selectables.length, 1);
     expect(delegate.selectables.length, 3);
   });
@@ -137,6 +138,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
     expect(registrar.selectables.length, 1);
 
     await pumpContainer(
@@ -148,6 +150,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
     expect(registrar.selectables.length, 0);
   });
 
@@ -169,6 +172,7 @@ void main() {
         ),
       ),
     );
+    await tester.pumpAndSettle();
     expect(registrar.selectables.length, 1);
   });
 }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -647,6 +647,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     Duration? duration,
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
   ]) {
+    print('in pump');
     return TestAsyncUtils.guard<void>(() => binding.pump(duration, phase));
   }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -647,7 +647,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     Duration? duration,
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
   ]) {
-    print('in pump');
     return TestAsyncUtils.guard<void>(() => binding.pump(duration, phase));
   }
 


### PR DESCRIPTION
When swapping out delegate of  selectioncontainer, if the newly passed in delegate doesn't have any selectable content(which is usually the case), the selectioncontainerstate will notify all of the listeners. One of the listener would be SelectionRegistrant._updateSelectionRegistrarSubscription, and since it doesn't have content, it would remove itself from the listener which causes concurrent modification

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
