### PR TITLE
Mark android_semantics_integration_test as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1471,6 +1471,7 @@ targets:
 
   - name: Linux_android android_semantics_integration_test
     recipe: devicelab/devicelab_drone
+    bringup: true # Flaky: https://github.com/flutter/flutter/issues/124636
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
Manually mark android_semantics_integration_test as flaky (https://github.com/flutter/flutter/issues/124636)