### PR TITLE
Remove the old canvaskit artifacts to not confuse the web runner.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -38,6 +38,7 @@ class FlutterCache extends Cache {
     registerArtifact(AndroidInternalBuildArtifacts(this));
     registerArtifact(IOSEngineArtifacts(this, platform: platform));
     registerArtifact(FlutterWebSdk(this));
+    registerArtifact(LegacyCanvasKitRemover(this));
     registerArtifact(FlutterSdk(this, platform: platform));
     registerArtifact(WindowsEngineArtifacts(this, platform: platform));
     registerArtifact(MacOSEngineArtifacts(this, platform: platform));
@@ -182,6 +183,38 @@ class FlutterWebSdk extends CachedArtifact {
     ErrorHandlingFileSystem.deleteIfExists(location, recursive: true);
     await artifactUpdater.downloadZipArchive('Downloading Web SDK...', url, location);
   }
+}
+
+// In previous builds, CanvasKit artifacts were stored in a different location
+// than they are now. Leaving those old artifacts in the cache confuses the
+// in-memory filesystem that the web runner uses, so this artifact will evict
+// them from our cache if they are there.
+class LegacyCanvasKitRemover extends ArtifactSet {
+  LegacyCanvasKitRemover(this.cache) : super(DevelopmentArtifact.web);
+
+  final Cache cache;
+
+  @override
+  String get name => 'legacy_canvaskit_remover';
+
+  Directory _getLegacyCanvasKitDirectory(FileSystem fileSystem) =>
+    fileSystem.directory(fileSystem.path.join(
+      cache.getRoot().path,
+      'canvaskit',
+    ));
+
+  @override
+  Future<bool> isUpToDate(FileSystem fileSystem) async =>
+    !(await _getLegacyCanvasKitDirectory(fileSystem).exists());
+
+  @override
+  Future<void> update(
+    ArtifactUpdater artifactUpdater,
+    Logger logger,
+    FileSystem fileSystem,
+    OperatingSystemUtils operatingSystemUtils,
+    {bool offline = false}
+  ) => _getLegacyCanvasKitDirectory(fileSystem).delete(recursive: true);
 }
 
 /// A cached artifact containing the dart:ui source code.


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/123737

The old canvaskit artifacts were confusing the in-memory filesystem that the web runner uses. Added another artifact set that removes the old canvaskit artifacts if they exist.