### PR TITLE
Deprecates string for reorderable list in material_localizations

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -424,26 +424,50 @@ abstract class MaterialLocalizations {
 
   /// The semantics label used for [ReorderableListView] to reorder an item in the
   /// list to the start of the list.
+  @Deprecated(
+    'Use the reorderItemToStart from WidgetsLocalizations instead. '
+    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+  )
   String get reorderItemToStart;
 
   /// The semantics label used for [ReorderableListView] to reorder an item in the
   /// list to the end of the list.
+  @Deprecated(
+    'Use the reorderItemToEnd from WidgetsLocalizations instead. '
+    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+  )
   String get reorderItemToEnd;
 
   /// The semantics label used for [ReorderableListView] to reorder an item in the
   /// list one space up the list.
+  @Deprecated(
+    'Use the reorderItemUp from WidgetsLocalizations instead. '
+    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+  )
   String get reorderItemUp;
 
   /// The semantics label used for [ReorderableListView] to reorder an item in the
   /// list one space down the list.
+  @Deprecated(
+    'Use the reorderItemDown from WidgetsLocalizations instead. '
+    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+  )
   String get reorderItemDown;
 
   /// The semantics label used for [ReorderableListView] to reorder an item in the
   /// list one space left in the list.
+  @Deprecated(
+    'Use the reorderItemLeft from WidgetsLocalizations instead. '
+    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+  )
   String get reorderItemLeft;
 
   /// The semantics label used for [ReorderableListView] to reorder an item in the
   /// list one space right in the list.
+  @Deprecated(
+    'Use the reorderItemRight from WidgetsLocalizations instead. '
+    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+  )
   String get reorderItemRight;
 
   /// The semantics hint to describe the tap action on an expanded [ExpandIcon].

--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -426,7 +426,7 @@ abstract class MaterialLocalizations {
   /// list to the start of the list.
   @Deprecated(
     'Use the reorderItemToStart from WidgetsLocalizations instead. '
-    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+    'This feature was deprecated after v3.10.0-2.0.pre.'
   )
   String get reorderItemToStart;
 
@@ -434,7 +434,7 @@ abstract class MaterialLocalizations {
   /// list to the end of the list.
   @Deprecated(
     'Use the reorderItemToEnd from WidgetsLocalizations instead. '
-    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+    'This feature was deprecated after v3.10.0-2.0.pre.'
   )
   String get reorderItemToEnd;
 
@@ -442,7 +442,7 @@ abstract class MaterialLocalizations {
   /// list one space up the list.
   @Deprecated(
     'Use the reorderItemUp from WidgetsLocalizations instead. '
-    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+    'This feature was deprecated after v3.10.0-2.0.pre.'
   )
   String get reorderItemUp;
 
@@ -450,7 +450,7 @@ abstract class MaterialLocalizations {
   /// list one space down the list.
   @Deprecated(
     'Use the reorderItemDown from WidgetsLocalizations instead. '
-    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+    'This feature was deprecated after v3.10.0-2.0.pre.'
   )
   String get reorderItemDown;
 
@@ -458,7 +458,7 @@ abstract class MaterialLocalizations {
   /// list one space left in the list.
   @Deprecated(
     'Use the reorderItemLeft from WidgetsLocalizations instead. '
-    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+    'This feature was deprecated after v3.10.0-2.0.pre.'
   )
   String get reorderItemLeft;
 
@@ -466,7 +466,7 @@ abstract class MaterialLocalizations {
   /// list one space right in the list.
   @Deprecated(
     'Use the reorderItemRight from WidgetsLocalizations instead. '
-    'This feature was deprecated after v3.10.0-2.0.pre-67-gdf48b922ca.'
+    'This feature was deprecated after v3.10.0-2.0.pre.'
   )
   String get reorderItemRight;
 


### PR DESCRIPTION
deprecates the these strings since they are now moved into widgetslocalizations

migration guide https://github.com/flutter/website/pull/8543/files

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
