### PR TITLE
Remove unused getRootRenderObject and getSelectedRenderObject service extensions

### DIFF
--- a/packages/flutter/lib/src/widgets/service_extensions.dart
+++ b/packages/flutter/lib/src/widgets/service_extensions.dart
@@ -352,17 +352,6 @@ enum WidgetInspectorServiceExtensions {
   getRootWidget,
 
   /// Name of service extension that, when called, will return the
-  /// [DiagnosticsNode] data for the root [RenderObject].
-  ///
-  /// See also:
-  ///
-  /// * [WidgetInspectorService.getRootRenderObject], which returns a json
-  ///   encoded String representation of this data.
-  /// * [WidgetInspectorService.initServiceExtensions], where the service
-  ///   extension is registered.
-  getRootRenderObject,
-
-  /// Name of service extension that, when called, will return the
   /// [DiagnosticsNode] data for the root [Element] of the summary tree, which
   /// only includes [Element]s that were created by user code.
   ///
@@ -402,17 +391,6 @@ enum WidgetInspectorServiceExtensions {
   /// * [WidgetInspectorService.initServiceExtensions], where the service
   ///   extension is registered.
   getDetailsSubtree,
-
-  /// Name of service extension that, when called, will return the
-  /// [DiagnosticsNode] data for the currently selected [RenderObject].
-  ///
-  /// See also:
-  ///
-  /// * [WidgetInspectorService.getSelectedRenderObject], which returns a json
-  ///   encoded String representation of this data.
-  /// * [WidgetInspectorService.initServiceExtensions], where the service
-  ///   extension is registered.
-  getSelectedRenderObject,
 
   /// Name of service extension that, when called, will return the
   /// [DiagnosticsNode] data for the currently selected [Element].

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1154,10 +1154,6 @@ mixin WidgetInspectorService {
       callback: _getRootWidget,
     );
     _registerObjectGroupServiceExtension(
-      name: WidgetInspectorServiceExtensions.getRootRenderObject.name,
-      callback: _getRootRenderObject,
-    );
-    _registerObjectGroupServiceExtension(
       name: WidgetInspectorServiceExtensions.getRootWidgetSummaryTree.name,
       callback: _getRootWidgetSummaryTree,
     );
@@ -1178,10 +1174,6 @@ mixin WidgetInspectorService {
           ),
         };
       },
-    );
-    _registerServiceExtensionWithArg(
-      name: WidgetInspectorServiceExtensions.getSelectedRenderObject.name,
-      callback: _getSelectedRenderObject,
     );
     _registerServiceExtensionWithArg(
       name: WidgetInspectorServiceExtensions.getSelectedWidget.name,
@@ -1881,17 +1873,6 @@ mixin WidgetInspectorService {
     });
   }
 
-  /// Returns a JSON representation of the [DiagnosticsNode] for the root
-  /// [RenderObject].
-  @protected
-  String getRootRenderObject(String groupName) {
-    return _safeJsonEncode(_getRootRenderObject(groupName));
-  }
-
-  Map<String, Object?>? _getRootRenderObject(String groupName) {
-    return _nodeToJson(RendererBinding.instance.renderView.toDiagnosticsNode(), InspectorSerializationDelegate(groupName: groupName, service: this));
-  }
-
   /// Returns a JSON representation of the subtree rooted at the
   /// [DiagnosticsNode] object that `diagnosticsNodeId` references providing
   /// information needed for the details subtree view.
@@ -1930,23 +1911,6 @@ mixin WidgetInspectorService {
         service: this,
       ),
     );
-  }
-
-  /// Returns a [DiagnosticsNode] representing the currently selected
-  /// [RenderObject].
-  ///
-  /// If the currently selected [RenderObject] is identical to the
-  /// [RenderObject] referenced by `previousSelectionId` then the previous
-  /// [DiagnosticsNode] is reused.
-  @protected
-  String getSelectedRenderObject(String previousSelectionId, String groupName) {
-    return _safeJsonEncode(_getSelectedRenderObject(previousSelectionId, groupName));
-  }
-
-  Map<String, Object?>? _getSelectedRenderObject(String? previousSelectionId, String groupName) {
-    final DiagnosticsNode? previousSelection = toObject(previousSelectionId) as DiagnosticsNode?;
-    final RenderObject? current = selection.current;
-    return _nodeToJson(current == previousSelection?.value ? previousSelection : current?.toDiagnosticsNode(), InspectorSerializationDelegate(groupName: groupName, service: this));
   }
 
   /// Returns a [DiagnosticsNode] representing the currently selected [Element].

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -154,7 +154,7 @@ void main() {
   tearDownAll(() async {
     // See widget_inspector_test.dart for tests of the ext.flutter.inspector
     // service extensions included in this count.
-    int widgetInspectorExtensionCount = 22;
+    int widgetInspectorExtensionCount = 20;
     if (WidgetInspectorService.instance.isWidgetCreationTracked()) {
       // Some inspector extensions are only exposed if widget creation locations
       // are tracked.


### PR DESCRIPTION
These are currently unused and will not work in a multi-view environment where we will have multiple render trees.

Work towards https://github.com/flutter/flutter/issues/121573.