### PR TITLE
[CP][ci.yaml] Disable packaging_test on release candidates (#124712)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -415,6 +415,10 @@ targets:
   - name: Linux flutter_packaging_test
     recipe: packaging/packaging
     timeout: 60
+    enabled_branches:
+      - master
+      - beta
+      - stable
     properties:
       task_name: flutter_packaging
       tags: >
@@ -2743,6 +2747,10 @@ targets:
   - name: Mac flutter_packaging_test
     recipe: packaging/packaging
     timeout: 60
+    enabled_branches:
+      - master
+      - beta
+      - stable
     properties:
       task_name: flutter_packaging
       tags: >
@@ -2751,6 +2759,10 @@ targets:
   - name: Mac_arm64 flutter_packaging_test
     recipe: packaging/packaging
     timeout: 60
+    enabled_branches:
+      - master
+      - beta
+      - stable
     properties:
       task_name: flutter_packaging
       tags: >
@@ -4918,6 +4930,10 @@ targets:
   - name: Windows flutter_packaging_test
     recipe: packaging/packaging
     timeout: 60
+    enabled_branches:
+      - master
+      - beta
+      - stable
     properties:
       task_name: flutter_packaging
       tags: >


### PR DESCRIPTION
[ci.yaml] Disable packaging_test on release candidates

These tests should not run on RC branches.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
