### PR TITLE
Add double click and double click + drag gestures to SelectionArea

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1329,6 +1329,10 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   TextPosition? _textSelectionStart;
   TextPosition? _textSelectionEnd;
 
+  TextPosition? _originWordSelectionStart;
+  TextPosition? _originWordSelectionEnd;
+  bool? _selectableContainsOriginWord;
+
   LayerLink? _startHandleLayerLink;
   LayerLink? _endHandleLayerLink;
 
@@ -1484,9 +1488,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
   }
 
-  TextPosition? _originWordSelectionStart;
-  TextPosition? _originWordSelectionEnd;
-  bool? _selectableContainsOriginWord;
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
     // Cache the boundaries of the origin word. If the origin word is not in the
     // current selectable then the _textSelectionEnd will be null.
@@ -1520,8 +1521,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     // maintain a selectables selection collapsed at 0 when the local position is
     // not located inside its rect.
     final (TextPosition start, TextPosition end)? wordBoundary = !_rect.contains(localPosition) ? null : _getWordBoundaryAtPosition(position);
-    TextPosition targetPosition = _clampTextPosition(wordBoundary != null ? isEnd ? wordBoundary.$2 : wordBoundary.$1 : position);
-
+    TextPosition targetPosition = wordBoundary != null ? isEnd ? wordBoundary.$2 : wordBoundary.$1 : position;
     if (_selectableContainsOriginWord!) {
       // Swap the start and end.
       if (targetPosition.offset >= _originWordSelectionEnd!.offset) {
@@ -1533,18 +1533,19 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       }
     } else {
       // If we are always moving the selection end edge then the selection will
-      // always extend to wordBoundary.$2. Instead it should expand to wordBoudary.$x
-      // that results in the largest selection.
+      // always extend to wordBoundary.$2. Instead the selection should expand to
+      // wordBoudary.$x that results in the largest selection.
       if (wordBoundary != null) {
         int lengthWhenExpandingToBegOfWord = (_textSelectionStart!.offset - wordBoundary!.$1.offset).abs();
         int lengthWhenExpandingToEndOfWord = (_textSelectionStart!.offset - wordBoundary!.$2.offset).abs();
         if (lengthWhenExpandingToBegOfWord > lengthWhenExpandingToEndOfWord) {
-          targetPosition = wordBoundary?.$1 ?? position;
+          targetPosition = wordBoundary!.$1;
         } else {
-          targetPosition = wordBoundary?.$2 ?? position;
+          targetPosition = wordBoundary!.$2;
         }
       }
     }
+    targetPosition = _clampTextPosition(targetPosition);
 
     _setSelectionPosition(targetPosition, isEnd: isEnd);
     if (targetPosition.offset == range.end) {
@@ -1584,6 +1585,9 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   SelectionResult _handleClearSelection() {
     _textSelectionStart = null;
     _textSelectionEnd = null;
+    _originWordSelectionStart = null;
+    _originWordSelectionEnd = null;
+    _selectableContainsOriginWord = null;
     return SelectionResult.none;
   }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1587,19 +1587,19 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     } else {
       // The localPosition is not contained within the current rect. The adjustedPosition
       // will either be at the end or beginning of the current rect.
-      if (existingSelectionStart != null && existingSelectionEnd != null) {
+      if (_selectableContainsOriginWord && existingSelectionStart != null && existingSelectionEnd != null) {
         final TextPosition edgeToKeepInPlace = isEnd ? existingSelectionStart : existingSelectionEnd;
         final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
         final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
 
         if (existingSelectionStart.offset < existingSelectionEnd.offset) {
-          if (shouldSwapEdgesWhenSelectionIsNormalized || position.offset == edgeToKeepInPlace.offset && _selectableContainsOriginWord) {
+          if (shouldSwapEdgesWhenSelectionIsNormalized || position.offset == edgeToKeepInPlace.offset) {
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
             _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
           }
         } else {
-          if (shouldSwapEdgesWhenSelectionNotNormalized || position.offset == edgeToKeepInPlace.offset && _selectableContainsOriginWord) {
+          if (shouldSwapEdgesWhenSelectionNotNormalized || position.offset == edgeToKeepInPlace.offset) {
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
             _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1397,7 +1397,15 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       case SelectionEventType.startEdgeUpdate:
       case SelectionEventType.endEdgeUpdate:
         final SelectionEdgeUpdateEvent edgeUpdate = event as SelectionEdgeUpdateEvent;
-        result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
+        final SelectionMode selectionMode = event.mode;
+        debugPrint(selectionMode.toString());
+
+        switch (selectionMode) {
+          case SelectionMode.character:
+            result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
+          case SelectionMode.words:
+            result = _updateSelectionEdgeByWord(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
+        }
       case SelectionEventType.clear:
         result = _handleClearSelection();
       case SelectionEventType.selectAll:
@@ -1474,6 +1482,33 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
   }
 
+  SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
+    _setSelectionPosition(null, isEnd: isEnd);
+    final Matrix4 transform = paragraph.getTransformTo(null);
+    transform.invert();
+    final Offset localPosition = MatrixUtils.transformPoint(transform, globalPosition);
+    if (_rect.isEmpty) {
+      return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+    }
+    final Offset adjustedOffset = SelectionUtils.adjustDragOffset(
+      _rect,
+      localPosition,
+      direction: paragraph.textDirection,
+    );
+
+    final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
+
+    final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
+    if (isEnd) {
+      debugPrint('setting end');
+      _setSelectionPosition(wordBoundary.$2, isEnd: isEnd);
+    } else {
+      debugPrint('setting start');
+      _setSelectionPosition(wordBoundary.$1, isEnd: isEnd);
+    }
+    return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
+  }
+
   TextPosition _clampTextPosition(TextPosition position) {
     // Affinity of range.end is upstream.
     if (position.offset > range.end ||
@@ -1511,6 +1546,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     if (_positionIsWithinCurrentSelection(position)) {
       return SelectionResult.end;
     }
+    final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
+    _textSelectionStart = wordBoundary.$1;
+    _textSelectionEnd = wordBoundary.$2;
+    return SelectionResult.end;
+  }
+
+  (TextPosition start, TextPosition end) _getWordBoundaryAtPosition(TextPosition position) {
     final TextRange word = paragraph.getWordBoundary(position);
     assert(word.isNormalized);
     if (word.start < range.start && word.end < range.start) {
@@ -1529,9 +1571,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       start = TextPosition(offset: word.start);
       end = TextPosition(offset: word.end, affinity: TextAffinity.upstream);
     }
-    _textSelectionStart = start;
-    _textSelectionEnd = end;
-    return SelectionResult.end;
+    return (start, end);
   }
 
   SelectionResult _handleDirectionallyExtendSelection(double horizontalBaseline, bool isExtent, SelectionExtendDirection movement) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1629,15 +1629,14 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
             if (position.offset == existingSelectionStart.offset && _selectableContainsOriginWord!) {
               // This case applies when the origin word is at the beginning of
               // the origin selectable, and the adjustedPosition is at the beginning
-              // of the rect, to keep the origin word in bounds, the end edge should
-              // stay at the end of the origin word.
+              // of the rect, to keep the origin word in bounds, the start edge should
+              // move to the end the origin word.
               //
               // This is only done when the current selectable contains the origin word,
               // if it does not then we are okay with the selection being collapsed
               // as a result of the adjustedPosition.
               final (TextPosition start, TextPosition end) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
-              _setSelectionPosition(localWordBoundary.$1, isEnd: !isEnd);
-              targetPosition = localWordBoundary.$2;
+              _setSelectionPosition(localWordBoundary.$2, isEnd: !isEnd);
             }
           } else {
             // The end of the selection is before the start.

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1515,57 +1515,48 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     TextPosition? targetPosition;
     if (wordBoundary != null) {
       assert(wordBoundary.wordStart.offset >= range.start && wordBoundary.wordEnd.offset <= range.end);
-      if (existingSelectionStart != null && existingSelectionEnd != null) {
+      if (_selectableContainsOriginWord && existingSelectionStart != null && existingSelectionEnd != null) {
         final TextPosition edgeToKeepInPlace = isEnd ? existingSelectionStart : existingSelectionEnd;
         final TextPosition currentMovingEdge = isEnd ? existingSelectionEnd : existingSelectionStart;
-        if (_selectableContainsOriginWord) {
-          // Swap the selection edges to keep the origin word in bounds, when the
-          // new position where to cause an inverted selection.
-          final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
-          final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
-          if (existingSelectionStart.offset <= existingSelectionEnd.offset) {
-            // The selection is normalized, i.e. the start of the selection is before
-            // the end.
-            if (shouldSwapEdgesWhenSelectionIsNormalized) {
-              targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
-              // The static edge is moved to the opposite end of the word boundary to
-              // keep the entire origin word in the selection.
-              final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
-              assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-              _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
-            } else {
-              // If the new position falls on the same position of the static
-              // edge, keep the selection at the same word boundary regardless
-              // of the affinity, so the origin word stays in bounds. If not then
-              // extend the selection to the boundary that would encompass the entire
-              // word at the new position.
-              targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
-            }
+        // Swap the selection edges to keep the origin word in bounds, when the
+        // new position where to cause an inverted selection.
+        final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
+        final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
+        if (existingSelectionStart.offset <= existingSelectionEnd.offset) {
+          // The selection is normalized, i.e. the start of the selection is before
+          // the end.
+          if (shouldSwapEdgesWhenSelectionIsNormalized) {
+            targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
+            // The static edge is moved to the opposite end of the word boundary to
+            // keep the entire origin word in the selection.
+            final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
+            assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
+            _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
           } else {
-            // The selection is not normalized, i.e. the end of the selection is before
-            // the start.
-            if (shouldSwapEdgesWhenSelectionNotNormalized) {
-              targetPosition = isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
-              // The static edge is moved to the opposite end of the word boundary to
-              // keep the entire origin word in the selection.
-              final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
-              assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-              _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);
-            } else {
-              // If the new position falls on the same position of the static
-              // edge, keep the selection at the same word boundary regardless
-              // of the affinity, so the origin word stays in bounds. If not then
-              // expand the selection to the boundary that would encompass the entire
-              // word at the new position.
-              targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
-            }
+            // If the new position falls on the same position of the static
+            // edge, keep the selection at the same word boundary regardless
+            // of the affinity, so the origin word stays in bounds. If not then
+            // extend the selection to the boundary that would encompass the entire
+            // word at the new position.
+            targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
           }
         } else {
-          // The edge should move to encompass the entire word at the new position.
-          if (position.offset < edgeToKeepInPlace.offset) {
-            targetPosition = wordBoundary.wordStart;
+          // The selection is not normalized, i.e. the end of the selection is before
+          // the start.
+          if (shouldSwapEdgesWhenSelectionNotNormalized) {
+            targetPosition = isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
+            // The static edge is moved to the opposite end of the word boundary to
+            // keep the entire origin word in the selection.
+            final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
+            assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
+            _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);
           } else {
-            targetPosition = wordBoundary.wordEnd;
+            // If the new position falls on the same position of the static
+            // edge, keep the selection at the same word boundary regardless
+            // of the affinity, so the origin word stays in bounds. If not then
+            // expand the selection to the boundary that would encompass the entire
+            // word at the new position.
+            targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
           }
         }
       } else {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1453,6 +1453,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdge(Offset globalPosition, {required bool isEnd}) {
+    // debugPrint('${this.hashCode}');
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
@@ -1482,6 +1483,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
+    // debugPrint('${this.hashCode}');
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1502,7 +1502,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     }
 
     _setSelectionPosition(null, isEnd: isEnd);
-
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
     final Offset localPosition = MatrixUtils.transformPoint(transform, globalPosition);
@@ -1516,7 +1515,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     );
 
     final TextPosition position = paragraph.getPositionForOffset(adjustedOffset);
-
     // Check if the original local position is within the rect, if it is not then
     // we do not need to look up the word boundary for that position. This is to
     // maintain a selectables selection collapsed at 0 when the local position is

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1527,7 +1527,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         if (existingSelectionStart.offset < existingSelectionEnd.offset) {
           // The selection is normalized, i.e. the start of the selection is before
           // the end.
-          if (shouldSwapEdgesWhenSelectionIsNormalized) {.
+          if (shouldSwapEdgesWhenSelectionIsNormalized) {
             targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
             // The static edge is moved to the opposite end of the word boundary to
             // keep the entire origin word in the selection

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1453,7 +1453,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdge(Offset globalPosition, {required bool isEnd}) {
-    // debugPrint('${this.hashCode}');
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
@@ -1483,7 +1482,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
-    // debugPrint('${this.hashCode}');
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1397,14 +1397,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       case SelectionEventType.startEdgeUpdate:
       case SelectionEventType.endEdgeUpdate:
         final SelectionEdgeUpdateEvent edgeUpdate = event as SelectionEdgeUpdateEvent;
-        final SelectionMode? mode = edgeUpdate.mode;
-        switch (mode) {
-          case null:
-          case SelectionMode.character:
-            result = _updateSelectionEdge(edgeUpdate.globalPosition, mode, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
-          case SelectionMode.word:
-            result = _updateSelectionEdge(edgeUpdate.globalPosition, mode, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
-        }
+        result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
       case SelectionEventType.clear:
         result = _handleClearSelection();
       case SelectionEventType.selectAll:
@@ -1452,7 +1445,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     _updateSelectionGeometry();
   }
 
-  SelectionResult _updateSelectionEdge(Offset globalPosition, SelectionMode? mode, {required bool isEnd}) {
+  SelectionResult _updateSelectionEdge(Offset globalPosition, {required bool isEnd}) {
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
@@ -1467,18 +1460,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     );
 
     final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
-    debugPrint(mode.toString());
-    switch (mode) {
-      case null:
-      case SelectionMode.character:
-        _setSelectionPosition(position, isEnd: isEnd);
-      case SelectionMode.word:
-        if (_positionIsWithinCurrentSelection(position)) {
-          return SelectionResult.end;
-        }
-        final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
-        _setSelectionPosition(wordBoundary.$1, isEnd: isEnd);
-    }
+    _setSelectionPosition(position, isEnd: isEnd);
     if (position.offset == range.end) {
       return SelectionResult.next;
     }
@@ -1529,13 +1511,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     if (_positionIsWithinCurrentSelection(position)) {
       return SelectionResult.end;
     }
-    final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
-    _textSelectionStart = wordBoundary.$1;
-    _textSelectionEnd = wordBoundary.$2;
-    return SelectionResult.end;
-  }
-
-  (TextPosition start, TextPosition end) _getWordBoundaryAtPosition(TextPosition position) {
     final TextRange word = paragraph.getWordBoundary(position);
     assert(word.isNormalized);
     if (word.start < range.start && word.end < range.start) {
@@ -1554,7 +1529,9 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       start = TextPosition(offset: word.start);
       end = TextPosition(offset: word.end, affinity: TextAffinity.upstream);
     }
-    return (start, end);
+    _textSelectionStart = start;
+    _textSelectionEnd = end;
+    return SelectionResult.end;
   }
 
   SelectionResult _handleDirectionallyExtendSelection(double horizontalBaseline, bool isExtent, SelectionExtendDirection movement) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1408,7 +1408,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
             result = _updateSelectionEdgeByWord(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
           case TextGranularity.document:
           case TextGranularity.line:
-            assert(granularity == TextGranularity.document || granularity == TextGranularity.line, 'Moving the selection edge by line or document is not supported.');
+            assert(granularity != TextGranularity.document && granularity != TextGranularity.line, 'Moving the selection edge by line or document is not supported.');
         }
       case SelectionEventType.clear:
         result = _handleClearSelection();
@@ -1529,7 +1529,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           if (shouldSwapEdgesWhenSelectionIsNormalized) {
             targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
             // The static edge is moved to the opposite end of the word boundary to
-            // keep the entire origin word in the selection
+            // keep the entire origin word in the selection.
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
             _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
@@ -1547,7 +1547,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           if (shouldSwapEdgesWhenSelectionNotNormalized) {
             targetPosition = isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
             // The static edge is moved to the opposite end of the word boundary to
-            // keep the entire origin word in the selection
+            // keep the entire origin word in the selection.
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
             _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1472,9 +1472,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     );
 
     final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
-    if (fullText == 'Item 17') {
-      debugPrint('moving to position $position $isEnd');
-    }
     _setSelectionPosition(position, isEnd: isEnd);
     if (position.offset == range.end) {
       return SelectionResult.next;
@@ -1577,6 +1574,37 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
             }
           }
         }
+      } else if (existingSelectionStart != null) {
+        if (isEnd) {
+          if (position.offset < existingSelectionStart.offset) {
+            targetPosition = wordBoundary.$1;
+          } else {
+            targetPosition = wordBoundary.$2;
+          }
+        } else {
+          // Move edge to closest word boundary.
+          final int differenceA = (position.offset - wordBoundary.$1.offset).abs();
+          final int differenceB = (position.offset - wordBoundary.$2.offset).abs();
+          targetPosition = differenceA < differenceB ? wordBoundary.$1 : wordBoundary.$2;
+        }
+      } else if (existingSelectionEnd != null) {
+        if (isEnd) {
+          // Move edge to closest word boundary.
+          final int differenceA = (position.offset - wordBoundary.$1.offset).abs();
+          final int differenceB = (position.offset - wordBoundary.$2.offset).abs();
+          targetPosition = differenceA < differenceB ? wordBoundary.$1 : wordBoundary.$2;
+        } else {
+          if (position.offset < existingSelectionEnd.offset) {
+            targetPosition = wordBoundary.$1;
+          } else {
+            targetPosition = wordBoundary.$2;
+          }
+        }
+      } else {
+        // Move edge to closest word boundary.
+        final int differenceA = (position.offset - wordBoundary.$1.offset).abs();
+        final int differenceB = (position.offset - wordBoundary.$2.offset).abs();
+        targetPosition = differenceA < differenceB ? wordBoundary.$1 : wordBoundary.$2;
       }
     } else {
       // The localPosition is not contained within the current rect. The adjustedPosition

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1679,12 +1679,8 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     assert(word.isNormalized);
     late TextPosition start;
     late TextPosition end;
-    // if (position.offset >= word.end) {
     if (position.offset > word.end) {
-      // This seems to cause an issue when dragging between words.
       start = end = TextPosition(offset: position.offset);
-      // start = TextPosition(offset: word.start);
-      // end = TextPosition(offset: word.end, affinity: TextAffinity.upstream);
     } else {
       start = TextPosition(offset: word.start);
       end = TextPosition(offset: word.end, affinity: TextAffinity.upstream);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1408,7 +1408,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
             result = _updateSelectionEdgeByWord(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
           case TextGranularity.document:
           case TextGranularity.line:
-            assert(granularity != TextGranularity.document && granularity != TextGranularity.line, 'Moving the selection edge by line or document is not supported.');
+            assert(false, 'Moving the selection edge by line or document is not supported.');
         }
       case SelectionEventType.clear:
         result = _handleClearSelection();
@@ -1505,9 +1505,9 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     if (wordBoundary != null) {
       assert(wordBoundary.wordStart.offset >= range.start && wordBoundary.wordEnd.offset <= range.end);
       if (_selectableContainsOriginWord && existingSelectionStart != null && existingSelectionEnd != null) {
-        final bool shouldSwapEdgesWhenSelectionIsNormalized = position.offset > existingSelectionEnd.offset;
-        final bool shouldSwapEdgesWhenSelectionNotNormalized = position.offset < existingSelectionEnd.offset;
-        final bool shouldSwapEdges = existingSelectionStart.offset < existingSelectionEnd.offset ? shouldSwapEdgesWhenSelectionIsNormalized : shouldSwapEdgesWhenSelectionNotNormalized;
+        final bool isSamePosition = position.offset == existingSelectionEnd.offset;
+        final bool isSelectionInverted = existingSelectionStart.offset > existingSelectionEnd.offset;
+        final bool shouldSwapEdges = !isSamePosition && (isSelectionInverted != (position.offset > existingSelectionEnd.offset));
         if (shouldSwapEdges) {
           if (position.offset < existingSelectionEnd.offset) {
             targetPosition = wordBoundary.wordStart;
@@ -1552,21 +1552,14 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         // When the selection is inverted by the new position it is necessary to
         // swap the start edge (moving edge) with the end edge (static edge) to
         // maintain the origin word within the selection.
-        final bool shouldSwapEdgesWhenSelectionIsNormalized = position.offset > existingSelectionEnd.offset;
-        final bool shouldSwapEdgesWhenSelectionNotNormalized = position.offset < existingSelectionEnd.offset;
+        final bool isSamePosition = position.offset == existingSelectionEnd.offset;
+        final bool isSelectionInverted = existingSelectionStart.offset > existingSelectionEnd.offset;
+        final bool shouldSwapEdges = !isSamePosition && (isSelectionInverted != (position.offset > existingSelectionEnd.offset));
 
-        if (existingSelectionStart.offset < existingSelectionEnd.offset) {
-          if (shouldSwapEdgesWhenSelectionIsNormalized || position.offset == existingSelectionEnd.offset) {
-            final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
-            assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-            _setSelectionPosition(localWordBoundary.wordStart, isEnd: true);
-          }
-        } else {
-          if (shouldSwapEdgesWhenSelectionNotNormalized || position.offset == existingSelectionEnd.offset) {
-            final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
-            assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-            _setSelectionPosition(localWordBoundary.wordEnd, isEnd: true);
-          }
+        if (shouldSwapEdges) {
+          final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
+          assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
+          _setSelectionPosition(isSelectionInverted ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: true);
         }
       }
     }
@@ -1583,9 +1576,9 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     if (wordBoundary != null) {
       assert(wordBoundary.wordStart.offset >= range.start && wordBoundary.wordEnd.offset <= range.end);
       if (_selectableContainsOriginWord && existingSelectionStart != null && existingSelectionEnd != null) {
-        final bool shouldSwapEdgesWhenSelectionIsNormalized = position.offset < existingSelectionStart.offset;
-        final bool shouldSwapEdgesWhenSelectionNotNormalized = position.offset > existingSelectionStart.offset;
-        final bool shouldSwapEdges = existingSelectionStart.offset < existingSelectionEnd.offset ? shouldSwapEdgesWhenSelectionIsNormalized : shouldSwapEdgesWhenSelectionNotNormalized;
+        final bool isSamePosition = position.offset == existingSelectionStart.offset;
+        final bool isSelectionInverted = existingSelectionStart.offset > existingSelectionEnd.offset;
+        final bool shouldSwapEdges = !isSamePosition && (isSelectionInverted != (position.offset < existingSelectionStart.offset));
         if (shouldSwapEdges) {
           if (position.offset < existingSelectionStart.offset) {
             targetPosition = wordBoundary.wordStart;
@@ -1630,21 +1623,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         // When the selection is inverted by the new position it is necessary to
         // swap the end edge (moving edge) with the start edge (static edge) to
         // maintain the origin word within the selection.
-        final bool shouldSwapEdgesWhenSelectionIsNormalized = position.offset < existingSelectionStart.offset;
-        final bool shouldSwapEdgesWhenSelectionNotNormalized = position.offset > existingSelectionStart.offset;
-
-        if (existingSelectionStart.offset < existingSelectionEnd.offset) {
-          if (shouldSwapEdgesWhenSelectionIsNormalized || position.offset == existingSelectionStart.offset) {
-            final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
-            assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-            _setSelectionPosition(localWordBoundary.wordEnd, isEnd: false);
-          }
-        } else {
-          if (shouldSwapEdgesWhenSelectionNotNormalized || position.offset == existingSelectionStart.offset) {
-            final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
-            assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-            _setSelectionPosition(localWordBoundary.wordStart, isEnd: false);
-          }
+        final bool isSamePosition = position.offset == existingSelectionStart.offset;
+        final bool isSelectionInverted = existingSelectionStart.offset > existingSelectionEnd.offset;
+        final bool shouldSwapEdges = isSelectionInverted != (position.offset < existingSelectionStart.offset) || isSamePosition;
+        if (shouldSwapEdges) {
+          final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
+          assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
+          _setSelectionPosition(isSelectionInverted ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: false);
         }
       }
     }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -18,6 +18,9 @@ import 'layout_helper.dart';
 import 'object.dart';
 import 'selection.dart';
 
+/// The start and end positions for a word.
+typedef _WordBoundaryRecord = ({TextPosition wordStart, TextPosition wordEnd});
+
 const String _kEllipsis = '\u2026';
 
 /// Used by the [RenderParagraph] to map its rendering children to their
@@ -1487,7 +1490,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   TextPosition _closestWordBoundary(
-    ({TextPosition wordStart, TextPosition wordEnd}) wordBoundary,
+    _WordBoundaryRecord wordBoundary,
     TextPosition position,
   ) {
     final int differenceA = (position.offset - wordBoundary.wordStart.offset).abs();
@@ -1496,7 +1499,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   TextPosition _updateSelectionStartEdgeByWord(
-    ({TextPosition wordStart, TextPosition wordEnd})? wordBoundary,
+    _WordBoundaryRecord? wordBoundary,
     TextPosition position,
     TextPosition? existingSelectionStart,
     TextPosition? existingSelectionEnd,
@@ -1517,7 +1520,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           // When the selection is inverted by the new position it is necessary to
           // swap the start edge (moving edge) with the end edge (static edge) to
           // maintain the origin word within the selection.
-          final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
+          final _WordBoundaryRecord localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
           assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
           _setSelectionPosition(existingSelectionEnd.offset == localWordBoundary.wordStart.offset ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: true);
         } else {
@@ -1557,7 +1560,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         final bool shouldSwapEdges = !isSamePosition && (isSelectionInverted != (position.offset > existingSelectionEnd.offset));
 
         if (shouldSwapEdges) {
-          final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
+          final _WordBoundaryRecord localWordBoundary = _getWordBoundaryAtPosition(existingSelectionEnd);
           assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
           _setSelectionPosition(isSelectionInverted ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: true);
         }
@@ -1567,7 +1570,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   TextPosition _updateSelectionEndEdgeByWord(
-    ({TextPosition wordStart, TextPosition wordEnd})? wordBoundary,
+    _WordBoundaryRecord? wordBoundary,
     TextPosition position,
     TextPosition? existingSelectionStart,
     TextPosition? existingSelectionEnd,
@@ -1588,7 +1591,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           // When the selection is inverted by the new position it is necessary to
           // swap the end edge (moving edge) with the start edge (static edge) to
           // maintain the origin word within the selection.
-          final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
+          final _WordBoundaryRecord localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
           assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
           _setSelectionPosition(existingSelectionStart.offset == localWordBoundary.wordStart.offset ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: false);
         } else {
@@ -1627,7 +1630,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         final bool isSelectionInverted = existingSelectionStart.offset > existingSelectionEnd.offset;
         final bool shouldSwapEdges = isSelectionInverted != (position.offset < existingSelectionStart.offset) || isSamePosition;
         if (shouldSwapEdges) {
-          final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
+          final _WordBoundaryRecord localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
           assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
           _setSelectionPosition(isSelectionInverted ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: false);
         }
@@ -1661,7 +1664,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     // we do not need to look up the word boundary for that position. This is to
     // maintain a selectables selection collapsed at 0 when the local position is
     // not located inside its rect.
-    final ({TextPosition wordStart, TextPosition wordEnd})? wordBoundary = !_rect.contains(localPosition) ? null : _getWordBoundaryAtPosition(position);
+    final _WordBoundaryRecord? wordBoundary = !_rect.contains(localPosition) ? null : _getWordBoundaryAtPosition(position);
     final TextPosition targetPosition = _clampTextPosition(isEnd ? _updateSelectionEndEdgeByWord(wordBoundary, position, existingSelectionStart, existingSelectionEnd) : _updateSelectionStartEdgeByWord(wordBoundary, position, existingSelectionStart, existingSelectionEnd));
 
     _setSelectionPosition(targetPosition, isEnd: isEnd);
@@ -1719,7 +1722,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     if (_positionIsWithinCurrentSelection(position)) {
       return SelectionResult.end;
     }
-    final ({TextPosition wordStart, TextPosition wordEnd}) wordBoundary = _getWordBoundaryAtPosition(position);
+    final _WordBoundaryRecord wordBoundary = _getWordBoundaryAtPosition(position);
     if (wordBoundary.wordStart.offset < range.start && wordBoundary.wordEnd.offset < range.start) {
       return SelectionResult.previous;
     } else if (wordBoundary.wordStart.offset > range.end && wordBoundary.wordEnd.offset > range.end) {
@@ -1733,7 +1736,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     return SelectionResult.end;
   }
 
-  ({TextPosition wordStart, TextPosition wordEnd}) _getWordBoundaryAtPosition(TextPosition position) {
+  _WordBoundaryRecord _getWordBoundaryAtPosition(TextPosition position) {
     final TextRange word = paragraph.getWordBoundary(position);
     assert(word.isNormalized);
     late TextPosition start;
@@ -2068,3 +2071,4 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   @override
   TextRange getWordBoundary(TextPosition position) => paragraph.getWordBoundary(position);
 }
+

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1536,8 +1536,9 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       // always extend to wordBoundary.$2. Instead the selection should expand to
       // wordBoudary.$x that results in the largest selection.
       if (wordBoundary != null) {
-        int lengthWhenExpandingToBegOfWord = (_textSelectionStart!.offset - wordBoundary!.$1.offset).abs();
-        int lengthWhenExpandingToEndOfWord = (_textSelectionStart!.offset - wordBoundary!.$2.offset).abs();
+        int selectionEdgeOffset = isEnd ? _textSelectionStart!.offset : _textSelectionEnd!.offset;
+        int lengthWhenExpandingToBegOfWord = (selectionEdgeOffset - wordBoundary!.$1.offset).abs();
+        int lengthWhenExpandingToEndOfWord = (selectionEdgeOffset - wordBoundary!.$2.offset).abs();
         if (lengthWhenExpandingToBegOfWord > lengthWhenExpandingToEndOfWord) {
           targetPosition = wordBoundary!.$1;
         } else {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -2071,4 +2071,3 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   @override
   TextRange getWordBoundary(TextPosition position) => paragraph.getWordBoundary(position);
 }
-

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1521,15 +1521,18 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     // maintain a selectables selection collapsed at 0 when the local position is
     // not located inside its rect.
     final (TextPosition start, TextPosition end)? wordBoundary = !_rect.contains(localPosition) ? null : _getWordBoundaryAtPosition(position);
-    TextPosition targetPosition = wordBoundary != null ? isEnd ? wordBoundary.$2 : wordBoundary.$1 : position;
+    TextPosition? targetPosition;
     if (_selectableContainsOriginWord!) {
       // Swap the start and end.
-      if (targetPosition.offset >= _originWordSelectionEnd!.offset) {
-        targetPosition = wordBoundary?.$2 ?? position;
+      if (position.offset >= _originWordSelectionEnd!.offset) {
+        targetPosition = wordBoundary?.$2;
         _setSelectionPosition(_originWordSelectionStart, isEnd: !isEnd);
-      } else if (targetPosition.offset <= _originWordSelectionStart!.offset) {
-        targetPosition = wordBoundary?.$1 ?? position;
+      } else if (position.offset <= _originWordSelectionStart!.offset) {
+        targetPosition = wordBoundary?.$1;
         _setSelectionPosition(_originWordSelectionEnd, isEnd: !isEnd);
+      } else {
+        targetPosition = wordBoundary?.$2;
+        _setSelectionPosition(_originWordSelectionStart, isEnd: !isEnd);
       }
     } else {
       // If we are always moving the selection end edge then the selection will
@@ -1546,7 +1549,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         }
       }
     }
-    targetPosition = _clampTextPosition(targetPosition);
+    targetPosition = _clampTextPosition(targetPosition ?? position);
 
     _setSelectionPosition(targetPosition, isEnd: isEnd);
     if (targetPosition.offset == range.end) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1393,7 +1393,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     late final SelectionResult result;
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
-    debugPrint('hello from renderParagraph dispatch selecton event $hashCode $existingSelectionStart $existingSelectionEnd');
     switch (event.type) {
       case SelectionEventType.startEdgeUpdate:
       case SelectionEventType.endEdgeUpdate:
@@ -1483,7 +1482,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
-    debugPrint('updateSelectionEdgeByWord $hashCode $_textSelectionStart $_textSelectionEnd');
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
@@ -1496,20 +1494,14 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       localPosition,
       direction: paragraph.textDirection,
     );
-    debugPrint('current rect $hashCode $_rect');
     final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
-    debugPrint('$globalPosition');
-    debugPrint('${paragraph.globalToLocal(globalPosition)}');
-    debugPrint('$localPosition');
-    debugPrint('$adjustedOffset');
-    debugPrint('${paragraph.getPositionForOffset(adjustedOffset)}');
-    debugPrint('$_clampTextPosition(paragraph.getPositionForOffset(adjustedOffset)');
-    debugPrint('$position');
 
     final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
-    final TextPosition targetPosition = isEnd ? wordBoundary.$2 : wordBoundary.$1;
+    TextPosition targetPosition = isEnd ? wordBoundary.$2 : wordBoundary.$1;
+    if (!_rect.contains(localPosition)) {
+      targetPosition = position;
+    }
     _setSelectionPosition(targetPosition, isEnd: isEnd);
-    debugPrint('updateSelectionEdgeByWord 2 $hashCode $_textSelectionStart $_textSelectionEnd');
     if (targetPosition.offset == range.end) {
       return SelectionResult.next;
     }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1527,8 +1527,10 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         if (existingSelectionStart.offset < existingSelectionEnd.offset) {
           // The selection is normalized, i.e. the start of the selection is before
           // the end.
-          if (shouldSwapEdgesWhenSelectionIsNormalized) {
+          if (shouldSwapEdgesWhenSelectionIsNormalized) {.
             targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
+            // The static edge is moved to the opposite end of the word boundary to
+            // keep the entire origin word in the selection
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
           } else {
@@ -1544,6 +1546,8 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           // the start.
           if (shouldSwapEdgesWhenSelectionNotNormalized) {
             targetPosition = isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
+            // The static edge is moved to the opposite end of the word boundary to
+            // keep the entire origin word in the selection
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);
           } else {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1329,7 +1329,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   TextPosition? _textSelectionStart;
   TextPosition? _textSelectionEnd;
 
-  bool? _selectableContainsOriginWord;
+  bool _selectableContainsOriginWord = false;
 
   LayerLink? _startHandleLayerLink;
   LayerLink? _endHandleLayerLink;
@@ -1492,7 +1492,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     // move the opposite edge outside of the origin word boundary and we are unable to recover.
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
-    _selectableContainsOriginWord ??= existingSelectionStart != null && existingSelectionEnd != null;
 
     // _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
@@ -1521,7 +1520,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       if (existingSelectionStart != null && existingSelectionEnd != null) {
         final TextPosition edgeToKeepInPlace = isEnd ? existingSelectionStart : existingSelectionEnd;
         final TextPosition currentMovingEdge = isEnd ? existingSelectionEnd : existingSelectionStart;
-        if (_selectableContainsOriginWord!) {
+        if (_selectableContainsOriginWord) {
           // final bool edgeToKeepInPlaceWithinWordBoundary = edgeToKeepInPlace.offset >= wordBoundary.wordStart.offset && edgeToKeepInPlace.offset <= wordBoundary.wordEnd.offset;
           // debugPrint('potentially swapping $position $edgeToKeepInPlace');
           // // if (edgeToKeepInPlaceWithinWordBoundary) {
@@ -1553,47 +1552,47 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
           // } else {
           //   targetPosition = wordBoundary.wordEnd;
           // }
-          // // Swap the selection edges to keep the origin word in bounds, when the
-          // // new position where to cause an inverted selection.
-          // final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
-          // final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
-          // if (existingSelectionStart.offset <= existingSelectionEnd.offset) {
-          //   // The selection is normalized, i.e. the start of the selection is before
-          //   // the end.
-          //   if (shouldSwapEdgesWhenSelectionIsNormalized) {
-          //     targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
-          //     // The static edge is moved to the opposite end of the word boundary to
-          //     // keep the entire origin word in the selection.
-          //     final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
-          //     assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-          //     _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
-          //   } else {
-          //     // If the new position falls on the same position of the static
-          //     // edge, keep the selection at the same word boundary regardless
-          //     // of the affinity, so the origin word stays in bounds. If not then
-          //     // extend the selection to the boundary that would encompass the entire
-          //     // word at the new position.
-          //     targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
-          //   }
-          // } else {
-          //   // The selection is not normalized, i.e. the end of the selection is before
-          //   // the start.
-          //   if (shouldSwapEdgesWhenSelectionNotNormalized) {
-          //     targetPosition = isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
-          //     // The static edge is moved to the opposite end of the word boundary to
-          //     // keep the entire origin word in the selection.
-          //     final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
-          //     assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
-          //     _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);
-          //   } else {
-          //     // If the new position falls on the same position of the static
-          //     // edge, keep the selection at the same word boundary regardless
-          //     // of the affinity, so the origin word stays in bounds. If not then
-          //     // expand the selection to the boundary that would encompass the entire
-          //     // word at the new position.
-          //     targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
-          //   }
-          // }
+          // Swap the selection edges to keep the origin word in bounds, when the
+          // new position where to cause an inverted selection.
+          final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
+          final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
+          if (existingSelectionStart.offset <= existingSelectionEnd.offset) {
+            // The selection is normalized, i.e. the start of the selection is before
+            // the end.
+            if (shouldSwapEdgesWhenSelectionIsNormalized) {
+              targetPosition = isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
+              // The static edge is moved to the opposite end of the word boundary to
+              // keep the entire origin word in the selection.
+              final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
+              assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
+              _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
+            } else {
+              // If the new position falls on the same position of the static
+              // edge, keep the selection at the same word boundary regardless
+              // of the affinity, so the origin word stays in bounds. If not then
+              // extend the selection to the boundary that would encompass the entire
+              // word at the new position.
+              targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
+            }
+          } else {
+            // The selection is not normalized, i.e. the end of the selection is before
+            // the start.
+            if (shouldSwapEdgesWhenSelectionNotNormalized) {
+              targetPosition = isEnd ? wordBoundary.wordEnd : wordBoundary.wordStart;
+              // The static edge is moved to the opposite end of the word boundary to
+              // keep the entire origin word in the selection.
+              final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
+              assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
+              _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);
+            } else {
+              // If the new position falls on the same position of the static
+              // edge, keep the selection at the same word boundary regardless
+              // of the affinity, so the origin word stays in bounds. If not then
+              // expand the selection to the boundary that would encompass the entire
+              // word at the new position.
+              targetPosition = position.offset == edgeToKeepInPlace.offset ? currentMovingEdge : isEnd ? wordBoundary.wordStart : wordBoundary.wordEnd;
+            }
+          }
         } else {
           debugPrint('normal no swapping');
           // The edge should move to encompass the entire word at the new position.
@@ -1628,13 +1627,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
 
         if (existingSelectionStart.offset < existingSelectionEnd.offset) {
-          if (shouldSwapEdgesWhenSelectionIsNormalized || position.offset == edgeToKeepInPlace.offset && _selectableContainsOriginWord!) {
+          if (shouldSwapEdgesWhenSelectionIsNormalized || position.offset == edgeToKeepInPlace.offset && _selectableContainsOriginWord) {
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
             _setSelectionPosition(isEnd ? localWordBoundary.wordEnd : localWordBoundary.wordStart, isEnd: !isEnd);
           }
         } else {
-          if (shouldSwapEdgesWhenSelectionNotNormalized || position.offset == edgeToKeepInPlace.offset && _selectableContainsOriginWord!) {
+          if (shouldSwapEdgesWhenSelectionNotNormalized || position.offset == edgeToKeepInPlace.offset && _selectableContainsOriginWord) {
             final ({TextPosition wordStart, TextPosition wordEnd}) localWordBoundary = _getWordBoundaryAtPosition(edgeToKeepInPlace);
             assert(localWordBoundary.wordStart.offset >= range.start && localWordBoundary.wordEnd.offset <= range.end);
             _setSelectionPosition(isEnd ? localWordBoundary.wordStart : localWordBoundary.wordEnd, isEnd: !isEnd);
@@ -1682,7 +1681,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   SelectionResult _handleClearSelection() {
     _textSelectionStart = null;
     _textSelectionEnd = null;
-    _selectableContainsOriginWord = null;
+    _selectableContainsOriginWord = false;
     return SelectionResult.none;
   }
 
@@ -1693,7 +1692,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _handleSelectWord(Offset globalPosition) {
-    _selectableContainsOriginWord = null;
+    _selectableContainsOriginWord = true;
 
     final TextPosition position = paragraph.getPositionForOffset(paragraph.globalToLocal(globalPosition));
     if (_positionIsWithinCurrentSelection(position)) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1536,13 +1536,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       // always extend to wordBoundary.$2. Instead the selection should expand to
       // wordBoudary.$x that results in the largest selection.
       if (wordBoundary != null) {
-        int selectionEdgeOffset = isEnd ? _textSelectionStart!.offset : _textSelectionEnd!.offset;
-        int lengthWhenExpandingToBegOfWord = (selectionEdgeOffset - wordBoundary!.$1.offset).abs();
-        int lengthWhenExpandingToEndOfWord = (selectionEdgeOffset - wordBoundary!.$2.offset).abs();
+        final int selectionEdgeOffset = isEnd ? _textSelectionStart!.offset : _textSelectionEnd!.offset;
+        final int lengthWhenExpandingToBegOfWord = (selectionEdgeOffset - wordBoundary.$1.offset).abs();
+        final int lengthWhenExpandingToEndOfWord = (selectionEdgeOffset - wordBoundary.$2.offset).abs();
         if (lengthWhenExpandingToBegOfWord > lengthWhenExpandingToEndOfWord) {
-          targetPosition = wordBoundary!.$1;
+          targetPosition = wordBoundary.$1;
         } else {
-          targetPosition = wordBoundary!.$2;
+          targetPosition = wordBoundary.$2;
         }
       }
     }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1500,9 +1500,16 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
     if (isEnd) {
       _setSelectionPosition(wordBoundary.$2, isEnd: isEnd);
+      if (wordBoundary.$2.offset == range.end) {
+        return SelectionResult.next;
+      }
     } else {
       _setSelectionPosition(wordBoundary.$1, isEnd: isEnd);
+      if (wordBoundary.$1.offset == range.start) {
+        return SelectionResult.previous;
+      }
     }
+
     return SelectionUtils.getResultBasedOnRect(_rect, localPosition);
   }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1473,6 +1473,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
 
     final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
     _setSelectionPosition(position, isEnd: isEnd);
+    debugPrint('moving $fullText end edge $isEnd to $position');
     if (position.offset == range.end) {
       return SelectionResult.next;
     }
@@ -1487,10 +1488,13 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
+    // When the start/end edges are swapped, i.e. the start is after the end, and the scrollable synthesizes an event
+    // for the start edge, this will potentially move the start edge outside of the origin word boundary and we are unable to recover.
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
     _selectableContainsOriginWord ??= existingSelectionStart != null && existingSelectionEnd != null;
 
+    debugPrint('beginning of update selection edge by word $fullText $_textSelectionStart, $_textSelectionEnd');
 
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
@@ -1710,6 +1714,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     targetPosition = _clampTextPosition(targetPosition ?? position);
 
     _setSelectionPosition(targetPosition, isEnd: isEnd);
+    debugPrint('$fullText moving isEnd: $isEnd to $targetPosition based on $position, current selectable? : ${_rect.contains(localPosition)} final start and end : $_textSelectionStart $_textSelectionEnd');
     if (targetPosition.offset == range.end) {
       return SelectionResult.next;
     }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1393,6 +1393,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     late final SelectionResult result;
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
+    debugPrint('hello from renderParagraph dispatch selecton event $hashCode $existingSelectionStart $existingSelectionEnd');
     switch (event.type) {
       case SelectionEventType.startEdgeUpdate:
       case SelectionEventType.endEdgeUpdate:
@@ -1482,6 +1483,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
+    debugPrint('updateSelectionEdgeByWord $hashCode $_textSelectionStart $_textSelectionEnd');
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
@@ -1494,20 +1496,26 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       localPosition,
       direction: paragraph.textDirection,
     );
-
+    debugPrint('current rect $hashCode $_rect');
     final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
+    debugPrint('$globalPosition');
+    debugPrint('${paragraph.globalToLocal(globalPosition)}');
+    debugPrint('$localPosition');
+    debugPrint('$adjustedOffset');
+    debugPrint('${paragraph.getPositionForOffset(adjustedOffset)}');
+    debugPrint('$_clampTextPosition(paragraph.getPositionForOffset(adjustedOffset)');
+    debugPrint('$position');
 
     final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
-    if (isEnd) {
-      _setSelectionPosition(wordBoundary.$2, isEnd: isEnd);
-      if (wordBoundary.$2.offset == range.end) {
-        return SelectionResult.next;
-      }
-    } else {
-      _setSelectionPosition(wordBoundary.$1, isEnd: isEnd);
-      if (wordBoundary.$1.offset == range.start) {
-        return SelectionResult.previous;
-      }
+    final TextPosition targetPosition = isEnd ? wordBoundary.$2 : wordBoundary.$1;
+    _setSelectionPosition(targetPosition, isEnd: isEnd);
+    debugPrint('updateSelectionEdgeByWord 2 $hashCode $_textSelectionStart $_textSelectionEnd');
+    if (targetPosition.offset == range.end) {
+      return SelectionResult.next;
+    }
+
+    if (targetPosition.offset == range.start) {
+      return SelectionResult.previous;
     }
 
     return SelectionUtils.getResultBasedOnRect(_rect, localPosition);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1398,7 +1398,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       case SelectionEventType.endEdgeUpdate:
         final SelectionEdgeUpdateEvent edgeUpdate = event as SelectionEdgeUpdateEvent;
         final SelectionMode selectionMode = event.mode;
-        debugPrint(selectionMode.toString());
 
         switch (selectionMode) {
           case SelectionMode.character:
@@ -1500,10 +1499,8 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
 
     final (TextPosition start, TextPosition end) wordBoundary = _getWordBoundaryAtPosition(position);
     if (isEnd) {
-      debugPrint('setting end');
       _setSelectionPosition(wordBoundary.$2, isEnd: isEnd);
     } else {
-      debugPrint('setting start');
       _setSelectionPosition(wordBoundary.$1, isEnd: isEnd);
     }
     return SelectionUtils.getResultBasedOnRect(_rect, localPosition);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1525,7 +1525,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         // new position where to cause an inverted selection.
         final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
         final bool shouldSwapEdgesWhenSelectionNotNormalized = isEnd ? position.offset > existingSelectionStart.offset : position.offset < existingSelectionEnd.offset;
-        if (existingSelectionStart.offset < existingSelectionEnd.offset) {
+        if (existingSelectionStart.offset <= existingSelectionEnd.offset) {
           // The selection is normalized, i.e. the start of the selection is before
           // the end.
           if (shouldSwapEdgesWhenSelectionIsNormalized) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1397,13 +1397,16 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       case SelectionEventType.startEdgeUpdate:
       case SelectionEventType.endEdgeUpdate:
         final SelectionEdgeUpdateEvent edgeUpdate = event as SelectionEdgeUpdateEvent;
-        final SelectionMode selectionMode = event.mode;
+        final TextGranularity granularity = event.granularity;
 
-        switch (selectionMode) {
-          case SelectionMode.character:
+        switch (granularity) {
+          case TextGranularity.character:
             result = _updateSelectionEdge(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
-          case SelectionMode.words:
+          case TextGranularity.word:
             result = _updateSelectionEdgeByWord(edgeUpdate.globalPosition, isEnd: edgeUpdate.type == SelectionEventType.endEdgeUpdate);
+          case TextGranularity.document:
+          case TextGranularity.line:
+            assert(granularity == TextGranularity.document || granularity == TextGranularity.line, 'Moving the selection edge by line or document is not supported.');
         }
       case SelectionEventType.clear:
         result = _handleClearSelection();

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1629,14 +1629,15 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
             if (position.offset == existingSelectionStart.offset && _selectableContainsOriginWord!) {
               // This case applies when the origin word is at the beginning of
               // the origin selectable, and the adjustedPosition is at the beginning
-              // of the rect, to keep the origin word in bounds, the start edge should
-              // move to the end the origin word.
+              // of the rect, to keep the origin word in bounds, the end edge should
+              // stay at the end of the origin word.
               //
               // This is only done when the current selectable contains the origin word,
               // if it does not then we are okay with the selection being collapsed
               // as a result of the adjustedPosition.
               final (TextPosition start, TextPosition end) localWordBoundary = _getWordBoundaryAtPosition(existingSelectionStart);
-              _setSelectionPosition(localWordBoundary.$2, isEnd: !isEnd);
+              _setSelectionPosition(localWordBoundary.$1, isEnd: !isEnd);
+              targetPosition = localWordBoundary.$2;
             }
           } else {
             // The end of the selection is before the start.

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1493,7 +1493,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
 
-    // _setSelectionPosition(null, isEnd: isEnd);
+    _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
     transform.invert();
     final Offset localPosition = MatrixUtils.transformPoint(transform, globalPosition);
@@ -1507,8 +1507,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     );
 
     final TextPosition position = paragraph.getPositionForOffset(adjustedOffset);
-    final bool isPositionOnPreviousSelection = _positionIsWithinCurrentSelection(position);
-    _setSelectionPosition(null, isEnd: isEnd);
     // Check if the original local position is within the rect, if it is not then
     // we do not need to look up the word boundary for that position. This is to
     // maintain a selectables selection collapsed at 0 when the local position is
@@ -1521,37 +1519,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         final TextPosition edgeToKeepInPlace = isEnd ? existingSelectionStart : existingSelectionEnd;
         final TextPosition currentMovingEdge = isEnd ? existingSelectionEnd : existingSelectionStart;
         if (_selectableContainsOriginWord) {
-          // final bool edgeToKeepInPlaceWithinWordBoundary = edgeToKeepInPlace.offset >= wordBoundary.wordStart.offset && edgeToKeepInPlace.offset <= wordBoundary.wordEnd.offset;
-          // debugPrint('potentially swapping $position $edgeToKeepInPlace');
-          // // if (edgeToKeepInPlaceWithinWordBoundary) {
-          // //   debugPrint('edgeToKeepInPlace is in new wordBoundary');
-          // // }
-          // // if (isPositionOnPreviousSelection) {
-          // //   debugPrint('position is within current selection');
-          // // }
-          // // debugPrint('$edgeToKeepInPlaceWithinWordBoundary $isPositionOnPreviousSelection');
-          // TextPosition pivotEdge = edgeToKeepInPlace;
-          // if (!isPositionOnPreviousSelection) {
-          //   if ((currentMovingEdge.offset < pivotEdge.offset && position.offset >= pivotEdge.offset)
-          //   || (currentMovingEdge.offset > pivotEdge.offset && position.offset <= pivotEdge.offset)) {
-          //     debugPrint('woah');
-          //     if (pivotEdge.affinity != position.affinity) {
-          //       _setSelectionPosition(currentMovingEdge, isEnd: !isEnd);
-          //       pivotEdge = currentMovingEdge;
-          //     }
-          //   }
-          //   // _setSelectionPosition(currentMovingEdge, isEnd: !isEnd);
-          //   // pivotEdge = currentMovingEdge;
-          //   debugPrint('swapping $isEnd $edgeToKeepInPlace $currentMovingEdge $_textSelectionStart $_textSelectionEnd $existingSelectionStart $existingSelectionEnd');
-          // }
-          // if (position.offset < pivotEdge.offset) {
-          //   targetPosition = wordBoundary.wordStart;
-          // } else if (position.offset == pivotEdge.offset && position.affinity == pivotEdge.affinity) {
-          //   debugPrint('same');
-          //   targetPosition = currentMovingEdge;
-          // } else {
-          //   targetPosition = wordBoundary.wordEnd;
-          // }
           // Swap the selection edges to keep the origin word in bounds, when the
           // new position where to cause an inverted selection.
           final bool shouldSwapEdgesWhenSelectionIsNormalized = isEnd ? position.offset < existingSelectionStart.offset : position.offset > existingSelectionEnd.offset;
@@ -1594,7 +1561,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
             }
           }
         } else {
-          debugPrint('normal no swapping');
           // The edge should move to encompass the entire word at the new position.
           if (position.offset < edgeToKeepInPlace.offset) {
             targetPosition = wordBoundary.wordStart;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1473,7 +1473,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
 
     final TextPosition position = _clampTextPosition(paragraph.getPositionForOffset(adjustedOffset));
     _setSelectionPosition(position, isEnd: isEnd);
-    debugPrint('moving $fullText end edge $isEnd to $position');
     if (position.offset == range.end) {
       return SelectionResult.next;
     }
@@ -1488,13 +1487,12 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   SelectionResult _updateSelectionEdgeByWord(Offset globalPosition, {required bool isEnd}) {
-    // When the start/end edges are swapped, i.e. the start is after the end, and the scrollable synthesizes an event
-    // for the start edge, this will potentially move the start edge outside of the origin word boundary and we are unable to recover.
+    // When the start/end edges are swapped, i.e. the start is after the end, and
+    // the scrollable synthesizes an event for the opposite edge, this will potentially
+    // move the opposite edge outside of the origin word boundary and we are unable to recover.
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
     _selectableContainsOriginWord ??= existingSelectionStart != null && existingSelectionEnd != null;
-
-    debugPrint('beginning of update selection edge by word $fullText $_textSelectionStart, $_textSelectionEnd');
 
     _setSelectionPosition(null, isEnd: isEnd);
     final Matrix4 transform = paragraph.getTransformTo(null);
@@ -1605,7 +1603,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     targetPosition = _clampTextPosition(targetPosition ?? position);
 
     _setSelectionPosition(targetPosition, isEnd: isEnd);
-    debugPrint('$fullText moving isEnd: $isEnd to $targetPosition based on $position, current selectable? : ${_rect.contains(localPosition)} final start and end : $_textSelectionStart $_textSelectionEnd');
     if (targetPosition.offset == range.end) {
       return SelectionResult.next;
     }

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -384,17 +384,25 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The [globalPosition] contains the location of the selection start edge.
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition
-  }) : super._(SelectionEventType.startEdgeUpdate);
+  }) : mode = null, super._(SelectionEventType.startEdgeUpdate);
 
   /// Creates a selection end edge update event.
   ///
   /// The [globalPosition] contains the new location of the selection end edge.
   const SelectionEdgeUpdateEvent.forEnd({
-    required this.globalPosition
+    required this.globalPosition,
+    this.mode = SelectionMode.character
   }) : super._(SelectionEventType.endEdgeUpdate);
+
+  final SelectionMode? mode;
 
   /// The new location of the selection edge.
   final Offset globalPosition;
+}
+
+enum SelectionMode {
+  character,
+  word
 }
 
 /// Extends the start or end of the selection by a given [TextGranularity].

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -388,8 +388,8 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The [granularity] contains the granularity which the selection edge should move by.
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition,
-    TextGranularity? textGranularity
-  }) : granularity = textGranularity ?? TextGranularity.character, super._(SelectionEventType.startEdgeUpdate);
+    TextGranularity? granularity
+  }) : granularity = granularity ?? TextGranularity.character, super._(SelectionEventType.startEdgeUpdate);
 
   /// Creates a selection end edge update event.
   ///
@@ -398,8 +398,8 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The [granularity] contains the granularity which the selection edge should move by.
   const SelectionEdgeUpdateEvent.forEnd({
     required this.globalPosition,
-    TextGranularity? textGranularity
-  }) : granularity = textGranularity ?? TextGranularity.character, super._(SelectionEventType.endEdgeUpdate);
+    TextGranularity? granularity
+  }) : granularity = granularity ?? TextGranularity.character, super._(SelectionEventType.endEdgeUpdate);
 
   /// The new location of the selection edge.
   final Offset globalPosition;

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -387,6 +387,7 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The [globalPosition] contains the location of the selection start edge.
   ///
   /// The [granularity] contains the granularity which the selection edge should move by.
+  /// This value defaults to [TextGranularity.character].
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition,
     TextGranularity? granularity
@@ -397,6 +398,7 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The [globalPosition] contains the new location of the selection end edge.
   ///
   /// The [granularity] contains the granularity which the selection edge should move by.
+  /// This value defaults to [TextGranularity.character].
   const SelectionEdgeUpdateEvent.forEnd({
     required this.globalPosition,
     TextGranularity? granularity

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -384,25 +384,17 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The [globalPosition] contains the location of the selection start edge.
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition
-  }) : mode = null, super._(SelectionEventType.startEdgeUpdate);
+  }) : super._(SelectionEventType.startEdgeUpdate);
 
   /// Creates a selection end edge update event.
   ///
   /// The [globalPosition] contains the new location of the selection end edge.
   const SelectionEdgeUpdateEvent.forEnd({
-    required this.globalPosition,
-    this.mode = SelectionMode.character
+    required this.globalPosition
   }) : super._(SelectionEventType.endEdgeUpdate);
-
-  final SelectionMode? mode;
 
   /// The new location of the selection edge.
   final Offset globalPosition;
-}
-
-enum SelectionMode {
-  character,
-  word
 }
 
 /// Extends the start or end of the selection by a given [TextGranularity].

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -55,17 +55,6 @@ enum SelectionResult {
   none,
 }
 
-/// The mode of a [SelectionEdgeUpdateEvent].
-///
-/// Used by [SelectionEdgeUpdateEvent] to decide how to move the selection.
-enum SelectionMode {
-  /// The selection moves by character.
-  character,
-
-  /// The selection moves word-by-word.
-  words,
-}
-
 /// The abstract interface to handle [SelectionEvent]s.
 ///
 /// This interface is extended by [Selectable] and [SelectionContainerDelegate]
@@ -386,7 +375,7 @@ class SelectWordSelectionEvent extends SelectionEvent {
 ///
 /// The [globalPosition] contains the new offset of the edge.
 ///
-/// The [mode] contains the granularity that the selection edge should move by.
+/// The [granularity] contains the granularity that the selection edge should move by.
 ///
 /// This event is dispatched when the framework detects [TapDragStartDetails] in
 /// [SelectionArea]'s gesture recognizers for mouse devices, or the selection
@@ -396,29 +385,29 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   ///
   /// The [globalPosition] contains the location of the selection start edge.
   ///
-  /// The [mode] contains the granularity which the selection edge should move by.
+  /// The [granularity] contains the granularity which the selection edge should move by.
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition,
-    SelectionMode? selectionMode
-  }) : mode = selectionMode ?? SelectionMode.character, super._(SelectionEventType.startEdgeUpdate);
+    TextGranularity? textGranularity
+  }) : granularity = textGranularity ?? TextGranularity.character, super._(SelectionEventType.startEdgeUpdate);
 
   /// Creates a selection end edge update event.
   ///
   /// The [globalPosition] contains the new location of the selection end edge.
   ///
-  /// The [mode] contains the granularity which the selection edge should move by.
+  /// The [granularity] contains the granularity which the selection edge should move by.
   const SelectionEdgeUpdateEvent.forEnd({
     required this.globalPosition,
-    SelectionMode? selectionMode
-  }) : mode = selectionMode ?? SelectionMode.character, super._(SelectionEventType.endEdgeUpdate);
+    TextGranularity? textGranularity
+  }) : granularity = textGranularity ?? TextGranularity.character, super._(SelectionEventType.endEdgeUpdate);
 
   /// The new location of the selection edge.
   final Offset globalPosition;
 
-  /// The granularity that the selection edge should move by.
+  /// The granularity for which the selection moves.
   ///
-  /// Defaults to [SelectionMode.character].
-  final SelectionMode mode;
+  /// Defaults to [TextGranularity.character].
+  final TextGranularity granularity;
 }
 
 /// Extends the start or end of the selection by a given [TextGranularity].

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -376,6 +376,7 @@ class SelectWordSelectionEvent extends SelectionEvent {
 /// The [globalPosition] contains the new offset of the edge.
 ///
 /// The [granularity] contains the granularity that the selection edge should move by.
+/// Only [TextGranularity.character] and [TextGranularity.word] are currently supported.
 ///
 /// This event is dispatched when the framework detects [TapDragStartDetails] in
 /// [SelectionArea]'s gesture recognizers for mouse devices, or the selection
@@ -405,6 +406,8 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   final Offset globalPosition;
 
   /// The granularity for which the selection moves.
+  ///
+  /// Only [TextGranularity.character] and [TextGranularity.word] are currently supported.
   ///
   /// Defaults to [TextGranularity.character].
   final TextGranularity granularity;

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -55,8 +55,14 @@ enum SelectionResult {
   none,
 }
 
+/// The mode of a [SelectionEdgeUpdateEvent].
+///
+/// Used by [SelectionEdgeUpdateEvent] to decide how to move the selection.
 enum SelectionMode {
+  /// The selection moves by character.
   character,
+
+  /// The selection moves word-by-word.
   words,
 }
 
@@ -380,13 +386,17 @@ class SelectWordSelectionEvent extends SelectionEvent {
 ///
 /// The [globalPosition] contains the new offset of the edge.
 ///
-/// This event is dispatched when the framework detects [DragStartDetails] in
+/// The [mode] contains the granularity that the selection edge should move by.
+///
+/// This event is dispatched when the framework detects [TapDragStartDetails] in
 /// [SelectionArea]'s gesture recognizers for mouse devices, or the selection
 /// handles have been dragged to new locations.
 class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// Creates a selection start edge update event.
   ///
   /// The [globalPosition] contains the location of the selection start edge.
+  ///
+  /// The [mode] contains the granularity which the selection edge should move by.
   const SelectionEdgeUpdateEvent.forStart({
     required this.globalPosition,
     SelectionMode? selectionMode
@@ -395,6 +405,8 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// Creates a selection end edge update event.
   ///
   /// The [globalPosition] contains the new location of the selection end edge.
+  ///
+  /// The [mode] contains the granularity which the selection edge should move by.
   const SelectionEdgeUpdateEvent.forEnd({
     required this.globalPosition,
     SelectionMode? selectionMode
@@ -403,6 +415,9 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   /// The new location of the selection edge.
   final Offset globalPosition;
 
+  /// The granularity that the selection edge should move by.
+  ///
+  /// Defaults to [SelectionMode.character].
   final SelectionMode mode;
 }
 

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -55,6 +55,11 @@ enum SelectionResult {
   none,
 }
 
+enum SelectionMode {
+  character,
+  words,
+}
+
 /// The abstract interface to handle [SelectionEvent]s.
 ///
 /// This interface is extended by [Selectable] and [SelectionContainerDelegate]
@@ -383,18 +388,22 @@ class SelectionEdgeUpdateEvent extends SelectionEvent {
   ///
   /// The [globalPosition] contains the location of the selection start edge.
   const SelectionEdgeUpdateEvent.forStart({
-    required this.globalPosition
-  }) : super._(SelectionEventType.startEdgeUpdate);
+    required this.globalPosition,
+    SelectionMode? selectionMode
+  }) : mode = selectionMode ?? SelectionMode.character, super._(SelectionEventType.startEdgeUpdate);
 
   /// Creates a selection end edge update event.
   ///
   /// The [globalPosition] contains the new location of the selection end edge.
   const SelectionEdgeUpdateEvent.forEnd({
-    required this.globalPosition
-  }) : super._(SelectionEventType.endEdgeUpdate);
+    required this.globalPosition,
+    SelectionMode? selectionMode
+  }) : mode = selectionMode ?? SelectionMode.character, super._(SelectionEventType.endEdgeUpdate);
 
   /// The new location of the selection edge.
   final Offset globalPosition;
+
+  final SelectionMode mode;
 }
 
 /// Extends the start or end of the selection by a given [TextGranularity].
@@ -686,7 +695,7 @@ class SelectionGeometry {
 
 /// The geometry information of a selection point.
 @immutable
-class SelectionPoint {
+class SelectionPoint with Diagnosticable {
   /// Creates a selection point object.
   ///
   /// All properties must not be null.
@@ -729,6 +738,14 @@ class SelectionPoint {
       lineHeight,
       handleType,
     );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
+    properties.add(DoubleProperty('lineHeight', lineHeight));
+    properties.add(EnumProperty('handleType', handleType));
   }
 }
 

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -760,7 +760,7 @@ class SelectionPoint with Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<Offset>('localPosition', localPosition));
     properties.add(DoubleProperty('lineHeight', lineHeight));
-    properties.add(EnumProperty('handleType', handleType));
+    properties.add(EnumProperty<TextSelectionHandleType>('handleType', handleType));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1184,11 +1184,6 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       event = SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset, granularity: event.granularity);
     }
     final SelectionResult result = super.handleSelectionEdgeUpdate(event);
-    // Update the drag location from geometries when the granularity that the
-    // selection edge moves by is not precise.
-    if (event.granularity != TextGranularity.character) {
-      _updateDragLocationsFromGeometries();
-    }
 
     // Result may be pending if one of the selectable child is also a scrollable.
     // In that case, the parent scrollable needs to wait for the child to finish
@@ -1429,7 +1424,6 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
   void ensureChildUpdated(Selectable selectable) {
     final double newRecord = state.position.pixels;
     final double? previousStartRecord = _selectableStartEdgeUpdateRecords[selectable];
-    debugPrint('${selectable.hashCode} ${selectable.getSelectedContent()?.plainText}, $_currentDragStartRelatedToOrigin $previousStartRecord $newRecord does not previousStartRecord ${previousStartRecord == null}, ${previousStartRecord != null && ((newRecord - previousStartRecord!).abs() > precisionErrorTolerance)}');
     if (_currentDragStartRelatedToOrigin != null &&
         (previousStartRecord == null || (newRecord - previousStartRecord).abs() > precisionErrorTolerance)) {
       // Make sure the selectable has up to date events.
@@ -1438,7 +1432,6 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset));
     }
     final double? previousEndRecord = _selectableEndEdgeUpdateRecords[selectable];
-    debugPrint('${selectable.hashCode} ${selectable.getSelectedContent()?.plainText}, $_currentDragEndRelatedToOrigin $previousEndRecord $newRecord does not have previousEndRecord ${previousEndRecord == null}, ${previousEndRecord != null && ((newRecord - previousEndRecord!).abs() > precisionErrorTolerance)}');
     if (_currentDragEndRelatedToOrigin != null &&
         (previousEndRecord == null || (newRecord - previousEndRecord).abs() > precisionErrorTolerance)) {
       // Make sure the selectable has up to date events.

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1184,6 +1184,11 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       event = SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset, granularity: event.granularity);
     }
     final SelectionResult result = super.handleSelectionEdgeUpdate(event);
+    // Update the drag location from geometries when the granularity that the
+    // selection edge moves by is not precise.
+    if (event.granularity != TextGranularity.character) {
+      _updateDragLocationsFromGeometries();
+    }
 
     // Result may be pending if one of the selectable child is also a scrollable.
     // In that case, the parent scrollable needs to wait for the child to finish
@@ -1424,6 +1429,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
   void ensureChildUpdated(Selectable selectable) {
     final double newRecord = state.position.pixels;
     final double? previousStartRecord = _selectableStartEdgeUpdateRecords[selectable];
+    debugPrint('${selectable.hashCode} ${selectable.getSelectedContent()?.plainText}, $_currentDragStartRelatedToOrigin $previousStartRecord $newRecord does not previousStartRecord ${previousStartRecord == null}, ${previousStartRecord != null && ((newRecord - previousStartRecord!).abs() > precisionErrorTolerance)}');
     if (_currentDragStartRelatedToOrigin != null &&
         (previousStartRecord == null || (newRecord - previousStartRecord).abs() > precisionErrorTolerance)) {
       // Make sure the selectable has up to date events.
@@ -1432,6 +1438,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset));
     }
     final double? previousEndRecord = _selectableEndEdgeUpdateRecords[selectable];
+    debugPrint('${selectable.hashCode} ${selectable.getSelectedContent()?.plainText}, $_currentDragEndRelatedToOrigin $previousEndRecord $newRecord does not have previousEndRecord ${previousEndRecord == null}, ${previousEndRecord != null && ((newRecord - previousEndRecord!).abs() > precisionErrorTolerance)}');
     if (_currentDragEndRelatedToOrigin != null &&
         (previousEndRecord == null || (newRecord - previousEndRecord).abs() > precisionErrorTolerance)) {
       // Make sure the selectable has up to date events.

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1177,11 +1177,11 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
     if (event.type == SelectionEventType.endEdgeUpdate) {
       _currentDragEndRelatedToOrigin = _inferPositionRelatedToOrigin(event.globalPosition);
       final Offset endOffset = _currentDragEndRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
-      event = SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset);
+      event = SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset, granularity: event.granularity);
     } else {
       _currentDragStartRelatedToOrigin = _inferPositionRelatedToOrigin(event.globalPosition);
       final Offset startOffset = _currentDragStartRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
-      event = SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset);
+      event = SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset, granularity: event.granularity);
     }
     final SelectionResult result = super.handleSelectionEdgeUpdate(event);
 
@@ -1400,10 +1400,10 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
     switch (event.type) {
       case SelectionEventType.startEdgeUpdate:
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
-        ensureChildUpdated(selectable);
+        ensureChildUpdated(selectable, (event as SelectionEdgeUpdateEvent).granularity);
       case SelectionEventType.endEdgeUpdate:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
-        ensureChildUpdated(selectable);
+        ensureChildUpdated(selectable, (event as SelectionEdgeUpdateEvent).granularity);
       case SelectionEventType.granularlyExtendSelection:
       case SelectionEventType.directionallyExtendSelection:
         ensureChildUpdated(selectable);
@@ -1421,7 +1421,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
   }
 
   @override
-  void ensureChildUpdated(Selectable selectable) {
+  void ensureChildUpdated(Selectable selectable, [TextGranularity? granularity]) {
     final double newRecord = state.position.pixels;
     final double? previousStartRecord = _selectableStartEdgeUpdateRecords[selectable];
     if (_currentDragStartRelatedToOrigin != null &&
@@ -1429,7 +1429,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       // Make sure the selectable has up to date events.
       final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
       final Offset startOffset = _currentDragStartRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
-      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset));
+      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset, granularity: granularity));
     }
     final double? previousEndRecord = _selectableEndEdgeUpdateRecords[selectable];
     if (_currentDragEndRelatedToOrigin != null &&
@@ -1437,7 +1437,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       // Make sure the selectable has up to date events.
       final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
       final Offset endOffset = _currentDragEndRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
-      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset));
+      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset, granularity: granularity));
     }
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1430,6 +1430,9 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
       final Offset startOffset = _currentDragStartRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
       selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset));
+      // Make sure we track that we have synthesized a start event for this selectable,
+      // so we don't synthesize events unnecessarily.
+      _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
     }
     final double? previousEndRecord = _selectableEndEdgeUpdateRecords[selectable];
     if (_currentDragEndRelatedToOrigin != null &&
@@ -1438,6 +1441,9 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
       final Offset endOffset = _currentDragEndRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
       selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset));
+      // Make sure we track that we have synthesized an end event for this selectable,
+      // so we don't synthesize events unnecessarily.
+      _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1400,10 +1400,10 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
     switch (event.type) {
       case SelectionEventType.startEdgeUpdate:
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
-        ensureChildUpdated(selectable, (event as SelectionEdgeUpdateEvent).granularity);
+        ensureChildUpdated(selectable);
       case SelectionEventType.endEdgeUpdate:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
-        ensureChildUpdated(selectable, (event as SelectionEdgeUpdateEvent).granularity);
+        ensureChildUpdated(selectable);
       case SelectionEventType.granularlyExtendSelection:
       case SelectionEventType.directionallyExtendSelection:
         ensureChildUpdated(selectable);
@@ -1421,7 +1421,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
   }
 
   @override
-  void ensureChildUpdated(Selectable selectable, [TextGranularity? granularity]) {
+  void ensureChildUpdated(Selectable selectable) {
     final double newRecord = state.position.pixels;
     final double? previousStartRecord = _selectableStartEdgeUpdateRecords[selectable];
     if (_currentDragStartRelatedToOrigin != null &&
@@ -1429,7 +1429,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       // Make sure the selectable has up to date events.
       final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
       final Offset startOffset = _currentDragStartRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
-      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset, granularity: granularity));
+      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: startOffset));
     }
     final double? previousEndRecord = _selectableEndEdgeUpdateRecords[selectable];
     if (_currentDragEndRelatedToOrigin != null &&
@@ -1437,7 +1437,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
       // Make sure the selectable has up to date events.
       final Offset deltaToOrigin = _getDeltaToScrollOrigin(state);
       final Offset endOffset = _currentDragEndRelatedToOrigin!.translate(-deltaToOrigin.dx, -deltaToOrigin.dy);
-      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset, granularity: granularity));
+      selectable.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: endOffset));
     }
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -500,7 +500,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   SelectionPoint? _initialDragStartSelectionPoint;
-
   bool _shouldMoveEndEdge(TapDragUpdateDetails details) {
     assert(_selectionDelegate.value.startSelectionPoint != null);
     _initialDragStartSelectionPoint = _initialDragStartSelectionPoint ?? _selectionDelegate.value.startSelectionPoint!;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -25,7 +25,6 @@ import 'media_query.dart';
 import 'overlay.dart';
 import 'platform_selectable_region_context_menu.dart';
 import 'selection_container.dart';
-import 'tap_and_drag_gestures.dart';
 import 'text_editing_intents.dart';
 import 'text_selection.dart';
 import 'text_selection_toolbar_anchors.dart';

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -499,45 +499,18 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     }
   }
 
-  SelectionPoint? _initialDragStartSelectionPoint;
-  bool _shouldMoveEndEdge(TapDragUpdateDetails details) {
-    assert(_selectionDelegate.value.startSelectionPoint != null || _initialDragStartSelectionPoint != null);
-    _initialDragStartSelectionPoint = _initialDragStartSelectionPoint ?? _selectionDelegate.value.startSelectionPoint!;
-    final bool isDraggingForwardFromOrigin = details.localOffsetFromOrigin.dx > 0;
-    final bool isPositionAboveStartingBaseline = details.localPosition.dy < _initialDragStartSelectionPoint!.localPosition.dy;
-    final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy - _initialDragStartSelectionPoint!.lineHeight;
-    final bool isPositionAtOrBelowStartingBaseline = details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy;
-
-    if (isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
-      return true;
-    } else if (!isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
-      return false;
-    }
-
-    return isPositionAtOrBelowStartingBaseline;
-  }
-
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
-        if (_shouldMoveEndEdge(details)) {
-          // Hold the start edge at the word located at the beginning of the drag.
-          _selectStartTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, textGranularity: TextGranularity.word);
-          _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
-        } else {
-          _selectStartTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
-          // Hold the end edge at the word located at the beginning of the drag.
-          _selectEndTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, textGranularity: TextGranularity.word);
-        }
+        _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
     }
   }
 
   void _handleMouseDragEnd(TapDragEndDetails details) {
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
-    _initialDragStartSelectionPoint = null;
   }
 
   void _updateSelectedContentIfNeeded() {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -506,7 +506,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     _initialDragStartSelectionPoint = _initialDragStartSelectionPoint ?? _selectionDelegate.value.startSelectionPoint!;
     final bool isDraggingForwardFromOrigin = details.localOffsetFromOrigin.dx > 0;
     final bool isPositionAboveStartingBaseline = details.localPosition.dy < _initialDragStartSelectionPoint!.localPosition.dy;
-    final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy - startGlyphHeight;
+    final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy - startGlyphHeight;
     final bool isPositionBelowStartingBaseline = details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy;
     // print(isDraggingForwardFromOrigin);
     // print(isPositionAboveStartingBaseLine);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -431,7 +431,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   // This method should be used in all instances when details.consecutiveTapCount
   // would be used.
   static int _getEffectiveConsecutiveTapCount(int rawCount) {
-    final int maxConsecutiveTap = 2;
+    const int maxConsecutiveTap = 2;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -918,7 +918,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// The `offset` is in global coordinates.
   ///
   /// Provide the `textGranularity` if the selection should not move by the default
-  /// [TextGranularity.character].
+  /// [TextGranularity.character]. Only [TextGranularity.character] and
+  /// [TextGranularity.word] are currently supported.
   ///
   /// See also:
   ///  * [_selectStartTo], which sets or updates selection start edge.
@@ -956,7 +957,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// The `offset` is in global coordinates.
   ///
   /// Provide the `textGranularity` if the selection should not move by the default
-  /// [TextGranularity.character].
+  /// [TextGranularity.character]. Only [TextGranularity.character] and
+  /// [TextGranularity.word] are currently supported.
   ///
   /// See also:
   ///  * [_selectEndTo], which sets or updates selection end edge.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -429,7 +429,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           (TapAndPanGestureRecognizer instance) {
         instance
           ..onTapDown = _startNewMouseSelectionGesture
-          ..onTapUp = _endNewMouseSelectionGesture
+          ..onTapUp = (TapDragUpDetails details) { _clearSelection(); }
           ..onDragStart = _handleMouseDragStart
           ..onDragUpdate = _handleMouseDragUpdate
           ..onDragEnd = _handleMouseDragEnd
@@ -452,40 +452,17 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _startNewMouseSelectionGesture(TapDragDownDetails details) {
-    switch(_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
-      case 1:
-        widget.focusNode.requestFocus();
-        hideToolbar();
-        _clearSelection();
-      case 2:
-        _selectWordAt(offset: details.globalPosition);
-        _updateSelectedContentIfNeeded();
-    }
-  }
-
-  void _endNewMouseSelectionGesture(TapDragUpDetails details) {
-    switch(_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
-      case 1:
-        _clearSelection();
-    }
+    widget.focusNode.requestFocus();
+    hideToolbar();
+    _clearSelection();
   }
 
   void _handleMouseDragStart(TapDragStartDetails details) {
-    switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
-      case 1:
-        _selectStartTo(offset: details.globalPosition);
-    }
+    _selectStartTo(offset: details.globalPosition);
   }
 
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {
-    switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
-      case 1:
-        debugPrint('character');
-        _selectEndTo(offset: details.globalPosition, continuous: true);
-      case 2:
-        debugPrint('word by word');
-        _selectEndTo(offset: details.globalPosition, continuous: true, mode: SelectionMode.word);
-    }
+    _selectEndTo(offset: details.globalPosition, continuous: true);
   }
 
   void _updateSelectedContentIfNeeded() {
@@ -588,7 +565,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// If the selectable subtree returns a [SelectionResult.pending], this method
   /// continues to send [SelectionEdgeUpdateEvent]s every frame until the result
   /// is not pending or users end their gestures.
-  void _triggerSelectionEndEdgeUpdate(SelectionMode? mode) {
+  void _triggerSelectionEndEdgeUpdate() {
     // This method can be called when the drag is not in progress. This can
     // happen if the child scrollable returns SelectionResult.pending, and
     // the selection area scheduled a selection update for the next frame, but
@@ -597,14 +574,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       return;
     }
     if (_selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, mode: mode)) == SelectionResult.pending) {
+        SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!)) == SelectionResult.pending) {
       _scheduledSelectionEndEdgeUpdate = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
         if (!_scheduledSelectionEndEdgeUpdate) {
           return;
         }
         _scheduledSelectionEndEdgeUpdate = false;
-        _triggerSelectionEndEdgeUpdate(mode);
+        _triggerSelectionEndEdgeUpdate();
       });
       return;
     }
@@ -717,7 +694,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     // The value corresponds to the paint origin of the selection handle.
     // Offset it to the center of the line to make it feel more natural.
     _selectionEndPosition = _selectionEndHandleDragPosition - Offset(0, _selectionDelegate.value.endSelectionPoint!.lineHeight / 2);
-    _triggerSelectionEndEdgeUpdate(null);
+    _triggerSelectionEndEdgeUpdate();
 
     _selectionOverlay!.updateMagnifier(_buildInfoForMagnifier(
       details.globalPosition,
@@ -876,14 +853,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_clearSelection], which clear the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
-  void _selectEndTo({required Offset offset, bool continuous = false, SelectionMode? mode}) {
+  void _selectEndTo({required Offset offset, bool continuous = false}) {
     if (!continuous) {
-      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: offset, mode: mode));
+      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: offset));
       return;
     }
     if (_selectionEndPosition != offset) {
       _selectionEndPosition = offset;
-      _triggerSelectionEndEdgeUpdate(mode);
+      _triggerSelectionEndEdgeUpdate();
     }
   }
 
@@ -1250,42 +1227,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     _selectionOverlay?.dispose();
     _selectionOverlay = null;
     super.dispose();
-  }
-
-  // Converts the details.consecutiveTapCount from a TapAndDrag*Details object,
-  // which can grow to be infinitely large, to a value between 1 and 3. The value
-  // that the raw count is converted to is based on the default observed behavior
-  // on the native platforms.
-  //
-  // This method should be used in all instances when details.consecutiveTapCount
-  // would be used.
-  static int _getEffectiveConsecutiveTapCount(int rawCount) {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-        // From observation, these platform's reset their tap count to 0 when
-        // the number of consecutive taps exceeds 3. For example on Debian Linux
-        // with GTK, when going past a triple click, on the fourth click the
-        // selection is moved to the precise click position, on the fifth click
-        // the word at the position is selected, and on the sixth click the
-        // paragraph at the position is selected.
-        return rawCount <= 3 ? rawCount : (rawCount % 3 == 0 ? 3 : rawCount % 3);
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        // From observation, these platform's either hold their tap count at 3.
-        // For example on macOS, when going past a triple click, the selection
-        // should be retained at the paragraph that was first selected on triple
-        // click.
-        return min(rawCount, 3);
-      case TargetPlatform.windows:
-        // From observation, this platform's consecutive tap actions alternate
-        // between double click and triple click actions. For example, after a
-        // triple click has selected a paragraph, on the next click the word at
-        // the clicked position will be selected, and on the next click the
-        // paragraph at the position is selected.
-        return rawCount < 2 ? rawCount : 2 + rawCount % 2;
-    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -504,7 +504,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case 1:
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
-        _selectStartTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
+        _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -436,7 +436,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
-        // From observation, these platform's reset their tap count to 0 when
+        // From observation, these platforms reset their tap count to 0 when
         // the number of consecutive taps exceeds the max consecutive tap supported.
         // For example on Debian Linux with GTK, when going past a triple click,
         // on the fourth click the selection is moved to the precise click
@@ -446,7 +446,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
-        // From observation, these platform's either hold their tap count at the max
+        // From observation, these platforms either hold their tap count at the max
         // consecutive tap supported. For example on macOS, when going past a triple
         // click, the selection should be retained at the paragraph that was first
         // selected on triple click.
@@ -514,11 +514,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       return false;
     }
 
-    if (isPositionAtOrBelowStartingBaseline) {
-      return true;
-    } else {
-      return false;
-    }
+    return isPositionAtOrBelowStartingBaseline;
   }
 
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -493,7 +493,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleMouseDragStart(TapDragStartDetails details) {
-    debugPrint('mouse drag start');
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         _selectStartTo(offset: details.globalPosition);
@@ -509,43 +508,30 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     final bool isPositionAboveStartingBaseline = details.localPosition.dy < _initialDragStartSelectionPoint!.localPosition.dy;
     final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy - startGlyphHeight;
     final bool isPositionAtOrBelowStartingBaseline = details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy;
-    // print(isDraggingForwardFromOrigin);
-    // print(isPositionAboveStartingBaseLine);
-    // print(isPositionBelowStartingBaseLine);
-    // print(isPositionClampedToStartingLine);
-    // print(details);
-    // print(_initialDragStartSelectionPoint);
 
     if (isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
-      debugPrint('dragging forward and clamped to line');
       return true;
     } else if (!isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
-      debugPrint('dragging backward and clamped to line');
       return false;
     }
 
     if (isPositionAtOrBelowStartingBaseline) {
-      debugPrint('below line');
       return true;
     } else {
-      debugPrint('above line');
       return false;
     }
   }
 
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {
-    debugPrint('mouse drag update');
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
         if (_shouldMoveEndEdge(details)) {
-          debugPrint('move end edge');
           // Hold the start edge at the word located at the beginning of the drag.
           _selectStartTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, selectionMode: SelectionMode.words);
           _selectEndTo(offset: details.globalPosition, continuous: true, selectionMode: SelectionMode.words);
         } else {
-          debugPrint('move start edge');
           _selectStartTo(offset: details.globalPosition, continuous: true, selectionMode: SelectionMode.words);
           // Hold the end edge at the word located at the beginning of the drag.
           _selectEndTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, selectionMode: SelectionMode.words);
@@ -554,7 +540,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleMouseDragEnd(TapDragEndDetails details) {
-    debugPrint('mouse drag end');
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
     _initialDragStartSelectionPoint = null;
@@ -663,7 +648,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     if (_scheduledSelectionEndEdgeUpdate || !_userDraggingSelectionEnd) {
       return;
     }
-    debugPrint('helllo from trigger selection end egde');
     if (_selectable?.dispatchSelectionEvent(
         SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, selectionMode: selectionMode)) == SelectionResult.pending) {
       _scheduledSelectionEndEdgeUpdate = true;
@@ -2211,7 +2195,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Updates the selection edges.
   @protected
   SelectionResult handleSelectionEdgeUpdate(SelectionEdgeUpdateEvent event) {
-    debugPrint('hello from handle Selection edge update');
     if (event.type == SelectionEventType.endEdgeUpdate) {
       return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);
     }
@@ -2220,7 +2203,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {
-    debugPrint('hello from multiselectablecontainer dispatchSelectionEvent');
     final bool selectionWillbeInProgress = event is! ClearSelectionEvent;
     if (!_selectionInProgress && selectionWillbeInProgress) {
       // Sort the selectable every time a selection start.
@@ -2281,7 +2263,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// treatments prior to sending the selection events.
   @protected
   SelectionResult dispatchSelectionEventToChild(Selectable selectable, SelectionEvent event) {
-    debugPrint('hello from dispatch to child');
     return selectable.dispatchSelectionEvent(event);
   }
 
@@ -2297,7 +2278,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// drag selection, once for start edge update event, once for end edge update
   /// event.
   SelectionResult _initSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
-    debugPrint('hello from initi selection');
     assert((isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1));
     int newIndex = -1;
     bool hasFoundEdgeIndex = false;
@@ -2349,7 +2329,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// selectable that contains the selection edge, and finds forward or backward
   /// if that selectable no longer contains the selection edge.
   SelectionResult _adjustSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
-    debugPrint('hello from adjust selection');
     assert(() {
       if (isEnd) {
         assert(currentSelectionEndIndex < selectables.length && currentSelectionEndIndex >= 0);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -25,6 +25,7 @@ import 'media_query.dart';
 import 'overlay.dart';
 import 'platform_selectable_region_context_menu.dart';
 import 'selection_container.dart';
+import 'tap_and_drag_gestures.dart';
 import 'text_editing_intents.dart';
 import 'text_selection.dart';
 import 'text_selection_toolbar_anchors.dart';
@@ -423,14 +424,15 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   // gestures.
 
   void _initMouseGestureRecognizer() {
-    _gestureRecognizers[PanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
-          () => PanGestureRecognizer(debugOwner:this, supportedDevices: <PointerDeviceKind>{ PointerDeviceKind.mouse }),
-          (PanGestureRecognizer instance) {
+    _gestureRecognizers[TapAndPanGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapAndPanGestureRecognizer>(
+          () => TapAndPanGestureRecognizer(debugOwner:this, supportedDevices: <PointerDeviceKind>{ PointerDeviceKind.mouse }),
+          (TapAndPanGestureRecognizer instance) {
         instance
-          ..onDown = _startNewMouseSelectionGesture
-          ..onStart = _handleMouseDragStart
-          ..onUpdate = _handleMouseDragUpdate
-          ..onEnd = _handleMouseDragEnd
+          ..onTapDown = _startNewMouseSelectionGesture
+          ..onTapUp = (TapDragUpDetails details) { _clearSelection(); }
+          ..onDragStart = _handleMouseDragStart
+          ..onDragUpdate = _handleMouseDragUpdate
+          ..onDragEnd = _handleMouseDragEnd
           ..onCancel = _clearSelection
           ..dragStartBehavior = DragStartBehavior.down;
       },
@@ -449,17 +451,17 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     );
   }
 
-  void _startNewMouseSelectionGesture(DragDownDetails details) {
+  void _startNewMouseSelectionGesture(TapDragDownDetails details) {
     widget.focusNode.requestFocus();
     hideToolbar();
     _clearSelection();
   }
 
-  void _handleMouseDragStart(DragStartDetails details) {
+  void _handleMouseDragStart(TapDragStartDetails details) {
     _selectStartTo(offset: details.globalPosition);
   }
 
-  void _handleMouseDragUpdate(DragUpdateDetails details) {
+  void _handleMouseDragUpdate(TapDragUpdateDetails details) {
     _selectEndTo(offset: details.globalPosition, continuous: true);
   }
 
@@ -470,7 +472,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     }
   }
 
-  void _handleMouseDragEnd(DragEndDetails details) {
+  void _handleMouseDragEnd(TapDragEndDetails details) {
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -451,9 +451,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     );
   }
 
-  Offset? _lastTapDownPosition;
   void _startNewMouseSelectionGesture(TapDragDownDetails details) {
-    _lastTapDownPosition = details.globalPosition;
     switch(_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         widget.focusNode.requestFocus();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -501,11 +501,11 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
 
   SelectionPoint? _initialDragStartSelectionPoint;
   bool _shouldMoveEndEdge(TapDragUpdateDetails details) {
-    assert(_selectionDelegate.value.startSelectionPoint != null);
+    assert(_selectionDelegate.value.startSelectionPoint != null || _initialDragStartSelectionPoint != null);
     _initialDragStartSelectionPoint = _initialDragStartSelectionPoint ?? _selectionDelegate.value.startSelectionPoint!;
     final bool isDraggingForwardFromOrigin = details.localOffsetFromOrigin.dx > 0;
     final bool isPositionAboveStartingBaseline = details.localPosition.dy < _initialDragStartSelectionPoint!.localPosition.dy;
-    final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy - startGlyphHeight;
+    final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy - _initialDragStartSelectionPoint!.lineHeight;
     final bool isPositionAtOrBelowStartingBaseline = details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy;
 
     if (isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -644,7 +644,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       return;
     }
     if (_selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, textGranularity: textGranularity)) == SelectionResult.pending) {
+        SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, granularity: textGranularity)) == SelectionResult.pending) {
       _scheduledSelectionEndEdgeUpdate = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
         if (!_scheduledSelectionEndEdgeUpdate) {
@@ -698,7 +698,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       return;
     }
     if (_selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forStart(globalPosition: _selectionStartPosition!, textGranularity: textGranularity)) == SelectionResult.pending) {
+        SelectionEdgeUpdateEvent.forStart(globalPosition: _selectionStartPosition!, granularity: textGranularity)) == SelectionResult.pending) {
       _scheduledSelectionStartEdgeUpdate = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
         if (!_scheduledSelectionStartEdgeUpdate) {
@@ -917,8 +917,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///
   /// The `offset` is in global coordinates.
   ///
-  /// Provide the `textGranularity` if the selection should not move the default
-  /// character by character.
+  /// Provide the `textGranularity` if the selection should not move by the default
+  /// [TextGranularity.character].
   ///
   /// See also:
   ///  * [_selectStartTo], which sets or updates selection start edge.
@@ -928,7 +928,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [selectAll], which selects the entire content.
   void _selectEndTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
-      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: offset, textGranularity: textGranularity));
+      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: offset, granularity: textGranularity));
       return;
     }
     if (_selectionEndPosition != offset) {
@@ -955,8 +955,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///
   /// The `offset` is in global coordinates.
   ///
-  /// Provide the `textGranularity` if the selection should not move the default
-  /// character by character.
+  /// Provide the `textGranularity` if the selection should not move by the default
+  /// [TextGranularity.character].
   ///
   /// See also:
   ///  * [_selectEndTo], which sets or updates selection end edge.
@@ -966,7 +966,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [selectAll], which selects the entire content.
   void _selectStartTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
-      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: offset, textGranularity: textGranularity));
+      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: offset, granularity: textGranularity));
       return;
     }
     if (_selectionStartPosition != offset) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -512,9 +512,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     // print(isDraggingForwardFromOrigin);
     // print(isPositionAboveStartingBaseLine);
     // print(isPositionBelowStartingBaseLine);
-    print(isPositionClampedToStartingLine);
-    print(details);
-    print(_initialDragStartSelectionPoint);
+    // print(isPositionClampedToStartingLine);
+    // print(details);
+    // print(_initialDragStartSelectionPoint);
 
     if (isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
       debugPrint('dragging forward and clamped to line');
@@ -663,6 +663,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     if (_scheduledSelectionEndEdgeUpdate || !_userDraggingSelectionEnd) {
       return;
     }
+    debugPrint('helllo from trigger selection end egde');
     if (_selectable?.dispatchSelectionEvent(
         SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, selectionMode: selectionMode)) == SelectionResult.pending) {
       _scheduledSelectionEndEdgeUpdate = true;
@@ -2210,6 +2211,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Updates the selection edges.
   @protected
   SelectionResult handleSelectionEdgeUpdate(SelectionEdgeUpdateEvent event) {
+    debugPrint('hello from handle Selection edge update');
     if (event.type == SelectionEventType.endEdgeUpdate) {
       return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);
     }
@@ -2218,6 +2220,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {
+    debugPrint('hello from multiselectablecontainer dispatchSelectionEvent');
     final bool selectionWillbeInProgress = event is! ClearSelectionEvent;
     if (!_selectionInProgress && selectionWillbeInProgress) {
       // Sort the selectable every time a selection start.
@@ -2278,6 +2281,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// treatments prior to sending the selection events.
   @protected
   SelectionResult dispatchSelectionEventToChild(Selectable selectable, SelectionEvent event) {
+    debugPrint('hello from dispatch to child');
     return selectable.dispatchSelectionEvent(event);
   }
 
@@ -2293,6 +2297,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// drag selection, once for start edge update event, once for end edge update
   /// event.
   SelectionResult _initSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
+    debugPrint('hello from initi selection');
     assert((isEnd && currentSelectionEndIndex == -1) || (!isEnd && currentSelectionStartIndex == -1));
     int newIndex = -1;
     bool hasFoundEdgeIndex = false;
@@ -2344,6 +2349,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// selectable that contains the selection edge, and finds forward or backward
   /// if that selectable no longer contains the selection edge.
   SelectionResult _adjustSelection(SelectionEdgeUpdateEvent event, {required bool isEnd}) {
+    debugPrint('hello from adjust selection');
     assert(() {
       if (isEnd) {
         assert(currentSelectionEndIndex < selectables.length && currentSelectionEndIndex >= 0);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -502,6 +502,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   SelectionPoint? _initialDragStartSelectionPoint;
 
   bool _shouldMoveEndEdge(TapDragUpdateDetails details) {
+    assert(_selectionDelegate.value.startSelectionPoint != null);
     _initialDragStartSelectionPoint = _initialDragStartSelectionPoint ?? _selectionDelegate.value.startSelectionPoint!;
     final bool isDraggingForwardFromOrigin = details.localOffsetFromOrigin.dx > 0;
     final bool isPositionAboveStartingBaseLine = details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy - _initialDragStartSelectionPoint!.lineHeight;
@@ -951,7 +952,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// The `continuous` argument defaults to false.
   ///
   /// The `offset` is in global coordinates.
-  /// 
+  ///
   /// Provide the `selectionMode` if the selection should not move the default
   /// character by character.
   ///

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -493,6 +493,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleMouseDragStart(TapDragStartDetails details) {
+    debugPrint('mouse drag start');
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         _selectStartTo(offset: details.globalPosition);
@@ -507,7 +508,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     final bool isDraggingForwardFromOrigin = details.localOffsetFromOrigin.dx > 0;
     final bool isPositionAboveStartingBaseline = details.localPosition.dy < _initialDragStartSelectionPoint!.localPosition.dy;
     final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy - startGlyphHeight;
-    final bool isPositionBelowStartingBaseline = details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy;
+    final bool isPositionAtOrBelowStartingBaseline = details.localPosition.dy >= _initialDragStartSelectionPoint!.localPosition.dy;
     // print(isDraggingForwardFromOrigin);
     // print(isPositionAboveStartingBaseLine);
     // print(isPositionBelowStartingBaseLine);
@@ -516,19 +517,24 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     print(_initialDragStartSelectionPoint);
 
     if (isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
+      debugPrint('dragging forward and clamped to line');
       return true;
     } else if (!isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
+      debugPrint('dragging backward and clamped to line');
       return false;
     }
 
-    if (isPositionBelowStartingBaseline) {
+    if (isPositionAtOrBelowStartingBaseline) {
+      debugPrint('below line');
       return true;
     } else {
+      debugPrint('above line');
       return false;
     }
   }
 
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {
+    debugPrint('mouse drag update');
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         _selectEndTo(offset: details.globalPosition, continuous: true);
@@ -548,6 +554,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleMouseDragEnd(TapDragEndDetails details) {
+    debugPrint('mouse drag end');
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
     _initialDragStartSelectionPoint = null;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -529,12 +529,12 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case 2:
         if (_shouldMoveEndEdge(details)) {
           // Hold the start edge at the word located at the beginning of the drag.
-          _selectStartTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, selectionMode: SelectionMode.words);
-          _selectEndTo(offset: details.globalPosition, continuous: true, selectionMode: SelectionMode.words);
+          _selectStartTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, textGranularity: TextGranularity.word);
+          _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
         } else {
-          _selectStartTo(offset: details.globalPosition, continuous: true, selectionMode: SelectionMode.words);
+          _selectStartTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
           // Hold the end edge at the word located at the beginning of the drag.
-          _selectEndTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, selectionMode: SelectionMode.words);
+          _selectEndTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, textGranularity: TextGranularity.word);
         }
     }
   }
@@ -640,7 +640,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// If the selectable subtree returns a [SelectionResult.pending], this method
   /// continues to send [SelectionEdgeUpdateEvent]s every frame until the result
   /// is not pending or users end their gestures.
-  void _triggerSelectionEndEdgeUpdate({SelectionMode? selectionMode}) {
+  void _triggerSelectionEndEdgeUpdate({TextGranularity? textGranularity}) {
     // This method can be called when the drag is not in progress. This can
     // happen if the child scrollable returns SelectionResult.pending, and
     // the selection area scheduled a selection update for the next frame, but
@@ -649,14 +649,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       return;
     }
     if (_selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, selectionMode: selectionMode)) == SelectionResult.pending) {
+        SelectionEdgeUpdateEvent.forEnd(globalPosition: _selectionEndPosition!, textGranularity: textGranularity)) == SelectionResult.pending) {
       _scheduledSelectionEndEdgeUpdate = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
         if (!_scheduledSelectionEndEdgeUpdate) {
           return;
         }
         _scheduledSelectionEndEdgeUpdate = false;
-        _triggerSelectionEndEdgeUpdate(selectionMode: selectionMode);
+        _triggerSelectionEndEdgeUpdate(textGranularity: textGranularity);
       });
       return;
     }
@@ -694,7 +694,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// If the selectable subtree returns a [SelectionResult.pending], this method
   /// continues to send [SelectionEdgeUpdateEvent]s every frame until the result
   /// is not pending or users end their gestures.
-  void _triggerSelectionStartEdgeUpdate({SelectionMode? selectionMode}) {
+  void _triggerSelectionStartEdgeUpdate({TextGranularity? textGranularity}) {
     // This method can be called when the drag is not in progress. This can
     // happen if the child scrollable returns SelectionResult.pending, and
     // the selection area scheduled a selection update for the next frame, but
@@ -703,14 +703,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       return;
     }
     if (_selectable?.dispatchSelectionEvent(
-        SelectionEdgeUpdateEvent.forStart(globalPosition: _selectionStartPosition!, selectionMode: selectionMode)) == SelectionResult.pending) {
+        SelectionEdgeUpdateEvent.forStart(globalPosition: _selectionStartPosition!, textGranularity: textGranularity)) == SelectionResult.pending) {
       _scheduledSelectionStartEdgeUpdate = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
         if (!_scheduledSelectionStartEdgeUpdate) {
           return;
         }
         _scheduledSelectionStartEdgeUpdate = false;
-        _triggerSelectionStartEdgeUpdate(selectionMode: selectionMode);
+        _triggerSelectionStartEdgeUpdate(textGranularity: textGranularity);
       });
       return;
     }
@@ -922,7 +922,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///
   /// The `offset` is in global coordinates.
   ///
-  /// Provide the `selectionMode` if the selection should not move the default
+  /// Provide the `textGranularity` if the selection should not move the default
   /// character by character.
   ///
   /// See also:
@@ -931,14 +931,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_clearSelection], which clear the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
-  void _selectEndTo({required Offset offset, bool continuous = false, SelectionMode? selectionMode}) {
+  void _selectEndTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
-      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: offset, selectionMode: selectionMode));
+      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forEnd(globalPosition: offset, textGranularity: textGranularity));
       return;
     }
     if (_selectionEndPosition != offset) {
       _selectionEndPosition = offset;
-      _triggerSelectionEndEdgeUpdate(selectionMode: selectionMode);
+      _triggerSelectionEndEdgeUpdate(textGranularity: textGranularity);
     }
   }
 
@@ -960,7 +960,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///
   /// The `offset` is in global coordinates.
   ///
-  /// Provide the `selectionMode` if the selection should not move the default
+  /// Provide the `textGranularity` if the selection should not move the default
   /// character by character.
   ///
   /// See also:
@@ -969,14 +969,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_clearSelection], which clear the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
-  void _selectStartTo({required Offset offset, bool continuous = false, SelectionMode? selectionMode}) {
+  void _selectStartTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
-      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: offset, selectionMode: selectionMode));
+      _selectable?.dispatchSelectionEvent(SelectionEdgeUpdateEvent.forStart(globalPosition: offset, textGranularity: textGranularity));
       return;
     }
     if (_selectionStartPosition != offset) {
       _selectionStartPosition = offset;
-      _triggerSelectionStartEdgeUpdate(selectionMode: selectionMode);
+      _triggerSelectionStartEdgeUpdate(textGranularity: textGranularity);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -451,7 +451,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     );
   }
 
+  Offset? _lastTapDownPosition;
   void _startNewMouseSelectionGesture(TapDragDownDetails details) {
+    _lastTapDownPosition = details.globalPosition;
     switch(_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
         widget.focusNode.requestFocus();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -504,7 +504,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case 1:
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
-        _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
+        _selectStartTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -505,10 +505,23 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     assert(_selectionDelegate.value.startSelectionPoint != null);
     _initialDragStartSelectionPoint = _initialDragStartSelectionPoint ?? _selectionDelegate.value.startSelectionPoint!;
     final bool isDraggingForwardFromOrigin = details.localOffsetFromOrigin.dx > 0;
-    final bool isPositionAboveStartingBaseLine = details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy - _initialDragStartSelectionPoint!.lineHeight;
-    final bool isPositionBelowStartingBaseLine = details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy;
+    final bool isPositionAboveStartingBaseline = details.localPosition.dy < _initialDragStartSelectionPoint!.localPosition.dy;
+    final bool isPositionClampedToStartingLine = isPositionAboveStartingBaseline && details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy - startGlyphHeight;
+    final bool isPositionBelowStartingBaseline = details.localPosition.dy > _initialDragStartSelectionPoint!.localPosition.dy;
+    // print(isDraggingForwardFromOrigin);
+    // print(isPositionAboveStartingBaseLine);
+    // print(isPositionBelowStartingBaseLine);
+    print(isPositionClampedToStartingLine);
+    print(details);
+    print(_initialDragStartSelectionPoint);
 
-    if (isDraggingForwardFromOrigin && isPositionAboveStartingBaseLine || isPositionBelowStartingBaseLine) {
+    if (isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
+      return true;
+    } else if (!isDraggingForwardFromOrigin && isPositionClampedToStartingLine) {
+      return false;
+    }
+
+    if (isPositionBelowStartingBaseline) {
       return true;
     } else {
       return false;
@@ -521,10 +534,12 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
         if (_shouldMoveEndEdge(details)) {
+          debugPrint('move end edge');
           // Hold the start edge at the word located at the beginning of the drag.
           _selectStartTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, selectionMode: SelectionMode.words);
           _selectEndTo(offset: details.globalPosition, continuous: true, selectionMode: SelectionMode.words);
         } else {
+          debugPrint('move start edge');
           _selectStartTo(offset: details.globalPosition, continuous: true, selectionMode: SelectionMode.words);
           // Hold the end edge at the word located at the beginning of the drag.
           _selectEndTo(offset: details.globalPosition - details.offsetFromOrigin, continuous: true, selectionMode: SelectionMode.words);

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -157,6 +157,7 @@ void main() {
 
     // Backwards selection.
     await gesture.down(textOffsetToPosition(paragraph, 3));
+    await tester.pumpAndSettle();
     expect(content, isNull);
     await gesture.moveTo(textOffsetToPosition(paragraph, 0));
     await gesture.up();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -56,6 +56,7 @@ void main() {
       renderSelectionSpy.events.clear();
 
       await gesture.moveTo(const Offset(200.0, 100.0));
+      debugPrint('${renderSelectionSpy.events}');
       expect(renderSelectionSpy.events.length, 2);
       expect(renderSelectionSpy.events[0].type, SelectionEventType.startEdgeUpdate);
       final SelectionEdgeUpdateEvent startEdge = renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -614,7 +614,7 @@ void main() {
       await tester.pump();
       expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 11));
       await gesture.up();
-    });
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
 
     testWidgets('mouse can select multiple widgets on double click drag', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -660,7 +660,7 @@ void main() {
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
 
       await gesture.up();
-    });
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
 
     testWidgets('mouse can select multiple widgets on double click drag and return to origin word', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -53,10 +53,10 @@ void main() {
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
+      await tester.pumpAndSettle();
       renderSelectionSpy.events.clear();
 
       await gesture.moveTo(const Offset(200.0, 100.0));
-      debugPrint('${renderSelectionSpy.events}');
       expect(renderSelectionSpy.events.length, 2);
       expect(renderSelectionSpy.events[0].type, SelectionEventType.startEdgeUpdate);
       final SelectionEdgeUpdateEvent startEdge = renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent;
@@ -250,6 +250,7 @@ void main() {
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
+      await tester.pumpAndSettle();
       expect(renderSelectionSpy.events.length, 1);
       expect(renderSelectionSpy.events[0], isA<ClearSelectionEvent>());
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
@@ -507,6 +508,7 @@ void main() {
       // Start a new drag.
       await gesture.up();
       await gesture.down(textOffsetToPosition(paragraph, 5));
+      await tester.pumpAndSettle();
       expect(paragraph.selections.isEmpty, isTrue);
 
       // Selecting across line should select to the end.
@@ -2417,6 +2419,7 @@ void main() {
 
     // Backwards selection.
     await gesture.down(textOffsetToPosition(paragraph, 3));
+    await tester.pumpAndSettle();
     expect(content, isNull);
     await gesture.moveTo(textOffsetToPosition(paragraph, 0));
     await gesture.up();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -749,18 +749,18 @@ void main() {
 
       await gesture.moveTo(textOffsetToPosition(paragraph3, 4));
       await tester.pump();
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 4));// 4,11
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 4));
 
       final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
       await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));// 0,11
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 5));// 5,14
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 5));
 
       final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
       await gesture.moveTo(textOffsetToPosition(paragraph1, 6));
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));// 0,11
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 0));// 0,14
-      expect(paragraph1.selections[0], const TextSelection(baseOffset: 12, extentOffset: 4));// 4,12
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 0));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 12, extentOffset: 4));
 
       await gesture.up();
     });

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -718,7 +718,7 @@ void main() {
       expect(paragraph3.selections.isEmpty, true);
 
       await gesture.up();
-    });
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
 
     testWidgets('mouse can reverse selection across multiple widgets on double click drag', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -616,6 +616,97 @@ void main() {
       await gesture.up();
     });
 
+    testWidgets('mouse can select multiple widgets on double click drag', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?'),
+                Text('Good, and you?'),
+                Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph1, 2));
+      await tester.pumpAndSettle();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 4));
+      await tester.pump();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      // Should select the rest of paragraph 1.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 6));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
+
+      await gesture.up();
+    });
+
+    testWidgets('mouse can reverse selection across multiple widgets on double click drag', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?'),
+                Text('Good, and you?'),
+                Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 10), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph3, 10));
+      await tester.pumpAndSettle();
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 6, extentOffset: 11));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 4));
+      await tester.pump();
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 4, extentOffset: 11));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 5, extentOffset: 14));
+
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 6));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 12));
+
+      await gesture.up();
+    });
+
     testWidgets('mouse can select multiple widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -763,7 +763,7 @@ void main() {
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 12, extentOffset: 4));
 
       await gesture.up();
-    });
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
 
     testWidgets('mouse can select multiple widgets', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -749,18 +749,18 @@ void main() {
 
       await gesture.moveTo(textOffsetToPosition(paragraph3, 4));
       await tester.pump();
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 4, extentOffset: 11));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 4));// 4,11
 
       final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
       await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 5, extentOffset: 14));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));// 0,11
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 5));// 5,14
 
       final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
       await gesture.moveTo(textOffsetToPosition(paragraph1, 6));
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
-      expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 12));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));// 0,11
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 0));// 0,14
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 12, extentOffset: 4));// 4,12
 
       await gesture.up();
     });


### PR DESCRIPTION
Adds double click to select a word.
Adds double click + drag to select word by word.

https://user-images.githubusercontent.com/948037/234363577-941c36bc-ac42-4b7f-84aa-26b106c9ff05.mov

Partially fixes #104552

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.