### PR TITLE
Remove package:js/dart:js_interop conflicts

### DIFF
--- a/packages/flutter/lib/src/foundation/_capabilities_web.dart
+++ b/packages/flutter/lib/src/foundation/_capabilities_web.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
+// For now, we're hiding dart:js_interop's `@JS` to avoid a conflict with
+// package:js' `@JS`. In the future, we should be able to remove package:js
+// altogether and just import dart:js_interop.
+import 'dart:js_interop' hide JS;
 import 'package:js/js.dart';
 
 // This value is set by the engine. It is used to determine if the application is

--- a/packages/flutter/lib/src/services/dom.dart
+++ b/packages/flutter/lib/src/services/dom.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
+// For now, we're hiding dart:js_interop's `@JS` to avoid a conflict with
+// package:js' `@JS`. In the future, we should be able to remove package:js
+// altogether and just import dart:js_interop.
+import 'dart:js_interop' hide JS;
 import 'package:js/js.dart';
 
 /// This file includes static interop helpers for Flutter Web.

--- a/packages/flutter/test/painting/_test_http_request.dart
+++ b/packages/flutter/test/painting/_test_http_request.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
+// For now, we're hiding dart:js_interop's `@JS` to avoid a conflict with
+// package:js' `@JS`. In the future, we should be able to remove package:js
+// altogether and just import dart:js_interop.
+import 'dart:js_interop' hide JS;
 
 import 'package:flutter/src/services/dom.dart';
 import 'package:js/js.dart';


### PR DESCRIPTION
dart:js_interop and package:js will start conflicting, since they both have an `@JS` annotation. Until we're ready to only use dart:js_interop (which will require updating the SDK constraints of every package), we should hide the `@JS` annotation from dart:js_interop. Due to shadowing, this is the behavior today, so there should be no functional change.

Unblocks https://dart-review.googlesource.com/c/sdk/+/294130/8 and prevents confusing shadowing of dart:js_interop annotations like we do today.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [Mentioned CL that is unblocked] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [Need test-exemption] I added new tests to check the change I am making, or this PR is [test-exempt].
- [Need to run] All existing and new tests are passing.
