### PR TITLE
[date_picker] [date_range_picker] add properties to change switch-to icons

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -71,17 +71,21 @@ const double _inputFormLandscapeHeight = 108.0;
 /// or [DatePickerEntryMode.input] (a text input field) mode.
 /// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
 ///
+/// {@template flutter.material.date_picker.switchToInputEntryModeIcon}
 /// An optional [switchToInputEntryModeIcon] argument can be used to
 /// display a custom Icon in the corner of the dialog
 /// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
 /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
 /// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+/// {@endtemplate}
 ///
+/// {@template flutter.material.date_picker.switchToCalendarEntryModeIcon}
 /// An optional [switchToCalendarEntryModeIcon] argument can be used to
 /// display a custom Icon in the corner of the dialog
 /// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
 /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
 /// If null, `Icon(Icons.calendar_today)` is used.
+/// {@endtemplate}
 ///
 /// An optional [selectableDayPredicate] function can be passed in to only allow
 /// certain days for selection. If provided, only the days that
@@ -388,18 +392,10 @@ class DatePickerDialog extends StatefulWidget {
   /// `initialEntryMode` parameter the next time the date picker is shown.
   final ValueChanged<DatePickerEntryMode>? onDatePickerModeChange;
 
-  /// An optional [switchToInputEntryModeIcon] argument can be used to
-  /// display a custom Icon in the corner of the dialog
-  /// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
-  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
-  /// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+  /// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
   final Icon? switchToInputEntryModeIcon;
 
-  /// An optional [switchToCalendarEntryModeIcon] argument can be used to
-  /// display a custom Icon in the corner of the dialog
-  /// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
-  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
-  /// If null, `Icon(Icons.calendar_today)` is used.
+  /// {@macro flutter.material.date_picker.switchToCalendarEntryModeIcon}
   final Icon? switchToCalendarEntryModeIcon;
 
   @override
@@ -938,17 +934,9 @@ class _DatePickerHeader extends StatelessWidget {
 /// grid) or [DatePickerEntryMode.input] (two text input fields) mode.
 /// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
 ///
-/// An optional [switchToInputEntryModeIcon] argument can be used to
-/// display a custom Icon in the corner of the dialog
-/// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
-/// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
-/// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+/// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
 ///
-/// An optional [switchToCalendarEntryModeIcon] argument can be used to
-/// display a custom Icon in the corner of the dialog
-/// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
-/// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
-/// If null, `Icon(Icons.calendar_today)` is used.
+/// {@macro flutter.material.date_picker.switchToCalendarEntryModeIcon}
 ///
 /// The following optional string parameters allow you to override the default
 /// text used for various parts of the dialog:
@@ -1306,18 +1294,10 @@ class DateRangePickerDialog extends StatefulWidget {
   ///    Flutter.
   final String? restorationId;
 
-  /// An optional [switchToInputEntryModeIcon] argument can be used to
-  /// display a custom Icon in the corner of the dialog
-  /// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
-  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
-  /// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+  /// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
   final Icon? switchToInputEntryModeIcon;
 
-  /// An optional [switchToCalendarEntryModeIcon] argument can be used to
-  /// display a custom Icon in the corner of the dialog
-  /// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
-  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
-  /// If null, `Icon(Icons.calendar_today)` is used.
+  /// {@macro flutter.material.date_picker.switchToCalendarEntryModeIcon}
   final Icon? switchToCalendarEntryModeIcon;
 
   @override

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -71,6 +71,18 @@ const double _inputFormLandscapeHeight = 108.0;
 /// or [DatePickerEntryMode.input] (a text input field) mode.
 /// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
 ///
+/// An optional [switchToInputEntryModeIcon] argument can be used to
+/// display a custom Icon in the corner of the dialog
+/// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
+/// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
+/// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+///
+/// An optional [switchToCalendarEntryModeIcon] argument can be used to
+/// display a custom Icon in the corner of the dialog
+/// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
+/// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
+/// If null, `Icon(Icons.calendar_today)` is used.
+///
 /// An optional [selectableDayPredicate] function can be passed in to only allow
 /// certain days for selection. If provided, only the days that
 /// [selectableDayPredicate] returns true for will be selectable. For example,
@@ -164,7 +176,9 @@ Future<DateTime?> showDatePicker({
   String? fieldLabelText,
   TextInputType? keyboardType,
   Offset? anchorPoint,
-  final ValueChanged<DatePickerEntryMode>? onDatePickerModeChange
+  final ValueChanged<DatePickerEntryMode>? onDatePickerModeChange,
+  final Icon? switchToInputEntryModeIcon,
+  final Icon? switchToCalendarEntryModeIcon,
 }) async {
   initialDate = DateUtils.dateOnly(initialDate);
   firstDate = DateUtils.dateOnly(firstDate);
@@ -204,6 +218,8 @@ Future<DateTime?> showDatePicker({
     fieldLabelText: fieldLabelText,
     keyboardType: keyboardType,
     onDatePickerModeChange: onDatePickerModeChange,
+    switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+    switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
   );
 
   if (textDirection != null) {
@@ -261,7 +277,9 @@ class DatePickerDialog extends StatefulWidget {
     this.fieldLabelText,
     this.keyboardType,
     this.restorationId,
-    this.onDatePickerModeChange
+    this.onDatePickerModeChange,
+    this.switchToInputEntryModeIcon,
+    this.switchToCalendarEntryModeIcon,
   }) : initialDate = DateUtils.dateOnly(initialDate),
        firstDate = DateUtils.dateOnly(firstDate),
        lastDate = DateUtils.dateOnly(lastDate),
@@ -369,6 +387,20 @@ class DatePickerDialog extends StatefulWidget {
   /// user's preferred entry mode and uses it to initialize the
   /// `initialEntryMode` parameter the next time the date picker is shown.
   final ValueChanged<DatePickerEntryMode>? onDatePickerModeChange;
+
+  /// An optional [switchToInputEntryModeIcon] argument can be used to
+  /// display a custom Icon in the corner of the dialog
+  /// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
+  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
+  /// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+  final Icon? switchToInputEntryModeIcon;
+
+  /// An optional [switchToCalendarEntryModeIcon] argument can be used to
+  /// display a custom Icon in the corner of the dialog
+  /// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
+  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
+  /// If null, `Icon(Icons.calendar_today)` is used.
+  final Icon? switchToCalendarEntryModeIcon;
 
   @override
   State<DatePickerDialog> createState() => _DatePickerDialogState();
@@ -576,7 +608,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
       case DatePickerEntryMode.calendar:
         picker = calendarDatePicker();
         entryModeButton = IconButton(
-          icon:  Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
+          icon: widget.switchToInputEntryModeIcon ?? Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
           color: headerForegroundColor,
           tooltip: localizations.inputDateModeButtonLabel,
           onPressed: _handleEntryModeToggle,
@@ -589,7 +621,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
       case DatePickerEntryMode.input:
         picker = inputDatePicker();
         entryModeButton = IconButton(
-          icon: const Icon(Icons.calendar_today),
+          icon: widget.switchToCalendarEntryModeIcon ?? const Icon(Icons.calendar_today),
           color: headerForegroundColor,
           tooltip: localizations.calendarModeButtonLabel,
           onPressed: _handleEntryModeToggle,
@@ -906,6 +938,18 @@ class _DatePickerHeader extends StatelessWidget {
 /// grid) or [DatePickerEntryMode.input] (two text input fields) mode.
 /// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
 ///
+/// An optional [switchToInputEntryModeIcon] argument can be used to
+/// display a custom Icon in the corner of the dialog
+/// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
+/// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
+/// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+///
+/// An optional [switchToCalendarEntryModeIcon] argument can be used to
+/// display a custom Icon in the corner of the dialog
+/// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
+/// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
+/// If null, `Icon(Icons.calendar_today)` is used.
+///
 /// The following optional string parameters allow you to override the default
 /// text used for various parts of the dialog:
 ///
@@ -997,6 +1041,8 @@ Future<DateTimeRange?> showDateRangePicker({
   TransitionBuilder? builder,
   Offset? anchorPoint,
   TextInputType keyboardType = TextInputType.datetime,
+  final Icon? switchToInputEntryModeIcon,
+  final Icon? switchToCalendarEntryModeIcon,
 }) async {
   assert(
     initialDateRange == null || !initialDateRange.start.isAfter(initialDateRange.end),
@@ -1046,6 +1092,8 @@ Future<DateTimeRange?> showDateRangePicker({
     fieldStartLabelText: fieldStartLabelText,
     fieldEndLabelText: fieldEndLabelText,
     keyboardType: keyboardType,
+    switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+    switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
   );
 
   if (textDirection != null) {
@@ -1134,6 +1182,8 @@ class DateRangePickerDialog extends StatefulWidget {
     this.fieldEndLabelText,
     this.keyboardType = TextInputType.datetime,
     this.restorationId,
+    this.switchToInputEntryModeIcon,
+    this.switchToCalendarEntryModeIcon,
   });
 
   /// The date range that the date range picker starts with when it opens.
@@ -1255,6 +1305,20 @@ class DateRangePickerDialog extends StatefulWidget {
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
   final String? restorationId;
+
+  /// An optional [switchToInputEntryModeIcon] argument can be used to
+  /// display a custom Icon in the corner of the dialog
+  /// when [DatePickerEntryMode] is [DatePickerEntryMode.calendar]. Clicking on
+  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.input].
+  /// If null, `Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit)` is used.
+  final Icon? switchToInputEntryModeIcon;
+
+  /// An optional [switchToCalendarEntryModeIcon] argument can be used to
+  /// display a custom Icon in the corner of the dialog
+  /// when [DatePickerEntryMode] is [DatePickerEntryMode.input]. Clicking on
+  /// icon changes the [DatePickerEntryMode] to [DatePickerEntryMode.calendar].
+  /// If null, `Icon(Icons.calendar_today)` is used.
+  final Icon? switchToCalendarEntryModeIcon;
 
   @override
   State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();
@@ -1378,7 +1442,7 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
           onCancel: _handleCancel,
           entryModeButton: showEntryModeButton
             ? IconButton(
-                icon: Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
+                icon: widget.switchToInputEntryModeIcon ?? Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
                 padding: EdgeInsets.zero,
                 tooltip: localizations.inputDateModeButtonLabel,
                 onPressed: _handleEntryModeToggle,
@@ -1444,7 +1508,7 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
           onCancel: _handleCancel,
           entryModeButton: showEntryModeButton
             ? IconButton(
-                icon: const Icon(Icons.calendar_today),
+                icon: widget.switchToCalendarEntryModeIcon ?? const Icon(Icons.calendar_today),
                 padding: EdgeInsets.zero,
                 tooltip: localizations.calendarModeButtonLabel,
                 onPressed: _handleEntryModeToggle,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -461,6 +461,119 @@ void main() {
       await tester.tap(find.text('OK'));
       await tester.pumpAndSettle();
     });
+
+    testWidgets('honors switchToInputEntryModeIcon', (WidgetTester tester) async {
+      Widget buildApp({bool? useMaterial3, Icon? switchToInputEntryModeIcon}) {
+       return MaterialApp(
+          theme: ThemeData(
+            useMaterial3: useMaterial3 ?? false,
+          ),
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  child: const Text('Click X'),
+                  onPressed: () {
+                    showDatePicker(
+                      context: context,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(2018),
+                      lastDate: DateTime(2030),
+                      switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(buildApp(useMaterial3: true));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        buildApp(
+          switchToInputEntryModeIcon: const Icon(Icons.keyboard),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.keyboard), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('honors switchToCalendarEntryModeIcon', (WidgetTester tester) async {
+      Widget buildApp({bool? useMaterial3, Icon? switchToCalendarEntryModeIcon}) {
+       return MaterialApp(
+          theme: ThemeData(
+            useMaterial3: useMaterial3 ?? false,
+          ),
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  child: const Text('Click X'),
+                  onPressed: () {
+                    showDatePicker(
+                      context: context,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(2018),
+                      lastDate: DateTime(2030),
+                      switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
+                      initialEntryMode: DatePickerEntryMode.input,
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(buildApp(useMaterial3: true));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        buildApp(
+          switchToCalendarEntryModeIcon: const Icon(Icons.favorite),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+    });
   });
 
   group('Calendar mode', () {

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1187,6 +1187,118 @@ void main() {
       expect(picker.keyboardType, keyboardType ?? TextInputType.datetime);
     });
   }
+
+  testWidgets('honors switchToInputEntryModeIcon', (WidgetTester tester) async {
+    Widget buildApp({bool? useMaterial3, Icon? switchToInputEntryModeIcon}) {
+      return MaterialApp(
+        theme: ThemeData(
+          useMaterial3: useMaterial3 ?? false,
+        ),
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                child: const Text('Click X'),
+                onPressed: () {
+                  showDateRangePicker(
+                    context: context,
+                    firstDate: DateTime(2020),
+                    lastDate: DateTime(2030),
+                    switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.edit), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(buildApp(useMaterial3: true));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(
+      buildApp(
+        switchToInputEntryModeIcon: const Icon(Icons.keyboard),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.keyboard), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('honors switchToCalendarEntryModeIcon', (WidgetTester tester) async {
+    Widget buildApp({bool? useMaterial3, Icon? switchToCalendarEntryModeIcon}) {
+      return MaterialApp(
+        theme: ThemeData(
+          useMaterial3: useMaterial3 ?? false,
+        ),
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                child: const Text('Click X'),
+                onPressed: () {
+                  showDateRangePicker(
+                    context: context,
+                    firstDate: DateTime(2020),
+                    lastDate: DateTime(2030),
+                    switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
+                    initialEntryMode: DatePickerEntryMode.input,
+                    cancelText: 'CANCEL',
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+    await tester.tap(find.text('CANCEL'));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(buildApp(useMaterial3: true));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+    await tester.tap(find.text('CANCEL'));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(
+      buildApp(
+        switchToCalendarEntryModeIcon: const Icon(Icons.favorite),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.favorite), findsOneWidget);
+    await tester.tap(find.text('CANCEL'));
+    await tester.pumpAndSettle();
+  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {


### PR DESCRIPTION
Adds `switchToInputEntryModeIcon` & `switchToCalendarEntryModeIcon` properties to `showDatePicker` & `showDateRangePicker`.

Fixes: #122840

## showDatePicker

| `switchToInputEntryModeIcon: default` | `switchToInputEntryModeIcon: Icons.keyboard` |
| --- | --- |
| ![dp_switchtoinputentrymodeicon_default](https://user-images.githubusercontent.com/13456345/232137065-1120af1f-630f-491b-8952-ce600ce24b7c.png) | ![dp_switchtoinputentrymodeicon_icon_keyboard](https://user-images.githubusercontent.com/13456345/232137067-188df306-83f8-47e7-82f6-89a11c8c508e.png) |

| `switchToCalendarEntryModeIcon: default` | `switchToCalendarEntryModeIcon: Icons.weekend` |
| --- | --- |
| ![dp_switchtocalendarentrymodeicon_default](https://user-images.githubusercontent.com/13456345/232137054-6dc1d90d-cb53-4c18-875e-df2a4b889c77.png) | ![dp_switchtocalendarentrymodeicon_icons_weekend](https://user-images.githubusercontent.com/13456345/232137062-8e2414d3-8019-4668-83b9-75d6a7836993.png) |

---

## showDateRangePicker

| `switchToInputEntryModeIcon: default` | `switchToInputEntryModeIcon: Icons.keyboard` |
| --- | --- |
| ![drp_switchtoinputentrymodeicon_default](https://user-images.githubusercontent.com/13456345/232137083-12eb7fbc-8297-4a6e-a370-8ee2bcc5ac85.png) | ![drp_switchtoinputentrymodeicon_icon_keyboard](https://user-images.githubusercontent.com/13456345/232137087-a68af61f-18f2-4dae-8f5e-60a6e331aab2.png) |

| `switchToCalendarEntryModeIcon: default` | `switchToCalendarEntryModeIcon: Icons.weekend` |
| --- | --- |
| ![drp_switchtocalendarentrymodeicon_default](https://user-images.githubusercontent.com/13456345/232137070-96256720-f918-4655-b90c-2cd7f801a672.png) | ![drp_switchtocalendarentrymodeicon_icons_weekend](https://user-images.githubusercontent.com/13456345/232137076-55e62c06-c28c-4d14-8185-079f6c67a81d.png) |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
