### PR TITLE
Add optional axis specifier to static scrollable methods

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -302,13 +302,13 @@ class Scrollable extends StatefulWidget {
   ///
   /// Calling this method will create a dependency on the [ScrollableState]
   /// that is returned, if there is one. This is typically the closest
-  /// [Scrollable], but may be a more distant ancestor if `axis` is used to
+  /// [Scrollable], but may be a more distant ancestor if [axis] is used to
   /// target a specific [Scrollable].
   ///
-  /// The optional [Axis] allows targeting of a specific [Scrollable] of that
-  /// axis, useful when Scrollables are nested. When [axis] is provided, the
-  /// nearest enclosing [ScrollableState] in that [Axis] is returned, or null
-  /// if there is none.
+  /// Using the optional [Axis] is useful when Scrollables are nested and the
+  /// target [Scrollable] is not the closest instance. When [axis] is provided,
+  /// the nearest enclosing [ScrollableState] in that [Axis] is returned, or
+  /// null if there is none.
   ///
   /// See also:
   ///
@@ -351,15 +351,15 @@ class Scrollable extends StatefulWidget {
   ///
   /// Calling this method will create a dependency on the [ScrollableState]
   /// that is returned, if there is one. This is typically the closest
-  /// [Scrollable], but may be a more distant ancestor if `axis` is used to
+  /// [Scrollable], but may be a more distant ancestor if [axis] is used to
   /// target a specific [Scrollable].
+  ///
+  /// Using the optional [Axis] is useful when Scrollables are nested and the
+  /// target [Scrollable] is not the closest instance. When [axis] is provided,
+  /// the nearest enclosing [ScrollableState] in that [Axis] is returned.
   ///
   /// If no [Scrollable] ancestor is found, then this method will assert in
   /// debug mode, and throw an exception in release mode.
-  ///
-  /// The optional [Axis] allows targeting of a specific [Scrollable] of that
-  /// axis, useful when Scrollables are nested. When [axis] is provided, the
-  /// nearest enclosing [ScrollableState] in that [Axis] is returned.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -322,7 +322,6 @@ class Scrollable extends StatefulWidget {
       final ScrollableState scrollable = (element.widget as _ScrollableScope).scrollable;
       if (axis == null || axisDirectionToAxis(scrollable.axisDirection) == axis) {
         // Establish the dependency on the correct context.
-        // Get the element.
         originalContext.dependOnInheritedElement(element);
         return scrollable;
       }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -315,27 +315,19 @@ class Scrollable extends StatefulWidget {
   /// * [Scrollable.of], which is similar to this method, but asserts
   ///   if no [Scrollable] ancestor is found.
   static ScrollableState? maybeOf(BuildContext context, { Axis? axis }) {
-    if (axis == null) {
-      final _ScrollableScope? widget = context.dependOnInheritedWidgetOfExactType<_ScrollableScope>();
-      return widget?.scrollable;
-    }
     // This is the context that will need to establish the dependency.
     final BuildContext originalContext = context;
-    ScrollableState? scrollable = context.getInheritedWidgetOfExactType<_ScrollableScope>()?.scrollable;
-    while (scrollable != null) {
-      if (axisDirectionToAxis(scrollable.axisDirection) == axis) {
-        if (context != originalContext) {
-          // Establish the dependency on the correct context.
-          // Get the element.
-          final InheritedElement element = context.getElementForInheritedWidgetOfExactType<_ScrollableScope>()!;
-          originalContext.dependOnInheritedElement(element);
-          return scrollable;
-        }
-        scrollable = context.dependOnInheritedWidgetOfExactType<_ScrollableScope>()?.scrollable;
+    InheritedElement? element = context.getElementForInheritedWidgetOfExactType<_ScrollableScope>();
+    while (element != null) {
+      final ScrollableState scrollable = (element.widget as _ScrollableScope).scrollable;
+      if (axis == null || axisDirectionToAxis(scrollable.axisDirection) == axis) {
+        // Establish the dependency on the correct context.
+        // Get the element.
+        originalContext.dependOnInheritedElement(element);
         return scrollable;
       }
       context = scrollable.context;
-      scrollable = context.getInheritedWidgetOfExactType<_ScrollableScope>()?.scrollable;
+      element = context.getElementForInheritedWidgetOfExactType<_ScrollableScope>();
     }
     return null;
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -426,7 +426,6 @@ class Scrollable extends StatefulWidget {
 
   /// Scrolls the scrollables that enclose the given context so as to make the
   /// given context visible.
-  // TODO(Piinks): Come back and implement for 2D
   static Future<void> ensureVisible(
     BuildContext context, {
     double alignment = 0.0,


### PR DESCRIPTION
This is motivated by part of the 2D scrolling proposal: [flutter.dev/go/2D-Foundation](https://flutter.dev/go/2D-Foundation)

This is one of the last little PRs to prep for the 2D scrolling foundation. 
This adds an optional `axis` parameter to the static Scrollable methods `[of, maybeOf, recommendDeferredLoadingForContext]`. This allows developers that are nesting scrollables (or one day using 2D scrolling) to look them up instead by a particular axis.

In general, even outside the context of 2D, I think this is helpful. I am often asked how to get the outer scrollable when nesting. Now it can be done.

There is also a small semantic refactor here in ScrollableState.build, this just creates a private method (_buildChrome) that will be overridden in 2D later. It is easier to add now than in the really big PR that will be.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
