### PR TITLE
Update usage of standalone`pub` executable in flutter_tools testing docs

### DIFF
--- a/packages/flutter_tools/test/integration.shard/README.md
+++ b/packages/flutter_tools/test/integration.shard/README.md
@@ -7,7 +7,7 @@ Dart VM and Flutter integration.
 Use this command to run (from the `flutter_tools` directory):
 
 ```shell
-../../bin/cache/dart-sdk/bin/pub run test test/integration.shard
+../../bin/cache/dart-sdk/bin/dart run test test/integration.shard
 ```
 
 You need to have downloaded the Dart SDK in your Flutter clone for this

--- a/packages/flutter_tools/test/web.shard/README.md
+++ b/packages/flutter_tools/test/web.shard/README.md
@@ -2,12 +2,12 @@
 
 These tests are not hermetic, and use the actual Flutter SDK. While
 they don't require actual devices, they run `flutter_tester` to test
-Dart web debug services (dwds)  and Flutter integration.
+Dart web debug services (dwds) and Flutter integration.
 
 Use this command to run (from the `flutter_tools` directory):
 
 ```shell
-../../bin/cache/dart-sdk/bin/pub run test test/web.shard
+../../bin/cache/dart-sdk/bin/dart run test test/web.shard
 ```
 
 These tests are expensive to run and do not give meaningful coverage


### PR DESCRIPTION
Just found this while trying to run the integration test shard of `flutter_tools` locally :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

