### PR TITLE
Add layer unique IDs to debug properties

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -689,9 +689,15 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
     properties.add(DiagnosticsProperty<Object?>('creator', debugCreator, defaultValue: null, level: DiagnosticLevel.debug));
     if (_engineLayer != null) {
       properties.add(DiagnosticsProperty<String>('engine layer', describeIdentity(_engineLayer)));
+      properties.add(DiagnosticsProperty<int>('engine layer id', _engineLayer?.uniqueId));
     }
     properties.add(DiagnosticsProperty<int>('handles', debugHandleCount));
   }
+
+  /// The unique ID for this layer within the engine.
+  ///
+  /// This can be useful in investigating performance issues.
+  int? get engineLayerId => engineLayer?.uniqueId;
 }
 
 /// A handle to prevent a [Layer]'s platform graphics resources from being
@@ -775,6 +781,9 @@ class PictureLayer extends Layer {
   /// commands are being culled.
   final Rect canvasBounds;
 
+  /// The unique ID of the picture returned when adding to the scene.
+  int? _pictureId;
+
   /// The picture recorded for this layer.
   ///
   /// The picture's coordinate system matches this layer's coordinate system.
@@ -834,7 +843,7 @@ class PictureLayer extends Layer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     assert(picture != null);
-    builder.addPicture(Offset.zero, picture!, isComplexHint: isComplexHint, willChangeHint: willChangeHint);
+    _pictureId = builder.addPicture(Offset.zero, picture!, isComplexHint: isComplexHint, willChangeHint: willChangeHint);
   }
 
   @override
@@ -846,12 +855,16 @@ class PictureLayer extends Layer {
       'raster cache hints',
       'isComplex = $isComplexHint, willChange = $willChangeHint',
     ));
+    properties.add(DiagnosticsProperty<int>('engine picture id', _pictureId));
   }
 
   @override
   bool findAnnotations<S extends Object>(AnnotationResult<S> result, Offset localPosition, { required bool onlyFirst }) {
     return false;
   }
+
+  @override
+  int? get engineLayerId => _pictureId;
 }
 
 /// A composited layer that maps a backend texture to a rectangle.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3743,6 +3743,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     properties.add(DiagnosticsProperty<Constraints>('constraints', _constraints, missingIfNull: true));
     // don't access it via the "layer" getter since that's only valid when we don't need paint
     properties.add(DiagnosticsProperty<ContainerLayer>('layer', _layerHandle.layer, defaultValue: null));
+    properties.add(DiagnosticsProperty<int>('layer engine id', _layerHandle.layer?.engineLayerId, defaultValue: null));
     properties.add(DiagnosticsProperty<SemanticsNode>('semantics node', _semantics, defaultValue: null));
     properties.add(FlagProperty(
       'isBlockingSemanticsOfPreviouslyPaintedNodes',

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -1027,6 +1027,26 @@ void main() {
 
     expect(platformViewLayer.supportsRasterization(), false);
   });
+
+  test('Layer unique IDs', () {
+    final SceneBuilder builder = SceneBuilder();
+    final PictureLayer pictureLayer = PictureLayer(Rect.zero);
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    canvas.drawPaint(Paint());
+    final Picture picture = recorder.endRecording();
+    pictureLayer.picture = picture;
+    pictureLayer.addToScene(builder);
+    final ClipRectLayer clipRectLayer = ClipRectLayer(clipRect: Rect.zero);
+    clipRectLayer.addToScene(builder);
+    final Scene scene = builder.build();
+    expect(pictureLayer.engineLayerId, greaterThan(0));
+    expect(clipRectLayer.engineLayerId, greaterThan(0));
+    expect(pictureLayer.engineLayerId, isNot(clipRectLayer.engineLayerId));
+    scene.dispose();
+    pictureLayer.dispose();
+    clipRectLayer.dispose();
+  });
 }
 
 class FakeEngineLayer extends Fake implements EngineLayer {
@@ -1037,6 +1057,9 @@ class FakeEngineLayer extends Fake implements EngineLayer {
     assert(!disposed);
     disposed = true;
   }
+
+  @override
+  int get uniqueId => 0;
 }
 
 class FakePicture extends Fake implements Picture {
@@ -1083,7 +1106,7 @@ class FakeSceneBuilder extends Fake implements SceneBuilder {
         return FakeOffsetEngineLayer();
       case #addPicture:
         addedPicture = true;
-        return;
+        return 0;
       case #pop:
         return;
     }


### PR DESCRIPTION
After adding new getters and return values to track engine unique IDs (in https://github.com/flutter/engine/pull/41291/), they can be added to `debugFillProperties` here. After this, they will be shown when dumping the layer tree / render tree.

2/2 towards fixing https://github.com/flutter/flutter/issues/125019

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.