### PR TITLE
Adjust selection rects inclusion criteria

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3848,7 +3848,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         if (paintBounds.bottom <= box.top) {
           break;
         }
-        if (paintBounds.contains(Offset(box.left, box.top)) || paintBounds.contains(Offset(box.right, box.bottom))) {
+        // Include any rect with overlap with paintBounds.
+        if ((paintBounds.left <= box.right || paintBounds.right >= box.left) &&
+            paintBounds.top <= box.bottom) {
           rects.add(SelectionRect(position: graphemeStart, bounds: box.toRect(), direction: box.direction));
         }
       }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3848,10 +3848,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         if (paintBounds.bottom <= box.top) {
           break;
         }
-        // Include any rect with overlap with paintBounds.
+        // Include any TextBox which intersects with the RenderEditable.
         if (paintBounds.left <= box.right &&
             box.left <= paintBounds.right &&
             paintBounds.top <= box.bottom) {
+          // At least some part of the letter is visible within the text field.
           rects.add(SelectionRect(position: graphemeStart, bounds: box.toRect(), direction: box.direction));
         }
       }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3849,7 +3849,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           break;
         }
         // Include any rect with overlap with paintBounds.
-        if ((paintBounds.left <= box.right || paintBounds.right >= box.left) &&
+        if (paintBounds.left <= box.right &&
+            box.left <= paintBounds.right &&
             paintBounds.top <= box.bottom) {
           rects.add(SelectionRect(position: graphemeStart, bounds: box.toRect(), direction: box.direction));
         }


### PR DESCRIPTION
Include rects with any overlap instead of only when top-left or bottom-right included. The previous criteria didn't send any selection rects when text was taller than the text box and scroll offset was not zero.

Part of #30476

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.