### PR TITLE
keeps listening to ImageStream even after the route has been pushed onto the stack

### DIFF
--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -881,7 +881,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('TickerMode controls stream registration', (WidgetTester tester) async {
+  testWidgets('Keep image stream listeners when TickerMode is disabled', (WidgetTester tester) async {
     final _TestImageStreamCompleter imageStreamCompleter = _TestImageStreamCompleter();
     final Image image = Image(
       excludeFromSemantics: true,
@@ -900,7 +900,7 @@ void main() {
         child: image,
       ),
     );
-    expect(imageStreamCompleter.listeners.length, 1);
+    expect(imageStreamCompleter.listeners.length, 2);
   });
 
   testWidgets('Verify Image shows correct RenderImage when changing to an already completed provider', (WidgetTester tester) async {
@@ -1199,8 +1199,8 @@ void main() {
     streamCompleter.setData(imageInfo: ImageInfo(image: await nextFrame()));
     streamCompleter.setData(imageInfo: ImageInfo(image: await nextFrame()));
     await tester.pump();
-    expect(lastFrame, 0);
-    expect(buildCount, 3);
+    expect(lastFrame, 2);
+    expect(buildCount, 4);
 
     await tester.pumpWidget(
       TickerMode(
@@ -1213,8 +1213,8 @@ void main() {
     );
 
     expect(tester.state(find.byType(Image)), same(state));
-    expect(lastFrame, 1); // missed a frame because we weren't animating at the time
-    expect(buildCount, 4);
+    expect(lastFrame, 2);
+    expect(buildCount, 5);
   });
 
   testWidgets('Image invokes loadingBuilder on chunk event notification', (WidgetTester tester) async {


### PR DESCRIPTION
Perhaps we should let the lifecycle of the image **DEFAULT** to follow the page, that is, only remove the listener of the image when the listener is truly `dispose`.

For the following two reasons, it may be more reasonable to continue listening to the `ImageStream` even after the page has been pushed onto the `Navigator` stack:

1. As the related issue indicates, when navigating back, the previous page may experience flickering due to images being re-decoded.
2. It is reasonable for the pages in the `Navigator` stack to maintain references to image resources.

Fixes https://github.com/flutter/flutter/issues/124382

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

