### PR TITLE
Stop running "_impeller_" benchmark variants

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3487,15 +3487,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: backdrop_filter_perf_ios__timeline_summary
 
-  - name: Mac_ios backdrop_filter_perf_impeller_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: backdrop_filter_perf_impeller_ios__timeline_summary
-
   - name: Mac_ios basic_material_app_ios__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3550,24 +3541,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: complex_layout_scroll_perf_bad_ios__timeline_summary
 
-  - name: Mac_ios complex_layout_scroll_perf_bad_impeller_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: complex_layout_scroll_perf_bad_impeller_ios__timeline_summary
-
-  - name: Mac_ios complex_layout_scroll_perf_impeller_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: complex_layout_scroll_perf_impeller_ios__timeline_summary
-
   - name: Mac_ios color_filter_and_fade_perf_ios__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3577,15 +3550,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: color_filter_and_fade_perf_ios__e2e_summary
 
-  - name: Mac_ios color_filter_and_fade_perf_impeller_ios__e2e_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: color_filter_and_fade_perf_impeller_ios__e2e_summary
-
   - name: Mac_ios imagefiltered_transform_animation_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3594,15 +3558,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: imagefiltered_transform_animation_perf_ios__timeline_summary
-
-  - name: Mac_ios imagefiltered_transform_animation_perf_impeller_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: imagefiltered_transform_animation_perf_impeller_ios__timeline_summary
 
   - name: Mac_ios external_ui_integration_test_ios
     recipe: devicelab/devicelab_drone
@@ -3844,16 +3799,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios
 
-  - name: Mac_ios microbenchmarks_impeller_ios
-    recipe: devicelab/devicelab_drone
-    bringup: true # Flaky: https://github.com/flutter/flutter/issues/106753
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: microbenchmarks_impeller_ios
-
   - name: Mac_ios native_platform_view_ui_tests_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3871,15 +3816,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: new_gallery_ios__transition_perf
-
-  - name: Mac_ios new_gallery_impeller_ios__transition_perf
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: new_gallery_impeller_ios__transition_perf
 
   - name: Mac_ios ios_picture_cache_complexity_scoring_perf__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3944,15 +3880,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: platform_views_scroll_perf_ios__timeline_summary
 
-  - name: Mac_ios platform_views_scroll_perf_impeller_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: platform_views_scroll_perf_impeller_ios__timeline_summary
-
   - name: Mac_ios platform_views_scroll_perf_non_intersecting_impeller_ios__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3989,15 +3916,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: wide_gamut_ios
 
-  - name: Mac_ios simple_animation_perf_impeller_ios
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: simple_animation_perf_impeller_ios
-
   - name: Mac_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -4025,15 +3943,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: fullscreen_textfield_perf_ios__e2e_summary
 
-  - name: Mac_ios fullscreen_textfield_perf_impeller_ios__e2e_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: fullscreen_textfield_perf_impeller_ios__e2e_summary
-
   - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -4043,15 +3952,6 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
 
-  - name: Mac_ios tiles_scroll_perf_impeller_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: tiles_scroll_perf_impeller_ios__timeline_summary
-
   - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -4060,15 +3960,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
-
-  - name: Mac_ios flutter_gallery__transition_perf_e2e_impeller_ios
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: flutter_gallery__transition_perf_e2e_impeller_ios
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Impeller is now the default on iOS, so these are redundant.

In a subsequent change, I'll clean up the source files for these.

