### PR TITLE
Search view shape should clip the view content

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -777,6 +777,7 @@ class _ViewContentState extends State<_ViewContent> {
           width: _viewRect.width,
           height: _viewRect.height,
           child: Material(
+            clipBehavior: Clip.antiAlias,
             shape: effectiveShape,
             color: effectiveBackgroundColor,
             surfaceTintColor: effectiveSurfaceTint,

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -755,6 +755,7 @@ void main() {
     expect(material.elevation, 6.0);
     expect(material.color, colorScheme.surface);
     expect(material.surfaceTintColor, colorScheme.surfaceTint);
+    expect(material.clipBehavior, Clip.antiAlias);
 
     final Finder findDivider = find.byType(Divider);
     final Container dividerContainer = tester.widget<Container>(find.descendant(of: findDivider, matching: find.byType(Container)).first);


### PR DESCRIPTION
Fixes #124426

This PR is to make the search view shape clip the view content.

Before: the highlight and the "i" of "item 9" are not clipped by the shape.

<img width="350" alt="Screenshot 2023-04-19 at 12 09 48 PM" src="https://user-images.githubusercontent.com/36861262/233201222-468820a9-8717-4b6c-8528-8125a40fc161.png">

After:

<img width="350" alt="Screenshot 2023-04-19 at 2 13 52 PM" src="https://user-images.githubusercontent.com/36861262/233201609-81f5a942-2390-4081-a9c7-c9523a7f9e72.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.