### PR TITLE
[flutter_tools] make overall_experience_test resilient to extraneous pub output

### DIFF
--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -582,7 +582,7 @@ void main() {
     );
     expect(result.exitCode, 0);
     expect(result.stderr, isEmpty);
-    expect(result.stdout, <Object>[
+    expect(result.stdout, containsAllInOrder(<Object>[
       startsWith('Launching '),
       startsWith('Syncing files to device Flutter test device...'),
       '',
@@ -626,6 +626,6 @@ void main() {
       startsWith('The Flutter DevTools debugger and profiler on Flutter test device is available at: http://'),
       '',
       'Application finished.',
-    ]);
+    ]));
   });
 }


### PR DESCRIPTION
use `containsAllInOrder` so that pub output doesn't cause htis test to fail, as in https://ci.chromium.org/p/flutter/builders/try/Linux%20tool_tests_general/22929?