### PR TITLE
Update xcode to 14c18 for host only bots

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -78,7 +78,7 @@ platform_properties:
         ]
       os: Mac-12
       device_type: none
-      xcode: 14c18 # xcode 14.0 beta 5
+      xcode: 14c18
   mac_arm64:
     properties:
       dependencies: >-
@@ -88,7 +88,7 @@ platform_properties:
       os: Mac-12
       device_type: none
       cpu: arm64
-      xcode: 14c18 # xcode 14.0 beta 5
+      xcode: 14c18
   mac_benchmark:
     properties:
       dependencies: >-
@@ -100,7 +100,7 @@ platform_properties:
       os: Mac-12
       tags: >
         ["devicelab", "hostonly", "mac"]
-      xcode: 14c18 # xcode 14.0 beta 5
+      xcode: 14c18
   mac_x64:
     properties:
       dependencies: >-
@@ -110,7 +110,7 @@ platform_properties:
       os: Mac-12
       device_type: none
       cpu: x86
-      xcode: 14c18 # xcode 14.0 beta 5
+      xcode: 14c18
   mac_android:
     properties:
       dependencies: >-
@@ -143,7 +143,7 @@ platform_properties:
       os: Mac-12
       cpu: x86
       device_os: iOS-16
-      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+      xcode: 14c18
   mac_arm64_ios:
     properties:
       dependencies: >-
@@ -155,7 +155,7 @@ platform_properties:
       os: Mac-12
       cpu: arm64
       device_os: iOS-16
-      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+      xcode: 14c18
   windows:
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -78,7 +78,7 @@ platform_properties:
         ]
       os: Mac-12
       device_type: none
-      xcode: 14a5294e # xcode 14.0 beta 5
+      xcode: 14c18 # xcode 14.0 beta 5
   mac_arm64:
     properties:
       dependencies: >-
@@ -88,7 +88,7 @@ platform_properties:
       os: Mac-12
       device_type: none
       cpu: arm64
-      xcode: 14a5294e # xcode 14.0 beta 5
+      xcode: 14c18 # xcode 14.0 beta 5
   mac_benchmark:
     properties:
       dependencies: >-
@@ -100,7 +100,7 @@ platform_properties:
       os: Mac-12
       tags: >
         ["devicelab", "hostonly", "mac"]
-      xcode: 14a5294e # xcode 14.0 beta 5
+      xcode: 14c18 # xcode 14.0 beta 5
   mac_x64:
     properties:
       dependencies: >-
@@ -110,7 +110,7 @@ platform_properties:
       os: Mac-12
       device_type: none
       cpu: x86
-      xcode: 14a5294e # xcode 14.0 beta 5
+      xcode: 14c18 # xcode 14.0 beta 5
   mac_android:
     properties:
       dependencies: >-
@@ -2511,7 +2511,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: animated_complex_opacity_perf_macos__e2e_summary
@@ -2523,7 +2523,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       task_name: basic_material_app_macos__compile
 
@@ -2533,7 +2533,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -2570,7 +2570,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -2590,7 +2590,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -2610,7 +2610,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -2630,7 +2630,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -2646,7 +2646,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: complex_layout_macos__compile
@@ -2658,7 +2658,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: complex_layout_macos__start_up
@@ -2670,7 +2670,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: complex_layout_scroll_perf_macos__timeline_summary
@@ -2692,7 +2692,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -2711,7 +2711,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -2725,7 +2725,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: flutter_gallery_macos__compile
@@ -2737,7 +2737,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: flutter_gallery_macos__start_up
@@ -2773,7 +2773,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       task_name: flutter_view_macos__start_up
 
@@ -2811,7 +2811,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "open_jdk", "version": "version:11"},
           {"dependency": "android_sdk", "version": "version:33v6"}
@@ -2883,7 +2883,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       task_name: hello_world_macos__compile
 
@@ -2894,7 +2894,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -2962,7 +2962,7 @@ targets:
       cpu: x86 # Codesigning fails on ARM https://github.com/flutter/flutter/issues/112033
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -2995,7 +2995,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       task_name: platform_view_macos__start_up
 
@@ -3006,7 +3006,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       tags: >
         ["devicelab", "hostonly", "mac"]
@@ -3020,7 +3020,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -3038,7 +3038,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -3092,7 +3092,7 @@ targets:
       cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -3111,7 +3111,7 @@ targets:
       cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -3129,7 +3129,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       shard: tool_host_cross_arch_tests
@@ -3148,7 +3148,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       shard: tool_host_cross_arch_tests
@@ -3171,7 +3171,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -3196,7 +3196,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -3221,7 +3221,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -3246,7 +3246,7 @@ targets:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "chrome_and_driver", "version": "version:110.0"},
           {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
         ]
@@ -3305,7 +3305,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       tags: >
         ["framework", "hostonly", "shard", "mac"]
@@ -3321,7 +3321,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14c18"}
         ]
       tags: >
         ["framework", "hostonly", "shard", "mac"]
@@ -3985,7 +3985,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -4003,7 +4003,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -4021,7 +4021,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
@@ -4054,7 +4054,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14c18"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >


### PR DESCRIPTION
With https://flutter-review.googlesource.com/c/recipes/+/42160, we are ready to make all tests consistent with xcode 14c18.