### PR TITLE
Fix JS types in _test_http_request.dart

### DIFF
--- a/packages/flutter/test/painting/_test_http_request.dart
+++ b/packages/flutter/test/painting/_test_http_request.dart
@@ -49,11 +49,15 @@ class TestHttpRequest {
         setRequestHeader: setRequestHeader.toJS,
         addEventListener: addEventListener.toJS,
     );
-    createGetter(_mock, 'headers', () => js_util.jsify(headers) as JSAny);
-    createGetter(_mock,
+    // TODO(srujzs): This is needed for when we reify JS types. Right now, JSAny
+    // is a typedef for Object?, but when we reify, it'll be its own type.
+    // ignore: unnecessary_cast
+    final JSAny mock = _mock as JSAny;
+    createGetter(mock, 'headers', () => js_util.jsify(headers) as JSAny);
+    createGetter(mock,
         'responseHeaders', () => js_util.jsify(responseHeaders) as JSAny);
-    createGetter(_mock, 'status', () => status.toJS);
-    createGetter(_mock, 'response', () => js_util.jsify(response) as JSAny);
+    createGetter(mock, 'status', () => status.toJS);
+    createGetter(mock, 'response', () => js_util.jsify(response) as JSAny);
   }
 
   late DomXMLHttpRequestMock _mock;
@@ -71,7 +75,9 @@ class TestHttpRequest {
 
   JSVoid addEventListener(JSString type, DomEventListener listener) {
     if (type.toDart == mockEvent?.type) {
-      (listener.toDart as DartDomEventListener)(mockEvent!.event);
+      final DartDomEventListener dartListener =
+        (listener as JSFunction).toDart as DartDomEventListener;
+      dartListener(mockEvent!.event);
     }
   }
 


### PR DESCRIPTION
Types are being reified in the JS backends, so these need to be addressed. Fixes two issues:

- @staticInterop types need to be casted to JS types
- JS functions need to be cast to JSFunction before conversion

Enables landing of https://dart-review.googlesource.com/c/sdk/+/295105.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
