### PR TITLE
Updated the BottomNavigationBar API doc to link to NavigationBar

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -63,7 +63,7 @@ enum BottomNavigationBarLandscapeLayout {
 /// A material widget that's displayed at the bottom of an app for selecting
 /// among a small number of views, typically between three and five.
 ///
-/// There is a newer version of this component, [NavigationBar], that's
+/// There is an updated version of this component, [NavigationBar], that's
 /// preferred for new applications and applications that are configured
 /// for Material 3 (see [ThemeData.useMaterial3]).
 ///

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -104,9 +104,9 @@ enum BottomNavigationBarLandscapeLayout {
 /// that's preferred for new applications and applications that are
 /// configured for Material 3 (see [ThemeData.useMaterial3]). The
 /// [NavigationBar] widget's visuals are a little bit different, see
-/// The Material 3 spec at
+/// the Material 3 spec at
 /// <https://m3.material.io/components/navigation-bar/overview> for
-/// more details. The API is is similar, destinations are defined with
+/// more details. The API is similar, destinations are defined with
 /// [NavigationDestination]s and [NavigationBar.onDestinationSelected]
 /// is called when a destination is tapped.
 ///

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -63,6 +63,10 @@ enum BottomNavigationBarLandscapeLayout {
 /// A material widget that's displayed at the bottom of an app for selecting
 /// among a small number of views, typically between three and five.
 ///
+/// There is a newer version of this component, [NavigationBar], that's
+/// preferred for new applications and applications that are configured
+/// for Material 3 (see [ThemeData.useMaterial3]).
+///
 /// The bottom navigation bar consists of multiple items in the form of
 /// text labels, icons, or both, laid out on top of a piece of material. It
 /// provides quick navigation between the top-level views of an app. For larger
@@ -93,6 +97,18 @@ enum BottomNavigationBarLandscapeLayout {
 ///    [BottomNavigationBarItem.backgroundColor] of the selected item. In this
 ///    case it's assumed that each item will have a different background color
 ///    and that background color will contrast well with white.
+///
+/// ## Updating to [NavigationBar]
+///
+/// There is an updated version of this component, [NavigationBar],
+/// that's preferred for new applications and applications that are
+/// configured for Material 3 (see [ThemeData.useMaterial3]). The
+/// [NavigationBar] widget's visuals are a little bit different, see
+/// The Material 3 spec at
+/// <https://m3.material.io/components/navigation-bar/overview> for
+/// more details. The API is is similar, destinations are defined with
+/// [NavigationDestination]s and [NavigationBar.onDestinationSelected]
+/// is called when a destination is tapped.
 ///
 /// {@tool dartpad}
 /// This example shows a [BottomNavigationBar] as it is used within a [Scaffold]


### PR DESCRIPTION
The BottomNavigationBar API doc now makes it clear that NavigationBar is preferred in new M3 applications.

Fixes https://github.com/flutter/flutter/issues/124687