### PR TITLE
When searching for the JDK bundled with an unrecognized version of Android Studio, assume the version to be the latest

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -492,6 +492,7 @@ the configured path by running this command: flutter config --android-studio-dir
         javaPath = globals.fs.path.join(directory, 'jre', 'jdk', 'Contents', 'Home');
       } else if (version != null && version!.major < 2022) {
         javaPath = globals.fs.path.join(directory, 'jre', 'Contents', 'Home');
+      // See https://github.com/flutter/flutter/issues/125246 for more context.
       } else {
         javaPath = globals.fs.path.join(directory, 'jbr', 'Contents', 'Home');
       }

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -162,6 +162,9 @@ class AndroidStudio {
   bool _isValid = false;
   final List<String> _validationMessages = <String>[];
 
+  /// The path of the JDK bundled with Android Studio.
+  ///
+  /// This will be null if the bundled JDK could not be found or run.
   String? get javaPath => _javaPath;
 
   bool get isValid => _isValid;

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -487,16 +487,16 @@ the configured path by running this command: flutter config --android-studio-dir
     if (globals.platform.isMacOS) {
       if (version != null && version!.major < 2020) {
         javaPath = globals.fs.path.join(directory, 'jre', 'jdk', 'Contents', 'Home');
-      } else if (version != null && version!.major == 2022) {
-        javaPath = globals.fs.path.join(directory, 'jbr', 'Contents', 'Home');
-      } else {
+      } else if (version != null && version!.major < 2022) {
         javaPath = globals.fs.path.join(directory, 'jre', 'Contents', 'Home');
+      } else {
+        javaPath = globals.fs.path.join(directory, 'jbr', 'Contents', 'Home');
       }
     } else {
-      if (version != null && version!.major == 2022) {
-        javaPath = globals.fs.path.join(directory, 'jbr');
-      } else {
+      if (version != null && version!.major < 2022) {
         javaPath = globals.fs.path.join(directory, 'jre');
+      } else {
+        javaPath = globals.fs.path.join(directory, 'jbr');
       }
     }
     final String javaExecutable = globals.fs.path.join(javaPath, 'bin', 'java');

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -800,7 +800,6 @@ void main() {
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
     });
-
   });
 
   group('installation detection on Linux', () {

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -86,7 +86,6 @@ void main() {
       },
     };
 
-    late Config config;
     late FileSystem fileSystem;
     late FileSystemUtils fsUtils;
     late Platform platform;
@@ -94,7 +93,6 @@ void main() {
     late FakeProcessManager processManager;
 
     setUp(() {
-      config = Config.test();
       fileSystem = MemoryFileSystem.test();
       plistUtils = FakePlistUtils();
       platform = FakePlatform(
@@ -585,12 +583,10 @@ void main() {
   });
 
   group('installation detection on Windows', () {
-    late Config config;
     late Platform platform;
     late FileSystem fileSystem;
 
     setUp(() {
-      config = Config.test();
       platform = FakePlatform(
         operatingSystem: 'windows',
         environment: <String, String>{

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -73,14 +73,14 @@ void main() {
       },
     };
 
-    const Map<String, Object> macStudioInfoPlistEAP = <String, Object>{
-      'CFBundleGetInfoString': 'Android Studio EAP AI-212.5712.43.2112.8233820, build AI-212.5712.43.2112.8233820. Copyright JetBrains s.r.o., (c) 2000-2022',
-      'CFBundleShortVersionString': 'EAP AI-212.5712.43.2112.8233820',
-      'CFBundleVersion': 'AI-212.5712.43.2112.8233820',
+    const Map<String, Object> macStudioInfoPlistEap_2022_3_1_11 = <String, Object>{
+      'CFBundleGetInfoString': 'Android Studio EAP AI-223.8836.35.2231.9848316, build AI-223.8836.35.2231.9848316. Copyright JetBrains s.r.o., (c) 2000-2023',
+      'CFBundleShortVersionString': 'EAP AI-223.8836.35.2231.9848316',
+      'CFBundleVersion': 'AI-223.8836.35.2231.9848316',
       'JVMOptions': <String, Object>{
         'Properties': <String, Object>{
           'idea.vendor.name' : 'Google',
-          'idea.paths.selector': 'AndroidStudio2021.2',
+          'idea.paths.selector': 'AndroidStudioPreview2022.3',
           'idea.platform.prefix': 'AndroidStudio',
         },
       },
@@ -241,10 +241,10 @@ void main() {
       globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
       final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
-      plistUtils.fileContents[plistFilePath] = macStudioInfoPlistEAP;
+      plistUtils.fileContents[plistFilePath] = macStudioInfoPlistEap_2022_3_1_11;
       processManager.addCommand(FakeCommand(
           command: <String>[
-            globals.fs.path.join(studioInApplicationPlistFolder, 'jre', 'Contents', 'Home', 'bin', 'java'),
+            globals.fs.path.join(studioInApplicationPlistFolder, 'jbr', 'Contents', 'Home', 'bin', 'java'),
             '-version',
           ],
           stderr: '123',
@@ -259,7 +259,7 @@ void main() {
         homeMac,
         'Library',
         'Application Support',
-        'AndroidStudio2021.2',
+        'AndroidStudioPreview2022.3',
       )));
       expect(studio.validationMessages, <String>['Java version 123']);
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -86,6 +86,7 @@ void main() {
       },
     };
 
+    late Config config;
     late FileSystem fileSystem;
     late FileSystemUtils fsUtils;
     late Platform platform;
@@ -93,6 +94,7 @@ void main() {
     late FakeProcessManager processManager;
 
     setUp(() {
+      config = Config.test();
       fileSystem = MemoryFileSystem.test();
       plistUtils = FakePlistUtils();
       platform = FakePlatform(
@@ -107,30 +109,30 @@ void main() {
     });
 
     testUsingContext('discovers Android Studio >=4.1 location', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlist4_1;
       processManager.addCommand(FakeCommand(
           command: <String>[
-            globals.fs.path.join(studioInApplicationPlistFolder, 'jre', 'jdk', 'Contents', 'Home', 'bin', 'java'),
+            fileSystem.path.join(studioInApplicationPlistFolder, 'jre', 'jdk', 'Contents', 'Home', 'bin', 'java'),
             '-version',
           ],
           stderr: '123',
         )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
       expect(studio, isNotNull);
-      expect(studio.pluginsPath, equals(globals.fs.path.join(
+      expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -149,30 +151,30 @@ void main() {
     });
 
     testUsingContext('discovers Android Studio >=2020.3 location', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlist2020_3;
       processManager.addCommand(FakeCommand(
           command: <String>[
-            globals.fs.path.join(studioInApplicationPlistFolder, 'jre', 'Contents', 'Home', 'bin', 'java'),
+            fileSystem.path.join(studioInApplicationPlistFolder, 'jre', 'Contents', 'Home', 'bin', 'java'),
             '-version',
           ],
           stderr: '123',
         )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
       expect(studio, isNotNull);
-      expect(studio.pluginsPath, equals(globals.fs.path.join(
+      expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -191,30 +193,30 @@ void main() {
     });
 
     testUsingContext('discovers Android Studio <4.1 location', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlist3_3;
       processManager.addCommand(FakeCommand(
           command: <String>[
-            globals.fs.path.join(studioInApplicationPlistFolder, 'jre', 'jdk', 'Contents', 'Home', 'bin', 'java'),
+            fileSystem.path.join(studioInApplicationPlistFolder, 'jre', 'jdk', 'Contents', 'Home', 'bin', 'java'),
             '-version',
           ],
           stderr: '123',
         )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
       expect(studio, isNotNull);
-      expect(studio.pluginsPath, equals(globals.fs.path.join(
+      expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -232,30 +234,30 @@ void main() {
     });
 
     testUsingContext('discovers Android Studio EAP location', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio with suffix.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlistEap_2022_3_1_11;
       processManager.addCommand(FakeCommand(
           command: <String>[
-            globals.fs.path.join(studioInApplicationPlistFolder, 'jbr', 'Contents', 'Home', 'bin', 'java'),
+            fileSystem.path.join(studioInApplicationPlistFolder, 'jbr', 'Contents', 'Home', 'bin', 'java'),
             '-version',
           ],
           stderr: '123',
         )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
       expect(studio, isNotNull);
-      expect(studio.pluginsPath, equals(globals.fs.path.join(
+      expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -273,29 +275,29 @@ void main() {
     });
 
     testUsingContext('does not discover Android Studio with JetBrainsToolboxApp wrapper', () {
-      final String applicationPlistFolder = globals.fs.path.join(
+      final String applicationPlistFolder = fileSystem.path.join(
         '/',
         'Applications',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(applicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(applicationPlistFolder).createSync(recursive: true);
 
-      final String applicationsPlistFilePath = globals.fs.path.join(applicationPlistFolder, 'Info.plist');
+      final String applicationsPlistFilePath = fileSystem.path.join(applicationPlistFolder, 'Info.plist');
       const Map<String, Object> jetbrainsInfoPlist = <String, Object>{
         'JetBrainsToolboxApp': 'ignored',
       };
       plistUtils.fileContents[applicationsPlistFilePath] = jetbrainsInfoPlist;
 
-      final String homeDirectoryPlistFolder = globals.fs.path.join(
-        globals.fsUtils.homeDirPath!,
+      final String homeDirectoryPlistFolder = fileSystem.path.join(
+        fsUtils.homeDirPath!,
         'Applications',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(homeDirectoryPlistFolder).createSync(recursive: true);
+      fileSystem.directory(homeDirectoryPlistFolder).createSync(recursive: true);
 
-      final String homeDirectoryPlistFilePath = globals.fs.path.join(homeDirectoryPlistFolder, 'Info.plist');
+      final String homeDirectoryPlistFilePath = fileSystem.path.join(homeDirectoryPlistFolder, 'Info.plist');
       plistUtils.fileContents[homeDirectoryPlistFilePath] = macStudioInfoPlist2020_3;
 
       expect(AndroidStudio.allInstalled().length, 1);
@@ -395,26 +397,26 @@ void main() {
     });
 
     testUsingContext('finds latest valid install', () {
-      final String applicationPlistFolder = globals.fs.path.join(
+      final String applicationPlistFolder = fileSystem.path.join(
         '/',
         'Applications',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(applicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(applicationPlistFolder).createSync(recursive: true);
 
-      final String applicationsPlistFilePath = globals.fs.path.join(applicationPlistFolder, 'Info.plist');
+      final String applicationsPlistFilePath = fileSystem.path.join(applicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[applicationsPlistFilePath] = macStudioInfoPlist3_3;
 
-      final String homeDirectoryPlistFolder = globals.fs.path.join(
-        globals.fsUtils.homeDirPath!,
+      final String homeDirectoryPlistFolder = fileSystem.path.join(
+        fsUtils.homeDirPath!,
         'Applications',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(homeDirectoryPlistFolder).createSync(recursive: true);
+      fileSystem.directory(homeDirectoryPlistFolder).createSync(recursive: true);
 
-      final String homeDirectoryPlistFilePath = globals.fs.path.join(homeDirectoryPlistFolder, 'Info.plist');
+      final String homeDirectoryPlistFilePath = fileSystem.path.join(homeDirectoryPlistFolder, 'Info.plist');
       plistUtils.fileContents[homeDirectoryPlistFilePath] = macStudioInfoPlist4_1;
 
       expect(AndroidStudio.allInstalled().length, 2);
@@ -428,21 +430,21 @@ void main() {
     });
 
     testUsingContext('extracts custom paths for directly downloaded Android Studio', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlist3_3;
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
       expect(studio, isNotNull);
-      expect(studio.pluginsPath, equals(globals.fs.path.join(
+      expect(studio.pluginsPath, equals(fileSystem.path.join(
         homeMac,
         'Library',
         'Application Support',
@@ -459,29 +461,29 @@ void main() {
     });
 
     testUsingContext('finds Android Studio 2020.3 bundled Java version', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlist2020_3;
       processManager.addCommand(FakeCommand(
         command: <String>[
-          globals.fs.path.join(studioInApplicationPlistFolder, 'jre', 'Contents', 'Home', 'bin', 'java'),
+          fileSystem.path.join(studioInApplicationPlistFolder, 'jre', 'Contents', 'Home', 'bin', 'java'),
           '-version',
         ],
         stderr: '123',
       )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
-      expect(studio.javaPath, equals(globals.fs.path.join(
+      expect(studio.javaPath, equals(fileSystem.path.join(
         studioInApplicationPlistFolder,
         'jre',
         'Contents',
@@ -498,29 +500,29 @@ void main() {
     });
 
     testUsingContext('finds Android Studio 2022.1 bundled Java version', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       plistUtils.fileContents[plistFilePath] = macStudioInfoPlist2022_1;
       processManager.addCommand(FakeCommand(
         command: <String>[
-          globals.fs.path.join(studioInApplicationPlistFolder, 'jbr', 'Contents', 'Home', 'bin', 'java'),
+          fileSystem.path.join(studioInApplicationPlistFolder, 'jbr', 'Contents', 'Home', 'bin', 'java'),
           '-version',
         ],
         stderr: '123',
       )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
-      expect(studio.javaPath, equals(globals.fs.path.join(
+      expect(studio.javaPath, equals(fileSystem.path.join(
         studioInApplicationPlistFolder,
         'jbr',
         'Contents',
@@ -537,15 +539,15 @@ void main() {
     });
 
     testUsingContext('finds bundled Java version when Android Studio version is unknown by assuming the latest version', () {
-      final String studioInApplicationPlistFolder = globals.fs.path.join(
+      final String studioInApplicationPlistFolder = fileSystem.path.join(
         '/',
         'Application',
         'Android Studio.app',
         'Contents',
       );
-      globals.fs.directory(studioInApplicationPlistFolder).createSync(recursive: true);
+      fileSystem.directory(studioInApplicationPlistFolder).createSync(recursive: true);
 
-      final String plistFilePath = globals.fs.path.join(studioInApplicationPlistFolder, 'Info.plist');
+      final String plistFilePath = fileSystem.path.join(studioInApplicationPlistFolder, 'Info.plist');
       final Map<String, Object> plistWithoutVersion = Map<String, Object>.from(macStudioInfoPlist2022_1);
       plistWithoutVersion['CFBundleShortVersionString'] = '';
       plistUtils.fileContents[plistFilePath] = plistWithoutVersion;
@@ -562,11 +564,11 @@ void main() {
       )
       );
       final AndroidStudio studio = AndroidStudio.fromMacOSBundle(
-        globals.fs.directory(studioInApplicationPlistFolder).parent.path,
+        fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
       expect(studio.version, null);
-      expect(studio.javaPath, equals(globals.fs.path.join(
+      expect(studio.javaPath, equals(fileSystem.path.join(
         studioInApplicationPlistFolder,
         'jbr',
         'Contents',
@@ -583,10 +585,12 @@ void main() {
   });
 
   group('installation detection on Windows', () {
+    late Config config;
     late Platform platform;
     late FileSystem fileSystem;
 
     setUp(() {
+      config = Config.test();
       platform = FakePlatform(
         operatingSystem: 'windows',
         environment: <String, String>{
@@ -753,11 +757,13 @@ void main() {
   group('installation detection on Linux', () {
     const String homeLinux = '/home/me';
 
+    late Config config;
     late FileSystem fileSystem;
     late FileSystemUtils fsUtils;
     late Platform platform;
 
     setUp(() {
+      config = Config.test();
       platform = FakePlatform(
         environment: <String, String>{'HOME': homeLinux},
       );
@@ -773,11 +779,11 @@ void main() {
           '$homeLinux/.AndroidStudio4.0/system/.home';
       const String studioInstallPath = '$homeLinux/AndroidStudio';
 
-      globals.fs.file(studioHomeFilePath)
+      fileSystem.file(studioHomeFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(studioInstallPath);
 
-      globals.fs.directory(studioInstallPath).createSync();
+      fileSystem.directory(studioInstallPath).createSync();
 
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
@@ -799,11 +805,11 @@ void main() {
           '$homeLinux/.cache/Google/AndroidStudio4.1/.home';
       const String studioInstallPath = '$homeLinux/AndroidStudio';
 
-      globals.fs.file(studioHomeFilePath)
+      fileSystem.file(studioHomeFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(studioInstallPath);
 
-      globals.fs.directory(studioInstallPath).createSync();
+      fileSystem.directory(studioInstallPath).createSync();
 
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
@@ -827,12 +833,12 @@ void main() {
           '$homeLinux/.local/share/JetBrains/Toolbox/apps/AndroidStudio/ch-0/201.7042882';
       const String pluginsInstallPath = '$studioInstallPath.plugins';
 
-      globals.fs.file(studioHomeFilePath)
+      fileSystem.file(studioHomeFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(studioInstallPath);
 
-      globals.fs.directory(studioInstallPath).createSync(recursive: true);
-      globals.fs.directory(pluginsInstallPath).createSync();
+      fileSystem.directory(studioInstallPath).createSync(recursive: true);
+      fileSystem.directory(pluginsInstallPath).createSync();
 
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
@@ -853,11 +859,11 @@ void main() {
       const String studioHomeFilePath = '$homeLinux/.cache/Google/AndroidStudio2020.3/.home';
       const String studioInstallPath = '$homeLinux/AndroidStudio';
 
-      globals.fs.file(studioHomeFilePath)
+      fileSystem.file(studioHomeFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(studioInstallPath);
 
-      globals.fs.directory(studioInstallPath).createSync();
+      fileSystem.directory(studioInstallPath).createSync();
 
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
@@ -874,11 +880,11 @@ void main() {
           '$homeLinux/.cache/Google/AndroidStudio2022.1/.home';
       const String studioInstallPath = '$homeLinux/AndroidStudio';
 
-      globals.fs.file(studioHomeFilePath)
+      fileSystem.file(studioHomeFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(studioInstallPath);
 
-      globals.fs.directory(studioInstallPath).createSync();
+      fileSystem.directory(studioInstallPath).createSync();
 
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
@@ -892,11 +898,11 @@ void main() {
 
     testUsingContext('finds bundled Java version despite Android Studio version being unknown', () {
       const String configuredStudioInstallPath = '$homeLinux/AndroidStudio';
-      globals.config.setValue('android-studio-dir', configuredStudioInstallPath);
+      config.setValue('android-studio-dir', configuredStudioInstallPath);
 
-      globals.fs.directory(configuredStudioInstallPath).createSync(recursive: true);
+      fileSystem.directory(configuredStudioInstallPath).createSync(recursive: true);
 
-      globals.fs.directory(configuredStudioInstallPath).createSync();
+      fileSystem.directory(configuredStudioInstallPath).createSync();
 
       fileSystem.file(fileSystem.path.join(configuredStudioInstallPath, 'jbr', 'bin', 'java')).createSync(recursive: true);
 
@@ -905,7 +911,7 @@ void main() {
       expect(studio.version, null);
       expect(studio.javaPath, equals('$configuredStudioInstallPath/jbr'));
     }, overrides: <Type, Generator>{
-      Config: () => Config.test(),
+      Config: () => config,
       FileSystem: () => fileSystem,
       FileSystemUtils: () => fsUtils,
       Platform: () => platform,
@@ -916,12 +922,12 @@ void main() {
       const String installPath = '/opt/android-studio-with-cheese-5.0';
       const String studioHome = '$homeLinux/.AndroidStudioWithCheese5.0';
       const String homeFile = '$studioHome/system/.home';
-      globals.fs.directory(installPath).createSync(recursive: true);
-      globals.fs.file(homeFile).createSync(recursive: true);
-      globals.fs.file(homeFile).writeAsStringSync(installPath);
+      fileSystem.directory(installPath).createSync(recursive: true);
+      fileSystem.file(homeFile).createSync(recursive: true);
+      fileSystem.file(homeFile).writeAsStringSync(installPath);
 
       final AndroidStudio studio =
-        AndroidStudio.fromHomeDot(globals.fs.directory(studioHome))!;
+        AndroidStudio.fromHomeDot(fileSystem.directory(studioHome))!;
       expect(studio, isNotNull);
       expect(studio.pluginsPath,
           equals('/home/me/.AndroidStudioWithCheese5.0/config/plugins'));
@@ -939,10 +945,12 @@ void main() {
   });
 
   group('latestValid', () {
+    late Config config;
     late Platform platform;
     late FileSystem fileSystem;
 
     setUp(() {
+      config = Config.test();
       platform = FakePlatform(
         operatingSystem: 'windows',
         environment: <String, String>{
@@ -1043,7 +1051,7 @@ void main() {
 
     testUsingContext('always chooses the install configured by --android-studio-dir, even if the install is invalid', () {
       const String configuredAndroidStudioDir = r'C:\Users\Dash\Desktop\android-studio';
-      globals.config.setValue('android-studio-dir', configuredAndroidStudioDir);
+      config.setValue('android-studio-dir', configuredAndroidStudioDir);
 
       // The directory exists, but nothing is inside.
       fileSystem.directory(configuredAndroidStudioDir).createSync(recursive: true);
@@ -1074,7 +1082,7 @@ void main() {
       for (final String javaPath in validJavaPaths) {
         (globals.processManager as FakeProcessManager).addCommand(FakeCommand(
           command: <String>[
-            globals.fs.path.join(javaPath),
+            fileSystem.path.join(javaPath),
             '-version',
           ],
         ));
@@ -1085,7 +1093,7 @@ void main() {
       expect(chosenInstall.directory, configuredAndroidStudioDir);
       expect(chosenInstall.isValid, false);
     }, overrides: <Type, Generator>{
-      Config: () => Config.test(),
+      Config: () => config,
       FileSystem: () => fileSystem,
       Platform: () => platform,
       ProcessManager: () => FakeProcessManager.empty(),
@@ -1093,7 +1101,7 @@ void main() {
 
     testUsingContext('throws a ToolExit if --android-studio-dir is configured but the directory does not exist', () async {
       const String configuredAndroidStudioDir = r'C:\Users\Dash\Desktop\android-studio';
-      globals.config.setValue('android-studio-dir', configuredAndroidStudioDir);
+      config.setValue('android-studio-dir', configuredAndroidStudioDir);
 
       expect(fileSystem.directory(configuredAndroidStudioDir).existsSync(), false);
       expect(() => AndroidStudio.latestValid(), throwsA(
@@ -1102,7 +1110,7 @@ void main() {
         )
       );
     }, overrides: <Type, Generator>{
-      Config: () => Config.test(),
+      Config: () => config,
       FileSystem: () => fileSystem,
       Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -734,7 +734,7 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
     });
 
-    testUsingContext('finds bundled Java version despite Android Studio version being unknown', () {
+    testUsingContext('finds bundled Java version when Android Studio version is unknown by assuming the latest version', () {
       fileSystem.file(r'C:\Users\Dash\AppData\Local\Google\AndroidStudio\.home')
         ..createSync(recursive: true)
         ..writeAsStringSync(r'C:\Program Files\AndroidStudio');
@@ -896,7 +896,7 @@ void main() {
       ProcessManager: () => FakeProcessManager.any(),
     });
 
-    testUsingContext('finds bundled Java version despite Android Studio version being unknown', () {
+    testUsingContext('finds bundled Java version when Android Studio version is unknown by assuming the latest version', () {
       const String configuredStudioInstallPath = '$homeLinux/AndroidStudio';
       config.setValue('android-studio-dir', configuredStudioInstallPath);
 

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -602,7 +602,7 @@ void main() {
         fileSystem.directory(studioInApplicationPlistFolder).parent.path,
       )!;
 
-      expect(studio.version, greaterThanOrEqualTo(Version(99999, null, null)));
+      expect(studio.version, equals(Version(99999, 99, 99)));
       expect(studio.javaPath, jdkPathFor2022);
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
@@ -793,7 +793,7 @@ void main() {
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
       const String expectedJdkLocationFor2022 = r'C:\Program Files\AndroidStudio\jbr';
-      expect(studio.version, greaterThanOrEqualTo(Version(99999, null, null)));
+      expect(studio.version, equals(Version(99999, 99, 99)));
       expect(studio.javaPath, equals(expectedJdkLocationFor2022));
     }, overrides: <Type, Generator>{
       Platform: () => platform,
@@ -983,7 +983,7 @@ void main() {
 
       final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
-      expect(studio.version, greaterThanOrEqualTo(Version(99999, null, null)));
+      expect(studio.version, equals(Version(99999, 99, 99)));
       expect(studio.javaPath, equals('$studioInstallPath/jbr'));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,


### PR DESCRIPTION
Fixes #125246 by restoring the intended behavior of #101862. That is, when searching for a JDK and we encounter an Android Studio version we don't recognize, assume it to be the latest version `flutter` is aware of.

Also does some light refactoring in the tests, like using test objects instead of referencing `globals`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
