### PR TITLE
Add Sliders to `macrobenchmarks`

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -34,6 +34,7 @@ const String kAnimatedComplexOpacityPerfRouteName = '/animated_complex_opacity';
 const String kAnimatedComplexImageFilteredPerfRouteName = '/animated_complex_image_filtered';
 const String kListTextLayoutRouteName = '/list_text_layout';
 const String kAnimatedBlurBackdropFilter = '/animated_blur_backdrop_filter';
+const String kSlidersRouteName = '/sliders';
 
 const String kOpacityPeepholeOneRectRouteName = '$kOpacityPeepholeRouteName/one_big_rect';
 const String kOpacityPeepholeColumnOfOpacityRouteName = '$kOpacityPeepholeRouteName/column_of_opacity';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -34,6 +34,7 @@ import 'src/raster_cache_use_memory.dart';
 import 'src/shader_mask_cache.dart';
 import 'src/simple_animation.dart';
 import 'src/simple_scroll.dart';
+import 'src/sliders.dart';
 import 'src/stack_size.dart';
 import 'src/text.dart';
 
@@ -85,6 +86,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kListTextLayoutRouteName: (BuildContext context) => const ColumnOfText(),
         kAnimatedComplexImageFilteredPerfRouteName: (BuildContext context) => const AnimatedComplexImageFiltered(),
         kAnimatedBlurBackdropFilter: (BuildContext context) => const AnimatedBlurBackdropFilter(),
+        kSlidersRouteName: (BuildContext context) => const SlidersPage(),
       },
     );
   }
@@ -317,6 +319,13 @@ class HomePage extends StatelessWidget {
             child: const Text('An animating backdrop filter'),
             onPressed: () {
               Navigator.pushNamed(context, kAnimatedBlurBackdropFilter);
+            },
+          ),
+          ElevatedButton(
+            key: const Key(kSlidersRouteName),
+            child: const Text('Sliders'),
+            onPressed: () {
+              Navigator.pushNamed(context, kSlidersRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/sliders.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/sliders.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class SlidersPage extends StatefulWidget {
+  const SlidersPage({super.key});
+
+  @override
+  State<SlidersPage> createState() => _SlidersPageState();
+}
+
+class _SlidersPageState extends State<SlidersPage> with TickerProviderStateMixin {
+ late AnimationController _sliderController;
+  late Animation<double> _sliderAnimation;
+  double _sliderValue = 0.0;
+  RangeValues _rangeSliderValues = const RangeValues(0.0, 1.0);
+
+  @override
+  void initState() {
+    super.initState();
+    _sliderController = AnimationController(
+      duration: const Duration(seconds: 1),
+      vsync: this,
+    )..repeat();
+    _sliderAnimation = Tween<double>(begin: 0, end: 1).animate(_sliderController)
+      ..addListener(() {
+        setState(() {
+          _sliderValue = _sliderAnimation.value;
+          _rangeSliderValues = RangeValues(
+            clampDouble(_sliderAnimation.value, 0, 0.45),
+            1.0 - clampDouble(_sliderAnimation.value, 0, 0.45),
+          );
+        });
+      });
+  }
+
+  @override
+  void dispose() {
+    _sliderController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Slider(
+            value: _sliderValue,
+            onChanged: (double value) { },
+          ),
+          RangeSlider(
+            values: _rangeSliderValues,
+            onChanged: (RangeValues values) { },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/sliders_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/sliders_perf_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTest(
+    'sliders_perf',
+    kSlidersRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/devicelab/bin/tasks/slider_perf_android.dart
+++ b/dev/devicelab/bin/tasks/slider_perf_android.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createSlidersPerfTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -308,6 +308,15 @@ TaskFunction createTextfieldPerfE2ETest() {
   ).run;
 }
 
+TaskFunction createSlidersPerfTest() {
+  return PerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test_driver/run_app.dart',
+    'sliders_perf',
+    testDriver: 'test_driver/sliders_perf_test.dart',
+  ).run;
+}
+
 TaskFunction createStackSizeTest() {
   final String testDirectory =
       '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';


### PR DESCRIPTION
This adds a performance test for `Slider` and `RangeSlider` to run on Android.
This is to measure upcoming changes to these widgets and compare their performance. 



https://user-images.githubusercontent.com/48603081/233633349-0bcad3c3-04a9-42dd-acd0-46b76ce51178.mp4





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
