### PR TITLE
Add docs for kIsWeb on defaultTargetPlatform

### DIFF
--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -68,4 +68,13 @@ const bool kDebugMode = !kReleaseMode && !kProfileMode;
 const double precisionErrorTolerance = 1e-10;
 
 /// A constant that is true if the application was compiled to run on the web.
+///
+/// See also:
+///
+/// * [defaultTargetPlatform], which is used by themes to find out which
+///   platform the application is running on (or, in the case of a web app,
+///   which platform the application's browser is running in). Can be overridden
+///   in tests with [debugDefaultTargetPlatformOverride].
+/// * [dart:io.Platform], a way to find out the browser's platform that is not
+///   overridable in tests.
 const bool kIsWeb = bool.fromEnvironment('dart.library.js_util');

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -26,6 +26,12 @@ import '_platform_io.dart'
 ///
 /// Tests can also create specific platform tests by and adding a `variant:`
 /// argument to the test and using a [TargetPlatformVariant].
+///
+/// See also:
+///
+/// * [kIsWeb], a boolean which is true if the application is running on the
+///   web, where [defaultTargetPlatform] tells you what platform the browser is
+///   running on.
 //
 // When adding support for a new platform (e.g. Windows Phone, Raspberry Pi),
 // first create a new value on the [TargetPlatform] enum, then add a rule for

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -30,7 +30,7 @@ import '_platform_io.dart'
 /// See also:
 ///
 /// * [kIsWeb], a boolean which is true if the application is running on the
-///   web, where [defaultTargetPlatform] tells you what platform the browser is
+///   web, where [defaultTargetPlatform] returns which platform the browser is
 ///   running on.
 //
 // When adding support for a new platform (e.g. Windows Phone, Raspberry Pi),


### PR DESCRIPTION
## Description

Adding some see also links to connect `defaultTargetPlatform` and `kIsWeb` docs.
