### PR TITLE
Run `Mac_arm64_ios run_debug_test_macos` in presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4034,7 +4034,6 @@ targets:
 
   - name: Mac_arm64_ios run_debug_test_macos
     recipe: devicelab/devicelab_drone
-    presubmit: false # https://github.com/flutter/flutter/issues/118827
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
This stopped running in presubmit due to https://github.com/flutter/flutter/pull/118828.

Fixes https://github.com/flutter/flutter/issues/118830

https://ci.chromium.org/p/flutter/builders/try/Mac_arm64_ios%20run_debug_test_macos/334
