### PR TITLE
Relabel JSFunction as JSExportedDartFunction

### DIFF
--- a/packages/flutter/test/painting/_test_http_request.dart
+++ b/packages/flutter/test/painting/_test_http_request.dart
@@ -76,7 +76,7 @@ class TestHttpRequest {
   JSVoid addEventListener(JSString type, DomEventListener listener) {
     if (type.toDart == mockEvent?.type) {
       final DartDomEventListener dartListener =
-        (listener as JSFunction).toDart as DartDomEventListener;
+        (listener as JSExportedDartFunction).toDart as DartDomEventListener;
       dartListener(mockEvent!.event);
     }
   }


### PR DESCRIPTION
toDart exists on the latter, not the former.

Fixing https://github.com/flutter/flutter/pull/125220.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

