### PR TITLE
fix RangeSlider, with no overlayShape shifts to the left

### DIFF
--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1772,7 +1772,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 }
 
 
-/// Base track shape that provides an implementation of [getPreferredRect] for
+/// Base range slider track shape that provides an implementation of [getPreferredRect] for
 /// default sizing.
 ///
 /// The height is set from [SliderThemeData.trackHeight] and the width of the

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1771,6 +1771,53 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
   }
 }
 
+
+/// Base track shape that provides an implementation of [getPreferredRect] for
+/// default sizing.
+///
+/// The height is set from [SliderThemeData.trackHeight] and the width of the
+/// parent box less the larger of the widths of [SliderThemeData.rangeThumbShape] and
+/// [SliderThemeData.overlayShape].
+///
+/// See also:
+///
+///  * [RectangularRangeSliderTrackShape], which is a track shape with sharp
+///    rectangular edges
+mixin BaseRangeSliderTrackShape {
+  /// Returns a rect that represents the track bounds that fits within the
+  /// [Slider].
+  ///
+  /// The width is the width of the [Slider] or [RangeSlider], but padded by
+  /// the max of the overlay and thumb radius. The height is defined by the
+  /// [SliderThemeData.trackHeight].
+  ///
+  /// The [Rect] is centered both horizontally and vertically within the slider
+  /// bounds.
+  Rect getPreferredRect({
+    required RenderBox parentBox,
+    Offset offset = Offset.zero,
+    required SliderThemeData sliderTheme,
+    bool isEnabled = false,
+    bool isDiscrete = false,
+  }) {
+    assert(sliderTheme.rangeThumbShape != null);
+    assert(sliderTheme.overlayShape != null);
+    assert(sliderTheme.trackHeight != null);
+    final double thumbWidth = sliderTheme.rangeThumbShape!.getPreferredSize(isEnabled, isDiscrete).width;
+    final double overlayWidth = sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete).width;
+    final double trackHeight = sliderTheme.trackHeight!;
+    assert(overlayWidth >= 0);
+    assert(trackHeight >= 0);
+
+    final double trackLeft = offset.dx + math.max(overlayWidth / 2, thumbWidth / 2);
+    final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
+    final double trackRight = trackLeft + parentBox.size.width - math.max(thumbWidth, overlayWidth);
+    final double trackBottom = trackTop + trackHeight;
+    // If the parentBox'size less than slider's size the trackRight will be less than trackLeft, so switch them.
+    return Rect.fromLTRB(math.min(trackLeft, trackRight), trackTop, math.max(trackLeft, trackRight), trackBottom);
+  }
+}
+
 /// A [RangeSlider] track that's a simple rectangle.
 ///
 /// It paints a solid colored rectangle, vertically centered in the
@@ -1798,34 +1845,12 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
 ///    the [RangeSlider]'s track.
 ///  * [RoundedRectRangeSliderTrackShape], for a similar track with rounded
 ///    edges.
-class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
+class RectangularRangeSliderTrackShape extends RangeSliderTrackShape with BaseRangeSliderTrackShape {
   /// Create a slider track with rectangular outer edges.
   ///
   /// The middle track segment is the selected range and is active, and the two
   /// outer track segments are inactive.
   const RectangularRangeSliderTrackShape();
-
-  @override
-  Rect getPreferredRect({
-    required RenderBox parentBox,
-    Offset offset = Offset.zero,
-    required SliderThemeData sliderTheme,
-    bool isEnabled = false,
-    bool isDiscrete = false,
-  }) {
-    assert(sliderTheme.overlayShape != null);
-    final double overlayWidth = sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete).width;
-    final double trackHeight = sliderTheme.trackHeight!;
-    assert(overlayWidth >= 0);
-    assert(trackHeight >= 0);
-
-    final double trackLeft = offset.dx + overlayWidth / 2;
-    final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
-    final double trackRight = trackLeft + parentBox.size.width - overlayWidth;
-    final double trackBottom = trackTop + trackHeight;
-    // If the parentBox'size less than slider's size the trackRight will be less than trackLeft, so switch them.
-    return Rect.fromLTRB(math.min(trackLeft, trackRight), trackTop, math.max(trackLeft, trackRight), trackBottom);
-  }
 
   @override
   void paint(
@@ -1913,35 +1938,12 @@ class RectangularRangeSliderTrackShape extends RangeSliderTrackShape {
 ///  * [RangeSliderTrackShape], which can be used to create custom shapes for
 ///    the [RangeSlider]'s track.
 ///  * [RectangularRangeSliderTrackShape], for a similar track with sharp edges.
-class RoundedRectRangeSliderTrackShape extends RangeSliderTrackShape {
+class RoundedRectRangeSliderTrackShape extends RangeSliderTrackShape with BaseRangeSliderTrackShape {
   /// Create a slider track with rounded outer edges.
   ///
   /// The middle track segment is the selected range and is active, and the two
   /// outer track segments are inactive.
   const RoundedRectRangeSliderTrackShape();
-
-  @override
-  Rect getPreferredRect({
-    required RenderBox parentBox,
-    Offset offset = Offset.zero,
-    required SliderThemeData sliderTheme,
-    bool isEnabled = false,
-    bool isDiscrete = false,
-  }) {
-    assert(sliderTheme.overlayShape != null);
-    assert(sliderTheme.trackHeight != null);
-    final double overlayWidth = sliderTheme.overlayShape!.getPreferredSize(isEnabled, isDiscrete).width;
-    final double trackHeight = sliderTheme.trackHeight!;
-    assert(overlayWidth >= 0);
-    assert(trackHeight >= 0);
-
-    final double trackLeft = offset.dx + overlayWidth / 2;
-    final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
-    final double trackRight = trackLeft + parentBox.size.width - overlayWidth;
-    final double trackBottom = trackTop + trackHeight;
-    // If the parentBox'size less than slider's size the trackRight will be less than trackLeft, so switch them.
-    return Rect.fromLTRB(math.min(trackLeft, trackRight), trackTop, math.max(trackLeft, trackRight), trackBottom);
-  }
 
   @override
   void paint(

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1787,9 +1787,8 @@ mixin BaseRangeSliderTrackShape {
   /// Returns a rect that represents the track bounds that fits within the
   /// [Slider].
   ///
-  /// The width is the width of the [Slider] or [RangeSlider], but padded by
-  /// the max of the overlay and thumb radius. The height is defined by the
-  /// [SliderThemeData.trackHeight].
+  /// The width is the width of the [RangeSlider], but padded by the max
+  /// of the overlay and thumb radius. The height is defined by the  [SliderThemeData.trackHeight].
   ///
   /// The [Rect] is centered both horizontally and vertically within the slider
   /// bounds.

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -1448,7 +1448,7 @@ void main() {
     expect(
       material,
       paints
-      // active track RRect. Starts 10 pixels from left of screen.
+        // active track RRect. Starts 10 pixels from left of screen.
         ..rrect(rrect: RRect.fromLTRBAndCorners(
           10.0,
           298.0,

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -1468,9 +1468,9 @@ void main() {
           topRight: const Radius.circular(2.0),
           bottomRight: const Radius.circular(2.0),
         ))
-      // The thumb Left.
+        // The thumb Left.
         ..circle(x: 10.0, y: 300.0, radius: 10.0)
-      // The thumb Right.
+        // The thumb Right.
         ..circle(x: 790.0, y: 300.0, radius: 10.0),
     );
   });

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -1459,7 +1459,7 @@ void main() {
         ))
       // active track RRect Start 10 pixels from left screen.
         ..rect(rect:const Rect.fromLTRB(10.0, 297.0, 790.0, 303.0),)
-      // inactive track RRect. Ends 10 pixels from right of screen.
+        // inactive track RRect. Ends 10 pixels from right of screen.
         ..rrect(rrect: RRect.fromLTRBAndCorners(
           790.0,
           298.0,

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -1430,6 +1430,51 @@ void main() {
     );
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/125467
+  testWidgets('The RangeSlider track layout correctly when the overlay size is smaller than the thumb size', (WidgetTester tester) async {
+    final SliderThemeData sliderTheme = ThemeData().sliderTheme.copyWith(
+      overlayShape: SliderComponentShape.noOverlay,
+    );
+
+    await tester.pumpWidget(_buildRangeApp(sliderTheme, values: const RangeValues(0.0, 1.0)));
+
+    final MaterialInkController material = Material.of(
+      tester.element(find.byType(RangeSlider)),
+    );
+
+    // The track rectangle begins at 10 pixels from the left of the screen and ends 10 pixels from the right
+    // (790 pixels from the left). The main check here it that the track itself should be centered on
+    // the 800 pixel-wide screen.
+    expect(
+      material,
+      paints
+      // active track RRect. Starts 10 pixels from left of screen.
+        ..rrect(rrect: RRect.fromLTRBAndCorners(
+          10.0,
+          298.0,
+          10.0,
+          302.0,
+          topLeft: const Radius.circular(2.0),
+          bottomLeft: const Radius.circular(2.0),
+        ))
+      // active track RRect Start 10 pixels from left screen.
+        ..rect(rect:const Rect.fromLTRB(10.0, 297.0, 790.0, 303.0),)
+      // inactive track RRect. Ends 10 pixels from right of screen.
+        ..rrect(rrect: RRect.fromLTRBAndCorners(
+          790.0,
+          298.0,
+          790.0,
+          302.0,
+          topRight: const Radius.circular(2.0),
+          bottomRight: const Radius.circular(2.0),
+        ))
+      // The thumb Left.
+        ..circle(x: 10.0, y: 300.0, radius: 10.0)
+      // The thumb Right.
+        ..circle(x: 790.0, y: 300.0, radius: 10.0),
+    );
+  });
+
   // Only the thumb, overlay, and tick mark have special shortcuts to provide
   // no-op or empty shapes.
   //


### PR DESCRIPTION
fixes  https://github.com/flutter/flutter/issues/125467

--------------------------

fix RectangularRangeSliderTrackShape and RoundedRectRangeSliderTrackShape. These two RangeSliderTrackShape do not take into account the width of RangeThumbShape. If the width of RangeThumbShape is larger than the width of OverlayShape, the RangeSlider will be drawn out of bounds and the display will not meet expectations. And the Slider trackShape calculation logic is in line with expectations, the modified reference BaseSliderTrackShape here, write a new BaseRangeSliderTrackShape


**BaseSliderTrackShape takes the width of the thumbShape into account when calculating 。left As follows**
<img width="994" alt="image" src="https://user-images.githubusercontent.com/13586150/234223975-7e6bd036-dbae-43a9-a1eb-03720a0b9591.png">
**But RoundedRectRangeSliderTrackShape did not consider rangeThumbShape RoundedRectRangeSliderTrackShape width, as follows**
<img width="963" alt="image" src="https://user-images.githubusercontent.com/13586150/234224673-b83247a8-7578-4361-932b-a5e714f96614.png">
**Therefore, the modification plan is:**
- Create BaseRangeSliderTrackShape reference BaseSliderTrackShape getPreferredRect**
- The core modification is to consider the width of rangeThumbShape when calculating the left of RangeSliderTrackShape

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/13586150/234226361-7a86294f-c359-4c8e-820d-cb5505459e61.png">




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
