### PR TITLE
Add FocusScope references in shortcuts related documentation

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1092,6 +1092,14 @@ class _ActionsScope extends InheritedWidget {
 /// provides focus and hover capabilities.
 ///
 /// It hosts its own [FocusNode] or uses [focusNode], if given.
+///
+/// See also:
+///  * [Shortcuts], a more powerful widget for defining key bindings.
+///  * [Focus], a widget that defines which widgets can receive keyboard focus.
+///  * [FocusScope], a widget that restricts focus traversal to its sub-tree of
+///    focus nodes. Consider adding a [FocusScope] as the direct child to a
+///    [FocusableActionDetector] when shortcuts are expected to be available
+///    after a call to [FocusNode.unfocus] on a descendant [FocusNode].
 class FocusableActionDetector extends StatefulWidget {
   /// Create a const [FocusableActionDetector].
   ///

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1079,6 +1079,10 @@ class _ShortcutsState extends State<Shortcuts> {
 /// See also:
 ///  * [Shortcuts], a more powerful widget for defining key bindings.
 ///  * [Focus], a widget that defines which widgets can receive keyboard focus.
+///  * [FocusScope], a widget that restricts focus traversal to its sub-tree of
+///    focus nodes. Consider adding a [FocusScope] as the direct child to a
+///    [CallbackShortcuts] when shortcuts are expected to be available after a
+///    call to [FocusNode.unfocus] on a descendant [FocusNode].
 class CallbackShortcuts extends StatelessWidget {
   /// Creates a const [CallbackShortcuts] widget.
   const CallbackShortcuts({


### PR DESCRIPTION
## Description

This PR adds some references to `FocusScope` to help users understanding why their shortcuts are no more active after a TextField in unfocused.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/97389

## Tests

Documentation only.
