### PR TITLE
Hide selection handles when double tap + drag to select on Android

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1027,7 +1027,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
       return false;
     }
 
-    if (cause == SelectionChangedCause.drag && defaultTargetPlatform == TargetPlatform.android) {
+    if (cause == SelectionChangedCause.drag && defaultTargetPlatform == TargetPlatform.android && _selectionGestureDetectorBuilder.lastConsecutiveTapCount > 1) {
       return false;
     }
 

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1027,6 +1027,10 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
       return false;
     }
 
+    if (cause == SelectionChangedCause.drag && defaultTargetPlatform == TargetPlatform.android) {
+      return false;
+    }
+
     if (cause == SelectionChangedCause.keyboard) {
       return false;
     }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1114,6 +1114,10 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       return false;
     }
 
+    if (cause == SelectionChangedCause.drag && Theme.of(context).platform == TargetPlatform.android) {
+      return false;
+    }
+
     if (widget.readOnly && _effectiveController.selection.isCollapsed) {
       return false;
     }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1114,7 +1114,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       return false;
     }
 
-    if (cause == SelectionChangedCause.drag && Theme.of(context).platform == TargetPlatform.android) {
+    if (cause == SelectionChangedCause.drag && Theme.of(context).platform == TargetPlatform.android && _selectionGestureDetectorBuilder.lastConsecutiveTapCount > 1) {
       return false;
     }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3942,7 +3942,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// Returns `false` if a toolbar couldn't be shown, such as when the toolbar
   /// is already shown, or when no text selection currently exists.
   @override
-  bool showToolbar() {
+  bool showToolbar([bool showHandles = false]) {
     // Web is using native dom elements to enable clipboard functionality of the
     // context menu: copy, paste, select, cut. It might also provide additional
     // functionality depending on the browser (such as translate). Due to this,
@@ -3957,6 +3957,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
     clipboardStatus.update();
     _selectionOverlay!.showToolbar();
+    if (showHandles) {
+      _selectionOverlay!.handlesVisible = true;
+      _selectionOverlay!.showHandles();
+    }
     return true;
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3941,6 +3941,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   ///
   /// Returns `false` if a toolbar couldn't be shown, such as when the toolbar
   /// is already shown, or when no text selection currently exists.
+  ///
+  /// By default `showHandles`, is `false`, and the toolbar is shown without the handles
+  /// handles. If `showHandles` is set to `true`, then the toolbar and the handles
+  /// will be shown.
   @override
   bool showToolbar([bool showHandles = false]) {
     // Web is using native dom elements to enable clipboard functionality of the

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2589,6 +2589,10 @@ class TextSelectionGestureDetectorBuilder {
     _dragStartViewportOffset = renderEditable.offset.pixels;
     _dragBeganOnPreviousSelection = _positionOnSelection(details.globalPosition, _dragStartSelection);
 
+    final bool shouldHideHandles = defaultTargetPlatform == TargetPlatform.android;
+    // The toolbar should be hidden while dragging.
+    editableText.hideToolbar(shouldHideHandles);
+
     if (_TextSelectionGestureDetectorState._getEffectiveConsecutiveTapCount(details.consecutiveTapCount) > 1) {
       // Do not set the selection on a consecutive tap and drag.
       return;
@@ -2888,7 +2892,8 @@ class TextSelectionGestureDetectorBuilder {
     _dragBeganOnPreviousSelection = null;
 
     if (_shouldShowSelectionToolbar && _TextSelectionGestureDetectorState._getEffectiveConsecutiveTapCount(details.consecutiveTapCount) == 2) {
-      editableText.showToolbar();
+      final bool shouldShowHandles = defaultTargetPlatform == TargetPlatform.android;
+      editableText.showToolbar(shouldShowHandles);
     }
 
     if (isShiftPressed) {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2019,6 +2019,13 @@ class TextSelectionGestureDetectorBuilder {
   bool get shouldShowSelectionToolbar => _shouldShowSelectionToolbar;
   bool _shouldShowSelectionToolbar = true;
 
+
+  /// The last consecutive tap count.
+  ///
+  /// This is set when [onTapDown] is called.
+  int get lastConsecutiveTapCount => _lastConsecutiveTapCount;
+  int _lastConsecutiveTapCount = 0;
+
   /// The [State] of the [EditableText] for which the builder will provide a
   /// [TextSelectionGestureDetector].
   @protected
@@ -2099,6 +2106,7 @@ class TextSelectionGestureDetectorBuilder {
     _shouldShowSelectionToolbar = kind == null
       || kind == PointerDeviceKind.touch
       || kind == PointerDeviceKind.stylus;
+    _lastConsecutiveTapCount = _TextSelectionGestureDetectorState._getEffectiveConsecutiveTapCount(details.consecutiveTapCount);
 
     // Handle shift + click selection if needed.
     final bool isShiftPressed = _containsShift(details.keysPressedOnDown);
@@ -2588,10 +2596,6 @@ class TextSelectionGestureDetectorBuilder {
     _dragStartScrollOffset = _scrollPosition;
     _dragStartViewportOffset = renderEditable.offset.pixels;
     _dragBeganOnPreviousSelection = _positionOnSelection(details.globalPosition, _dragStartSelection);
-
-    final bool shouldHideHandles = defaultTargetPlatform == TargetPlatform.android;
-    // The toolbar should be hidden while dragging. The handles are hidden on Android.
-    editableText.hideToolbar(shouldHideHandles);
 
     if (_TextSelectionGestureDetectorState._getEffectiveConsecutiveTapCount(details.consecutiveTapCount) > 1) {
       // Do not set the selection on a consecutive tap and drag.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2590,7 +2590,7 @@ class TextSelectionGestureDetectorBuilder {
     _dragBeganOnPreviousSelection = _positionOnSelection(details.globalPosition, _dragStartSelection);
 
     final bool shouldHideHandles = defaultTargetPlatform == TargetPlatform.android;
-    // The toolbar should be hidden while dragging.
+    // The toolbar should be hidden while dragging. The handles are hidden on Android.
     editableText.hideToolbar(shouldHideHandles);
 
     if (_TextSelectionGestureDetectorState._getEffectiveConsecutiveTapCount(details.consecutiveTapCount) > 1) {
@@ -2892,6 +2892,8 @@ class TextSelectionGestureDetectorBuilder {
     _dragBeganOnPreviousSelection = null;
 
     if (_shouldShowSelectionToolbar && _TextSelectionGestureDetectorState._getEffectiveConsecutiveTapCount(details.consecutiveTapCount) == 2) {
+      // The handles are hidden on Android when the drag began, and they are shown
+      // again when the drag ends.
       final bool shouldShowHandles = defaultTargetPlatform == TargetPlatform.android;
       editableText.showToolbar(shouldShowHandles);
     }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9453,6 +9453,74 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Can double tap + drag to select word by word hides the selection handles on Android',
+    (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+
+      const String testValue = 'abc def ghi';
+      await tester.enterText(find.byType(TextField), testValue);
+      await skipPastScrollingAnimation(tester);
+
+      final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
+      final Offset hPos = textOffsetToPosition(tester, testValue.indexOf('h'));
+
+      // Tap on text field to gain focus, and set selection to '|e'.
+      final TestGesture gesture = await tester.startGesture(ePos);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, testValue.indexOf('e'));
+
+      // Here we tap on '|e' again, to register a double tap. This will select
+      // the word at the tapped position.
+      await gesture.down(ePos);
+      await tester.pumpAndSettle();
+
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
+
+      // Drag, right after the double tap, to select word by word.
+      // Moving to the position of 'h', will extend the selection to 'ghi'.
+      await gesture.moveTo(hPos);
+      await tester.pumpAndSettle();
+
+      final List<FadeTransition> transitions = find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
+        matching: find.byType(FadeTransition),
+      ).evaluate().map((Element e) => e.widget).cast<FadeTransition>().toList();
+      expect(transitions.length, 2);
+      final FadeTransition left = transitions[0];
+      final FadeTransition right = transitions[1];
+      expect(left.opacity.value, equals(0.0));
+      expect(right.opacity.value, equals(0.0));
+
+      // Toolbar should be hidden during a drag.
+      expect(find.byType(TextButton), findsNothing);
+      expect(controller.selection.baseOffset, testValue.indexOf('d'));
+      expect(controller.selection.extentOffset, testValue.indexOf('i') + 1);
+
+      // Toolbar should re-appear after a drag.
+      await gesture.up();
+      await tester.pump();
+      expect(find.byType(TextButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(4));
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
   group('Triple tap/click', () {
     const String testValueA = 'Now is the time for\n' // 20
         'all good people\n'                         // 20 + 16 => 36

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9498,13 +9498,13 @@ void main() {
       await gesture.moveTo(hPos);
       await tester.pumpAndSettle();
 
-      final List<FadeTransition> transitions = find.descendant(
+      List<FadeTransition> transitions = find.descendant(
         of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
         matching: find.byType(FadeTransition),
       ).evaluate().map((Element e) => e.widget).cast<FadeTransition>().toList();
       expect(transitions.length, 2);
-      final FadeTransition left = transitions[0];
-      final FadeTransition right = transitions[1];
+      FadeTransition left = transitions[0];
+      FadeTransition right = transitions[1];
       expect(left.opacity.value, equals(0.0));
       expect(right.opacity.value, equals(0.0));
 
@@ -9515,8 +9515,17 @@ void main() {
 
       // Toolbar should re-appear after a drag.
       await gesture.up();
-      await tester.pump();
+      await tester.pumpAndSettle();
       expect(find.byType(TextButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(4));
+      transitions = find.descendant(
+        of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
+        matching: find.byType(FadeTransition),
+      ).evaluate().map((Element e) => e.widget).cast<FadeTransition>().toList();
+      expect(transitions.length, 2);
+      left = transitions[0];
+      right = transitions[1];
+      expect(left.opacity.value, equals(1.0));
+      expect(right.opacity.value, equals(1.0));
     },
     variant: TargetPlatformVariant.only(TargetPlatform.android),
   );

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1695,7 +1695,7 @@ class FakeEditableTextState extends EditableTextState {
   RenderEditable get renderEditable => _editableKey.currentContext!.findRenderObject()! as RenderEditable;
 
   @override
-  bool showToolbar() {
+  bool showToolbar([bool showHandles = false]) {
     showToolbarCalled = true;
     return true;
   }


### PR DESCRIPTION
This changes hides the selection handles when double tap + dragging to select word by word on Android.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.