### PR TITLE
Remove flavors_test_macos

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2703,20 +2703,6 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac flavors_test_macos
-    bringup: true
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14c18"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
-      task_name: flavors_test_macos
-
   - name: Mac_benchmark flutter_gallery_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
This test has been failing for the past >1000 runs, and is wedging a bot for 30 minutes as the failure mode is a timeout.

Fixes https://github.com/flutter/flutter/issues/119782
