### PR TITLE
[flutter_tools] more debugging for timeouts in break_on_framework_exceptions test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -81,6 +81,8 @@ abstract class FlutterTestDriver {
       // intended only for use in local debugging.
       // ignore: avoid_print
       print('$time$_logPrefix$line');
+    } else {
+      printOnFailure('$time$_logPrefix$line');
     }
   }
 


### PR DESCRIPTION
Better debugging to investigate: https://github.com/flutter/flutter/issues/125241

When the `test/integration.shard/break_on_framework_exceptions_test.dart` test times out, log out verbose logging to give clues as to why it did not complete.

From one local run it looks like the test runner is failing to load a test file (when I checked the path locally, the file was there, and re-running the `flutter test ...` invocation succeeded--in that the app threw an exception):

```
14:12 +26 -1: breaks when StatefulWidget.build throws [E]
  Timed out launching `flutter test`
  package:matcher                                                        fail
  test/integration.shard/break_on_framework_exceptions_test.dart 623:11  _timeoutAfter.<fn>

250s            Spawning flutter [test, --disable-service-auth-codes, --machine, --start-paused, test/test.dart] in /tmp/flutter_break_on_framework_exceptions.GUJDAZ

251s <=stdout=  {"protocolVersion":"0.1.1","runnerVersion":null,"pid":25763,"type":"start","time":0}

<=stdout=  {"suite":{"id":0,"platform":"vm","path":"/tmp/flutter_break_on_framework_exceptions.GUJDAZ/test/test.dart"},"type":"suite","time":0}

<=stdout=  {"test":{"id":1,"name":"loading /tmp/flutter_break_on_framework_exceptions.GUJDAZ/test/test.dart","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":null,"column":null,"url":null},"type":"testStart","time":0}

258s <=stdout=  {"testID":1,"error":"Exception: the Dart compiler exited unexpectedly.","stackTrace":"package:flutter_tools/src/base/common.dart 10:3  throwToolExit\npackage:flutter_tools/src/compile.dart 813:13    DefaultResidentCompiler._compile.<fn>\ndart:async/zone.dart 1391:47                     _rootRun\ndart:async/zone.dart 1301:19                     _CustomZone.run\ndart:async/zone.dart 1209:7                      _CustomZone.runGuarded\ndart:async/stream_impl.dart 392:13               _BufferingStreamSubscription._sendDone.sendDone\ndart:async/stream_impl.dart 402:7                _BufferingStreamSubscription._sendDone\ndart:async/stream_impl.dart 291:7                _BufferingStreamSubscription._close\ndart:async/stream_transformers.dart 87:11        _SinkTransformerStreamSubscription._close\ndart:async/stream_transformers.dart 21:11        _EventSinkWrapper.close\ndart:convert/string_conversion.dart 241:11       _StringAdapterSink.close\ndart:convert/line_splitter.dart 141:11           _LineSplitterSink.close\ndart:async/stream_transformers.dart 132:24       _SinkTransformerStreamSubscription._handleDone\ndart:async/zone.dart 1391:47                     _rootRun\ndart:async/zone.dart 1301:19                     _CustomZone.run\ndart:async/zone.dart 1209:7                      _CustomZone.runGuarded\ndart:async/stream_impl.dart 392:13               _BufferingStreamSubscription._sendDone.sendDone\ndart:async/stream_impl.dart 402:7                _BufferingStreamSubscription._sendDone\ndart:async/stream_impl.dart 291:7                _BufferingStreamSubscription._close\ndart:async/stream_transformers.dart 87:11        _SinkTransformerStreamSubscription._close\ndart:async/stream_transformers.dart 21:11        _EventSinkWrapper.close\ndart:convert/string_conversion.dart 241:11       _StringAdapterSink.close\ndart:convert/string_conversion.dart 295:20       _Utf8ConversionSink.close\ndart:convert/chunked_conversion.dart 78:18       _ConverterStreamEventSink.close\ndart:async/stream_transformers.dart 132:24       _SinkTransformerStreamSubscription._handleDone\ndart:async/zone.dart 1391:47                     _rootRun\ndart:async/zone.dart 1301:19                     _CustomZone.run\ndart:async/zone.dart 1209:7                      _CustomZone.runGuarded\ndart:async/stream_impl.dart 392:13               _BufferingStreamSubscription._sendDone.sendDone\ndart:async/stream_impl.dart 402:7                _BufferingStreamSubscription._sendDone\ndart:async/stream_impl.dart...

<=stdout=  {"testID":1,"error":"Failed to load \"/tmp/flutter_break_on_framework_exceptions.GUJDAZ/test/test.dart\": Compilation failed for testPath=/tmp/flutter_break_on_framework_exceptions.GUJDAZ/test/test.dart","stackTrace":"","isFailure":false,"type":"error","time":7518}

<=stdout=  {"testID":1,"result":"error","skipped":false,"hidden":false,"type":"testDone","time":7521}

<=stdout=  {"count":1,"time":7526,"type":"allSuites"}

<=stdout=  {"success":false,"type":"done","time":7529}

259s            Process exited (1)

371s            Expecting test.startedProcess event
[+    95] <=stdout=  {"suite":{"id":0,"platform":"vm","path":"/tmp/flutter_break_on_framework_exceptions.GUJDAZ/test/test.dart"},"type":"suite","time":0}
[+    95] <=stdout=  {"test":{"id":1,"name":"loading /tmp/flutter_break_on_framework_exceptions.GUJDAZ/test/test.dart","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":null,"column":null,"url":null},"type":"testStart","time":0}
[+  7600] <=stdout=  {"testID":1,"error":"Exception: the Dart compiler exited unexpectedly.","stackTrace":"package:flutter_tools/src/base/common.dart 10:3  throwToolExit\npackage:flutter_tools/src/compile.dart 813:13    DefaultResidentCompiler._compile.<fn>\ndart:async/zone.dart 1391:47                     _rootRun\ndart:async/zone.dart 1301:19                     _CustomZone.run\ndart:async/zone.dart 1209:7                      _CustomZone.runGuarded\ndart:async/stream_impl.dart 392:13               _BufferingStreamSubscription._sendDone.sendDone\ndart:async/stream_impl.dart 402:7                _BufferingStreamSubscription._sendDone\ndart:async/stream_impl.dart 291:7                _BufferingStreamSubscription._close\ndart:async/stream_transformers.dart 87:11        _SinkTransformerStreamSubscription._close\ndart:async/stream_transformers.dart 21:11        _EventSinkWrapper.close\ndart:convert/string_conversion.dart 241:11       _StringAdapterSink.close\ndart:convert/line_splitter.dart 141:11           _LineSplitterSink.close\ndart:async/stream_transformers.dart 132:24       _SinkTransformerStreamSubscription._handleDone\ndart:async/zone.dart 1391:47                     _rootRun\ndart:async/zone.dart 1301:19                     _CustomZone.run\ndart:async/zone.dart 1209:7                      _CustomZone.runGuarded\ndart:async/stream_impl.dart 392:13               _BufferingStreamSubscription._sendDone.sendDone\ndart:async/stream_impl.dart 402:7                _BufferingStreamSubscription._sendDone\ndart:async/stream_impl.dart 291:7                _BufferingStreamSubscription._close\ndart:async/stream_transformers.dart 87:11        _SinkTransformerStreamSubscription._close\ndart:async/stream_transformers.dart 21:11        _EventSinkWrapper.close\ndart:convert/string_conversion.dart 241:11       _StringAdapterSink.close\ndart:convert/string_conversion.dart 295:20       _Utf8ConversionSink.close\ndart:convert/chunked_conversion.dart 78:18       _ConverterStreamEventSink.close\ndart:async/stream_transformers.dart 132:24...

Expecting test.startedProcess event is taking longer than usual...
```