### PR TITLE
Disposing the unavailable images evicted by ImageCache in time

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -587,6 +587,10 @@ abstract class ImageStreamCompleter with Diagnosticable {
     }
   }
 
+  /// Whether the image is disposed.
+  @protected
+  @visibleForTesting
+  bool get isDisposed => _disposed;
   bool _disposed = false;
 
   @mustCallSuper

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1063,7 +1063,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
     if (TickerMode.of(context)) {
       _listenToStream();
     } else {
-      _stopListeningToStream(keepStreamAlive: true);
+      _stopListeningToStream();
     }
 
     super.didChangeDependencies();

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1901,8 +1901,9 @@ void main() {
     expect(image.debugGetOpenHandleStackTraces()!.length, 0);
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/87442
 
-  testWidgets('Keeps stream alive when ticker mode is disabled',  (WidgetTester tester) async {
+  testWidgets('Timely dispose unavailable image when ticker mode is disabled',  (WidgetTester tester) async {
     imageCache.maximumSize = 0;
+    // Ensure `ImageCache` is disabled.
     final ui.Image image = (await tester.runAsync(() => createTestImage(cache: false)))!;
     final _TestImageProvider provider = _TestImageProvider();
     provider.complete(image);
@@ -1922,12 +1923,8 @@ void main() {
     );
     expect(find.byType(Image), findsOneWidget);
 
-    await tester.pumpWidget(TickerMode(
-        enabled: true,
-        child: Image(image: provider),
-      ),
-    );
-    expect(find.byType(Image), findsOneWidget);
+    // Timely release the memory of unavailable images evicted by `ImageCache`.
+    expect(provider._streamCompleter.isDisposed, true);
   });
 
   testWidgets('Load a good image after a bad image was loaded should not call errorBuilder', (WidgetTester tester) async {


### PR DESCRIPTION
Avoid additional keepalive to prevent disposing unavailable images that have already been evicted by `ImageCache`.

Fixes https://github.com/flutter/flutter/issues/125608

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
