### PR TITLE
Increase Xcode minimum version to 14

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -18,7 +18,7 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../ios/xcodeproj.dart';
 
-Version get xcodeRequiredVersion => Version(13, null, null);
+Version get xcodeRequiredVersion => Version(14, 0, 1);
 
 /// Diverging this number from the minimum required version will provide a doctor
 /// warning, not error, that users should upgrade Xcode.

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -18,7 +18,7 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../ios/xcodeproj.dart';
 
-Version get xcodeRequiredVersion => Version(14, 0, 1);
+Version get xcodeRequiredVersion => Version(14, null, null);
 
 /// Diverging this number from the minimum required version will provide a doctor
 /// warning, not error, that users should upgrade Xcode.

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -155,7 +155,7 @@ void main() {
 
         testWithoutContext('version checks pass when version meets minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(14, 0, 1);
+          xcodeProjectInterpreter.version = Version(14, null, null);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
           expect(xcode.isRecommendedVersionSatisfactory, isTrue);
@@ -171,7 +171,7 @@ void main() {
 
         testWithoutContext('version checks pass when minor version exceeds minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(14, 3, 1);
+          xcodeProjectInterpreter.version = Version(14, 3, 0);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
           expect(xcode.isRecommendedVersionSatisfactory, isTrue);
@@ -202,7 +202,7 @@ void main() {
 
         testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(14, 0, 1);
+          xcodeProjectInterpreter.version = Version(14, null, null);
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
           expect(fakeProcessManager, hasNoRemainingExpectations);

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -155,7 +155,7 @@ void main() {
 
         testWithoutContext('version checks pass when version meets minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(13, null, null);
+          xcodeProjectInterpreter.version = Version(14, 0, 1);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
           expect(xcode.isRecommendedVersionSatisfactory, isTrue);
@@ -163,7 +163,7 @@ void main() {
 
         testWithoutContext('version checks pass when major version exceeds minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(14, 0, 0);
+          xcodeProjectInterpreter.version = Version(15, 0, 0);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
           expect(xcode.isRecommendedVersionSatisfactory, isTrue);
@@ -171,7 +171,7 @@ void main() {
 
         testWithoutContext('version checks pass when minor version exceeds minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(13, 3, 0);
+          xcodeProjectInterpreter.version = Version(14, 3, 1);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
           expect(xcode.isRecommendedVersionSatisfactory, isTrue);
@@ -179,7 +179,7 @@ void main() {
 
         testWithoutContext('version checks pass when patch version exceeds minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(13, 0, 2);
+          xcodeProjectInterpreter.version = Version(14, 0, 2);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
           expect(xcode.isRecommendedVersionSatisfactory, isTrue);
@@ -202,7 +202,7 @@ void main() {
 
         testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(13, null, null);
+          xcodeProjectInterpreter.version = Version(14, 0, 1);
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
           expect(fakeProcessManager, hasNoRemainingExpectations);

--- a/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
@@ -56,7 +56,7 @@ void main() {
       final ValidationResult result = await validator.validate();
       expect(result.type, ValidationType.partial);
       expect(result.messages.last.type, ValidationMessageType.error);
-      expect(result.messages.last.message, contains('Flutter requires Xcode 13 or higher'));
+      expect(result.messages.last.message, contains('Flutter requires Xcode 14.0.1 or higher'));
     });
 
     testWithoutContext('Emits partial status when Xcode below recommended version', () async {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
@@ -56,7 +56,7 @@ void main() {
       final ValidationResult result = await validator.validate();
       expect(result.type, ValidationType.partial);
       expect(result.messages.last.type, ValidationMessageType.error);
-      expect(result.messages.last.message, contains('Flutter requires Xcode 14.0.1 or higher'));
+      expect(result.messages.last.message, contains('Flutter requires Xcode 14 or higher'));
     });
 
     testWithoutContext('Emits partial status when Xcode below recommended version', () async {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -326,13 +326,13 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   bool get isInstalled => true;
 
   @override
-  String get versionText => 'Xcode 14.0.1';
+  String get versionText => 'Xcode 14';
 
   @override
-  Version get version => Version(14, 0, 1);
+  Version get version => Version(14, null, null);
 
   @override
-  String get build => '14A400';
+  String get build => '14A309';
 
   @override
   Future<Map<String, String>> getBuildSettings(

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -326,13 +326,13 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   bool get isInstalled => true;
 
   @override
-  String get versionText => 'Xcode 13';
+  String get versionText => 'Xcode 14.0.1';
 
   @override
-  Version get version => Version(13, null, null);
+  Version get version => Version(14, 0, 1);
 
   @override
-  String get build => '13C100';
+  String get build => '14A400';
 
   @override
   Future<Map<String, String>> getBuildSettings(


### PR DESCRIPTION
Looks like CocoaPods 1.12.1 is incompatible with < Xcode 14 due to https://github.com/CocoaPods/CocoaPods/pull/11828 (see https://github.com/flutter/flutter/issues/123890 for context).

Bump the minimum Xcode version allowed by tooling to 14, released September 2022.

```
[!] Xcode - develop for iOS and macOS (Xcode 13.4)
    ✗ Flutter requires Xcode 14 or higher.
      Download the latest version or update via the Mac App Store.
```

Fixes https://github.com/flutter/flutter/issues/125286.
Previous bump at #97746.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
