### PR TITLE
Update dartdoc to v6.2.2.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 6.2.1
+    "$DART" pub global activate dartdoc 6.2.2
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
This PR updates the dartdoc version to v6.2.2.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v6.2.2

The main impact for Flutter is to update dartdoc to add chips to class and/or mixin pages for class modifiers.  See dart-lang/dartdoc#3391, dart-lang/dartdoc#3402.   This will also be a cherry-pick candidate for 3.1 if it can land in time.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ test-exempt ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
