### PR TITLE
[tools] fix `expect` calls in `FakeCommand`

### DIFF
--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -111,13 +111,13 @@ class FakeCommand {
     final List<dynamic> matchers = this.command.map((Pattern x) => x is String ? x : matches(x)).toList();
     expect(command, matchers);
     if (this.workingDirectory != null) {
-      expect(this.workingDirectory, workingDirectory);
+      expect(workingDirectory, this.workingDirectory);
     }
     if (this.environment != null) {
-      expect(this.environment, environment);
+      expect(environment, this.environment);
     }
     if (this.encoding != null) {
-      expect(this.encoding, encoding);
+      expect(encoding, this.encoding);
     }
   }
 }


### PR DESCRIPTION
Fixes #125782.

Would be nice to figure out a way to put this under test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
