### PR TITLE
Add sample code for SliverAppBar

### DIFF
--- a/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for [SliverAppBar].
@@ -14,9 +10,16 @@ void main() {
   runApp(const StretchableSliverAppBar());
 }
 
-class StretchableSliverAppBar extends StatelessWidget {
+class StretchableSliverAppBar extends StatefulWidget {
   const StretchableSliverAppBar({super.key});
 
+  @override
+  State<StretchableSliverAppBar> createState() =>
+      _StretchableSliverAppBarState();
+}
+
+class _StretchableSliverAppBarState extends State<StretchableSliverAppBar> {
+  bool _stretch = true;
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -25,8 +28,10 @@ class StretchableSliverAppBar extends StatelessWidget {
         physics: const BouncingScrollPhysics(),
         slivers: <Widget>[
           SliverAppBar(
-            stretch: true,
-            onStretchTrigger: () async {},
+            stretch: _stretch,
+            onStretchTrigger: () async {
+              // Triggers when stretching
+            },
             expandedHeight: 200.0,
             flexibleSpace: const FlexibleSpaceBar(
               title: Text('SliverAppBar'),
@@ -48,6 +53,31 @@ class StretchableSliverAppBar extends StatelessWidget {
             ),
           ),
         ],
+      ),
+      bottomNavigationBar: BottomAppBar(
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: OverflowBar(
+            overflowAlignment: OverflowBarAlignment.center,
+            alignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Text('stretch'),
+                  Switch(
+                    onChanged: (bool val) {
+                      setState(() {
+                        _stretch = val;
+                      });
+                    },
+                    value: _stretch,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
       ),
     ));
   }

--- a/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [SliverAppBar].
+
+void main() {
+  runApp(const StretchableSliverAppBar());
+}
+
+class StretchableSliverAppBar extends StatelessWidget {
+  const StretchableSliverAppBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        home: Scaffold(
+      body: CustomScrollView(
+        physics: const BouncingScrollPhysics(),
+        slivers: <Widget>[
+          SliverAppBar(
+            stretch: true,
+            onStretchTrigger: () async {},
+            expandedHeight: 200.0,
+            flexibleSpace: const FlexibleSpaceBar(
+              title: Text('SliverAppBar'),
+              background: FlutterLogo(),
+            ),
+          ),
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (BuildContext context, int index) {
+                return Container(
+                  color: index.isOdd ? Colors.white : Colors.black12,
+                  height: 100.0,
+                  child: Center(
+                    child: Text('$index', textScaleFactor: 5),
+                  ),
+                );
+              },
+              childCount: 20,
+            ),
+          ),
+        ],
+      ),
+    ));
+  }
+}

--- a/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
@@ -32,6 +32,12 @@ class _StretchableSliverAppBarState extends State<StretchableSliverAppBar> {
             onStretchTrigger: () async {
               // Triggers when stretching
             },
+            // [stretchTriggerOffset] describes the amount of overscroll that must occur
+            // to trigger [onStretchTrigger]
+            //
+            // Setting [stretchTriggerOffset] to a value of 300.0 will trigger
+            // [onStretchTrigger] when the user has overscrolled by 300.0 pixels.
+            stretchTriggerOffset: 300.0,
             expandedHeight: 200.0,
             flexibleSpace: const FlexibleSpaceBar(
               title: Text('SliverAppBar'),

--- a/examples/api/test/material/appbar/sliver_app_bar.4_test.dart
+++ b/examples/api/test/material/appbar/sliver_app_bar.4_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/app_bar/sliver_app_bar.4.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+const Offset _kOffset = Offset(0.0, 200.0);
+
+void main() {
+  testWidgets('SliverAppbar can be stretched', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.StretchableSliverAppBar(),
+    );
+
+    expect(find.widgetWithText(SliverAppBar, 'SliverAppBar'), findsOneWidget);
+    expect(tester.getBottomLeft(find.text('SliverAppBar')).dy, 184.0);
+
+    await tester.drag(find.text('0'), _kOffset,
+        touchSlopY: 0, warnIfMissed: false);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(
+        tester.getBottomLeft(find.text('SliverAppBar')).dy, 187.63506380825314);
+  });
+}

--- a/examples/api/test/material/appbar/sliver_app_bar.4_test.dart
+++ b/examples/api/test/material/appbar/sliver_app_bar.4_test.dart
@@ -15,6 +15,10 @@ void main() {
       const example.StretchableSliverAppBar(),
     );
 
+    final Finder switchFinder = find.byType(Switch);
+    Switch materialSwitch = tester.widget<Switch>(switchFinder);
+    expect(materialSwitch.value, true);
+
     expect(find.widgetWithText(SliverAppBar, 'SliverAppBar'), findsOneWidget);
     expect(tester.getBottomLeft(find.text('SliverAppBar')).dy, 184.0);
 
@@ -22,7 +26,21 @@ void main() {
         touchSlopY: 0, warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
+    expect(find.widgetWithText(SliverAppBar, 'SliverAppBar'), findsOneWidget);
     expect(
         tester.getBottomLeft(find.text('SliverAppBar')).dy, 187.63506380825314);
+
+    await tester.tap(switchFinder);
+    await tester.pumpAndSettle();
+    materialSwitch = tester.widget<Switch>(switchFinder);
+    expect(materialSwitch.value, false);
+
+    await tester.drag(find.text('0'), _kOffset,
+        touchSlopY: 0, warnIfMissed: false);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(find.text('SliverAppBar'), findsOneWidget);
+    expect(tester.getBottomLeft(find.text('SliverAppBar')).dy, 184.0);
   });
 }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1402,6 +1402,13 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 /// {@end-tool}
 ///
 /// {@tool dartpad}
+/// Here is an example of [SliverAppBar] when using [stretch] and [onStretchTrigger]
+/// 
+///  ** See code in examples/api/lib/material/app_bar/sliver_app_bar.4.dart **
+/// {@end-tool}
+///
+/// 
+/// {@tool dartpad}
 /// This sample shows a [SliverAppBar] and it's behavior when using the
 /// [pinned], [snap] and [floating] parameters.
 ///

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1402,7 +1402,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 /// {@end-tool}
 ///
 /// {@tool dartpad}
-/// Here is an example of [SliverAppBar] when using [stretch] and [onStretchTrigger]
+/// Here is an example of [SliverAppBar] when using [stretch] and [onStretchTrigger].
 ///
 ///  ** See code in examples/api/lib/material/app_bar/sliver_app_bar.4.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1403,11 +1403,11 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///
 /// {@tool dartpad}
 /// Here is an example of [SliverAppBar] when using [stretch] and [onStretchTrigger]
-/// 
+///
 ///  ** See code in examples/api/lib/material/app_bar/sliver_app_bar.4.dart **
 /// {@end-tool}
 ///
-/// 
+///
 /// {@tool dartpad}
 /// This sample shows a [SliverAppBar] and it's behavior when using the
 /// [pinned], [snap] and [floating] parameters.


### PR DESCRIPTION
This PR adds an another example for SliverAppBar, showing the use of stretch and onStretchTrigger


https://user-images.githubusercontent.com/68919043/235420973-2bfb9871-9e05-4d87-9538-941d43178c76.mp4

Fixes #125651 

### Adds sample code for SliverAppBar [stretch, onStretchTrigger]

This PR adds an another simple and easily understandable example code for SliverAppBar.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
