### PR TITLE
Clarify Visual Studio isn't strictly necessary for Windows development

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -228,7 +228,7 @@ class UserMessages {
   String get windows10SdkNotFound =>
       'Unable to locate a Windows 10 SDK. If building fails, install the Windows 10 SDK in Visual Studio.';
   String visualStudioMissing(String workload) =>
-      'Visual Studio not installed; this is necessary for Windows development.\n'
+      'Visual Studio not installed; this is necessary to develop Windows apps.\n'
       'Download at https://visualstudio.microsoft.com/downloads/.\n'
       'Please install the "$workload" workload, including all of its default components';
   String visualStudioTooOld(String minimumVersion, String workload) =>

--- a/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio_validator.dart
@@ -15,7 +15,7 @@ class VisualStudioValidator extends DoctorValidator {
     required UserMessages userMessages,
   }) : _visualStudio = visualStudio,
        _userMessages = userMessages,
-       super('Visual Studio - develop for Windows');
+       super('Visual Studio - develop Windows apps');
 
   final VisualStudio _visualStudio;
   final UserMessages _userMessages;


### PR DESCRIPTION
Update `flutter doctor` to clarify that Visual Studio is needed only if creating Windows apps. Windows users targeting Android do not need to install Visual Studio.