### PR TITLE
Fix nullability of ClipRRect.borderRadius

### DIFF
--- a/packages/flutter/lib/src/cupertino/list_section.dart
+++ b/packages/flutter/lib/src/cupertino/list_section.dart
@@ -402,8 +402,7 @@ class CupertinoListSection extends StatelessWidget {
       );
     }
 
-    BorderRadius? childrenGroupBorderRadius;
-    DecoratedBox? decoratedChildrenGroup;
+    Widget? decoratedChildrenGroup;
     if (children != null && children!.isNotEmpty) {
       // We construct childrenWithDividers as follows:
       // Insert a short divider between all rows.
@@ -425,15 +424,11 @@ class CupertinoListSection extends StatelessWidget {
         childrenWithDividers.add(longDivider);
       }
 
-      switch (type) {
-        case CupertinoListSectionType.insetGrouped:
-          childrenGroupBorderRadius = _kDefaultInsetGroupedBorderRadius;
-        case CupertinoListSectionType.base:
-          childrenGroupBorderRadius = BorderRadius.zero;
-      }
+      final BorderRadius childrenGroupBorderRadius = switch (type) {
+        CupertinoListSectionType.insetGrouped => _kDefaultInsetGroupedBorderRadius,
+        CupertinoListSectionType.base => BorderRadius.zero,
+      };
 
-      // Refactored the decorate children group in one place to avoid repeating it
-      // twice down bellow in the returned widget.
       decoratedChildrenGroup = DecoratedBox(
         decoration: decoration ??
             BoxDecoration(
@@ -444,6 +439,17 @@ class CupertinoListSection extends StatelessWidget {
               borderRadius: childrenGroupBorderRadius,
             ),
         child: Column(children: childrenWithDividers),
+      );
+
+      decoratedChildrenGroup = Padding(
+        padding: margin,
+        child: clipBehavior == Clip.none
+            ? decoratedChildrenGroup
+            : ClipRRect(
+                borderRadius: childrenGroupBorderRadius,
+                clipBehavior: clipBehavior,
+                child: decoratedChildrenGroup,
+              ),
       );
     }
 
@@ -464,17 +470,8 @@ class CupertinoListSection extends StatelessWidget {
                 child: headerWidget,
               ),
             ),
-          if (children != null && children!.isNotEmpty)
-            Padding(
-              padding: margin,
-              child: clipBehavior == Clip.none
-                  ? decoratedChildrenGroup
-                  : ClipRRect(
-                      borderRadius: childrenGroupBorderRadius,
-                      clipBehavior: clipBehavior,
-                      child: decoratedChildrenGroup,
-                    ),
-            ),
+          if (decoratedChildrenGroup != null)
+            decoratedChildrenGroup,
           if (footerWidget != null)
             Align(
               alignment: AlignmentDirectional.centerStart,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -850,7 +850,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
     this.clipper,
     this.clipBehavior = Clip.antiAlias,
     super.child,
-  }) : assert(borderRadius != null || clipper != null);
+  });
 
   /// The border radius of the rounded corners.
   ///
@@ -858,7 +858,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   /// exceed width/height.
   ///
   /// This value is ignored if [clipper] is non-null.
-  final BorderRadiusGeometry? borderRadius;
+  final BorderRadiusGeometry borderRadius;
 
   /// If non-null, determines which clip to use.
   final CustomClipper<RRect>? clipper;
@@ -871,7 +871,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   @override
   RenderClipRRect createRenderObject(BuildContext context) {
     return RenderClipRRect(
-      borderRadius: borderRadius!,
+      borderRadius: borderRadius,
       clipper: clipper,
       clipBehavior: clipBehavior,
       textDirection: Directionality.maybeOf(context),
@@ -881,7 +881,7 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, RenderClipRRect renderObject) {
     renderObject
-      ..borderRadius = borderRadius!
+      ..borderRadius = borderRadius
       ..clipBehavior = clipBehavior
       ..clipper = clipper
       ..textDirection = Directionality.maybeOf(context);


### PR DESCRIPTION
The property was typed as nullable, but the code assumed its always non-null. This makes the property non-nullable as well.

Also refactors CupertinoListSection, which was flagged by the analyzer when borderRadius became non-nullable (no functional change, just cleaning up existing code to avoid the warning).