### PR TITLE
[tools] When running Android SDK tools, set JAVA_HOME to the home of the JDK bundled with Android Studio

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -552,6 +552,16 @@ class AndroidSdk {
     if (_sdkManagerEnv == null) {
       // If we can locate Java, then add it to the path used to run the Android SDK manager.
       _sdkManagerEnv = <String, String>{};
+      final String? javaHome = findJavaHome(
+        androidStudio: globals.androidStudio,
+        fileSystem: globals.fs,
+        operatingSystemUtils: globals.os,
+        platform: globals.platform,
+      );
+      if (javaHome != null) {
+        _sdkManagerEnv![javaHomeEnvironmentVariable] = javaHome;
+      }
+
       final String? javaBinary = findJavaBinary(
         androidStudio: globals.androidStudio,
         fileSystem: globals.fs,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/124776.
Related to https://github.com/flutter/flutter/issues/124252.
Followup to https://github.com/flutter/flutter/pull/124233.

When performing Java-dependent activities across the tool, we prefer to use the java runtime that is bundled with Android Studio on the host machine.

However, we fail to set JAVA_HOME when validating Android SDK license acceptance. In the case that JAVA_HOME is set on the host machine, we can end up using the wrong java runtime.

## TODO

Need to figure out a way to get this under test. This is difficult, because [we currently fake `AndroidSdk` in tests](https://github.com/flutter/flutter/blob/55502fc36a16f25deebd9539f5288e12525f350f/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart#L593).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
