### PR TITLE
Mark build_test builds as bringup.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2139,6 +2139,7 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf
     recipe: devicelab/devicelab_drone_build_test
+    bringup: true # https://github.com/flutter/flutter/issues/1258979
     presubmit: false
     timeout: 60
     properties:
@@ -2151,6 +2152,7 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone_build_test
+    bringup: true # https://github.com/flutter/flutter/issues/1258979
     presubmit: false
     timeout: 60
     properties:
@@ -2163,6 +2165,7 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone_build_test
+    bringup: true # https://github.com/flutter/flutter/issues/1258979
     presubmit: false
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2148,7 +2148,7 @@ targets:
       task_name: flutter_gallery__transition_perf
       artifact: gallery__transition_perf
       drone_dimensions: >
-        ["device_os=N","os=Ubuntu", "device_type=msm8952"]
+        ["device_os=N","os=Linux", "device_type=msm8952"]
 
   - name: Linux_build_test flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone_build_test
@@ -2161,7 +2161,7 @@ targets:
       task_name: flutter_gallery__transition_perf_e2e
       artifact: gallery__transition_perf_e2e
       drone_dimensions: >
-        ["device_os=N","os=Ubuntu", "device_type=msm8952"]
+        ["device_os=N","os=Linux", "device_type=msm8952"]
 
   - name: Linux_build_test flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone_build_test
@@ -2174,7 +2174,7 @@ targets:
       task_name: flutter_gallery__transition_perf_hybrid
       artifact: gallery__transition_perf_hybrid
       drone_dimensions: >
-        ["device_os=N","os=Ubuntu", "device_type=msm8952"]
+        ["device_os=N","os=Linux", "device_type=msm8952"]
 
   - name: Linux_android flutter_gallery__transition_perf_with_semantics
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2139,7 +2139,7 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true # https://github.com/flutter/flutter/issues/1258979
+    bringup: true # https://github.com/flutter/flutter/issues/125897
     presubmit: false
     timeout: 60
     properties:
@@ -2152,7 +2152,7 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true # https://github.com/flutter/flutter/issues/1258979
+    bringup: true # https://github.com/flutter/flutter/issues/125897
     presubmit: false
     timeout: 60
     properties:
@@ -2165,7 +2165,7 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true # https://github.com/flutter/flutter/issues/1258979
+    bringup: true # https://github.com/flutter/flutter/issues/125897
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
They require an additional dimension to be passed as part of the .ci.yaml configuration.

Bug: https://github.com/flutter/flutter/issues/125897

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
