### PR TITLE
Adding printOnFailure for result of process

### DIFF
--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -177,7 +177,7 @@ void main() {
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_size_test.');
 
-    final ProcessResult result = await processManager.run(<String>[
+    final List<String> command = <String>[
       flutterBin,
       'build',
       'apk',
@@ -185,8 +185,19 @@ void main() {
       '--code-size-directory=${tempDir.path}',
       '--target-platform=android-arm64',
       '--release',
-    ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
+    ];
+    final String workingDirectory = fileSystem.path.join(
+      getFlutterRoot(),
+      'examples',
+      'hello_world',
+    );
+    final ProcessResult result = await processManager.run(
+      command,
+      workingDirectory: workingDirectory,
+    );
 
+    printOnFailure('workingDirectory: $workingDirectory');
+    printOnFailure('command:\n${command.join(" ")}');
     printOnFailure('stdout:\n${result.stdout}');
     printOnFailure('stderr:\n${result.stderr}');
 

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -187,6 +187,9 @@ void main() {
       '--release',
     ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
 
+    printOnFailure('stdout:\n${result.stdout}');
+    printOnFailure('stdout:\n${result.stderr}');
+
     expect(result.exitCode, 0);
     expect(tempDir.existsSync(), true);
     expect(tempDir.childFile('snapshot.arm64-v8a.json').existsSync(), true);

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -188,7 +188,7 @@ void main() {
     ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
 
     printOnFailure('stdout:\n${result.stdout}');
-    printOnFailure('stdout:\n${result.stderr}');
+    printOnFailure('stderr:\n${result.stderr}');
 
     expect(result.exitCode, 0);
     expect(tempDir.existsSync(), true);


### PR DESCRIPTION
Adding a `printOnFailure` call into the flakey test to help debug the cause for future failures.

- Reference issue: https://github.com/flutter/flutter/issues/125512

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
