### PR TITLE
Adds vmservices to retrieve android applink settings

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_app_link_settings.dart
+++ b/packages/flutter_tools/lib/src/android/android_app_link_settings.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+/// A data class for app links related project settings.
+///
+/// See https://developer.android.com/training/app-links.
+@immutable
+class AndroidAppLinkSettings {
+  const AndroidAppLinkSettings({
+    required this.applicationId,
+    required this.domains,
+  });
+
+  /// The application id of the android sub-project.
+  final String applicationId;
+
+  /// The associated web domains of the android sub-project.
+  final List<String> domains;
+}

--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -42,4 +42,16 @@ abstract class AndroidBuilder {
 
   /// Returns a list of available build variant from the Android project.
   Future<List<String>> getBuildVariants({required FlutterProject project});
+
+  /// Returns the application id for the given build variant.
+  Future<String> getApplicationIdForVariant(
+    String buildVariant, {
+    required FlutterProject project,
+  });
+
+  /// Returns a list of app link domains for the given build variant.
+  Future<List<String>> getAppLinkDomainsForVariant(
+    String buildVariant, {
+    required FlutterProject project,
+  });
 }

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -38,9 +38,9 @@ import 'migrations/android_studio_java_gradle_conflict_migration.dart';
 import 'migrations/top_level_gradle_build_file_migration.dart';
 import 'multidex.dart';
 
-/// The regex to grab variant names from printVariants gradle task
+/// The regex to grab variant names from printBuildVariants gradle task
 ///
-/// The task is defined in flutter/packages/flutter_tools/gradle/flutter.gradle.
+/// The task is defined in flutter/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
 ///
 /// The expected output from the task should be similar to:
 ///
@@ -49,6 +49,34 @@ import 'multidex.dart';
 /// BuildVariant: profile
 final RegExp _kBuildVariantRegex = RegExp('^BuildVariant: (?<$_kBuildVariantRegexGroupName>.*)\$');
 const String _kBuildVariantRegexGroupName = 'variant';
+const String _kBuildVariantTaskName = 'printBuildVariants';
+
+/// The regex to grab variant names from print${BuildVariant}ApplicationId gradle task
+///
+/// The task is defined in flutter/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+///
+/// The expected output from the task should be similar to:
+///
+/// ApplicationId: com.example.my_id
+final RegExp _kApplicationIdRegex = RegExp('^ApplicationId: (?<$_kApplicationIdRegexGroupName>.*)\$');
+const String _kApplicationIdRegexGroupName = 'applicationId';
+String _getPrintApplicationIdTaskFor(String buildVariant) {
+  return _taskForBuildVariant('print', buildVariant, 'ApplicationId');
+}
+
+/// The regex to grab app link domains from print${BuildVariant}AppLinkDomains gradle task
+///
+/// The task is defined in flutter/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+///
+/// The expected output from the task should be similar to:
+///
+/// Domain: domain.com
+/// Domain: another-domain.dev
+final RegExp _kAppLinkDomainsRegex = RegExp('^Domain: (?<$_kAppLinkDomainsGroupName>.*)\$');
+const String _kAppLinkDomainsGroupName = 'domain';
+String _getPrintAppLinkDomainsTaskFor(String buildVariant) {
+  return _taskForBuildVariant('print', buildVariant, 'AppLinkDomains');
+}
 
 /// The directory where the APK artifact is generated.
 Directory getApkDirectory(FlutterProject project) {
@@ -89,8 +117,13 @@ Directory getRepoDirectory(Directory buildDirectory) {
 String _taskFor(String prefix, BuildInfo buildInfo) {
   final String buildType = camelCase(buildInfo.modeName);
   final String productFlavor = buildInfo.flavor ?? '';
-  return '$prefix${sentenceCase(productFlavor)}${sentenceCase(buildType)}';
+  return _taskForBuildVariant(prefix, '$productFlavor${sentenceCase(buildType)}');
 }
+
+String _taskForBuildVariant(String prefix, String buildVariant, [String suffix = '']) {
+  return '$prefix${sentenceCase(buildVariant)}$suffix';
+}
+
 
 /// Returns the task to build an APK.
 @visibleForTesting
@@ -238,6 +271,34 @@ class AndroidGradleBuilder implements AndroidBuilder {
       configOnly: configOnly,
       maxRetries: 1,
     );
+  }
+
+  Future<RunResult> _runGradleTask(
+    String taskName, {
+    List<String> options = const <String>[],
+    required FlutterProject project
+  }) async {
+    final Status status = _logger.startProgress(
+      "Running Gradle task '$taskName'...",
+    );
+    final List<String> command = <String>[
+      _gradleUtils.getExecutable(project),
+      ...options, // suppresses gradle output.
+      taskName,
+    ];
+
+    RunResult result;
+    try {
+      result = await _processUtils.run(
+        command,
+        workingDirectory: project.android.hostAppGradleRoot.path,
+        allowReentrantFlutter: true,
+        environment: _java?.environment,
+      );
+    } finally {
+      status.stop();
+    }
+    return result;
   }
 
   /// Builds an app.
@@ -727,28 +788,14 @@ class AndroidGradleBuilder implements AndroidBuilder {
 
   @override
   Future<List<String>> getBuildVariants({required FlutterProject project}) async {
-    final Status status = _logger.startProgress(
-      "Running Gradle task 'printBuildVariants'...",
-    );
-    final List<String> command = <String>[
-      _gradleUtils.getExecutable(project),
-      '-q', // suppresses gradle output.
-      'printBuildVariants',
-    ];
-
     final Stopwatch sw = Stopwatch()
       ..start();
-    RunResult result;
-    try {
-      result = await _processUtils.run(
-        command,
-        workingDirectory: project.android.hostAppGradleRoot.path,
-        allowReentrantFlutter: true,
-        environment: _java?.environment,
-      );
-    } finally {
-      status.stop();
-    }
+    final RunResult result = await _runGradleTask(
+      _kBuildVariantTaskName,
+      options: const <String>['-q'],
+      project: project,
+    );
+
     _usage.sendTiming('print', 'android build variants', sw.elapsed);
 
     if (result.exitCode != 0) {
@@ -764,6 +811,65 @@ class AndroidGradleBuilder implements AndroidBuilder {
       }
     }
     return options;
+  }
+
+  @override
+  Future<String> getApplicationIdForVariant(
+    String buildVariant, {
+    required FlutterProject project,
+  }) async {
+    final String taskName = _getPrintApplicationIdTaskFor(buildVariant);
+    final Stopwatch sw = Stopwatch()
+      ..start();
+    final RunResult result = await _runGradleTask(
+      taskName,
+      options: const <String>['-q'],
+      project: project,
+    );
+    _usage.sendTiming('print', 'application id', sw.elapsed);
+
+    if (result.exitCode != 0) {
+      _logger.printStatus(result.stdout, wrap: false);
+      _logger.printError(result.stderr, wrap: false);
+      return '';
+    }
+    for (final String line in LineSplitter.split(result.stdout)) {
+      final RegExpMatch? match = _kApplicationIdRegex.firstMatch(line);
+      if (match != null) {
+        return match.namedGroup(_kApplicationIdRegexGroupName)!;
+      }
+    }
+    return '';
+  }
+
+  @override
+  Future<List<String>> getAppLinkDomainsForVariant(
+    String buildVariant, {
+    required FlutterProject project,
+  }) async {
+    final String taskName = _getPrintAppLinkDomainsTaskFor(buildVariant);
+    final Stopwatch sw = Stopwatch()
+      ..start();
+    final RunResult result = await _runGradleTask(
+      taskName,
+      options: const <String>['-q'],
+      project: project,
+    );
+    _usage.sendTiming('print', 'application id', sw.elapsed);
+
+    if (result.exitCode != 0) {
+      _logger.printStatus(result.stdout, wrap: false);
+      _logger.printError(result.stderr, wrap: false);
+      return const <String>[];
+    }
+    final List<String> domains = <String>[];
+    for (final String line in LineSplitter.split(result.stdout)) {
+      final RegExpMatch? match = _kAppLinkDomainsRegex.firstMatch(line);
+      if (match != null) {
+        domains.add(match.namedGroup(_kAppLinkDomainsGroupName)!);
+      }
+    }
+    return domains;
   }
 }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -7,6 +7,7 @@ import 'package:xml/xml.dart';
 import 'package:yaml/yaml.dart';
 
 import '../src/convert.dart';
+import 'android/android_app_link_settings.dart';
 import 'android/android_builder.dart';
 import 'android/gradle_utils.dart' as gradle;
 import 'base/common.dart';
@@ -477,11 +478,28 @@ class AndroidProject extends FlutterProjectPlatform {
   /// Returns true if the current version of the Gradle plugin is supported.
   late final bool isSupportedVersion = _computeSupportedVersion();
 
+  /// Gets all build variants of this project.
   Future<List<String>> getBuildVariants() async {
     if (!existsSync() || androidBuilder == null) {
       return const <String>[];
     }
     return androidBuilder!.getBuildVariants(project: parent);
+  }
+
+  /// Returns app link related project settings for a given build variant.
+  ///
+  /// Use [getBuildVariants] to get all of the available build variants.
+  Future<AndroidAppLinkSettings> getAppLinksSettings({required String variant}) async {
+    if (!existsSync() || androidBuilder == null) {
+      return const AndroidAppLinkSettings(
+        applicationId: '',
+        domains: <String>[],
+      );
+    }
+    return AndroidAppLinkSettings(
+      applicationId: await androidBuilder!.getApplicationIdForVariant(variant, project: parent),
+      domains: await androidBuilder!.getAppLinkDomainsForVariant(variant, project: parent),
+    );
   }
 
   bool _computeSupportedVersion() {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:vm_service/vm_service.dart' as vm_service;
 
+import 'android/android_app_link_settings.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/io.dart' as io;
@@ -42,6 +43,7 @@ const String kFlutterGetSkSLServiceName = 'flutterGetSkSL';
 const String kFlutterGetIOSBuildOptionsServiceName = 'flutterGetIOSBuildOptions';
 const String kFlutterGetAndroidBuildVariantsServiceName = 'flutterGetAndroidBuildVariants';
 const String kFlutterGetIOSUniversalLinkSettingsServiceName = 'flutterGetIOSUniversalLinkSettings';
+const String kFlutterGetAndroidAppLinkSettingsName = 'flutterGetAndroidAppLinkSettings';
 
 /// The error response code from an unrecoverable compilation failure.
 const int kIsolateReloadBarred = 1005;
@@ -356,6 +358,21 @@ Future<vm_service.VmService> setUpVmService({
     });
     registrationRequests.add(
       vmService.registerService(kFlutterGetIOSUniversalLinkSettingsServiceName, kFlutterToolAlias),
+    );
+
+    vmService.registerServiceCallback(kFlutterGetAndroidAppLinkSettingsName, (Map<String, Object?> params) async {
+      final String variant = params['variant']! as String;
+      final AndroidAppLinkSettings settings = await flutterProject.android.getAppLinksSettings(variant: variant);
+      return <String, Object>{
+        'result': <String, Object>{
+          kResultType: kResultTypeSuccess,
+          'applicationId': settings.applicationId,
+          'domains': settings.domains,
+        },
+      };
+    });
+    registrationRequests.add(
+      vmService.registerService(kFlutterGetAndroidAppLinkSettingsName, kFlutterToolAlias),
     );
   }
 

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -869,6 +869,129 @@ Gradle Crashed
       AndroidStudio: () => FakeAndroidStudio(),
     });
 
+    testUsingContext('can call custom gradle task getApplicationIdForVariant and parse the result', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        usage: testUsage,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+      );
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          'gradlew',
+          '-q',
+          'printFreeDebugApplicationId',
+        ],
+        stdout: '''
+ApplicationId: com.example.id
+        ''',
+      ));
+      final String actual = await builder.getApplicationIdForVariant(
+        'freeDebug',
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      );
+      expect(actual, 'com.example.id');
+    }, overrides: <Type, Generator>{
+      AndroidStudio: () => FakeAndroidStudio(),
+    });
+
+    testUsingContext('can call custom gradle task getApplicationIdForVariant with unknown crash', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        usage: testUsage,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+      );
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          'gradlew',
+          '-q',
+          'printFreeDebugApplicationId',
+        ],
+        stdout: '''
+unknown crash
+        ''',
+      ));
+      final String actual = await builder.getApplicationIdForVariant(
+        'freeDebug',
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      );
+      expect(actual, '');
+    }, overrides: <Type, Generator>{
+      AndroidStudio: () => FakeAndroidStudio(),
+    });
+
+    testUsingContext('can call custom gradle task getAppLinkDomainsForVariant and parse the result', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        usage: testUsage,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+      );
+
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          'gradlew',
+          '-q',
+          'printFreeDebugAppLinkDomains',
+        ],
+        stdout: '''
+Domain: example.com
+Domain: example2.com
+        ''',
+      ));
+      final List<String> actual = await builder.getAppLinkDomainsForVariant(
+        'freeDebug',
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      );
+      expect(actual, <String>['example.com', 'example2.com']);
+    }, overrides: <Type, Generator>{
+      AndroidStudio: () => FakeAndroidStudio(),
+    });
+
+    testUsingContext('can call custom gradle task getAppLinkDomainsForVariant with unknown crash', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: logger,
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        usage: testUsage,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+        androidStudio: FakeAndroidStudio(),
+      );
+
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          'gradlew',
+          '-q',
+          'printFreeDebugAppLinkDomains',
+        ],
+        stdout: '''
+unknown crash
+        ''',
+      ));
+      final List<String> actual = await builder.getAppLinkDomainsForVariant(
+        'freeDebug',
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      );
+      expect(actual.isEmpty, isTrue);
+    }, overrides: <Type, Generator>{
+      AndroidStudio: () => FakeAndroidStudio(),
+    });
+
     testUsingContext("doesn't indicate how to consume an AAR when printHowToConsumeAar is false", () async {
       final AndroidGradleBuilder builder = AndroidGradleBuilder(
         java: FakeJava(),

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -871,6 +871,7 @@ Gradle Crashed
 
     testUsingContext('can call custom gradle task getApplicationIdForVariant and parse the result', () async {
       final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        java: FakeJava(),
         logger: logger,
         processManager: processManager,
         fileSystem: fileSystem,
@@ -901,6 +902,7 @@ ApplicationId: com.example.id
 
     testUsingContext('can call custom gradle task getApplicationIdForVariant with unknown crash', () async {
       final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        java: FakeJava(),
         logger: logger,
         processManager: processManager,
         fileSystem: fileSystem,
@@ -931,6 +933,7 @@ unknown crash
 
     testUsingContext('can call custom gradle task getAppLinkDomainsForVariant and parse the result', () async {
       final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        java: FakeJava(),
         logger: logger,
         processManager: processManager,
         fileSystem: fileSystem,
@@ -963,6 +966,7 @@ Domain: example2.com
 
     testUsingContext('can call custom gradle task getAppLinkDomainsForVariant with unknown crash', () async {
       final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        java: FakeJava(),
         logger: logger,
         processManager: processManager,
         fileSystem: fileSystem,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -86,6 +86,10 @@ const List<VmServiceExpectation> kAttachIsolateExpectations =
     'service': kFlutterGetIOSUniversalLinkSettingsServiceName,
     'alias': kFlutterToolAlias,
   }),
+  FakeVmServiceRequest(method: 'registerService', args: <String, Object>{
+    'service': kFlutterGetAndroidAppLinkSettingsName,
+    'alias': kFlutterToolAlias,
+  }),
   FakeVmServiceRequest(
     method: 'streamListen',
     args: <String, Object>{

--- a/packages/flutter_tools/test/integration.shard/android_gradle_print_app_link_domains_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_print_app_link_domains_test.dart
@@ -1,0 +1,189 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:collection/collection.dart';
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/android/gradle_utils.dart'
+    show getGradlewFileName;
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:xml/xml.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+final XmlElement pureHttpIntentFilter = XmlElement(
+  XmlName('intent-filter'),
+  <XmlAttribute>[XmlAttribute(XmlName('autoVerify', 'android'), 'true')],
+  <XmlElement>[
+    XmlElement(
+      XmlName('action'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.action.VIEW')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.DEFAULT')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.BROWSABLE')],
+    ),
+    XmlElement(
+      XmlName('data'),
+      <XmlAttribute>[
+        XmlAttribute(XmlName('scheme', 'android'), 'http'),
+        XmlAttribute(XmlName('host', 'android'), 'pure-http.com'),
+      ],
+    ),
+  ],
+);
+
+final XmlElement nonHttpIntentFilter = XmlElement(
+  XmlName('intent-filter'),
+  <XmlAttribute>[XmlAttribute(XmlName('autoVerify', 'android'), 'true')],
+  <XmlElement>[
+    XmlElement(
+      XmlName('action'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.action.VIEW')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.DEFAULT')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.BROWSABLE')],
+    ),
+    XmlElement(
+      XmlName('data'),
+      <XmlAttribute>[
+        XmlAttribute(XmlName('scheme', 'android'), 'custom'),
+        XmlAttribute(XmlName('host', 'android'), 'custom.com'),
+      ],
+    ),
+  ],
+);
+
+final XmlElement hybridIntentFilter = XmlElement(
+  XmlName('intent-filter'),
+  <XmlAttribute>[XmlAttribute(XmlName('autoVerify', 'android'), 'true')],
+  <XmlElement>[
+    XmlElement(
+      XmlName('action'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.action.VIEW')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.DEFAULT')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.BROWSABLE')],
+    ),
+    XmlElement(
+      XmlName('data'),
+      <XmlAttribute>[
+        XmlAttribute(XmlName('scheme', 'android'), 'custom'),
+        XmlAttribute(XmlName('host', 'android'), 'hybrid.com'),
+      ],
+    ),
+    XmlElement(
+      XmlName('data'),
+      <XmlAttribute>[
+        XmlAttribute(XmlName('scheme', 'android'), 'http'),
+      ],
+    ),
+  ],
+);
+
+final XmlElement nonAutoVerifyIntentFilter = XmlElement(
+  XmlName('intent-filter'),
+  <XmlAttribute>[],
+  <XmlElement>[
+    XmlElement(
+      XmlName('action'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.action.VIEW')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.DEFAULT')],
+    ),
+    XmlElement(
+      XmlName('category'),
+      <XmlAttribute>[XmlAttribute(XmlName('name', 'android'), 'android.intent.category.BROWSABLE')],
+    ),
+    XmlElement(
+      XmlName('data'),
+      <XmlAttribute>[
+        XmlAttribute(XmlName('scheme', 'android'), 'http'),
+        XmlAttribute(XmlName('host', 'android'), 'non-auto-verify.com'),
+      ],
+    ),
+  ],
+);
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext(
+      'gradle task exists named print<mode>AppLinkDomains that prints app link domains', () async {
+    // Create a new flutter project.
+    final String flutterBin =
+    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      'create',
+      tempDir.path,
+      '--project-name=testapp',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+    // Adds intent filters for app links
+    final String androidManifestPath =  fileSystem.path.join(tempDir.path, 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
+    final io.File androidManifestFile = io.File(androidManifestPath);
+    final XmlDocument androidManifest = XmlDocument.parse(androidManifestFile.readAsStringSync());
+    final XmlElement activity = androidManifest.findAllElements('activity').first;
+    activity.children.add(pureHttpIntentFilter);
+    activity.children.add(nonHttpIntentFilter);
+    activity.children.add(hybridIntentFilter);
+    activity.children.add(nonAutoVerifyIntentFilter);
+    androidManifestFile.writeAsStringSync(androidManifest.toString(), flush: true);
+
+    // Ensure that gradle files exists from templates.
+    result = await processManager.run(<String>[
+      flutterBin,
+      'build',
+      'apk',
+      '--config-only',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+
+    final Directory androidApp = tempDir.childDirectory('android');
+    result = await processManager.run(<String>[
+      '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+      ...getLocalEngineArguments(),
+      '-q', // quiet output.
+      'printDebugAppLinkDomains',
+    ], workingDirectory: androidApp.path);
+
+    expect(result.exitCode, 0);
+
+    const List<String> expectedLines = <String>[
+      // Should only pick up the pure and hybrid intent filters
+      'Domain: pure-http.com',
+      'Domain: hybrid.com',
+    ];
+    final List<String> actualLines = LineSplitter.split(result.stdout.toString()).toList();
+    expect(const ListEquality<String>().equals(actualLines, expectedLines), isTrue);
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/android_gradle_print_application_id_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_print_application_id_test.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/android/gradle_utils.dart'
+    show getGradlewFileName;
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext(
+      'gradle task exists named print<mode>ApplicationId that prints application id', () async {
+    // Create a new flutter project.
+    final String flutterBin =
+    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      'create',
+      tempDir.path,
+      '--project-name=testapp',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+    // Ensure that gradle files exists from templates.
+    result = await processManager.run(<String>[
+      flutterBin,
+      'build',
+      'apk',
+      '--config-only',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+
+    final Directory androidApp = tempDir.childDirectory('android');
+    result = await processManager.run(<String>[
+      '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+      ...getLocalEngineArguments(),
+      '-q', // quiet output.
+      'printDebugApplicationId',
+    ], workingDirectory: androidApp.path);
+    // Verify that gradlew has a javaVersion task.
+    expect(result.exitCode, 0);
+    // Verify the format is a number on its own line.
+    const List<String> expectedLines = <String>[
+      'ApplicationId: com.example.testapp',
+    ];
+    final List<String> actualLines = LineSplitter.split(result.stdout.toString()).toList();
+    expect(const ListEquality<String>().equals(actualLines, expectedLines), isTrue);
+  });
+}

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -39,6 +39,12 @@ class FakeAndroidBuilder implements AndroidBuilder {
 
   @override
   Future<List<String>> getBuildVariants({required FlutterProject project}) async => const <String>[];
+
+  @override
+  Future<List<String>> getAppLinkDomainsForVariant(String buildVariant, {required FlutterProject project}) async => const <String>[];
+
+  @override
+  Future<String> getApplicationIdForVariant(String buildVariant, {required FlutterProject project}) async => '';
 }
 
 /// Creates a [FlutterProject] in a directory named [flutter_project]


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/120408

Added two gradle tasks, one for grabing the application id, one for grabbing app link domains.

Added a new vmservices to call these two gradle tasks and return the result.

The expected work flow is that the devtool will first call a vmservices to grab all avaliable build variants. It will then choose one of the build variant and call this new services to get application id and app link domains.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
