### PR TITLE
Fix for ticket #123315:  https://github.com/flutter/flutter/issues/123315

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -684,6 +684,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   void _actionHandler(_AdjustSliderIntent intent) {
     final _RenderSlider renderSlider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
     final TextDirection textDirection = Directionality.of(_renderObjectKey.currentContext!);
+    bool sliderIncreased = false;
+    widget.onChangeStart?.call(widget.value);
+
     switch (intent.type) {
       case _SliderAdjustmentType.right:
         switch (textDirection) {
@@ -691,18 +694,30 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
             renderSlider.decreaseAction();
           case TextDirection.ltr:
             renderSlider.increaseAction();
+            sliderIncreased = true;
         }
       case _SliderAdjustmentType.left:
         switch (textDirection) {
           case TextDirection.rtl:
             renderSlider.increaseAction();
+            sliderIncreased = true;
           case TextDirection.ltr:
             renderSlider.decreaseAction();
         }
       case _SliderAdjustmentType.up:
         renderSlider.increaseAction();
+        sliderIncreased = true;
       case _SliderAdjustmentType.down:
         renderSlider.decreaseAction();
+    }
+
+    if(sliderIncreased)
+    {
+      widget.onChangeEnd?.call(_lerp(clampDouble(renderSlider.value  + renderSlider._semanticActionUnit,0.0,1.0)));
+    }
+    else
+    {
+      widget.onChangeEnd?.call(_lerp(clampDouble(renderSlider.value  - renderSlider._semanticActionUnit,0.0,1.0)));
     }
   }
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2375,6 +2375,99 @@ void main() {
     expect(bottomSliderValue, 0.5, reason: 'unfocused bottom Slider unaffected by third arrowRight');
   });
 
+testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values', (WidgetTester tester) async
+{
+  const Map<ShortcutActivator, Intent> shortcuts = <ShortcutActivator, Intent>{
+      SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
+      SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(TraversalDirection.right),
+      SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
+      SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
+    };
+
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    double sliderValue = 0.5;
+    double onChangeStartVal = 0;
+    double onChangeEndVal = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Shortcuts(
+          shortcuts: shortcuts,
+          child: Material(
+            child: Center(
+              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                return MediaQuery(
+                  data: const MediaQueryData(navigationMode: NavigationMode.directional),
+                  child: Column(
+                    children: <Widget>[
+                      Slider(
+                        value: sliderValue,
+                        onChangeStart: (double newValue)
+                        {
+                          setState(() {
+                            onChangeStartVal = newValue;
+                          });
+                        },
+                        onChangeEnd: (double newValue)
+                        {
+                          setState(() {
+                            onChangeEndVal = newValue;
+                          });
+                        },
+                        onChanged: (double newValue) {
+                          setState(() {
+                            sliderValue = newValue;
+                          });
+                        },
+                        autofocus: true,
+                      ),
+                    ]
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(onChangeStartVal, 0.5, reason: 'the value onChangeStart was initial slider value as expected');
+    expect(sliderValue, 0.55, reason: 'slider increased after first arrowRight');
+    expect(onChangeEndVal, 0.55, reason: 'the value onChangeEnd increased as expected');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
+    expect(sliderValue, 0.50, reason: 'slider decreased after arrow left');
+    expect(onChangeEndVal, 0.50, reason: 'the value onChangeEnd decreased as expected');
+
+
+    for(int i =0; i<2; i++)
+    {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+    }
+
+    //Im rounding to fixed because the .6 segment always returns a long double whereas the others don't
+     expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
+     expect(num.parse(sliderValue.toStringAsFixed(1)), 0.6, reason: 'slider increased by two steps');
+     expect(num.parse(onChangeEndVal.toStringAsFixed(1)), 0.6, reason: 'the value onChangeEnd increased as expected');
+
+    for(int i =0; i<15; i++)
+    {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+    }
+
+     expect(onChangeStartVal, 0.0, reason: 'the slider should be at furthest left segment and cant move past zero down');
+     expect(sliderValue, 0.0, reason: 'slider decreased to zero as expected');
+     expect(onChangeEndVal, 0.0,reason: 'the value onChangeEnd decreased to zero as expected');
+
+});
+
   testWidgets('Slider gains keyboard focus when it gains semantics focus on Windows', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;


### PR DESCRIPTION
This PR makes changes to the _actionHandler function used on the Slider.Dart Widget for Key Events. It ensures onChangeStart is called at the beginning of a Key Event and onChangeEnd at the end of one. This PR includes a test for the changes made.
I ran all existing tests after my changes were made and they passed.

![image](https://user-images.githubusercontent.com/22826361/236305961-d24942b9-ab6b-4129-a4bc-bc8b11b51c38.png)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
