### PR TITLE
Add `--verbose` flags for flakey tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -163,7 +163,7 @@ void main() {
 
   testWithoutContext('--analyze-size is not supported in combination with --split-debug-info', () async {
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
-    final ProcessResult result = await processManager.run(<String>[
+    final List<String> command = <String>[
       flutterBin,
       'build',
       'apk',
@@ -171,7 +171,16 @@ void main() {
       '--analyze-size',
       '--target-platform=android-arm64',
       '--split-debug-info=infos',
-    ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
+    ];
+    final String workingDirectory =
+        fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
+    final ProcessResult result =
+        await processManager.run(command, workingDirectory: workingDirectory);
+
+    printOnFailure('workingDirectory: $workingDirectory');
+    printOnFailure('command:\n${command.join(" ")}');
+    printOnFailure('stdout:\n${result.stdout}');
+    printOnFailure('stderr:\n${result.stderr}');
 
     expect(result.stderr.toString(), contains('"--analyze-size" cannot be combined with "--split-debug-info"'));
 

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -25,6 +25,7 @@ void main() {
       flutterBin,
       'build',
       'apk',
+      '--verbose',
       '--analyze-size',
       '--target-platform=android-arm64',
     ], workingDirectory: workingDirectory);
@@ -61,6 +62,7 @@ void main() {
       flutterBin,
       'build',
       'ios',
+      '--verbose',
       '--analyze-size',
       '--code-size-directory=${codeSizeDir.path}',
       '--no-codesign',
@@ -99,6 +101,7 @@ void main() {
     final ProcessResult configResult = await processManager.run(<String>[
       flutterBin,
       'config',
+      '--verbose',
       '--enable-macos-desktop',
     ], workingDirectory: workingDirectory);
 
@@ -144,6 +147,7 @@ void main() {
       flutterBin,
       'build',
       'apk',
+      '--verbose',
       '--analyze-size',
       '--target-platform=android-arm64',
       '--debug',
@@ -163,6 +167,7 @@ void main() {
       flutterBin,
       'build',
       'apk',
+      '--verbose',
       '--analyze-size',
       '--target-platform=android-arm64',
       '--split-debug-info=infos',
@@ -181,6 +186,7 @@ void main() {
       flutterBin,
       'build',
       'apk',
+      '--verbose',
       '--analyze-size',
       '--code-size-directory=${tempDir.path}',
       '--target-platform=android-arm64',


### PR DESCRIPTION
Related to:
- https://github.com/flutter/flutter/issues/125512

Adding verbose flags to get printed out on error to help debug the cause of the flakey test

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
