### PR TITLE
[web] Make HtmlElementView more useful

### DIFF
--- a/packages/flutter/lib/src/services/dom.dart
+++ b/packages/flutter/lib/src/services/dom.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: public_member_api_docs
+
 // For now, we're hiding dart:js_interop's `@JS` to avoid a conflict with
 // package:js' `@JS`. In the future, we should be able to remove package:js
 // altogether and just import dart:js_interop.
@@ -272,6 +274,15 @@ extension DomElementExtension on DomElement {
 
   /// Returns the class list of this element.
   external DomTokenList get classList;
+
+  @JS('setAttribute')
+  external JSVoid _setAttribute(JSString name, JSString value);
+  JSVoid setAttribute(String name, String value) =>
+      _setAttribute(name.toJS, value.toJS);
+
+  @JS('removeAttribute')
+  external JSVoid _removeAttribute(JSString name);
+  void removeAttribute(String name) => _removeAttribute(name.toJS);
 }
 
 /// An HTML element in the DOM.
@@ -370,6 +381,13 @@ extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
     priority ??= '';
     _setProperty(propertyName.toJS, value.toJS, priority.toJS);
   }
+
+  @JS('removeProperty')
+  external JSString _removeProperty(JSString property);
+
+  /// Removes a CSS property by name.
+  String removeProperty(String property) =>
+      _removeProperty(property.toJS).toDart;
 }
 
 /// The HTML head element.

--- a/packages/flutter/lib/src/widgets/_html_element_controller_io.dart
+++ b/packages/flutter/lib/src/widgets/_html_element_controller_io.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+/// Controls an HTML platform view.
+///
+/// Used by [HtmlElementView] to create HTML elements and set their attributes
+/// and styles.
+class HtmlElementViewController extends PlatformViewController {
+  /// Creates a new [HtmlElementViewController] for a platform view of type
+  /// [viewType].
+  HtmlElementViewController(
+    this.viewId,
+    this.viewType,
+  );
+
+  @override
+  final int viewId;
+
+  /// The unique identifier for the HTML view type to be embedded by this widget.
+  ///
+  /// A PlatformViewFactory for this type must have been registered.
+  final String viewType;
+
+  /// Creates the HTML element.
+  Future<void> initialize() async {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  /// Sets [attributes] on the platform view's HTML element.
+  void setAttributes(Map<String, String> attributes) {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  /// Removes [attributeKeys] from the platform view's HTML element.
+  void removeAttributes(Iterable<String> attributeKeys) {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  /// Sets [styles] on the platform view's HTML element.
+  void setStyles(Map<String, String> styles) {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  /// Removes [styleKeys] from the platform view's HTML element.
+  void removeStyles(Iterable<String> styleKeys) {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  @override
+  Future<void> clearFocus() async {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  @override
+  Future<void> dispatchPointerEvent(PointerEvent event) async {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+
+  @override
+  Future<void> dispose() async {
+    throw UnimplementedError('This should not be reachable on non-web platforms');
+  }
+}

--- a/packages/flutter/lib/src/widgets/_html_element_controller_web.dart
+++ b/packages/flutter/lib/src/widgets/_html_element_controller_web.dart
@@ -1,0 +1,94 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui_web' as ui_web;
+
+import 'package:flutter/services.dart';
+
+import '../services/dom.dart';
+
+/// Controls an HTML platform view.
+///
+/// Used by [HtmlElementView] to create HTML elements and set their attributes
+/// and styles.
+class HtmlElementViewController extends PlatformViewController {
+  /// Creates a new [HtmlElementViewController] for a platform view of type
+  /// [viewType].
+  HtmlElementViewController(
+    this.viewId,
+    this.viewType,
+  );
+
+  @override
+  final int viewId;
+
+  /// The unique identifier for the HTML view type to be embedded by this widget.
+  ///
+  /// A PlatformViewFactory for this type must have been registered.
+  final String viewType;
+
+  bool _initialized = false;
+
+  DomElement _getElement() {
+    assert(_initialized);
+    return ui_web.platformViewRegistry.getViewById(viewId);
+  }
+
+  /// Creates the HTML element.
+  Future<void> initialize() async {
+    final Map<String, dynamic> args = <String, dynamic>{
+      'id': viewId,
+      'viewType': viewType,
+    };
+    await SystemChannels.platform_views.invokeMethod<void>('create', args);
+    _initialized = true;
+  }
+
+  /// Sets [attributes] on the platform view's HTML element.
+  void setAttributes(Map<String, String> attributes) {
+    final DomElement element = _getElement();
+    for (final MapEntry<String, String> attribute in attributes.entries) {
+      element.setAttribute(attribute.key, attribute.value);
+    }
+  }
+
+  /// Removes [attributeKeys] from the platform view's HTML element.
+  void removeAttributes(Iterable<String> attributeKeys) {
+    final DomElement element = _getElement();
+    attributeKeys.forEach(element.removeAttribute);
+  }
+
+  /// Sets [styles] on the platform view's HTML element.
+  void setStyles(Map<String, String> styles) {
+    final DomElement element = _getElement();
+    for (final MapEntry<String, String> style in styles.entries) {
+      element.style.setProperty(style.key, style.value);
+    }
+  }
+
+  /// Removes [styleKeys] from the platform view's HTML element.
+  void removeStyles(Iterable<String> styleKeys) {
+    final DomElement element = _getElement();
+    styleKeys.forEach(element.style.removeProperty);
+  }
+
+  @override
+  Future<void> clearFocus() async {
+    // Currently this does nothing on Flutter Web.
+    // TODO(het): Implement this. See https://github.com/flutter/flutter/issues/39496
+  }
+
+  @override
+  Future<void> dispatchPointerEvent(PointerEvent event) async {
+    // We do not dispatch pointer events to HTML views because they may contain
+    // cross-origin iframes, which only accept user-generated events.
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_initialized) {
+      await SystemChannels.platform_views.invokeMethod<void>('dispose', viewId);
+    }
+  }
+}


### PR DESCRIPTION
Add the ability to set html attributes and styles on the `HtmlElementView` widget. This makes the widget much more convenient to use and avoids the registration of multiple view factories unnecessarily (e.g. [pointer_interceptor](https://github.com/flutter/packages/blob/a0f8fd89af1a3e35343250ba7e2518b8b2d651cf/packages/pointer_interceptor/lib/src/web.dart#L69-L70)).

- [x] Depends on https://github.com/flutter/engine/pull/41877
- [ ] Depends on https://github.com/flutter/engine/pull/41784