### PR TITLE
 [Refactor] Fix style in example

### DIFF
--- a/examples/image_list/lib/main.dart
+++ b/examples/image_list/lib/main.dart
@@ -119,7 +119,7 @@ Future<void> main() async {
   runApp(MyApp(port));
 }
 
-const int IMAGES = 50;
+const int images = 50;
 
 @immutable
 class MyApp extends StatelessWidget {
@@ -159,7 +159,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 
   Widget createImage(final int index, final Completer<bool> completer) {
     return Image.network(
-        'https://localhost:${widget.port}/${_counter * IMAGES + index}',
+        'https://localhost:${widget.port}/${_counter * images + index}',
         frameBuilder: (
           BuildContext context,
           Widget child,
@@ -177,14 +177,14 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final List<AnimationController> controllers = <AnimationController>[
-      for (int i = 0; i < IMAGES; i++)
+      for (int i = 0; i < images; i++)
         AnimationController(
           duration: const Duration(milliseconds: 3600),
           vsync: this,
         )..repeat(),
     ];
     final List<Completer<bool>> completers = <Completer<bool>>[
-      for (int i = 0; i < IMAGES; i++)
+      for (int i = 0; i < images; i++)
         Completer<bool>(),
     ];
     final List<Future<bool>> futures = completers.map(
@@ -204,7 +204,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Row(children: createImageList(IMAGES, completers, controllers)),
+            Row(children: createImageList(images, completers, controllers)),
             const Text(
               'You have pushed the button this many times:',
             ),


### PR DESCRIPTION
Replaces #125616

I just fixed "IMAGES" to "images" in examples/image_list.
Currently, "PREFER uses the lower case of the constant name ".

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
