### PR TITLE
[Tool] Output help on 'flutter pub'

### DIFF
--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -123,7 +123,7 @@ class CustomDevicesCommand extends FlutterCommand {
 
   final CustomDevicesConfig _customDevicesConfig;
   final FeatureFlags _featureFlags;
-  final void Function(Object) _usagePrintFn;
+  final PrintFn _usagePrintFn;
 
   @override
   String get description {

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -18,8 +18,14 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
 
+/// The function signature of the [print] function.
+typedef PrintFn = void Function(Object?);
+
 class PackagesCommand extends FlutterCommand {
-  PackagesCommand() {
+  PackagesCommand({
+    PrintFn usagePrintFn = print,
+  }) : _usagePrintFn = usagePrintFn
+  {
     addSubcommand(PackagesGetCommand('get', "Get the current package's dependencies.", PubContext.pubGet));
     addSubcommand(PackagesGetCommand('upgrade', "Upgrade the current package's dependencies to latest versions.", PubContext.pubUpgrade));
     addSubcommand(PackagesGetCommand('add', 'Add a dependency to pubspec.yaml.', PubContext.pubAdd));
@@ -40,6 +46,8 @@ class PackagesCommand extends FlutterCommand {
     addSubcommand(PackagesPassthroughCommand());
   }
 
+  final PrintFn _usagePrintFn;
+
   @override
   final String name = 'pub';
 
@@ -54,6 +62,9 @@ class PackagesCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async => FlutterCommandResult.fail();
+
+  @override
+  void printUsage() => _usagePrintFn(usage);
 }
 
 class PackagesTestCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -171,13 +171,16 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
   @override
   Future<void> run(Iterable<String> args) {
-    // Have an invocation of 'build' print out it's sub-commands.
+    // Have invocations of 'build', 'custom-devices', and 'pub' print out
+    // their sub-commands.
     // TODO(ianh): Move this to the Build command itself somehow.
     if (args.length == 1) {
       if (args.first == 'build') {
         args = <String>['build', '-h'];
       } else if (args.first == 'custom-devices') {
         args = <String>['custom-devices', '-h'];
+      } else if (args.first == 'pub') {
+        args = <String>['pub', '-h'];
       }
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/pub_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/pub_test.dart
@@ -30,6 +30,20 @@ void main() {
     Cache.enableLocking();
   });
 
+  testUsingContext('pub shows help', () async {
+    Object? usage;
+    final PackagesCommand command = PackagesCommand(
+      usagePrintFn: (Object? object) => usage = object,
+    );
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+    await runner.run(<String>['pub']);
+
+    expect(usage, allOf(
+      contains('Commands for managing Flutter packages.'),
+      contains('Usage: flutter pub <subcommand> [arguments]'),
+    ));
+  });
+
   testUsingContext('pub get usage values are resilient to missing package config files before running "pub get"', () async {
     fileSystem.currentDirectory.childFile('pubspec.yaml').createSync();
     fileSystem.currentDirectory.childFile('.flutter-plugins').createSync();


### PR DESCRIPTION
This change makes `flutter pub` show the help usage:

```
PS > flutter pub
Commands for managing Flutter packages.

Global options:
-h, --help                  Print this usage information.
-v, --verbose               Noisy logging, including all shell commands executed.
                            If used with "--help", shows hidden options. If used with "flutter
                            doctor", shows additional diagnostic information. (Use "-vv" to force
                            verbose logging in those cases.)
-d, --device-id             Target device id or name (prefixes allowed).
    --version               Reports the version of this tool.
    --suppress-analytics    Suppress analytics reporting for the current CLI invocation.
    --disable-telemetry     Disable telemetry reporting when this command runs.

Usage: flutter pub <subcommand> [arguments]
-h, --help    Print this usage information.

Available subcommands:
  add         Add a dependency to pubspec.yaml.
  cache       Work with the Pub system cache.
  deps        Print package dependencies.
  downgrade   Downgrade packages in a Flutter project.
  get         Get the current package's dependencies.
  global      Work with Pub global packages.
  login       Log into pub.dev.
  logout      Log out of pub.dev.
  outdated    Analyze dependencies to find which ones can be upgraded.
  pub         Pass the remaining arguments to Dart's "pub" tool.
  publish     Publish the current package to pub.dartlang.org.
  remove      Removes a dependency from the current package.
  run         Run an executable from a package.
  test        Run the "test" package.
  token       Manage authentication tokens for hosted pub repositories.
  upgrade     Upgrade the current package's dependencies to latest versions.
  uploader    Manage uploaders for a package on pub.dev.
  version     Print Pub version.

Run "flutter help" to see global options.
```

Previously it showed an error message:

```
PS > flutter pub
Missing subcommand for "flutter pub".


Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.
```

Addresses https://github.com/flutter/flutter/issues/110025

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
