### PR TITLE
Fix platformLocation path and search dropping

### DIFF
--- a/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
@@ -99,11 +99,10 @@ class HashUrlStrategy extends ui_web.UrlStrategy {
   String prepareExternalUrl(String internalUrl) {
     // It's convention that if the hash path is empty, we omit the `#`; however,
     // if the empty URL is pushed it won't replace any existing fragment. So
-    // when the hash path is empty, we instead return the location's path and
+    // when the hash path is empty, we still return the location's path and
     // query.
-    return internalUrl.isEmpty
-        ? '${_platformLocation.pathname}${_platformLocation.search}'
-        : '#$internalUrl';
+    return '${_platformLocation.pathname}${_platformLocation.search}'
+        '${internalUrl.isEmpty ? '' : '#$internalUrl'}';
   }
 
   @override

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -46,6 +46,23 @@ void main() {
       location.hash = '#';
       expect(strategy.getPath(), '/');
     });
+
+    test('allows location path/search before fragment', () {
+      const String internalUrl = '/menu?foo=bar';
+      final HashUrlStrategy strategy = HashUrlStrategy(location);
+
+      location.pathname = '/';
+      expect(strategy.prepareExternalUrl(internalUrl), '/#/menu?foo=bar');
+
+      location.pathname = '/main';
+      expect(strategy.prepareExternalUrl(internalUrl), '/main#/menu?foo=bar');
+
+      location.search = '?foo=bar';
+      expect(
+        strategy.prepareExternalUrl(internalUrl),
+        '/main?foo=bar#/menu?foo=bar',
+      );
+    });
   });
 
   group('$PathUrlStrategy', () {


### PR DESCRIPTION
This PR fixes the dropping of both the `path` and `search` fields from the platform location in the URL when using Flutter Web and brings it in par with similar technologies (e.g. React Router).
It allows developers to keep the original path and/or search parameters in the URL, which are perfectly valid even while fragment routing is present.

**Example use case:**
Call a Flutter Web app with initial config parameters in the URL: 
`http://my-flutter.app/?skipIntro=true`

**Example:**
Before initial routing:
`http://localhost:45389/?foo=bar`
After routing:
`http://localhost:45389/#/menu`
After routing (with fix):
`http://localhost:45389/?foo=bar#menu`

Fixes #116415

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
