### PR TITLE
Remove dead code

### DIFF
--- a/dev/integration_tests/web_e2e_tests/lib/scroll_wheel_main.dart
+++ b/dev/integration_tests/web_e2e_tests/lib/scroll_wheel_main.dart
@@ -74,9 +74,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 abstract class DeltaMode {
-  static const int kPixel = 0x00;
   static const int kLine = 0x01;
-  static const int kPage = 0x02;
 }
 
 void dispatchMouseWheelEvent(int mouseX, int mouseY,

--- a/examples/api/lib/material/color_scheme/dynamic_content_color.0.dart
+++ b/examples/api/lib/material/color_scheme/dynamic_content_color.0.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 
 const Widget divider = SizedBox(height: 10);
 const double narrowScreenWidthThreshold = 400;
-const double imageSize = 150;
 
 void main() => runApp(DynamicColorExample());
 

--- a/examples/api/lib/widgets/magnifier/magnifier.0.dart
+++ b/examples/api/lib/widgets/magnifier/magnifier.0.dart
@@ -8,7 +8,6 @@ void main() => runApp(const MagnifierExampleApp());
 
 class MagnifierExampleApp extends StatefulWidget {
   const MagnifierExampleApp({super.key});
-  static const Size loupeSize = Size(200, 200);
 
   @override
   State<MagnifierExampleApp> createState() => _MagnifierExampleAppState();

--- a/examples/api/lib/widgets/text_magnifier/text_magnifier.0.dart
+++ b/examples/api/lib/widgets/text_magnifier/text_magnifier.0.dart
@@ -17,8 +17,6 @@ class TextMagnifierExampleApp extends StatelessWidget {
   final TextDirection textDirection;
   final String text;
 
-  static const Size loupeSize = Size(200, 200);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -64,7 +64,7 @@ void main() {
     );
 
     final List<PointerEvent> events = <PointerEvent>[];
-    binding.onHandleEvent = events.add;
+    TestGestureFlutterBinding.instance.onHandleEvent = events.add;
 
     GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 2);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -14,8 +14,6 @@ class TestIntent extends Intent {
 class TestAction extends Action<Intent> {
   TestAction();
 
-  static const LocalKey key = ValueKey<Type>(TestAction);
-
   int calls = 0;
 
   @override

--- a/packages/flutter/test/widgets/render_object_element_test.dart
+++ b/packages/flutter/test/widgets/render_object_element_test.dart
@@ -51,17 +51,6 @@ class SwapperWithProperOverrides extends Swapper {
   SwapperElement createElement() => SwapperElementWithProperOverrides(this);
 }
 
-class SwapperWithNoOverrides extends Swapper {
-  const SwapperWithNoOverrides({
-    super.key,
-    super.stable,
-    super.swapper,
-  });
-
-  @override
-  SwapperElement createElement() => SwapperElementWithNoOverrides(this);
-}
-
 abstract class SwapperElement extends RenderObjectElement {
   SwapperElement(Swapper super.widget);
 
@@ -145,10 +134,6 @@ class SwapperElementWithProperOverrides extends SwapperElement {
       renderObject.setSwapper(null, slot! as bool);
     }
   }
-}
-
-class SwapperElementWithNoOverrides extends SwapperElement {
-  SwapperElementWithNoOverrides(super.widget);
 }
 
 class RenderSwapper extends RenderBox {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1909,8 +1909,6 @@ class TestAction extends CallbackAction<Intent> {
   TestAction({
     required super.onInvoke,
   });
-
-  static const LocalKey key = ValueKey<Type>(TestAction);
 }
 
 /// An activator that accepts down events that has [key] as the logical key.

--- a/packages/flutter_localizations/test/widgets/translations_test.dart
+++ b/packages/flutter_localizations/test/widgets/translations_test.dart
@@ -2,13 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-final String rootDirectoryPath = Directory.current.path;
 
 void main() {
   for (final String language in kWidgetsSupportedLanguages) {


### PR DESCRIPTION
Dead code was flagged by `unreachable_from_main` lint, which is still experimental and not ready to be enabled yet.