### PR TITLE
When flutter reports an exception "thrown building Widget", tell users the exact widget type (will PR)

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5093,7 +5093,7 @@ abstract class ComponentElement extends Element {
       _debugDoingBuild = false;
       built = ErrorWidget.builder(
         _reportException(
-          ErrorDescription('building $this'),
+          ErrorDescription('building $this (widget type: ${_widget?.runtimeType})'),
           e,
           stack,
           informationCollector: () => <DiagnosticsNode>[
@@ -5113,7 +5113,7 @@ abstract class ComponentElement extends Element {
     } catch (e, stack) {
       built = ErrorWidget.builder(
         _reportException(
-          ErrorDescription('building $this'),
+          ErrorDescription('building $this (widget type: ${_widget?.runtimeType})'),
           e,
           stack,
           informationCollector: () => <DiagnosticsNode>[


### PR DESCRIPTION
Close https://github.com/flutter/flutter/issues/126306

Again, this is just the rough draft. If you think this looks acceptable I will add tests and polish the error message (e.g. avoid code duplication)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
