### PR TITLE
Fix `MultiChildLayoutDelegate.hasChild` doc

### DIFF
--- a/examples/api/lib/widgets/basic/custom_multi_child_layout.0.dart
+++ b/examples/api/lib/widgets/basic/custom_multi_child_layout.0.dart
@@ -6,10 +6,10 @@ import 'package:flutter/material.dart';
 
 /// Flutter code sample for [CustomMultiChildLayout].
 
-void main() => runApp(const ExampleApp());
+void main() => runApp(const CustomMultiChildLayoutApp());
 
-class ExampleApp extends StatelessWidget {
-  const ExampleApp({super.key});
+class CustomMultiChildLayoutApp extends StatelessWidget {
+  const CustomMultiChildLayoutApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +19,7 @@ class ExampleApp extends StatelessWidget {
         // see the layout change.
         textDirection: TextDirection.ltr,
         child: Scaffold(
-          body: ExampleWidget(),
+          body: CustomMultiChildLayoutExample(),
         ),
       ),
     );
@@ -82,8 +82,8 @@ class _CascadeLayoutDelegate extends MultiChildLayoutDelegate {
   }
 }
 
-class ExampleWidget extends StatelessWidget {
-  const ExampleWidget({super.key});
+class CustomMultiChildLayoutExample extends StatelessWidget {
+  const CustomMultiChildLayoutExample({super.key});
 
   static const Map<String, Color> _colors = <String, Color>{
     'Red': Colors.red,

--- a/examples/api/test/widgets/basic/custom_multi_child_layout.0_test.dart
+++ b/examples/api/test/widgets/basic/custom_multi_child_layout.0_test.dart
@@ -12,7 +12,7 @@ void main() {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
-          body: example.ExampleWidget(),
+          body: example.CustomMultiChildLayoutApp(),
         ),
       ),
     );
@@ -24,7 +24,7 @@ void main() {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
-          body: example.ExampleWidget(),
+          body: example.CustomMultiChildLayoutExample(),
         ),
       ),
     );
@@ -40,7 +40,7 @@ void main() {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
-          body: example.ExampleWidget(),
+          body: example.CustomMultiChildLayoutExample(),
         ),
       ),
     );

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -130,8 +130,8 @@ abstract class MultiChildLayoutDelegate {
   /// Call this from the [performLayout] method to determine which children
   /// are available, if the child list might vary.
   ///
-  /// Avoid calling this from [getSize] as the child list is not available
-  /// until layout size is determined.
+  /// This method cannot be called from [getSize] as the size is not allowed
+  /// to depend on the children.
   bool hasChild(Object childId) => _idToChild![childId] != null;
 
   /// Ask the child to update its layout within the limits specified by

--- a/packages/flutter/lib/src/rendering/custom_layout.dart
+++ b/packages/flutter/lib/src/rendering/custom_layout.dart
@@ -127,9 +127,11 @@ abstract class MultiChildLayoutDelegate {
 
   /// True if a non-null LayoutChild was provided for the specified id.
   ///
-  /// Call this from the [performLayout] or [getSize] methods to
-  /// determine which children are available, if the child list might
-  /// vary.
+  /// Call this from the [performLayout] method to determine which children
+  /// are available, if the child list might vary.
+  ///
+  /// Avoid calling this from [getSize] as the child list is not available
+  /// until layout size is determined.
   bool hasChild(Object childId) => _idToChild![childId] != null;
 
   /// Ask the child to update its layout within the limits specified by


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/115898

`hasChild` checks `_idToChild` map.  `_idToChild` is not assigned until `_callPerformLayout` is called.
So `hasChild` shouldn't be called in `getSize`.

https://github.com/flutter/flutter/blob/df789c9e76098e82f80f2c5de8b5560f360afa40/packages/flutter/lib/src/rendering/custom_layout.dart#L400-L404

Updated docs and example class names.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
