### PR TITLE
Add checkmark style to CupertinoRadio

### DIFF
--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -78,6 +78,7 @@ class CupertinoRadio<T> extends StatefulWidget {
     this.fillColor,
     this.focusColor,
     this.focusNode,
+    this.useCheckmarkStyle = false,
     this.autofocus = false,
   });
 
@@ -145,6 +146,12 @@ class CupertinoRadio<T> extends StatefulWidget {
   /// ** See code in examples/api/lib/cupertino/radio/cupertino_radio.toggleable.0.dart **
   /// {@end-tool}
   final bool toggleable;
+
+  /// Controls whether the radio displays in a checkbox style or the default iOS
+  /// radio style.
+  ///
+  /// Defaults to false.
+  final bool useCheckmarkStyle;
 
   /// The color to use when this radio button is selected.
   ///
@@ -263,7 +270,8 @@ class _CupertinoRadioState<T> extends State<CupertinoRadio<T>> with TickerProvid
           ..activeColor = downPosition != null ? effectiveActivePressedOverlayColor : effectiveActiveColor
           ..inactiveColor = effectiveInactiveColor
           ..fillColor = effectiveFillColor
-          ..value = value,
+          ..value = value
+          ..checkmarkStyle = widget.useCheckmarkStyle,
       ),
     );
   }
@@ -290,28 +298,64 @@ class _RadioPainter extends ToggleablePainter {
     notifyListeners();
   }
 
+  bool get checkmarkStyle => _checkmarkStyle;
+  bool _checkmarkStyle = false;
+  set checkmarkStyle(bool value) {
+    if(value == _checkmarkStyle) {
+      return;
+    }
+    _checkmarkStyle = value;
+    notifyListeners();
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
 
     final Offset center = (Offset.zero & size).center;
 
-    // Outer border
     final Paint paint = Paint()
-      ..color = inactiveColor
-      ..style = PaintingStyle.fill
-      ..strokeWidth = 0.1;
-    canvas.drawCircle(center, _kOuterRadius, paint);
+        ..color = inactiveColor
+        ..style = PaintingStyle.fill
+        ..strokeWidth = 0.1;
 
-    paint.style = PaintingStyle.stroke;
-    paint.color = CupertinoColors.inactiveGray;
-    canvas.drawCircle(center, _kOuterRadius, paint);
-
-    if (value ?? false) {
-      paint.style = PaintingStyle.fill;
-      paint.color = activeColor;
+    if (checkmarkStyle) {
+      if(value ?? false) {
+        final Path path = Path();
+        final Paint checkPaint = Paint()
+          ..color = activeColor
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2.5
+          ..strokeCap = StrokeCap.round;
+        // The ratios for the offsets below were found from looking at the checkbox
+        // examples on in the HIG docs. The distance from the needed point to the
+        // edge was measured, then devided by the total width.
+        final double width = _size.width;
+        final Offset origin = Offset(center.dx - (width/2), center.dy - (width/2));
+        final Offset start = Offset(width * 0.25, width * 0.52);
+        final Offset mid = Offset(width * 0.46, width * 0.75);
+        final Offset end = Offset(width * 0.72, width * 0.29);
+        path.moveTo(origin.dx + start.dx, origin.dy + start.dy);
+        path.lineTo(origin.dx + mid.dx, origin.dy + mid.dy);
+        canvas.drawPath(path, checkPaint);
+        path.moveTo(origin.dx + mid.dx, origin.dy + mid.dy);
+        path.lineTo(origin.dx + end.dx, origin.dy + end.dy);
+        canvas.drawPath(path, checkPaint);
+      }
+    } else {
+      // Outer border
       canvas.drawCircle(center, _kOuterRadius, paint);
-      paint.color = fillColor;
-      canvas.drawCircle(center, _kInnerRadius, paint);
+
+      paint.style = PaintingStyle.stroke;
+      paint.color = CupertinoColors.inactiveGray;
+      canvas.drawCircle(center, _kOuterRadius, paint);
+
+      if (value ?? false) {
+        paint.style = PaintingStyle.fill;
+        paint.color = activeColor;
+        canvas.drawCircle(center, _kOuterRadius, paint);
+        paint.color = fillColor;
+        canvas.drawCircle(center, _kInnerRadius, paint);
+      }
     }
 
     if (isFocused) {

--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -301,7 +301,7 @@ class _RadioPainter extends ToggleablePainter {
   bool get checkmarkStyle => _checkmarkStyle;
   bool _checkmarkStyle = false;
   set checkmarkStyle(bool value) {
-    if(value == _checkmarkStyle) {
+    if (value == _checkmarkStyle) {
       return;
     }
     _checkmarkStyle = value;
@@ -319,7 +319,7 @@ class _RadioPainter extends ToggleablePainter {
         ..strokeWidth = 0.1;
 
     if (checkmarkStyle) {
-      if(value ?? false) {
+      if (value ?? false) {
         final Path path = Path();
         final Paint checkPaint = Paint()
           ..color = activeColor

--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -324,16 +324,13 @@ class _RadioPainter extends ToggleablePainter {
         final Paint checkPaint = Paint()
           ..color = activeColor
           ..style = PaintingStyle.stroke
-          ..strokeWidth = 2.5
+          ..strokeWidth = 2
           ..strokeCap = StrokeCap.round;
-        // The ratios for the offsets below were found from looking at the checkbox
-        // examples on in the HIG docs. The distance from the needed point to the
-        // edge was measured, then devided by the total width.
         final double width = _size.width;
         final Offset origin = Offset(center.dx - (width/2), center.dy - (width/2));
         final Offset start = Offset(width * 0.25, width * 0.52);
         final Offset mid = Offset(width * 0.46, width * 0.75);
-        final Offset end = Offset(width * 0.72, width * 0.29);
+        final Offset end = Offset(width * 0.85, width * 0.29);
         path.moveTo(origin.dx + start.dx, origin.dy + start.dy);
         path.lineTo(origin.dx + mid.dx, origin.dy + mid.dy);
         canvas.drawPath(path, checkPaint);

--- a/packages/flutter/lib/src/cupertino/radio.dart
+++ b/packages/flutter/lib/src/cupertino/radio.dart
@@ -78,8 +78,8 @@ class CupertinoRadio<T> extends StatefulWidget {
     this.fillColor,
     this.focusColor,
     this.focusNode,
-    this.useCheckmarkStyle = false,
     this.autofocus = false,
+    this.useCheckmarkStyle = false,
   });
 
   /// The value represented by this radio button.

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -96,7 +96,8 @@ class Radio<T> extends StatefulWidget {
     this.visualDensity,
     this.focusNode,
     this.autofocus = false,
-  }) : _radioType = _RadioType.material;
+  }) : _radioType = _RadioType.material,
+       useAdaptiveCheckmarkStyle = false;
 
   /// Creates an adaptive [Radio] based on whether the target platform is iOS
   /// or macOS, following Material design's
@@ -110,6 +111,8 @@ class Radio<T> extends StatefulWidget {
   /// If a [CupertinoRadio] is created, the following parameters are ignored:
   /// [mouseCursor], [fillColor], [hoverColor], [overlayColor], [splashRadius],
   /// [materialTapTargetSize], [visualDensity].
+  ///
+  /// [useAdaptiveCheckmarkStyle] is used only if a [CupertinoRadio] is created.
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
   const Radio.adaptive({
@@ -129,6 +132,7 @@ class Radio<T> extends StatefulWidget {
     this.visualDensity,
     this.focusNode,
     this.autofocus = false,
+    this.useAdaptiveCheckmarkStyle = false
   }) : _radioType = _RadioType.adaptive;
 
   /// The value represented by this radio button.
@@ -345,6 +349,14 @@ class Radio<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
+  /// Controls wether the checkmark style is used in an iOS style radio.
+  ///
+  /// This property will only be used if [Radio.adaptive] shows the Cupertino
+  /// widget.
+  ///
+  /// Defaults to false.
+  final bool useAdaptiveCheckmarkStyle;
+
   final _RadioType _radioType;
 
   bool get _selected => value == groupValue;
@@ -427,6 +439,7 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
               focusColor: widget.focusColor,
               focusNode: widget.focusNode,
               autofocus: widget.autofocus,
+              useCheckmarkStyle: widget.useAdaptiveCheckmarkStyle,
             );
         }
     }

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -349,10 +349,11 @@ class Radio<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// Controls whether the checkmark style is used in an iOS style radio.
+  /// Controls whether the checkmark style is used in an iOS-style radio.
   ///
-  /// This property will only be used if [Radio.adaptive] shows the Cupertino
-  /// widget.
+  /// Only usable under the [Radio.adaptive] constructor. If set to true, on
+  /// Apple platforms the radio button will appear as an iOS styled checkmark.
+  /// Controls the [CupertinoRadio] through [CupertinoRadio.useCheckmarkStyle].
   ///
   /// Defaults to false.
   final bool useCupertinoCheckmarkStyle;

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -97,7 +97,7 @@ class Radio<T> extends StatefulWidget {
     this.focusNode,
     this.autofocus = false,
   }) : _radioType = _RadioType.material,
-       useAdaptiveCheckmarkStyle = false;
+       useCupertinoCheckmarkStyle = false;
 
   /// Creates an adaptive [Radio] based on whether the target platform is iOS
   /// or macOS, following Material design's
@@ -112,7 +112,7 @@ class Radio<T> extends StatefulWidget {
   /// [mouseCursor], [fillColor], [hoverColor], [overlayColor], [splashRadius],
   /// [materialTapTargetSize], [visualDensity].
   ///
-  /// [useAdaptiveCheckmarkStyle] is used only if a [CupertinoRadio] is created.
+  /// [useCupertinoCheckmarkStyle] is used only if a [CupertinoRadio] is created.
   ///
   /// The target platform is based on the current [Theme]: [ThemeData.platform].
   const Radio.adaptive({
@@ -132,7 +132,7 @@ class Radio<T> extends StatefulWidget {
     this.visualDensity,
     this.focusNode,
     this.autofocus = false,
-    this.useAdaptiveCheckmarkStyle = false
+    this.useCupertinoCheckmarkStyle = false
   }) : _radioType = _RadioType.adaptive;
 
   /// The value represented by this radio button.
@@ -349,13 +349,13 @@ class Radio<T> extends StatefulWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// Controls wether the checkmark style is used in an iOS style radio.
+  /// Controls whether the checkmark style is used in an iOS style radio.
   ///
   /// This property will only be used if [Radio.adaptive] shows the Cupertino
   /// widget.
   ///
   /// Defaults to false.
-  final bool useAdaptiveCheckmarkStyle;
+  final bool useCupertinoCheckmarkStyle;
 
   final _RadioType _radioType;
 
@@ -439,7 +439,7 @@ class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, Togg
               focusColor: widget.focusColor,
               focusNode: widget.focusNode,
               autofocus: widget.autofocus,
-              useCheckmarkStyle: widget.useAdaptiveCheckmarkStyle,
+              useCheckmarkStyle: widget.useCupertinoCheckmarkStyle,
             );
         }
     }

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -447,7 +447,7 @@ class RadioListTile<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget control;
+    final Widget control;
     switch (_radioType) {
       case _RadioType.material:
         control = Radio<T>(

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -189,6 +189,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
   }) : _radioType = _RadioType.material,
+       useAdaptiveCheckmarkStyle = false,
        assert(!isThreeLine || subtitle != null);
 
   /// Creates a combination of a list tile and a platform adaptive radio.
@@ -226,6 +227,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
+    this.useAdaptiveCheckmarkStyle = false,
   }) : _radioType = _RadioType.adaptive,
        assert(!isThreeLine || subtitle != null);
 
@@ -435,9 +437,17 @@ class RadioListTile<T> extends StatelessWidget {
 
   final _RadioType _radioType;
 
+  /// Determines wether or not to use the checkbox style for the [CupertinoRadio]
+  /// control.
+  ///
+  /// Only usuable under the [RadioListTile.adaptive] constructor. If set to
+  /// true, on Apple platforms the radio button will appear as an iOS styled
+  /// checkmark.
+  final bool useAdaptiveCheckmarkStyle;
+
   @override
   Widget build(BuildContext context) {
-    final Widget control;
+    Widget control;
     switch (_radioType) {
       case _RadioType.material:
         control = Radio<T>(
@@ -468,6 +478,7 @@ class RadioListTile<T> extends StatelessWidget {
           hoverColor: hoverColor,
           overlayColor: overlayColor,
           splashRadius: splashRadius,
+          useAdaptiveCheckmarkStyle: useAdaptiveCheckmarkStyle,
         );
     }
 

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -442,7 +442,10 @@ class RadioListTile<T> extends StatelessWidget {
   ///
   /// Only usable under the [RadioListTile.adaptive] constructor. If set to
   /// true, on Apple platforms the radio button will appear as an iOS styled
-  /// checkmark.
+  /// checkmark. Controls the [CupertinoRadio] through
+  /// [CupertinoRadio.useCheckmarkStyle].
+  ///
+  /// Defaults to false.
   final bool useCupertinoCheckmarkStyle;
 
   @override

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -189,7 +189,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
   }) : _radioType = _RadioType.material,
-       useAdaptiveCheckmarkStyle = false,
+       useCupertinoCheckmarkStyle = false,
        assert(!isThreeLine || subtitle != null);
 
   /// Creates a combination of a list tile and a platform adaptive radio.
@@ -227,7 +227,7 @@ class RadioListTile<T> extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
-    this.useAdaptiveCheckmarkStyle = false,
+    this.useCupertinoCheckmarkStyle = false,
   }) : _radioType = _RadioType.adaptive,
        assert(!isThreeLine || subtitle != null);
 
@@ -440,10 +440,10 @@ class RadioListTile<T> extends StatelessWidget {
   /// Determines wether or not to use the checkbox style for the [CupertinoRadio]
   /// control.
   ///
-  /// Only usuable under the [RadioListTile.adaptive] constructor. If set to
+  /// Only usable under the [RadioListTile.adaptive] constructor. If set to
   /// true, on Apple platforms the radio button will appear as an iOS styled
   /// checkmark.
-  final bool useAdaptiveCheckmarkStyle;
+  final bool useCupertinoCheckmarkStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -478,7 +478,7 @@ class RadioListTile<T> extends StatelessWidget {
           hoverColor: hoverColor,
           overlayColor: overlayColor,
           splashRadius: splashRadius,
-          useAdaptiveCheckmarkStyle: useAdaptiveCheckmarkStyle,
+          useCupertinoCheckmarkStyle: useCupertinoCheckmarkStyle,
         );
     }
 

--- a/packages/flutter/test/cupertino/radio_test.dart
+++ b/packages/flutter/test/cupertino/radio_test.dart
@@ -357,7 +357,6 @@ void main() {
         child: CupertinoRadio<int>(
           value: 1,
           groupValue: 1,
-          useCheckmarkStyle: false,
           onChanged: (int? i) { },
         ),
       ),

--- a/packages/flutter/test/cupertino/radio_test.dart
+++ b/packages/flutter/test/cupertino/radio_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -348,6 +349,62 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
     await tester.pumpAndSettle();
     expect(groupValue, equals(2));
+  });
+
+  testWidgets('Show a checkmark when useCheckmarkStyle is true', (WidgetTester tester) async {
+    await tester.pumpWidget(CupertinoApp(
+      home: Center(
+        child: CupertinoRadio<int>(
+          value: 1,
+          groupValue: 1,
+          useCheckmarkStyle: false,
+          onChanged: (int? i) { },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Has no checkmark when useCheckmarkStyle is false
+    expect(
+      tester.firstRenderObject<RenderBox>(find.byType(CupertinoRadio<int>)),
+      isNot(paints..path())
+    );
+
+    await tester.pumpWidget(CupertinoApp(
+      home: Center(
+        child: CupertinoRadio<int>(
+          value: 1,
+          groupValue: 2,
+          useCheckmarkStyle: true,
+          onChanged: (int? i) { },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Has no checkmark when group value doesn't match the value
+    expect(
+      tester.firstRenderObject<RenderBox>(find.byType(CupertinoRadio<int>)),
+      isNot(paints..path())
+    );
+
+    await tester.pumpWidget(CupertinoApp(
+      home: Center(
+        child: CupertinoRadio<int>(
+          value: 1,
+          groupValue: 1,
+          useCheckmarkStyle: true,
+          onChanged: (int? i) { },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Draws a path to show the checkmark when toggled on
+    expect(
+      tester.firstRenderObject<RenderBox>(find.byType(CupertinoRadio<int>)),
+      paints..path()
+    );
   });
 
   testWidgets('Do not crash when widget disappears while pointer is down', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes: #102813

Adds a checkmark style to the Cupertino Radio. Also allows the Radio.adaptive and RadioListTile.adaptive widgets to control whether they use the checkmark style for their Cupertino widgets or not.

This is how it looks in action:

https://github.com/flutter/flutter/assets/58190796/b409b270-42dd-404a-9350-d2c3e1d7fa4e



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
