### PR TITLE
Add `cpu: x86` dimension and xcode dependency for Mac_build_test targets

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -115,6 +115,8 @@ platform_properties:
     properties:
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14e222b"},
+          {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "apple_signing", "version": "version:2022_to_2023"}
         ]
       os: Mac-12

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -119,6 +119,7 @@ platform_properties:
         ]
       os: Mac-12
       device_type: none
+      cpu: x86
       xcode: 14e222b
   mac_android:
     properties:


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/111164.

My local LED was based on `cpu: x86` dimension and `xcode` dependency. But these are missed in the above PR, which caused test failure: https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_build_test%20flutter_gallery__transition_perf_e2e_ios/19/overview