### PR TITLE
Allow mixing in PreferredSizeWidget

### DIFF
--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -26,7 +26,7 @@ import 'framework.dart';
 // from being implemented, which is the exact opposite of the spirit of the
 // `avoid_implementing_value_types` lint.)
 // ignore: avoid_implementing_value_types
-abstract class PreferredSizeWidget implements Widget {
+abstract mixin class PreferredSizeWidget implements Widget {
   /// The size this widget would prefer if it were otherwise unconstrained.
   ///
   /// In many cases it's only necessary to define one preferred dimension.

--- a/packages/flutter/test/widgets/preferred_size_test.dart
+++ b/packages/flutter/test/widgets/preferred_size_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // ignore_for_file: unused_element
 
 // Regression test for https://github.com/flutter/flutter/issues/126512

--- a/packages/flutter/test/widgets/preferred_size_test.dart
+++ b/packages/flutter/test/widgets/preferred_size_test.dart
@@ -1,18 +1,156 @@
+// ignore_for_file: unused_element
+
 // Regression test for https://github.com/flutter/flutter/issues/126512
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 class _ExtendPreferredSizeWidget extends PreferredSizeWidget {
   @override
-  Size get preferredSize => Size.fromHeight(40);
+  Key? get key => null;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(40);
+
+  @override
+  Element createElement() {
+    throw UnimplementedError('createElement() is not implemented');
+  }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() => const <DiagnosticsNode>[];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {}
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) {
+    throw UnimplementedError('toDiagnosticsNode() is not implemented');
+  }
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return '';
+  }
+
+  @override
+  String toStringDeep({
+    String prefixLineOne = '',
+    String? prefixOtherLines,
+    TextTreeConfiguration? parentConfiguration,
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    return '';
+  }
+
+  @override
+  String toStringShallow({
+    String joiner = ', ',
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    return '';
+  }
+
+  @override
+  String toStringShort() => '';
 }
 
 class _ImplementPreferredSizeWidget implements PreferredSizeWidget {
   @override
-  Size get preferredSize => Size.fromHeight(40);
+  Key? get key => null;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(40);
+
+  @override
+  Element createElement() {
+    throw UnimplementedError('createElement() is not implemented');
+  }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() => const <DiagnosticsNode>[];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {}
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) {
+    throw UnimplementedError('toDiagnosticsNode() is not implemented');
+  }
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return '';
+  }
+
+  @override
+  String toStringDeep({
+    String prefixLineOne = '',
+    String? prefixOtherLines,
+    TextTreeConfiguration? parentConfiguration,
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    return '';
+  }
+
+  @override
+  String toStringShallow({
+    String joiner = ', ',
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    return '';
+  }
+
+  @override
+  String toStringShort() => '';
 }
 
 class _MixInPreferredSizeWidget with PreferredSizeWidget {
   @override
-  Size get preferredSize => Size.fromHeight(40);
+  Key? get key => null;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(40);
+
+  @override
+  Element createElement() {
+    throw UnimplementedError('createElement() is not implemented');
+  }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() => const <DiagnosticsNode>[];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {}
+
+  @override
+  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) {
+    throw UnimplementedError('toDiagnosticsNode() is not implemented');
+  }
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return '';
+  }
+
+  @override
+  String toStringDeep({
+    String prefixLineOne = '',
+    String? prefixOtherLines,
+    TextTreeConfiguration? parentConfiguration,
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    return '';
+  }
+
+  @override
+  String toStringShallow({
+    String joiner = ', ',
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    return '';
+  }
+
+  @override
+  String toStringShort() => '';
 }

--- a/packages/flutter/test/widgets/preferred_size_test.dart
+++ b/packages/flutter/test/widgets/preferred_size_test.dart
@@ -1,0 +1,18 @@
+// Regression test for https://github.com/flutter/flutter/issues/126512
+
+import 'package:flutter/widgets.dart';
+
+class _ExtendPreferredSizeWidget extends PreferredSizeWidget {
+  @override
+  Size get preferredSize => Size.fromHeight(40);
+}
+
+class _ImplementPreferredSizeWidget implements PreferredSizeWidget {
+  @override
+  Size get preferredSize => Size.fromHeight(40);
+}
+
+class _MixInPreferredSizeWidget with PreferredSizeWidget {
+  @override
+  Size get preferredSize => Size.fromHeight(40);
+}


### PR DESCRIPTION
Due to the migration to Dart 3.0, the PreferredSizeWidget was not able to be mixed in per the diagram at 
https://github.com/dart-lang/language/blob/main/accepted/future-releases/class-modifiers/feature-specification.md

Pre 3.0 this was still the case.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes #126512

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
