### PR TITLE
Fix `showDatePicker` in input mode throws an `ArgumentError`

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -884,7 +884,12 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
     if (day == null || day < 1 || day > _getDaysInMonth(year, month)) {
       return null;
     }
-    return DateTime(year, month, day);
+
+    try {
+      return DateTime(year, month, day);
+    } on ArgumentError {
+      return null;
+    }
   }
 
   @override

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -960,6 +960,34 @@ void main() {
         expect(find.text(errorInvalidText!), findsOneWidget);
       });
     });
+
+    testWidgets('Invalid entered text shows error on autovalidate', (WidgetTester tester) async {
+      // This is a regression test for https://github.com/flutter/flutter/issues/126397.
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        final TextField field = textField(tester);
+        field.controller!.clear();
+
+        // Enter some text to trigger autovalidate.
+        await tester.enterText(find.byType(TextField), 'xyz');
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Invalid format validation error should be shown.
+        expect(find.text('Invalid format.'), findsOneWidget);
+
+        // Clear the text.
+        field.controller!.clear();
+
+        // Enter an invalid date that is too long while autovalidate is still on.
+        await tester.enterText(find.byType(TextField), '10/05/2023666777889');
+        await tester.pump();
+
+        // Invalid format validation error should be shown.
+        expect(find.text('Invalid format.'), findsOneWidget);
+        // Should not throw an exception.
+        expect(tester.takeException(), null);
+      });
+    });
   });
 
   group('Semantics', () {

--- a/packages/flutter/test/material/localizations_test.dart
+++ b/packages/flutter/test/material/localizations_test.dart
@@ -187,4 +187,25 @@ void main() {
 
     expect(MaterialLocalizations.of(localizationsAvailable.currentContext!), isA<MaterialLocalizations>());
   });
+
+  testWidgets("parseCompactDate doesn't throw an exception on invalid text", (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/126397.
+    final GlobalKey localizations = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          key: localizations,
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+
+    final MaterialLocalizations materialLocalizations = MaterialLocalizations.of(localizations.currentContext!);
+    expect(materialLocalizations.parseCompactDate('10/05/2023'), isNotNull);
+    expect(tester.takeException(), null);
+
+    expect(materialLocalizations.parseCompactDate('10/05/2023666777889'), null);
+    expect(tester.takeException(), null);
+  });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/126397

The `parseCompactDate` method in `material_localizations.dart` with long text throws an argument error before the date picker could handle it to show a validation error while the date picker is on autovalidate.

This PR adds `try/catch` in the `parseCompactDate` to return null on the argument error.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
