### PR TITLE
Make dpr available during Scrollable disposal

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_context.dart
@@ -42,6 +42,10 @@ abstract class ScrollContext {
   /// The direction in which the widget scrolls.
   AxisDirection get axisDirection;
 
+  /// The [FlutterView.devicePixelRatio] of the view that the [Scrollable] this
+  /// [ScrollContext] is associated with is drawn into.
+  double get devicePixelRatio;
+
   /// Whether the contents of the widget should ignore [PointerEvent] inputs.
   ///
   /// Setting this value to true prevents the use from interacting with the

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -12,7 +12,6 @@ import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'framework.dart';
-import 'media_query.dart';
 import 'notification_listener.dart';
 import 'page_storage.dart';
 import 'scroll_activity.dart';
@@ -20,7 +19,6 @@ import 'scroll_context.dart';
 import 'scroll_metrics.dart';
 import 'scroll_notification.dart';
 import 'scroll_physics.dart';
-import 'view.dart';
 
 export 'scroll_activity.dart' show ScrollHoldController;
 
@@ -241,7 +239,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   }
 
   @override
-  double get devicePixelRatio => MediaQuery.maybeDevicePixelRatioOf(context.storageContext) ?? View.of(context.storageContext).devicePixelRatio;
+  double get devicePixelRatio => context.devicePixelRatio;
 
   /// Update the scroll position ([pixels]) to a given pixel value.
   ///

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -28,6 +28,7 @@ import 'scrollable_helpers.dart';
 import 'selectable_region.dart';
 import 'selection_container.dart';
 import 'ticker_provider.dart';
+import 'view.dart';
 import 'viewport.dart';
 
 export 'package:flutter/physics.dart' show Tolerance;
@@ -531,6 +532,10 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   TickerProvider get vsync => this;
 
   @override
+  double get devicePixelRatio => _devicePixelRatio;
+  late double _devicePixelRatio;
+
+  @override
   BuildContext? get notificationContext => _gestureDetectorKey.currentContext;
 
   @override
@@ -596,6 +601,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   @override
   void didChangeDependencies() {
     _mediaQueryGestureSettings = MediaQuery.maybeGestureSettingsOf(context);
+    _devicePixelRatio = MediaQuery.maybeDevicePixelRatioOf(context) ?? View.of(context).devicePixelRatio;
     _updatePosition();
     super.didChangeDependencies();
   }
@@ -980,7 +986,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<ScrollPosition>('position', position));
+    properties.add(DiagnosticsProperty<ScrollPosition>('position', _position));
     properties.add(DiagnosticsProperty<ScrollPhysics>('effective physics', _physics));
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126454.

In certain situations (see linked bug) the Scrollable needs access to the DPR of the View it is drawn into during disposal. Since inherited widget lookups are not allowed during disposal, we cannot look up the DPR dynamically in these situations. Instead, we have to cache the DPR when lookups are still allowed.