### PR TITLE
Fix crash from invalid ListWheelViewport assertion

### DIFF
--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
+import '../rendering/rendering_tester.dart';
 
 class SpyFixedExtentScrollController extends FixedExtentScrollController {
   /// Override for test visibility only.
@@ -526,6 +527,63 @@ void main() {
     await tester.pumpWidget(const SizedBox.expand());
     expect(controller.hasListeners, false);
     expect(controller.positions.length, 0);
+  });
+
+  testWidgets('Registers taps and does not crash with certain diameterRatio', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/126491
+
+    final List<int> children = List<int>.generate(100, (int index) => index);
+    final List<int> paintedChildren = <int>[];
+    final Set<int> tappedChildren = <int>{};
+
+    await tester.pumpWidget(CupertinoApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: Center(
+          child: SizedBox(
+            height: 120,
+            child: CupertinoPicker(
+              itemExtent: 55,
+              diameterRatio: 0.9,
+              onSelectedItemChanged: (int index) {},
+              children: children
+                .map<Widget>((int index) =>
+                  GestureDetector(
+                    key: ValueKey<int>(index),
+                    onTap: () {
+                      tappedChildren.add(index);
+                    },
+                    child: SizedBox(
+                      width: 55,
+                      height: 55,
+                      child: CustomPaint(
+                        painter: TestCallbackPainter(onPaint: () {
+                          paintedChildren.add(index);
+                        }),
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    // Children are painted two times for whatever reason
+    expect(paintedChildren, <int>[0, 1, 0, 1]);
+
+    // Expect hitting 0 and 1, which are painted
+    await tester.tap(find.byKey(const ValueKey<int>(0)));
+    expect(tappedChildren, const <int>[0]);
+
+    await tester.tap(find.byKey(const ValueKey<int>(1)));
+    expect(tappedChildren, const <int>[0, 1]);
+
+    // The third child is not painted, so is not hit
+    await tester.tap(find.byKey(const ValueKey<int>(2)), warnIfMissed: false);
+    expect(tappedChildren, const <int>[0, 1]);
   });
 
 }

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -1642,6 +1642,65 @@ void main() {
 
       expect(pageController.page, 1.0);
     });
+
+    testWidgets('ListWheelScrollView does not crash and does not allow taps on children that were laid out, but not painted', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/12649
+
+      final FixedExtentScrollController controller = FixedExtentScrollController();
+      final List<int> children = List<int>.generate(100, (int index) => index);
+      final List<int> paintedChildren = <int>[];
+      final Set<int> tappedChildren = <int>{};
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              height: 120,
+              child: ListWheelScrollView.useDelegate(
+                controller: controller,
+                physics: const FixedExtentScrollPhysics(),
+                diameterRatio: 0.9,
+                itemExtent: 55,
+                squeeze: 1.45,
+                childDelegate: ListWheelChildListDelegate(
+                  children: children
+                    .map((int index) => GestureDetector(
+                      key: ValueKey<int>(index),
+                      onTap: () {
+                        tappedChildren.add(index);
+                      },
+                      child: SizedBox(
+                        width: 55,
+                        height: 55,
+                        child: CustomPaint(
+                          painter: TestCallbackPainter(onPaint: () {
+                            paintedChildren.add(index);
+                          }),
+                        ),
+                      ),
+                    ))
+                    .toList(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(paintedChildren, <int>[0, 1]);
+
+      // Expect hitting 0 and 1, which are painted
+      await tester.tap(find.byKey(const ValueKey<int>(0)));
+      expect(tappedChildren, const <int>[0]);
+
+      await tester.tap(find.byKey(const ValueKey<int>(1)));
+      expect(tappedChildren, const <int>[0, 1]);
+
+      // The third child is not painted, so is not hit
+      await tester.tap(find.byKey(const ValueKey<int>(2)), warnIfMissed: false);
+      expect(tappedChildren, const <int>[0, 1]);
+    });
   });
 
   testWidgets('ListWheelScrollView creates only one opacity layer for all children', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126491

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
