### PR TITLE
Let `runAsync` allow re-entrance, or allow users to know whether it is already running async tasks

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -480,6 +480,11 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     Duration additionalTime = const Duration(milliseconds: 1000),
   });
 
+  /// Like [runAsync], but allow it to be re-enter.
+  Future<T?> runAsyncReentrant<T>(Future<T> Function() callback) {
+    return runningAsyncTasks ? callback() : runAsync(callback);
+  }
+
   /// Artificially calls dispatchLocalesChanged on the Widget binding,
   /// then flushes microtasks.
   ///

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -422,6 +422,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// [LiveTestWidgetsFlutterBinding] (tests running using `flutter run`).
   test_package.Timeout get defaultTestTimeout;
 
+  /// Is async tasks being run.
+  bool get runningAsyncTasks;
+
   /// The current time.
   ///
   /// In the automated test environment (`flutter test`), this is a fake clock
@@ -1201,6 +1204,9 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   Completer<void>? _pendingAsyncTasks;
 
   @override
+  bool get runningAsyncTasks => _pendingAsyncTasks != null;
+
+  @override
   Clock get clock {
     assert(inTest);
     return _clock!;
@@ -1700,6 +1706,9 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   bool _expectingFrameToReassemble = false;
   bool _viewNeedsPaint = false;
   bool _runningAsyncTasks = false;
+
+  @override
+  bool get runningAsyncTasks => _runningAsyncTasks;
 
   /// The strategy for [pump]ing and requesting new frames.
   ///


### PR DESCRIPTION
Close https://github.com/flutter/flutter/issues/126545

I will add tests if this looks roughly acceptable :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
