### PR TITLE
Increase test timeout for analyzer_benchmark to 60 minutes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -203,6 +203,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      test_timeout_secs: "3600"
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126451
