### PR TITLE
Add CrossAxisAlignment.stretchToMaxIntrinsic

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -184,6 +184,7 @@ enum CrossAxisAlignment {
   stretch,
 
   /// Require the children to match the largest intrinsic cross axis size.
+  /// This option is computationally expensive.
   ///
   /// This causes the constraints passed to the children to be tight in the
   /// cross axis.


### PR DESCRIPTION
This PR is adding CrossAxisAlignment.stretchToMaxIntrinsic to Flex to enable tightening cross axis constraints to the largest intrinsic height/width.

Fixes #126631 

1. CrossAxisAlignment.start
2. CrossAxisAlignment.stretchToMaxIntrinsic
![image](https://github.com/flutter/flutter/assets/71181265/39e005fc-7902-476c-a5de-69c8fc1484fb)
![image](https://github.com/flutter/flutter/assets/71181265/c5fdd42b-0ef9-46a1-b570-5383f2b0a603)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
