### PR TITLE
Fix ContinousRectangleBorder with a non zero width is too large

### DIFF
--- a/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/continuous_rectangle_border.dart
@@ -145,10 +145,14 @@ class ContinuousRectangleBorder extends OutlinedBorder {
       case BorderStyle.none:
         break;
       case BorderStyle.solid:
-        canvas.drawPath(
-          getOuterPath(rect, textDirection: textDirection),
-          side.toPaint(),
-        );
+        final Path outer = getOuterPath(rect, textDirection: textDirection);
+        final Path inner = getInnerPath(rect, textDirection: textDirection);
+        final Paint paint = Paint()..color = side.color;
+        canvas.saveLayer(rect, paint);
+        canvas.drawPath(outer, paint);
+        final Paint paintInner = Paint()..blendMode = BlendMode.srcOut;
+        canvas.drawPath(inner, paintInner);
+        canvas.restore();
     }
   }
 

--- a/packages/flutter/test/painting/continuous_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/continuous_rectangle_border_test.dart
@@ -249,4 +249,46 @@ void main() {
     );
   });
 
+  testWidgets('ContinuousRectangleBorder with non-zero width border', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/78855
+    const double borderWidth = 20.0;
+    const ContinuousRectangleBorder border = ContinuousRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(50.0)),
+      side: BorderSide(width: borderWidth),
+    );
+
+    const Rect outerRect = Rect.fromLTWH(10.0, 10.0, 100.0, 100.0);
+    final Rect innerRect = outerRect.deflate(borderWidth);
+
+    // Verify that the border is painted using two paths (outer and inner).
+    expect(
+      (Canvas canvas) => border.paint(canvas, outerRect),
+      paints
+        ..path(
+          // The middle of each side of outerRect should be included
+          includes: <Offset>[
+            outerRect.centerLeft,
+            outerRect.topCenter,
+            outerRect.centerRight,
+            outerRect.bottomCenter,
+          ],
+        )
+        ..path(
+          // The middle of each side of innerRect should be included
+          includes: <Offset>[
+            innerRect.centerLeft,
+            innerRect.topCenter,
+            innerRect.centerRight,
+            innerRect.bottomCenter,
+          ],
+          // The middle of each side of outerRect should be excluded
+          excludes: <Offset>[
+            outerRect.centerLeft,
+            outerRect.topCenter,
+            outerRect.centerRight,
+            outerRect.bottomCenter,
+          ],
+        ),
+    );
+  });
 }


### PR DESCRIPTION
## Description

This PR changes how `ContinousRectangleBorder` is painted to avoid painting the border outside of the given bounds.

**Before**
`ContinousRectangleBorder` was painted using `Canvas.drawPath` and a `Paint.strokeWidth` equals to the border side width. Doing so half of the border was painted outside the bounds.

**After**
`ContinousRectangleBorder` is painted using two calls to `Canvas.drawPath`, one for the outer path and one for the inner path. 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/102869

## Tests

Adds 1 test.

