### PR TITLE
Fix focus behavior and provided thumb and focus color aren't applied to Cupertino variant of `Switch.adaptive`

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -570,22 +570,22 @@ class Switch extends StatelessWidget {
 
   Widget _buildCupertinoSwitch(BuildContext context) {
     final Size size = _getSwitchSize(context);
-    return Focus(
-      focusNode: focusNode,
-      onFocusChange: onFocusChange,
-      autofocus: autofocus,
-      child: Container(
-        width: size.width, // Same size as the Material switch.
-        height: size.height,
-        alignment: Alignment.center,
-        child: CupertinoSwitch(
-          dragStartBehavior: dragStartBehavior,
-          value: value,
-          onChanged: onChanged,
-          activeColor: activeColor,
-          trackColor: inactiveTrackColor,
-          applyTheme: applyCupertinoTheme,
-        ),
+    return Container(
+      width: size.width, // Same size as the Material switch.
+      height: size.height,
+      alignment: Alignment.center,
+      child: CupertinoSwitch(
+        dragStartBehavior: dragStartBehavior,
+        value: value,
+        onChanged: onChanged,
+        activeColor: activeColor,
+        trackColor: inactiveTrackColor,
+        thumbColor: thumbColor?.resolve(<MaterialState>{}),
+        applyTheme: applyCupertinoTheme,
+        focusColor: focusColor,
+        focusNode: focusNode,
+        onFocusChange: onFocusChange,
+        autofocus: autofocus,
       ),
     );
   }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/126637
fixes https://github.com/flutter/flutter/issues/126669

##  ~~To be merged after https://github.com/flutter/flutter/pull/126684~~

### Description

1.  Fix the Cupertino variant of `Switch.adaptive` requires two tab key presses to focus.
2.  Fix `thumbColor` & `focusColor` aren't applied.

### Before
Requires two tab presses to focus. and `thumbColor` & `focusColor` aren't applied.

https://github.com/flutter/flutter/assets/48603081/24635551-0794-443f-8320-32fdaa5de57a


### After
Single tab key to focus (no additional focus node) and `thumbColor` & `focusColor` are applied.

https://github.com/flutter/flutter/assets/48603081/9bf42fd8-c7e0-475a-b933-192a94650b0c

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
