### PR TITLE
Fix copyWith method of ActionIconThemeData

### DIFF
--- a/packages/flutter/lib/src/material/action_icons_theme.dart
+++ b/packages/flutter/lib/src/material/action_icons_theme.dart
@@ -55,10 +55,10 @@ class ActionIconThemeData with Diagnosticable {
     WidgetBuilder? endDrawerButtonIconBuilder,
   }) {
     return ActionIconThemeData(
-      backButtonIconBuilder: backButtonIconBuilder ?? backButtonIconBuilder,
-      closeButtonIconBuilder: closeButtonIconBuilder ?? closeButtonIconBuilder,
-      drawerButtonIconBuilder: drawerButtonIconBuilder ?? drawerButtonIconBuilder,
-      endDrawerButtonIconBuilder: endDrawerButtonIconBuilder ?? endDrawerButtonIconBuilder,
+      backButtonIconBuilder: backButtonIconBuilder ?? this.backButtonIconBuilder,
+      closeButtonIconBuilder: closeButtonIconBuilder ?? this.closeButtonIconBuilder,
+      drawerButtonIconBuilder: drawerButtonIconBuilder ?? this.drawerButtonIconBuilder,
+      endDrawerButtonIconBuilder: endDrawerButtonIconBuilder ?? this.endDrawerButtonIconBuilder,
     );
   }
 

--- a/packages/flutter/test/material/action_icons_theme_test.dart
+++ b/packages/flutter/test/material/action_icons_theme_test.dart
@@ -15,6 +15,29 @@ void main() {
         const ActionIconThemeData().copyWith().hashCode);
   });
 
+  test('ActionIconThemeData copyWith to replace given fields with the new values', () {
+    const ActionIconThemeData a = ActionIconThemeData();
+    Widget buttonIconBuilder(BuildContext context) {
+      return const SizedBox();
+    }
+    expect(a, isNot(a.copyWith(backButtonIconBuilder: buttonIconBuilder)));
+    expect(a, isNot(a.copyWith(closeButtonIconBuilder: buttonIconBuilder)));
+    expect(a, isNot(a.copyWith(drawerButtonIconBuilder: buttonIconBuilder)));
+    expect(a, isNot(a.copyWith(endDrawerButtonIconBuilder: buttonIconBuilder)));
+
+    // To ensure that using blank copyWith on object that isn't
+    // `const ActionIconThemeData()` returns object with same values.
+    ActionIconThemeData b;
+    b = a.copyWith(backButtonIconBuilder: buttonIconBuilder);
+    expect(b, b.copyWith());
+    b = a.copyWith(closeButtonIconBuilder: buttonIconBuilder);
+    expect(b, b.copyWith());
+    b = a.copyWith(drawerButtonIconBuilder: buttonIconBuilder);
+    expect(b, b.copyWith());
+    b = a.copyWith(endDrawerButtonIconBuilder: buttonIconBuilder);
+    expect(b, b.copyWith());
+  });
+
   test('ActionIconThemeData defaults', () {
     const ActionIconThemeData themeData = ActionIconThemeData();
     expect(themeData.backButtonIconBuilder, null);

--- a/packages/flutter/test/material/action_icons_theme_test.dart
+++ b/packages/flutter/test/material/action_icons_theme_test.dart
@@ -15,27 +15,40 @@ void main() {
         const ActionIconThemeData().copyWith().hashCode);
   });
 
-  test('ActionIconThemeData copyWith to replace given fields with the new values', () {
-    const ActionIconThemeData a = ActionIconThemeData();
-    Widget buttonIconBuilder(BuildContext context) {
+  testWidgets('ActionIconThemeData copyWith overrides all properties', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/126762.
+    Widget originalButtonBuilder(BuildContext context) {
       return const SizedBox();
     }
-    expect(a, isNot(a.copyWith(backButtonIconBuilder: buttonIconBuilder)));
-    expect(a, isNot(a.copyWith(closeButtonIconBuilder: buttonIconBuilder)));
-    expect(a, isNot(a.copyWith(drawerButtonIconBuilder: buttonIconBuilder)));
-    expect(a, isNot(a.copyWith(endDrawerButtonIconBuilder: buttonIconBuilder)));
+    Widget newButtonBuilder(BuildContext context) {
+      return const Icon(Icons.add);
+    }
 
-    // To ensure that using blank copyWith on object that isn't
-    // `const ActionIconThemeData()` returns object with same values.
-    ActionIconThemeData b;
-    b = a.copyWith(backButtonIconBuilder: buttonIconBuilder);
-    expect(b, b.copyWith());
-    b = a.copyWith(closeButtonIconBuilder: buttonIconBuilder);
-    expect(b, b.copyWith());
-    b = a.copyWith(drawerButtonIconBuilder: buttonIconBuilder);
-    expect(b, b.copyWith());
-    b = a.copyWith(endDrawerButtonIconBuilder: buttonIconBuilder);
-    expect(b, b.copyWith());
+    // Create a ActionIconThemeData with all properties set.
+    final ActionIconThemeData original = ActionIconThemeData(
+      backButtonIconBuilder: originalButtonBuilder,
+      closeButtonIconBuilder: originalButtonBuilder,
+      drawerButtonIconBuilder: originalButtonBuilder,
+      endDrawerButtonIconBuilder: originalButtonBuilder,
+    );
+    // Check if the all properties are copied.
+    final ActionIconThemeData copy = original.copyWith();
+    expect(copy.backButtonIconBuilder, originalButtonBuilder);
+    expect(copy.closeButtonIconBuilder, originalButtonBuilder);
+    expect(copy.drawerButtonIconBuilder, originalButtonBuilder);
+    expect(copy.endDrawerButtonIconBuilder, originalButtonBuilder);
+
+    // Check if the properties are overriden.
+    final ActionIconThemeData overridden = original.copyWith(
+      backButtonIconBuilder: newButtonBuilder,
+      closeButtonIconBuilder: newButtonBuilder,
+      drawerButtonIconBuilder: newButtonBuilder,
+      endDrawerButtonIconBuilder: newButtonBuilder,
+    );
+    expect(overridden.backButtonIconBuilder, newButtonBuilder);
+    expect(overridden.closeButtonIconBuilder, newButtonBuilder);
+    expect(overridden.drawerButtonIconBuilder, newButtonBuilder);
+    expect(overridden.endDrawerButtonIconBuilder, newButtonBuilder);
   });
 
   test('ActionIconThemeData defaults', () {


### PR DESCRIPTION
Fixes copyWith method of ActionIconThemeData, now using blank copyWith on [ActionIconThemeData] object that isn't `const ActionIconThemeData()` returns object with same values.

*List which issues are fixed by this PR.*
Fixes https://github.com/flutter/flutter/issues/126762

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
