### PR TITLE
`Slider.onChangeStart` & `Slider.onChangeEnd` are not called on keyboard shortcuts

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -684,6 +684,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   void _actionHandler(_AdjustSliderIntent intent) {
     final _RenderSlider renderSlider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
     final TextDirection textDirection = Directionality.of(_renderObjectKey.currentContext!);
+    bool sliderIncreased = false;
+    widget.onChangeStart?.call(widget.value);
+
     switch (intent.type) {
       case _SliderAdjustmentType.right:
         switch (textDirection) {
@@ -691,18 +694,30 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
             renderSlider.decreaseAction();
           case TextDirection.ltr:
             renderSlider.increaseAction();
+            sliderIncreased = true;
         }
       case _SliderAdjustmentType.left:
         switch (textDirection) {
           case TextDirection.rtl:
             renderSlider.increaseAction();
+            sliderIncreased = true;
           case TextDirection.ltr:
             renderSlider.decreaseAction();
         }
       case _SliderAdjustmentType.up:
         renderSlider.increaseAction();
+        sliderIncreased = true;
       case _SliderAdjustmentType.down:
         renderSlider.decreaseAction();
+    }
+
+    if(sliderIncreased)
+    {
+      widget.onChangeEnd?.call(_lerp(clampDouble(renderSlider.value  + renderSlider._semanticActionUnit,0.0,1.0)));
+    }
+    else
+    {
+      widget.onChangeEnd?.call(_lerp(clampDouble(renderSlider.value  - renderSlider._semanticActionUnit,0.0,1.0)));
     }
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1820,7 +1820,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   double get currentValue {
-    return clampDouble(value , 0.0, 1.0);
+    return clampDouble(value, 0.0, 1.0);
   }
 
   double increaseValue() {

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -684,8 +684,6 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   void _actionHandler(_AdjustSliderIntent intent) {
     final _RenderSlider renderSlider = _renderObjectKey.currentContext!.findRenderObject()! as _RenderSlider;
     final TextDirection textDirection = Directionality.of(_renderObjectKey.currentContext!);
-    bool sliderIncreased = false;
-    widget.onChangeStart?.call(widget.value);
 
     switch (intent.type) {
       case _SliderAdjustmentType.right:
@@ -694,26 +692,19 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
             renderSlider.decreaseAction();
           case TextDirection.ltr:
             renderSlider.increaseAction();
-            sliderIncreased = true;
         }
       case _SliderAdjustmentType.left:
         switch (textDirection) {
           case TextDirection.rtl:
             renderSlider.increaseAction();
-            sliderIncreased = true;
           case TextDirection.ltr:
             renderSlider.decreaseAction();
         }
       case _SliderAdjustmentType.up:
         renderSlider.increaseAction();
-        sliderIncreased = true;
       case _SliderAdjustmentType.down:
         renderSlider.decreaseAction();
     }
-
-    final double changeUnit = renderSlider._semanticActionUnit;
-    final double sliderAdjustment = renderSlider.value + (sliderIncreased ? changeUnit : -changeUnit);
-    widget.onChangeEnd?.call(_lerp(clampDouble(sliderAdjustment,0.0,1.0)));
   }
 
   bool _focused = false;
@@ -1812,14 +1803,32 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void increaseAction() {
     if (isInteractive) {
-      onChanged!(clampDouble(value + _semanticActionUnit, 0.0, 1.0));
+      onChangeStart!(currentValue);
+      final double increase = increaseValue();
+      onChanged!(increase);
+      onChangeEnd!(increase);
     }
   }
 
   void decreaseAction() {
     if (isInteractive) {
-      onChanged!(clampDouble(value - _semanticActionUnit, 0.0, 1.0));
+      onChangeStart!(currentValue);
+      final double decrease = decreaseValue();
+      onChanged!(decrease);
+      onChangeEnd!(decrease);
     }
+  }
+
+  double get currentValue {
+    return clampDouble(value , 0.0, 1.0);
+  }
+
+  double increaseValue() {
+    return clampDouble(value + _semanticActionUnit, 0.0, 1.0);
+  }
+
+  double decreaseValue() {
+    return clampDouble(value - _semanticActionUnit, 0.0, 1.0);
   }
 }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -711,14 +711,9 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         renderSlider.decreaseAction();
     }
 
-    if(sliderIncreased)
-    {
-      widget.onChangeEnd?.call(_lerp(clampDouble(renderSlider.value  + renderSlider._semanticActionUnit,0.0,1.0)));
-    }
-    else
-    {
-      widget.onChangeEnd?.call(_lerp(clampDouble(renderSlider.value  - renderSlider._semanticActionUnit,0.0,1.0)));
-    }
+    final double changeUnit = renderSlider._semanticActionUnit;
+    final double sliderAdjustment = renderSlider.value + (sliderIncreased ? changeUnit : -changeUnit);
+    widget.onChangeEnd?.call(_lerp(clampDouble(sliderAdjustment,0.0,1.0)));
   }
 
   bool _focused = false;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2389,6 +2389,99 @@ void main() {
     expect(bottomSliderValue, 0.5, reason: 'unfocused bottom Slider unaffected by third arrowRight');
   });
 
+testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values', (WidgetTester tester) async
+{
+  const Map<ShortcutActivator, Intent> shortcuts = <ShortcutActivator, Intent>{
+      SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
+      SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(TraversalDirection.right),
+      SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
+      SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
+    };
+
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    double sliderValue = 0.5;
+    double onChangeStartVal = 0;
+    double onChangeEndVal = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Shortcuts(
+          shortcuts: shortcuts,
+          child: Material(
+            child: Center(
+              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                return MediaQuery(
+                  data: const MediaQueryData(navigationMode: NavigationMode.directional),
+                  child: Column(
+                    children: <Widget>[
+                      Slider(
+                        value: sliderValue,
+                        onChangeStart: (double newValue)
+                        {
+                          setState(() {
+                            onChangeStartVal = newValue;
+                          });
+                        },
+                        onChangeEnd: (double newValue)
+                        {
+                          setState(() {
+                            onChangeEndVal = newValue;
+                          });
+                        },
+                        onChanged: (double newValue) {
+                          setState(() {
+                            sliderValue = newValue;
+                          });
+                        },
+                        autofocus: true,
+                      ),
+                    ]
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(onChangeStartVal, 0.5, reason: 'the value onChangeStart was initial slider value as expected');
+    expect(sliderValue, 0.55, reason: 'slider increased after first arrowRight');
+    expect(onChangeEndVal, 0.55, reason: 'the value onChangeEnd increased as expected');
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pumpAndSettle();
+    expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
+    expect(sliderValue, 0.50, reason: 'slider decreased after arrow left');
+    expect(onChangeEndVal, 0.50, reason: 'the value onChangeEnd decreased as expected');
+
+
+    for(int i =0; i<2; i++)
+    {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pumpAndSettle();
+    }
+
+    //Im rounding to fixed because the .6 segment always returns a long double whereas the others don't
+     expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
+     expect(num.parse(sliderValue.toStringAsFixed(1)), 0.6, reason: 'slider increased by two steps');
+     expect(num.parse(onChangeEndVal.toStringAsFixed(1)), 0.6, reason: 'the value onChangeEnd increased as expected');
+
+    for(int i =0; i<15; i++)
+    {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pumpAndSettle();
+    }
+
+     expect(onChangeStartVal, 0.0, reason: 'the slider should be at furthest left segment and cant move past zero down');
+     expect(sliderValue, 0.0, reason: 'slider decreased to zero as expected');
+     expect(onChangeEndVal, 0.0,reason: 'the value onChangeEnd decreased to zero as expected');
+
+});
+
   testWidgets('Slider gains keyboard focus when it gains semantics focus on Windows', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2125,17 +2125,29 @@ void main() {
 
   testWidgets('Slider can be incremented and decremented by keyboard shortcuts - LTR', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-    double value = 0.5;
+    double startValue = 0.0;
+    double currentValue = 0.5;
+    double endValue = 0.0;
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Center(
             child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
               return Slider(
-                value: value,
+                value: currentValue,
+                onChangeStart: (double newValue) {
+                  setState(() {
+                    startValue = newValue;
+                  });
+                },
                 onChanged: (double newValue) {
                   setState(() {
-                    value = newValue;
+                    currentValue = newValue;
+                  });
+                },
+                onChangeEnd: (double newValue) {
+                  setState(() {
+                    endValue = newValue;
                   });
                 },
                 autofocus: true,
@@ -2149,34 +2161,54 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
-    expect(value, 0.55);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.55);
+    expect(endValue, 0.55);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.55);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
-    expect(value, 0.55);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.55);
+    expect(endValue, 0.55);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.55);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android,  TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows }));
 
   testWidgets('Slider can be incremented and decremented by keyboard shortcuts - LTR', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-    double value = 0.5;
+    double startValue = 0.0;
+    double currentValue = 0.5;
+    double endValue = 0.0;
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
           child: Center(
             child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
               return Slider(
-                value: value,
+                value: currentValue,
+                onChangeStart: (double newValue) {
+                  setState(() {
+                    startValue = newValue;
+                  });
+                },
                 onChanged: (double newValue) {
                   setState(() {
-                    value = newValue;
+                    currentValue = newValue;
+                  });
+                },
+                onChangeEnd: (double newValue) {
+                  setState(() {
+                    endValue = newValue;
                   });
                 },
                 autofocus: true,
@@ -2190,24 +2222,34 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
-    expect(value, 0.6);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.6);
+    expect(endValue, 0.6);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.6);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
-    expect(value, 0.6);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.6);
+    expect(endValue, 0.6);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.6);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Slider can be incremented and decremented by keyboard shortcuts - RTL', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-    double value = 0.5;
+    double startValue = 0.0;
+    double currentValue = 0.5;
+    double endValue = 0.0;
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -2216,10 +2258,20 @@ void main() {
               return Directionality(
                 textDirection: TextDirection.rtl,
                 child: Slider(
-                  value: value,
+                  value: currentValue,
+                  onChangeStart: (double newValue) {
+                    setState(() {
+                      startValue = newValue;
+                    });
+                  },
                   onChanged: (double newValue) {
                     setState(() {
-                      value = newValue;
+                      currentValue = newValue;
+                    });
+                  },
+                  onChangeEnd: (double newValue) {
+                    setState(() {
+                      endValue = newValue;
                     });
                   },
                   autofocus: true,
@@ -2234,24 +2286,34 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
-    expect(value, 0.45);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.45);
+    expect(endValue, 0.45);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.45);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
-    expect(value, 0.55);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.55);
+    expect(endValue, 0.55);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.55);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android,  TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows }));
 
   testWidgets('Slider can be incremented and decremented by keyboard shortcuts - RTL', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-    double value = 0.5;
+    double startValue = 0.0;
+    double currentValue = 0.5;
+    double endValue = 0.0;
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -2260,10 +2322,20 @@ void main() {
               return Directionality(
                 textDirection: TextDirection.rtl,
                 child: Slider(
-                  value: value,
+                  value: currentValue,
+                  onChangeStart: (double newValue) {
+                    setState(() {
+                      startValue = newValue;
+                    });
+                  },
                   onChanged: (double newValue) {
                     setState(() {
-                      value = newValue;
+                      currentValue = newValue;
+                    });
+                  },
+                  onChangeEnd: (double newValue) {
+                    setState(() {
+                      endValue = newValue;
                     });
                   },
                   autofocus: true,
@@ -2278,19 +2350,27 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
-    expect(value, 0.4);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.4);
+    expect(endValue, 0.4);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.4);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
-    expect(value, 0.6);
+    expect(startValue, 0.5);
+    expect(currentValue, 0.6);
+    expect(endValue, 0.6);
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
-    expect(value, 0.5);
+    expect(startValue, 0.6);
+    expect(currentValue, 0.5);
+    expect(endValue, 0.5);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('In directional nav, Slider can be navigated out of by using up and down arrows', (WidgetTester tester) async {
@@ -2388,153 +2468,6 @@ void main() {
     expect(topSliderValue, 0.5, reason: 'focused top Slider decreased after third arrowRight');
     expect(bottomSliderValue, 0.5, reason: 'unfocused bottom Slider unaffected by third arrowRight');
   });
-
-  Map<ShortcutActivator, Intent> setUpKeyShortcuts()
-  {
-    return const <ShortcutActivator, Intent>{
-      SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
-      SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(TraversalDirection.right),
-      SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
-      SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
-    };
-  }
-
-testWidgets('Slider calls onChangeStart and onChangeEnd when adjusted with a single press of arrow key', (WidgetTester tester) async
-{
-    final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
-    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-    double sliderValue = 0.5;
-    double onChangeStartVal = 0;
-    double onChangeEndVal = 0;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Shortcuts(
-          shortcuts: shortcuts,
-          child: Material(
-            child: Center(
-              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-                return MediaQuery(
-                  data: const MediaQueryData(navigationMode: NavigationMode.directional),
-                  child: Column(
-                    children: <Widget>[
-                      Slider(
-                        value: sliderValue,
-                        onChangeStart: (double newValue)
-                        {
-                          setState(() {
-                            onChangeStartVal = newValue;
-                          });
-                        },
-                        onChangeEnd: (double newValue)
-                        {
-                          setState(() {
-                            onChangeEndVal = newValue;
-                          });
-                        },
-                        onChanged: (double newValue) {
-                          setState(() {
-                            sliderValue = newValue;
-                          });
-                        },
-                        autofocus: true,
-                      ),
-                    ]
-                  ),
-                );
-              }),
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    await tester.pumpAndSettle();
-    expect(onChangeStartVal, 0.5, reason: 'the value onChangeStart was initial slider value, as expected');
-    expect(sliderValue, 0.55, reason: 'slider increased after first arrowRight');
-    expect(onChangeEndVal, 0.55, reason: 'the value onChangeEnd increased as expected');
-
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-    await tester.pumpAndSettle();
-    expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
-    expect(sliderValue, 0.50, reason: 'slider decreased after arrow left');
-    expect(onChangeEndVal, 0.50, reason: 'the value onChangeEnd decreased as expected');
-});
-
-testWidgets('Slider calls onChangeStart and onChangeEnd when adjusted with multiple presses of arrow keys', (WidgetTester tester) async
-{
-    final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
-    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-    double sliderValue = 0.5;
-    double onChangeStartVal = 0;
-    double onChangeEndVal = 0;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Shortcuts(
-          shortcuts: shortcuts,
-          child: Material(
-            child: Center(
-              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-                return MediaQuery(
-                  data: const MediaQueryData(navigationMode: NavigationMode.directional),
-                  child: Column(
-                    children: <Widget>[
-                      Slider(
-                        value: sliderValue,
-                        onChangeStart: (double newValue)
-                        {
-                          setState(() {
-                            onChangeStartVal = newValue;
-                          });
-                        },
-                        onChangeEnd: (double newValue)
-                        {
-                          setState(() {
-                            onChangeEndVal = newValue;
-                          });
-                        },
-                        onChanged: (double newValue) {
-                          setState(() {
-                            sliderValue = newValue;
-                          });
-                        },
-                        autofocus: true,
-                      ),
-                    ]
-                  ),
-                );
-              }),
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    for(int i =0; i<2; i++)
-    {
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.pumpAndSettle();
-    }
-
-    //Im rounding to fixed because the .6 segment always returns a long double whereas the others don't
-     expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change started');
-     expect(num.parse(sliderValue.toStringAsFixed(1)), 0.6, reason: 'slider increased by two steps');
-     expect(num.parse(onChangeEndVal.toStringAsFixed(1)), 0.6, reason: 'the value onChangeEnd increased, as expected');
-
-    for(int i =0; i<15; i++)
-    {
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      await tester.pumpAndSettle();
-    }
-
-     expect(onChangeStartVal, 0.0, reason: 'the slider should be at furthest left segment and cant move past zero ');
-     expect(sliderValue, 0.0, reason: 'slider decreased to zero as expected');
-     expect(onChangeEndVal, 0.0,reason: 'the value onChangeEnd decreased to zero as expected');
-});
 
   testWidgets('Slider gains keyboard focus when it gains semantics focus on Windows', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2402,7 +2402,6 @@ void main() {
 testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values on single event calls', (WidgetTester tester) async
 {
     final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
-
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     double sliderValue = 0.5;
     double onChangeStartVal = 0;
@@ -2462,13 +2461,11 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
     expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
     expect(sliderValue, 0.50, reason: 'slider decreased after arrow left');
     expect(onChangeEndVal, 0.50, reason: 'the value onChangeEnd decreased as expected');
-
 });
 
 testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values on multiple event calls', (WidgetTester tester) async
 {
     final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
-
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     double sliderValue = 0.5;
     double onChangeStartVal = 0;
@@ -2537,7 +2534,6 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
      expect(onChangeStartVal, 0.0, reason: 'the slider should be at furthest left segment and cant move past zero down');
      expect(sliderValue, 0.0, reason: 'slider decreased to zero as expected');
      expect(onChangeEndVal, 0.0,reason: 'the value onChangeEnd decreased to zero as expected');
-
 });
 
   testWidgets('Slider gains keyboard focus when it gains semantics focus on Windows', (WidgetTester tester) async {

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2399,7 +2399,7 @@ void main() {
     };
   }
 
-testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values on single event calls', (WidgetTester tester) async
+testWidgets('Slider calls onChangeStart and onChangeEnd when adjusted with a single press of arrow key', (WidgetTester tester) async
 {
     final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
@@ -2452,7 +2452,7 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
-    expect(onChangeStartVal, 0.5, reason: 'the value onChangeStart was initial slider value as expected');
+    expect(onChangeStartVal, 0.5, reason: 'the value onChangeStart was initial slider value, as expected');
     expect(sliderValue, 0.55, reason: 'slider increased after first arrowRight');
     expect(onChangeEndVal, 0.55, reason: 'the value onChangeEnd increased as expected');
 
@@ -2463,7 +2463,7 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
     expect(onChangeEndVal, 0.50, reason: 'the value onChangeEnd decreased as expected');
 });
 
-testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values on multiple event calls', (WidgetTester tester) async
+testWidgets('Slider calls onChangeStart and onChangeEnd when adjusted with multiple presses of arrow keys', (WidgetTester tester) async
 {
     final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
@@ -2521,9 +2521,9 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
     }
 
     //Im rounding to fixed because the .6 segment always returns a long double whereas the others don't
-     expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change ended');
+     expect(onChangeStartVal, 0.55, reason: 'the value onChangeStart should be where last change started');
      expect(num.parse(sliderValue.toStringAsFixed(1)), 0.6, reason: 'slider increased by two steps');
-     expect(num.parse(onChangeEndVal.toStringAsFixed(1)), 0.6, reason: 'the value onChangeEnd increased as expected');
+     expect(num.parse(onChangeEndVal.toStringAsFixed(1)), 0.6, reason: 'the value onChangeEnd increased, as expected');
 
     for(int i =0; i<15; i++)
     {
@@ -2531,7 +2531,7 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
       await tester.pumpAndSettle();
     }
 
-     expect(onChangeStartVal, 0.0, reason: 'the slider should be at furthest left segment and cant move past zero down');
+     expect(onChangeStartVal, 0.0, reason: 'the slider should be at furthest left segment and cant move past zero ');
      expect(sliderValue, 0.0, reason: 'slider decreased to zero as expected');
      expect(onChangeEndVal, 0.0,reason: 'the value onChangeEnd decreased to zero as expected');
 });

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -2389,14 +2389,19 @@ void main() {
     expect(bottomSliderValue, 0.5, reason: 'unfocused bottom Slider unaffected by third arrowRight');
   });
 
-testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values', (WidgetTester tester) async
-{
-  const Map<ShortcutActivator, Intent> shortcuts = <ShortcutActivator, Intent>{
+  Map<ShortcutActivator, Intent> setUpKeyShortcuts()
+  {
+    return const <ShortcutActivator, Intent>{
       SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
       SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(TraversalDirection.right),
       SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
       SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
     };
+  }
+
+testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values on single event calls', (WidgetTester tester) async
+{
+    final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
 
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     double sliderValue = 0.5;
@@ -2458,6 +2463,59 @@ testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd
     expect(sliderValue, 0.50, reason: 'slider decreased after arrow left');
     expect(onChangeEndVal, 0.50, reason: 'the value onChangeEnd decreased as expected');
 
+});
+
+testWidgets('When adjusting slider with arrow keys onChangeStart and onChangeEnd callbacks are activated and display correct values on multiple event calls', (WidgetTester tester) async
+{
+    final Map<ShortcutActivator, Intent> shortcuts = setUpKeyShortcuts();
+
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    double sliderValue = 0.5;
+    double onChangeStartVal = 0;
+    double onChangeEndVal = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Shortcuts(
+          shortcuts: shortcuts,
+          child: Material(
+            child: Center(
+              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                return MediaQuery(
+                  data: const MediaQueryData(navigationMode: NavigationMode.directional),
+                  child: Column(
+                    children: <Widget>[
+                      Slider(
+                        value: sliderValue,
+                        onChangeStart: (double newValue)
+                        {
+                          setState(() {
+                            onChangeStartVal = newValue;
+                          });
+                        },
+                        onChangeEnd: (double newValue)
+                        {
+                          setState(() {
+                            onChangeEndVal = newValue;
+                          });
+                        },
+                        onChanged: (double newValue) {
+                          setState(() {
+                            sliderValue = newValue;
+                          });
+                        },
+                        autofocus: true,
+                      ),
+                    ]
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
 
     for(int i =0; i<2; i++)
     {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/123315
--------

This PR makes changes to the _actionHandler function used on the Slider.Dart Widget for Key Events. It ensures onChangeStart is called at the beginning of a Key Event and onChangeEnd at the end of one. This PR includes a test for the changes made.
I ran all existing tests after my changes were made and they passed.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
