### PR TITLE
Move `Mac_build_test flutter_gallery__transition_perf_e2e_ios` to prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3925,18 +3925,8 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
 
-  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: flutter_gallery__transition_perf_e2e_ios
-
   - name: Mac_build_test flutter_gallery__transition_perf_e2e_ios
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true # New target: https://github.com/flutter/flutter/pull/111164
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
Target `Mac_build_test flutter_gallery__transition_perf_e2e_ios` was enabled in staging: https://github.com/flutter/flutter/pull/111164, and it has passed more than 50 runs: https://ci.chromium.org/p/flutter/builders/staging/Mac_build_test%20flutter_gallery__transition_perf_e2e_ios?limit=50. 

Manually enabling it in prod and removing the old `Mac_ios flutter_gallery__transition_perf_e2e_ios`.

The `Mac_build_test` one does the same thing as `Mac_ios` one, but separating build and test steps in separate targets.

Context: https://github.com/flutter/flutter/issues/103542