### PR TITLE
Fix DataTableThemeData.copyWith handling of dataRowHeight

### DIFF
--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -137,10 +137,14 @@ class DataTableThemeData with Diagnosticable {
     MaterialStateProperty<MouseCursor?>? headingCellCursor,
     MaterialStateProperty<MouseCursor?>? dataRowCursor,
   }) {
+    assert(dataRowHeight == null || (dataRowMinHeight == null && dataRowMaxHeight == null),
+      'dataRowHeight ($dataRowHeight) must not be set if dataRowMinHeight ($dataRowMinHeight) or dataRowMaxHeight ($dataRowMaxHeight) are set.');
+    dataRowMinHeight = dataRowHeight ?? dataRowMinHeight;
+    dataRowMaxHeight = dataRowHeight ?? dataRowMaxHeight;
+
     return DataTableThemeData(
       decoration: decoration ?? this.decoration,
       dataRowColor: dataRowColor ?? this.dataRowColor,
-      dataRowHeight: dataRowHeight ?? this.dataRowHeight,
       dataRowMinHeight: dataRowMinHeight ?? this.dataRowMinHeight,
       dataRowMaxHeight: dataRowMaxHeight ?? this.dataRowMaxHeight,
       dataTextStyle: dataTextStyle ?? this.dataTextStyle,

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   test('DataTableThemeData copyWith dataRowHeight', () {
-    const themeData = DataTableThemeData(
+    const DataTableThemeData themeData = DataTableThemeData(
       dataRowMinHeight: 10,
       dataRowMaxHeight: 10,
     );

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -13,6 +13,16 @@ void main() {
     expect(const DataTableThemeData().hashCode, const DataTableThemeData().copyWith().hashCode);
   });
 
+  test('DataTableThemeData copyWith dataRowHeight', () {
+    const themeData = DataTableThemeData(
+      dataRowMinHeight: 10,
+      dataRowMaxHeight: 10,
+    );
+    expect(themeData, themeData.copyWith());
+    expect(themeData.copyWith(dataRowMinHeight: 20, dataRowMaxHeight: 20),
+           themeData.copyWith(dataRowHeight: 20));
+  });
+
   test('DataTableThemeData lerp special cases', () {
     const DataTableThemeData data = DataTableThemeData();
     expect(identical(DataTableThemeData.lerp(data, data, 0.5), data), true);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126676
