### PR TITLE
Clip search view content during animation

### DIFF
--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -1639,6 +1639,46 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byIcon(Icons.arrow_back), findsOneWidget);
   });
+
+  testWidgets('Search view route does not throw exception during pop animation', (WidgetTester tester) async {
+    // regression test for https://github.com/flutter/flutter/issues/126590.
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Center(
+          child: SearchAnchor(
+            builder: (BuildContext context, SearchController controller) {
+              return IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {
+                  controller.openView();
+                },
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return List<Widget>.generate(5, (int index) {
+                final String item = 'item $index';
+                return ListTile(
+                  leading: const Icon(Icons.history),
+                  title: Text(item),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () {},
+                );
+              });
+            }),
+        ),
+      ),
+    ));
+
+    // Open search view
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    // Pop search view route
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.pumpAndSettle();
+
+    // No exception.
+  });
 }
 
 TextStyle? _iconStyle(WidgetTester tester, IconData icon) {


### PR DESCRIPTION
Fixes #126590

This PR is to clip the view content when the view size is not big enough, such as during animation.
Also removes some unused properties in `_ViewContent` class: `getRect` and `viewConstraints`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
