### PR TITLE
Handle null return from WillPopCallback

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1499,7 +1499,9 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     final _ModalScopeState<T>? scope = _scopeKey.currentState;
     assert(scope != null);
     for (final WillPopCallback callback in List<WillPopCallback>.of(_willPopCallbacks)) {
-      if (!await callback()) {
+      // TODO(goderbauer): Tests using the Component Framework in google3 insist on returning
+      //   null for mocked out WillPopCallbacks. Fix that to remove ignore.
+      if (await callback() != true) { // ignore: no_literal_bool_comparisons
         return RoutePopDisposition.doNotPop;
       }
     }


### PR DESCRIPTION
Partial revert of https://github.com/flutter/flutter/pull/126647 to work around issue in google3.

See b/283046390