### PR TITLE
Remove deprecated OverscrollIndicatorNotification.disallowGlow

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -999,16 +999,6 @@ class OverscrollIndicatorNotification extends Notification with ViewportNotifica
   /// Defaults to true, cannot be null.
   bool accepted = true;
 
-  /// Call this method if the glow should be prevented. This method is
-  /// deprecated in favor of [disallowIndicator].
-  @Deprecated(
-    'Use disallowIndicator instead. '
-    'This feature was deprecated after v2.5.0-6.0.pre.',
-  )
-  void disallowGlow() {
-    accepted = false;
-  }
-
   /// Call this method if the overscroll indicator should be prevented.
   void disallowIndicator() {
     accepted = false;

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -26,8 +26,8 @@ import 'transitions.dart';
 ///
 /// [GlowingOverscrollIndicator] generates [OverscrollIndicatorNotification]
 /// before showing an overscroll indication. To prevent the indicator from
-/// showing the indication, call [OverscrollIndicatorNotification.disallowGlow]
-/// on the notification.
+/// showing the indication, call
+/// [OverscrollIndicatorNotification.disallowIndicator] on the notification.
 ///
 /// Created automatically by [ScrollBehavior.buildOverscrollIndicator] on platforms
 /// (e.g., Android) that commonly use this type of overscroll indication.


### PR DESCRIPTION
The deprecated OverscrollIndicatorNotification.disallowGlow has expired and is removed in the PR. The replacement is OverscrollIndicatorNotification.disallowIndicator. This deprecation was introduced in https://github.com/flutter/flutter/pull/87839 when the StretchingOverscrollIndicator was added. The name change made it clearer since there is now more than one overscroll indicator.

This change is supported by dart fix. ✅ 

Part of https://github.com/flutter/flutter/issues/127042

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
