### PR TITLE
mark windows build tests non-bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4070,7 +4070,6 @@ targets:
   - name: Windows build_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4089,7 +4088,6 @@ targets:
   - name: Windows build_tests_2_4
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4108,7 +4106,6 @@ targets:
   - name: Windows build_tests_3_4
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4127,7 +4124,6 @@ targets:
   - name: Windows build_tests_4_4
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-


### PR DESCRIPTION
This is a follow-up to https://github.com/flutter/flutter/commit/aa0a1a7ae1467f54e962a5616e5bf4385fbf1daf. I was forced to mark these targets bringup in that PR because the targets were technically new (since each name changed 3 -> 4), so this is marking them non-bringup.