### PR TITLE
Update ListTile to match M3 spec

### DIFF
--- a/dev/tools/gen_defaults/bin/gen_defaults.dart
+++ b/dev/tools/gen_defaults/bin/gen_defaults.dart
@@ -168,7 +168,7 @@ Future<void> main(List<String> args) async {
   IconButtonTemplate('md.comp.filled-tonal-icon-button', 'FilledTonalIconButton', '$materialLib/icon_button.dart', tokens).updateFile();
   IconButtonTemplate('md.comp.outlined-icon-button', 'OutlinedIconButton', '$materialLib/icon_button.dart', tokens).updateFile();
   InputChipTemplate('InputChip', '$materialLib/input_chip.dart', tokens).updateFile();
-  ListTileTemplate('LisTile', '$materialLib/list_tile.dart', tokens).updateFile();
+  ListTileTemplate('ListTile', '$materialLib/list_tile.dart', tokens).updateFile();
   InputDecoratorTemplate('InputDecorator', '$materialLib/input_decorator.dart', tokens).updateFile();
   MenuTemplate('Menu', '$materialLib/menu_anchor.dart', tokens).updateFile();
   NavigationBarTemplate('NavigationBar', '$materialLib/navigation_bar.dart', tokens).updateFile();

--- a/dev/tools/gen_defaults/lib/expansion_tile_template.dart
+++ b/dev/tools/gen_defaults/lib/expansion_tile_template.dart
@@ -29,10 +29,10 @@ class _${blockName}DefaultsM3 extends ExpansionTileThemeData {
 
   @override
   Color? get collapsedIconColor => ${componentColor('md.comp.list.list-item.trailing-icon')};
-  
+
   @override
   bool? get showTopDividerWhenExpanded => true;
-  
+
   @override
   bool? get showBottomDividerWhenExpanded => true;
 }

--- a/dev/tools/gen_defaults/lib/expansion_tile_template.dart
+++ b/dev/tools/gen_defaults/lib/expansion_tile_template.dart
@@ -22,7 +22,7 @@ class _${blockName}DefaultsM3 extends ExpansionTileThemeData {
   Color? get textColor => ${componentColor('md.comp.list.list-item.label-text')};
 
   @override
-  Color? get iconColor => ${componentColor('md.comp.list.list-item.selected.trailing-icon')};
+  Color? get iconColor => ${componentColor('md.comp.list.list-item.list-item.trailing-icon')};
 
   @override
   Color? get collapsedTextColor => ${componentColor('md.comp.list.list-item.label-text')};

--- a/dev/tools/gen_defaults/lib/expansion_tile_template.dart
+++ b/dev/tools/gen_defaults/lib/expansion_tile_template.dart
@@ -29,6 +29,12 @@ class _${blockName}DefaultsM3 extends ExpansionTileThemeData {
 
   @override
   Color? get collapsedIconColor => ${componentColor('md.comp.list.list-item.trailing-icon')};
+  
+  @override
+  bool? get showTopDividerWhenExpanded => true;
+  
+  @override
+  bool? get showBottomDividerWhenExpanded => true;
 }
 ''';
 }

--- a/dev/tools/gen_defaults/lib/list_tile_template.dart
+++ b/dev/tools/gen_defaults/lib/list_tile_template.dart
@@ -33,7 +33,16 @@ class _${blockName}DefaultsM3 extends ListTileThemeData {
   TextStyle? get titleTextStyle => ${textStyle("md.comp.list.list-item.label-text")};
 
   @override
+  TextStyle? get overlineTextColor => ${componentColor("md.comp.list.list-item.overline")};
+
+  @override
+  TextStyle? get overlineTextStyle => ${textStyle("md.comp.list.list-item.overline")};
+
+  @override
   TextStyle? get subtitleTextStyle => ${textStyle("md.comp.list.list-item.supporting-text")};
+
+  @override
+  TextStyle? get leadingAndTrailingTextColor => ${componentColor("md.comp.list.list-item.trailing-supporting-text")};
 
   @override
   TextStyle? get leadingAndTrailingTextStyle => ${textStyle("md.comp.list.list-item.trailing-supporting-text")};

--- a/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.1.dart
+++ b/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.1.dart
@@ -56,6 +56,7 @@ class _CheckboxListTileExampleState extends State<CheckboxListTileExample> {
                 checkboxValue2 = value!;
               });
             },
+            titleAlignment: ListTileTitleAlignment.threeLine,
             title: const Text('Headline'),
             subtitle: const Text(
                 'Longer supporting text to demonstrate how the text wraps and the checkbox is centered vertically with the text.'),

--- a/examples/api/lib/material/list_tile/list_tile.2.dart
+++ b/examples/api/lib/material/list_tile/list_tile.2.dart
@@ -40,7 +40,7 @@ class ListTileExample extends StatelessWidget {
             leading: CircleAvatar(child: Text('B')),
             title: Text('Headline'),
             subtitle: Text(
-                'Longer supporting text to demonstrate how the text wraps and how the leading and trailing widgets are centered vertically with the text.'),
+                'Longer supporting text to demonstrate how the text wraps and how the leading and trailing widgets are top aligned when the height is greater than 88dp.'),
             trailing: Icon(Icons.favorite_rounded),
           ),
           Divider(height: 0),
@@ -48,7 +48,7 @@ class ListTileExample extends StatelessWidget {
             leading: CircleAvatar(child: Text('C')),
             title: Text('Headline'),
             subtitle: Text(
-                "Longer supporting text to demonstrate how the text wraps and how setting 'ListTile.isThreeLine = true' aligns leading and trailing widgets to the top vertically with the text."),
+                "Longer supporting text to demonstrate how the text wraps and how setting 'ListTile.isThreeLine = true' aligns leading and trailing widgets to the top vertically with the text with 12dp padding."),
             trailing: Icon(Icons.favorite_rounded),
             isThreeLine: true,
           ),

--- a/examples/api/lib/material/list_tile/list_tile.4.dart
+++ b/examples/api/lib/material/list_tile/list_tile.4.dart
@@ -58,6 +58,10 @@ class _ListTileExampleState extends State<ListTileExample> {
                   child: Text('threeLine'),
                 ),
                 const PopupMenuItem<ListTileTitleAlignment>(
+                  value: ListTileTitleAlignment.material3,
+                  child: Text('material3'),
+                ),
+                const PopupMenuItem<ListTileTitleAlignment>(
                   value: ListTileTitleAlignment.titleHeight,
                   child: Text('titleHeight'),
                 ),

--- a/examples/api/lib/material/list_tile/list_tile.5.dart
+++ b/examples/api/lib/material/list_tile/list_tile.5.dart
@@ -1,0 +1,1334 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [ListTile].
+
+void main() => runApp(const ListTileApp());
+
+class ListTileApp extends StatefulWidget {
+  const ListTileApp({super.key});
+
+  @override
+  State<ListTileApp> createState() => _ListTileAppState();
+}
+
+class _ListTileAppState extends State<ListTileApp> {
+  bool useMaterial3 = true;
+  bool isDark = false;
+  bool useAdaptiveVisualDensity = false;
+  bool showDividers = false;
+  bool isLtr = true;
+
+  void onToggleUseMaterial3(bool newUseMaterial3) {
+    if (newUseMaterial3 != useMaterial3) {
+      setState(() {
+        useMaterial3 = newUseMaterial3;
+      });
+    }
+  }
+
+  void onToggleThemeMode(bool newIsDark) {
+    if (newIsDark != isDark) {
+      setState(() {
+        isDark = newIsDark;
+      });
+    }
+  }
+
+  void onToggleVisualDensity(bool newUseAdaptiveVisualDensity) {
+    if (newUseAdaptiveVisualDensity != useAdaptiveVisualDensity) {
+      setState(() {
+        useAdaptiveVisualDensity = newUseAdaptiveVisualDensity;
+      });
+    }
+  }
+
+  void onToggleShowDividers(bool newShowDividers) {
+    if (newShowDividers != showDividers) {
+      setState(() {
+        showDividers = newShowDividers;
+      });
+    }
+  }
+
+  void onToggleIsLtr(bool newIsLtr) {
+    if (newIsLtr != isLtr) {
+      setState(() {
+        isLtr = newIsLtr;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        useMaterial3: useMaterial3,
+        visualDensity: useAdaptiveVisualDensity
+            ? VisualDensity.adaptivePlatformDensity
+            : VisualDensity.standard,
+        colorSchemeSeed: Colors.orange,
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: useMaterial3,
+        visualDensity: useAdaptiveVisualDensity
+            ? VisualDensity.adaptivePlatformDensity
+            : VisualDensity.standard,
+        colorSchemeSeed: Colors.orange,
+        brightness: Brightness.dark,
+      ),
+      themeMode: isDark ? ThemeMode.dark : ThemeMode.light,
+      home: Directionality(
+        textDirection: isLtr ? TextDirection.ltr : TextDirection.rtl,
+        child: ListTileExample(
+          useMaterial3: useMaterial3,
+          onToggleUseMaterial3: onToggleUseMaterial3,
+          isDark: isDark,
+          onToggleThemeMode: onToggleThemeMode,
+          useAdaptiveVisualDensity: useAdaptiveVisualDensity,
+          onToggleVisualDensity: onToggleVisualDensity,
+          showDividers: showDividers,
+          onToggleShowDividers: onToggleShowDividers,
+          isLtr: isLtr,
+          onToggleIsLtr: onToggleIsLtr,
+        ),
+      ),
+    );
+  }
+}
+
+double listWidth = 360.0;
+double cardWidth = listWidth;
+
+Text headline = const Text('Headline');
+Text supportingText = const Text('Supporting text');
+String longSupportingText =
+    'Supporting text that is long enough to fill up multiple lines';
+Text overline = const Text('Overline');
+Text trailingSupportingText = const Text('100+');
+CircleAvatar avatar = const CircleAvatar(child: Text('A'));
+Icon leadingIcon = const Icon(Icons.person_outline);
+Icon trailingIcon = const Icon(Icons.arrow_right);
+final Checkbox trailingCheckbox =
+    Checkbox(value: true, onChanged: (bool? _) {});
+ImagePlaceholder leadingImage = const ImagePlaceholder(height: 56, width: 56);
+ImagePlaceholder leadingVideo = const ImagePlaceholder(height: 64, width: 114);
+
+class ListTileExample extends StatelessWidget {
+  const ListTileExample({
+    super.key,
+    required this.useMaterial3,
+    required this.onToggleUseMaterial3,
+    required this.isDark,
+    required this.onToggleThemeMode,
+    required this.useAdaptiveVisualDensity,
+    required this.onToggleVisualDensity,
+    required this.showDividers,
+    required this.onToggleShowDividers,
+    required this.isLtr,
+    required this.onToggleIsLtr,
+  });
+
+  final bool useMaterial3;
+  final void Function(bool useMaterial3) onToggleUseMaterial3;
+
+  final bool isDark;
+  final void Function(bool isDark) onToggleThemeMode;
+
+  final bool useAdaptiveVisualDensity;
+  final void Function(bool useAdaptiveVisualDensity) onToggleVisualDensity;
+
+  final bool showDividers;
+  final void Function(bool showDividers) onToggleShowDividers;
+
+  final bool isLtr;
+  final void Function(bool newIsLtr) onToggleIsLtr;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('ListTile Material ${useMaterial3 ? '3' : '2'} Samples'),
+        actions: <Widget>[menu()],
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Center(
+            child: Column(
+              children: <Widget>[
+                OneLineLists(showDividers: showDividers),
+                const SizedBox(height: 16),
+                TwoLineListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                TwoLineOverlineListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                ThreeLineListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                ThreeLineOverlineListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                CheckboxListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                RadioListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                SwitchListTiles(showDividers: showDividers),
+                const SizedBox(height: 16),
+                ExpansionTiles(showDividers: showDividers),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget menu() {
+    return PopupMenuButton<int>(
+      icon: const Icon(Icons.more_vert),
+      onSelected: (int value) {
+        switch (value) {
+          case 0:
+            onToggleUseMaterial3(!useMaterial3);
+          case 1:
+            onToggleThemeMode(!isDark);
+          case 2:
+            onToggleVisualDensity(!useAdaptiveVisualDensity);
+          case 3:
+            onToggleShowDividers(!showDividers);
+          case 4:
+            onToggleIsLtr(!isLtr);
+        }
+      },
+      itemBuilder: (BuildContext context) => <PopupMenuEntry<int>>[
+        CheckedPopupMenuItem<int>(
+          value: 0,
+          checked: useMaterial3,
+          child: const Text('Use Material 3'),
+        ),
+        CheckedPopupMenuItem<int>(
+          value: 1,
+          checked: isDark,
+          child: const Text('Use dark mode'),
+        ),
+        CheckedPopupMenuItem<int>(
+          value: 2,
+          checked: useAdaptiveVisualDensity,
+          child: const Text('Use adaptive platform density'),
+        ),
+        CheckedPopupMenuItem<int>(
+          value: 3,
+          checked: showDividers,
+          child: const Text('Show dividers'),
+        ),
+        CheckedPopupMenuItem<int>(
+          value: 4,
+          checked: isLtr,
+          child: const Text('Left-to-right text'),
+        ),
+      ],
+    );
+  }
+}
+
+class OneLineLists extends StatelessWidget {
+  const OneLineLists({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'One-line ListTiles',
+      showDividers: showDividers,
+      children: <Widget>[
+        ListTile(
+          title: headline,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          leading: leadingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          leading: avatar,
+          trailing: trailingCheckbox,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          leading: leadingImage,
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          trailing: trailingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          trailing: const Text('10 Episodes'),
+          onTap: () {},
+        ),
+      ],
+    );
+  }
+}
+
+class TwoLineListTiles extends StatelessWidget {
+  const TwoLineListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Two-line ListTiles',
+      showDividers: showDividers,
+      children: <Widget>[
+        ListTile(
+          title: headline,
+          subtitle: supportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: supportingText,
+          leading: leadingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: supportingText,
+          leading: avatar,
+          trailing: trailingCheckbox,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: supportingText,
+          leading: leadingImage,
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: supportingText,
+          leading: leadingVideo,
+          trailing: IconButton(onPressed: () {}, icon: trailingIcon),
+          leadingConstraint: ListTileConstraint.video,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          subtitle: supportingText,
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          trailing: trailingIcon,
+          onTap: () {},
+        ),
+      ],
+    );
+  }
+}
+
+class TwoLineOverlineListTiles extends StatelessWidget {
+  const TwoLineOverlineListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      showDividers: showDividers,
+      titleText: 'Two-line Overline ListTiles',
+      children: <Widget>[
+        ListTile(
+          title: headline,
+          overline: supportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          overline: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          overline: supportingText,
+          leading: leadingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          overline: supportingText,
+          leading: avatar,
+          trailing: trailingCheckbox,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          overline: supportingText,
+          leading: leadingImage,
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          overline: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingImage,
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          overline: supportingText,
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          trailing: trailingIcon,
+          onTap: () {},
+        ),
+      ],
+    );
+  }
+}
+
+class ThreeLineListTiles extends StatelessWidget {
+  const ThreeLineListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Three-line ListTiles',
+      showDividers: showDividers,
+      children: <Widget>[
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: avatar,
+          trailing: trailingCheckbox,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          titleAlignment: ListTileTitleAlignment.threeLine,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingImage,
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          trailing: trailingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          titleAlignment: ListTileTitleAlignment.threeLine,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingVideo,
+          trailing: IconButton(onPressed: () {}, icon: trailingIcon),
+          leadingConstraint: ListTileConstraint.video,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+      ],
+    );
+  }
+}
+
+class ThreeLineOverlineListTiles extends StatelessWidget {
+  const ThreeLineOverlineListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Three-line Overline ListTiles',
+      showDividers: showDividers,
+      children: <Widget>[
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          overline: supportingText,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          overline: supportingText,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          overline: supportingText,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: avatar,
+          trailing: trailingCheckbox,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          overline: supportingText,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingImage,
+          leadingConstraint: ListTileConstraint.image,
+          trailing: trailingSupportingText,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          overline: supportingText,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          trailing: trailingIcon,
+          onTap: () {},
+        ),
+        ListTile(
+          title: headline,
+          isThreeLine: true,
+          overline: supportingText,
+          subtitle: Text(
+            longSupportingText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          leading: leadingVideo,
+          trailing: IconButton(onPressed: () {}, icon: trailingIcon),
+          leadingConstraint: ListTileConstraint.video,
+          trailingConstraint:
+              ListTileConstraint.icon24,
+          onTap: () {},
+        ),
+      ],
+    );
+  }
+}
+
+class CheckboxListTiles extends StatefulWidget {
+  const CheckboxListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  State<CheckboxListTiles> createState() => _CheckboxListTilesState();
+}
+
+class _CheckboxListTilesState extends State<CheckboxListTiles> {
+  bool leadingControlAffinity = false;
+
+  void _onAffinityChanged(bool value) {
+    setState(() {
+      leadingControlAffinity = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Checkbox List Tiles',
+      showDividers: widget.showDividers,
+      controls: <Widget>[
+        SwitchListTile(
+          value: leadingControlAffinity,
+          onChanged: _onAffinityChanged,
+          title: const Text('Leading control affinity'),
+        )
+      ],
+      children: <Widget>[
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            secondary: leadingIcon,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            secondary: avatar,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            secondary: leadingImage,
+            secondaryConstraint: ListTileConstraint.image,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            secondary: leadingVideo,
+            secondaryConstraint: ListTileConstraint.video,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            subtitle: supportingText,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            title: headline,
+            overline: supportingText,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              CheckboxListTile(
+            value: value,
+            onChanged: (bool? b) => onChanged(b ?? false),
+            isThreeLine: true,
+            title: headline,
+            subtitle: supportingText,
+            overline: supportingText,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class RadioListTiles extends StatefulWidget {
+  const RadioListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  State<RadioListTiles> createState() => _RadioListTilesState();
+}
+
+class _RadioListTilesState extends State<RadioListTiles> {
+  int selectedValue = 1;
+  bool leadingControlAffinity = true;
+
+  void _onSelectedChanged(int? i) {
+    setState(() {
+      selectedValue = i ?? 1;
+    });
+  }
+
+  void _onAffinityChanged(bool value) {
+    setState(() {
+      leadingControlAffinity = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Radio List Tiles',
+      showDividers: widget.showDividers,
+      controls: <Widget>[
+        SwitchListTile(
+          value: leadingControlAffinity,
+          onChanged: _onAffinityChanged,
+          title: const Text('Leading control affinity'),
+        ),
+      ],
+      children: <Widget>[
+        RadioListTile<int>(
+          value: 1,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 2,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          title: headline,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 3,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          title: headline,
+          secondary: leadingIcon,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 4,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          title: headline,
+          subtitle: supportingText,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 5,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          title: headline,
+          overline: supportingText,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 6,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          title: headline,
+          subtitle: supportingText,
+          secondary: leadingImage,
+          secondaryConstraint: ListTileConstraint.image,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 7,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          title: headline,
+          subtitle: supportingText,
+          secondary: leadingVideo,
+          secondaryConstraint: ListTileConstraint.video,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+        RadioListTile<int>(
+          value: 8,
+          groupValue: selectedValue,
+          onChanged: _onSelectedChanged,
+          isThreeLine: true,
+          title: headline,
+          subtitle: supportingText,
+          overline: supportingText,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+        ),
+      ],
+    );
+  }
+}
+
+class SwitchListTiles extends StatefulWidget {
+  const SwitchListTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  State<SwitchListTiles> createState() => _SwitchListTilesState();
+}
+
+class _SwitchListTilesState extends State<SwitchListTiles> {
+  bool leadingControlAffinity = false;
+
+  void _onAffinityChanged(bool value) {
+    setState(() {
+      leadingControlAffinity = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Switch List Tiles',
+      showDividers: widget.showDividers,
+      controls: <Widget>[
+        SwitchListTile(
+          value: leadingControlAffinity,
+          onChanged: _onAffinityChanged,
+          title: const Text('Leading control affinity'),
+        ),
+      ],
+      children: <Widget>[
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            secondary: leadingIcon,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            subtitle: supportingText,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            subtitle: supportingText,
+            secondary: avatar,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            subtitle: supportingText,
+            secondary: leadingImage,
+            secondaryConstraint: ListTileConstraint.image,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            subtitle: supportingText,
+            secondary: leadingVideo,
+            secondaryConstraint: ListTileConstraint.video,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            title: headline,
+            overline: supportingText,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            isThreeLine: true,
+            title: headline,
+            subtitle: supportingText,
+            overline: supportingText,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+        ToggleBooleanState(
+          builder: (bool value, void Function(bool value) onChanged) =>
+              SwitchListTile(
+            value: value,
+            onChanged: onChanged,
+            isThreeLine: true,
+            title: headline,
+            subtitle: supportingText,
+            secondary: leadingIcon,
+            controlAffinity: leadingControlAffinity
+                ? ListTileControlAffinity.leading
+                : ListTileControlAffinity.trailing,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ExpansionTiles extends StatefulWidget {
+  const ExpansionTiles({super.key, required this.showDividers});
+
+  final bool showDividers;
+
+  @override
+  State<ExpansionTiles> createState() => _ExpansionTilesState();
+}
+
+class _ExpansionTilesState extends State<ExpansionTiles> {
+  bool leadingControlAffinity = false;
+
+  void _onAffinityChanged(bool value) {
+    setState(() {
+      leadingControlAffinity = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListCard(
+      titleText: 'Expansion Tiles',
+      showDividers: widget.showDividers,
+      controls: <Widget>[
+        SwitchListTile(
+          value: leadingControlAffinity,
+          onChanged: _onAffinityChanged,
+          title: const Text('Leading control affinity'),
+        ),
+      ],
+      children: <Widget>[
+        ExpansionTile(
+          title: headline,
+          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+          children: const <Widget>[
+            ListTile(title: Text('Expanding item 1')),
+            ListTile(title: Text('Expanding item 2')),
+            ListTile(title: Text('Expanding item 3')),
+          ],
+        ),
+        ExpansionTile(
+          title: headline,
+          subtitle: supportingText,
+          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+          children: const <Widget>[
+            ListTile(title: Text('Expanding item 1')),
+            ListTile(title: Text('Expanding item 2')),
+            ListTile(title: Text('Expanding item 3')),
+          ],
+        ),
+        ExpansionTile(
+          title: headline,
+          overline: supportingText,
+          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+          children: const <Widget>[
+            ListTile(title: Text('Expanding item 1')),
+            ListTile(title: Text('Expanding item 2')),
+            ListTile(title: Text('Expanding item 3')),
+          ],
+        ),
+        ExpansionTile(
+          title: headline,
+          subtitle: supportingText,
+          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          leading: avatar,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+          children: const <Widget>[
+            ListTile(title: Text('Expanding item 1')),
+            ListTile(title: Text('Expanding item 2')),
+            ListTile(title: Text('Expanding item 3')),
+          ],
+        ),
+        ExpansionTile(
+          title: headline,
+          subtitle: supportingText,
+          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          leading: leadingVideo,
+          leadingConstraint: ListTileConstraint.video,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+          children: const <Widget>[
+            ListTile(title: Text('Expanding item 1')),
+            ListTile(title: Text('Expanding item 2')),
+            ListTile(title: Text('Expanding item 3')),
+          ],
+        ),
+        ExpansionTile(
+          title: headline,
+          overline: supportingText,
+          subtitle: supportingText,
+          isThreeLine: true,
+          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          controlAffinity: leadingControlAffinity
+              ? ListTileControlAffinity.leading
+              : ListTileControlAffinity.trailing,
+          children: const <Widget>[
+            ListTile(title: Text('Expanding item 1')),
+            ListTile(title: Text('Expanding item 2')),
+            ListTile(title: Text('Expanding item 3')),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class ListCard extends StatelessWidget {
+  const ListCard({
+    super.key,
+    required this.titleText,
+    required this.showDividers,
+    this.controls,
+    required this.children,
+  });
+
+  final String titleText;
+  final bool showDividers;
+  final List<Widget>? controls;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: cardWidth),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          child: Column(
+            children: <Widget>[
+              Container(
+                alignment: Alignment.topLeft,
+                padding: const EdgeInsets.only(left: 16.0),
+                child: Text(
+                  titleText,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+              ),
+              const SizedBox(height: 16.0),
+              if (controls != null) ...controls!,
+              ColoredBox(
+                color: Theme.of(context).colorScheme.surface,
+                child: Material(
+                  child: Column(
+                    children: showDividers
+                      ? ListTile.divideTiles(context: context, tiles: children)
+                          .toList()
+                      : children,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ImagePlaceholder extends StatelessWidget {
+  const ImagePlaceholder({
+    super.key,
+    required this.height,
+    required this.width,
+  });
+
+  final double height;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      foregroundPainter: ImagePainter(),
+      child: Container(
+        width: width,
+        height: height,
+        // clipBehavior: Clip.hardEdge,
+        color: Colors.grey.shade300,
+      ),
+    );
+  }
+}
+
+class ToggleBooleanState extends StatefulWidget {
+  const ToggleBooleanState({super.key, required this.builder});
+
+  final Widget Function(bool value, void Function(bool value) onChanged)
+      builder;
+
+  @override
+  State<ToggleBooleanState> createState() => _ToggleBooleanStateState();
+}
+
+class _ToggleBooleanStateState extends State<ToggleBooleanState> {
+  bool value = true;
+
+  void _onChanged(bool value) {
+    setState(() {
+      this.value = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(value, _onChanged);
+  }
+}
+
+class ImagePainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()..color = Colors.black26;
+    final Offset center = Offset(size.width / 2, size.height / 2);
+    final double objectWidth = size.width / 3;
+    final double offset = size.width / 5;
+
+    Path triangle({required Offset center, required double width}) {
+      final double height = 0.5 * width * math.sqrt(3.0);
+      final Offset top = center.translate(0.0, -height / 2.0);
+      final Offset bottomRight = top.translate(width / 2.0, height);
+      final Offset bottomLeft = bottomRight.translate(-width, 0.0);
+      return Path()
+        ..moveTo(top.dx, top.dy)
+        ..lineTo(bottomRight.dx, bottomRight.dy)
+        ..lineTo(bottomLeft.dx, bottomLeft.dy)
+        ..lineTo(top.dx, top.dy);
+    }
+
+    canvas.clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
+    canvas.drawCircle(center.translate(offset, offset), objectWidth / 2, paint);
+    canvas.drawRect(
+      Rect.fromCircle(
+        center: center.translate(-offset, offset),
+        radius: objectWidth / 2.4,
+      ),
+      paint,
+    );
+    canvas.drawPath(
+      triangle(
+        center: center.translate(0.0, -offset),
+        width: objectWidth,
+      ),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return false;
+  }
+}

--- a/examples/api/lib/material/list_tile/list_tile.5.dart
+++ b/examples/api/lib/material/list_tile/list_tile.5.dart
@@ -1116,7 +1116,7 @@ class _ExpansionTilesState extends State<ExpansionTiles> {
         ExpansionTile(
           title: headline,
           subtitle: supportingText,
-          showTopDividerWhenExpanded: !Theme.of(context).useMaterial3,
+          showTopDividerWhenExpanded: true, //!Theme.of(context).useMaterial3,
           controlAffinity: leadingControlAffinity
               ? ListTileControlAffinity.leading
               : ListTileControlAffinity.trailing,

--- a/examples/api/lib/material/radio_list_tile/radio_list_tile.1.dart
+++ b/examples/api/lib/material/radio_list_tile/radio_list_tile.1.dart
@@ -57,6 +57,7 @@ class _RadioListTileExampleState extends State<RadioListTileExample> {
                 _groceryItem = value;
               });
             },
+            titleAlignment: ListTileTitleAlignment.threeLine,
             title: const Text('Tomato'),
             subtitle: const Text(
                 'Longer supporting text to demonstrate how the text wraps and the radio is centered vertically with the text.'),

--- a/examples/api/lib/material/switch_list_tile/switch_list_tile.1.dart
+++ b/examples/api/lib/material/switch_list_tile/switch_list_tile.1.dart
@@ -55,6 +55,7 @@ class _SwitchListTileExampleState extends State<SwitchListTileExample> {
                 switchValue2 = value!;
               });
             },
+            titleAlignment: ListTileTitleAlignment.threeLine,
             title: const Text('Headline'),
             subtitle: const Text(
                 'Longer supporting text to demonstrate how the text wraps and the switch is centered vertically with the text.'),

--- a/examples/api/test/material/checkbox_list_tile/checkbox_list_tile.1_test.dart
+++ b/examples/api/test/material/checkbox_list_tile/checkbox_list_tile.1_test.dart
@@ -18,19 +18,19 @@ void main() {
     Offset checkboxTopLeft = tester.getTopLeft(find.byType(Checkbox).at(0));
 
     // The checkbox is centered vertically with the text.
-    expect(checkboxTopLeft - tileTopLeft, const Offset(736.0, 16.0));
+    expect(checkboxTopLeft - tileTopLeft, const Offset(744.0, 16.0));
 
     tileTopLeft = tester.getTopLeft(find.byType(CheckboxListTile).at(1));
     checkboxTopLeft = tester.getTopLeft(find.byType(Checkbox).at(1));
 
     // The checkbox is centered vertically with the text.
-    expect(checkboxTopLeft - tileTopLeft, const Offset(736.0, 30.0));
+    expect(checkboxTopLeft - tileTopLeft, const Offset(744.0, 30.0));
 
     tileTopLeft = tester.getTopLeft(find.byType(CheckboxListTile).at(2));
     checkboxTopLeft = tester.getTopLeft(find.byType(Checkbox).at(2));
 
     // The checkbox is aligned to the top vertically with the text.
-    expect(checkboxTopLeft - tileTopLeft, const Offset(736.0, 8.0));
+    expect(checkboxTopLeft - tileTopLeft, const Offset(744.0, 4.0));
   });
 
   testWidgets('Checkboxes can be checked', (WidgetTester tester) async {

--- a/examples/api/test/material/list_tile/list_tile.2_test.dart
+++ b/examples/api/test/material/list_tile/list_tile.2_test.dart
@@ -27,15 +27,15 @@ void main() {
     trailingTopLeft = tester.getTopLeft(find.byType(Icon).at(1));
 
     // The leading and trailing widgets are centered vertically with the text.
-    expect(leadingTopLeft - listTileTopLeft, const Offset(16.0, 30.0));
-    expect(trailingTopLeft - listTileTopLeft, const Offset(752.0, 38.0));
+    expect(leadingTopLeft - listTileTopLeft, const Offset(16.0, 8.0));
+    expect(trailingTopLeft - listTileTopLeft, const Offset(752.0, 8.0));
 
     listTileTopLeft = tester.getTopLeft(find.byType(ListTile).at(2));
     leadingTopLeft = tester.getTopLeft(find.byType(CircleAvatar).at(2));
     trailingTopLeft = tester.getTopLeft(find.byType(Icon).at(2));
 
     // The leading and trailing widgets are aligned to the top vertically with the text.
-    expect(leadingTopLeft - listTileTopLeft, const Offset(16.0, 8.0));
-    expect(trailingTopLeft - listTileTopLeft, const Offset(752.0, 8.0));
+    expect(leadingTopLeft - listTileTopLeft, const Offset(16.0, 12.0));
+    expect(trailingTopLeft - listTileTopLeft, const Offset(752.0, 12.0));
   });
 }

--- a/examples/api/test/material/list_tile/list_tile.4_test.dart
+++ b/examples/api/test/material/list_tile/list_tile.4_test.dart
@@ -16,9 +16,10 @@ void main() {
     Offset leadingOffset = tester.getTopLeft(find.byType(Checkbox));
     Offset trailingOffset = tester.getTopRight(find.byIcon(Icons.adaptive.more));
 
-    // The default title alignment is threeLine.
-    expect(leadingOffset.dy - titleOffset.dy, 48.0);
-    expect(trailingOffset.dy - titleOffset.dy, 60.0);
+    // The default title alignment is material3, subtitle overflows to force
+    // top align of leading and trailing
+    expect(leadingOffset.dy - titleOffset.dy, 0.0);
+    expect(trailingOffset.dy - titleOffset.dy, 12.0); // icon is padded in the button
 
     await tester.tap(find.byIcon(Icons.adaptive.more));
     await tester.pumpAndSettle();

--- a/examples/api/test/material/list_tile/list_tile.5_test.dart
+++ b/examples/api/test/material/list_tile/list_tile.5_test.dart
@@ -1,0 +1,226 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/list_tile/list_tile.5.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Size size(Element e) {
+  final RenderBox r = e.renderObject! as RenderBox;
+  return r.size;
+}
+
+Offset center(Element e) {
+  return size(e).center(Offset.zero);
+}
+
+bool menuItemChecked(String text) {
+  return (find
+          .ancestor(
+            of: find.text(text),
+            matching: find.byType(CheckedPopupMenuItem<int>),
+          )
+          .evaluate()
+          .first
+          .widget as CheckedPopupMenuItem<int>)
+      .checked;
+}
+
+void main() {
+  testWidgets('List tile widths are constrained by cards',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ListTileApp(),
+    );
+
+    final Offset pageCenter = tester.getCenter(find.byType(MaterialApp));
+
+    find
+        .descendant(
+          of: find.byType(ListCard, skipOffstage: false),
+          matching: find.byType(ListTile, skipOffstage: false),
+        )
+        .evaluate()
+        .mapIndexed((int index, Element listTile) {
+      expect(center(listTile).dx, pageCenter.dx,
+          reason: '$index should be centered');
+      expect(size(listTile).width, 360,
+          reason: '$index should have its width constrained by its Card');
+    });
+  });
+
+  testWidgets('can toggle text direction', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ListTileApp(),
+    );
+
+    find
+        .descendant(
+          of: find.byType(ListCard, skipOffstage: false),
+          matching: find.byType(Directionality, skipOffstage: false),
+        )
+        .evaluate()
+        .mapIndexed((int index, Element directionality) {
+      expect(
+        (directionality.widget as Directionality).textDirection,
+        TextDirection.ltr,
+        reason: '$index should default to ltr',
+      );
+    });
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Left-to-right text'), true);
+    await tester.tap(
+      find.ancestor(
+        of: find.text('Left-to-right text'),
+        matching: find.byType(CheckedPopupMenuItem<int>),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    find
+        .descendant(
+          of: find.byType(ListCard, skipOffstage: false),
+          matching: find.byType(Directionality, skipOffstage: false),
+        )
+        .evaluate()
+        .mapIndexed((int index, Element directionality) {
+      expect(
+        (directionality.widget as Directionality).textDirection,
+        TextDirection.rtl,
+        reason: '$index should change to rtl',
+      );
+    });
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Left-to-right text'), false);
+  });
+
+  testWidgets('can toggle density', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ListTileApp(),
+    );
+
+    expect(
+      (find.byType(MaterialApp).evaluate().first.widget as MaterialApp)
+          .theme!
+          .visualDensity,
+      VisualDensity.standard,
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Use adaptive platform density'), false);
+    await tester.tap(
+      find.ancestor(
+        of: find.text('Use adaptive platform density'),
+        matching: find.byType(CheckedPopupMenuItem<int>),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      (find.byType(MaterialApp).evaluate().first.widget as MaterialApp)
+          .theme!
+          .visualDensity,
+      VisualDensity.adaptivePlatformDensity,
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Use adaptive platform density'), true);
+  });
+
+  testWidgets('can toggle light and dark', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ListTileApp(),
+    );
+
+    expect(
+      (find.byType(MaterialApp).evaluate().first.widget as MaterialApp)
+          .themeMode,
+      ThemeMode.light,
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Use dark mode'), false);
+    await tester.tap(
+      find.ancestor(
+        of: find.text('Use dark mode'),
+        matching: find.byType(CheckedPopupMenuItem<int>),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      (find.byType(MaterialApp).evaluate().first.widget as MaterialApp)
+          .themeMode,
+      ThemeMode.dark,
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Use dark mode'), true);
+  });
+
+  testWidgets('can toggle Material 2 and 3', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ListTileApp(),
+    );
+
+    expect(
+      (find.byType(MaterialApp).evaluate().first.widget as MaterialApp)
+          .theme!
+          .useMaterial3,
+      true,
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Use Material 3'), true);
+    await tester.tap(
+      find.ancestor(
+        of: find.text('Use Material 3'),
+        matching: find.byType(CheckedPopupMenuItem<int>),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      (find.byType(MaterialApp).evaluate().first.widget as MaterialApp)
+          .theme!
+          .useMaterial3,
+      false,
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Use Material 3'), false);
+  });
+
+  testWidgets('can toggle dividers', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ListTileApp(),
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Show dividers'), false);
+    await tester.tap(
+      find.ancestor(
+        of: find.text('Show dividers'),
+        matching: find.byType(CheckedPopupMenuItem<int>),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(menuItemChecked('Show dividers'), true);
+  });
+}

--- a/examples/api/test/material/radio_list_tile/radio_list_tile.1_test.dart
+++ b/examples/api/test/material/radio_list_tile/radio_list_tile.1_test.dart
@@ -18,19 +18,24 @@ void main() {
     Offset radioTopLeft = tester.getTopLeft(find.byType(Radio<example.Groceries>).at(0));
 
     // The radio is centered vertically with the text.
-    expect(radioTopLeft - tileTopLeft, const Offset(16.0, 16.0));
+    expect(radioTopLeft - tileTopLeft, const Offset(8.0, 16.0));
 
     tileTopLeft = tester.getTopLeft(find.byType(RadioListTile<example.Groceries>).at(1));
     radioTopLeft = tester.getTopLeft(find.byType(Radio<example.Groceries>).at(1));
 
+
+    print('tile: ${tester.getSize(find.byType(RadioListTile<example.Groceries>).at(1))}');
+    print('title: ${tester.getSize(find.byType(Text).at(2))}');
+    print('subtitle: ${tester.getSize(find.byType(Text).at(3))}');
+    print('tile: ${tester.getSize(find.byType(Radio<example.Groceries>).at(1))}');
     // The radio is centered vertically with the text.
-    expect(radioTopLeft - tileTopLeft, const Offset(16.0, 30.0));
+    expect(radioTopLeft - tileTopLeft, const Offset(8.0, 30.0));
 
     tileTopLeft = tester.getTopLeft(find.byType(RadioListTile<example.Groceries>).at(2));
     radioTopLeft = tester.getTopLeft(find.byType(Radio<example.Groceries>).at(2));
 
     // The radio is aligned to the top vertically with the text.
-    expect(radioTopLeft - tileTopLeft, const Offset(16.0, 8.0));
+    expect(radioTopLeft - tileTopLeft, const Offset(8.0, 4.0));
   });
 
   testWidgets('Radios can be checked', (WidgetTester tester) async {

--- a/examples/api/test/material/switch_list_tile/switch_list_tile.1_test.dart
+++ b/examples/api/test/material/switch_list_tile/switch_list_tile.1_test.dart
@@ -18,19 +18,19 @@ void main() {
     Offset switchTopLeft = tester.getTopLeft(find.byType(Switch).at(0));
 
     // The switch is centered vertically with the text.
-    expect(switchTopLeft - tileTopLeft, const Offset(716.0, 16.0));
+    expect(switchTopLeft - tileTopLeft, const Offset(720.0, 16.0));
 
     tileTopLeft = tester.getTopLeft(find.byType(SwitchListTile).at(1));
     switchTopLeft = tester.getTopLeft(find.byType(Switch).at(1));
 
     // The switch is centered vertically with the text.
-    expect(switchTopLeft - tileTopLeft, const Offset(716.0, 30.0));
+    expect(switchTopLeft - tileTopLeft, const Offset(720.0, 30.0));
 
     tileTopLeft = tester.getTopLeft(find.byType(SwitchListTile).at(2));
     switchTopLeft = tester.getTopLeft(find.byType(Switch).at(2));
 
     // The switch is aligned to the top vertically with the text.
-    expect(switchTopLeft - tileTopLeft, const Offset(716.0, 8.0));
+    expect(switchTopLeft - tileTopLeft, const Offset(720.0, 8.0));
   });
 
   testWidgets('Switches can be checked', (WidgetTester tester) async {

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -495,12 +495,12 @@ class CheckboxListTile extends StatelessWidget {
   /// {@macro flutter.material.checkbox.semanticLabel}
   final String? checkboxSemanticLabel;
 
-  /// Defines how [leading], [trailing] and [title]
+  /// Defines how the underlying [ListTile.leading] and [ListTile.trailing]
   /// are vertically aligned relative to the [ListTile].
   ///
   /// If this property is null then [ListTileThemeData.titleAlignment]
   /// is used. If that is also null then [ListTileTitleAlignment.material3]
-  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used if [ThemeData.useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
   /// is used.
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -182,10 +182,12 @@ class CheckboxListTile extends StatelessWidget {
     this.enabled,
     this.tileColor,
     this.title,
+    this.overline,
     this.subtitle,
     this.isThreeLine = false,
     this.dense,
     this.secondary,
+    this.secondaryConstraint,
     this.selected = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.contentPadding,
@@ -195,9 +197,18 @@ class CheckboxListTile extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.checkboxSemanticLabel,
+    this.titleAlignment,
   }) : _checkboxType = _CheckboxType.material,
        assert(tristate || value != null),
-       assert(!isThreeLine || subtitle != null);
+       assert(
+         !(subtitle == null && isThreeLine),
+         'ListTile.subtitle must be present when CheckboxListTile.isThreeLine == true',
+       ),
+       assert(
+         !(subtitle != null && overline != null && !isThreeLine),
+         'CheckboxListTile.subtitle and CheckboxListTile.overline must not be present '
+         'together when CheckboxListTile.isThreeLine == false',
+       );
 
   /// Creates a combination of a list tile and a platform adaptive checkbox.
   ///
@@ -226,10 +237,12 @@ class CheckboxListTile extends StatelessWidget {
     this.enabled,
     this.tileColor,
     this.title,
+    this.overline,
     this.subtitle,
     this.isThreeLine = false,
     this.dense,
     this.secondary,
+    this.secondaryConstraint,
     this.selected = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.contentPadding,
@@ -239,9 +252,17 @@ class CheckboxListTile extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.checkboxSemanticLabel,
+    this.titleAlignment,
   }) : _checkboxType = _CheckboxType.adaptive,
-       assert(tristate || value != null),
-       assert(!isThreeLine || subtitle != null);
+       assert(
+         !(subtitle == null && isThreeLine),
+         'ListTile.subtitle must be present when CheckboxListTile.isThreeLine == true',
+       ),
+       assert(
+         !(subtitle != null && overline != null && !isThreeLine),
+         'CheckboxListTile.subtitle and CheckboxListTile.overline must not be present '
+         'together when CheckboxListTile.isThreeLine == false',
+       );
 
   /// Whether this checkbox is checked.
   final bool? value;
@@ -374,6 +395,11 @@ class CheckboxListTile extends StatelessWidget {
   /// Typically a [Text] widget.
   final Widget? title;
 
+  /// Additional content displayed above the title.
+  ///
+  /// Typically a [Text] widget.
+  final Widget? overline;
+
   /// Additional content displayed below the title.
   ///
   /// Typically a [Text] widget.
@@ -384,10 +410,22 @@ class CheckboxListTile extends StatelessWidget {
   /// Typically an [Icon] widget.
   final Widget? secondary;
 
+  /// Defines how [ListTile.leading] is constrained and aligned to the [ListTile].
+  ///
+  /// The default value is [ListTileConstraint.standard].
+  final ListTileConstraint? secondaryConstraint;
+
   /// Whether this list tile is intended to display three lines of text.
   ///
-  /// If false, the list tile is treated as having one line if the subtitle is
-  /// null and treated as having two lines if the subtitle is non-null.
+  /// If true, then [overline] or [subtitle] must be non-null (since it is expected to give
+  /// the second and third lines of text).
+  ///
+  /// If false, the list tile is treated as having one line if the [overline] or [subtitle] is
+  /// null and treated as having two lines if the subtitle is non-null. It must only have
+  /// one of [overline] or [subtitle].
+  ///
+  /// When using a [Text] widget for [title], [overline] and [subtitle], you can enforce
+  /// line limits using [Text.maxLines].
   final bool isThreeLine;
 
   /// Whether this list tile is part of a vertically dense list.
@@ -457,6 +495,20 @@ class CheckboxListTile extends StatelessWidget {
   /// {@macro flutter.material.checkbox.semanticLabel}
   final String? checkboxSemanticLabel;
 
+  /// Defines how [leading], [trailing] and [title]
+  /// are vertically aligned relative to the [ListTile].
+  ///
+  /// If this property is null then [ListTileThemeData.titleAlignment]
+  /// is used. If that is also null then [ListTileTitleAlignment.material3]
+  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
+  final ListTileTitleAlignment? titleAlignment;
+
   final _CheckboxType _checkboxType;
 
   void _handleValueChange() {
@@ -517,14 +569,20 @@ class CheckboxListTile extends StatelessWidget {
     }
 
     Widget? leading, trailing;
+    ListTileConstraint? leadingConstraint, trailingConstraint;
+
     switch (controlAffinity) {
       case ListTileControlAffinity.leading:
         leading = control;
+        leadingConstraint = ListTileConstraint.icon24;
         trailing = secondary;
+        trailingConstraint = secondaryConstraint;
       case ListTileControlAffinity.trailing:
       case ListTileControlAffinity.platform:
         leading = secondary;
+        leadingConstraint = secondaryConstraint;
         trailing = control;
+        trailingConstraint = ListTileConstraint.icon24;
     }
     final ThemeData theme = Theme.of(context);
     final CheckboxThemeData checkboxTheme = CheckboxTheme.of(context);
@@ -539,8 +597,11 @@ class CheckboxListTile extends StatelessWidget {
         selectedColor: effectiveActiveColor,
         leading: leading,
         title: title,
+        overline: overline,
         subtitle: subtitle,
         trailing: trailing,
+        leadingConstraint: leadingConstraint,
+        trailingConstraint: trailingConstraint,
         isThreeLine: isThreeLine,
         dense: dense,
         enabled: enabled ?? onChanged != null,
@@ -555,6 +616,7 @@ class CheckboxListTile extends StatelessWidget {
         focusNode: focusNode,
         onFocusChange: onFocusChange,
         enableFeedback: enableFeedback,
+        titleAlignment: titleAlignment,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -254,8 +254,8 @@ class ExpansionTile extends StatefulWidget {
     this.titleAlignment,
     this.leadingConstraint,
     this.trailingConstraint,
-    this.showTopDividerWhenExpanded = true,
-    this.showBottomDividerWhenExpanded = true,
+    this.showTopDividerWhenExpanded,
+    this.showBottomDividerWhenExpanded,
   }) : assert(
          expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
          'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -556,13 +556,15 @@ class ExpansionTile extends StatefulWidget {
 
   /// Show a [Divider] above the [ExpansionTile] when expanded.
   ///
-  /// Defaults to true.
-  final bool showTopDividerWhenExpanded;
+  /// If this property is null, the [ExpansionTileThemeData.showTopDividerWhenExpanded]
+  /// is used. If that is also null, true is used
+  final bool? showTopDividerWhenExpanded;
 
   /// Show a [Divider] below the [ExpansionTile] when expanded.
   ///
-  /// Defaults to true.
-  final bool showBottomDividerWhenExpanded;
+  /// If this property is null, the [ExpansionTileThemeData.showBottomDividerWhenExpanded]
+  /// is used. If that is also null, true is used
+  final bool? showBottomDividerWhenExpanded;
 
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
@@ -680,9 +682,9 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   Widget _buildChildren(BuildContext context, Widget? child) {
     final ThemeData theme = Theme.of(context);
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
-    final ShapeBorder expansionTileBorder = _border.value ?? const Border(
-            top: BorderSide(color: Colors.transparent),
-            bottom: BorderSide(color: Colors.transparent),
+    final ShapeBorder expansionTileBorder = _border.value ?? Border(
+            top: Divider.createBorderSide(context, color: Colors.transparent),
+            bottom: Divider.createBorderSide(context, color: Colors.transparent),
           );
     final Clip clipBehavior = widget.clipBehavior ?? expansionTileTheme.clipBehavior ?? Clip.none;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
@@ -758,22 +760,27 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ExpansionTileThemeData defaults = theme.useMaterial3
       ? _ExpansionTileDefaultsM3(context)
       : _ExpansionTileDefaultsM2(context);
+    final bool showTopDividerWhenExpanded = widget.showTopDividerWhenExpanded
+      ?? expansionTileTheme.showTopDividerWhenExpanded
+      ?? defaults.showTopDividerWhenExpanded!;
+    final bool showBottomDividerWhenExpanded = widget.showBottomDividerWhenExpanded
+      ?? expansionTileTheme.showBottomDividerWhenExpanded
+      ?? defaults.showBottomDividerWhenExpanded!;
+    final BorderSide transparentBorder = Divider.createBorderSide(context, color: Colors.transparent);
+    final BorderSide coloredBorder = Divider.createBorderSide(context);
+
     _borderTween
       ..begin = widget.collapsedShape
         ?? expansionTileTheme.collapsedShape
-        ?? const Border(
-          top: BorderSide(color: Colors.transparent),
-          bottom: BorderSide(color: Colors.transparent),
+        ?? Border(
+          top: transparentBorder,
+          bottom: transparentBorder,
         )
       ..end = widget.shape
         ?? expansionTileTheme.collapsedShape
         ?? Border(
-          top: widget.showTopDividerWhenExpanded
-              ? Divider.createBorderSide(context)
-              : const BorderSide(color: Colors.transparent),
-          bottom: widget.showBottomDividerWhenExpanded
-              ? Divider.createBorderSide(context)
-              : const BorderSide(color: Colors.transparent),
+          top: showTopDividerWhenExpanded ? coloredBorder : transparentBorder,
+          bottom: showBottomDividerWhenExpanded ? coloredBorder : transparentBorder,
         );
     _headerColorTween
       ..begin = widget.collapsedTextColor
@@ -837,6 +844,12 @@ class _ExpansionTileDefaultsM2 extends ExpansionTileThemeData {
 
   @override
   Color? get collapsedIconColor => _theme.unselectedWidgetColor;
+
+  @override
+  bool? get showTopDividerWhenExpanded => true;
+
+  @override
+  bool? get showBottomDividerWhenExpanded => true;
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - ExpansionTile
@@ -866,6 +879,12 @@ class _ExpansionTileDefaultsM3 extends ExpansionTileThemeData {
 
   @override
   Color? get collapsedIconColor => _colors.onSurfaceVariant;
+
+  @override
+  bool? get showTopDividerWhenExpanded => true;
+
+  @override
+  bool? get showBottomDividerWhenExpanded => true;
 }
 
 // END GENERATED TOKEN PROPERTIES - ExpansionTile

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -21,7 +21,7 @@ const Duration _kExpand = Duration(milliseconds: 200);
 /// Enables control over a single [ExpansionTile]'s expanded/collapsed state.
 ///
 /// It can be useful to expand or collapse an [ExpansionTile]
-/// programatically, for example to reconfigure an existing expansion
+/// programmatically, for example to reconfigure an existing expansion
 /// tile based on a system event. To do so, create an [ExpansionTile]
 /// with an [ExpansionTileController] that's owned by a stateful widget
 /// or look up the tile's automatically created [ExpansionTileController]
@@ -540,12 +540,12 @@ class ExpansionTile extends StatefulWidget {
   /// than supplying a controller.
   final ExpansionTileController? controller;
 
-  /// Defines how [leading], [trailing] and [title]
+  /// Defines how the underlying [leading] and [trailing]
   /// are vertically aligned relative to the [ListTile].
   ///
   /// If this property is null then [ListTileThemeData.titleAlignment]
   /// is used. If that is also null then [ListTileTitleAlignment.material3]
-  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used if [ThemeData.useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
   /// is used.
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -52,6 +52,8 @@ class ExpansionTileThemeData with Diagnosticable {
     this.shape,
     this.collapsedShape,
     this.clipBehavior,
+    this.showTopDividerWhenExpanded,
+    this.showBottomDividerWhenExpanded,
   });
 
   /// Overrides the default value of [ExpansionTile.backgroundColor].
@@ -90,6 +92,12 @@ class ExpansionTileThemeData with Diagnosticable {
   /// Overrides the default value of [ExpansionTile.clipBehavior].
   final Clip? clipBehavior;
 
+  /// Overrides the default value of [ExpansionTile.showTopDividerWhenExpanded].
+  final bool? showTopDividerWhenExpanded;
+
+  /// Overrides the default value of [ExpansionTile.showBottomDividerWhenExpanded].
+  final bool? showBottomDividerWhenExpanded;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ExpansionTileThemeData copyWith({
@@ -105,6 +113,8 @@ class ExpansionTileThemeData with Diagnosticable {
     ShapeBorder? shape,
     ShapeBorder? collapsedShape,
     Clip? clipBehavior,
+    bool? showTopDividerWhenExpanded,
+    bool? showBottomDividerWhenExpanded,
   }) {
     return ExpansionTileThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -119,8 +129,12 @@ class ExpansionTileThemeData with Diagnosticable {
       shape: shape ?? this.shape,
       collapsedShape: collapsedShape ?? this.collapsedShape,
       clipBehavior: clipBehavior ?? this.clipBehavior,
+      showTopDividerWhenExpanded: showTopDividerWhenExpanded ?? this.showTopDividerWhenExpanded,
+      showBottomDividerWhenExpanded: showBottomDividerWhenExpanded ?? this.showBottomDividerWhenExpanded,
     );
   }
+
+  static bool? _lerpBool(bool? a, bool? b, double t) => t < 0.5 ? a : b;
 
   /// Linearly interpolate between ExpansionTileThemeData objects.
   static ExpansionTileThemeData? lerp(ExpansionTileThemeData? a, ExpansionTileThemeData? b, double t) {
@@ -139,6 +153,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedTextColor: Color.lerp(a?.collapsedTextColor, b?.collapsedTextColor, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
       collapsedShape: ShapeBorder.lerp(a?.collapsedShape, b?.collapsedShape, t),
+      showTopDividerWhenExpanded: _lerpBool(a?.showTopDividerWhenExpanded, b?.showTopDividerWhenExpanded, t),
+      showBottomDividerWhenExpanded: _lerpBool(a?.showBottomDividerWhenExpanded, b?.showBottomDividerWhenExpanded, t),
     );
   }
 
@@ -157,6 +173,8 @@ class ExpansionTileThemeData with Diagnosticable {
       shape,
       collapsedShape,
       clipBehavior,
+      showTopDividerWhenExpanded,
+      showBottomDividerWhenExpanded,
     );
   }
 
@@ -180,7 +198,9 @@ class ExpansionTileThemeData with Diagnosticable {
       && other.collapsedTextColor == collapsedTextColor
       && other.shape == shape
       && other.collapsedShape == collapsedShape
-      && other.clipBehavior == clipBehavior;
+      && other.clipBehavior == clipBehavior
+      && other.showTopDividerWhenExpanded == showTopDividerWhenExpanded
+      && other.showBottomDividerWhenExpanded == showBottomDividerWhenExpanded;
   }
 
   @override
@@ -198,6 +218,8 @@ class ExpansionTileThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('collapsedShape', collapsedShape, defaultValue: null));
     properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior, defaultValue: null));
+    properties.add(DiagnosticsProperty<bool>('showTopDividerWhenExpanded', showTopDividerWhenExpanded, defaultValue: null));
+    properties.add(DiagnosticsProperty<bool>('showBottomDividerWhenExpanded', showBottomDividerWhenExpanded, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -514,6 +514,16 @@ class ListTileConstraint {
     bool? ignoreHorizontalTilePadding,
     ListTilePaddingCorrection Function(Size widgetSize)? paddingCorrection,
   }) {
+    if (
+      <Object?>[maxSize, minimumTileHeight, leadingHorizontalTitleGap,
+        trailingHorizontalTitleGap, ignoreHorizontalTilePadding,
+        paddingCorrection]
+          .where((Object? e) => e != null)
+          .isEmpty
+    ) {
+      return this;
+    }
+
     return ListTileConstraint(
       maxSize: maxSize ?? this.maxSize,
       minimumTileHeight: minimumTileHeight ?? this.minimumTileHeight,
@@ -522,6 +532,25 @@ class ListTileConstraint {
       ignoreHorizontalTilePadding: ignoreHorizontalTilePadding ?? this.ignoreHorizontalTilePadding,
       paddingCorrection: paddingCorrection ?? this.paddingCorrection,
     );
+  }
+
+  @override
+  String toString() {
+    switch (this) {
+      case standard:
+        return 'ListTileConstraint.standard';
+      case icon24:
+        return 'ListTileConstraint.icon24';
+      case switchTile:
+        return 'ListTileConstraint.switchTile';
+      case avatar:
+        return 'ListTileConstraint.avatar';
+      case image:
+        return 'ListTileConstraint.image';
+      case video:
+        return 'ListTileConstraint.video';
+    }
+    return 'ListTileConstraint()';
   }
 }
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -256,7 +256,7 @@ class ListTileConstraint {
     required bool isLeading,
     required ListTileLineCount numberOfLines,
   }) {
-    switch(numberOfLines) {
+    switch (numberOfLines) {
       case ListTileLineCount.oneLine: {
         if (useMaterial3 || isLeading) {
           return isDense ? 48.0 : 56.0;
@@ -344,7 +344,7 @@ class ListTileConstraint {
 
   /// A constraint that can be applied to an [Icon], such as for an [IconButton].
   ///
-  /// Note that using default styles, when [ListTile.isMaterial3] is false
+  /// When [ListTile.isMaterial3] is false, and using default styles,
   /// this will cause the [IconButton]'s splash to clip off the [ListTile].
   static const ListTileConstraint icon24 =
     ListTileConstraint(
@@ -1368,7 +1368,7 @@ class ListTile extends StatelessWidget {
       );
     final EdgeInsetsDirectional effectiveContentPadding = baseContentPadding
         .toDirectional(textDirection)
-        .clamp(EdgeInsets.zero, clamp)
+        .clamp(EdgeInsets.zero, clamp) // ignore_clamp_double_lint
         .toDirectional(textDirection);
     final EdgeInsets resolvedContentPadding = effectiveContentPadding.resolve(textDirection);
 
@@ -1893,7 +1893,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
     _parentPadding = value;
     markNeedsLayout();
   }
-  
+
   @override
   bool get sizedByParent => false;
 
@@ -1934,12 +1934,12 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
     double baseDefaultTileHeight() {
       switch (numberOfLines) {
         case ListTileLineCount.oneLine: {
-          // NOTE: this does not follow the M2 spec which should have a base height
+          // This does not follow the M2 spec which should have a base height
           // of 48 for one-line lists with no leading element
           return (isDense ? 48.0 : 56.0);
         }
         case ListTileLineCount.twoLine: {
-          // NOTE: this does not follow the M2 spec which should have a base height
+          // This does not follow the M2 spec which should have a base height
           // of 64 for two-line lists with no leading element
           return (isDense ? 64.0 : 72.0);
         }
@@ -2143,7 +2143,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
           tileHeight > 88.0 || (isDense && tileHeight > 76.0)
       ) {
         // Top align
-        // Note there is an inconsistency in the spec. In the written component
+        // There is an inconsistency in the spec. In the written component
         // it is tileHeight >= 88, but this conflicts with the one and two line
         // video layouts which are centred.
         overlineY = minVerticalPadding;
@@ -2168,7 +2168,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
       double? titleBaseline;
       double? overlineBaseline;
       double? subtitleBaseline;
-      switch(numberOfLines) {
+      switch (numberOfLines) {
         case ListTileLineCount.oneLine: break;
         case ListTileLineCount.twoLine: {
           if (leading == null) {
@@ -2301,7 +2301,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
           tileHeight > 88.0 || (isDense && tileHeight > 76.0)
         ) {
           // Top align
-          // Note there is an inconsistency on the spec. In the written component
+          // There is an inconsistency on the spec. In the written component
           // it is tileHeight >= 88, but this conflicts with the one and two line
           // video layouts which are centred.
           leadingY = math.max(_minVerticalPadding - leadingPaddingCorrection.top, 0.0);
@@ -2323,7 +2323,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
         //  - For smaller tiles, trailing should always be centered. Leading can be
         //    centered or closer to the top. It should never be further than 16dp
         //    to the top.
-        // NOTE: baseline offset of trailing supporting text is not supported.
+        // Baseline offset of trailing supporting text is not supported.
         if (tileHeight > 72.0) {
           leadingY = math.max(16.0 - leadingPaddingCorrection.top, 0.0);
           trailingY = math.max(16.0 - trailingPaddingCorrection.top, 0.0);

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -664,7 +664,7 @@ class ListTileConstraint {
 /// {@end-tool}
 ///
 /// {@tool dartpad}
-/// This sample shows [ListTileConstraints] can be used to
+/// This sample shows [ListTileConstraint] can be used to
 /// configure the [leading] and [trailing] widgets to make the list in the
 /// Material 3 spec.
 ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -344,7 +344,7 @@ class ListTileConstraint {
 
   /// A constraint that can be applied to an [Icon], such as for an [IconButton].
   ///
-  /// When [ListTile.isMaterial3] is false, and using default styles,
+  /// When [ThemeData.useMaterial3] is false, and using default styles,
   /// this will cause the [IconButton]'s splash to clip off the [ListTile].
   static const ListTileConstraint icon24 =
     ListTileConstraint(
@@ -401,12 +401,12 @@ class ListTileConstraint {
 
   /// Constraints for a standard Material 2 or 3 video.
   ///
-  /// When [ListTile.useMaterial3] is true, this limits the leading or
+  /// When [ThemeData.useMaterial3] is true, this limits the leading or
   /// trailing element size to 56h x 100w when dense, otherwise 64h x 114w.
   /// The tile height to is forced to 72 when dense, otherwise to 88. The
   /// leading horizontal title gap is 16.
   ///
-  /// When [ListTile.useMaterial3] is false, this limits the leading or
+  /// When [ThemeData.useMaterial3] is false, this limits the leading or
   /// trailing element size to 48h x 86w when dense, otherwise 56h x 100w.
   /// The tile height to is forced to 64 when dense, otherwise to 72. If
   /// [ListTile.isThreeLine] is also true, the leading horizontal title gap
@@ -452,8 +452,9 @@ class ListTileConstraint {
   /// Constraints for an element with symmetric padding, such as an
   /// [IconButton].
   ///
-  /// Uses the same values as [ListTileConstraint.standard]
-  /// except it applies [ListTilePaddingCorrections.center].
+  /// Uses the same values as [ListTileConstraint.standard] except it
+  /// determines the padding at runtime by comparing the [correctedSize]
+  /// to the actual widget size.
   static ListTileConstraint center(Size correctedSize) {
     return ListTileConstraint(
       maxSize: _defaultSize,
@@ -634,7 +635,7 @@ class ListTileConstraint {
 /// {@end-tool}
 ///
 /// {@tool dartpad}
-/// This sample shows [ListTileLeadingTrailingConstraints] can be used to
+/// This sample shows [ListTileConstraints] can be used to
 /// configure the [leading] and [trailing] widgets to make the list in the
 /// Material 3 spec.
 ///
@@ -1158,12 +1159,12 @@ class ListTile extends StatelessWidget {
   /// that is also null, then a default value of 40 is used.
   final double? minLeadingWidth;
 
-  /// Defines how [ListTile.leading], [ListTile.trailing] and [ListTile.title]
+  /// Defines how [ListTile.leading] and [ListTile.trailing]
   /// are vertically aligned relative to the [ListTile].
   ///
   /// If this property is null then [ListTileThemeData.titleAlignment]
   /// is used. If that is also null then [ListTileTitleAlignment.material3]
-  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used if [ThemeData.useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
   /// is used.
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -52,7 +52,10 @@ class ListTileThemeData with Diagnosticable {
     this.iconColor,
     this.textColor,
     this.titleTextStyle,
+    this.overlineTextColor,
+    this.overlineTextStyle,
     this.subtitleTextStyle,
+    this.leadingAndTrailingTextColor,
     this.leadingAndTrailingTextStyle,
     this.contentPadding,
     this.tileColor,
@@ -87,8 +90,17 @@ class ListTileThemeData with Diagnosticable {
   /// Overrides the default value of [ListTile.titleTextStyle].
   final TextStyle? titleTextStyle;
 
+  /// Overrides the default value of [ListTile.overlineTextColor].
+  final Color? overlineTextColor;
+
+  /// Overrides the default value of [ListTile.overlineTextStyle].
+  final TextStyle? overlineTextStyle;
+
   /// Overrides the default value of [ListTile.subtitleTextStyle].
   final TextStyle? subtitleTextStyle;
+
+  /// Overrides the default value of [ListTile.leadingAndTrailingTextColor].
+  final Color? leadingAndTrailingTextColor;
 
   /// Overrides the default value of [ListTile.leadingAndTrailingTextStyle].
   final TextStyle? leadingAndTrailingTextStyle;
@@ -133,7 +145,10 @@ class ListTileThemeData with Diagnosticable {
     Color? iconColor,
     Color? textColor,
     TextStyle? titleTextStyle,
+    Color? overlineTextColor,
+    TextStyle? overlineTextStyle,
     TextStyle? subtitleTextStyle,
+    Color? leadingAndTrailingTextColor,
     TextStyle? leadingAndTrailingTextStyle,
     EdgeInsetsGeometry? contentPadding,
     Color? tileColor,
@@ -155,7 +170,10 @@ class ListTileThemeData with Diagnosticable {
       iconColor: iconColor ?? this.iconColor,
       textColor: textColor ?? this.textColor,
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
+      overlineTextColor: overlineTextColor ?? this.overlineTextColor,
+      overlineTextStyle: overlineTextStyle ?? this.overlineTextStyle,
       subtitleTextStyle: subtitleTextStyle ?? this.subtitleTextStyle,
+      leadingAndTrailingTextColor: leadingAndTrailingTextColor ?? this.leadingAndTrailingTextColor,
       leadingAndTrailingTextStyle: leadingAndTrailingTextStyle ?? this.leadingAndTrailingTextStyle,
       contentPadding: contentPadding ?? this.contentPadding,
       tileColor: tileColor ?? this.tileColor,
@@ -183,7 +201,10 @@ class ListTileThemeData with Diagnosticable {
       iconColor: Color.lerp(a?.iconColor, b?.iconColor, t),
       textColor: Color.lerp(a?.textColor, b?.textColor, t),
       titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
+      overlineTextColor: Color.lerp(a?.overlineTextColor, b?.overlineTextColor, t),
+      overlineTextStyle: TextStyle.lerp(a?.overlineTextStyle, b?.overlineTextStyle, t),
       subtitleTextStyle: TextStyle.lerp(a?.subtitleTextStyle, b?.subtitleTextStyle, t),
+      leadingAndTrailingTextColor: Color.lerp(a?.leadingAndTrailingTextColor, b?.leadingAndTrailingTextColor, t),
       leadingAndTrailingTextStyle: TextStyle.lerp(a?.leadingAndTrailingTextStyle, b?.leadingAndTrailingTextStyle, t),
       contentPadding: EdgeInsetsGeometry.lerp(a?.contentPadding, b?.contentPadding, t),
       tileColor: Color.lerp(a?.tileColor, b?.tileColor, t),
@@ -199,7 +220,7 @@ class ListTileThemeData with Diagnosticable {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll(<Object?>[
     dense,
     shape,
     style,
@@ -207,7 +228,10 @@ class ListTileThemeData with Diagnosticable {
     iconColor,
     textColor,
     titleTextStyle,
+    overlineTextColor,
+    overlineTextStyle,
     subtitleTextStyle,
+    leadingAndTrailingTextColor,
     leadingAndTrailingTextStyle,
     contentPadding,
     tileColor,
@@ -219,7 +243,7 @@ class ListTileThemeData with Diagnosticable {
     mouseCursor,
     visualDensity,
     titleAlignment,
-  );
+  ]);
 
   @override
   bool operator ==(Object other) {
@@ -236,7 +260,10 @@ class ListTileThemeData with Diagnosticable {
       && other.selectedColor == selectedColor
       && other.iconColor == iconColor
       && other.titleTextStyle == titleTextStyle
+      && other.overlineTextColor == overlineTextColor
+      && other.overlineTextStyle == overlineTextStyle
       && other.subtitleTextStyle == subtitleTextStyle
+      && other.leadingAndTrailingTextColor == leadingAndTrailingTextColor
       && other.leadingAndTrailingTextStyle == leadingAndTrailingTextStyle
       && other.textColor == textColor
       && other.contentPadding == contentPadding
@@ -261,7 +288,10 @@ class ListTileThemeData with Diagnosticable {
     properties.add(ColorProperty('iconColor', iconColor, defaultValue: null));
     properties.add(ColorProperty('textColor', textColor, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('titleTextStyle', titleTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<Color>('overlineTextColor', overlineTextColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<TextStyle>('overlineTextStyle', overlineTextStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('subtitleTextStyle', subtitleTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<Color>('leadingAndTrailingTextColor', leadingAndTrailingTextColor, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('leadingAndTrailingTextStyle', leadingAndTrailingTextStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('contentPadding', contentPadding, defaultValue: null));
     properties.add(ColorProperty('tileColor', tileColor, defaultValue: null));
@@ -481,7 +511,10 @@ class ListTileTheme extends InheritedTheme {
     Color? iconColor,
     Color? textColor,
     TextStyle? titleTextStyle,
+    Color? overlineTextColor,
+    TextStyle? overlineTextStyle,
     TextStyle? subtitleTextStyle,
+    Color? leadingAndTrailingTextColor,
     TextStyle? leadingAndTrailingTextStyle,
     EdgeInsetsGeometry? contentPadding,
     Color? tileColor,
@@ -508,7 +541,9 @@ class ListTileTheme extends InheritedTheme {
             iconColor: iconColor ?? parent.iconColor,
             textColor: textColor ?? parent.textColor,
             titleTextStyle: titleTextStyle ?? parent.titleTextStyle,
+            overlineTextColor: overlineTextColor ?? parent.overlineTextColor,
             subtitleTextStyle: subtitleTextStyle ?? parent.subtitleTextStyle,
+            leadingAndTrailingTextColor: leadingAndTrailingTextColor ?? parent.leadingAndTrailingTextColor,
             leadingAndTrailingTextStyle: leadingAndTrailingTextStyle ?? parent.leadingAndTrailingTextStyle,
             contentPadding: contentPadding ?? parent.contentPadding,
             tileColor: tileColor ?? parent.tileColor,

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -173,10 +173,12 @@ class RadioListTile<T> extends StatelessWidget {
     this.splashRadius,
     this.materialTapTargetSize,
     this.title,
+    this.overline,
     this.subtitle,
     this.isThreeLine = false,
     this.dense,
     this.secondary,
+    this.secondaryConstraint,
     this.selected = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.autofocus = false,
@@ -188,9 +190,18 @@ class RadioListTile<T> extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
+    this.titleAlignment,
   }) : _radioType = _RadioType.material,
        useCupertinoCheckmarkStyle = false,
-       assert(!isThreeLine || subtitle != null);
+       assert(
+         !(subtitle == null && isThreeLine),
+         'ListTile.subtitle must be present when CheckboxListTile.isThreeLine == true',
+       ),
+       assert(
+         !(subtitle != null && overline != null && !isThreeLine),
+         'CheckboxListTile.subtitle and CheckboxListTile.overline must not be present '
+           'together when CheckboxListTile.isThreeLine == false',
+       );
 
   /// Creates a combination of a list tile and a platform adaptive radio.
   ///
@@ -212,10 +223,12 @@ class RadioListTile<T> extends StatelessWidget {
     this.splashRadius,
     this.materialTapTargetSize,
     this.title,
+    this.overline,
     this.subtitle,
     this.isThreeLine = false,
     this.dense,
     this.secondary,
+    ListTileConstraint? secondaryConstraint,
     this.selected = false,
     this.controlAffinity = ListTileControlAffinity.platform,
     this.autofocus = false,
@@ -228,8 +241,18 @@ class RadioListTile<T> extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.useCupertinoCheckmarkStyle = false,
+    this.titleAlignment,
   }) : _radioType = _RadioType.adaptive,
-       assert(!isThreeLine || subtitle != null);
+       secondaryConstraint = secondaryConstraint ?? ListTileConstraint.standard,
+       assert(
+         !(subtitle == null && isThreeLine),
+         'ListTile.subtitle must be present when CheckboxListTile.isThreeLine == true',
+       ),
+       assert(
+         !(subtitle != null && overline != null && !isThreeLine),
+         'CheckboxListTile.subtitle and CheckboxListTile.overline must not be present '
+           'together when CheckboxListTile.isThreeLine == false',
+       );
 
   /// The value represented by this radio button.
   final T value;
@@ -357,6 +380,11 @@ class RadioListTile<T> extends StatelessWidget {
   /// Typically a [Text] widget.
   final Widget? title;
 
+  /// Additional content displayed above the title.
+  ///
+  /// Typically a [Text] widget.
+  final Widget? overline;
+
   /// Additional content displayed below the title.
   ///
   /// Typically a [Text] widget.
@@ -367,10 +395,22 @@ class RadioListTile<T> extends StatelessWidget {
   /// Typically an [Icon] widget.
   final Widget? secondary;
 
+  /// Defines how [ListTile.leading] is constrained and aligned to the [ListTile].
+  ///
+  /// The default value is [ListTileConstraint.standard].
+  final ListTileConstraint? secondaryConstraint;
+
   /// Whether this list tile is intended to display three lines of text.
   ///
-  /// If false, the list tile is treated as having one line if the subtitle is
-  /// null and treated as having two lines if the subtitle is non-null.
+  /// If true, then [overline] or [subtitle] must be non-null (since it is expected to give
+  /// the second and third lines of text).
+  ///
+  /// If false, the list tile is treated as having one line if the [overline] or [subtitle] is
+  /// null and treated as having two lines if the subtitle is non-null. It must only have
+  /// one of [overline] or [subtitle].
+  ///
+  /// When using a [Text] widget for [title], [overline] and [subtitle], you can enforce
+  /// line limits using [Text.maxLines].
   final bool isThreeLine;
 
   /// Whether this list tile is part of a vertically dense list.
@@ -435,6 +475,20 @@ class RadioListTile<T> extends StatelessWidget {
   ///  * [Feedback] for providing platform-specific feedback to certain actions.
   final bool? enableFeedback;
 
+  /// Defines how [leading], [trailing] and [title]
+  /// are vertically aligned relative to the [ListTile].
+  ///
+  /// If this property is null then [ListTileThemeData.titleAlignment]
+  /// is used. If that is also null then [ListTileTitleAlignment.material3]
+  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
+  final ListTileTitleAlignment? titleAlignment;
+
   final _RadioType _radioType;
 
   /// Determines wether or not to use the checkbox style for the [CupertinoRadio]
@@ -486,14 +540,19 @@ class RadioListTile<T> extends StatelessWidget {
     }
 
     Widget? leading, trailing;
+    ListTileConstraint? leadingConstraint, trailingConstraint;
     switch (controlAffinity) {
       case ListTileControlAffinity.leading:
       case ListTileControlAffinity.platform:
         leading = control;
+        leadingConstraint = ListTileConstraint.icon24;
         trailing = secondary;
+        trailingConstraint = secondaryConstraint;
       case ListTileControlAffinity.trailing:
         leading = secondary;
+        leadingConstraint = secondaryConstraint;
         trailing = control;
+        trailingConstraint = ListTileConstraint.icon24;
     }
     final ThemeData theme = Theme.of(context);
     final RadioThemeData radioThemeData = RadioTheme.of(context);
@@ -508,8 +567,11 @@ class RadioListTile<T> extends StatelessWidget {
         selectedColor: effectiveActiveColor,
         leading: leading,
         title: title,
+        overline: overline,
         subtitle: subtitle,
         trailing: trailing,
+        leadingConstraint: leadingConstraint,
+        trailingConstraint: trailingConstraint,
         isThreeLine: isThreeLine,
         dense: dense,
         enabled: onChanged != null,

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -475,12 +475,12 @@ class RadioListTile<T> extends StatelessWidget {
   ///  * [Feedback] for providing platform-specific feedback to certain actions.
   final bool? enableFeedback;
 
-  /// Defines how [leading], [trailing] and [title]
+  /// Defines how the underlying [ListTile.leading] and [ListTile.trailing]
   /// are vertically aligned relative to the [ListTile].
   ///
   /// If this property is null then [ListTileThemeData.titleAlignment]
   /// is used. If that is also null then [ListTileTitleAlignment.material3]
-  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used if [ThemeData.useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
   /// is used.
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -594,6 +594,7 @@ class RadioListTile<T> extends StatelessWidget {
         focusNode: focusNode,
         onFocusChange: onFocusChange,
         enableFeedback: enableFeedback,
+        titleAlignment: titleAlignment,
       ),
     );
   }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -1656,7 +1656,7 @@ class _SwitchConfigM2 with _SwitchConfig {
   double get switchHeightCollapsed => _kSwitchMinSize;
 
   @override
-  double get switchWidth => trackWidth - 2 * (trackHeight / 2.0) + _kSwitchMinSize;
+  double get switchWidth => trackWidth - trackHeight + _kSwitchMinSize;
 
   @override
   double get thumbRadiusWithIcon => 10.0;
@@ -1940,7 +1940,7 @@ class _SwitchConfigM3 with _SwitchConfig {
   double get switchHeightCollapsed => _kSwitchMinSize;
 
   @override
-  double get switchWidth => trackWidth - 2 * (trackHeight / 2.0) + _kSwitchMinSize;
+  double get switchWidth => trackWidth - trackHeight + _kSwitchMinSize;
 
   @override
   double get thumbRadiusWithIcon => 24.0 / 2;

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -515,12 +515,12 @@ class SwitchListTile extends StatelessWidget {
   /// Normally, this property is left to its default value, false.
   final bool selected;
 
-  /// Defines how [leading], [trailing] and [title]
+  /// Defines how the underlying [ListTile.leading] and [ListTile.trailing]
   /// are vertically aligned relative to the [ListTile].
   ///
   /// If this property is null then [ListTileThemeData.titleAlignment]
   /// is used. If that is also null then [ListTileTitleAlignment.material3]
-  /// is used if [useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
+  /// is used if [ThemeData.useMaterial3] is true, otherwise [ListTileTitleAlignment.titleHeight]
   /// is used.
   ///
   /// See also:

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -251,6 +251,18 @@ abstract class EdgeInsetsGeometry {
   ///    based on the `direction` argument.
   EdgeInsets resolve(TextDirection? direction);
 
+  /// Convert this instance into an [EdgeInsetsDirectional], which uses
+  /// relative coordinates (i.e. the 'start' coordinate is the distance
+  /// from the left when text is left-to-right and the distance from
+  /// the right when text is right-to-left).
+  ///
+  /// See also:
+  ///
+  ///  * [EdgeInsets], which flips the determines direction
+  ///    based on the `direction` argument.
+  ///  * [EdgeInsetsDirectional], for which this is a no-op (returns itself).
+  EdgeInsetsDirectional toDirectional(TextDirection? direction);
+
   @override
   String toString() {
     if (_start == 0.0 && _end == 0.0) {
@@ -631,6 +643,17 @@ class EdgeInsets extends EdgeInsetsGeometry {
   @override
   EdgeInsets resolve(TextDirection? direction) => this;
 
+  @override
+  EdgeInsetsDirectional toDirectional(TextDirection? direction) {
+    assert(direction != null);
+    switch (direction!) {
+      case TextDirection.ltr:
+        return EdgeInsetsDirectional.fromSTEB(_left, _top, _right, _bottom);
+      case TextDirection.rtl:
+        return EdgeInsetsDirectional.fromSTEB(_right, _top, _left, _bottom);
+    }
+  }
+
   /// Creates a copy of this EdgeInsets but with the given fields replaced
   /// with the new values.
   EdgeInsets copyWith({
@@ -904,6 +927,9 @@ class EdgeInsetsDirectional extends EdgeInsetsGeometry {
         return EdgeInsets.fromLTRB(start, top, end, bottom);
     }
   }
+
+  @override
+  EdgeInsetsDirectional toDirectional(TextDirection? direction) => this;
 }
 
 class _MixedEdgeInsets extends EdgeInsetsGeometry {
@@ -1005,6 +1031,27 @@ class _MixedEdgeInsets extends EdgeInsetsGeometry {
         return EdgeInsets.fromLTRB(_end + _left, _top, _start + _right, _bottom);
       case TextDirection.ltr:
         return EdgeInsets.fromLTRB(_start + _left, _top, _end + _right, _bottom);
+    }
+  }
+
+  @override
+  EdgeInsetsDirectional toDirectional(TextDirection? direction) {
+    assert(direction != null);
+    switch (direction!) {
+      case TextDirection.rtl:
+        return EdgeInsetsDirectional.fromSTEB(
+          _start + _right,
+          _top,
+          _end + _left,
+          _bottom,
+        );
+      case TextDirection.ltr:
+        return EdgeInsetsDirectional.fromSTEB(
+          _start + _left,
+          _top,
+          _end + _right,
+          _bottom,
+        );
     }
   }
 }

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -138,7 +138,7 @@ void main() {
             value: false,
             onChanged: null,
             title: Text('Title'),
-            contentPadding: EdgeInsets.fromLTRB(10, 18, 4, 2),
+            contentPadding: EdgeInsets.fromLTRB(10, 18, 9, 2),
           ),
         ),
       ),
@@ -151,7 +151,7 @@ void main() {
     final Rect tallerWidget = checkboxRect.height > titleRect.height ? checkboxRect : titleRect;
 
     // Check the offsets of Checkbox and title after padding is applied.
-    expect(paddingRect.right, checkboxRect.right + 4);
+    expect(paddingRect.right, checkboxRect.right + 1.0);
     expect(paddingRect.left, titleRect.left - 10);
 
     // Calculate the remaining height from the default ListTile height.

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -65,7 +65,7 @@ void main() {
         child: SingleChildScrollView(
           child: Column(
             children: <Widget>[
-              ListTile(title: const Text('Top'), key: topKey),
+              ListTile(title: const Text('Top'), key: topKey, leading: const Icon(Icons.person)),
               ExpansionTile(
                 key: expandedKey,
                 initiallyExpanded: true,
@@ -76,6 +76,7 @@ void main() {
                   ListTile(
                     key: tileKey,
                     title: const Text('0'),
+                    leading: const Icon(Icons.person),
                   ),
                 ],
               ),
@@ -86,6 +87,7 @@ void main() {
                   ListTile(
                     key: tileKey,
                     title: const Text('0'),
+                    leading: const Icon(Icons.person),
                   ),
                 ],
               ),
@@ -93,7 +95,7 @@ void main() {
                 key: defaultKey,
                 title: Text('Default'),
                 children: <Widget>[
-                  ListTile(title: Text('0')),
+                  ListTile(title: Text('0'), leading: Icon(Icons.person)),
                 ],
               ),
             ],
@@ -107,23 +109,32 @@ void main() {
       of: find.byKey(key),
       matching: find.byType(Container),
     ));
+    DecoratedBox? getDecoratedBox(Key key, {int at = 0}) => tester.widgetList<DecoratedBox>(
+        find.descendant(of: find.byKey(key), matching: find.byType(DecoratedBox))
+      ).elementAt(at);
 
-    expect(getHeight(topKey), getHeight(expandedKey) - getHeight(tileKey) - 2.0);
-    expect(getHeight(topKey), getHeight(collapsedKey) - 2.0);
-    expect(getHeight(topKey), getHeight(defaultKey) - 2.0);
+    final double singleLineListTileHeight = getHeight(topKey);
+
+    expect(getHeight(expandedKey) - getHeight(tileKey), singleLineListTileHeight);
+    expect(getHeight(collapsedKey), singleLineListTileHeight);
+    expect(getHeight(defaultKey), singleLineListTileHeight);
 
     // expansionTile should have Clip.antiAlias as clipBehavior
     expect(getContainer(expandedKey).clipBehavior, clipBehavior);
 
-    ShapeDecoration expandedContainerDecoration = getContainer(expandedKey).decoration! as ShapeDecoration;
+    BoxDecoration expandedContainerDecoration = getContainer(expandedKey).decoration! as BoxDecoration;
     expect(expandedContainerDecoration.color, Colors.red);
-    expect((expandedContainerDecoration.shape as Border).top.color, dividerColor);
-    expect((expandedContainerDecoration.shape as Border).bottom.color, dividerColor);
 
-    ShapeDecoration collapsedContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
+    ShapeDecoration expandedDecoratedBoxDecoration = getDecoratedBox(expandedKey, at: 1)!.decoration as ShapeDecoration;
+    expect((expandedDecoratedBoxDecoration.shape as Border).top.color, dividerColor);
+    expect((expandedDecoratedBoxDecoration.shape as Border).bottom.color, dividerColor);
+
+    BoxDecoration collapsedContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
     expect(collapsedContainerDecoration.color, Colors.transparent);
-    expect((collapsedContainerDecoration.shape as Border).top.color, Colors.transparent);
-    expect((collapsedContainerDecoration.shape as Border).bottom.color, Colors.transparent);
+
+    ShapeDecoration collapsedDecoratedBoxDecoration = getDecoratedBox(collapsedKey, at: 1)!.decoration as ShapeDecoration;
+    expect((collapsedDecoratedBoxDecoration.shape as Border).top.color, Colors.transparent);
+    expect((collapsedDecoratedBoxDecoration.shape as Border).bottom.color, Colors.transparent);
 
     await tester.tap(find.text('Expanded'));
     await tester.tap(find.text('Collapsed'));
@@ -133,29 +144,35 @@ void main() {
 
     // Pump to the middle of the animation for expansion.
     await tester.pump(const Duration(milliseconds: 100));
-    final ShapeDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
+    final BoxDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
     expect(collapsingContainerDecoration.color, Colors.transparent);
-    expect((collapsingContainerDecoration.shape as Border).top.color, const Color(0x15222222));
-    expect((collapsingContainerDecoration.shape as Border).bottom.color, const Color(0x15222222));
+
+    final ShapeDecoration collapsingDecoratedBoxDecoration = getDecoratedBox(collapsedKey, at: 1)!.decoration as ShapeDecoration;
+    expect((collapsingDecoratedBoxDecoration.shape as Border).top.color, const Color(0x15222222));
+    expect((collapsingDecoratedBoxDecoration.shape as Border).bottom.color, const Color(0x15222222));
 
     // Pump all the way to the end now.
     await tester.pump(const Duration(seconds: 1));
 
-    expect(getHeight(topKey), getHeight(expandedKey) - 2.0);
-    expect(getHeight(topKey), getHeight(collapsedKey) - getHeight(tileKey) - 2.0);
-    expect(getHeight(topKey), getHeight(defaultKey) - getHeight(tileKey) - 2.0);
+    expect(getHeight(expandedKey), singleLineListTileHeight);
+    expect(getHeight(collapsedKey) - getHeight(tileKey), singleLineListTileHeight);
+    expect(getHeight(defaultKey) - getHeight(tileKey), singleLineListTileHeight);
 
     // Expanded should be collapsed now.
-    expandedContainerDecoration = getContainer(expandedKey).decoration! as ShapeDecoration;
+    expandedContainerDecoration = getContainer(expandedKey).decoration! as BoxDecoration;
     expect(expandedContainerDecoration.color, Colors.transparent);
-    expect((expandedContainerDecoration.shape as Border).top.color, Colors.transparent);
-    expect((expandedContainerDecoration.shape as Border).bottom.color, Colors.transparent);
+
+    expandedDecoratedBoxDecoration = getDecoratedBox(expandedKey, at: 1)!.decoration as ShapeDecoration;
+    expect((expandedDecoratedBoxDecoration.shape as Border).top.color, Colors.transparent);
+    expect((expandedDecoratedBoxDecoration.shape as Border).bottom.color, Colors.transparent);
 
     // Collapsed should be expanded now.
-    collapsedContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
+    collapsedContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
     expect(collapsedContainerDecoration.color, Colors.transparent);
-    expect((collapsedContainerDecoration.shape as Border).top.color, dividerColor);
-    expect((collapsedContainerDecoration.shape as Border).bottom.color, dividerColor);
+
+    collapsedDecoratedBoxDecoration = getDecoratedBox(collapsedKey, at: 1)!.decoration as ShapeDecoration;
+    expect((collapsedDecoratedBoxDecoration.shape as Border).top.color, dividerColor);
+    expect((collapsedDecoratedBoxDecoration.shape as Border).bottom.color, dividerColor);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('ExpansionTile Theme dependencies', (WidgetTester tester) async {
@@ -505,10 +522,10 @@ void main() {
       ),
     ));
 
-    ShapeDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
+    BoxDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(expansionTileKey),
       matching: find.byType(Container),
-    )).decoration! as ShapeDecoration;
+    )).decoration! as BoxDecoration;
 
     expect(shapeDecoration.color, collapsedBackgroundColor);
 
@@ -518,12 +535,41 @@ void main() {
     shapeDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(expansionTileKey),
       matching: find.byType(Container),
-    )).decoration! as ShapeDecoration;
+    )).decoration! as BoxDecoration;
 
     expect(shapeDecoration.color, backgroundColor);
   });
 
-  testWidgets('ExpansionTile default iconColor, textColor', (WidgetTester tester) async {
+  testWidgets('ExpansionTile default iconColor, textColor Material 2', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: false);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: const Material(
+        child: ExpansionTile(
+          title: TestText('title'),
+          trailing: TestIcon(),
+          children: <Widget>[
+            SizedBox(height: 100, width: 100),
+          ],
+        ),
+      ),
+    ));
+
+    Color getIconColor() => tester.state<TestIconState>(find.byType(TestIcon)).iconTheme.color!;
+    Color getTextColor() => tester.state<TestTextState>(find.byType(TestText)).textStyle.color!;
+
+    expect(getIconColor(), theme.unselectedWidgetColor);
+    expect(getTextColor(), theme.textTheme.titleMedium!.color);
+
+    await tester.tap(find.text('title'));
+    await tester.pumpAndSettle();
+
+    expect(getIconColor(), theme.colorScheme.primary);
+    expect(getTextColor(), theme.colorScheme.primary);
+  });
+
+  testWidgets('ExpansionTile default iconColor, textColor Material 3', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
 
     await tester.pumpWidget(MaterialApp(
@@ -548,7 +594,7 @@ void main() {
     await tester.tap(find.text('title'));
     await tester.pumpAndSettle();
 
-    expect(getIconColor(), theme.colorScheme.primary);
+    expect(getIconColor(), theme.colorScheme.onSurfaceVariant);
     expect(getTextColor(), theme.colorScheme.onSurface);
   });
 
@@ -620,20 +666,19 @@ void main() {
       ),
     ));
 
-    Container getContainer(Key key) => tester.firstWidget(find.descendant(
-      of: find.byKey(key),
-      matching: find.byType(Container),
-    ));
+    DecoratedBox? getDecoratedBox(Key key, {int at = 0}) => tester.widgetList<DecoratedBox>(
+        find.descendant(of: find.byKey(key), matching: find.byType(DecoratedBox))
+    ).elementAt(at);
 
     // expansionTile should be Collapsed now.
-    ShapeDecoration expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
+    ShapeDecoration expandedContainerDecoration = getDecoratedBox(expansionTileKey, at: 1)!.decoration as ShapeDecoration;
     expect(expandedContainerDecoration.shape, collapsedShape);
 
     await tester.tap(find.text('ExpansionTile'));
     await tester.pumpAndSettle();
 
     // expansionTile should be Expanded now.
-    expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
+    expandedContainerDecoration = getDecoratedBox(expansionTileKey, at: 1)!.decoration as ShapeDecoration;
     expect(expandedContainerDecoration.shape, shape);
   });
 

--- a/packages/flutter/test/material/expansion_tile_theme_test.dart
+++ b/packages/flutter/test/material/expansion_tile_theme_test.dart
@@ -169,11 +169,14 @@ void main() {
         ),
       ),
     );
+    DecoratedBox? getDecoratedBox(Key key, {int at = 0}) => tester.widgetList<DecoratedBox>(
+        find.descendant(of: find.byKey(key), matching: find.byType(DecoratedBox))
+    ).elementAt(at);
 
-    final ShapeDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
+    final BoxDecoration boxDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(tileKey),
       matching: find.byType(Container),
-    )).decoration! as ShapeDecoration;
+    )).decoration! as BoxDecoration;
 
     final Clip tileClipBehavior = tester.firstWidget<Container>(find.descendant(
       of: find.byKey(tileKey),
@@ -184,7 +187,7 @@ void main() {
     expect(tileClipBehavior, clipBehavior);
 
     // Check the tile's collapsed background color when collapsedBackgroundColor is applied.
-    expect(shapeDecoration.color, collapsedBackgroundColor);
+    expect(boxDecoration.color, collapsedBackgroundColor);
 
     final Rect titleRect = tester.getRect(find.text('Collapsed Tile'));
     final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
@@ -208,7 +211,7 @@ void main() {
     // Check the collapsed text color when textColor is applied.
     expect(getTextColor(), collapsedTextColor);
     // Check the collapsed ShapeBorder when shape is applied.
-    expect(shapeDecoration.shape, collapsedShape);
+    expect((getDecoratedBox(tileKey, at: 1)!.decoration as ShapeDecoration).shape, collapsedShape);
   });
 
   testWidgets('ExpansionTileTheme - expanded', (WidgetTester tester) async {
@@ -260,13 +263,16 @@ void main() {
         ),
       ),
     );
+    DecoratedBox? getDecoratedBox(Key key, {int at = 0}) => tester.widgetList<DecoratedBox>(
+        find.descendant(of: find.byKey(key), matching: find.byType(DecoratedBox))
+    ).elementAt(at);
 
-    final ShapeDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
+    final BoxDecoration boxDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(tileKey),
       matching: find.byType(Container),
-    )).decoration! as ShapeDecoration;
+    )).decoration! as BoxDecoration;
     // Check the tile's background color when backgroundColor is applied.
-    expect(shapeDecoration.color, backgroundColor);
+    expect(boxDecoration.color, backgroundColor);
 
     final Rect titleRect = tester.getRect(find.text('Expanded Tile'));
     final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
@@ -290,7 +296,7 @@ void main() {
     // Check the expanded text color when textColor is applied.
     expect(getTextColor(), textColor);
     // Check the expanded ShapeBorder when shape is applied.
-    expect(shapeDecoration.shape, collapsedShape);
+    expect((getDecoratedBox(tileKey, at: 1)!.decoration as ShapeDecoration).shape, collapsedShape);
 
     // Check the child position when expandedAlignment is applied.
     final Rect childRect = tester.getRect(find.text('Tile 1'));

--- a/packages/flutter/test/material/expansion_tile_theme_test.dart
+++ b/packages/flutter/test/material/expansion_tile_theme_test.dart
@@ -67,6 +67,8 @@ void main() {
     expect(theme.shape, null);
     expect(theme.collapsedShape, null);
     expect(theme.clipBehavior, null);
+    expect(theme.showTopDividerWhenExpanded, null);
+    expect(theme.showBottomDividerWhenExpanded, null);
   });
 
   testWidgets('Default ExpansionTileThemeData debugFillProperties', (WidgetTester tester) async {
@@ -96,6 +98,8 @@ void main() {
       shape: Border(),
       collapsedShape: Border(),
       clipBehavior: Clip.antiAlias,
+      showTopDividerWhenExpanded: true,
+      showBottomDividerWhenExpanded: false,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -116,6 +120,8 @@ void main() {
       'shape: Border.all(BorderSide(width: 0.0, style: none))',
       'collapsedShape: Border.all(BorderSide(width: 0.0, style: none))',
       'clipBehavior: Clip.antiAlias',
+      'showTopDividerWhenExpanded: true',
+      'showBottomDividerWhenExpanded: false',
     ]);
   });
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2819,7 +2819,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 16.0, 800.0 - 16.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 37.5, 800.0 - 16.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0, hasIssue99933 ? 52 : 37.5 + 14.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
@@ -2830,7 +2830,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 16.0, 800.0 - 16.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 37.5, 800.0 - 16.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0, hasIssue99933 ? 52 : 37.5 + 14.0));
     });
 
     testWidgets('Padding correction two line, empty, Material 3', (WidgetTester tester) async {
@@ -2920,7 +2920,7 @@ void main() {
         trailingConstraint: ListTileConstraint.video,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 20.5, 800.0 - 16.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 59.5, 800.0 - 16.0, 59.5 + 14.0));
 
@@ -2934,7 +2934,7 @@ void main() {
         trailingConstraint: ListTileConstraint.video,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 20.5, 800.0 - 16.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 59.5, 800.0 - 16.0, 59.5 + 14.0));
     });
@@ -3068,7 +3068,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 16.0, 800.0 - 16.0 * 2.0 - 56.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 37.5, 800.0 - 16.0 * 2.0 - 56.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 29.0, 800.0 - 16.0, 29.0 + 14.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3079,7 +3079,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 16.0, 800.0 - 16.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 37.5, 800.0 - 16.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 29.0, 16.0 + 56.0, 29.0 + 14.0));
     });
 
@@ -3169,7 +3169,7 @@ void main() {
         trailing: trailingSupportText,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 20.5, 800.0 - 16.0 * 2.0 - 56.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0 * 2.0 - 56.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 59.5, 800.0 - 16.0 * 2.0 - 56.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 14.0));
@@ -3183,7 +3183,7 @@ void main() {
         trailing: trailingSupportText,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 20.5, 800.0 - 16.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 59.5, 800.0 - 16.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 14.0));
@@ -3332,7 +3332,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.0, 800.0 - 16.0 * 2.0 - 24.0, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 41.5, 800.0 - 16.0 * 2.0 - 24.0, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 24.0, 800.0 - 16.0, 24.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3345,7 +3345,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 20.0, 800.0 - 16.0 * 2 - 40, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 41.5, 800.0 - 16.0 * 2 - 40, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 24.0, 16.0 + 24.0, 24.0 + 24.0));
     });
 
@@ -3436,7 +3436,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 16.0, 800.0 - 16.0 * 2 - 40, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 52 : 337.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3449,7 +3449,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.5, 800.0 - 16.0 * 2.0 - 24.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 24.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 59.5, 800.0 - 16.0 * 2.0 - 24.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
@@ -3465,7 +3465,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 20.5, 800.0 - 16.0 * 2 - 40, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 59.5, 800.0 - 16.0 * 2 - 40, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
@@ -3636,7 +3636,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 16.0, 8.0 + 40.0, 16.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.0, 800.0 - 16.0 * 2.0 - 24.0, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 41.5, 800.0 - 16.0 * 2.0 - 24.0, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 16.0, 800.0 - 8.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3651,7 +3651,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 40.0 - 8.0, 16.0, 800.0 - 8.0, 16.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 20.0, 800.0 - 16.0 * 2 - 40, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 41.5, 800.0 - 16.0 * 2 - 40, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 16.0, 8.0 + 40.0, 16.0 + 40.0));
     });
 
@@ -3754,7 +3754,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 16.0, 800.0 - 16.0 * 2 - 40, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 58 : 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3769,7 +3769,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.5, 800.0 - 16.0 * 2.0 - 24.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 24.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 59.5, 800.0 - 16.0 * 2.0 - 24.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
@@ -3787,7 +3787,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 20.5, 800.0 - 16.0 * 2 - 40, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 31 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 21 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 59.5, 800.0 - 16.0 * 2 - 40, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
@@ -3966,7 +3966,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.0, 800.0 - 16.0 * 2.0 - 40.0, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 41.5, 800.0 - 16.0 * 2.0 - 40.0, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2.0 - 40.0, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3981,7 +3981,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 20.0, 800.0 - 16.0 * 2 - 40.0, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 41.5, 800.0 - 16.0 * 2 - 40.0, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2 - 40.0, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
     });
 
@@ -4099,7 +4099,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.5, 800.0 - 16.0 * 2.0 - 40.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 40.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 40.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 59.5, 800.0 - 16.0 * 2.0 - 40.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
@@ -4117,7 +4117,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 20.5, 800.0 - 16.0 * 2 - 40.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 36.0, 800.0 - 16.0 * 2 - 40.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 59.5, 800.0 - 16.0 * 2 - 40.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
@@ -4296,7 +4296,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 8.0, 16.0 + 56.0, 8.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 20.0, 800.0 - 16.0 * 2.0 - 56.0, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 41.5, 800.0 - 16.0 * 2.0 - 56.0, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 8.0, 800.0 - 16.0, 8.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4311,7 +4311,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 8.0, 800.0 - 16.0, 8.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 20.0, 800.0 - 16.0 * 2 - 56, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 41.5, 800.0 - 16.0 * 2 - 56, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 * 2 - 56, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 8.0, 16.0 + 56.0, 8.0 + 56.0));
     });
 
@@ -4429,7 +4429,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 20.5, 800.0 - 16.0 * 2.0 - 56.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 36.0, 800.0 - 16.0 * 2.0 - 56.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 59.5, 800.0 - 16.0 * 2.0 - 56.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 56.0));
@@ -4447,7 +4447,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 20.5, 800.0 - 16.0 * 2 - 56, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 56, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0 * 2 - 56, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 59.5, 800.0 - 16.0 * 2 - 56, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 56.0));
@@ -4626,7 +4626,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 8.0, 100.0, 8.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 + 100.0, 20.0, 800.0 - 16.0 - 100.0, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 + 100.0, 41.5, 800.0 - 16.0 - 100.0, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 + 100.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 - 100.0, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 100.0, 8.0, 800.0, 8.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4641,7 +4641,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 100.0, 8.0, 800.0, 8.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 + 100.0, 20.0, 800.0 - 16.0 - 100, 20.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 + 100.0, 41.5, 800.0 - 16.0 - 100, 41.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 + 100.0, hasIssue99933 ? 42 : 41.5, 800.0 - 16.0 - 100, hasIssue99933 ? 56 : 41.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 8.0, 100.0, 8.0 + 56.0));
     });
 
@@ -4739,7 +4739,7 @@ void main() {
         leading: leadingVideo,
         trailing: trailingVideo,
         leadingConstraint: ListTileConstraint.video,
-        trailingConstraint: ListTileConstraint.video,
+        trailingConstraint: ListTileConstraint.video  ,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 100, 16.0, 800.0, 16.0 + 56.0));
@@ -4759,7 +4759,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 16.0, 100.0, 16.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(20.0 + 100.0, 20.5, 800.0 - 20.0 - 100.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 21 : 20.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(20.0 + 100.0, 36.0, 800.0 - 20.0 - 100.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, 59.5, 800.0 - 20.0 - 100.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 100.0, 16.0, 800.0, 16.0 + 56.0));
@@ -4777,7 +4777,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 100.0, 16.0, 800.0, 16.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(20.0 + 100.0, 20.5, 800.0 - 20.0 - 100.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 21 : 20.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(20.0 + 100.0, 36.0, 800.0 - 20.0 - 100.0, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, 59.5, 800.0 - 20.0 - 100.0, 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 16.0, 100.0, 16.0 + 56.0));

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -3787,7 +3787,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 31 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 21 : 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
       expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2922,7 +2922,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 59.5, 800.0 - 16.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0, hasIssue99933 ? 74 : 59.5 + 14.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
@@ -2936,7 +2936,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 59.5, 800.0 - 16.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0, hasIssue99933 ? 74 : 59.5 + 14.0));
     });
 
     testWidgets('Padding correction three line, empty, Material 3', (WidgetTester tester) async {
@@ -3171,7 +3171,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0 * 2.0 - 56.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 59.5, 800.0 - 16.0 * 2.0 - 56.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 14.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3185,7 +3185,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 59.5, 800.0 - 16.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 14.0));
     });
 
@@ -3451,7 +3451,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 24.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 59.5, 800.0 - 16.0 * 2.0 - 24.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3467,7 +3467,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 59.5, 800.0 - 16.0 * 2 - 40, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
     });
 
@@ -3771,7 +3771,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 24.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 59.5, 800.0 - 16.0 * 2.0 - 24.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3789,7 +3789,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 31 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 21 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 59.5, 800.0 - 16.0 * 2 - 40, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
     });
 
@@ -4101,7 +4101,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 40.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 40.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 59.5, 800.0 - 16.0 * 2.0 - 40.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2.0 - 40.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4119,7 +4119,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 36.0, 800.0 - 16.0 * 2 - 40.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 59.5, 800.0 - 16.0 * 2 - 40.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2 - 40.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
     });
 
@@ -4431,7 +4431,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 56.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 36.0, 800.0 - 16.0 * 2.0 - 56.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 59.5, 800.0 - 16.0 * 2.0 - 56.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4449,7 +4449,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 56.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 56, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0 * 2 - 56, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 59.5, 800.0 - 16.0 * 2 - 56, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 60 : 59.5, 800.0 - 16.0 * 2 - 56, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 56.0));
     });
 
@@ -4761,7 +4761,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 16.0, 100.0, 16.0 + 56.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 21 : 20.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(20.0 + 100.0, 36.0, 800.0 - 20.0 - 100.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, 59.5, 800.0 - 20.0 - 100.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 60 : 59.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 100.0, 16.0, 800.0, 16.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4779,7 +4779,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 100.0, 16.0, 800.0, 16.0 + 56.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 21 : 20.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(20.0 + 100.0, 36.0, 800.0 - 20.0 - 100.0, 36.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, 59.5, 800.0 - 20.0 - 100.0, 59.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 60 : 59.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 74 : 59.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 16.0, 100.0, 16.0 + 56.0));
     });
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2785,6 +2785,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, empty, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
@@ -2792,7 +2797,7 @@ void main() {
         trailingConstraint: ListTileConstraint.video,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 16.5, 800.0 - 16.0, 16.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 17 : 16.5, 800.0 - 16.0, hasIssue99933 ? 27 : 16.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 32.0, 800.0 - 16.0, 32.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -2803,7 +2808,7 @@ void main() {
         trailingConstraint: ListTileConstraint.video,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 16.5, 800.0 - 16.0, 16.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 17 : 16.5, 800.0 - 16.0, hasIssue99933 ? 27 : 16.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 32.0, 800.0 - 16.0, 32.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -2878,6 +2883,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, empty, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -2887,7 +2897,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 16.0, 800.0 - 16.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 37.5, 800.0 - 16.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0, hasIssue99933 ? 52 : 37.5 + 14.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
@@ -2899,7 +2909,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 16.0, 800.0 - 16.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 37.5, 800.0 - 16.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0, hasIssue99933 ? 52 : 37.5 + 14.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
@@ -3025,13 +3035,18 @@ void main() {
     });
 
     testWidgets('Padding correction two line, trailing text, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
         trailing: trailingSupportText,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 16.5, 800.0 - 16.0 * 2.0 - 56.0, 16.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 17 : 16.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 27 : 16.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 32.0, 800.0 - 16.0 * 2.0 - 56.0, 32.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 29.0, 800.0 - 16.0, 29.0 + 14.0));
 
@@ -3042,7 +3057,7 @@ void main() {
         trailing: trailingSupportText,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 16.5, 800.0 - 16.0, 16.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 17 : 16.5, 800.0 - 16.0, hasIssue99933 ? 27 : 16.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 32.0, 800.0 - 16.0, 32.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 29.0, 16.0 + 56.0, 29.0 + 14.0));
 
@@ -3118,6 +3133,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, trailing text, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -3126,7 +3146,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 16.0, 800.0 - 16.0 * 2.0 - 56.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 37.5, 800.0 - 16.0 * 2.0 - 56.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 14.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3138,7 +3158,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 16.0, 800.0 - 16.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 37.5, 800.0 - 16.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 14.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3273,6 +3293,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, icon, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
@@ -3281,7 +3306,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.5, 800.0 - 16.0 * 2.0 - 24.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 24.0, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 24.0, 800.0 - 16.0, 24.0 + 24.0));
 
@@ -3294,7 +3319,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 20.5, 800.0 - 16.0 * 2 - 40, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 24.0, 16.0 + 24.0, 24.0 + 24.0));
 
@@ -3382,6 +3407,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, icon, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -3392,7 +3422,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 16.0, 800.0 - 16.0 * 2.0 - 24.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 37.5, 800.0 - 16.0 * 2.0 - 24.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3406,7 +3436,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 24.0, 16.0, 800.0 - 16.0, 16.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 16.0, 800.0 - 16.0 * 2 - 40, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 37.5, 800.0 - 16.0 * 2 - 40, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 52 : 337.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 24.0, 16.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3561,6 +3591,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, iconButton, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
@@ -3571,7 +3606,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 16.0, 8.0 + 40.0, 16.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.5, 800.0 - 16.0 * 2.0 - 24.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 24.0, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 16.0, 800.0 - 8.0, 16.0 + 40.0));
 
@@ -3586,7 +3621,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 40.0 - 8.0, 16.0, 800.0 - 8.0, 16.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 20.5, 800.0 - 16.0 * 2 - 40, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 * 2 - 40, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 16.0, 8.0 + 40.0, 16.0 + 40.0));
 
@@ -3686,6 +3721,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, iconButton, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -3698,7 +3738,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 16.0, 800.0 - 16.0 * 2.0 - 24.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 37.5, 800.0 - 16.0 * 2.0 - 24.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2.0 - 24.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3714,7 +3754,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 8.0 - 40.0, 8.0, 800.0 - 8.0, 8.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 16.0, 800.0 - 16.0 * 2 - 40, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 37.5, 800.0 - 16.0 * 2 - 40, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40, hasIssue99933 ? 58 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(8.0, 8.0, 8.0 + 40.0, 8.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3881,6 +3921,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, avatar, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
@@ -3891,7 +3936,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 20.5, 800.0 - 16.0 * 2.0 - 40.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 40.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 36.0, 800.0 - 16.0 * 2.0 - 40.0, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
 
@@ -3906,7 +3951,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 20.5, 800.0 - 16.0 * 2 - 40.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 40.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 36.0, 800.0 - 16.0 * 2 - 40.0, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
 
@@ -4006,6 +4051,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, avatar, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -4018,7 +4068,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 16.0, 800.0 - 16.0 * 2.0 - 40.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, 37.5, 800.0 - 16.0 * 2.0 - 40.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 40.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2.0 - 40.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4034,7 +4084,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 16.0, 800.0 - 16.0 * 2 - 40.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 37.5, 800.0 - 16.0 * 2 - 40.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 40.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4201,6 +4251,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, image, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
@@ -4211,7 +4266,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 8.0, 16.0 + 56.0, 8.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 20.5, 800.0 - 16.0 * 2.0 - 56.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 36.0, 800.0 - 16.0 * 2.0 - 56.0, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 8.0, 800.0 - 16.0, 8.0 + 56.0));
 
@@ -4226,7 +4281,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 8.0, 800.0 - 16.0, 8.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 20.5, 800.0 - 16.0 * 2 - 56, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 * 2 - 56, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0 * 2 - 56, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 8.0, 16.0 + 56.0, 8.0 + 56.0));
 
@@ -4326,6 +4381,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, image, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -4338,7 +4398,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 16.0, 800.0 - 16.0 * 2.0 - 56.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, 37.5, 800.0 - 16.0 * 2.0 - 56.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2.0 + 56.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2.0 - 56.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4354,7 +4414,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 16.0 - 56.0, 16.0, 800.0 - 16.0, 16.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 16.0, 800.0 - 16.0 * 2 - 56, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 37.5, 800.0 - 16.0 * 2 - 56, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 38 : 37.5, 800.0 - 16.0 * 2 - 56, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 56.0, 16.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4521,6 +4581,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, video, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         overline: overline,
@@ -4531,7 +4596,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 8.0, 100.0, 8.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 + 100.0, 20.5, 800.0 - 16.0 - 100.0, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 + 100.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 - 100.0, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 + 100.0, 36.0, 800.0 - 16.0 - 100.0, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 100.0, 8.0, 800.0, 8.0 + 56.0));
 
@@ -4546,7 +4611,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 100.0, 8.0, 800.0, 8.0 + 56.0));
-      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 + 100.0, 20.5, 800.0 - 16.0 - 100, 20.5 + 10.0));
+      expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 + 100.0, hasIssue99933 ? 21 : 20.5, 800.0 - 16.0 - 100, hasIssue99933 ? 31 : 20.5 + 10.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 + 100.0, 36.0, 800.0 - 16.0 - 100, 36.0 + 16.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 8.0, 100.0, 8.0 + 56.0));
 
@@ -4646,6 +4711,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, video, Material 2', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: false,
         isThreeLine: true,
@@ -4658,7 +4728,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 16.0, 100.0, 16.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(20.0 + 100.0, 16.0, 800.0 - 20.0 - 100.0, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, 37.5, 800.0 - 20.0 - 100.0, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 38 : 37.5, 800.0 - 20.0 - 100.0, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 100, 16.0, 800.0, 16.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4674,7 +4744,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 100, 16.0, 800.0, 16.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(20.0 + 100.0, 16.0, 800.0 - 20.0 - 100, 16.0 + 16.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, 37.5, 800.0 - 20.0 - 100, 37.5 + 14.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(20.0 + 100.0, hasIssue99933 ? 38 : 37.5, 800.0 - 20.0 - 100, hasIssue99933 ? 52 : 37.5 + 14.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 16.0, 100.0, 16.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2651,7 +2651,7 @@ void main() {
 
     // If [ThemeData.useMaterial3] is true, then title alignment should
     // default to [ListTileTitleAlignment.material3].
-    await tester.pumpWidget(buildFrame(isThreeLine: false));
+    await tester.pumpWidget(buildFrame());
     Offset tileOffset = tester.getTopLeft(find.byType(ListTile));
     Offset leadingOffset = tester.getTopLeft(find.byKey(leadingKey));
     Offset trailingOffset = tester.getTopRight(find.byKey(trailingKey));

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -256,6 +256,11 @@ void main() {
       ),
     ));
 
+    // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+    //                A bug in the HTML renderer and/or Chrome 96+ causes a
+    //                discrepancy in the paragraph height.
+    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
     double height(String key) => tester.getSize(find.byKey(Key(key))).height;
     double heightChild(String parent, Type child, int at) {
       return tester.getSize(find.descendant(
@@ -307,7 +312,7 @@ void main() {
     expect(verticalOffsetFromParent('D', Text, 1), 12 + heightChild('D', Text, 0));
     expect(childBottom('D', Text, 0), childTop('D', Text, 1));
 
-    expect(height('E'), 88.0);
+    expect(height('E'), hasIssue99933 ? 89.0 : 88.0);
     expect(verticalOffsetFromParent('E', Text, 0), 12);
     expect(verticalOffsetFromParent('E', Text, 1), 12 + heightChild('E', Text, 0));
     expect(childBottom('E', Text, 0), childTop('E', Text, 1));
@@ -2824,6 +2829,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, empty, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
@@ -2831,8 +2841,8 @@ void main() {
         trailingConstraint: ListTileConstraint.video,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 14.0, 800.0 - 24.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 38.0, 800.0 - 24.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 24.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 24.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
@@ -2842,8 +2852,8 @@ void main() {
         trailingConstraint: ListTileConstraint.video,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0, 14.0, 800.0 - 16.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0, 38.0, 800.0 - 16.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
@@ -2920,6 +2930,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, empty, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -2929,7 +2944,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 12.0, 800.0 - 24.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 24.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 24.0, hasIssue99933 ? 57 : 36.0 + 20.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
@@ -2941,7 +2956,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0, 12.0, 800.0 - 16.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0, 36.0, 800.0 - 16.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0, 36.0, 800.0 - 16.0, hasIssue99933 ? 57 : 36.0 + 20.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
@@ -2954,7 +2969,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 12.0, 800.0 - 24.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 28.0, 800.0 - 24.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 52.0, 800.0 - 24.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 52.0, 800.0 - 24.0,  hasIssue99933 ? 73 : 52.0 + 20.0));
 
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
@@ -2968,7 +2983,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(24.0, 12.0, 800.0 - 16.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0, 28.0, 800.0 - 16.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0, 52.0, 800.0 - 16.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0, 52.0, 800.0 - 16.0, hasIssue99933 ? 73 : 52.0 + 20.0));
     });
 
     testWidgets('Padding correction one line, trailing text, Material 2', (WidgetTester tester) async {
@@ -3054,14 +3069,19 @@ void main() {
     });
 
     testWidgets('Padding correction two line, trailing text, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
         trailing: trailingSupportText,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 14.0, 800.0 - 16.0 - 46.0 - 24.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 38.0, 800.0 - 16.0 - 46.0 - 24.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0 - 46.0 - 24.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0 - 46.0 - 24.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 46.0 - 24.0, 28.0, 800.0 - 24.0, 28.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3071,8 +3091,8 @@ void main() {
         trailing: trailingSupportText,
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 14.0, 800.0 - 16.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 38.0, 800.0 - 16.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 28.0, 24.0 + 46.0, 28.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3150,6 +3170,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, trailing text, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -3158,7 +3183,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 12.0, 800.0 - 16.0 - 46.0 - 24.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0 - 46.0 - 24.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 36.0, 800.0 - 16.0 - 46.0 - 24.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 46.0 - 24.0, 12.0, 800.0 - 24.0, 12.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3170,7 +3195,7 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 12.0, 800.0 - 16.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 36.0, 800.0 - 16.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 36.0, 800.0 - 16.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 46.0, 12.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3183,7 +3208,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0, 12.0, 800.0 - 16.0 - 46.0 - 24.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0, 28.0, 800.0 - 16.0 - 46.0 - 24.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 52.0, 800.0 - 16.0 - 46.0 - 24.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0, 52.0, 800.0 - 16.0 - 46.0 - 24.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 46.0 - 24.0, 12.0, 800.0 - 24.0, 12.0 + 16.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3197,7 +3222,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 12.0, 800.0 - 16.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 28.0, 800.0 - 16.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 52.0, 800.0 - 16.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 46.0 + 16.0, 52.0, 800.0 - 16.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 46.0, 12.0 + 16.0));
     });
 
@@ -3300,6 +3325,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, icon, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
@@ -3308,8 +3338,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 24.0, 16.0 + 24.0, 24.0 + 24.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 14.0, 800.0 - 16.0 - 24.0 - 24.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 38.0, 800.0 - 16.0 - 24.0 - 24.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 24.0, 24.0, 800.0 - 24.0, 24.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3321,8 +3351,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 24.0, 24.0, 800 - 16.0, 24.0 + 24.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 14.0, 800.0 - 24.0 - 16.0 * 2.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 38.0, 800.0 - 24.0 - 16.0 * 2.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, hasIssue99933 ? 13.5 :14.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 24.0, 24.0 + 24.0, 24.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3412,6 +3442,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, icon, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -3422,7 +3457,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 12.0, 16.0 + 24.0, 12.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 12.0, 800.0 - 16.0 - 24.0 - 24.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 - 24.0 - 24.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 24.0, 12.0, 800.0 - 24.0, 12.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3436,7 +3471,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 24.0, 12.0, 800 - 16.0, 12.0 + 24.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 12.0, 800.0 - 24.0 - 16.0 * 2.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 36.0, 800.0 - 24.0 - 16.0 * 2.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 36.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 24.0, 12.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3451,7 +3486,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 12.0, 16.0 + 24.0, 12.0 + 24.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 12.0, 800.0 - 16.0 - 24.0 - 24.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 28.0, 800.0 - 16.0 - 24.0 - 24.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 52.0, 800.0 - 16.0 - 24.0 - 24.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 52.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 24.0, 12.0, 800.0 - 24.0, 12.0 + 24.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3467,7 +3502,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 24.0, 12.0, 800 - 16.0, 12.0 + 24.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 12.0, 800.0 - 24.0 - 16.0 * 2.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 28.0, 800.0 - 24.0 - 16.0 * 2.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 52.0, 800.0 - 24.0 - 16.0 * 2.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 52.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 24.0, 12.0 + 24.0));
     });
 
@@ -3586,6 +3621,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, iconButton, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
@@ -3596,8 +3636,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 16.0, 8.0 + 40.0, 16.0 + 40.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 14.0, 800.0 - 16.0 - 24.0 - 24.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 38.0, 800.0 - 16.0 - 24.0 - 24.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 16.0 - 40.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3611,8 +3651,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 40.0 - 8.0, 16.0, 800.0 - 8.0, 16.0 + 40.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 14.0, 800.0 - 24.0 - 16.0 * 2.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 38.0, 800.0 - 24.0 - 16.0 * 2.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3714,6 +3754,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, iconButton, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -3726,7 +3771,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 4.0, 8.0 + 40.0, 4.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 12.0, 800.0 - 16.0 - 24.0 - 24.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 - 24.0 - 24.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 36.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 40.0 - 16.0, 4.0, 800.0 - 16.0, 4.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3742,7 +3787,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 8.0 - 40.0, 4.0, 800 - 8.0, 4.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 12.0, 800.0 - 24.0 - 16.0 * 2.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 36.0, 800.0 - 24.0 - 16.0 * 2.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 36.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 4.0, 16.0 + 40.0, 4.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3759,7 +3804,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(8.0, 4.0, 8.0 + 40.0, 4.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 12.0, 800.0 - 16.0 - 24.0 - 24.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 28.0, 800.0 - 16.0 - 24.0 - 24.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 52.0, 800.0 - 16.0 - 24.0 - 24.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 24.0, 52.0, 800.0 - 16.0 - 24.0 - 24.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 40.0 - 16.0, 4.0, 800.0 - 16.0, 4.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3777,7 +3822,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 8.0 - 40.0, 4.0, 800 - 8.0, 4.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 12.0, 800.0 - 24.0 - 16.0 * 2.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 28.0, 800.0 - 24.0 - 16.0 * 2.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 52.0, 800.0 - 24.0 - 16.0 * 2.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 24.0 + 16.0, 52.0, 800.0 - 24.0 - 16.0 * 2.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(16.0, 4.0, 16.0 + 40.0, 4.0 + 40.0));
     });
 
@@ -3896,6 +3941,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, avatar, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
@@ -3906,8 +3956,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 16.0, 16.0 + 40.0, 16.0 + 40.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 14.0, 800.0 - 16.0 - 40.0 - 24.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 38.0, 800.0 - 16.0 - 40.0 - 24.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0 - 40.0 - 24.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0 - 40.0 - 24.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 40.0, 16.0, 800.0 - 24.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -3921,8 +3971,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 40.0 - 16.0, 16.0, 800.0 - 16.0, 16.0 + 40.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 14.0, 800.0 - 40.0 - 16.0 * 2.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 38.0, 800.0 - 40.0 - 16.0 * 2.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, hasIssue99933 ? 13.5 :14.0, 800.0 - 40.0 - 16.0 * 2.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 40.0 - 16.0 * 2.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 16.0, 24.0 + 40.0, 16.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4024,6 +4074,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, avatar, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -4036,7 +4091,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 12.0, 16.0 + 40.0, 12.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 12.0, 800.0 - 16.0 - 40.0 - 24.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 36.0, 800.0 - 16.0 - 40.0 - 24.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 36.0, 800.0 - 16.0 - 40.0 - 24.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 40.0, 12.0, 800.0 - 24.0, 12.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4052,7 +4107,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 40.0, 12.0, 800 - 16.0, 12.0 + 40.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 12.0, 800.0 - 40.0 - 16.0 * 2.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 36.0, 800.0 - 40.0 - 16.0 * 2.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 36.0, 800.0 - 40.0 - 16.0 * 2.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 40.0, 12.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4069,7 +4124,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 12.0, 16.0 + 40.0, 12.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 12.0, 800.0 - 16.0 - 40.0 - 24.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 28.0, 800.0 - 16.0 - 40.0 - 24.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 52.0, 800.0 - 16.0 - 40.0 - 24.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 40.0, 52.0, 800.0 - 16.0 - 40.0 - 24.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 40.0, 12.0, 800.0 - 24.0, 12.0 + 40.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4087,7 +4142,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 40.0, 12.0, 800 - 16.0, 12.0 + 40.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 12.0, 800.0 - 40.0 - 16.0 * 2.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 28.0, 800.0 - 40.0 - 16.0 * 2.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 52.0, 800.0 - 40.0 - 16.0 * 2.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 40.0 + 16.0, 52.0, 800.0 - 40.0 - 16.0 * 2.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 40.0, 12.0 + 40.0));
     });
 
@@ -4206,6 +4261,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, image, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
@@ -4216,8 +4276,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 8.0, 16.0 + 56.0, 8.0 + 56.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 14.0, 800.0 - 16.0 - 56.0 - 24.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 38.0, 800.0 - 16.0 - 56.0 - 24.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 16.0 - 56.0 - 24.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 16.0 - 56.0 - 24.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 56.0, 8.0, 800.0 - 24.0, 8.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4231,8 +4291,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 72.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 56.0 - 16.0, 8.0, 800.0 - 16.0, 8.0 + 56.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 14.0, 800.0 - 56.0 - 16.0 * 2.0, 14.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 38.0, 800.0 - 56.0 - 16.0 * 2.0, 38.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, hasIssue99933 ? 13.5 : 14.0, 800.0 - 56.0 - 16.0 * 2.0, hasIssue99933 ? 37.5 : 14.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, hasIssue99933 ? 37.5 : 38.0, 800.0 - 56.0 - 16.0 * 2.0, hasIssue99933 ? 58.5 : 38.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 8.0, 24.0 + 56.0, 8.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4334,6 +4394,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, image, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -4346,7 +4411,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 12.0, 16.0 + 56.0, 12.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 12.0, 800.0 - 16.0 - 56.0 - 24.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0 - 56.0 - 24.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 36.0, 800.0 - 16.0 - 56.0 - 24.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 56.0, 12.0, 800.0 - 24.0, 12.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4362,7 +4427,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 56.0, 12.0, 800 - 16.0, 12.0 + 56.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 12.0, 800.0 - 56.0 - 16.0 * 2.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 36.0, 800.0 - 56.0 - 16.0 * 2.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 36.0, 800.0 - 56.0 - 16.0 * 2.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 56.0, 12.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4379,7 +4444,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(16.0, 12.0, 16.0 + 56.0, 12.0 + 56.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 12.0, 800.0 - 16.0 - 56.0 - 24.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 28.0, 800.0 - 16.0 - 56.0 - 24.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 52.0, 800.0 - 16.0 - 56.0 - 24.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 * 2 + 56.0, 52.0, 800.0 - 16.0 - 56.0 - 24.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 24.0 - 56.0, 12.0, 800.0 - 24.0, 12.0 + 56.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4397,7 +4462,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800.0 - 16.0 - 56.0, 12.0, 800 - 16.0, 12.0 + 56.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 12.0, 800.0 - 56.0 - 16.0 * 2.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 28.0, 800.0 - 56.0 - 16.0 * 2.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 52.0, 800.0 - 56.0 - 16.0 * 2.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(24.0 + 56.0 + 16.0, 52.0, 800.0 - 56.0 - 16.0 * 2.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(24.0, 12.0, 24.0 + 56.0, 12.0 + 56.0));
     });
 
@@ -4516,6 +4581,11 @@ void main() {
     });
 
     testWidgets('Padding correction two line, video, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         subtitle: subtitle,
@@ -4526,8 +4596,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 12.0, 114.0, 12.0 + 64.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 + 114.0, 22.0, 800.0 - 16.0 - 114.0, 22.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 + 114.0, 46.0, 800.0 - 16.0 - 114.0, 46.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(16.0 + 114.0, hasIssue99933 ? 21.5 : 22.0, 800.0 - 16.0 - 114.0, hasIssue99933 ? 45.5 : 22.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(16.0 + 114.0, hasIssue99933 ? 45.5 : 46.0, 800.0 - 16.0 - 114.0, hasIssue99933 ? 66.5 : 46.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 114.0, 12.0, 800.0, 12.0 + 64.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4541,8 +4611,8 @@ void main() {
       ));
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 114.0, 12.0, 800.0, 12.0 + 64.0));
-      expect(rect(tester, titleKey), const Rect.fromLTRB(114.0 + 16.0, 22.0, 800.0 - 114.0 - 16.0, 22.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 46.0, 800.0 - 114.0 - 16.0, 46.0 + 20.0));
+      expect(rect(tester, titleKey), const Rect.fromLTRB(114.0 + 16.0, hasIssue99933 ? 21.5 : 22.0, 800.0 - 114.0 - 16.0, hasIssue99933 ? 45.5 : 22.0 + 24.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, hasIssue99933 ? 45.5 : 46.0, 800.0 - 114.0 - 16.0, hasIssue99933 ? 66.5 : 46.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 12.0, 114.0, 12.0 + 64.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4644,6 +4714,11 @@ void main() {
     });
 
     testWidgets('Padding correction three line, video, Material 3', (WidgetTester tester) async {
+      // TODO(jamesgorman2): https://github.com/flutter/flutter/issues/99933
+      //                A bug in the HTML renderer and/or Chrome 96+ causes a
+      //                discrepancy in the paragraph height.
+      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
       await tester.pumpWidget(buildFrame(
         useMaterial3: true,
         isThreeLine: true,
@@ -4656,7 +4731,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 12.0, 114.0, 12.0 + 64.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(114.0 + 16.0, 12.0, 800.0 - 16.0 - 114.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 36.0, 800.0 - 16.0 - 114.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 36.0, 800.0 - 16.0 - 114.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 114.0, 12.0, 800.0, 12.0 + 64.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4672,7 +4747,7 @@ void main() {
       expect(rect(tester, tileKey), const Rect.fromLTRB(0.0, 0.0, 800.0, 88.0));
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 114.0, 12.0, 800.0, 12.0 + 64.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(114.0 + 16.0, 12.0, 800.0 - 114.0 - 16.0, 12.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 36.0, 800.0 - 114.0 - 16.0, 36.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 36.0, 800.0 - 114.0 - 16.0, hasIssue99933 ? 57 : 36.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 12.0, 114.0, 12.0 + 64.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4689,7 +4764,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(0.0, 12.0, 114.0, 12.0 + 64.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(114.0 + 16.0, 12.0, 800.0 - 16.0 - 114.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(114.0 + 16.0, 28.0, 800.0 - 16.0 - 114.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 52.0, 800.0 - 16.0 - 114.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 52.0, 800.0 - 16.0 - 114.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(800 - 114.0, 12.0, 800.0, 12.0 + 64.0));
 
       await tester.pumpWidget(buildFrame(
@@ -4707,7 +4782,7 @@ void main() {
       expect(rect(tester, leadingKey), const Rect.fromLTRB(800 - 114.0, 12.0, 800.0, 12.0 + 64.0));
       expect(rect(tester, overlineKey), const Rect.fromLTRB(114.0 + 16.0, 12.0, 800.0 - 114.0 - 16.0, 12.0 + 16.0));
       expect(rect(tester, titleKey), const Rect.fromLTRB(114.0 + 16.0, 28.0, 800.0 - 114.0 - 16.0, 28.0 + 24.0));
-      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 52.0, 800.0 - 114.0 - 16.0, 52.0 + 20.0));
+      expect(rect(tester, subtitleKey), const Rect.fromLTRB(114.0 + 16.0, 52.0, 800.0 - 114.0 - 16.0, hasIssue99933 ? 73 : 52.0 + 20.0));
       expect(rect(tester, trailingKey), const Rect.fromLTRB(0.0, 12.0, 114.0, 12.0 + 64.0));
     });
 

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -351,6 +351,7 @@ void main() {
               data: const ListTileThemeData(
                 selectedColor: selectedColor,
                 textColor: defaultColor,
+                leadingAndTrailingTextColor: defaultColor,
               ),
               child: Builder(
                 builder: (BuildContext context) {

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -621,7 +621,7 @@ void main() {
             value: true,
             title: const Text('Title'),
             onChanged: (_){},
-            contentPadding: const EdgeInsets.fromLTRB(8, 10, 15, 20),
+            contentPadding: const EdgeInsets.fromLTRB(10, 10, 15, 20),
           ),
         ),
       ),
@@ -642,7 +642,7 @@ void main() {
     expect(paddingRect.bottom, tallerRect.bottom + extraHeight / 2 + 20); //bottom padding
 
     // Check for correct left and right padding
-    expect(paddingRect.left, radioRect.left - 8); //left padding
+    expect(paddingRect.left, radioRect.left - 2.0); //left padding
     expect(paddingRect.right, titleRect.right + 15); //right padding
   });
 

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -245,11 +245,11 @@ void main() {
     await tester.pumpWidget(buildFrame(TextDirection.ltr));
 
     expect(tester.getTopLeft(find.text('L')).dx, 10.0); // contentPadding.start = 10
-    expect(tester.getTopRight(find.byType(Switch)).dx, 780.0); // 800 - contentPadding.end
+    expect(tester.getTopRight(find.byType(Switch)).dx, 784.0); // 800 - contentPadding.end + 4
 
     await tester.pumpWidget(buildFrame(TextDirection.rtl));
 
-    expect(tester.getTopLeft(find.byType(Switch)).dx, 20.0); // contentPadding.end = 20
+    expect(tester.getTopLeft(find.byType(Switch)).dx, 16.0); // contentPadding.end = 20 - 4
     expect(tester.getTopRight(find.text('L')).dx, 790.0); // 800 - contentPadding.start
   });
 

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -146,6 +146,71 @@ void main() {
       const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr),
       isNot(const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.rtl)),
     );
+    expect(
+      const EdgeInsets.fromLTRB(5, 10, 15, 30).add(const EdgeInsetsDirectional.fromSTEB(10, 15, 20, 25))
+        .resolve(TextDirection.rtl),
+      const EdgeInsets.fromLTRB(25, 25, 25, 55),
+    );
+    expect(
+      const EdgeInsets.fromLTRB(5, 10, 15, 30).add(const EdgeInsetsDirectional.fromSTEB(10, 15, 20, 25))
+        .resolve(TextDirection.ltr),
+      const EdgeInsets.fromLTRB(15, 25, 35, 55),
+    );
+  });
+
+  test('EdgeInsetsGeometry.toDirectional', () {
+    expect(
+      const EdgeInsets.fromLTRB(10.0, 20.0, 30.0, 40.0).toDirectional(TextDirection.ltr),
+      const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0),
+    );
+    expect(
+      const EdgeInsets.fromLTRB(99.0, 98.0, 97.0, 96.0).toDirectional(TextDirection.rtl),
+      const EdgeInsetsDirectional.fromSTEB(97.0, 98.0, 99.0, 96.0),
+    );
+    expect(const EdgeInsets.all(50.0).toDirectional(TextDirection.ltr), const EdgeInsetsDirectional.fromSTEB(50.0, 50.0, 50.0, 50.0));
+    expect(const EdgeInsets.all(50.0).toDirectional(TextDirection.rtl), const EdgeInsetsDirectional.fromSTEB(50.0, 50.0, 50.0, 50.0));
+    expect(
+      const EdgeInsets.only(left: 963.25).toDirectional(TextDirection.ltr),
+      const EdgeInsetsDirectional.fromSTEB(963.25, 0.0, 0.0, 0.0),
+    );
+    expect(
+      const EdgeInsets.only(top: 963.25).toDirectional(TextDirection.ltr),
+      const EdgeInsetsDirectional.fromSTEB(0.0, 963.25, 0.0, 0.0),
+    );
+    expect(
+      const EdgeInsets.only(right: 963.25).toDirectional(TextDirection.ltr),
+      const EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 963.25, 0.0),
+    );
+    expect(
+      const EdgeInsets.only(bottom: 963.25).toDirectional(TextDirection.ltr),
+      const EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 963.25),
+    );
+    expect(
+      const EdgeInsets.only(left: 963.25).toDirectional(TextDirection.rtl),
+      const EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 963.25, 0.0),
+    );
+    expect(
+      const EdgeInsets.only(top: 963.25).toDirectional(TextDirection.rtl),
+      const EdgeInsetsDirectional.fromSTEB(0.0, 963.25, 0.0, 0.0),
+    );
+    expect(
+      const EdgeInsets.only(right: 963.25).toDirectional(TextDirection.rtl),
+      const EdgeInsetsDirectional.fromSTEB(963.25, 0.0, 0.0, 0.0),
+    );
+    expect(
+      const EdgeInsets.only(bottom: 963.25).toDirectional(TextDirection.rtl),
+      const EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 963.25),
+    );
+    expect(
+      const EdgeInsets.fromLTRB(5, 10, 15, 30).add(const EdgeInsetsDirectional.fromSTEB(10, 15, 20, 25))
+          .toDirectional(TextDirection.rtl),
+      const EdgeInsetsDirectional.fromSTEB(25, 25, 25, 55),
+    );
+    expect(
+      const EdgeInsets.fromLTRB(5, 10, 15, 30).add(const EdgeInsetsDirectional.fromSTEB(10, 15, 20, 25))
+          .toDirectional(TextDirection.ltr),
+      const EdgeInsetsDirectional.fromSTEB(15, 25, 35, 55),
+    );
   });
 
   test('EdgeInsets equality', () {


### PR DESCRIPTION
Fixes #127075

This PR is larger than I'd like but it needed to cover a lot of ground. This code _should_ only impact M3 ListTiles by default.

`ListTile`
* add `overline` with color and style 
    * for both M2 and M3 
    * update assertions
* add `leadingAndTrailingTextColor` 
     * for both M2 and M3
* add M3 text layout * vertically align text elements by box 
     * top align box if `isThreeLine` or tile height > 88; otherwise 
     * center align box
* add `material3` leading/trailing 
     * same as `threeLine` but will top align if tile height > 88
* increase vertical padding to 12dp when `isThreeLine`
* add `ListTileConstraint` and `ListTilePaddingCorrection` to: 
     * constrain the max size of the leading/trailing widget 
     * force a minimum tile height 
     * specify a leading/trailing title gap 
     * ignore the start/end padding (for large widgets like video) 
     * apply a padding correction to align leading/trailing widgets
* add sensible defaults for `ListTileConstraint`
* refactor layout logic * the addition of `overline` and `ListTileConstraint` significantly increases branching
* documentation 
     * fix links to M2/M3 specs 
     * additional `See also`s

[NEW] `examples/../list_tile.5.dart`
* render the M3 spec list examples
* allow switching to M2, platform density, rtl, dark mode, dividers

`examples/../list_tile.[2, 4].dart`
* update with new defaults
* update tests as needed

`EdgeInsetsGeometry`
* add a method to convert `EditInsetsGeometry` to `EdgeInsetsDirectional`. Inverse of `resolve()`

`CheckBoxListTile`, `RadioListTile`, SwitchListTile`
* apply padding correction
* add `overline`, `secondaryConstraint` and `titleAlignment`
* update constructor assertions
* update tests as needed

`ExpansionTile`
* allow optional dividers when expanded
* use `Divider.createBorderSide()` to create `BorderSide`
* dividers are drawn over the `ExpansionTile`, not as padding
* add `overline`, `titleAlignment`, `isThreeLine`, `leadingConstraint` and `trailingConstraint`
* `trailing` moved to widgets section
* M3 icon color updated
* update tests as needed

`Switch`
* remove no-op maths

`gen_defaults.dart`
* fix typo

Not addressed:
 * difference between flutter Material and the M2 spec 
      * except leading video widget layout and how vertical text overlap is handled

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
