### PR TITLE
Revert "Remove obsolete drawShadow bounds workaround"

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2017,6 +2017,7 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
 
     _updateClip();
     final RRect offsetRRect = _clip!.shift(offset);
+    final Rect offsetBounds = offsetRRect.outerRect;
     final Path offsetRRectAsPath = Path()..addRRect(offsetRRect);
     bool paintShadows = true;
     assert(() {
@@ -2037,6 +2038,14 @@ class RenderPhysicalModel extends _RenderPhysicalModelBase<RRect> {
 
     final Canvas canvas = context.canvas;
     if (elevation != 0.0 && paintShadows) {
+      // The drawShadow call doesn't add the region of the shadow to the
+      // picture's bounds, so we draw a hardcoded amount of extra space to
+      // account for the maximum potential area of the shadow.
+      // TODO(jsimmons): remove this when Skia does it for us.
+      canvas.drawRect(
+        offsetBounds.inflate(20.0),
+        _transparentPaint,
+      );
       canvas.drawShadow(
         offsetRRectAsPath,
         shadowColor,


### PR DESCRIPTION
Reverts flutter/flutter#127052, which seems to be breaking the build because of a goldens failure.

```
The following TestFailure was thrown running a test:
Expected: one widget whose rasterized image matches golden image "shadow.PhysicalModel.enabled.png"
  Actual: _WidgetTypeFinder:<exactly one widget with type "Container" (ignoring offstage widgets):
Container(bg: Color(0xfffff59d), margin: EdgeInsets.all(150.0))>
```

See https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20web_tests_6/11051/overview