### PR TITLE
Revert "Handle null return from WillPopCallback"

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1499,9 +1499,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     final _ModalScopeState<T>? scope = _scopeKey.currentState;
     assert(scope != null);
     for (final WillPopCallback callback in List<WillPopCallback>.of(_willPopCallbacks)) {
-      // TODO(goderbauer): Tests using the Component Framework in google3 insist on returning
-      //   null for mocked out WillPopCallbacks. Fix that to remove ignore.
-      if (await callback() != true) { // ignore: no_literal_bool_comparisons
+      if (!await callback()) {
         return RoutePopDisposition.doNotPop;
       }
     }


### PR DESCRIPTION
Reverts flutter/flutter#127039

Google3 has been fixed, so this work around is no longe necessary.