### PR TITLE
Remove deprecated `primaryVariant` and `secondaryVariant` from `ColorScheme`

### DIFF
--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -112,16 +112,6 @@ class ColorScheme with Diagnosticable {
     Color? onInverseSurface,
     Color? inversePrimary,
     Color? surfaceTint,
-    @Deprecated(
-      'Use primary or primaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? primaryVariant,
-    @Deprecated(
-      'Use secondary or secondaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? secondaryVariant,
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -141,8 +131,6 @@ class ColorScheme with Diagnosticable {
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _primaryVariant = primaryVariant,
-       _secondaryVariant = secondaryVariant,
        _surfaceTint = surfaceTint;
 
   /// Generate a [ColorScheme] derived from the given `seedColor`.
@@ -277,16 +265,6 @@ class ColorScheme with Diagnosticable {
     Color? onInverseSurface,
     Color? inversePrimary,
     Color? surfaceTint,
-    @Deprecated(
-      'Use primary or primaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? primaryVariant = const Color(0xff3700b3),
-    @Deprecated(
-      'Use secondary or secondaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? secondaryVariant = const Color(0xff018786),
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -306,8 +284,6 @@ class ColorScheme with Diagnosticable {
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _primaryVariant = primaryVariant,
-       _secondaryVariant = secondaryVariant,
        _surfaceTint = surfaceTint;
 
   /// Create the recommended dark color scheme that matches the
@@ -344,16 +320,6 @@ class ColorScheme with Diagnosticable {
     Color? onInverseSurface,
     Color? inversePrimary,
     Color? surfaceTint,
-    @Deprecated(
-      'Use primary or primaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? primaryVariant = const Color(0xff3700B3),
-    @Deprecated(
-      'Use secondary or secondaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? secondaryVariant = const Color(0xff03dac6),
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -373,8 +339,6 @@ class ColorScheme with Diagnosticable {
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _primaryVariant = primaryVariant,
-       _secondaryVariant = secondaryVariant,
        _surfaceTint = surfaceTint;
 
   /// Create a high contrast ColorScheme based on a purple primary color that
@@ -411,16 +375,6 @@ class ColorScheme with Diagnosticable {
     Color? onInverseSurface,
     Color? inversePrimary,
     Color? surfaceTint,
-    @Deprecated(
-      'Use primary or primaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? primaryVariant = const Color(0xff000088),
-    @Deprecated(
-      'Use secondary or secondaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? secondaryVariant = const Color(0xff018786),
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -440,8 +394,6 @@ class ColorScheme with Diagnosticable {
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _primaryVariant = primaryVariant,
-       _secondaryVariant = secondaryVariant,
        _surfaceTint = surfaceTint;
 
   /// Create a high contrast ColorScheme based on the dark
@@ -478,16 +430,6 @@ class ColorScheme with Diagnosticable {
     Color? onInverseSurface,
     Color? inversePrimary,
     Color? surfaceTint,
-    @Deprecated(
-      'Use primary or primaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? primaryVariant = const Color(0xffbe9eff),
-    @Deprecated(
-      'Use secondary or secondaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? secondaryVariant = const Color(0xff66fff9),
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -507,8 +449,6 @@ class ColorScheme with Diagnosticable {
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _primaryVariant = primaryVariant,
-       _secondaryVariant = secondaryVariant,
        _surfaceTint = surfaceTint;
 
   /// Create a color scheme from a [MaterialColor] swatch.
@@ -532,9 +472,7 @@ class ColorScheme with Diagnosticable {
 
     return ColorScheme(
       primary: primarySwatch,
-      primaryVariant: primaryColorDark ?? (isDark ? Colors.black : primarySwatch[700]!),
       secondary: secondary,
-      secondaryVariant: isDark ? Colors.tealAccent[700]! : primarySwatch[700]!,
       surface: cardColor ?? (isDark ? Colors.grey[800]! : Colors.white),
       background: backgroundColor ?? (isDark ? Colors.grey[700]! : primarySwatch[200]!),
       error: errorColor ?? Colors.red[700]!,
@@ -726,22 +664,6 @@ class ColorScheme with Diagnosticable {
   /// elevation.
   Color get surfaceTint => _surfaceTint ?? primary;
 
-  final Color? _primaryVariant;
-  /// A darker version of the primary color.
-  @Deprecated(
-    'Use primary or primaryContainer instead. '
-    'This feature was deprecated after v2.6.0-0.0.pre.'
-  )
-  Color get primaryVariant => _primaryVariant ?? primary;
-
-  final Color? _secondaryVariant;
-  /// A darker version of the secondary color.
-  @Deprecated(
-    'Use secondary or secondaryContainer instead. '
-    'This feature was deprecated after v2.6.0-0.0.pre.'
-  )
-  Color get secondaryVariant => _secondaryVariant ?? secondary;
-
   /// Creates a copy of this color scheme with the given fields
   /// replaced by the non-null parameter values.
   ColorScheme copyWith({
@@ -776,16 +698,6 @@ class ColorScheme with Diagnosticable {
     Color? onInverseSurface,
     Color? inversePrimary,
     Color? surfaceTint,
-    @Deprecated(
-      'Use primary or primaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? primaryVariant,
-    @Deprecated(
-      'Use secondary or secondaryContainer instead. '
-      'This feature was deprecated after v2.6.0-0.0.pre.'
-    )
-    Color? secondaryVariant,
   }) {
     return ColorScheme(
       brightness: brightness ?? this.brightness,
@@ -818,8 +730,6 @@ class ColorScheme with Diagnosticable {
       inverseSurface : inverseSurface ?? this.inverseSurface,
       onInverseSurface : onInverseSurface ?? this.onInverseSurface,
       inversePrimary : inversePrimary ?? this.inversePrimary,
-      primaryVariant: primaryVariant ?? this.primaryVariant,
-      secondaryVariant: secondaryVariant ?? this.secondaryVariant,
       surfaceTint: surfaceTint ?? this.surfaceTint,
     );
   }
@@ -862,8 +772,6 @@ class ColorScheme with Diagnosticable {
       inverseSurface: Color.lerp(a.inverseSurface, b.inverseSurface, t),
       onInverseSurface: Color.lerp(a.onInverseSurface, b.onInverseSurface, t),
       inversePrimary: Color.lerp(a.inversePrimary, b.inversePrimary, t),
-      primaryVariant: Color.lerp(a.primaryVariant, b.primaryVariant, t),
-      secondaryVariant: Color.lerp(a.secondaryVariant, b.secondaryVariant, t),
       surfaceTint: Color.lerp(a.surfaceTint, b.surfaceTint, t),
     );
   }
@@ -907,8 +815,6 @@ class ColorScheme with Diagnosticable {
       && other.inverseSurface == inverseSurface
       && other.onInverseSurface == onInverseSurface
       && other.inversePrimary == inversePrimary
-      && other.primaryVariant == primaryVariant
-      && other.secondaryVariant == secondaryVariant
       && other.surfaceTint == surfaceTint;
   }
 
@@ -945,8 +851,6 @@ class ColorScheme with Diagnosticable {
       inverseSurface,
       onInverseSurface,
       inversePrimary,
-      primaryVariant,
-      secondaryVariant,
       surfaceTint,
     ),
   );
@@ -985,8 +889,6 @@ class ColorScheme with Diagnosticable {
     properties.add(ColorProperty('inverseSurface', inverseSurface, defaultValue: defaultScheme.inverseSurface));
     properties.add(ColorProperty('onInverseSurface', onInverseSurface, defaultValue: defaultScheme.onInverseSurface));
     properties.add(ColorProperty('inversePrimary', inversePrimary, defaultValue: defaultScheme.inversePrimary));
-    properties.add(ColorProperty('primaryVariant', primaryVariant, defaultValue: defaultScheme.primaryVariant));
-    properties.add(ColorProperty('secondaryVariant', secondaryVariant, defaultValue: defaultScheme.secondaryVariant));
     properties.add(ColorProperty('surfaceTint', surfaceTint, defaultValue: defaultScheme.surfaceTint));
   }
 

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -457,7 +457,6 @@ class ColorScheme with Diagnosticable {
   /// color scheme.
   factory ColorScheme.fromSwatch({
     MaterialColor primarySwatch = Colors.blue,
-    Color? primaryColorDark,
     Color? accentColor,
     Color? cardColor,
     Color? backgroundColor,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -561,9 +561,7 @@ class _SnackBarState extends State<SnackBar> {
         : theme.copyWith(
             colorScheme: ColorScheme(
               primary: colorScheme.onPrimary,
-              primaryVariant: colorScheme.onPrimary,
               secondary: buttonColor,
-              secondaryVariant: colorScheme.onSecondary,
               surface: colorScheme.onSurface,
               background: defaults.backgroundColor!,
               error: colorScheme.onError,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -500,7 +500,6 @@ class ThemeData with Diagnosticable {
     // with the existing default ThemeData color values.
     colorScheme ??= ColorScheme.fromSwatch(
       primarySwatch: primarySwatch,
-      primaryColorDark: primaryColorDark,
       accentColor: isDark ? Colors.tealAccent[200]! : primarySwatch[500]!,
       cardColor: cardColor,
       backgroundColor: isDark ? Colors.grey[700]! : primarySwatch[200]!,

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -52,9 +52,6 @@ void main() {
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.surfaceTint, scheme.primary);
-
-    expect(scheme.primaryVariant, const Color(0xff3700b3));
-    expect(scheme.secondaryVariant, const Color(0xff018786));
   });
 
   test('dark scheme matches the spec', () {
@@ -94,9 +91,6 @@ void main() {
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.surfaceTint, scheme.primary);
-
-    expect(scheme.primaryVariant, const Color(0xff3700b3));
-    expect(scheme.secondaryVariant, const Color(0xff03dac6));
   });
 
   test('high contrast light scheme matches the spec', () {
@@ -136,9 +130,6 @@ void main() {
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.surfaceTint, scheme.primary);
-
-    expect(scheme.primaryVariant, const Color(0xff000088));
-    expect(scheme.secondaryVariant, const Color(0xff018786));
   });
 
   test('high contrast dark scheme matches the spec', () {
@@ -178,9 +169,6 @@ void main() {
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.surfaceTint, scheme.primary);
-
-    expect(scheme.primaryVariant, const Color(0xffbe9eff));
-    expect(scheme.secondaryVariant, const Color(0xff66fff9));
   });
 
   test('can generate a light scheme from a seed color', () {
@@ -251,9 +239,6 @@ void main() {
         onInverseSurface: const Color(0x0000001A),
         inversePrimary: const Color(0x0000001B),
         surfaceTint: const Color(0x0000001C),
-
-        primaryVariant: const Color(0x0000001D),
-        secondaryVariant: const Color(0x0000001F),
     );
 
     expect(scheme.brightness, Brightness.dark);
@@ -287,9 +272,6 @@ void main() {
     expect(scheme.onInverseSurface, const Color(0x0000001A));
     expect(scheme.inversePrimary, const Color(0x0000001B));
     expect(scheme.surfaceTint, const Color(0x0000001C));
-
-    expect(scheme.primaryVariant, const Color(0x0000001D));
-    expect(scheme.secondaryVariant, const Color(0x0000001F));
   });
 
   test('can generate a dark scheme from a seed color', () {
@@ -406,9 +388,6 @@ void main() {
     expect(scheme.onInverseSurface, const Color(0xfff3eff4));
     expect(scheme.inversePrimary, const Color(0xffc0c1ff));
     expect(scheme.surfaceTint, const Color(0xff4040f3));
-
-    expect(scheme.primaryVariant, const Color(0xff4040f3));
-    expect(scheme.secondaryVariant, const Color(0xff5d5c72));
   }, skip: isBrowser, // [intended] uses dart:typed_data.
 );
 
@@ -446,8 +425,6 @@ void main() {
     expect(scheme.inverseSurface, const Color(0xffe5e1e6));
     expect(scheme.onInverseSurface, const Color(0xff313034));
     expect(scheme.inversePrimary, const Color(0xff4040f3));
-    expect(scheme.primaryVariant, const Color(0xffc0c1ff));
-    expect(scheme.secondaryVariant, const Color(0xffc6c4dd));
     expect(scheme.surfaceTint, const Color(0xffc0c1ff));
     }, skip: isBrowser, // [intended] uses dart:isolate and io.
   );


### PR DESCRIPTION
This PR is to remove deprecated `primaryVariant` and `secondaryVariant` from framework. These two apis are made obsolete in #93427

Part of https://github.com/flutter/flutter/issues/127042

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
