### PR TITLE
Run Mac intel only targets on both intel and arm

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2575,7 +2575,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2595,7 +2594,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2615,7 +2613,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2635,7 +2632,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2792,7 +2788,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:f808dcff91b221ae313e540c09d79696cd08b8de"},
@@ -3055,7 +3050,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3074,7 +3068,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14e222b"},
@@ -3093,7 +3086,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14e222b"},


### PR DESCRIPTION
The slowness issue was resolved with latest xcode: https://github.com/flutter/flutter/issues/119750, and all these targets should resume on both platforms as before. This will help mitigate high queue time on intel bots.

This PR updates these targets:

- Mac plugin_test_ios: https://github.com/flutter/flutter/issues/119764
- Mac build_tests: https://github.com/flutter/flutter/pull/120620
- Mac plugin_test: https://github.com/flutter/flutter/pull/120714
- Mac plugin_test_macos: https://github.com/flutter/flutter/pull/122212
- Mac framework_tests_misc: https://github.com/flutter/flutter/pull/122618
