### PR TITLE
Fix app launch and device log listener race condition for simulators

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -506,6 +506,8 @@ class IOSDevice extends Device {
           logger: _logger,
         );
       }
+
+      final Future<Uri?>? futureDeviceUri = vmServiceDiscovery?.uri;
       if (iosDeployDebugger == null) {
         installationResult = await _iosDeploy.launchApp(
           deviceId: id,
@@ -555,7 +557,7 @@ class IOSDevice extends Device {
       Uri? localUri;
       if (isWirelesslyConnected) {
         // Wait for Dart VM Service to start up.
-        final Uri? serviceURL = await vmServiceDiscovery?.uri;
+        final Uri? serviceURL = await futureDeviceUri;
         if (serviceURL == null) {
           await iosDeployDebugger?.stopAndDumpBacktrace();
           await dispose();
@@ -584,7 +586,7 @@ class IOSDevice extends Device {
 
         mDNSLookupTimer.cancel();
       } else {
-        localUri = await vmServiceDiscovery?.uri;
+        localUri = await futureDeviceUri;
       }
       timer.cancel();
       if (localUri == null) {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -506,7 +506,6 @@ class IOSDevice extends Device {
           logger: _logger,
         );
       }
-
       if (iosDeployDebugger == null) {
         installationResult = await _iosDeploy.launchApp(
           deviceId: id,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -507,7 +507,6 @@ class IOSDevice extends Device {
         );
       }
 
-      final Future<Uri?>? futureDeviceUri = vmServiceDiscovery?.uri;
       if (iosDeployDebugger == null) {
         installationResult = await _iosDeploy.launchApp(
           deviceId: id,
@@ -557,7 +556,7 @@ class IOSDevice extends Device {
       Uri? localUri;
       if (isWirelesslyConnected) {
         // Wait for Dart VM Service to start up.
-        final Uri? serviceURL = await futureDeviceUri;
+        final Uri? serviceURL = await vmServiceDiscovery?.uri;
         if (serviceURL == null) {
           await iosDeployDebugger?.stopAndDumpBacktrace();
           await dispose();
@@ -586,7 +585,7 @@ class IOSDevice extends Device {
 
         mDNSLookupTimer.cancel();
       } else {
-        localUri = await futureDeviceUri;
+        localUri = await vmServiceDiscovery?.uri;
       }
       timer.cancel();
       if (localUri == null) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -461,6 +461,8 @@ class IOSSimulator extends Device {
       );
     }
 
+    final Future<Uri?>? futureDeviceUri = vmServiceDiscovery?.uri;
+
     // Launch the updated application in the simulator.
     try {
       // Use the built application's Info.plist to get the bundle identifier,
@@ -489,7 +491,8 @@ class IOSSimulator extends Device {
     globals.printTrace('Waiting for VM Service port to be available...');
 
     try {
-      final Uri? deviceUri = await vmServiceDiscovery?.uri;
+
+      final Uri? deviceUri = await futureDeviceUri;
       if (deviceUri != null) {
         return LaunchResult.succeeded(vmServiceUri: deviceUri);
       }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -450,9 +450,9 @@ class IOSSimulator extends Device {
       platformArgs,
     );
 
-    final DeviceLogReader deviceLogReader = getLogReader(app: package);
     ProtocolDiscovery? vmServiceDiscovery;
     if (debuggingOptions.debuggingEnabled) {
+      final DeviceLogReader deviceLogReader = getLogReader(app: package);
       vmServiceDiscovery = ProtocolDiscovery.vmService(
         deviceLogReader,
         ipv6: ipv6,
@@ -460,14 +460,14 @@ class IOSSimulator extends Device {
         devicePort: debuggingOptions.deviceVmServicePort,
         logger: globals.logger,
       );
-    }
 
-    // When the ProtocolDiscovery above is created, it starts listening to the
-    // `deviceLogReader`. On listen, the `deviceLogReader` launches a command
-    // to get the device logs.
-    // Wait for that command to finish starting before launching the app.
-    if (deviceLogReader is _IOSSimulatorLogReader) {
-      await deviceLogReader.deviceLogStarted.future;
+      // When the ProtocolDiscovery above is created, it starts listening to the
+      // `deviceLogReader`. On listen, the `deviceLogReader` launches a command
+      // to get the device logs.
+      // Wait for that command to finish starting before launching the app.
+      if (deviceLogReader is _IOSSimulatorLogReader) {
+        await deviceLogReader.deviceLogStarted.future;
+      }
     }
 
     // Launch the updated application in the simulator.


### PR DESCRIPTION
There is a race condition between device log listener starting and the app launch process.

We start listening for the device logs here
https://github.com/flutter/flutter/blob/343718945bcbcc356dbb8b1c51fcd5655dd5bb87/packages/flutter_tools/lib/src/ios/simulators.dart#L455
https://github.com/flutter/flutter/blob/343718945bcbcc356dbb8b1c51fcd5655dd5bb87/packages/flutter_tools/lib/src/protocol_discovery.dart#L27
Which launches a command like `xcrun simctl spawn`
https://github.com/flutter/flutter/blob/343718945bcbcc356dbb8b1c51fcd5655dd5bb87/packages/flutter_tools/lib/src/ios/simulators.dart#L688-L689
https://github.com/flutter/flutter/blob/343718945bcbcc356dbb8b1c51fcd5655dd5bb87/packages/flutter_tools/lib/src/ios/simulators.dart#L703-L708

However, since it happens `onListen`, we don't wait for it complete before launching the app (`xcrun simctl launch`)
https://github.com/flutter/flutter/blob/343718945bcbcc356dbb8b1c51fcd5655dd5bb87/packages/flutter_tools/lib/src/ios/simulators.dart#L477

Which can cause the `xcrun simctl spawn` command to execute after the `xcrun simctl launch`.

Discovered in https://github.com/dart-lang/http/issues/938.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
