### PR TITLE
Add fallback font to IconData class

### DIFF
--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -280,6 +280,7 @@ class Icon extends StatelessWidget {
           fontSize: iconSize,
           fontFamily: icon!.fontFamily,
           package: icon!.fontPackage,
+          fontFamilyFallback: icon!.fontFamilyFallback,
           shadows: iconShadows,
         ),
       ),

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -31,6 +31,7 @@ class IconData {
     this.fontFamily,
     this.fontPackage,
     this.matchTextDirection = false,
+    this.fontFamilyFallback,
   });
 
   /// The Unicode code point at which this icon is stored in the icon font.
@@ -56,6 +57,11 @@ class IconData {
   /// [Directionality] is [TextDirection.rtl].
   final bool matchTextDirection;
 
+  /// The ordered list of font families to fall back on when a glyph cannot be found in a higher priority font family.
+  /// For more details refer to the documentation of [TextStyle]
+  /// https://api.flutter.dev/flutter/painting/TextStyle/fontFamilyFallback.html
+  final List<String>? fontFamilyFallback;
+
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) {
@@ -65,11 +71,21 @@ class IconData {
         && other.codePoint == codePoint
         && other.fontFamily == fontFamily
         && other.fontPackage == fontPackage
-        && other.matchTextDirection == matchTextDirection;
+        && other.matchTextDirection == matchTextDirection
+        && listEquals(other.fontFamilyFallback, fontFamilyFallback);
   }
 
   @override
-  int get hashCode => Object.hash(codePoint, fontFamily, fontPackage, matchTextDirection);
+  int get hashCode {
+    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+    return Object.hash(
+      codePoint,
+      fontFamily,
+      fontPackage,
+      matchTextDirection,
+      fontFamilyFallback == null ? null : Object.hashAll(fontFamilyFallback),
+    );
+  }
 
   @override
   String toString() => 'IconData(U+${codePoint.toRadixString(16).toUpperCase().padLeft(5, '0')})';

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -77,13 +77,12 @@ class IconData {
 
   @override
   int get hashCode {
-    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
     return Object.hash(
       codePoint,
       fontFamily,
       fontPackage,
       matchTextDirection,
-      fontFamilyFallback == null ? null : Object.hashAll(fontFamilyFallback),
+      Object.hashAll(fontFamilyFallback ?? const <String?>[]),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -58,7 +58,8 @@ class IconData {
   final bool matchTextDirection;
 
   /// The ordered list of font families to fall back on when a glyph cannot be found in a higher priority font family.
-  /// For more details refer to the documentation of [TextStyle]
+  ///
+  /// For more details, refer to the documentation of [TextStyle]
   final List<String>? fontFamilyFallback;
 
   @override

--- a/packages/flutter/lib/src/widgets/icon_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_data.dart
@@ -59,7 +59,6 @@ class IconData {
 
   /// The ordered list of font families to fall back on when a glyph cannot be found in a higher priority font family.
   /// For more details refer to the documentation of [TextStyle]
-  /// https://api.flutter.dev/flutter/painting/TextStyle/fontFamilyFallback.html
   final List<String>? fontFamilyFallback;
 
   @override

--- a/packages/flutter/test/widgets/icon_test.dart
+++ b/packages/flutter/test/widgets/icon_test.dart
@@ -127,6 +127,20 @@ void main() {
     expect(richText.text.style!.fontFamily, equals('Roboto'));
   });
 
+  testWidgets('Icon with custom fontFamilyFallback', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Icon(IconData(0x41, fontFamilyFallback: <String>['FallbackFont'])),
+        ),
+      ),
+    );
+
+    final RichText richText = tester.firstWidget(find.byType(RichText));
+    expect(richText.text.style!.fontFamilyFallback, equals(<String>['FallbackFont']));
+  });
+
   testWidgets('Icon with semantic label', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 


### PR DESCRIPTION
This PR adds an ability to specify `fallbackFont` for `Icon` class via `IconData` props.

Read detailed description here https://github.com/flutter/flutter/issues/126670

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
