### PR TITLE
Avoid catching errors in TextPainter tests

### DIFF
--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1348,11 +1348,11 @@ void main() {
     // In tests, paint() will throw an UnimplementedError due to missing drawParagraph method.
     expect(
       () => painter.paint(MockCanvas(), Offset.zero),
-      throwsA(isA<UnimplementedError>().having(
-        (UnimplementedError error) => error.message,
+      isNot(throwsA(isA<StateError>().having(
+        (StateError error) => error.message,
         'message',
-        contains('drawParagraph'),
-      )),
+        contains('TextPainter.paint called when text geometry was not yet calculated'),
+      ))),
     );
     painter.dispose();
   }, skip: isBrowser && !isCanvasKit); // https://github.com/flutter/flutter/issues/56308

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -368,15 +368,14 @@ void main() {
 
   test('TextPainter error test', () {
     final TextPainter painter = TextPainter(textDirection: TextDirection.ltr);
-    Object? e;
-    try {
-      painter.paint(MockCanvas(), Offset.zero);
-    } catch (exception) {
-      e = exception;
-    }
+
     expect(
-      e.toString(),
-      contains('TextPainter.paint called when text geometry was not yet calculated'),
+      () => painter.paint(MockCanvas(), Offset.zero),
+      throwsA(isA<StateError>().having(
+        (StateError error) => error.message,
+        'message',
+        contains('TextPainter.paint called when text geometry was not yet calculated'),
+      )),
     );
     painter.dispose();
   });
@@ -1310,15 +1309,13 @@ void main() {
       PlaceholderDimensions(size: Size(50, 30), alignment: ui.PlaceholderAlignment.bottom),
     ]);
 
-    Object? e;
-    try {
-      painter.paint(MockCanvas(), Offset.zero);
-    } catch (exception) {
-      e = exception;
-    }
     expect(
-      e.toString(),
-      contains('TextPainter.paint called when text geometry was not yet calculated'),
+      () => painter.paint(MockCanvas(), Offset.zero),
+      throwsA(isA<StateError>().having(
+        (StateError error) => error.message,
+        'message',
+        contains('TextPainter.paint called when text geometry was not yet calculated'),
+      )),
     );
     painter.dispose();
   }, skip: isBrowser && !isCanvasKit); // https://github.com/flutter/flutter/issues/56308
@@ -1348,16 +1345,14 @@ void main() {
       PlaceholderDimensions(size: Size(50, 30), alignment: ui.PlaceholderAlignment.bottom),
     ]);
 
-    Object? e;
-    try {
-      painter.paint(MockCanvas(), Offset.zero);
-    } catch (exception) {
-      e = exception;
-    }
     // In tests, paint() will throw an UnimplementedError due to missing drawParagraph method.
     expect(
-      e.toString(),
-      isNot(contains('TextPainter.paint called when text geometry was not yet calculated')),
+      () => painter.paint(MockCanvas(), Offset.zero),
+      throwsA(isA<UnimplementedError>().having(
+        (UnimplementedError error) => error.message,
+        'message',
+        contains('drawParagraph'),
+      )),
     );
     painter.dispose();
   }, skip: isBrowser && !isCanvasKit); // https://github.com/flutter/flutter/issues/56308


### PR DESCRIPTION
This PR swaps error catching with `expect` in `TextPainter` tests.

test-exempt: no functional change

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
