### PR TITLE
ScaleGestureRecognizer: make pointerCount public

### DIFF
--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -393,6 +393,14 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   /// {@endtemplate}
   Offset trackpadScrollToScaleFactor;
 
+  /// The number of pointers being tracked by the gesture recognizer.
+  ///
+  /// Typically this is the number of fingers being used to pan the widget using the gesture
+  /// recognizer.
+  int get pointerCount {
+    return _pointerPanZooms.length + _pointerQueue.length;
+  }
+
   late Offset _initialFocalPoint;
   Offset? _currentFocalPoint;
   late double _initialSpan;
@@ -441,10 +449,6 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
       scale *= p.scale / _initialPanZoomScaleFactor;
     }
     return scale;
-  }
-
-  int get _pointerCount {
-    return _pointerPanZooms.length + _pointerQueue.length;
   }
 
   double _computeRotationFactor() {
@@ -566,7 +570,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     for (final _PointerPanZoomData p in _pointerPanZooms.values) {
       focalPoint += p.focalPoint;
     }
-    _currentFocalPoint = _pointerCount > 0 ? focalPoint / _pointerCount.toDouble() : Offset.zero;
+    _currentFocalPoint = pointerCount > 0 ? focalPoint / pointerCount.toDouble() : Offset.zero;
 
     if (previousFocalPoint == null) {
       _localFocalPoint = PointerEvent.transformPosition(
@@ -662,9 +666,9 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
           if (pixelsPerSecond.distanceSquared > kMaxFlingVelocity * kMaxFlingVelocity) {
             velocity = Velocity(pixelsPerSecond: (pixelsPerSecond / pixelsPerSecond.distance) * kMaxFlingVelocity);
           }
-          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(velocity: velocity, scaleVelocity: _scaleVelocityTracker?.getVelocity().pixelsPerSecond.dx ?? -1, pointerCount: _pointerCount)));
+          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(velocity: velocity, scaleVelocity: _scaleVelocityTracker?.getVelocity().pixelsPerSecond.dx ?? -1, pointerCount: pointerCount)));
         } else {
-          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(scaleVelocity: _scaleVelocityTracker?.getVelocity().pixelsPerSecond.dx ?? -1, pointerCount: _pointerCount)));
+          invokeCallback<void>('onEnd', () => onEnd!(ScaleEndDetails(scaleVelocity: _scaleVelocityTracker?.getVelocity().pixelsPerSecond.dx ?? -1, pointerCount: pointerCount)));
         }
       }
       _state = _ScaleState.accepted;
@@ -706,7 +710,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
             focalPoint: _currentFocalPoint!,
             localFocalPoint: _localFocalPoint,
             rotation: _computeRotationFactor(),
-            pointerCount: _pointerCount,
+            pointerCount: pointerCount,
             focalPointDelta: _delta,
           ));
         });
@@ -721,7 +725,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
         onStart!(ScaleStartDetails(
           focalPoint: _currentFocalPoint!,
           localFocalPoint: _localFocalPoint,
-          pointerCount: _pointerCount,
+          pointerCount: pointerCount,
         ));
       });
     }

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -79,6 +79,7 @@ void main() {
     updatedDelta = null;
     expect(didEndScale, isFalse);
     expect(didTap, isFalse);
+    expect(scale.pointerCount, 1);
 
     // Two-finger scaling
     final TestPointer pointer2 = TestPointer(2);
@@ -87,6 +88,7 @@ void main() {
     tap.addPointer(down2);
     tester.closeArena(2);
     tester.route(down2);
+    expect(scale.pointerCount, 2);
 
     expect(didEndScale, isTrue);
     didEndScale = false;


### PR DESCRIPTION
make `pointCount` in `ScaleGestureRecognizer` public to handle pointer event depending on the number of pointers.

https://github.com/flutter/flutter/issues/127309

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
