### PR TITLE
Support keeping a bottom sheet with a DraggableScrollableSheet from closing on drag/fling to min extent

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -315,7 +315,7 @@ class _BottomSheetState extends State<BottomSheet> {
   }
 
   bool extentChanged(DraggableScrollableNotification notification) {
-    if (notification.extent == notification.minExtent) {
+    if (notification.extent == notification.minExtent && notification.shouldCloseOnMinExtent) {
       widget.onClosing();
     }
     return false;

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -3190,7 +3190,9 @@ class _StandardBottomSheetState extends State<_StandardBottomSheet> {
       scaffold.showBodyScrim(false, 0.0);
     }
     // If the Scaffold.bottomSheet != null, we're a persistent bottom sheet.
-    if (notification.extent == notification.minExtent && scaffold.widget.bottomSheet == null) {
+    if (notification.extent == notification.minExtent &&
+        scaffold.widget.bottomSheet == null &&
+        notification.shouldCloseOnMinExtent) {
       close();
     }
     return false;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -308,6 +308,7 @@ class DraggableScrollableSheet extends StatefulWidget {
     this.snapSizes,
     this.snapAnimationDuration,
     this.controller,
+    this.shouldCloseOnMinExtent = true,
     required this.builder,
   })  : assert(minChildSize >= 0.0),
         assert(maxChildSize <= 1.0),
@@ -391,6 +392,13 @@ class DraggableScrollableSheet extends StatefulWidget {
   /// A controller that can be used to programmatically control this sheet.
   final DraggableScrollableController? controller;
 
+  /// Whether the sheet, when dragged (or flung) to its minimum size, should
+  /// cause its parent sheet to close.
+  ///
+  /// Set on emitted [DraggableScrollableNotification]s. It is up to parent
+  /// classes to properly read and handle this value.
+  final bool shouldCloseOnMinExtent;
+
   /// The builder that creates a child to display in this widget, which will
   /// use the provided [ScrollController] to enable dragging and scrolling
   /// of the contents.
@@ -432,6 +440,7 @@ class DraggableScrollableNotification extends Notification with ViewportNotifica
     required this.maxExtent,
     required this.initialExtent,
     required this.context,
+    this.shouldCloseOnMinExtent = true,
   }) : assert(0.0 <= minExtent),
        assert(maxExtent <= 1.0),
        assert(minExtent <= extent),
@@ -457,6 +466,12 @@ class DraggableScrollableNotification extends Notification with ViewportNotifica
   /// of the viewport, for instance. A listener can only assume this context
   /// is live when it first gets the notification.
   final BuildContext context;
+
+  /// Whether the widget that fired this notification, when dragged (or flung)
+  /// to minExtent, should cause its parent sheet to close.
+  ///
+  /// It is up to parent classes to properly read and handle this value.
+  final bool shouldCloseOnMinExtent;
 
   @override
   void debugFillDescription(List<String> description) {
@@ -487,6 +502,7 @@ class _DraggableSheetExtent {
     ValueNotifier<double>? currentSize,
     bool? hasDragged,
     bool? hasChanged,
+    this.shouldCloseOnMinExtent = true,
   })  : assert(minSize >= 0),
         assert(maxSize <= 1),
         assert(minSize <= initialSize),
@@ -504,6 +520,7 @@ class _DraggableSheetExtent {
   final List<double> snapSizes;
   final Duration? snapAnimationDuration;
   final double initialSize;
+  final bool shouldCloseOnMinExtent;
   final ValueNotifier<double> _currentSize;
   double availablePixels;
 
@@ -576,6 +593,7 @@ class _DraggableSheetExtent {
       extent: currentSize,
       initialExtent: initialSize,
       context: context,
+      shouldCloseOnMinExtent: shouldCloseOnMinExtent,
     ).dispatch(context);
   }
 
@@ -598,6 +616,7 @@ class _DraggableSheetExtent {
     required List<double> snapSizes,
     required double initialSize,
     Duration? snapAnimationDuration,
+    bool shouldCloseOnMinExtent = true,
   }) {
     return _DraggableSheetExtent(
       minSize: minSize,
@@ -613,6 +632,7 @@ class _DraggableSheetExtent {
           : initialSize),
       hasDragged: hasDragged,
       hasChanged: hasChanged,
+      shouldCloseOnMinExtent: shouldCloseOnMinExtent,
     );
   }
 }
@@ -631,6 +651,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       snapSizes: _impliedSnapSizes(),
       snapAnimationDuration: widget.snapAnimationDuration,
       initialSize: widget.initialChildSize,
+      shouldCloseOnMinExtent: widget.shouldCloseOnMinExtent,
     );
     _scrollController = _DraggableScrollableSheetScrollController(extent: _extent);
     widget.controller?._attach(_scrollController);

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -185,6 +185,44 @@ void main() {
     expect(find.text('Two'), findsNothing);
   });
 
+  testWidgets('Verify DraggableScrollableSheet.shouldCloseOnMinExtent == false prevents dismissal', (WidgetTester tester) async {
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        key: scaffoldKey,
+        body: const Center(child: Text('body')),
+      ),
+    ));
+
+    scaffoldKey.currentState!.showBottomSheet<void>((BuildContext context) {
+      return DraggableScrollableSheet(
+        expand: false,
+        shouldCloseOnMinExtent: false,
+        builder: (_, ScrollController controller) {
+          return ListView(
+            controller: controller,
+            shrinkWrap: true,
+            children: const <Widget>[
+              SizedBox(height: 100.0, child: Text('One')),
+              SizedBox(height: 100.0, child: Text('Two')),
+              SizedBox(height: 100.0, child: Text('Three')),
+            ],
+          );
+        },
+      );
+    });
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Two'), findsOneWidget);
+
+    await tester.drag(find.text('Two'), const Offset(0.0, 400.0));
+    await tester.pumpAndSettle();
+
+     expect(find.text('Two'), findsOneWidget);
+  });
+
   testWidgets('Verify that a BottomSheet animates non-linearly', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 


### PR DESCRIPTION
- Adds shouldCloseOnMinExtent flag to DraggableScrollableSheet; this is passed to DraggableScrollableNotification.
- Listeners on DraggableScrollableNotification (BottomSheet and Scaffold) examine flag when deciding whether to close sheet when hitting min extent.

Fixes #127236
Design rationale: https://github.com/flutter/flutter/issues/127236#issuecomment-1557591657
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


