### PR TITLE
Remove null-safety argument from DartPad doc samples

### DIFF
--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -13,7 +13,7 @@
         </p>
     </div>
     <iframe class="snippet-dartpad"
-        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;null_safety=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}&amp;channel={{channel}}">
+        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}&amp;channel={{channel}}">
     </iframe>
 </div>
 {@end-inject-html}

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -444,7 +444,6 @@ void sanityCheckDocs([Platform platform = const LocalPlatform()]) {
   final List<String> argumentRegExps = <String>[
     r'split=\d+',
     r'run=true',
-    r'null_safety=true',
     r'sample_id=widgets\.Listener\.\d+',
     'sample_channel=$expectedBranch',
     'channel=$expectedBranch',


### PR DESCRIPTION
Removes the `null_safety=true` query parameter from DartPad samples in the API docs, since all DartPad channels only support null safety now and the parameter does nothing.

## Test

Removing code, but updates the check in the dartdoc tool for the removal.
