### PR TITLE
Remove scrollbar deprecations isAlwaysShown and hoverThickness

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -53,8 +53,7 @@ const double _kScrollbarCrossAxisMargin = 3.0;
 /// {@tool dartpad}
 /// When [thumbVisibility] is true, the scrollbar thumb will remain visible without the
 /// fade animation. This requires that a [ScrollController] is provided to controller,
-/// or that the [PrimaryScrollController] is available. [isAlwaysShown] is
-/// deprecated in favor of `thumbVisibility`.
+/// or that the [PrimaryScrollController] is available.
 ///
 /// ** See code in examples/api/lib/cupertino/scrollbar/cupertino_scrollbar.1.dart **
 /// {@end-tool}
@@ -82,20 +81,10 @@ class CupertinoScrollbar extends RawScrollbar {
     this.radiusWhileDragging = defaultRadiusWhileDragging,
     ScrollNotificationPredicate? notificationPredicate,
     super.scrollbarOrientation,
-    @Deprecated(
-      'Use thumbVisibility instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
-    )
-    bool? isAlwaysShown,
   }) : assert(thickness < double.infinity),
        assert(thicknessWhileDragging < double.infinity),
-       assert(
-         isAlwaysShown == null || thumbVisibility == null,
-         'Scrollbar thumb appearance should only be controlled with thumbVisibility, '
-         'isAlwaysShown is deprecated.'
-       ),
        super(
-         thumbVisibility: isAlwaysShown ?? thumbVisibility ?? false,
+         thumbVisibility: thumbVisibility ?? false,
          fadeDuration: _kScrollbarFadeDuration,
          timeToFade: _kScrollbarTimeToFade,
          pressDuration: const Duration(milliseconds: 100),

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -96,25 +96,11 @@ class Scrollbar extends StatelessWidget {
     this.interactive,
     this.scrollbarOrientation,
     @Deprecated(
-      'Use thumbVisibility instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
-    )
-    this.isAlwaysShown,
-    @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
       'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     this.showTrackOnHover,
-    @Deprecated(
-      'Use ScrollbarThemeData.thickness to resolve based on the current state instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
-    )
-    this.hoverThickness,
-  }) : assert(
-         thumbVisibility == null || isAlwaysShown == null,
-         'Scrollbar thumb appearance should only be controlled with thumbVisibility, '
-         'isAlwaysShown is deprecated.'
-       );
+  });
 
   /// {@macro flutter.widgets.Scrollbar.child}
   final Widget child;
@@ -131,19 +117,7 @@ class Scrollbar extends StatelessWidget {
   /// If the thumb visibility is related to the scrollbar's material state,
   /// use the global [ScrollbarThemeData.thumbVisibility] or override the
   /// sub-tree's theme data.
-  ///
-  /// Replaces deprecated [isAlwaysShown].
   final bool? thumbVisibility;
-
-  /// {@macro flutter.widgets.Scrollbar.isAlwaysShown}
-  ///
-  /// To show the scrollbar thumb based on a [MaterialState], use
-  /// [ScrollbarThemeData.thumbVisibility].
-  @Deprecated(
-    'Use thumbVisibility instead. '
-    'This feature was deprecated after v2.9.0-1.0.pre.',
-  )
-  final bool? isAlwaysShown;
 
   /// {@macro flutter.widgets.Scrollbar.trackVisibility}
   ///
@@ -171,21 +145,6 @@ class Scrollbar extends StatelessWidget {
     'This feature was deprecated after v3.4.0-19.0.pre.',
   )
   final bool? showTrackOnHover;
-
-  /// The thickness of the scrollbar when a hover state is active and
-  /// [showTrackOnHover] is true.
-  ///
-  /// If this property is null, then [ScrollbarThemeData.thickness] of
-  /// [ThemeData.scrollbarTheme] is used to resolve a thickness. If that is also
-  /// null, the default value is 12.0 pixels.
-  ///
-  /// This is deprecated, use [ScrollbarThemeData.thickness] to resolve based on
-  /// the current state instead.
-  @Deprecated(
-    'Use ScrollbarThemeData.thickness to resolve based on the current state instead. '
-    'This feature was deprecated after v2.9.0-1.0.pre.',
-  )
-  final double? hoverThickness;
 
   /// The thickness of the scrollbar in the cross axis of the scrollable.
   ///
@@ -216,7 +175,7 @@ class Scrollbar extends StatelessWidget {
   Widget build(BuildContext context) {
     if (Theme.of(context).platform == TargetPlatform.iOS) {
       return CupertinoScrollbar(
-        thumbVisibility: isAlwaysShown ?? thumbVisibility ?? false,
+        thumbVisibility: thumbVisibility ?? false,
         thickness: thickness ?? CupertinoScrollbar.defaultThickness,
         thicknessWhileDragging: thickness ?? CupertinoScrollbar.defaultThicknessWhileDragging,
         radius: radius ?? CupertinoScrollbar.defaultRadius,
@@ -229,10 +188,9 @@ class Scrollbar extends StatelessWidget {
     }
     return _MaterialScrollbar(
       controller: controller,
-      thumbVisibility: isAlwaysShown ?? thumbVisibility,
+      thumbVisibility: thumbVisibility,
       trackVisibility: trackVisibility,
       showTrackOnHover: showTrackOnHover,
-      hoverThickness: hoverThickness,
       thickness: thickness,
       radius: radius,
       notificationPredicate: notificationPredicate,
@@ -250,7 +208,6 @@ class _MaterialScrollbar extends RawScrollbar {
     super.thumbVisibility,
     super.trackVisibility,
     this.showTrackOnHover,
-    this.hoverThickness,
     super.thickness,
     super.radius,
     ScrollNotificationPredicate? notificationPredicate,
@@ -264,7 +221,6 @@ class _MaterialScrollbar extends RawScrollbar {
        );
 
   final bool? showTrackOnHover;
-  final double? hoverThickness;
 
   @override
   _MaterialScrollbarState createState() => _MaterialScrollbarState();
@@ -280,7 +236,7 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   late bool _useAndroidScrollbar;
 
   @override
-  bool get showScrollbar => widget.thumbVisibility ?? _scrollbarTheme.thumbVisibility?.resolve(_states) ?? _scrollbarTheme.isAlwaysShown ?? false;
+  bool get showScrollbar => widget.thumbVisibility ?? _scrollbarTheme.thumbVisibility?.resolve(_states) ?? false;
 
   @override
   bool get enableGestures => widget.interactive ?? _scrollbarTheme.interactive ?? !_useAndroidScrollbar;
@@ -370,8 +326,7 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   MaterialStateProperty<double> get _thickness {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.hovered) && _trackVisibility.resolve(states)) {
-        return widget.hoverThickness
-          ?? _scrollbarTheme.thickness?.resolve(states)
+        return _scrollbarTheme.thickness?.resolve(states)
           ?? _kScrollbarThicknessWithTrack;
       }
       // The default scrollbar thickness is smaller on mobile.

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -46,25 +46,14 @@ class ScrollbarThemeData with Diagnosticable {
     this.minThumbLength,
     this.interactive,
     @Deprecated(
-      'Use thumbVisibility instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
-    )
-    this.isAlwaysShown,
-    @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
       'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     this.showTrackOnHover,
-  }) : assert(
-         isAlwaysShown == null || thumbVisibility == null,
-         'Scrollbar thumb appearance should only be controlled with thumbVisibility, '
-         'isAlwaysShown is deprecated.'
-       );
+  });
 
   /// Overrides the default value of [Scrollbar.thumbVisibility] in all
   /// descendant [Scrollbar] widgets.
-  ///
-  /// Replaces deprecated [isAlwaysShown].
   final MaterialStateProperty<bool?>? thumbVisibility;
 
   /// Overrides the default value of [Scrollbar.thickness] in all
@@ -85,16 +74,6 @@ class ScrollbarThemeData with Diagnosticable {
     'This feature was deprecated after v3.4.0-19.0.pre.',
   )
   final bool? showTrackOnHover;
-
-  /// Overrides the default value of [Scrollbar.isAlwaysShown] in all
-  /// descendant [Scrollbar] widgets.
-  ///
-  /// Deprecated in favor of [thumbVisibility].
-  @Deprecated(
-    'Use thumbVisibility instead. '
-    'This feature was deprecated after v2.9.0-1.0.pre.',
-  )
-  final bool? isAlwaysShown;
 
   /// Overrides the default value of [Scrollbar.interactive] in all
   /// descendant [Scrollbar] widgets.
@@ -170,12 +149,6 @@ class ScrollbarThemeData with Diagnosticable {
     double? mainAxisMargin,
     double? minThumbLength,
     @Deprecated(
-      'Use thumbVisibility instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
-    )
-    bool? isAlwaysShown,
-
-    @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
       'This feature was deprecated after v3.4.0-19.0.pre.',
     )
@@ -186,7 +159,6 @@ class ScrollbarThemeData with Diagnosticable {
       thickness: thickness ?? this.thickness,
       trackVisibility: trackVisibility ?? this.trackVisibility,
       showTrackOnHover: showTrackOnHover ?? this.showTrackOnHover,
-      isAlwaysShown: isAlwaysShown ?? this.isAlwaysShown,
       interactive: interactive ?? this.interactive,
       radius: radius ?? this.radius,
       thumbColor: thumbColor ?? this.thumbColor,
@@ -212,7 +184,6 @@ class ScrollbarThemeData with Diagnosticable {
       thickness: MaterialStateProperty.lerp<double?>(a?.thickness, b?.thickness, t, lerpDouble),
       trackVisibility: MaterialStateProperty.lerp<bool?>(a?.trackVisibility, b?.trackVisibility, t, _lerpBool),
       showTrackOnHover: _lerpBool(a?.showTrackOnHover, b?.showTrackOnHover, t),
-      isAlwaysShown: _lerpBool(a?.isAlwaysShown, b?.isAlwaysShown, t),
       interactive: _lerpBool(a?.interactive, b?.interactive, t),
       radius: Radius.lerp(a?.radius, b?.radius, t),
       thumbColor: MaterialStateProperty.lerp<Color?>(a?.thumbColor, b?.thumbColor, t, Color.lerp),
@@ -230,7 +201,6 @@ class ScrollbarThemeData with Diagnosticable {
     thickness,
     trackVisibility,
     showTrackOnHover,
-    isAlwaysShown,
     interactive,
     radius,
     thumbColor,
@@ -254,7 +224,6 @@ class ScrollbarThemeData with Diagnosticable {
       && other.thickness == thickness
       && other.trackVisibility == trackVisibility
       && other.showTrackOnHover == showTrackOnHover
-      && other.isAlwaysShown == isAlwaysShown
       && other.interactive == interactive
       && other.radius == radius
       && other.thumbColor == thumbColor
@@ -272,7 +241,6 @@ class ScrollbarThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('thickness', thickness, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('trackVisibility', trackVisibility, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('showTrackOnHover', showTrackOnHover, defaultValue: null));
-    properties.add(DiagnosticsProperty<bool>('isAlwaysShown', isAlwaysShown, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('interactive', interactive, defaultValue: null));
     properties.add(DiagnosticsProperty<Radius>('radius', radius, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('thumbColor', thumbColor, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -984,19 +984,9 @@ class RawScrollbar extends StatefulWidget {
     this.mainAxisMargin = 0.0,
     this.crossAxisMargin = 0.0,
     this.padding,
-    @Deprecated(
-      'Use thumbVisibility instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
-    )
-    this.isAlwaysShown,
   }) : assert(
-         thumbVisibility == null || isAlwaysShown == null,
-         'Scrollbar thumb appearance should only be controlled with thumbVisibility, '
-         'isAlwaysShown is deprecated.'
-       ),
-       assert(
-         !((thumbVisibility == false || isAlwaysShown == false) && (trackVisibility ?? false)),
-         'A scrollbar track cannot be drawn without a scrollbar thumb.'
+         !(thumbVisibility == false && (trackVisibility ?? false)),
+         'A scrollbar track cannot be drawn without a scrollbar thumb.',
        ),
        assert(minThumbLength >= 0),
        assert(minOverscrollLength == null || minOverscrollLength <= minThumbLength),
@@ -1149,99 +1139,11 @@ class RawScrollbar extends StatefulWidget {
   ///     scroll view associated with the parent [PrimaryScrollController].
   ///   * [PrimaryScrollController], which associates a [ScrollController] with
   ///     a subtree.
-  ///
-  /// Replaces deprecated [isAlwaysShown].
   /// {@endtemplate}
   ///
   /// Subclass [Scrollbar] can hide and show the scrollbar thumb in response to
   /// [MaterialState]s by using [ScrollbarThemeData.thumbVisibility].
   final bool? thumbVisibility;
-
-  /// {@template flutter.widgets.Scrollbar.isAlwaysShown}
-  /// Indicates that the scrollbar thumb should be visible, even when a scroll
-  /// is not underway.
-  ///
-  /// When false, the scrollbar will be shown during scrolling
-  /// and will fade out otherwise.
-  ///
-  /// When true, the scrollbar will always be visible and never fade out. This
-  /// requires that the Scrollbar can access the [ScrollController] of the
-  /// associated Scrollable widget. This can either be the provided [controller],
-  /// or the [PrimaryScrollController] of the current context.
-  ///
-  ///   * When providing a controller, the same ScrollController must also be
-  ///     provided to the associated Scrollable widget.
-  ///   * The [PrimaryScrollController] is used by default for a [ScrollView]
-  ///     that has not been provided a [ScrollController] and that has a
-  ///     [ScrollView.scrollDirection] of [Axis.vertical]. This automatic
-  ///     behavior does not apply to those with Axis.horizontal. To explicitly
-  ///     use the PrimaryScrollController, set [ScrollView.primary] to true.
-  ///
-  /// Defaults to false when null.
-  ///
-  /// {@tool snippet}
-  ///
-  /// ```dart
-  /// // (e.g. in a stateful widget)
-  ///
-  /// final ScrollController controllerOne = ScrollController();
-  /// final ScrollController controllerTwo = ScrollController();
-  ///
-  /// @override
-  /// Widget build(BuildContext context) {
-  /// return Column(
-  ///   children: <Widget>[
-  ///     SizedBox(
-  ///        height: 200,
-  ///        child: Scrollbar(
-  ///          thumbVisibility: true,
-  ///          controller: controllerOne,
-  ///          child: ListView.builder(
-  ///            controller: controllerOne,
-  ///            itemCount: 120,
-  ///            itemBuilder: (BuildContext context, int index) {
-  ///              return Text('item $index');
-  ///            },
-  ///          ),
-  ///        ),
-  ///      ),
-  ///      SizedBox(
-  ///        height: 200,
-  ///        child: CupertinoScrollbar(
-  ///          thumbVisibility: true,
-  ///          controller: controllerTwo,
-  ///          child: SingleChildScrollView(
-  ///            controller: controllerTwo,
-  ///            child: const SizedBox(
-  ///              height: 2000,
-  ///              width: 500,
-  ///              child: Placeholder(),
-  ///            ),
-  ///          ),
-  ///        ),
-  ///      ),
-  ///    ],
-  ///   );
-  /// }
-  /// ```
-  /// {@end-tool}
-  ///
-  /// See also:
-  ///
-  ///   * [RawScrollbarState.showScrollbar], an overridable getter which uses
-  ///     this value to override the default behavior.
-  ///   * [ScrollView.primary], which indicates whether the ScrollView is the primary
-  ///     scroll view associated with the parent [PrimaryScrollController].
-  ///   * [PrimaryScrollController], which associates a [ScrollController] with
-  ///     a subtree.
-  ///
-  /// This is deprecated, [thumbVisibility] should be used instead.
-  /// {@endtemplate}
-  @Deprecated(
-    'Use thumbVisibility instead. '
-    'This feature was deprecated after v2.9.0-1.0.pre.',
-  )
-  final bool? isAlwaysShown;
 
   /// The [OutlinedBorder] of the scrollbar's thumb.
   ///
@@ -1453,14 +1355,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   /// Subclasses can override this getter to make its value depend on an inherited
   /// theme.
   ///
-  /// Defaults to false when [RawScrollbar.isAlwaysShown] or
-  /// [RawScrollbar.thumbVisibility] is null.
-  ///
-  /// See also:
-  ///
-  ///   * [RawScrollbar.isAlwaysShown], which overrides the default behavior.
+  /// Defaults to false when [RawScrollbar.thumbVisibility] is null.
   @protected
-  bool get showScrollbar => widget.isAlwaysShown ?? widget.thumbVisibility ?? false;
+  bool get showScrollbar => widget.thumbVisibility ?? false;
 
   bool get _showTrack => showScrollbar && (widget.trackVisibility ?? false);
 
@@ -1546,9 +1443,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       : 'provided ScrollController';
 
     String when = '';
-    if (widget.isAlwaysShown ?? false) {
-      when = 'Scrollbar.isAlwaysShown is true';
-    } else if (widget.thumbVisibility ?? false) {
+    if (widget.thumbVisibility ?? false) {
       when = 'Scrollbar.thumbVisibility is true';
     } else if (enableGestures) {
       when = 'the scrollbar is interactive';
@@ -1658,9 +1553,8 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   @override
   void didUpdateWidget(T oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.isAlwaysShown != oldWidget.isAlwaysShown
-        || widget.thumbVisibility != oldWidget.thumbVisibility) {
-      if ((widget.isAlwaysShown ?? false) || (widget.thumbVisibility ?? false)) {
+    if (widget.thumbVisibility != oldWidget.thumbVisibility) {
+      if (widget.thumbVisibility ?? false) {
         assert(_debugScheduleCheckHasValidScrollPosition());
         _fadeoutTimer?.cancel();
         _fadeoutAnimationController.animateTo(1.0);

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -400,14 +400,14 @@ void main() {
     },
   );
 
-  testWidgets('When isAlwaysShown is true, must pass a controller or find PrimaryScrollController', (WidgetTester tester) async {
+  testWidgets('When thumbVisibility is true, must pass a controller or find PrimaryScrollController', (WidgetTester tester) async {
       Widget viewWithScroll() {
         return const Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
             data: MediaQueryData(),
             child: CupertinoScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               child: SingleChildScrollView(
                 child: SizedBox(
                   width: 4000.0,
@@ -425,7 +425,7 @@ void main() {
     },
   );
 
-  testWidgets('When isAlwaysShown is true, must pass a controller or find PrimaryScrollController that is attached to a scroll view', (WidgetTester tester) async {
+  testWidgets('When thumbVisibility is true, must pass a controller or find PrimaryScrollController that is attached to a scroll view', (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
       Widget viewWithScroll() {
         return Directionality(
@@ -434,7 +434,7 @@ void main() {
             data: const MediaQueryData(),
             child: CupertinoScrollbar(
               controller: controller,
-              isAlwaysShown: true,
+              thumbVisibility: true,
               child: const SingleChildScrollView(
                 child: SizedBox(
                   width: 4000.0,
@@ -526,7 +526,7 @@ void main() {
     expect(find.byType(CupertinoScrollbar), paints..rrect());
   });
 
-  testWidgets('On first render with isAlwaysShown: true, the thumb shows with PrimaryScrollController', (WidgetTester tester) async {
+  testWidgets('On first render with thumbVisibility: true, the thumb shows with PrimaryScrollController', (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
       Widget viewWithScroll() {
         return Directionality(
@@ -538,7 +538,7 @@ void main() {
               child: Builder(
                 builder: (BuildContext context) {
                   return const CupertinoScrollbar(
-                    isAlwaysShown: true,
+                    thumbVisibility: true,
                     child: SingleChildScrollView(
                       primary: true,
                       child: SizedBox(
@@ -560,7 +560,7 @@ void main() {
     },
   );
 
-  testWidgets('On first render with isAlwaysShown: true, the thumb shows', (WidgetTester tester) async {
+  testWidgets('On first render with thumbVisibility: true, the thumb shows', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     Widget viewWithScroll() {
       return Directionality(
@@ -570,7 +570,7 @@ void main() {
           child: PrimaryScrollController(
             controller: controller,
             child: CupertinoScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: controller,
               child: const SingleChildScrollView(
                 child: SizedBox(
@@ -593,7 +593,7 @@ void main() {
     expect(find.byType(CupertinoScrollbar), paints..rrect());
   });
 
-  testWidgets('On first render with isAlwaysShown: false, the thumb is hidden', (WidgetTester tester) async {
+  testWidgets('On first render with thumbVisibility: false, the thumb is hidden', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     Widget viewWithScroll() {
       return Directionality(
@@ -621,9 +621,9 @@ void main() {
     expect(find.byType(CupertinoScrollbar), isNot(paints..rect()));
   });
 
-  testWidgets('With isAlwaysShown: true, fling a scroll. While it is still scrolling, set isAlwaysShown: false. The thumb should not fade out until the scrolling stops.', (WidgetTester tester) async {
+  testWidgets('With thumbVisibility: true, fling a scroll. While it is still scrolling, set thumbVisibility: false. The thumb should not fade out until the scrolling stops.', (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = true;
+      bool thumbVisibility = true;
       Widget viewWithScroll() {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
@@ -634,7 +634,7 @@ void main() {
                 child: Stack(
                   children: <Widget>[
                     CupertinoScrollbar(
-                      isAlwaysShown: isAlwaysShown,
+                      thumbVisibility: thumbVisibility,
                       controller: controller,
                       child: SingleChildScrollView(
                         controller: controller,
@@ -649,10 +649,10 @@ void main() {
                       child: CupertinoButton(
                         onPressed: () {
                           setState(() {
-                            isAlwaysShown = !isAlwaysShown;
+                            thumbVisibility = !thumbVisibility;
                           });
                         },
-                        child: const Text('change isAlwaysShown'),
+                        child: const Text('change thumbVisibility'),
                       ),
                     ),
                   ],
@@ -679,10 +679,10 @@ void main() {
   );
 
   testWidgets(
-    'With isAlwaysShown: false, set isAlwaysShown: true. The thumb should be always shown directly',
+    'With thumbVisibility: false, set thumbVisibility: true. The thumb should be always shown directly',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = false;
+      bool thumbVisibility = false;
       Widget viewWithScroll() {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
@@ -693,7 +693,7 @@ void main() {
                 child: Stack(
                   children: <Widget>[
                     CupertinoScrollbar(
-                      isAlwaysShown: isAlwaysShown,
+                      thumbVisibility: thumbVisibility,
                       controller: controller,
                       child: SingleChildScrollView(
                         controller: controller,
@@ -708,10 +708,10 @@ void main() {
                       child: CupertinoButton(
                         onPressed: () {
                           setState(() {
-                            isAlwaysShown = !isAlwaysShown;
+                            thumbVisibility = !thumbVisibility;
                           });
                         },
-                        child: const Text('change isAlwaysShown'),
+                        child: const Text('change thumbVisibility'),
                       ),
                     ),
                   ],
@@ -733,11 +733,11 @@ void main() {
   );
 
   testWidgets(
-    'With isAlwaysShown: false, fling a scroll. While it is still scrolling, set isAlwaysShown: true. '
+    'With thumbVisibility: false, fling a scroll. While it is still scrolling, set thumbVisibility: true. '
     'The thumb should not fade even after the scrolling stops',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = false;
+      bool thumbVisibility = false;
       Widget viewWithScroll() {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
@@ -748,7 +748,7 @@ void main() {
                 child: Stack(
                   children: <Widget>[
                     CupertinoScrollbar(
-                      isAlwaysShown: isAlwaysShown,
+                      thumbVisibility: thumbVisibility,
                       controller: controller,
                       child: SingleChildScrollView(
                         controller: controller,
@@ -763,10 +763,10 @@ void main() {
                       child: CupertinoButton(
                         onPressed: () {
                           setState(() {
-                            isAlwaysShown = !isAlwaysShown;
+                            thumbVisibility = !thumbVisibility;
                           });
                         },
-                        child: const Text('change isAlwaysShown'),
+                        child: const Text('change thumbVisibility'),
                       ),
                     ),
                   ],
@@ -800,11 +800,11 @@ void main() {
   );
 
   testWidgets(
-    'Toggling isAlwaysShown while not scrolling fades the thumb in/out. '
+    'Toggling thumbVisibility while not scrolling fades the thumb in/out. '
     'This works even when you have never scrolled at all yet',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = true;
+      bool thumbVisibility = true;
       Widget viewWithScroll() {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
@@ -815,7 +815,7 @@ void main() {
                 child: Stack(
                   children: <Widget>[
                     CupertinoScrollbar(
-                      isAlwaysShown: isAlwaysShown,
+                      thumbVisibility: thumbVisibility,
                       controller: controller,
                       child: SingleChildScrollView(
                         controller: controller,
@@ -830,10 +830,10 @@ void main() {
                       child: CupertinoButton(
                         onPressed: () {
                           setState(() {
-                            isAlwaysShown = !isAlwaysShown;
+                            thumbVisibility = !thumbVisibility;
                           });
                         },
-                        child: const Text('change isAlwaysShown'),
+                        child: const Text('change thumbVisibility'),
                       ),
                     ),
                   ],
@@ -1011,7 +1011,7 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: CupertinoScrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: SingleChildScrollView(
               controller: scrollController,
@@ -1155,7 +1155,7 @@ void main() {
         home: PrimaryScrollController(
           controller: scrollController,
           child: CupertinoScrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: const SingleChildScrollView(
               child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1266,7 +1266,7 @@ void main() {
         home: PrimaryScrollController(
           controller: scrollController,
           child: CupertinoScrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             scrollbarOrientation: ScrollbarOrientation.left,
             child: const SingleChildScrollView(

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3801,7 +3801,7 @@ void main() {
                 title: const Text('AppBar'),
               ),
               body: Scrollbar(
-                isAlwaysShown: true,
+                thumbVisibility: true,
                 controller: controller,
                 child: ListView(
                   controller: controller,

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -265,14 +265,14 @@ void main() {
   });
 
   testWidgets(
-    'When isAlwaysShown is true, must pass a controller or find PrimaryScrollController',
+    'When thumbVisibility is true, must pass a controller or find PrimaryScrollController',
     (WidgetTester tester) async {
       Widget viewWithScroll() {
         return _buildBoilerplate(
           child: Theme(
             data: ThemeData(),
             child: const Scrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               child: SingleChildScrollView(
                 child: SizedBox(
                   width: 4000.0,
@@ -291,7 +291,7 @@ void main() {
   );
 
   testWidgets(
-    'When isAlwaysShown is true, must pass a controller that is attached to a scroll view or find PrimaryScrollController',
+    'When thumbVisibility is true, must pass a controller that is attached to a scroll view or find PrimaryScrollController',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
       Widget viewWithScroll() {
@@ -299,7 +299,7 @@ void main() {
           child: Theme(
             data: ThemeData(),
             child: Scrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: controller,
               child: const SingleChildScrollView(
                 child: SizedBox(
@@ -318,14 +318,14 @@ void main() {
     },
   );
 
-  testWidgets('On first render with isAlwaysShown: true, the thumb shows', (WidgetTester tester) async {
+  testWidgets('On first render with thumbVisibility: true, the thumb shows', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     Widget viewWithScroll() {
       return _buildBoilerplate(
         child: Theme(
           data: ThemeData(),
           child: Scrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: controller,
             child: SingleChildScrollView(
               controller: controller,
@@ -344,7 +344,7 @@ void main() {
     expect(find.byType(Scrollbar), paints..rect());
   });
 
-  testWidgets('On first render with isAlwaysShown: true, the thumb shows with PrimaryScrollController', (WidgetTester tester) async {
+  testWidgets('On first render with thumbVisibility: true, the thumb shows with PrimaryScrollController', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     Widget viewWithScroll() {
       return _buildBoilerplate(
@@ -355,7 +355,7 @@ void main() {
             child: Builder(
               builder: (BuildContext context) {
                 return const Scrollbar(
-                  isAlwaysShown: true,
+                  thumbVisibility: true,
                   child: SingleChildScrollView(
                     primary: true,
                     child: SizedBox(
@@ -376,14 +376,14 @@ void main() {
     expect(find.byType(Scrollbar), paints..rect());
   });
 
-  testWidgets('On first render with isAlwaysShown: false, the thumb is hidden', (WidgetTester tester) async {
+  testWidgets('On first render with thumbVisibility: false, the thumb is hidden', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     Widget viewWithScroll() {
       return _buildBoilerplate(
         child: Theme(
           data: ThemeData(),
           child: Scrollbar(
-            isAlwaysShown: false,
+            thumbVisibility: false,
             controller: controller,
             child: SingleChildScrollView(
               controller: controller,
@@ -403,10 +403,10 @@ void main() {
   });
 
   testWidgets(
-    'With isAlwaysShown: true, fling a scroll. While it is still scrolling, set isAlwaysShown: false. The thumb should not fade out until the scrolling stops.',
+    'With thumbVisibility: true, fling a scroll. While it is still scrolling, set thumbVisibility: false. The thumb should not fade out until the scrolling stops.',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = true;
+      bool thumbVisibility = true;
       Widget viewWithScroll() {
         return _buildBoilerplate(
           child: StatefulBuilder(
@@ -418,12 +418,12 @@ void main() {
                     child: const Icon(Icons.threed_rotation),
                     onPressed: () {
                       setState(() {
-                        isAlwaysShown = !isAlwaysShown;
+                        thumbVisibility = !thumbVisibility;
                       });
                     },
                   ),
                   body: Scrollbar(
-                    isAlwaysShown: isAlwaysShown,
+                    thumbVisibility: thumbVisibility,
                     controller: controller,
                     child: SingleChildScrollView(
                       controller: controller,
@@ -457,10 +457,10 @@ void main() {
   );
 
   testWidgets(
-    'With isAlwaysShown: false, set isAlwaysShown: true. The thumb should be always shown directly',
+    'With thumbVisibility: false, set thumbVisibility: true. The thumb should be always shown directly',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = false;
+      bool thumbVisibility = false;
       Widget viewWithScroll() {
         return _buildBoilerplate(
           child: StatefulBuilder(
@@ -472,12 +472,12 @@ void main() {
                     child: const Icon(Icons.threed_rotation),
                     onPressed: () {
                       setState(() {
-                        isAlwaysShown = !isAlwaysShown;
+                        thumbVisibility = !thumbVisibility;
                       });
                     },
                   ),
                   body: Scrollbar(
-                    isAlwaysShown: isAlwaysShown,
+                    thumbVisibility: thumbVisibility,
                     controller: controller,
                     child: SingleChildScrollView(
                       controller: controller,
@@ -506,10 +506,10 @@ void main() {
   );
 
   testWidgets(
-    'With isAlwaysShown: false, fling a scroll. While it is still scrolling, set isAlwaysShown: true. The thumb should not fade even after the scrolling stops',
+    'With thumbVisibility: false, fling a scroll. While it is still scrolling, set thumbVisibility: true. The thumb should not fade even after the scrolling stops',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = false;
+      bool thumbVisibility = false;
       Widget viewWithScroll() {
         return _buildBoilerplate(
           child: StatefulBuilder(
@@ -521,12 +521,12 @@ void main() {
                     child: const Icon(Icons.threed_rotation),
                     onPressed: () {
                       setState(() {
-                        isAlwaysShown = !isAlwaysShown;
+                        thumbVisibility = !thumbVisibility;
                       });
                     },
                   ),
                   body: Scrollbar(
-                    isAlwaysShown: isAlwaysShown,
+                    thumbVisibility: thumbVisibility,
                     controller: controller,
                     child: SingleChildScrollView(
                       controller: controller,
@@ -566,10 +566,10 @@ void main() {
   );
 
   testWidgets(
-    'Toggling isAlwaysShown while not scrolling fades the thumb in/out. This works even when you have never scrolled at all yet',
+    'Toggling thumbVisibility while not scrolling fades the thumb in/out. This works even when you have never scrolled at all yet',
     (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
-      bool isAlwaysShown = true;
+      bool thumbVisibility = true;
       Widget viewWithScroll() {
         return _buildBoilerplate(
           child: StatefulBuilder(
@@ -581,12 +581,12 @@ void main() {
                     child: const Icon(Icons.threed_rotation),
                     onPressed: () {
                       setState(() {
-                        isAlwaysShown = !isAlwaysShown;
+                        thumbVisibility = !thumbVisibility;
                       });
                     },
                   ),
                   body: Scrollbar(
-                    isAlwaysShown: isAlwaysShown,
+                    thumbVisibility: thumbVisibility,
                     controller: controller,
                     child: SingleChildScrollView(
                       controller: controller,
@@ -685,7 +685,7 @@ void main() {
           data: const MediaQueryData(),
           child: Scrollbar(
             interactive: true,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: SingleChildScrollView(
               controller: scrollController,
@@ -855,7 +855,7 @@ void main() {
           controller: scrollController,
           child: Scrollbar(
             interactive: true,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: const SingleChildScrollView(
               child: SizedBox(width: 4000.0, height: 4000.0),
@@ -941,7 +941,9 @@ void main() {
   testWidgets('Scrollbar thumb color completes a hover animation', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(isAlwaysShown: true)),
+        theme: ThemeData(
+          scrollbarTheme: ScrollbarThemeData(thumbVisibility: MaterialStateProperty.all(true)),
+        ),
         home: const SingleChildScrollView(
           child: SizedBox(width: 4000.0, height: 4000.0),
         ),
@@ -986,8 +988,8 @@ void main() {
   testWidgets('Hover animation is not triggered by tap gestures', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(
-          isAlwaysShown: true,
+        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+          thumbVisibility: MaterialStateProperty.all(true),
           showTrackOnHover: true,
         )),
         home: const SingleChildScrollView(
@@ -1128,7 +1130,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
-          isAlwaysShown: true,
+          thumbVisibility: MaterialStateProperty.all(true),
           trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
             if (states.contains(MaterialState.hovered)) {
               return true;
@@ -1192,8 +1194,8 @@ void main() {
   testWidgets('Scrollbar showTrackOnHover', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(
-          isAlwaysShown: true,
+        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+          thumbVisibility: MaterialStateProperty.all(true),
           showTrackOnHover: true,
         )),
         home: const SingleChildScrollView(
@@ -1389,7 +1391,7 @@ void main() {
           controller: scrollController,
           child: Scrollbar(
             interactive: false,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: const SingleChildScrollView(
               child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1457,7 +1459,7 @@ void main() {
         home: PrimaryScrollController(
           controller: scrollController,
           child: Scrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: SingleChildScrollView(
               dragStartBehavior: DragStartBehavior.down,
@@ -1552,7 +1554,7 @@ void main() {
           controller: scrollController,
           child: Scrollbar(
             interactive: true,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: const SingleChildScrollView(
               child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1714,10 +1716,10 @@ void main() {
     );
   });
 
-  testWidgets('Scrollbar.isAlwaysShown triggers assertion when multiple ScrollPositions are attached.', (WidgetTester tester) async {
+  testWidgets('Scrollbar.thumbVisibility triggers assertion when multiple ScrollPositions are attached.', (WidgetTester tester) async {
     Widget getTabContent({ ScrollController? scrollController }) {
       return Scrollbar(
-        isAlwaysShown: true,
+        thumbVisibility: true,
         controller: scrollController,
         child: ListView.builder(
           controller: scrollController,
@@ -1794,7 +1796,7 @@ void main() {
             controller: scrollController,
             child: Scrollbar(
               interactive: true,
-              isAlwaysShown: true,
+              thumbVisibility: true,
               scrollbarOrientation: orientation,
               controller: scrollController,
               child: const SingleChildScrollView(

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -38,7 +38,7 @@ void main() {
         home: ScrollConfiguration(
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             showTrackOnHover: true,
             controller: scrollController,
             child: SingleChildScrollView(
@@ -131,7 +131,7 @@ void main() {
       home: ScrollConfiguration(
         behavior: const NoScrollbarBehavior(),
         child: Scrollbar(
-          isAlwaysShown: true,
+          thumbVisibility: true,
           controller: scrollController,
           child: SingleChildScrollView(
             controller: scrollController,
@@ -261,7 +261,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(interactive: false)),
       home: Scrollbar(
-        isAlwaysShown: true,
+        thumbVisibility: true,
         controller: scrollController,
         child: SingleChildScrollView(
           controller: scrollController,
@@ -309,7 +309,7 @@ void main() {
       theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(interactive: false)),
       home: Scrollbar(
         interactive: true,
-        isAlwaysShown: true,
+        thumbVisibility: true,
         controller: scrollController,
         child: SingleChildScrollView(
           controller: scrollController,
@@ -353,7 +353,6 @@ void main() {
 
   testWidgets('Scrollbar widget properties take priority over theme', (WidgetTester tester) async {
     const double thickness = 4.0;
-    const double hoverThickness = 4.0;
     const bool showTrackOnHover = true;
     const Radius radius = Radius.circular(3.0);
     final ScrollController scrollController = ScrollController();
@@ -367,7 +366,6 @@ void main() {
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
             thickness: thickness,
-            hoverThickness: hoverThickness,
             thumbVisibility: true,
             showTrackOnHover: showTrackOnHover,
             radius: radius,
@@ -426,19 +424,18 @@ void main() {
       find.byType(Scrollbar),
       paints
         ..rect(
-          rect: const Rect.fromLTRB(792.0, 0.0, 800.0, 600.0),
+          rect: const Rect.fromLTRB(784.0, 0.0, 800.0, 600.0),
           color: const Color(0x08000000),
         )
         ..line(
-          p1: const Offset(792.0, 0.0),
-          p2: const Offset(792.0, 600.0),
+          p1: const Offset(784.0, 0.0),
+          p2: const Offset(784.0, 600.0),
           strokeWidth: 1.0,
           color: const Color(0x1a000000),
         )
         ..rrect(
           rrect: RRect.fromRectAndRadius(
-            // Scrollbar thumb is larger
-            const Rect.fromLTRB(794.0, 10.0, 798.0, 100.0),
+            const Rect.fromLTRB(786.0, 10.0, 798.0, 100.0),
             const Radius.circular(3.0),
           ),
           // Hover color
@@ -461,7 +458,7 @@ void main() {
         home: ScrollConfiguration(
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             showTrackOnHover: true,
             controller: scrollController,
             child: SingleChildScrollView(
@@ -636,7 +633,7 @@ void main() {
         home: ScrollConfiguration(
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             showTrackOnHover: true,
             controller: scrollController,
             child: SingleChildScrollView(

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -693,7 +693,7 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: RawScrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: SingleChildScrollView(
               controller: scrollController,
@@ -958,7 +958,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: const SingleChildScrollView(
                 child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1013,7 +1013,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: const SingleChildScrollView(
                 child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1071,7 +1071,7 @@ void main() {
             child: PrimaryScrollController(
               controller: scrollController,
               child: RawScrollbar(
-                isAlwaysShown: true,
+                thumbVisibility: true,
                 controller: scrollController,
                 child: const SingleChildScrollView(
                   primary: true,
@@ -1139,7 +1139,7 @@ void main() {
             child: PrimaryScrollController(
               controller: scrollController,
               child: RawScrollbar(
-                isAlwaysShown: true,
+                thumbVisibility: true,
                 controller: scrollController,
                 child: const SingleChildScrollView(
                   child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1262,7 +1262,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: const SingleChildScrollView(
                 child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1428,7 +1428,7 @@ void main() {
     FlutterError.onError = handler;
   });
 
-  testWidgets('RawScrollbar.isAlwaysShown asserts that a ScrollPosition is attached', (WidgetTester tester) async {
+  testWidgets('RawScrollbar.thumbVisibility asserts that a ScrollPosition is attached', (WidgetTester tester) async {
     final FlutterExceptionHandler? handler = FlutterError.onError;
     FlutterErrorDetails? error;
     FlutterError.onError = (FlutterErrorDetails details) {
@@ -1441,7 +1441,7 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: RawScrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: ScrollController(),
             thumbColor: const Color(0x11111111),
             child: const SingleChildScrollView(
@@ -1518,7 +1518,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: const SingleChildScrollView(
                 child: SizedBox(width: 4000.0, height: 4000.0),
@@ -1691,7 +1691,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: const SingleChildScrollView(
                 reverse: true,
@@ -1764,7 +1764,7 @@ void main() {
           data: const MediaQueryData(),
           child: RawScrollbar(
             mainAxisMargin: 10,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: scrollController,
             child: SingleChildScrollView(
               controller: scrollController,
@@ -1797,7 +1797,7 @@ void main() {
               borderRadius: BorderRadius.all(Radius.circular(8.0))
             ),
             controller: scrollController,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SizedBox(height: 1000.0),
@@ -1833,7 +1833,7 @@ void main() {
             controller: scrollController,
             minThumbLength: 21,
             minOverscrollLength: 8,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SizedBox(width: 1000.0, height: 50000.0),
@@ -1859,7 +1859,7 @@ void main() {
             shape: const CircleBorder(side: BorderSide(width: 2.0)),
             thickness: 36.0,
             controller: scrollController,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SizedBox(height: 1000.0, width: 1000),
@@ -1894,7 +1894,7 @@ void main() {
           child: RawScrollbar(
             controller: scrollController,
             crossAxisMargin: 30,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SizedBox(width: 1000.0, height: 1000.0),
@@ -1920,7 +1920,7 @@ void main() {
             thickness: 20,
             shape: const RoundedRectangleBorder(borderRadius: BorderRadius.only(topLeft: Radius.circular(8))),
             controller: scrollController,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SizedBox(height: 1000.0, width: 1000.0),
@@ -1952,7 +1952,7 @@ void main() {
           data: const MediaQueryData(),
           child: RawScrollbar(
             controller: scrollController,
-            isAlwaysShown: true,
+              thumbVisibility: true,
             minOverscrollLength: 8.0,
             minThumbLength: 36.0,
             child: SingleChildScrollView(
@@ -1984,7 +1984,7 @@ void main() {
           data: const MediaQueryData(),
           child: RawScrollbar(
             controller: scrollController,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SizedBox(height: 1000.0),
@@ -2010,7 +2010,7 @@ void main() {
           data: const MediaQueryData(),
           child: RawScrollbar(
             controller: scrollController,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
                 controller: scrollController,
                 child: SizedBox(width: double.infinity, height: height)
@@ -2044,7 +2044,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: const SingleChildScrollView(
                 child: SizedBox(
@@ -2084,7 +2084,7 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: RawScrollbar(
-            isAlwaysShown: true,
+            thumbVisibility: true,
             controller: verticalScrollController,
             // This scrollbar will receive scroll notifications from both nested
             // scroll views of opposite axes, but should stay on the vertical
@@ -2149,7 +2149,7 @@ void main() {
               return notification.depth == 0;
             },
             controller: scrollController,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: const SingleChildScrollView(),
@@ -2179,7 +2179,7 @@ void main() {
           child: RawScrollbar(
             controller: scrollController,
             interactive: true,
-            isAlwaysShown: true,
+            thumbVisibility: true,
             child: SingleChildScrollView(
               controller: scrollController,
               child: Container(
@@ -2222,7 +2222,7 @@ void main() {
             child: PrimaryScrollController(
               controller: scrollController,
               child: RawScrollbar(
-                isAlwaysShown: true,
+                thumbVisibility: true,
                 controller: scrollController,
                 child: CustomScrollView(
                   primary: true,
@@ -2304,7 +2304,7 @@ void main() {
             child: PrimaryScrollController(
               controller: scrollController,
               child: RawScrollbar(
-                isAlwaysShown: true,
+                thumbVisibility: true,
                 controller: scrollController,
                 child: CustomScrollView(
                   center: uniqueKey,
@@ -2730,7 +2730,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: CustomScrollView(
                 controller: scrollController,
@@ -2800,7 +2800,7 @@ void main() {
           child: PrimaryScrollController(
             controller: scrollController,
             child: RawScrollbar(
-              isAlwaysShown: true,
+              thumbVisibility: true,
               controller: scrollController,
               child: CustomScrollView(
                 controller: scrollController,


### PR DESCRIPTION
The deprecated `[RawScrollbar/Scrollbar/CupertinoScrollbar/ScrollbarThemeData].isAlwaysShown` has expired and is removed in thi PR.
Also, `Scrollbar.hoverThickness` is also removed after having expired.

The replacement for `isAlwaysShown` is `thumbVisibility`. This deprecation was introduced in #96957. The name change came from new behaviors like a track that is conditionally visible. Since the original API only referred to the thumb, the name was changed to reflect this intention. This change is supported by dart fix. ✅ 

The replacement for `hoverThickness` is `ScrollbarThemeData.thickness`, which is a MaterialStateProperty that allows for the thickness to respond to multiple states including hover. This deprecation was introduced in #97173. This change is not supported by dart fix. 😞  

Part of https://github.com/flutter/flutter/issues/127042

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
