### PR TITLE
Remove const for Scaffold in segmented_button.0.dart

### DIFF
--- a/examples/api/lib/material/segmented_button/segmented_button.0.dart
+++ b/examples/api/lib/material/segmented_button/segmented_button.0.dart
@@ -17,7 +17,7 @@ class SegmentedButtonApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(useMaterial3: true),
-      home: const Scaffold(
+      home: Scaffold(
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
# Versions in use

- Dart: 2.19.6
- Flutter: 3.7.12 (channel stable)

# Issue
Compiling this sample app quickly ended with the following error message.

`lib/main.dart(22,18): error GD5B17B6A: Cannot invoke a non-'const' constructor where a const expression is expected.`

# Fix
To fix this error, I removed the `const` keyword for the `Scaffold`.