### PR TITLE
Fix wasm-opt location when using local_web_sdk

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -1108,7 +1108,7 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
           );
         case Artifact.wasmOptBinary:
           return _fileSystem.path.join(
-            _getDartSdkPath(), 'bin', 'snapshots',
+            _getDartSdkPath(), 'bin', 'utils',
             _artifactToFileName(artifact, _platform, mode),
           );
         case Artifact.genSnapshot:

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -418,6 +418,13 @@ void main() {
         fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk',
             'bin', 'snapshots', 'dart2js.dart.snapshot'),
       );
+      expect(
+        artifacts.getArtifactPath(
+          Artifact.wasmOptBinary,
+          platform: TargetPlatform.web_javascript),
+        fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk',
+            'bin', 'utils', 'wasm-opt'),
+      );
     });
 
     testWithoutContext('getEngineType', () {


### PR DESCRIPTION
We were looking up the wrong path for `wasm-opt` previously when using the `local-web-sdk` flag.