### PR TITLE
Revert "Replace rsync when unzipping artifacts on a Mac (#126703)"

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -8,7 +8,6 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'common.dart';
-import 'error_handling_io.dart';
 import 'file_system.dart';
 import 'io.dart';
 import 'logger.dart';
@@ -424,11 +423,7 @@ class _MacOSUtils extends _PosixUtils {
     return _hostPlatform!;
   }
 
-  /// Unzip into a temporary directory.
-  ///
-  /// For every file/directory/link in the unzipped file, delete the
-  /// corresponding entity in the [targetDirectory] before moving from the
-  /// temporary directory to the [targetDirectory].
+  // unzip, then rsync
   @override
   void unzip(File file, Directory targetDirectory) {
     if (!_processManager.canRun('unzip')) {
@@ -436,35 +431,35 @@ class _MacOSUtils extends _PosixUtils {
       // error in bin/internal/update_dart_sdk.sh
       throwToolExit('Missing "unzip" tool. Unable to extract ${file.path}.\nConsider running "brew install unzip".');
     }
-    final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync('flutter_${file.basename}.');
-    try {
-      // Unzip to a temporary directory.
+    if (_processManager.canRun('rsync')) {
+      final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync('flutter_${file.basename}.');
+      try {
+        // Unzip to a temporary directory.
+        _processUtils.runSync(
+          <String>['unzip', '-o', '-q', file.path, '-d', tempDirectory.path],
+          throwOnError: true,
+          verboseExceptions: true,
+        );
+        for (final FileSystemEntity unzippedFile in tempDirectory.listSync(followLinks: false)) {
+          // rsync --delete the unzipped files so files removed from the archive are also removed from the target.
+          // Add the '-8' parameter to avoid mangling filenames with encodings that do not match the current locale.
+          _processUtils.runSync(
+            <String>['rsync', '-8', '-av', '--delete', unzippedFile.path, targetDirectory.path],
+            throwOnError: true,
+            verboseExceptions: true,
+          );
+        }
+      } finally {
+        tempDirectory.deleteSync(recursive: true);
+      }
+    } else {
+      // Fall back to just unzipping.
+      _logger.printTrace('Unable to find rsync, falling back to direct unzipping.');
       _processUtils.runSync(
-        <String>['unzip', '-o', '-q', file.path, '-d', tempDirectory.path],
+        <String>['unzip', '-o', '-q', file.path, '-d', targetDirectory.path],
         throwOnError: true,
         verboseExceptions: true,
       );
-      for (final FileSystemEntity unzippedFile in tempDirectory.listSync(followLinks: false)) {
-        final FileSystemEntityType fileType = targetDirectory.fileSystem.typeSync(
-          targetDirectory.fileSystem.path.join(targetDirectory.path, unzippedFile.basename),
-          followLinks: false,
-        );
-        final FileSystemEntity fileToReplace;
-        if (fileType == FileSystemEntityType.directory) {
-          fileToReplace = targetDirectory.childDirectory(unzippedFile.basename);
-        } else if (fileType == FileSystemEntityType.link) {
-          fileToReplace = targetDirectory.childLink(unzippedFile.basename);
-        } else {
-          fileToReplace = targetDirectory.childFile(unzippedFile.basename);
-        }
-        // Delete existing version before moving.
-        ErrorHandlingFileSystem.deleteIfExists(fileToReplace, recursive: true);
-        unzippedFile.renameSync(fileToReplace.path);
-      }
-    } on FileSystemException catch (e) {
-      _logger.printTrace('${e.message}: ${e.osError}');
-    } finally {
-      tempDirectory.deleteSync(recursive: true);
     }
   }
 }

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -626,7 +626,29 @@ void main() {
   });
 
   group('unzip on macOS', () {
-    testWithoutContext('unzip and copy to empty folder', () {
+    testWithoutContext('falls back to unzip when rsync cannot run', () {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fakeProcessManager.excludedExecutables.add('rsync');
+
+      final BufferLogger logger = BufferLogger.test();
+      final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: FakePlatform(operatingSystem: 'macos'),
+        processManager: fakeProcessManager,
+      );
+
+      final Directory targetDirectory = fileSystem.currentDirectory;
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>['unzip', '-o', '-q', 'foo.zip', '-d', targetDirectory.path],
+      ));
+
+      macOSUtils.unzip(fileSystem.file('foo.zip'), targetDirectory);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(logger.traceText, contains('Unable to find rsync'));
+    });
+
+    testWithoutContext('unzip and rsyncs', () {
       final FileSystem fileSystem = MemoryFileSystem.test();
 
       final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
@@ -654,100 +676,27 @@ void main() {
             tempDirectory.childDirectory('dirB').childFile('fileB').createSync(recursive: true);
           },
         ),
+        FakeCommand(command: <String>[
+          'rsync',
+          '-8',
+          '-av',
+          '--delete',
+          tempDirectory.childDirectory('dirA').path,
+          targetDirectory.path,
+        ]),
+        FakeCommand(command: <String>[
+          'rsync',
+          '-8',
+          '-av',
+          '--delete',
+          tempDirectory.childDirectory('dirB').path,
+          targetDirectory.path,
+        ]),
       ]);
 
       macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory);
       expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(tempDirectory, isNot(exists));
-      expect(targetDirectory.childDirectory('dirA').childFile('fileA').existsSync(), isTrue);
-      expect(targetDirectory.childDirectory('dirB').childFile('fileB').existsSync(), isTrue);
-    });
-
-    testWithoutContext('unzip and copy to preexisting folder', () {
-      final FileSystem fileSystem = MemoryFileSystem.test();
-
-      final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
-        fileSystem: fileSystem,
-        logger: BufferLogger.test(),
-        platform: FakePlatform(operatingSystem: 'macos'),
-        processManager: fakeProcessManager,
-      );
-
-      final Directory targetDirectory = fileSystem.currentDirectory;
-      final File origFileA = targetDirectory.childDirectory('dirA').childFile('fileA');
-      origFileA.createSync(recursive: true);
-      origFileA.writeAsStringSync('old');
-      expect(targetDirectory.childDirectory('dirA').childFile('fileA').existsSync(), isTrue);
-      expect(targetDirectory.childDirectory('dirA').childFile('fileA').readAsStringSync(), 'old');
-
-      final Directory tempDirectory = fileSystem.systemTempDirectory.childDirectory('flutter_foo.zip.rand0');
-      fakeProcessManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            'unzip',
-            '-o',
-            '-q',
-            'foo.zip',
-            '-d',
-            tempDirectory.path,
-          ],
-          onRun: () {
-            expect(tempDirectory, exists);
-            final File newFileA = tempDirectory.childDirectory('dirA').childFile('fileA');
-            newFileA.createSync(recursive: true);
-            newFileA.writeAsStringSync('new');
-            tempDirectory.childDirectory('dirB').childFile('fileB').createSync(recursive: true);
-          },
-        ),
-      ]);
-
-      macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory);
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-      expect(tempDirectory, isNot(exists));
-      expect(targetDirectory.childDirectory('dirA').childFile('fileA').existsSync(), isTrue);
-      expect(targetDirectory.childDirectory('dirA').childFile('fileA').readAsStringSync(), 'new');
-      expect(targetDirectory.childDirectory('dirB').childFile('fileB').existsSync(), isTrue);
-    });
-
-    testWithoutContext('unzip and copy to preexisting folder with type mismatch', () {
-      final FileSystem fileSystem = MemoryFileSystem.test();
-
-      final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
-        fileSystem: fileSystem,
-        logger: BufferLogger.test(),
-        platform: FakePlatform(operatingSystem: 'macos'),
-        processManager: fakeProcessManager,
-      );
-
-      final Directory targetDirectory = fileSystem.currentDirectory;
-      final Directory origFileA = targetDirectory.childDirectory('dirA').childDirectory('fileA');
-      origFileA.createSync(recursive: true);
-      expect(targetDirectory.childDirectory('dirA').childDirectory('fileA').existsSync(), isTrue);
-
-      final Directory tempDirectory = fileSystem.systemTempDirectory.childDirectory('flutter_foo.zip.rand0');
-      fakeProcessManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>[
-            'unzip',
-            '-o',
-            '-q',
-            'foo.zip',
-            '-d',
-            tempDirectory.path,
-          ],
-          onRun: () {
-            expect(tempDirectory, exists);
-            tempDirectory.childDirectory('dirA').childFile('fileA').createSync(recursive: true);
-            tempDirectory.childDirectory('dirB').childFile('fileB').createSync(recursive: true);
-          },
-        ),
-      ]);
-
-      macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory);
-      expect(fakeProcessManager, hasNoRemainingExpectations);
-      expect(tempDirectory, isNot(exists));
-      expect(targetDirectory.childDirectory('dirA').childFile('fileA').existsSync(), isTrue);
-      expect(targetDirectory.childDirectory('dirB').childFile('fileB').existsSync(), isTrue);
     });
   });
 


### PR DESCRIPTION
This reverts commit 2b3cd7f4d9fd522e2e691fbd169c0c0e1fd7c9e8.

Fixes https://github.com/flutter/flutter/issues/127281.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
