### PR TITLE
`SearchBar` should not be impacted by overall `InputDecorationTheme`

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1244,7 +1244,7 @@ class _SearchBarState extends State<SearchBar> {
                           enabledBorder: InputBorder.none,
                           border: InputBorder.none,
                           focusedBorder: InputBorder.none,
-                          contentPadding: const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0),
+                          contentPadding: const EdgeInsets.symmetric(vertical: 12.0),
                         )),
                       ),
                     ),

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1235,10 +1235,17 @@ class _SearchBarState extends State<SearchBar> {
                         controller: widget.controller,
                         style: effectiveTextStyle,
                         decoration: InputDecoration(
-                          border: InputBorder.none,
                           hintText: widget.hintText,
+                        ).applyDefaults(InputDecorationTheme(
                           hintStyle: effectiveHintStyle,
-                        ),
+
+                          // The configuration below is to make sure that the text field
+                          // in `SearchBar` will not be overridden by the overall `InputDecorationTheme`
+                          enabledBorder: InputBorder.none,
+                          border: InputBorder.none,
+                          focusedBorder: InputBorder.none,
+                          contentPadding: const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0),
+                        )),
                       ),
                     ),
                   )

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -1728,21 +1728,10 @@ void main() {
       inputDecorationTheme: inputDecorationTheme
     );
 
-    testWidgets('Overall InputDecorationTheme does not override text field style'
-        ' in SearchBar', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: theme,
-          home: const Center(
-            child: Material(
-              child: SearchBar(hintText: 'hint text'),
-            ),
-          ),
-        ),
-      );
-
+    void checkDecorationInSearchBar(WidgetTester tester) {
       final Finder textField = findTextField();
       final InputDecoration? decoration = tester.widget<TextField>(textField).decoration;
+
       expect(decoration?.border, InputBorder.none);
       expect(decoration?.focusedBorder, InputBorder.none);
       expect(decoration?.enabledBorder, InputBorder.none);
@@ -1757,6 +1746,23 @@ void main() {
       expect(decoration?.hoverColor, null);
       expect(decoration?.contentPadding, const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
       expect(decoration?.hintStyle?.color, theme.colorScheme.onSurfaceVariant);
+    }
+
+    testWidgets('Overall InputDecorationTheme does not override text field style'
+        ' in SearchBar', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: const Center(
+            child: Material(
+              child: SearchBar(hintText: 'hint text'),
+            ),
+          ),
+        ),
+      );
+
+      // Check input decoration in `SearchBar`
+      checkDecorationInSearchBar(tester);
 
       // Check search bar defaults.
       final Finder searchBarMaterial = find.descendant(
@@ -1795,22 +1801,8 @@ void main() {
       await tester.tap(find.byIcon(Icons.search));
       await tester.pumpAndSettle();
 
-      final Finder textField = findTextField();
-      final InputDecoration? decoration = tester.widget<TextField>(textField).decoration;
-      expect(decoration?.border, InputBorder.none);
-      expect(decoration?.focusedBorder, InputBorder.none);
-      expect(decoration?.enabledBorder, InputBorder.none);
-      expect(decoration?.errorBorder, null);
-      expect(decoration?.focusedErrorBorder, null);
-      expect(decoration?.disabledBorder, null);
-      expect(decoration?.constraints, null);
-      expect(decoration?.isCollapsed, false);
-      expect(decoration?.filled, false);
-      expect(decoration?.fillColor, null);
-      expect(decoration?.focusColor, null);
-      expect(decoration?.hoverColor, null);
-      expect(decoration?.contentPadding, const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
-      expect(decoration?.hintStyle?.color, theme.colorScheme.onSurfaceVariant);
+      // Check input decoration in `SearchBar`
+      checkDecorationInSearchBar(tester);
 
       // Check search bar defaults in search view route.
       final Finder searchBarMaterial = find.descendant(

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -31,29 +31,7 @@ void main() {
     );
 
     final Material material = tester.widget<Material>(searchBarMaterial);
-    expect(material.animationDuration, const Duration(milliseconds: 200));
-    expect(material.borderOnForeground, true);
-    expect(material.borderRadius, null);
-    expect(material.clipBehavior, Clip.none);
-    expect(material.color, colorScheme.surface);
-    expect(material.elevation, 6.0);
-    expect(material.shadowColor, colorScheme.shadow);
-    expect(material.surfaceTintColor, colorScheme.surfaceTint);
-    expect(material.shape, const StadiumBorder());
-
-    final Text helperText = tester.widget(find.text('hint text'));
-    expect(helperText.style?.color, colorScheme.onSurfaceVariant);
-    expect(helperText.style?.fontSize, 16.0);
-    expect(helperText.style?.fontFamily, 'Roboto');
-    expect(helperText.style?.fontWeight, FontWeight.w400);
-
-    const String input = 'entered text';
-    await tester.enterText(find.byType(SearchBar), input);
-    final EditableText inputText = tester.widget(find.text(input));
-    expect(inputText.style.color, colorScheme.onSurface);
-    expect(inputText.style.fontSize, 16.0);
-    expect(helperText.style?.fontFamily, 'Roboto');
-    expect(inputText.style.fontWeight, FontWeight.w400);
+    checkSearchBarDefaults(tester, colorScheme, material);
   });
 
   testWidgets('SearchBar respects controller property', (WidgetTester tester) async {
@@ -643,19 +621,21 @@ void main() {
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
     await tester.pump();
-    final Text helperText = tester.widget(find.text('hint text'));
+    Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
+    helperText = tester.widget(find.text('hint text'));
+    expect(helperText.style?.color, pressedColor);
     await gesture.removePointer();
-    expect(helperText.style?.color, hoveredColor);
 
     // On focused.
     await tester.tap(find.byType(SearchBar));
     await tester.pump();
-    expect(helperText.style?.color, hoveredColor);
+    helperText = tester.widget(find.text('hint text'));
+    expect(helperText.style?.color, focusedColor);
   });
 
   testWidgets('SearchBar respects textStyle property', (WidgetTester tester) async {
@@ -676,19 +656,21 @@ void main() {
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
     await tester.pump();
-    final EditableText inputText = tester.widget(find.text('input text'));
+    EditableText inputText = tester.widget(find.text('input text'));
     expect(inputText.style.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
     await gesture.removePointer();
-    expect(inputText.style.color, hoveredColor);
+    inputText = tester.widget(find.text('input text'));
+    expect(inputText.style.color, pressedColor);
 
     // On focused.
     await tester.tap(find.byType(SearchBar));
     await tester.pump();
-    expect(inputText.style.color, hoveredColor);
+    inputText = tester.widget(find.text('input text'));
+    expect(inputText.style.color, focusedColor);
   });
 
   testWidgets('hintStyle can override textStyle for hintText', (WidgetTester tester) async {
@@ -709,19 +691,21 @@ void main() {
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
     await tester.pump();
-    final Text helperText = tester.widget(find.text('hint text'));
+    Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
     await gesture.removePointer();
-    expect(helperText.style?.color, hoveredColor);
+    helperText = tester.widget(find.text('hint text'));
+    expect(helperText.style?.color, pressedColor);
 
     // On focused.
     await tester.tap(find.byType(SearchBar));
     await tester.pump();
-    expect(helperText.style?.color, hoveredColor);
+    helperText = tester.widget(find.text('hint text'));
+    expect(helperText.style?.color, focusedColor);
   });
 
   testWidgets('The search view defaults', (WidgetTester tester) async {
@@ -1716,6 +1700,169 @@ void main() {
     final Rect searchViewRect = tester.getRect(find.descendant(of: findViewContent(), matching: find.byType(SizedBox)).first);
     expect(searchViewRect.topLeft, equals(const Offset(rootSpacing, rootSpacing)));
   });
+
+
+  // regression tests for https://github.com/flutter/flutter/issues/126623
+  group('Overall InputDecorationTheme does not impact SearchBar and SearchView', () {
+
+    const InputDecorationTheme inputDecorationTheme = InputDecorationTheme(
+      focusColor: Colors.green,
+      hoverColor: Colors.blue,
+      outlineBorder: BorderSide(color: Colors.pink, width: 10),
+      isDense: true,
+      contentPadding: EdgeInsets.symmetric(horizontal: 20),
+      hintStyle: TextStyle(color: Colors.purpleAccent),
+      fillColor: Colors.tealAccent,
+      filled: true,
+      isCollapsed: true,
+      border: OutlineInputBorder(),
+      focusedBorder: UnderlineInputBorder(),
+      enabledBorder: UnderlineInputBorder(),
+      errorBorder: UnderlineInputBorder(),
+      focusedErrorBorder: UnderlineInputBorder(),
+      disabledBorder: UnderlineInputBorder(),
+      constraints: BoxConstraints(maxWidth: 300),
+    );
+    final ThemeData theme = ThemeData(
+      useMaterial3: true,
+      inputDecorationTheme: inputDecorationTheme
+    );
+
+    testWidgets('Overall InputDecorationTheme does not override text field style'
+        ' in SearchBar', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: const Center(
+            child: Material(
+              child: SearchBar(hintText: 'hint text'),
+            ),
+          ),
+        ),
+      );
+
+      final Finder textField = findTextField();
+      final InputDecoration? decoration = tester.widget<TextField>(textField).decoration;
+      expect(decoration?.border, InputBorder.none);
+      expect(decoration?.focusedBorder, InputBorder.none);
+      expect(decoration?.enabledBorder, InputBorder.none);
+      expect(decoration?.errorBorder, null);
+      expect(decoration?.focusedErrorBorder, null);
+      expect(decoration?.disabledBorder, null);
+      expect(decoration?.constraints, null);
+      expect(decoration?.isCollapsed, false);
+      expect(decoration?.filled, false);
+      expect(decoration?.fillColor, null);
+      expect(decoration?.focusColor, null);
+      expect(decoration?.hoverColor, null);
+      expect(decoration?.contentPadding, const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
+      expect(decoration?.hintStyle?.color, theme.colorScheme.onSurfaceVariant);
+
+      // Check search bar defaults.
+      final Finder searchBarMaterial = find.descendant(
+        of: find.byType(SearchBar),
+        matching: find.byType(Material),
+      );
+
+      final Material material = tester.widget<Material>(searchBarMaterial);
+      checkSearchBarDefaults(tester, theme.colorScheme, material);
+    });
+
+    testWidgets('Overall InputDecorationTheme does not override text field style'
+        ' in the search view route', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: theme,
+          home: Scaffold(
+            body: Material(
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: SearchAnchor(
+                  viewHintText: 'hint text',
+                  builder: (BuildContext context, SearchController controller) {
+                    return const Icon(Icons.search);
+                  },
+                  suggestionsBuilder: (BuildContext context, SearchController controller) {
+                    return <Widget>[];
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
+
+      final Finder textField = findTextField();
+      final InputDecoration? decoration = tester.widget<TextField>(textField).decoration;
+      expect(decoration?.border, InputBorder.none);
+      expect(decoration?.focusedBorder, InputBorder.none);
+      expect(decoration?.enabledBorder, InputBorder.none);
+      expect(decoration?.errorBorder, null);
+      expect(decoration?.focusedErrorBorder, null);
+      expect(decoration?.disabledBorder, null);
+      expect(decoration?.constraints, null);
+      expect(decoration?.isCollapsed, false);
+      expect(decoration?.filled, false);
+      expect(decoration?.fillColor, null);
+      expect(decoration?.focusColor, null);
+      expect(decoration?.hoverColor, null);
+      expect(decoration?.contentPadding, const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
+      expect(decoration?.hintStyle?.color, theme.colorScheme.onSurfaceVariant);
+
+      // Check search bar defaults in search view route.
+      final Finder searchBarMaterial = find.descendant(
+        of: find.descendant(of: findViewContent(), matching: find.byType(SearchBar)),
+        matching: find.byType(Material),
+      ).first;
+
+      final Material material = tester.widget<Material>(searchBarMaterial);
+      expect(material.color, Colors.transparent);
+      expect(material.elevation, 0.0);
+      final Text hintText = tester.widget(find.text('hint text'));
+      expect(hintText.style?.color, theme.colorScheme.onSurfaceVariant);
+
+      const String input = 'entered text';
+      await tester.enterText(find.byType(SearchBar), input);
+      final EditableText inputText = tester.widget(find.text(input));
+      expect(inputText.style.color, theme.colorScheme.onSurface);
+    });
+  });
+}
+
+Future<void> checkSearchBarDefaults(WidgetTester tester, ColorScheme colorScheme, Material material) async {
+  expect(material.animationDuration, const Duration(milliseconds: 200));
+  expect(material.borderOnForeground, true);
+  expect(material.borderRadius, null);
+  expect(material.clipBehavior, Clip.none);
+  expect(material.color, colorScheme.surface);
+  expect(material.elevation, 6.0);
+  expect(material.shadowColor, colorScheme.shadow);
+  expect(material.surfaceTintColor, colorScheme.surfaceTint);
+  expect(material.shape, const StadiumBorder());
+
+  final Text helperText = tester.widget(find.text('hint text'));
+  expect(helperText.style?.color, colorScheme.onSurfaceVariant);
+  expect(helperText.style?.fontSize, 16.0);
+  expect(helperText.style?.fontFamily, 'Roboto');
+  expect(helperText.style?.fontWeight, FontWeight.w400);
+
+  const String input = 'entered text';
+  await tester.enterText(find.byType(SearchBar), input);
+  final EditableText inputText = tester.widget(find.text(input));
+  expect(inputText.style.color, colorScheme.onSurface);
+  expect(inputText.style.fontSize, 16.0);
+  expect(helperText.style?.fontFamily, 'Roboto');
+  expect(inputText.style.fontWeight, FontWeight.w400);
+}
+
+Finder findTextField() {
+  return find.descendant(
+    of: find.byType(SearchBar),
+    matching: find.byType(TextField)
+  );
 }
 
 TextStyle? _iconStyle(WidgetTester tester, IconData icon) {


### PR DESCRIPTION
Fixes #126623

This PR is to make sure that the text field decoration in `SearchBar` is not overridden by any `InputDecorationTheme`.
This fix doesn't add a new property `decorator` for `SearchBar` as the issue proposed, because there are some unrelated properties that `SearchBar` doesn't need.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
