### PR TITLE
handleSelectWord in MultiSelectableSelectionContainerDelegate should handle rects inside of rects

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1478,7 +1478,10 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     assert(word.isNormalized);
     // Fragments are separated by placeholder span, the word boundary shouldn't
     // expand across fragments.
-    assert(word.start >= range.start && word.end <= range.end);
+    final bool wordInsideSelectableBounds = word.start >= range.start && word.end <= range.end;
+    if (!wordInsideSelectableBounds) {
+      return SelectionResult.next;
+    }
     late TextPosition start;
     late TextPosition end;
     if (position.offset >= word.end) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1476,12 +1476,14 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     }
     final TextRange word = paragraph.getWordBoundary(position);
     assert(word.isNormalized);
-    // Fragments are separated by placeholder span, the word boundary shouldn't
-    // expand across fragments.
-    final bool wordInsideSelectableBounds = word.start >= range.start && word.end <= range.end;
-    if (!wordInsideSelectableBounds) {
+    if (word.start < range.start && word.end < range.start) {
+      return SelectionResult.previous;
+    } else if (word.start > range.end && word.end > range.end) {
       return SelectionResult.next;
     }
+    // Fragments are separated by placeholder span, the word boundary shouldn't
+    // expand across fragments.
+    assert(word.start >= range.start && word.end <= range.end);
     late TextPosition start;
     late TextPosition end;
     if (position.offset >= word.end) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1908,6 +1908,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         if (lastSelectionResult == SelectionResult.next) {
           continue;
         }
+        if (index == 0 && lastSelectionResult == SelectionResult.previous) {
+          return SelectionResult.previous;
+        }
         if (selectables[index].value != existingGeometry) {
           // Geometry has changed as a result of select word, need to clear the
           // selection of other selectables to keep selection in sync.
@@ -1916,7 +1919,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             .forEach((Selectable target) => dispatchSelectionEventToChild(target, const ClearSelectionEvent()));
           currentSelectionStartIndex = currentSelectionEndIndex = index;
         }
-        return index == 0 ? lastSelectionResult : SelectionResult.end;
+        return SelectionResult.end;
       }
     }
     return SelectionResult.next;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1916,7 +1916,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             .forEach((Selectable target) => dispatchSelectionEventToChild(target, const ClearSelectionEvent()));
           currentSelectionStartIndex = currentSelectionEndIndex = index;
         }
-        return lastSelectionResult;
+        return index == 0 ? lastSelectionResult : SelectionResult.end;
       }
     }
     if (lastSelectionResult == SelectionResult.next) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1911,6 +1911,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         if (index == 0 && lastSelectionResult == SelectionResult.previous) {
           return SelectionResult.previous;
         }
+        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
+          return SelectionResult.next;
+        }
         if (selectables[index].value != existingGeometry) {
           // Geometry has changed as a result of select word, need to clear the
           // selection of other selectables to keep selection in sync.
@@ -1920,9 +1923,15 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
           currentSelectionStartIndex = currentSelectionEndIndex = index;
         }
         return SelectionResult.end;
+      } else {
+        if (lastSelectionResult == SelectionResult.next) {
+          currentSelectionStartIndex = currentSelectionEndIndex = index - 1;
+          return SelectionResult.end;
+        }
       }
     }
-    return SelectionResult.next;
+    assert(lastSelectionResult == null);
+    return SelectionResult.end;
   }
 
   /// Removes the selection of all selectables this delegate manages.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1894,7 +1894,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
       if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
-        SelectionResult result = dispatchSelectionEventToChild(selectables[index], event);
+        final SelectionResult result = dispatchSelectionEventToChild(selectables[index], event);
         if (result == SelectionResult.next) {
           continue;
         }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1888,9 +1888,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   // of a given selectable.
   List<Rect> _selectableContains(Selectable containerSelectable, List<Selectable> selectables) {
     bool rectIsCompletelyInside(Rect r1, Rect r2) {
-      return r1.left <= r2.left && 
-            r1.right >= r2.right && 
-            r1.top <= r2.top && 
+      return r1.left <= r2.left &&
+            r1.right >= r2.right &&
+            r1.top <= r2.top &&
             r1.bottom >= r2.bottom;
     }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1888,14 +1888,15 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// [SelectWordSelectionEvent.globalPosition].
   @protected
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
+    SelectionResult? lastSelectionResult;
     for (int index = 0; index < selectables.length; index += 1) {
       final Rect localRect = Rect.fromLTWH(0, 0, selectables[index].size.width, selectables[index].size.height);
       final Matrix4 transform = selectables[index].getTransformTo(null);
       final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
       if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
-        final SelectionResult result = dispatchSelectionEventToChild(selectables[index], event);
-        if (result == SelectionResult.previous || result == SelectionResult.next) {
+        lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
+        if (lastSelectionResult == SelectionResult.previous || lastSelectionResult == SelectionResult.next) {
           continue;
         }
         if (selectables[index].value != existingGeometry) {
@@ -1908,6 +1909,11 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         }
         return SelectionResult.end;
       }
+    }
+    if (lastSelectionResult == SelectionResult.next) {
+      return SelectionResult.next;
+    } else if (lastSelectionResult == SelectionResult.previous) {
+      return SelectionResult.previous;
     }
     return SelectionResult.none;
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1669,12 +1669,21 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   ///
   /// Returns positive if a is lower, negative if a is higher.
   static int _compareHorizontally(Rect a, Rect b) {
+    // a encloses b.
     if (a.left - b.left < precisionErrorTolerance && a.right - b.right > - precisionErrorTolerance) {
-      // a encloses b.
+      // b ends before a.
+      if (a.right - b.right > precisionErrorTolerance) {
+        return 1;
+      }
       return -1;
     }
+
+    // b encloses a.
     if (b.left - a.left < precisionErrorTolerance && b.right - a.right > - precisionErrorTolerance) {
-      // b encloses a.
+      // a ends before b.
+      if (b.right - a.right > precisionErrorTolerance) {
+        return -1;
+      }
       return 1;
     }
     if ((a.left - b.left).abs() > precisionErrorTolerance) {
@@ -1896,7 +1905,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
-        if (lastSelectionResult == SelectionResult.previous || lastSelectionResult == SelectionResult.next) {
+        if (lastSelectionResult == SelectionResult.next) {
           continue;
         }
         if (selectables[index].value != existingGeometry) {
@@ -1907,13 +1916,11 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
             .forEach((Selectable target) => dispatchSelectionEventToChild(target, const ClearSelectionEvent()));
           currentSelectionStartIndex = currentSelectionEndIndex = index;
         }
-        return SelectionResult.end;
+        return lastSelectionResult;
       }
     }
     if (lastSelectionResult == SelectionResult.next) {
       return SelectionResult.next;
-    } else if (lastSelectionResult == SelectionResult.previous) {
-      return SelectionResult.previous;
     }
     return SelectionResult.none;
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1919,10 +1919,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         return index == 0 ? lastSelectionResult : SelectionResult.end;
       }
     }
-    if (lastSelectionResult == SelectionResult.next) {
-      return SelectionResult.next;
-    }
-    return SelectionResult.none;
+    return SelectionResult.next;
   }
 
   /// Removes the selection of all selectables this delegate manages.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1895,7 +1895,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         final SelectionResult result = dispatchSelectionEventToChild(selectables[index], event);
-        if (result == SelectionResult.next) {
+        if (result == SelectionResult.previous || result == SelectionResult.next) {
           continue;
         }
         if (selectables[index].value != existingGeometry) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1931,7 +1931,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
           break;
         }
       }
-      if (globalRect.contains(event.globalPosition) && rectsInside.isEmpty || globalRect.contains(event.globalPosition) && !positionInsideInnerRects) {
+      if (globalRect.contains(event.globalPosition) && !positionInsideInnerRects) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         dispatchSelectionEventToChild(selectables[index], event);
         if (selectables[index].value != existingGeometry) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1924,14 +1924,14 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       final Matrix4 transform = selectables[index].getTransformTo(null);
       final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
       final List<Rect> rectsInside = _selectableContains(selectables[index], selectables);
-      bool positionInEncompassing = false;
+      bool positionInsideInnerRects = false;
       for (final Rect rect in rectsInside) {
         if (rect.contains(event.globalPosition)) {
-          positionInEncompassing = true;
+          positionInsideInnerRects = true;
           break;
         }
       }
-      if (globalRect.contains(event.globalPosition) && rectsInside.isEmpty || globalRect.contains(event.globalPosition) && !positionInEncompassing) {
+      if (globalRect.contains(event.globalPosition) && rectsInside.isEmpty || globalRect.contains(event.globalPosition) && !positionInsideInnerRects) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         dispatchSelectionEventToChild(selectables[index], event);
         if (selectables[index].value != existingGeometry) {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -770,6 +770,48 @@ void main() {
     );
 
     testWidgets(
+      'select word can when a selectables rect is completely inside of another selectables rect', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/127076.
+      final UniqueKey outerText = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: Scaffold(
+              body: Center(
+                child: Text.rich(
+                  const TextSpan(
+                      children: <InlineSpan>[
+                        TextSpan(
+                          text:
+                              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                        ),
+                        WidgetSpan(child: Text('Some text in a WidgetSpan. ')),
+                        TextSpan(text: 'Hello, world.'),
+                      ],
+                  ),
+                  key: outerText,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.byKey(outerText), matching: find.byType(RichText)).first);
+      // Right click to select word at position.
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 125), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      // Should select "Hello".
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 124, extentOffset: 129));
+    },
+      skip: isBrowser, // https://github.com/flutter/flutter/issues/61020
+    );
+
+    testWidgets(
       'widget span is ignored if it does not contain text - non Apple',
       (WidgetTester tester) async {
         final UniqueKey outerText = UniqueKey();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -770,7 +770,7 @@ void main() {
     );
 
     testWidgets(
-      'select word can when a selectables rect is completely inside of another selectables rect', (WidgetTester tester) async {
+      'can select word when a selectables rect is completely inside of another selectables rect', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/127076.
       final UniqueKey outerText = UniqueKey();
       await tester.pumpWidget(


### PR DESCRIPTION
Fixes #127076

Sometimes a `Selectable`s rect may contain another `Selectable`s rect within it. In the case of `handleSelectWord` when choosing which `Selectable` to dispatch the `SelectionEvent` to, the event would be dispatched to the wrong `Selectable` causing an assertion error to be thrown. 

<img width="577" alt="Screenshot 2023-05-24 at 2 46 13 AM" src="https://github.com/flutter/flutter/assets/948037/bb246966-acad-4d81-bd87-758c3ea6ea39">

In the picture above the red outline shows the rect of a two-line piece of text. And the blue rect shows the rect of a piece of text that is on the second line of the two-line piece of text, but has been separated into its own rect for some case, for example when `TextSpan`s are separated by a `WidgetSpan`.

We should check if the text layout of the selectable that has been dispatched the SelectionEvent contains the word, if not then return `SelectionResult.next`, and continue to look through the list of selectables.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.