### PR TITLE
Log all lines from ios-deploy

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -94,6 +94,26 @@ void main () {
         logger = BufferLogger.test();
       });
 
+      testWithoutContext('print all lines', () async {
+        final StreamController<List<int>> stdin = StreamController<List<int>>();
+        final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(
+            command: const <String>['ios-deploy'],
+            stdout: "(mylldb)    platform select remote-'ios' --sysroot\r\n(mylldb)     run\r\nsuccess\r\nrandom string\r\n",
+            stdin: IOSink(stdin.sink),
+          ),
+        ]);
+        final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
+          processManager: processManager,
+          logger: logger,
+        );
+        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
+        expect(logger.traceText, contains("(mylldb)    platform select remote-'ios' --sysroot"));
+        expect(logger.traceText, contains('(mylldb)     run'));
+        expect(logger.traceText, contains('success'));
+        expect(logger.traceText, contains('random string'));
+      });
+
       testWithoutContext('custom lldb prompt', () async {
         final StreamController<List<int>> stdin = StreamController<List<int>>();
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2457,7 +2457,6 @@ flutter:
     });
 
     testUsingContext('IOSDeviceLogReader does not print logs', () async {
-      //
       final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
         iMobileDevice: IMobileDevice(
           artifacts: artifacts,

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/targets/scene_importer.dart';
 import 'package:flutter_tools/src/build_system/targets/shader_compiler.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/devfs.dart';
@@ -27,6 +28,8 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/ios/devices.dart';
+import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_devtools_handler.dart';
@@ -41,6 +44,7 @@ import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_devices.dart';
 import '../src/fake_vm_services.dart';
 import '../src/fakes.dart';
 import '../src/testbed.dart';
@@ -2438,6 +2442,71 @@ flutter:
     expect(flutterDevice.devFS!.hasSetAssetDirectory, true);
     expect(fakeVmServiceHost!.hasRemainingExpectations, false);
   }));
+
+  group('startEchoingDeviceLog', () {
+    late FakeProcessManager processManager;
+    late Artifacts artifacts;
+    late Cache fakeCache;
+    late BufferLogger logger;
+
+    setUp(() {
+      processManager = FakeProcessManager.empty();
+      fakeCache = Cache.test(processManager: FakeProcessManager.any());
+      artifacts = Artifacts.test();
+      logger = BufferLogger.test();
+    });
+
+    testUsingContext('IOSDeviceLogReader does not print logs', () async {
+      //
+      final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
+        iMobileDevice: IMobileDevice(
+          artifacts: artifacts,
+          processManager: processManager,
+          cache: fakeCache,
+          logger: logger,
+        ),
+        useSyslog: false,
+      );
+      device = FakeDevice(deviceLogReader: logReader);
+      final TestFlutterDevice flutterDevice = TestFlutterDevice(
+        device,
+      );
+
+      await flutterDevice.startEchoingDeviceLog();
+      final Future<List<String>> linesFromStream = logReader.logLines.toList();
+      logReader.linesController.add('event');
+      await logReader.linesController.close();
+      final List<String> lines = await linesFromStream;
+
+      expect(lines, contains('event'));
+      expect(logger.statusText, isEmpty);
+
+      await flutterDevice.stopEchoingDeviceLog();
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+
+    testUsingContext('Non-IOSDeviceLogReader does print logs', () async {
+      final FakeDeviceLogReader logReader = FakeDeviceLogReader();
+      device = FakeDevice(deviceLogReader: logReader);
+      final TestFlutterDevice flutterDevice = TestFlutterDevice(
+        device,
+      );
+
+      await flutterDevice.startEchoingDeviceLog();
+      final Future<List<String>> linesFromStream = logReader.logLines.toList();
+      logReader.addLine('event');
+      await logReader.dispose();
+      final List<String> lines = await linesFromStream;
+
+      expect(lines, contains('event'));
+      expect(logger.statusText, contains('event'));
+
+      await flutterDevice.stopEchoingDeviceLog();
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
+    });
+  });
 }
 
 // This implements [dds.DartDevelopmentService], not the [DartDevelopmentService]
@@ -2676,13 +2745,16 @@ class FakeDevice extends Fake implements Device {
     this.supportsHotRestart = true,
     this.supportsScreenshot = true,
     this.supportsFlutterExit = true,
+    DeviceLogReader? deviceLogReader,
   }) : _isLocalEmulator = isLocalEmulator,
        _targetPlatform = targetPlatform,
-       _sdkNameAndVersion = sdkNameAndVersion;
+       _sdkNameAndVersion = sdkNameAndVersion,
+       _deviceLogReader = deviceLogReader;
 
   final bool _isLocalEmulator;
   final TargetPlatform _targetPlatform;
   final String _sdkNameAndVersion;
+  final DeviceLogReader? _deviceLogReader;
 
   bool disposed = false;
   bool appStopped = false;
@@ -2740,7 +2812,12 @@ class FakeDevice extends Fake implements Device {
   FutureOr<DeviceLogReader> getLogReader({
     ApplicationPackage? app,
     bool includePastLogs = false,
-  }) => NoOpDeviceLogReader(name);
+  }) {
+    if (_deviceLogReader != null) {
+      return _deviceLogReader!;
+    }
+    return NoOpDeviceLogReader(name);
+  }
 
   @override
   DevicePortForwarder portForwarder = const NoOpDevicePortForwarder();


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/127222 that was reverted in https://github.com/flutter/flutter/pull/127405.

Fixed `Mac_ios microbenchmarks_ios` test failure by not echoing logs twice.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
