### PR TITLE
[Linux] Ignore deprecation of libupower call in example

### DIFF
--- a/examples/platform_channel/linux/my_application.cc
+++ b/examples/platform_channel/linux/my_application.cc
@@ -217,7 +217,12 @@ static void my_application_activate(GApplication* application) {
                            G_CALLBACK(up_device_added_cb), self);
   g_signal_connect_swapped(self->up_client, "device-removed",
                            G_CALLBACK(up_device_removed_cb), self);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+// TODO(cbracken): https://github.com/flutter/flutter/issues/127506
+// Migrate to up_client_get_devices2 once available.
   g_autoptr(GPtrArray) devices = up_client_get_devices(self->up_client);
+#pragma clang diagnostic pop
   for (guint i = 0; i < devices->len; i++) {
     g_autoptr(UpDevice) device =
         static_cast<UpDevice*>(g_ptr_array_index(devices, i));


### PR DESCRIPTION
The Linux platform channels sample makes a call to the libupower function `up_client_get_devices`, which was deprecated in libupower 0.99.8 in favour of `up_client_get_devices2`.

The prod bots have been migrated to focal, which ships libupower 0.99.11 in which the old function is deprecated and the new one is available.

The try bots have not yet been migrated and remain on bionic, which ships libupower 0.99.7 in which the old function is not deprecated and the new one is not available.

This marks the line in question to ignore deprecation warnings. Once all bots have migrated to focal, we'll migrate to the new function. See tracking issue below.

See: https://upower.freedesktop.org/docs/UpClient.html#up-client-get-devices

Issue: https://github.com/flutter/flutter/issues/127506

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
