### PR TITLE
Fix bottom sheet rebuilding when tapping

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -220,7 +220,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// [VerticalDragGestureRecognizer] and [HorizontalDragGestureRecognizer] are
   /// calculated by [computeHitSlop], while [computePanSlop] is used for
   /// [PanGestureRecognizer].
-  /// 
   ///
   /// If true, the drag callbacks will only be dispatched when this recognizer has
   /// won the arena and the drag threshold has been met.

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -77,7 +77,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     super.debugOwner,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
-    this.requireDragThreshold = false,
+    this.onlyAcceptDragOnThreshold = false,
     super.supportedDevices,
     AllowedButtonsFilter? allowedButtonsFilter,
   }) : super(allowedButtonsFilter: allowedButtonsFilter ?? _defaultButtonAcceptBehavior);
@@ -220,7 +220,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// has won the arena.
   ///
   /// This value defaults to false.
-  bool requireDragThreshold;
+  bool onlyAcceptDragOnThreshold;
 
   /// Determines the type of velocity estimation method to use for a potential
   /// drag gesture, when a new pointer is added.
@@ -419,7 +419,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   void acceptGesture(int pointer) {
     assert(!_acceptedActivePointers.contains(pointer));
     _acceptedActivePointers.add(pointer);
-    if (requireDragThreshold ? _hasDragThresholdBeenMet : true) {
+    if (onlyAcceptDragOnThreshold ? _hasDragThresholdBeenMet : true) {
       _checkDrag(pointer);
     }
   }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -77,7 +77,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     super.debugOwner,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
-    this.onlyDispatchDragCallbacksWhenThresholdMet = false,
+    this.requireDragThreshold = false,
     super.supportedDevices,
     AllowedButtonsFilter? allowedButtonsFilter,
   }) : super(allowedButtonsFilter: allowedButtonsFilter ?? _defaultButtonAcceptBehavior);
@@ -211,17 +211,16 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// If null then [kMaxFlingVelocity] is used.
   double? maxFlingVelocity;
 
-  /// Whether the drag callbacks should only be dispatched when the drag threshold
-  /// has been met.
+  /// Whether the drag threshold should be met before dispatching any drag callbacks.
   ///
   /// If true, the drag callbacks will only be dispatched when this recognizer has
   /// won the arena and the drag threshold has been met.
   ///
-  /// If false, the drag callbacks will be dispatched when this recognizer has won
-  /// the arena.
+  /// If false, the drag callbacks will be dispatched immediately when this recognizer
+  /// has won the arena.
   ///
   /// This value defaults to false.
-  bool onlyDispatchDragCallbacksWhenThresholdMet;
+  bool requireDragThreshold;
 
   /// Determines the type of velocity estimation method to use for a potential
   /// drag gesture, when a new pointer is added.
@@ -420,7 +419,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   void acceptGesture(int pointer) {
     assert(!_acceptedActivePointers.contains(pointer));
     _acceptedActivePointers.add(pointer);
-    if (onlyDispatchDragCallbacksWhenThresholdMet ? _hasDragThresholdBeenMet : !onlyDispatchDragCallbacksWhenThresholdMet) {
+    if (requireDragThreshold ? _hasDragThresholdBeenMet : true) {
       _checkDrag(pointer);
     }
   }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -420,7 +420,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   void acceptGesture(int pointer) {
     assert(!_acceptedActivePointers.contains(pointer));
     _acceptedActivePointers.add(pointer);
-    if (onlyDispatchDragCallbacksWhenThresholdMet ? _hasDragThresholdBeenMet && _state != _DragState.accepted : _state != _DragState.accepted) {
+    if (onlyDispatchDragCallbacksWhenThresholdMet ? _hasDragThresholdBeenMet : !onlyDispatchDragCallbacksWhenThresholdMet) {
       _checkDrag(pointer);
     }
   }
@@ -470,6 +470,9 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _checkDrag(int pointer) {
+    if (_state == _DragState.accepted) {
+      return;
+    }
     _state = _DragState.accepted;
     final OffsetPair delta = _pendingDragOffset;
     final Duration? timestamp = _lastPendingEventTimestamp;

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -419,7 +419,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   void acceptGesture(int pointer) {
     assert(!_acceptedActivePointers.contains(pointer));
     _acceptedActivePointers.add(pointer);
-    if (onlyAcceptDragOnThreshold ? _hasDragThresholdBeenMet : true) {
+    if (!onlyAcceptDragOnThreshold || _hasDragThresholdBeenMet) {
       _checkDrag(pointer);
     }
   }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -213,6 +213,15 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   /// Whether the drag threshold should be met before dispatching any drag callbacks.
   ///
+  /// The drag threshold is met when the global distance traveled by a pointer has
+  /// exceeded the defined threshold on the relevant axis, i.e. y-axis for the
+  /// [VerticalDragGestureRecognizer], x-axis for the [HorizontalDragGestureRecognizer],
+  /// and the entire plane for [PanGestureRecognizer]. The threshold for both
+  /// [VerticalDragGestureRecognizer] and [HorizontalDragGestureRecognizer] are
+  /// calculated by [computeHitSlop], while [computePanSlop] is used for
+  /// [PanGestureRecognizer].
+  /// 
+  ///
   /// If true, the drag callbacks will only be dispatched when this recognizer has
   /// won the arena and the drag threshold has been met.
   ///

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -1323,7 +1323,7 @@ class _BottomSheetGestureDetector extends StatelessWidget {
               ..onStart = onVerticalDragStart
               ..onUpdate = onVerticalDragUpdate
               ..onEnd = onVerticalDragEnd
-              ..onlyDispatchDragCallbacksWhenThresholdMet = true;
+              ..onlyAcceptDragOnThreshold = true;
           },
         ),
       },

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -1333,7 +1333,6 @@ class _BottomSheetGestureDetector extends StatelessWidget {
 }
 
 
-
 // BEGIN GENERATED TOKEN PROPERTIES - BottomSheet
 
 // Do not edit by hand. The code between the "BEGIN GENERATED" and

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -357,15 +357,14 @@ class _BottomSheetState extends State<BottomSheet> {
         dragHandleColor: widget.dragHandleColor,
         dragHandleSize: widget.dragHandleSize,
       );
-      // Only add [GestureDetector] to the drag handle when the rest of the
+      // Only add [_BottomSheetGestureDetector] to the drag handle when the rest of the
       // bottom sheet is not draggable. If the whole bottom sheet is draggable,
       // no need to add it.
       if (!widget.enableDrag) {
-        dragHandle = GestureDetector(
+        dragHandle = _BottomSheetGestureDetector(
           onVerticalDragStart: _handleDragStart,
           onVerticalDragUpdate: _handleDragUpdate,
           onVerticalDragEnd: _handleDragEnd,
-          excludeFromSemantics: true,
           child: dragHandle,
         );
       }
@@ -407,11 +406,10 @@ class _BottomSheetState extends State<BottomSheet> {
       );
     }
 
-    return !widget.enableDrag ? bottomSheet : GestureDetector(
+    return !widget.enableDrag ? bottomSheet : _BottomSheetGestureDetector(
       onVerticalDragStart: _handleDragStart,
       onVerticalDragUpdate: _handleDragUpdate,
       onVerticalDragEnd: _handleDragEnd,
-      excludeFromSemantics: true,
       child: bottomSheet,
     );
   }
@@ -1298,6 +1296,40 @@ PersistentBottomSheetController<T> showBottomSheet<T>({
     enableDrag: enableDrag,
     transitionAnimationController: transitionAnimationController,
   );
+}
+
+class _BottomSheetGestureDetector extends StatelessWidget {
+  const _BottomSheetGestureDetector({
+    required this.child,
+    required this.onVerticalDragStart,
+    required this.onVerticalDragUpdate,
+    required this.onVerticalDragEnd,
+  });
+
+  final Widget child;
+  final GestureDragStartCallback onVerticalDragStart;
+  final GestureDragUpdateCallback onVerticalDragUpdate;
+  final GestureDragEndCallback onVerticalDragEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return RawGestureDetector(
+      excludeFromSemantics: true,
+      gestures: <Type, GestureRecognizerFactory<GestureRecognizer>>{
+        VerticalDragGestureRecognizer : GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
+          () => VerticalDragGestureRecognizer(debugOwner: this),
+          (VerticalDragGestureRecognizer instance) {
+            instance
+              ..onStart = onVerticalDragStart
+              ..onUpdate = onVerticalDragUpdate
+              ..onEnd = onVerticalDragEnd
+              ..onlyDispatchDragCallbacksWhenThresholdMet = true;
+          },
+        ),
+      },
+      child: child,
+    );
+  }
 }
 
 

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -1332,7 +1332,6 @@ class _BottomSheetGestureDetector extends StatelessWidget {
   }
 }
 
-
 // BEGIN GENERATED TOKEN PROPERTIES - BottomSheet
 
 // Do not edit by hand. The code between the "BEGIN GENERATED" and

--- a/packages/flutter/test/gestures/monodrag_test.dart
+++ b/packages/flutter/test/gestures/monodrag_test.dart
@@ -75,7 +75,7 @@ void main() {
   });
 
   testGesture('DragGestureRecognizer should not dispatch drag callbacks when it wins the arena if onlyDispatchDragCallbacksWhenThresholdMet is true and the threshold has not been met', (GestureTester tester) {
-    VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
+    final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
     final List<String> dragCallbacks = <String>[];
     verticalDrag
       ..onlyDispatchDragCallbacksWhenThresholdMet = true
@@ -109,7 +109,7 @@ void main() {
   });
 
   testGesture('DragGestureRecognizer should dispatch drag callbacks when it wins the arena if onlyDispatchDragCallbacksWhenThresholdMet is false and the threshold has not been met', (GestureTester tester) {
-    VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
+    final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
     final List<String> dragCallbacks = <String>[];
     verticalDrag
       ..onlyDispatchDragCallbacksWhenThresholdMet = false

--- a/packages/flutter/test/gestures/monodrag_test.dart
+++ b/packages/flutter/test/gestures/monodrag_test.dart
@@ -74,11 +74,11 @@ void main() {
     GestureBinding.instance.handleEvent(up91, HitTestEntry(MockHitTestTarget()));
   });
 
-  testGesture('DragGestureRecognizer should not dispatch drag callbacks when it wins the arena if requireDragThreshold is true and the threshold has not been met', (GestureTester tester) {
+  testGesture('DragGestureRecognizer should not dispatch drag callbacks when it wins the arena if onlyAcceptDragOnThreshold is true and the threshold has not been met', (GestureTester tester) {
     final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
     final List<String> dragCallbacks = <String>[];
     verticalDrag
-      ..requireDragThreshold = true
+      ..onlyAcceptDragOnThreshold = true
       ..onStart = (DragStartDetails details) {
         dragCallbacks.add('onStart');
       }
@@ -108,11 +108,11 @@ void main() {
     dragCallbacks.clear();
   });
 
-  testGesture('DragGestureRecognizer should dispatch drag callbacks when it wins the arena if requireDragThreshold is false and the threshold has not been met', (GestureTester tester) {
+  testGesture('DragGestureRecognizer should dispatch drag callbacks when it wins the arena if onlyAcceptDragOnThreshold is false and the threshold has not been met', (GestureTester tester) {
     final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
     final List<String> dragCallbacks = <String>[];
     verticalDrag
-      ..requireDragThreshold = false
+      ..onlyAcceptDragOnThreshold = false
       ..onStart = (DragStartDetails details) {
         dragCallbacks.add('onStart');
       }

--- a/packages/flutter/test/gestures/monodrag_test.dart
+++ b/packages/flutter/test/gestures/monodrag_test.dart
@@ -74,11 +74,11 @@ void main() {
     GestureBinding.instance.handleEvent(up91, HitTestEntry(MockHitTestTarget()));
   });
 
-  testGesture('DragGestureRecognizer should not dispatch drag callbacks when it wins the arena if onlyDispatchDragCallbacksWhenThresholdMet is true and the threshold has not been met', (GestureTester tester) {
+  testGesture('DragGestureRecognizer should not dispatch drag callbacks when it wins the arena if requireDragThreshold is true and the threshold has not been met', (GestureTester tester) {
     final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
     final List<String> dragCallbacks = <String>[];
     verticalDrag
-      ..onlyDispatchDragCallbacksWhenThresholdMet = true
+      ..requireDragThreshold = true
       ..onStart = (DragStartDetails details) {
         dragCallbacks.add('onStart');
       }
@@ -108,11 +108,11 @@ void main() {
     dragCallbacks.clear();
   });
 
-  testGesture('DragGestureRecognizer should dispatch drag callbacks when it wins the arena if onlyDispatchDragCallbacksWhenThresholdMet is false and the threshold has not been met', (GestureTester tester) {
+  testGesture('DragGestureRecognizer should dispatch drag callbacks when it wins the arena if requireDragThreshold is false and the threshold has not been met', (GestureTester tester) {
     final VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
     final List<String> dragCallbacks = <String>[];
     verticalDrag
-      ..onlyDispatchDragCallbacksWhenThresholdMet = false
+      ..requireDragThreshold = false
       ..onStart = (DragStartDetails details) {
         dragCallbacks.add('onStart');
       }

--- a/packages/flutter/test/gestures/monodrag_test.dart
+++ b/packages/flutter/test/gestures/monodrag_test.dart
@@ -74,6 +74,75 @@ void main() {
     GestureBinding.instance.handleEvent(up91, HitTestEntry(MockHitTestTarget()));
   });
 
+  testGesture('DragGestureRecognizer should not dispatch drag callbacks when it wins the arena if onlyDispatchDragCallbacksWhenThresholdMet is true and the threshold has not been met', (GestureTester tester) {
+    VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
+    final List<String> dragCallbacks = <String>[];
+    verticalDrag
+      ..onlyDispatchDragCallbacksWhenThresholdMet = true
+      ..onStart = (DragStartDetails details) {
+        dragCallbacks.add('onStart');
+      }
+      ..onUpdate = (DragUpdateDetails details) {
+        dragCallbacks.add('onUpdate');
+      }
+      ..onEnd = (DragEndDetails details) {
+        dragCallbacks.add('onEnd');
+      };
+
+    const PointerDownEvent down1 = PointerDownEvent(
+      pointer: 6,
+      position: Offset(10.0, 10.0),
+    );
+
+    const PointerUpEvent up1 = PointerUpEvent(
+      pointer: 6,
+      position: Offset(10.0, 10.0),
+    );
+
+    verticalDrag.addPointer(down1);
+    tester.closeArena(down1.pointer);
+    tester.route(down1);
+    tester.route(up1);
+    expect(dragCallbacks.isEmpty, true);
+    verticalDrag.dispose();
+    dragCallbacks.clear();
+  });
+
+  testGesture('DragGestureRecognizer should dispatch drag callbacks when it wins the arena if onlyDispatchDragCallbacksWhenThresholdMet is false and the threshold has not been met', (GestureTester tester) {
+    VerticalDragGestureRecognizer verticalDrag = VerticalDragGestureRecognizer();
+    final List<String> dragCallbacks = <String>[];
+    verticalDrag
+      ..onlyDispatchDragCallbacksWhenThresholdMet = false
+      ..onStart = (DragStartDetails details) {
+        dragCallbacks.add('onStart');
+      }
+      ..onUpdate = (DragUpdateDetails details) {
+        dragCallbacks.add('onUpdate');
+      }
+      ..onEnd = (DragEndDetails details) {
+        dragCallbacks.add('onEnd');
+      };
+
+    const PointerDownEvent down1 = PointerDownEvent(
+      pointer: 6,
+      position: Offset(10.0, 10.0),
+    );
+
+    const PointerUpEvent up1 = PointerUpEvent(
+      pointer: 6,
+      position: Offset(10.0, 10.0),
+    );
+
+    verticalDrag.addPointer(down1);
+    tester.closeArena(down1.pointer);
+    tester.route(down1);
+    tester.route(up1);
+    expect(dragCallbacks.isEmpty, false);
+    expect(dragCallbacks, <String>['onStart', 'onEnd']);
+    verticalDrag.dispose();
+    dragCallbacks.clear();
+  });
+
   group('Recognizers on different button filters:', () {
     final List<String> recognized = <String>[];
     late HorizontalDragGestureRecognizer primaryRecognizer;

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -200,6 +200,7 @@ void main() {
   });
 
   testWidgets('Tapping on a BottomSheet should not trigger a rebuild when enableDrag is true', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/126833.
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     int buildCount = 0;
 

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -199,6 +199,42 @@ void main() {
     expect(find.text('BottomSheet'), findsNothing);
   });
 
+  testWidgets('Tapping on a BottomSheet should not trigger a rebuild when enableDrag is true', (WidgetTester tester) async {
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    int buildCount = 0;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        key: scaffoldKey,
+        body: const Center(child: Text('body')),
+      ),
+    ));
+
+    await tester.pump();
+    expect(buildCount, 0);
+    expect(find.text('BottomSheet'), findsNothing);
+
+    scaffoldKey.currentState!.showBottomSheet<void>((BuildContext context) {
+      buildCount++;
+      return const SizedBox(
+        height: 200.0,
+        child: Text('BottomSheet'),
+      );
+    },
+     enableDrag: true,
+    );
+
+    await tester.pumpAndSettle();
+    expect(buildCount, 1);
+    expect(find.text('BottomSheet'), findsOneWidget);
+
+    // Tap on bottom sheet should not trigger a rebuild.
+    await tester.tap(find.text('BottomSheet'));
+    await tester.pumpAndSettle();
+    expect(buildCount, 1);
+    expect(find.text('BottomSheet'), findsOneWidget);
+  });
+
   testWidgets('Modal BottomSheet builder should only be called once', (WidgetTester tester) async {
     late BuildContext savedContext;
 


### PR DESCRIPTION
This fixes an issue where the bottom sheet would rebuild when `enableDrag` is set to true on every tap. This is because `DragGestureRecognizer` would win the arena by default and dispatch the `drag` callbacks (in `acceptGesture`) even though it had not met the drag threshold. This changes keep the default behavior of `DragGestureRecognizer` the same, but adds a parameter `onlyAcceptDragOnThreshold` that a user can use to stop drag callbacks from being fired when the drag threshold has not been met.

Fixes #126833

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.