### PR TITLE
Remove button announcement for `MenuItemButton` and `SubmenuButton`

### DIFF
--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -42,6 +42,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
     required this.autofocus,
     required this.clipBehavior,
     this.statesController,
+    this.isSemanticButton = true,
     required this.child,
   });
 
@@ -99,6 +100,15 @@ abstract class ButtonStyleButton extends StatefulWidget {
 
   /// {@macro flutter.material.inkwell.statesController}
   final MaterialStatesController? statesController;
+
+  /// Determine whether this subtree represents a button.
+  ///
+  /// If this is null, the screen reader will not announce "button" when this button
+  /// is focused. This is useful for [MenuItemButton] and [SubmenuButton] when we
+  /// traverse the menu system.
+  ///
+  /// Defaults to true.
+  final bool? isSemanticButton;
 
   /// Typically the button's label.
   ///
@@ -425,7 +435,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
 
     return Semantics(
       container: true,
-      button: true,
+      button: widget.isSemanticButton,
       enabled: widget.enabled,
       child: _InputPadding(
         minSize: minSize,

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -103,7 +103,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
 
   /// Determine whether this subtree represents a button.
   ///
-  /// If this is null, the screen reader will not announce "button" when this button
+  /// If this is null, the screen reader will not announce "button" when this
   /// is focused. This is useful for [MenuItemButton] and [SubmenuButton] when we
   /// traverse the menu system.
   ///

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1062,7 +1062,7 @@ class _MenuItemButtonState extends State<MenuItemButton> {
       style: mergedStyle,
       statesController: widget.statesController,
       clipBehavior: widget.clipBehavior,
-      isSemanticButton: false,
+      isSemanticButton: null,
       child: _MenuItemLabel(
         leadingIcon: widget.leadingIcon,
         shortcut: widget.shortcut,
@@ -1904,7 +1904,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
           focusNode: _buttonFocusNode,
           onHover: _enabled ? (bool hovering) => handleHover(hovering, context) : null,
           onPressed: _enabled ? () => toggleShowMenu(context) : null,
-          isSemanticButton: false,
+          isSemanticButton: null,
           child: _MenuItemLabel(
             leadingIcon: widget.leadingIcon,
             trailingIcon: widget.trailingIcon,

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1062,6 +1062,7 @@ class _MenuItemButtonState extends State<MenuItemButton> {
       style: mergedStyle,
       statesController: widget.statesController,
       clipBehavior: widget.clipBehavior,
+      isSemanticButton: false,
       child: _MenuItemLabel(
         leadingIcon: widget.leadingIcon,
         shortcut: widget.shortcut,
@@ -1903,6 +1904,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
           focusNode: _buttonFocusNode,
           onHover: _enabled ? (bool hovering) => handleHover(hovering, context) : null,
           onPressed: _enabled ? () => toggleShowMenu(context) : null,
+          isSemanticButton: false,
           child: _MenuItemLabel(
             leadingIcon: widget.leadingIcon,
             trailingIcon: widget.trailingIcon,

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -87,6 +87,7 @@ class TextButton extends ButtonStyleButton {
     super.autofocus = false,
     super.clipBehavior = Clip.none,
     super.statesController,
+    super.isSemanticButton,
     required Widget super.child,
   });
 

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3093,7 +3093,7 @@ void main() {
             child: SubmenuButton(
               onHover: (bool value) {},
               style: SubmenuButton.styleFrom(fixedSize: const Size(88.0, 36.0)),
-              menuChildren: [],
+              menuChildren: const <Widget>[],
               child: const Text('ABC'),
             ),
           ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
+import '../widgets/semantics_tester.dart';
 
 void main() {
   late MenuController controller;
@@ -3038,6 +3039,86 @@ void main() {
       await tester.tap(find.byType(RadioMenuButton<int>).last);
       await tester.pumpAndSettle();
       expect(radioValue, 1);
+    });
+  });
+
+  group('Semantics', () {
+    testWidgets('MenuItemButton is not a semantic button', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: MenuItemButton(
+              style: MenuItemButton.styleFrom(fixedSize: const Size(88.0, 36.0)),
+              onPressed: () { },
+              child: const Text('ABC'),
+            ),
+          ),
+        ),
+      );
+
+      // The flags should not have SemanticsFlag.isButton
+      expect(semantics, hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics.rootChild(
+              actions: <SemanticsAction>[
+                SemanticsAction.tap,
+              ],
+              label: 'ABC',
+              rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
+              transform: Matrix4.translationValues(356.0, 276.0, 0.0),
+              flags: <SemanticsFlag>[
+                SemanticsFlag.hasEnabledState,
+                SemanticsFlag.isEnabled,
+                SemanticsFlag.isFocusable,
+              ],
+              textDirection: TextDirection.ltr,
+            ),
+          ],
+        ),
+        ignoreId: true,
+      ));
+
+      semantics.dispose();
+    });
+
+    testWidgets('SubMenuButton is not a semantic button', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SubmenuButton(
+              onHover: (bool value) {},
+              style: SubmenuButton.styleFrom(fixedSize: const Size(88.0, 36.0)),
+              menuChildren: [],
+              child: const Text('ABC'),
+            ),
+          ),
+        ),
+      );
+
+      // The flags should not have SemanticsFlag.isButton
+      expect(semantics, hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics.rootChild(
+              label: 'ABC',
+              rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
+              transform: Matrix4.translationValues(356.0, 276.0, 0.0),
+              flags: <SemanticsFlag>[
+                SemanticsFlag.hasEnabledState,
+              ],
+              textDirection: TextDirection.ltr,
+            ),
+          ],
+        ),
+        ignoreId: true,
+      ));
+
+      semantics.dispose();
     });
   });
 }


### PR DESCRIPTION
Related to #127617.
This is just to remove "button" announcement when we traverse menu items. 

Todo:
For `SubmenuButton`, we should be able to announce its status: collapsed or expanded after we announce its text label and shortcut. But currently `Semantics.hint` doesn't work. It might be because hint is not wired up. Will take a look on the engine side.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.