### PR TITLE
Remove a bad assert from tooltip implementation

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -425,6 +425,12 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   TapGestureRecognizer? _tapRecognizer;
 
   // The ids of mouse devices that are keeping the tooltip from being dismissed.
+  //
+  // Device ids are added to this set in _handleMouseEnter, and removed in
+  // _handleMouseExit. The set is cleared in _handleTapToDismiss, typically when
+  // a PointerDown event interacts with some other UI component.
+  //
+  // The _handleMouseEnter and _handleMouseExit calls should be balanced.
   final Set<int> _activeHoveringPointerDevices = <int>{};
   AnimationStatus _animationStatus = AnimationStatus.dismissed;
   void _handleStatusChanged(AnimationStatus status) {
@@ -469,18 +475,14 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       'timer must not be active when the tooltip is fading out',
     );
     switch (_controller.status) {
-      case AnimationStatus.dismissed:
-        if (withDelay.inMicroseconds > 0) {
-          _timer ??= Timer(withDelay, show);
-        } else {
-          show();
-        }
+      case AnimationStatus.dismissed when withDelay.inMicroseconds > 0:
+        _timer ??= Timer(withDelay, show);
       // If the tooltip is already fading in or fully visible, skip the
       // animation and show the tooltip immediately.
+      case AnimationStatus.dismissed:
       case AnimationStatus.forward:
       case AnimationStatus.reverse:
       case AnimationStatus.completed:
-        // Fade in if needed and schedule to hide.
         show();
     }
   }
@@ -646,7 +648,9 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _handleMouseExit(PointerExitEvent event) {
-    if (!mounted) {
+    // A PointerDown event that interacts with other UI components could dismiss
+    // the tooltip and clear the the _activeHoveringPointerDevices set.
+    if (!mounted || _activeHoveringPointerDevices.isEmpty) {
       return;
     }
     assert(_activeHoveringPointerDevices.isNotEmpty);
@@ -699,45 +703,36 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   // https://material.io/components/tooltips#specs
   double _getDefaultTooltipHeight() {
-    final ThemeData theme = Theme.of(context);
-    switch (theme.platform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return 24.0;
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-        return 32.0;
-    }
+    return switch (Theme.of(context).platform) {
+      TargetPlatform.macOS ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => 24.0,
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.iOS     => 32.0,
+    };
   }
 
   EdgeInsets _getDefaultPadding() {
-    final ThemeData theme = Theme.of(context);
-    switch (theme.platform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0);
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-        return const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0);
-    }
+    return switch (Theme.of(context).platform) {
+      TargetPlatform.macOS ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.iOS     => const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+    };
   }
 
   double _getDefaultFontSize() {
-    final ThemeData theme = Theme.of(context);
-    switch (theme.platform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return 12.0;
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-        return 14.0;
-    }
+    return switch (Theme.of(context).platform) {
+      TargetPlatform.macOS ||
+      TargetPlatform.linux ||
+      TargetPlatform.windows => 12.0,
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.iOS     => 14.0,
+    };
   }
 
   void _createNewEntry() {

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -429,8 +429,6 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   // Device ids are added to this set in _handleMouseEnter, and removed in
   // _handleMouseExit. The set is cleared in _handleTapToDismiss, typically when
   // a PointerDown event interacts with some other UI component.
-  //
-  // The _handleMouseEnter and _handleMouseExit calls should be balanced.
   final Set<int> _activeHoveringPointerDevices = <int>{};
   AnimationStatus _animationStatus = AnimationStatus.dismissed;
   void _handleStatusChanged(AnimationStatus status) {
@@ -648,12 +646,9 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _handleMouseExit(PointerExitEvent event) {
-    // A PointerDown event that interacts with other UI components could dismiss
-    // the tooltip and clear the the _activeHoveringPointerDevices set.
     if (!mounted || _activeHoveringPointerDevices.isEmpty) {
       return;
     }
-    assert(_activeHoveringPointerDevices.isNotEmpty);
     _activeHoveringPointerDevices.remove(event.device);
     if (_activeHoveringPointerDevices.isEmpty) {
       _scheduleDismissTooltip(withDelay: _hoverShowDuration);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/127575

The `_handleMouseEnter` and `_handleMouseExit` calls are balanced, but the tooltip could be dismissed by an external `PointerDown` event interacting with a different UI component so the ` assert(_activeHoveringPointerDevices.isNotEmpty);` does not really make sense.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
