### PR TITLE
Revert "Log all lines from ios-deploy (#127502)"

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -348,12 +348,6 @@ class IOSDeployDebugger {
           .transform<String>(utf8.decoder)
           .transform<String>(const LineSplitter())
           .listen((String line) {
-
-        // TODO(vashworth): Revert after https://github.com/flutter/flutter/issues/121231 is resolved.
-        if (line.isNotEmpty) {
-          _logger.printTrace(line);
-        }
-
         _monitorIOSDeployFailure(line, _logger);
 
         // (lldb)    platform select remote-'ios' --sysroot
@@ -371,6 +365,7 @@ class IOSDeployDebugger {
           }
           final String prompt = line.substring(0, promptEndIndex);
           lldbRun = RegExp(RegExp.escape(prompt) + r'\s*run');
+          _logger.printTrace(line);
           return;
         }
 
@@ -389,6 +384,7 @@ class IOSDeployDebugger {
         // success
         // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: The Dart VM service is listening on http://127.0.0.1:57782/
         if (lldbRun.hasMatch(line)) {
+          _logger.printTrace(line);
           _debuggerState = _IOSDeployDebuggerState.launching;
           // TODO(vashworth): Remove all debugger state comments when https://github.com/flutter/flutter/issues/126412 is resolved.
           _logger.printTrace('Debugger state set to launching.');
@@ -397,6 +393,7 @@ class IOSDeployDebugger {
         // Next line after "run" must be "success", or the attach failed.
         // Example: "error: process launch failed"
         if (_debuggerState == _IOSDeployDebuggerState.launching) {
+          _logger.printTrace(line);
           final bool attachSuccess = line == 'success';
           _debuggerState = attachSuccess ? _IOSDeployDebuggerState.attached : _IOSDeployDebuggerState.detached;
           _logger.printTrace('Debugger state set to ${attachSuccess ? 'attached' : 'detached'}.');
@@ -411,6 +408,7 @@ class IOSDeployDebugger {
         // process signal SIGSTOP
         if (line.contains(_signalStop)) {
           // The app is about to be stopped. Only show in verbose mode.
+          _logger.printTrace(line);
           return;
         }
 
@@ -423,6 +421,7 @@ class IOSDeployDebugger {
 
         if (line == _backTraceAll) {
           // The app is stopped and the backtrace for all threads will be printed.
+          _logger.printTrace(line);
           // Even though we're not "detached", just stopped, mark as detached so the backtrace
           // is only show in verbose.
           _debuggerState = _IOSDeployDebuggerState.detached;
@@ -439,6 +438,7 @@ class IOSDeployDebugger {
 
         if (line.contains('PROCESS_STOPPED') || _lldbProcessStopped.hasMatch(line)) {
           // The app has been stopped. Dump the backtrace, and detach.
+          _logger.printTrace(line);
           _iosDeployProcess?.stdin.writeln(_backTraceAll);
           if (_processResumeCompleter == null) {
             detach();
@@ -449,17 +449,20 @@ class IOSDeployDebugger {
         if (line.contains('PROCESS_EXITED') || _lldbProcessExit.hasMatch(line)) {
           // The app exited or crashed, so exit. Continue passing debugging
           // messages to the log reader until it exits to capture crash dumps.
+          _logger.printTrace(line);
           exit();
           return;
         }
         if (_lldbProcessDetached.hasMatch(line)) {
           // The debugger has detached from the app, and there will be no more debugging messages.
           // Kill the ios-deploy process.
+          _logger.printTrace(line);
           exit();
           return;
         }
 
         if (_lldbProcessResuming.hasMatch(line)) {
+          _logger.printTrace(line);
           // we marked this detached when we received [_backTraceAll]
           _debuggerState = _IOSDeployDebuggerState.attached;
           _logger.printTrace('Debugger state set to attached.');
@@ -467,6 +470,7 @@ class IOSDeployDebugger {
         }
 
         if (_debuggerState != _IOSDeployDebuggerState.attached) {
+          _logger.printTrace(line);
           return;
         }
         if (lastLineFromDebugger != null && lastLineFromDebugger!.isNotEmpty && line.isEmpty) {
@@ -484,7 +488,7 @@ class IOSDeployDebugger {
           .transform<String>(const LineSplitter())
           .listen((String line) {
         _monitorIOSDeployFailure(line, _logger);
-        _logger.printTrace('error: $line');
+        _logger.printTrace(line);
       });
       unawaited(_iosDeployProcess!.exitCode.then((int status) async {
         _logger.printTrace('ios-deploy exited with code $exitCode');

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -94,26 +94,6 @@ void main () {
         logger = BufferLogger.test();
       });
 
-      testWithoutContext('print all lines', () async {
-        final StreamController<List<int>> stdin = StreamController<List<int>>();
-        final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-          FakeCommand(
-            command: const <String>['ios-deploy'],
-            stdout: "(mylldb)    platform select remote-'ios' --sysroot\r\n(mylldb)     run\r\nsuccess\r\nrandom string\r\n",
-            stdin: IOSink(stdin.sink),
-          ),
-        ]);
-        final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
-          processManager: processManager,
-          logger: logger,
-        );
-        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
-        expect(logger.traceText, contains("(mylldb)    platform select remote-'ios' --sysroot"));
-        expect(logger.traceText, contains('(mylldb)     run'));
-        expect(logger.traceText, contains('success'));
-        expect(logger.traceText, contains('random string'));
-      });
-
       testWithoutContext('custom lldb prompt', () async {
         final StreamController<List<int>> stdin = StreamController<List<int>>();
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[


### PR DESCRIPTION
This reverts commit a19b3436eead2e64bb2b014f14afcd8fab8c9d32.

We added this logging to try and determine if the reason for Dart VM errors (https://github.com/flutter/flutter/issues/121231) was caused by some issue with the streams.
A recent test proves that is not the case:
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20platform_view_ios__start_up/11046/overview
The test shows the Dart VM url in the device log. However, the test log does NOT show a log for the Dart VM url but does show the stack trace, which all come from the main stream, which means it's not an issue with the secondary streams not receiving the log.

So reverting the debugging we added.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
