### PR TITLE
[Linux] Use up_client_get_devices2 when possible

### DIFF
--- a/examples/platform_channel/linux/my_application.cc
+++ b/examples/platform_channel/linux/my_application.cc
@@ -217,12 +217,13 @@ static void my_application_activate(GApplication* application) {
                            G_CALLBACK(up_device_added_cb), self);
   g_signal_connect_swapped(self->up_client, "device-removed",
                            G_CALLBACK(up_device_removed_cb), self);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-// TODO(cbracken): https://github.com/flutter/flutter/issues/127506
-// Migrate to up_client_get_devices2 once available.
+#if UP_CHECK_VERSION(0, 99, 8)
+  // up_client_get_devices was deprecated and replaced with
+  // up_client_get_devices2 in libupower 0.99.8.
+  g_autoptr(GPtrArray) devices = up_client_get_devices2(self->up_client);
+#else
   g_autoptr(GPtrArray) devices = up_client_get_devices(self->up_client);
-#pragma clang diagnostic pop
+#endif
   for (guint i = 0; i < devices->len; i++) {
     g_autoptr(UpDevice) device =
         static_cast<UpDevice*>(g_ptr_array_index(devices, i));


### PR DESCRIPTION
The Linux platform channels sample makes a call to the libupower function `up_client_get_devices`, which was deprecated in libupower 0.99.8 in favour of `up_client_get_devices2`.

In order to build both for users on older versions of libupower, such as 0.99.7, which ships with Ubuntu 18.04 (Bionic), as well as users on newer versions where `up_client_get_devices` is deprecated, this adds a preprocessor check and selects the function available on the host system on which the build takes place.

The Flutter devicelab prod bots have been migrated to Ubuntu 20.04 LTS (Focal) which includes 0.99.11, but the trybots are still in the process of being migrated. This allows the build to work on both, and makes life easier for users running on a variety of Linux distributions.

No tests are added or modified since `up_client_get_devices` and `up_client_get_devices2` have the same semantics.

See: https://upower.freedesktop.org/docs/UpClient.html#up-client-get-devices
See: https://gitlab.freedesktop.org/upower/upower/-/blob/master/libupower-glib/up-version.h.in

Note: the `UP_CHECK_VERSION` macro has been around since 2010 (13 years ago), when DKP was forked into libupower. https://gitlab.freedesktop.org/upower/upower/-/commit/27fada20be7feba6783abc5b6cad91ee274ad3df

Issue: https://github.com/flutter/flutter/issues/127611

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
