### PR TITLE
Remove more `test_api/src` imports

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -161,7 +161,7 @@ import 'dart:developer' as developer;
 ''');
   }
   buffer.write('''
-import 'package:test_api/src/remote_listener.dart';
+import 'package:test_api/backend.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:stack_trace/stack_trace.dart';
 

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -218,7 +218,7 @@ String generateTestEntrypoint({
   ${testConfigPath != null ? "import '${Uri.file(testConfigPath)}' as test_config;" : ""}
   import 'package:stream_channel/stream_channel.dart';
   import 'package:flutter_test/flutter_test.dart';
-  import 'package:test_api//backend.dart';
+  import 'package:test_api/backend.dart';
 
   Future<void> main() async {
     ui.debugEmulateFlutterTesterEnvironment = true;

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -218,9 +218,7 @@ String generateTestEntrypoint({
   ${testConfigPath != null ? "import '${Uri.file(testConfigPath)}' as test_config;" : ""}
   import 'package:stream_channel/stream_channel.dart';
   import 'package:flutter_test/flutter_test.dart';
-  import 'package:test_api/src/backend/stack_trace_formatter.dart'; // ignore: implementation_imports
-  import 'package:test_api/src/remote_listener.dart'; // ignore: implementation_imports
-  import 'package:test_api/src/backend/suite_channel_manager.dart'; // ignore: implementation_imports
+  import 'package:test_api//backend.dart';
 
   Future<void> main() async {
     ui.debugEmulateFlutterTesterEnvironment = true;


### PR DESCRIPTION
Replace imports of `src/remote_listener.dart` with `backend.dart` which exports `RemoteListener`.

Remove the unused imports of `src/backend/stack_trace_formatter.dart` (no uses of `StackTraceFormatter`) and
`src/backend/suite_channel_manager.dart` (no uses of `SuiteChannelManager`).