### PR TITLE
fix: `ExpansionTileTheme.shape` assignment in `ExpansionTile`

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -683,7 +683,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
           bottom: BorderSide(color: Colors.transparent),
         )
       ..end = widget.shape
-        ?? expansionTileTheme.collapsedShape
+        ?? expansionTileTheme.shape
         ?? Border(
           top: BorderSide(color: theme.dividerColor),
           bottom: BorderSide(color: theme.dividerColor),

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -638,55 +638,6 @@ void main() {
     expect(expandedContainerDecoration.shape, shape);
   });
 
-  testWidgets('ExpansionTile shape from ExpansionTileTheme', (WidgetTester tester) async {
-    const Key expansionTileKey = PageStorageKey<String>('expansionTile');
-
-    const Border collapsedShape = Border(top: BorderSide(color: Colors.blue), bottom: BorderSide(color: Colors.green));
-    final Border shape = Border.all(color: Colors.red);
-
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: SingleChildScrollView(
-          child: ExpansionTileTheme(
-            data: ExpansionTileThemeData(
-              collapsedShape: collapsedShape,
-              shape: shape,
-            ),
-            child: const Column(
-              children: <Widget>[
-                ExpansionTile(
-                  key: expansionTileKey,
-                  title: Text('ExpansionTile'),
-                  children: <Widget>[
-                    ListTile(
-                      title: Text('0'),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    ));
-
-    Container getContainer(Key key) => tester.firstWidget(find.descendant(
-          of: find.byKey(key),
-          matching: find.byType(Container),
-        ));
-
-    // expansionTile should be Collapsed now.
-    ShapeDecoration expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
-    expect(expandedContainerDecoration.shape, collapsedShape);
-
-    await tester.tap(find.text('ExpansionTile'));
-    await tester.pumpAndSettle();
-
-    // expansionTile should be Expanded now.
-    expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
-    expect(expandedContainerDecoration.shape, shape);
-  });
-
   testWidgets('ExpansionTile platform controlAffinity test', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Material(

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -638,6 +638,55 @@ void main() {
     expect(expandedContainerDecoration.shape, shape);
   });
 
+  testWidgets('ExpansionTile shape from ExpansionTileTheme', (WidgetTester tester) async {
+    const Key expansionTileKey = PageStorageKey<String>('expansionTile');
+
+    const Border collapsedShape = Border(top: BorderSide(color: Colors.blue), bottom: BorderSide(color: Colors.green));
+    final Border shape = Border.all(color: Colors.red);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: ExpansionTileTheme(
+            data: ExpansionTileThemeData(
+              collapsedShape: collapsedShape,
+              shape: shape,
+            ),
+            child: const Column(
+              children: <Widget>[
+                ExpansionTile(
+                  key: expansionTileKey,
+                  title: Text('ExpansionTile'),
+                  children: <Widget>[
+                    ListTile(
+                      title: Text('0'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    Container getContainer(Key key) => tester.firstWidget(find.descendant(
+          of: find.byKey(key),
+          matching: find.byType(Container),
+        ));
+
+    // expansionTile should be Collapsed now.
+    ShapeDecoration expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
+    expect(expandedContainerDecoration.shape, collapsedShape);
+
+    await tester.tap(find.text('ExpansionTile'));
+    await tester.pumpAndSettle();
+
+    // expansionTile should be Expanded now.
+    expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
+    expect(expandedContainerDecoration.shape, shape);
+  });
+
   testWidgets('ExpansionTile platform controlAffinity test', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Material(

--- a/packages/flutter/test/material/expansion_tile_theme_test.dart
+++ b/packages/flutter/test/material/expansion_tile_theme_test.dart
@@ -290,7 +290,7 @@ void main() {
     // Check the expanded text color when textColor is applied.
     expect(getTextColor(), textColor);
     // Check the expanded ShapeBorder when shape is applied.
-    expect(shapeDecoration.shape, collapsedShape);
+    expect(shapeDecoration.shape, shape);
 
     // Check the child position when expandedAlignment is applied.
     final Rect childRect = tester.getRect(find.text('Tile 1'));


### PR DESCRIPTION
The ExpansionTile was not following `shape` from ExpansionTileTheme as it was assigning wrong parameter to the tween.

fixes #129785

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
