### PR TITLE
playing around and trying to migrate FlutterPluginKts to not use Groo…

### DIFF
--- a/packages/flutter_tools/gradle/build.gradle.kts
+++ b/packages/flutter_tools/gradle/build.gradle.kts
@@ -4,6 +4,7 @@
 
 plugins {
     `groovy-gradle-plugin`
+    kotlin("jvm") version "1.8.20"
 }
 
 repositories {
@@ -31,4 +32,5 @@ dependencies {
     //  * AGP version constants in packages/flutter_tools/lib/src/android/gradle_utils.dart
     //  * AGP version in buildscript block in packages/flutter_tools/gradle/src/main/flutter.groovy
     compileOnly("com.android.tools.build:gradle:7.3.0")
+    implementation("org.jetbrains.kotlin:kotlin-script-runtime:1.8.20")
 }

--- a/packages/flutter_tools/gradle/src/main/kotlin/flutter.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/flutter.gradle.kts
@@ -2,32 +2,35 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-apply<FlutterPluginKts>()
+import org.gradle.api.Project
+import org.gradle.api.Plugin
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.tasks.Copy
+
 
 class FlutterPluginKts : Plugin<Project> {
     override fun apply(project: Project) {
-        // Use withGroovyBuilder and getProperty() to access Groovy metaprogramming.
-        project.withGroovyBuilder {
-            getProperty("android").withGroovyBuilder {
-                getProperty("defaultConfig").withGroovyBuilder {
-                    if (project.hasProperty("multidex-enabled") &&
-                        project.property("multidex-enabled").toString().toBoolean()) {
-                        setProperty("multiDexEnabled", true)
-                        getProperty("manifestPlaceholders").withGroovyBuilder {
-                            setProperty("applicationName", "io.flutter.app.FlutterMultiDexApplication")
-                        }
-                    } else {
-                        var baseApplicationName: String = "android.app.Application"
-                        if (project.hasProperty("base-application-name")) {
-                            baseApplicationName = project.property("base-application-name").toString()
-                        }
-                        // Setting to android.app.Application is the same as omitting the attribute.
-                        getProperty("manifestPlaceholders").withGroovyBuilder {
-                            setProperty("applicationName", baseApplicationName)
-                        }
-                    }
-                }
-            }
-        }
+        // From https://developer.android.com/build/extend-agp
+//        val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+//        androidComponents.finalizeDsl { extension ->
+//            extension.defaultConfig {
+//                if (project.hasProperty("multidex-enabled") &&
+//                        project.property("multidex-enabled").toString().toBoolean()) {
+//                    multiDexEnabled = true
+//                    manifestPlaceholders["applicationName"] = "io.flutter.app.FlutterMultiDexApplication"
+//                } else {
+//                    var baseApplicationName: String = "android.app.Application"
+//                    if (project.hasProperty("base-application-name")) {
+//                        baseApplicationName = project.property("base-application-name").toString()
+//                    }
+//                    // Setting to android.app.Application is the same as omitting the attribute.
+//                    manifestPlaceholders["applicationName"] = baseApplicationName
+//                }
+//
+//                it.multiDexEnabled = true
+//            }
+//        }
     }
 }
+
+// apply<FlutterPluginKts>()


### PR DESCRIPTION
Some preliminary work toward #121541.

WIP.

<details><summary>Logs</summary>
<p>

```
$ pwd                                                                                                                                            exit 1
/Users/bartek/fvm/versions/master/examples/hello_world/android
bartek at Barteks-MacBook in android on flutter_plugin_kotlin
$ ./gradlew :app:assembleDebug

> Configure project :app
e: /Users/bartek/fvm/versions/master/packages/flutter_tools/gradle/src/main/kotlin/flutter.gradle.kts:7:12: Unresolved reference: android

FAILURE: Build failed with an exception.

* Where:
Script '/Users/bartek/fvm/versions/master/packages/flutter_tools/gradle/src/main/kotlin/flutter.gradle.kts' line: 7

* What went wrong:
Script compilation error:

  Line 7: import com.android.build.api.variant.AndroidComponentsExtension
                     ^ Unresolved reference: android

1 error

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 609ms
6 actionable tasks: 6 up-to-date
```


</p>
</details>

Notes:
- `import`s in non-build `.kts` files is somewhat messed up?
- Because of the above, the plugin will likely have to be migrated to Kotlin all at once


