### PR TITLE
Fixes in Cupertino pl localizations

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/cupertino_pl.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_pl.arb
@@ -28,9 +28,9 @@
   "cutButtonLabel": "Wytnij",
   "copyButtonLabel": "Kopiuj",
   "pasteButtonLabel": "Wklej",
-  "selectAllButtonLabel": "Wybierz wszystkie",
+  "selectAllButtonLabel": "Zaznacz wszystko",
   "tabSemanticsLabel": "Karta $tabIndex z $tabCount",
   "modalBarrierDismissLabel": "Zamknij",
   "searchTextFieldPlaceholderLabel": "Szukaj",
-  "noSpellCheckReplacementsLabel": "No Replacements Found"
+  "noSpellCheckReplacementsLabel": "Nie znaleziono zastąpień"
 }


### PR DESCRIPTION
This PR:
- fixes an incorrect Polish translation for `selectAllButtonLabel` in Cupertino strings 
- translates `noSpellCheckReplacementsLabel`