### PR TITLE
Workaround for Dart VM timeout

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -471,6 +471,7 @@ List<String> _flutterCommandArgs(String command, List<String> options) {
     if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath],
     if (localWebSdk != null) ...<String>['--local-web-sdk', localWebSdk],
     ...options,
+    '--ci',
   ];
 }
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -471,7 +471,10 @@ List<String> _flutterCommandArgs(String command, List<String> options) {
     if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath],
     if (localWebSdk != null) ...<String>['--local-web-sdk', localWebSdk],
     ...options,
-    '--ci',
+    // Use CI flag when running devicelab tests, except for `packages` commands.
+    // `packages` commands effectively runs the `pub` tool, which does not have
+    // the same allowed args.
+    if (!command.startsWith('packages')) '--ci',
   ];
 }
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -471,10 +471,10 @@ List<String> _flutterCommandArgs(String command, List<String> options) {
     if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath],
     if (localWebSdk != null) ...<String>['--local-web-sdk', localWebSdk],
     ...options,
-    // Use CI flag when running devicelab tests, except for `packages` commands.
-    // `packages` commands effectively runs the `pub` tool, which does not have
+    // Use CI flag when running devicelab tests, except for `packages`/`pub` commands.
+    // `packages`/`pub` commands effectively runs the `pub` tool, which does not have
     // the same allowed args.
-    if (!command.startsWith('packages')) '--ci',
+    if (!command.startsWith('packages') && !command.startsWith('pub')) '--ci',
   ];
 }
 

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -33,6 +33,7 @@ import '../resident_runner.dart';
 import '../run_cold.dart';
 import '../run_hot.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 import '../vmservice.dart';
 
 /// A Flutter-command that attaches to applications that have been launched
@@ -528,6 +529,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
       ddsPort: ddsPort,
       devToolsServerAddress: devToolsServerAddress,
       serveObservatory: serveObservatory,
+      usingCISystem: usingCISystem,
     );
 
     return buildInfo.isDebug
@@ -535,7 +537,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
           flutterDevices,
           target: targetFile,
           debuggingOptions: debuggingOptions,
-          packagesFilePath: globalResults!['packages'] as String?,
+          packagesFilePath: globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
           projectRootPath: stringArg('project-root'),
           dillOutputPath: stringArg('output-dill'),
           ipv6: usesIpv6,

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -6,6 +6,7 @@ import '../base/common.dart';
 import '../cache.dart';
 import '../globals.dart' as globals;
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 import '../version.dart';
 
 class ChannelCommand extends FlutterCommand {
@@ -40,7 +41,7 @@ class ChannelCommand extends FlutterCommand {
       case 0:
         await _listChannels(
           showAll: boolArg('all'),
-          verbose: globalResults?['verbose'] == true,
+          verbose: globalResults?[FlutterGlobalOptions.kVerboseFlag] == true,
         );
         return FlutterCommandResult.success();
       case 1:

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -25,6 +25,7 @@ import '../custom_devices/custom_devices_config.dart';
 import '../device_port_forwarder.dart';
 import '../features.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 
 /// just the function signature of the [print] function.
 /// The Object arg may be null.
@@ -811,7 +812,7 @@ Delete a device from the config file.
   Future<FlutterCommandResult> runCommand() async {
     checkFeatureEnabled();
 
-    final String? id = globalResults!['device-id'] as String?;
+    final String? id = globalResults![FlutterGlobalOptions.kDeviceIdOption] as String?;
     if (id == null || !customDevicesConfig.contains(id)) {
       throwToolExit('Couldn\'t find device with id "$id" in config at "${customDevicesConfig.configPath}"');
     }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -26,6 +26,7 @@ import '../resident_runner.dart';
 import '../run_cold.dart';
 import '../run_hot.dart';
 import '../runner/flutter_command.dart';
+import '../runner/flutter_command_runner.dart';
 import '../tracing.dart';
 import '../vmservice.dart';
 import '../web/web_runner.dart';
@@ -247,6 +248,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         uninstallFirst: uninstallFirst,
         enableDartProfiling: enableDartProfiling,
         enableEmbedderApi: enableEmbedderApi,
+        usingCISystem: usingCISystem,
       );
     } else {
       return DebuggingOptions.enabled(
@@ -298,6 +300,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         serveObservatory: boolArg('serve-observatory'),
         enableDartProfiling: enableDartProfiling,
         enableEmbedderApi: enableEmbedderApi,
+        usingCISystem: usingCISystem,
       );
     }
   }
@@ -643,7 +646,7 @@ class RunCommand extends RunCommandBase {
               : globals.fs.file(applicationBinaryPath),
           trackWidgetCreation: trackWidgetCreation,
           projectRootPath: stringArg('project-root'),
-          packagesFilePath: globalResults!['packages'] as String?,
+          packagesFilePath: globalResults![FlutterGlobalOptions.kPackagesOption] as String?,
           dillOutputPath: stringArg('output-dill'),
           ipv6: ipv6 ?? false,
           multidexEnabled: boolArg('multidex'),

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -422,6 +422,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       disablePortPublication: true,
       enableDds: enableDds,
       nullAssertions: boolArg(FlutterOptions.kNullAssertions),
+      usingCISystem: usingCISystem,
     );
 
     Device? integrationTestDevice;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -971,6 +971,7 @@ class DebuggingOptions {
     this.serveObservatory = false,
     this.enableDartProfiling = true,
     this.enableEmbedderApi = false,
+    this.usingCISystem = false,
    }) : debuggingEnabled = true;
 
   DebuggingOptions.disabled(this.buildInfo, {
@@ -993,6 +994,7 @@ class DebuggingOptions {
       this.uninstallFirst = false,
       this.enableDartProfiling = true,
       this.enableEmbedderApi = false,
+      this.usingCISystem = false,
     }) : debuggingEnabled = false,
       useTestFonts = false,
       startPaused = false,
@@ -1069,6 +1071,7 @@ class DebuggingOptions {
     required this.serveObservatory,
     required this.enableDartProfiling,
     required this.enableEmbedderApi,
+    required this.usingCISystem,
   });
 
   final bool debuggingEnabled;
@@ -1109,6 +1112,7 @@ class DebuggingOptions {
   final bool serveObservatory;
   final bool enableDartProfiling;
   final bool enableEmbedderApi;
+  final bool usingCISystem;
 
   /// Whether the tool should try to uninstall a previously installed version of the app.
   ///
@@ -1243,6 +1247,7 @@ class DebuggingOptions {
     'serveObservatory': serveObservatory,
     'enableDartProfiling': enableDartProfiling,
     'enableEmbedderApi': enableEmbedderApi,
+    'usingCISystem': usingCISystem,
   };
 
   static DebuggingOptions fromJson(Map<String, Object?> json, BuildInfo buildInfo) =>
@@ -1294,6 +1299,7 @@ class DebuggingOptions {
       serveObservatory: (json['serveObservatory'] as bool?) ?? false,
       enableDartProfiling: (json['enableDartProfiling'] as bool?) ?? true,
       enableEmbedderApi: (json['enableEmbedderApi'] as bool?) ?? false,
+      usingCISystem: (json['usingCISystem'] as bool?) ?? false,
     );
 }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -915,10 +915,7 @@ class IOSDeviceLogReader extends DeviceLogReader {
   /// since sometimes `ios-deploy` does not return the Dart VM url:
   /// https://github.com/flutter/flutter/issues/121231
   bool get useBothLogDeviceReaders {
-    if (_usingCISystem && _majorSdkVersion >= 16) {
-      return true;
-    }
-    return false;
+    return _usingCISystem && _majorSdkVersion >= 16;
   }
 
   void _listenToSysLog() {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -36,6 +36,8 @@ import 'devfs.dart';
 import 'device.dart';
 import 'features.dart';
 import 'globals.dart' as globals;
+import 'ios/application_package.dart';
+import 'ios/devices.dart';
 import 'project.dart';
 import 'resident_devtools_handler.dart';
 import 'run_cold.dart';
@@ -391,11 +393,19 @@ class FlutterDevice {
     return devFS!.create();
   }
 
-  Future<void> startEchoingDeviceLog() async {
+  Future<void> startEchoingDeviceLog(DebuggingOptions debuggingOptions) async {
     if (_loggingSubscription != null) {
       return;
     }
-    final Stream<String> logStream = (await device!.getLogReader(app: package)).logLines;
+    final Stream<String> logStream;
+    if (device is IOSDevice) {
+      logStream = (device! as IOSDevice).getLogReader(
+        app: package as IOSApp?,
+        usingCISystem: debuggingOptions.usingCISystem,
+      ).logLines;
+    } else {
+      logStream = (await device!.getLogReader(app: package)).logLines;
+    }
     _loggingSubscription = logStream.listen((String line) {
       if (!line.contains(globals.kVMServiceMessageRegExp)) {
         globals.printStatus(line, wrap: false);
@@ -451,7 +461,7 @@ class FlutterDevice {
       'multidex': hotRunner.multidexEnabled,
     };
 
-    await startEchoingDeviceLog();
+    await startEchoingDeviceLog(hotRunner.debuggingOptions);
 
     // Start the application.
     final Future<LaunchResult> futureResult = device!.startApp(
@@ -519,7 +529,7 @@ class FlutterDevice {
     platformArgs['trace-startup'] = coldRunner.traceStartup;
     platformArgs['multidex'] = coldRunner.multidexEnabled;
 
-    await startEchoingDeviceLog();
+    await startEchoingDeviceLog(coldRunner.debuggingOptions);
 
     final LaunchResult result = await device!.startApp(
       applicationPackage,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -304,7 +304,10 @@ abstract class FlutterCommand extends Command<void> {
   /// Path to the Dart's package config file.
   ///
   /// This can be overridden by some of its subclasses.
-  String? get packagesPath => globalResults?['packages'] as String?;
+  String? get packagesPath => stringArg(FlutterGlobalOptions.kPackagesOption, global: true);
+
+  /// Whether flutter is being run from our CI.
+  bool get usingCISystem => boolArg(FlutterGlobalOptions.kContinuousIntegrationFlag, global: true);
 
   /// The value of the `--filesystem-scheme` argument.
   ///
@@ -1634,16 +1637,29 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
   ///
   /// If no flag named [name] was added to the [ArgParser], an [ArgumentError]
   /// will be thrown.
-  bool boolArg(String name) => argResults![name] as bool;
+  bool boolArg(String name, {bool global = false}) {
+    if (global) {
+      return globalResults![name] as bool;
+    }
+    return argResults![name] as bool;
+  }
 
   /// Gets the parsed command-line option named [name] as a `String`.
   ///
   /// If no option named [name] was added to the [ArgParser], an [ArgumentError]
   /// will be thrown.
-  String? stringArg(String name) => argResults![name] as String?;
+  String? stringArg(String name, {bool global = false}) {
+    if (global) {
+      return globalResults![name] as String?;
+    }
+    return argResults![name] as String?;
+  }
 
   /// Gets the parsed command-line option named [name] as `List<String>`.
-  List<String> stringsArg(String name) {
+  List<String> stringsArg(String name, {bool global = false}) {
+    if (global) {
+      return globalResults![name]! as List<String>? ?? <String>[];
+    }
     return argResults![name]! as List<String>? ?? <String>[];
   }
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1658,9 +1658,9 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
   /// Gets the parsed command-line option named [name] as `List<String>`.
   List<String> stringsArg(String name, {bool global = false}) {
     if (global) {
-      return globalResults![name]! as List<String>? ?? <String>[];
+      return globalResults![name] as List<String>;
     }
-    return argResults![name]! as List<String>? ?? <String>[];
+    return argResults![name] as List<String>;
   }
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -20,6 +20,30 @@ import '../globals.dart' as globals;
 import '../tester/flutter_tester.dart';
 import '../web/web_device.dart';
 
+/// Common flutter command line options.
+abstract final class FlutterGlobalOptions {
+  static const String kColorFlag = 'color';
+  static const String kContinuousIntegrationFlag = 'ci';
+  static const String kDeviceIdOption = 'device-id';
+  static const String kDisableTelemetryFlag = 'disable-telemetry';
+  static const String kEnableTelemetryFlag = 'enable-telemetry';
+  static const String kLocalEngineOption = 'local-engine';
+  static const String kLocalEngineSrcPathOption = 'local-engine-src-path';
+  static const String kLocalWebSDKOption = 'local-web-sdk';
+  static const String kMachineFlag = 'machine';
+  static const String kPackagesOption = 'packages';
+  static const String kPrefixedErrorsFlag = 'prefixed-errors';
+  static const String kQuietFlag = 'quiet';
+  static const String kShowTestDeviceFlag = 'show-test-device';
+  static const String kShowWebServerDeviceFlag = 'show-web-server-device';
+  static const String kSuppressAnalyticsFlag = 'suppress-analytics';
+  static const String kVerboseFlag = 'verbose';
+  static const String kVersionCheckFlag = 'version-check';
+  static const String kVersionFlag = 'version';
+  static const String kWrapColumnOption = 'wrap-column';
+  static const String kWrapFlag = 'wrap';
+}
+
 class FlutterCommandRunner extends CommandRunner<void> {
   FlutterCommandRunner({ bool verboseHelp = false }) : super(
     'flutter',
@@ -33,80 +57,80 @@ class FlutterCommandRunner extends CommandRunner<void> {
       '  flutter run [options]\n'
       '    Run your Flutter application on an attached device or in an emulator.',
   ) {
-    argParser.addFlag('verbose',
+    argParser.addFlag(FlutterGlobalOptions.kVerboseFlag,
         abbr: 'v',
         negatable: false,
         help: 'Noisy logging, including all shell commands executed.\n'
               'If used with "--help", shows hidden options. '
               'If used with "flutter doctor", shows additional diagnostic information. '
               '(Use "-vv" to force verbose logging in those cases.)');
-    argParser.addFlag('prefixed-errors',
+    argParser.addFlag(FlutterGlobalOptions.kPrefixedErrorsFlag,
         negatable: false,
         help: 'Causes lines sent to stderr to be prefixed with "ERROR:".',
         hide: !verboseHelp);
-    argParser.addFlag('quiet',
+    argParser.addFlag(FlutterGlobalOptions.kQuietFlag,
         negatable: false,
         hide: !verboseHelp,
         help: 'Reduce the amount of output from some commands.');
-    argParser.addFlag('wrap',
+    argParser.addFlag(FlutterGlobalOptions.kWrapFlag,
         hide: !verboseHelp,
         help: 'Toggles output word wrapping, regardless of whether or not the output is a terminal.',
         defaultsTo: true);
-    argParser.addOption('wrap-column',
+    argParser.addOption(FlutterGlobalOptions.kWrapColumnOption,
         hide: !verboseHelp,
         help: 'Sets the output wrap column. If not set, uses the width of the terminal. No '
               'wrapping occurs if not writing to a terminal. Use "--no-wrap" to turn off wrapping '
               'when connected to a terminal.');
-    argParser.addOption('device-id',
+    argParser.addOption(FlutterGlobalOptions.kDeviceIdOption,
         abbr: 'd',
         help: 'Target device id or name (prefixes allowed).');
-    argParser.addFlag('version',
+    argParser.addFlag(FlutterGlobalOptions.kVersionFlag,
         negatable: false,
         help: 'Reports the version of this tool.');
-    argParser.addFlag('machine',
+    argParser.addFlag(FlutterGlobalOptions.kMachineFlag,
         negatable: false,
         hide: !verboseHelp,
         help: 'When used with the "--version" flag, outputs the information using JSON.');
-    argParser.addFlag('color',
+    argParser.addFlag(FlutterGlobalOptions.kColorFlag,
         hide: !verboseHelp,
         help: 'Whether to use terminal colors (requires support for ANSI escape sequences).',
         defaultsTo: true);
-    argParser.addFlag('version-check',
+    argParser.addFlag(FlutterGlobalOptions.kVersionCheckFlag,
         defaultsTo: true,
         hide: !verboseHelp,
         help: 'Allow Flutter to check for updates when this command runs.');
-    argParser.addFlag('suppress-analytics',
+    argParser.addFlag(FlutterGlobalOptions.kSuppressAnalyticsFlag,
         negatable: false,
         help: 'Suppress analytics reporting for the current CLI invocation.');
-    argParser.addFlag('disable-telemetry',
+    argParser.addFlag(FlutterGlobalOptions.kDisableTelemetryFlag,
         negatable: false,
         help: 'Disable telemetry reporting each time a flutter or dart '
               'command runs, until it is re-enabled.');
-    argParser.addFlag('enable-telemetry',
+    argParser.addFlag(FlutterGlobalOptions.kEnableTelemetryFlag,
         negatable: false,
         help: 'Enable telemetry reporting each time a flutter or dart '
               'command runs.');
-    argParser.addOption('packages',
+    argParser.addOption(FlutterGlobalOptions.kPackagesOption,
         hide: !verboseHelp,
         help: 'Path to your "package_config.json" file.');
     if (verboseHelp) {
       argParser.addSeparator('Local build selection options (not normally required):');
     }
 
-    argParser.addOption('local-engine-src-path',
+    argParser.addOption(FlutterGlobalOptions.kLocalEngineSrcPathOption,
         hide: !verboseHelp,
         help: 'Path to your engine src directory, if you are building Flutter locally.\n'
               'Defaults to \$$kFlutterEngineEnvironmentVariableName if set, otherwise defaults to '
               'the path given in your pubspec.yaml dependency_overrides for $kFlutterEnginePackageName, '
               'if any.');
 
-    argParser.addOption('local-engine',
+    argParser.addOption(FlutterGlobalOptions.kLocalEngineOption,
         hide: !verboseHelp,
         help: 'Name of a build output within the engine out directory, if you are building Flutter locally.\n'
               'Use this to select a specific version of the engine if you have built multiple engine targets.\n'
               'This path is relative to "--local-engine-src-path" (see above).');
 
-    argParser.addOption('local-web-sdk',
+    argParser.addOption(FlutterGlobalOptions.kLocalWebSDKOption,
         hide: !verboseHelp,
         help: 'Name of a build output within the engine out directory, if you are building Flutter locally.\n'
               'Use this to select a specific version of the web sdk if you have built multiple engine targets.\n'
@@ -115,15 +139,21 @@ class FlutterCommandRunner extends CommandRunner<void> {
     if (verboseHelp) {
       argParser.addSeparator('Options for testing the "flutter" tool itself:');
     }
-    argParser.addFlag('show-test-device',
+    argParser.addFlag(FlutterGlobalOptions.kShowTestDeviceFlag,
         negatable: false,
         hide: !verboseHelp,
         help: 'List the special "flutter-tester" device in device listings. '
               'This headless device is used to test Flutter tooling.');
-    argParser.addFlag('show-web-server-device',
+    argParser.addFlag(FlutterGlobalOptions.kShowWebServerDeviceFlag,
         negatable: false,
         hide: !verboseHelp,
         help: 'List the special "web-server" device in device listings.',
+    );
+    argParser.addFlag(
+      FlutterGlobalOptions.kContinuousIntegrationFlag,
+      negatable: false,
+      help: 'Enable a set of CI-specific test debug settings.',
+      hide: !verboseHelp,
     );
   }
 
@@ -198,8 +228,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
     // If the flag for enabling or disabling telemetry is passed in,
     // we will return out
-    if (topLevelResults.wasParsed('disable-telemetry') ||
-        topLevelResults.wasParsed('enable-telemetry')) {
+    if (topLevelResults.wasParsed(FlutterGlobalOptions.kDisableTelemetryFlag) ||
+        topLevelResults.wasParsed(FlutterGlobalOptions.kEnableTelemetryFlag)) {
       return;
     }
 
@@ -207,43 +237,43 @@ class FlutterCommandRunner extends CommandRunner<void> {
     // wrapping will occur at this width explicitly, and won't adapt if the
     // terminal size changes during a run.
     int? wrapColumn;
-    if (topLevelResults.wasParsed('wrap-column')) {
+    if (topLevelResults.wasParsed(FlutterGlobalOptions.kWrapColumnOption)) {
       try {
-        wrapColumn = int.parse(topLevelResults['wrap-column'] as String);
+        wrapColumn = int.parse(topLevelResults[FlutterGlobalOptions.kWrapColumnOption] as String);
         if (wrapColumn < 0) {
-          throwToolExit(userMessages.runnerWrapColumnInvalid(topLevelResults['wrap-column']));
+          throwToolExit(userMessages.runnerWrapColumnInvalid(topLevelResults[FlutterGlobalOptions.kWrapColumnOption]));
         }
       } on FormatException {
-        throwToolExit(userMessages.runnerWrapColumnParseError(topLevelResults['wrap-column']));
+        throwToolExit(userMessages.runnerWrapColumnParseError(topLevelResults[FlutterGlobalOptions.kWrapColumnOption]));
       }
     }
 
     // If we're not writing to a terminal with a defined width, then don't wrap
     // anything, unless the user explicitly said to.
-    final bool useWrapping = topLevelResults.wasParsed('wrap')
-        ? topLevelResults['wrap'] as bool
-        : globals.stdio.terminalColumns != null && topLevelResults['wrap'] as bool;
+    final bool useWrapping = topLevelResults.wasParsed(FlutterGlobalOptions.kWrapFlag)
+        ? topLevelResults[FlutterGlobalOptions.kWrapFlag] as bool
+        : globals.stdio.terminalColumns != null && topLevelResults[FlutterGlobalOptions.kWrapFlag] as bool;
     contextOverrides[OutputPreferences] = OutputPreferences(
       wrapText: useWrapping,
-      showColor: topLevelResults['color'] as bool?,
+      showColor: topLevelResults[FlutterGlobalOptions.kColorFlag] as bool?,
       wrapColumn: wrapColumn,
     );
 
-    if (((topLevelResults['show-test-device'] as bool?) ?? false)
-        || topLevelResults['device-id'] == FlutterTesterDevices.kTesterDeviceId) {
+    if (((topLevelResults[FlutterGlobalOptions.kShowTestDeviceFlag] as bool?) ?? false)
+        || topLevelResults[FlutterGlobalOptions.kDeviceIdOption] == FlutterTesterDevices.kTesterDeviceId) {
       FlutterTesterDevices.showFlutterTesterDevice = true;
     }
-    if (((topLevelResults['show-web-server-device'] as bool?) ?? false)
-        || topLevelResults['device-id'] == WebServerDevice.kWebServerDeviceId) {
+    if (((topLevelResults[FlutterGlobalOptions.kShowWebServerDeviceFlag] as bool?) ?? false)
+        || topLevelResults[FlutterGlobalOptions.kDeviceIdOption] == WebServerDevice.kWebServerDeviceId) {
       WebServerDevice.showWebServerDevice = true;
     }
 
     // Set up the tooling configuration.
     final EngineBuildPaths? engineBuildPaths = await globals.localEngineLocator?.findEnginePath(
-      engineSourcePath: topLevelResults['local-engine-src-path'] as String?,
-      localEngine: topLevelResults['local-engine'] as String?,
-      localWebSdk: topLevelResults['local-web-sdk'] as String?,
-      packagePath: topLevelResults['packages'] as String?,
+      engineSourcePath: topLevelResults[FlutterGlobalOptions.kLocalEngineSrcPathOption] as String?,
+      localEngine: topLevelResults[FlutterGlobalOptions.kLocalEngineOption] as String?,
+      localWebSdk: topLevelResults[FlutterGlobalOptions.kLocalWebSDKOption] as String?,
+      packagePath: topLevelResults[FlutterGlobalOptions.kPackagesOption] as String?,
     );
     if (engineBuildPaths != null) {
       contextOverrides.addAll(<Type, Object?>{
@@ -256,24 +286,24 @@ class FlutterCommandRunner extends CommandRunner<void> {
         return MapEntry<Type, Generator>(type, () => value);
       }),
       body: () async {
-        globals.logger.quiet = (topLevelResults['quiet'] as bool?) ?? false;
+        globals.logger.quiet = (topLevelResults[FlutterGlobalOptions.kQuietFlag] as bool?) ?? false;
 
         if (globals.platform.environment['FLUTTER_ALREADY_LOCKED'] != 'true') {
           await globals.cache.lock();
         }
 
-        if ((topLevelResults['suppress-analytics'] as bool?) ?? false) {
+        if ((topLevelResults[FlutterGlobalOptions.kSuppressAnalyticsFlag] as bool?) ?? false) {
           globals.flutterUsage.suppressAnalytics = true;
         }
 
         globals.flutterVersion.ensureVersionFile();
-        final bool machineFlag = topLevelResults['machine'] as bool? ?? false;
+        final bool machineFlag = topLevelResults[FlutterGlobalOptions.kMachineFlag] as bool? ?? false;
         final bool ci = await globals.botDetector.isRunningOnBot;
         final bool redirectedCompletion = !globals.stdio.hasTerminal &&
             (topLevelResults.command?.name ?? '').endsWith('-completion');
         final bool isMachine = machineFlag || ci || redirectedCompletion;
-        final bool versionCheckFlag = topLevelResults['version-check'] as bool? ?? false;
-        final bool explicitVersionCheckPassed = topLevelResults.wasParsed('version-check') && versionCheckFlag;
+        final bool versionCheckFlag = topLevelResults[FlutterGlobalOptions.kVersionCheckFlag] as bool? ?? false;
+        final bool explicitVersionCheckPassed = topLevelResults.wasParsed(FlutterGlobalOptions.kVersionCheckFlag) && versionCheckFlag;
 
         if (topLevelResults.command?.name != 'upgrade' &&
             (explicitVersionCheckPassed || (versionCheckFlag && !isMachine))) {
@@ -281,13 +311,13 @@ class FlutterCommandRunner extends CommandRunner<void> {
         }
 
         // See if the user specified a specific device.
-        final String? specifiedDeviceId = topLevelResults['device-id'] as String?;
+        final String? specifiedDeviceId = topLevelResults[FlutterGlobalOptions.kDeviceIdOption] as String?;
         if (specifiedDeviceId != null) {
           globals.deviceManager?.specifiedDeviceId = specifiedDeviceId;
         }
 
-        if ((topLevelResults['version'] as bool?) ?? false) {
-          globals.flutterUsage.sendCommand('version');
+        if ((topLevelResults[FlutterGlobalOptions.kVersionFlag] as bool?) ?? false) {
+          globals.flutterUsage.sendCommand(FlutterGlobalOptions.kVersionFlag);
           globals.flutterVersion.fetchTagsAndUpdate();
           String status;
           if (machineFlag) {
@@ -312,7 +342,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
   List<String> getRepoRoots() {
     final String root = globals.fs.path.absolute(Cache.flutterRoot!);
     // not bin, and not the root
-    return <String>['dev', 'examples', 'packages'].map<String>((String item) {
+    return <String>['dev', 'examples', FlutterGlobalOptions.kPackagesOption].map<String>((String item) {
       return globals.fs.path.join(root, item);
     }).toList();
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -342,7 +342,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
   List<String> getRepoRoots() {
     final String root = globals.fs.path.absolute(Cache.flutterRoot!);
     // not bin, and not the root
-    return <String>['dev', 'examples', FlutterGlobalOptions.kPackagesOption].map<String>((String item) {
+    return <String>['dev', 'examples', 'packages'].map<String>((String item) {
       return globals.fs.path.join(root, item);
     }).toList();
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -1381,6 +1381,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   DeviceLogReader getLogReader({
     IOSApp? app,
     bool includePastLogs = false,
+    bool usingCISystem = false,
   }) {
     if (onGetLogReader == null) {
       throw UnimplementedError(

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -425,6 +425,7 @@ void main() {
       '--enable-software-rendering',
       '--skia-deterministic-rendering',
       '--enable-embedder-api',
+      '--ci',
     ]), throwsToolExit());
 
     final DebuggingOptions options = await command.createDebuggingOptions(false);
@@ -440,6 +441,7 @@ void main() {
     expect(options.traceSystrace, true);
     expect(options.enableSoftwareRendering, true);
     expect(options.skiaDeterministicRendering, true);
+    expect(options.usingCISystem, true);
   }, overrides: <Type, Generator>{
     Cache: () => Cache.test(processManager: FakeProcessManager.any()),
     FileSystem: () => MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1096,6 +1096,7 @@ void main() {
       '--enable-software-rendering',
       '--skia-deterministic-rendering',
       '--enable-embedder-api',
+      '--ci',
     ]), throwsToolExit());
 
     final DebuggingOptions options = await command.createDebuggingOptions(false);
@@ -1114,6 +1115,7 @@ void main() {
     expect(options.impellerForceGL, true);
     expect(options.enableSoftwareRendering, true);
     expect(options.skiaDeterministicRendering, true);
+    expect(options.usingCISystem, true);
   }, overrides: <Type, Generator>{
     Cache: () => Cache.test(processManager: FakeProcessManager.any()),
     FileSystem: () => MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -32,9 +32,9 @@ void main() {
 
   testUsingContext('Global arg results are available in FlutterCommands', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
+      commandFunction: () async {
+        return const FlutterCommandResult(ExitStatus.success);
+      },
     );
 
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
@@ -48,16 +48,16 @@ void main() {
 
   testUsingContext('Global arg results are available in FlutterCommands sub commands', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
+      commandFunction: () async {
+        return const FlutterCommandResult(ExitStatus.success);
+      },
     );
 
     final DummyFlutterCommand subcommand = DummyFlutterCommand(
       name: 'sub',
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
+      commandFunction: () async {
+        return const FlutterCommandResult(ExitStatus.success);
+      },
     );
 
     command.addSubcommand(subcommand);
@@ -74,9 +74,9 @@ void main() {
 
   testUsingContext('bool? safe argResults', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
+      commandFunction: () async {
+        return const FlutterCommandResult(ExitStatus.success);
+      },
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addFlag('key');
@@ -100,9 +100,9 @@ void main() {
 
   testUsingContext('String? safe argResults', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
+      commandFunction: () async {
+        return const FlutterCommandResult(ExitStatus.success);
+      },
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addOption('key');
@@ -122,9 +122,9 @@ void main() {
 
   testUsingContext('List<String> safe argResults', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
-        commandFunction: () async {
-          return const FlutterCommandResult(ExitStatus.success);
-        }
+      commandFunction: () async {
+        return const FlutterCommandResult(ExitStatus.success);
+      },
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addMultiOption(

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -30,6 +30,22 @@ void main() {
     }
   }));
 
+  testUsingContext('Global arg results are available in FlutterCommands', () async {
+    final DummyFlutterCommand command = DummyFlutterCommand(
+        commandFunction: () async {
+          return const FlutterCommandResult(ExitStatus.success);
+        }
+    );
+
+    final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
+
+    runner.addCommand(command);
+    await runner.run(<String>['dummy', '--${FlutterGlobalOptions.kContinuousIntegrationFlag}']);
+
+    expect(command.globalResults, isNotNull);
+    expect(command.boolArg(FlutterGlobalOptions.kContinuousIntegrationFlag, global: true), true);
+  });
+
   testUsingContext('bool? safe argResults', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
         commandFunction: () async {

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -46,6 +46,32 @@ void main() {
     expect(command.boolArg(FlutterGlobalOptions.kContinuousIntegrationFlag, global: true), true);
   });
 
+  testUsingContext('Global arg results are available in FlutterCommands sub commands', () async {
+    final DummyFlutterCommand command = DummyFlutterCommand(
+        commandFunction: () async {
+          return const FlutterCommandResult(ExitStatus.success);
+        }
+    );
+
+    final DummyFlutterCommand subcommand = DummyFlutterCommand(
+      name: 'sub',
+        commandFunction: () async {
+          return const FlutterCommandResult(ExitStatus.success);
+        }
+    );
+
+    command.addSubcommand(subcommand);
+
+    final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
+
+    runner.addCommand(command);
+    runner.addCommand(subcommand);
+    await runner.run(<String>['dummy', 'sub', '--${FlutterGlobalOptions.kContinuousIntegrationFlag}']);
+
+    expect(subcommand.globalResults, isNotNull);
+    expect(subcommand.boolArg(FlutterGlobalOptions.kContinuousIntegrationFlag, global: true), true);
+  });
+
   testUsingContext('bool? safe argResults', () async {
     final DummyFlutterCommand command = DummyFlutterCommand(
         commandFunction: () async {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -289,6 +289,7 @@ void main() {
           device: device,
           app: appPackage,
           iMobileDevice: IMobileDevice.test(processManager: FakeProcessManager.any()),
+          platform: macPlatform,
         );
         logReader.idevicesyslogProcess = process;
         return logReader;

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -289,7 +289,6 @@ void main() {
           device: device,
           app: appPackage,
           iMobileDevice: IMobileDevice.test(processManager: FakeProcessManager.any()),
-          platform: macPlatform,
         );
         logReader.idevicesyslogProcess = process;
         return logReader;

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -395,7 +395,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
       expect(logReader.useBothLogDeviceReaders, isFalse);
     });
 
-    testWithoutContext('syslog only sends Dart VM message to stream when useBothLogDeviceReaders is true', () async {
+    testWithoutContext('syslog only sends flutter messages to stream when useBothLogDeviceReaders is true', () async {
       processManager.addCommand(
         FakeCommand(
             command: <String>[
@@ -405,6 +405,8 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
 Runner(Flutter)[297] <Notice>: A is for ari
 Runner(Flutter)[297] <Notice>: I is for ichigo
 May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is listening on http://127.0.0.1:63098/35ZezGIQLnw=/
+May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: This is a test
+May 30 13:56:28 Runner(Flutter)[2037] <Notice>: [VERBOSE-2:FlutterDarwinContextMetalImpeller.mm(39)] Using the Impeller rendering backend.
 '''
         ),
       );
@@ -422,7 +424,10 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
 
       expect(logReader.useBothLogDeviceReaders, isTrue);
       expect(processManager, hasNoRemainingExpectations);
-      expect(lines, <String>['flutter: The Dart VM service is listening on http://127.0.0.1:63098/35ZezGIQLnw=/']);
+      expect(lines, <String>[
+        'flutter: The Dart VM service is listening on http://127.0.0.1:63098/35ZezGIQLnw=/',
+        'flutter: This is a test'
+      ]);
     });
 
     testWithoutContext('IOSDeviceLogReader uses both syslog and ios-deploy debugger', () async {
@@ -433,13 +438,15 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
             ],
             stdout: '''
 May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is listening on http://127.0.0.1:63098/35ZezGIQLnw=/
+May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: Check for duplicate
+May 30 13:56:28 Runner(Flutter)[2037] <Notice>: [VERBOSE-2:FlutterDarwinContextMetalImpeller.mm(39)] Using the Impeller rendering backend.
 '''
         ),
       );
 
       final Stream<String> debuggingLogs = Stream<String>.fromIterable(<String>[
+        '2023-06-01 12:49:01.445093-0500 Runner[2225:533240] flutter: Check for duplicate',
         '(lldb) 2023-05-30 13:48:52.461894-0500 Runner[2019:1101495] [VERBOSE-2:FlutterDarwinContextMetalImpeller.mm(39)] Using the Impeller rendering backend.',
-        '',
       ]);
 
       final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
@@ -460,18 +467,13 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
 
       expect(logReader.useBothLogDeviceReaders, isTrue);
       expect(processManager, hasNoRemainingExpectations);
-      expect(
-        lines.contains(
-          '(lldb) 2023-05-30 13:48:52.461894-0500 Runner[2019:1101495] [VERBOSE-2:FlutterDarwinContextMetalImpeller.mm(39)] Using the Impeller rendering backend.',
-        ),
-        isTrue,
-      );
-      expect(
-        lines.contains(
-          'flutter: The Dart VM service is listening on http://127.0.0.1:63098/35ZezGIQLnw=/',
-        ),
-        isTrue,
-      );
+      expect(lines.length, 3);
+      expect(lines, containsAll(<String>[
+        '(lldb) 2023-05-30 13:48:52.461894-0500 Runner[2019:1101495] [VERBOSE-2:FlutterDarwinContextMetalImpeller.mm(39)] Using the Impeller rendering backend.',
+        'flutter: The Dart VM service is listening on http://127.0.0.1:63098/35ZezGIQLnw=/',
+        'flutter: Check for duplicate',
+      ]));
+
     });
 
     testWithoutContext('IOSDeviceLogReader only uses ios-deploy debugger when useBothLogDeviceReaders is false', () async {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/async_guard.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -28,7 +27,6 @@ void main() {
   late Cache fakeCache;
   late BufferLogger logger;
   late String ideviceSyslogPath;
-  final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');
 
   setUp(() {
     processManager = FakeProcessManager.empty();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -75,7 +75,6 @@ Runner(UIKit)[297] <Notice>: E is for enpitsu"
           cache: fakeCache,
           logger: logger,
         ),
-        platform: macPlatform,
       );
       final List<String> lines = await logReader.logLines.toList();
 
@@ -104,7 +103,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           cache: fakeCache,
           logger: logger,
         ),
-        platform: macPlatform,
       );
       final List<String> lines = await logReader.logLines.toList();
 
@@ -139,7 +137,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           cache: fakeCache,
           logger: logger,
         ),
-        platform: macPlatform,
       );
       final List<String> lines = await logReader.logLines.toList();
 
@@ -185,7 +182,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           cache: fakeCache,
           logger: logger,
         ),
-        platform: macPlatform,
       );
       logReader.connectedVMService = vmService;
 
@@ -228,7 +224,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           cache: fakeCache,
           logger: logger,
         ),
-        platform: macPlatform,
       );
       logReader.connectedVMService = vmService;
 
@@ -265,7 +260,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           logger: logger,
         ),
         useSyslog: false,
-        platform: macPlatform,
       );
       final FakeIOSDeployDebugger iosDeployDebugger = FakeIOSDeployDebugger();
       iosDeployDebugger.logLines = debuggingLogs;
@@ -290,7 +284,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           logger: logger,
         ),
         useSyslog: false,
-        platform: macPlatform,
       );
       final Completer<void> streamComplete = Completer<void>();
       final FakeIOSDeployDebugger iosDeployDebugger = FakeIOSDeployDebugger();
@@ -310,7 +303,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           logger: logger,
         ),
         useSyslog: false,
-        platform: macPlatform,
       );
       final FakeIOSDeployDebugger iosDeployDebugger = FakeIOSDeployDebugger();
       logReader.debuggerStream = iosDeployDebugger;
@@ -335,7 +327,6 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           logger: logger,
         ),
         useSyslog: false,
-        platform: macPlatform,
       );
       Object? exception;
       StackTrace? trace;
@@ -362,13 +353,7 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
 
   group('both syslog and debugger stream', () {
 
-    testWithoutContext('useBothLogDeviceReaders is true when user is swarming and sdk is at least 16', () {
-      final FakePlatform macPlatform = FakePlatform(
-        operatingSystem: 'macos',
-        environment: <String, String>{
-          'USER': 'swarming',
-        },
-      );
+    testWithoutContext('useBothLogDeviceReaders is true when CI option is true and sdk is at least 16', () {
       final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
         iMobileDevice: IMobileDevice(
           artifacts: artifacts,
@@ -376,20 +361,14 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           cache: fakeCache,
           logger: logger,
         ),
+        usingCISystem: true,
         majorSdkVersion: 16,
-        platform: macPlatform,
       );
 
       expect(logReader.useBothLogDeviceReaders, isTrue);
     });
 
     testWithoutContext('useBothLogDeviceReaders is false when sdk is less than 16', () {
-      final FakePlatform macPlatform = FakePlatform(
-        operatingSystem: 'macos',
-        environment: <String, String>{
-          'USER': 'swarming',
-        },
-      );
       final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
         iMobileDevice: IMobileDevice(
           artifacts: artifacts,
@@ -397,20 +376,14 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           cache: fakeCache,
           logger: logger,
         ),
+        usingCISystem: true,
         majorSdkVersion: 15,
-        platform: macPlatform,
       );
 
       expect(logReader.useBothLogDeviceReaders, isFalse);
     });
 
-    testWithoutContext('useBothLogDeviceReaders is false when user is not swarming', () {
-      final FakePlatform macPlatform = FakePlatform(
-        operatingSystem: 'macos',
-        environment: <String, String>{
-          'USER': 'no',
-        },
-      );
+    testWithoutContext('useBothLogDeviceReaders is false when CI option is false', () {
       final IOSDeviceLogReader logReader = IOSDeviceLogReader.test(
         iMobileDevice: IMobileDevice(
           artifacts: artifacts,
@@ -419,20 +392,12 @@ Runner(libsystem_asl.dylib)[297] <Notice>: libMobileGestalt
           logger: logger,
         ),
         majorSdkVersion: 16,
-        platform: macPlatform,
       );
 
       expect(logReader.useBothLogDeviceReaders, isFalse);
     });
 
     testWithoutContext('syslog only sends Dart VM message to stream when useBothLogDeviceReaders is true', () async {
-      final FakePlatform macPlatform = FakePlatform(
-        operatingSystem: 'macos',
-        environment: <String, String>{
-          'USER': 'swarming',
-        },
-      );
-
       processManager.addCommand(
         FakeCommand(
             command: <String>[
@@ -452,8 +417,8 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
           cache: fakeCache,
           logger: logger,
         ),
+        usingCISystem: true,
         majorSdkVersion: 16,
-        platform: macPlatform,
       );
       final List<String> lines = await logReader.logLines.toList();
 
@@ -463,13 +428,6 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
     });
 
     testWithoutContext('IOSDeviceLogReader uses both syslog and ios-deploy debugger', () async {
-      final FakePlatform macPlatform = FakePlatform(
-        operatingSystem: 'macos',
-        environment: <String, String>{
-          'USER': 'swarming',
-        },
-      );
-
       processManager.addCommand(
         FakeCommand(
             command: <String>[
@@ -493,8 +451,8 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
           cache: fakeCache,
           logger: logger,
         ),
+        usingCISystem: true,
         majorSdkVersion: 16,
-        platform: macPlatform,
       );
       final FakeIOSDeployDebugger iosDeployDebugger = FakeIOSDeployDebugger();
       iosDeployDebugger.logLines = debuggingLogs;
@@ -532,7 +490,6 @@ May 30 13:56:28 Runner(Flutter)[2037] <Notice>: flutter: The Dart VM service is 
           logger: logger,
         ),
         majorSdkVersion: 16,
-        platform: macPlatform,
       );
       final FakeIOSDeployDebugger iosDeployDebugger = FakeIOSDeployDebugger();
       iosDeployDebugger.logLines = debuggingLogs;


### PR DESCRIPTION
Workaround solution for: https://github.com/flutter/flutter/issues/121231
See https://github.com/flutter/flutter/issues/120808#issuecomment-1551826299 Error Case 2 for more information.

Sometimes the `ios-deploy` process does not return the logs from the application. We've been unable to figure out why. This is a solution to workaround that by using `idevicesyslog` alongside `ios-deploy` as a backup in getting the log for the Dart VM url. As explained in https://github.com/flutter/flutter/issues/120808#issuecomment-1551826299, when error case 2 happens, the `idevicesyslog` does successfully find the Dart VM.

Also, in the comments of the code it mentions `syslog` is not written on iOS 13+, this was added in response to this issue: https://github.com/flutter/flutter/issues/41133.

However, `idevicesyslog` does in fact work (at least for iOS 16), we use it to collect device logs for our CI tests already: https://github.com/flutter/flutter/blob/1dc26f80f04c1c1091a83c5fead9b3aa83483292/dev/devicelab/lib/framework/devices.dart#L998-L1006


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
