### PR TITLE
Remove LiveTestRenderView

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -33,6 +33,10 @@ class ViewConfiguration {
   final double devicePixelRatio;
 
   /// Creates a transformation matrix that applies the [devicePixelRatio].
+  ///
+  /// The matrix translates points from the local coordinate system of the
+  /// app (in logical pixels) to the global coordinate system of the
+  /// physical view (in physical pixels).
   Matrix4 toMatrix() {
     return Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1.0);
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -36,7 +36,7 @@ class ViewConfiguration {
   ///
   /// The matrix translates points from the local coordinate system of the
   /// app (in logical pixels) to the global coordinate system of the
-  /// physical view (in physical pixels).
+  /// [FlutterView] (in physical pixels).
   Matrix4 toMatrix() {
     return Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1.0);
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -216,6 +216,12 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     if (child != null) {
       context.paintChild(child!, offset);
     }
+    assert(() {
+      for (final DebugPaintCallback paintCallback in _debugPaintCallbacks) {
+        paintCallback(context, offset, this);
+      }
+      return true;
+    }());
   }
 
   @override
@@ -385,4 +391,19 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
       properties.add(DiagnosticsNode.message('semantics enabled'));
     }
   }
+
+  static final List<DebugPaintCallback> _debugPaintCallbacks = <DebugPaintCallback>[];
+
+  ///
+  static void debugAddPaintCallback(DebugPaintCallback callback) {
+    _debugPaintCallbacks.add(callback);
+  }
+
+  ///
+  static void debugRemovePaintCallback(DebugPaintCallback callback) {
+    _debugPaintCallbacks.remove(callback);
+  }
 }
+
+///
+typedef DebugPaintCallback = void Function(PaintingContext context, Offset offset, RenderView renderView);

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -563,27 +563,24 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     });
   }
 
-  /// Convert the given point from the global coordinate space to the local
-  /// one.
+  /// Convert the given point from the global coordinate space of the provided
+  /// [RenderView] to its local one (both expressed in logical pixels).
   ///
-  /// It translates the point from the global coordinate space of the device (in
-  /// logical pixels) to the local coordinate space of the test (also in logical
-  /// pixels). It does not apply the device pixel ratio (used to translate
-  /// to/from physical pixels).
+  /// This method operates in logical pixels for both coordinate spaces. It does
+  /// not apply the device pixel ratio (used to translate to/from physical
+  /// pixels).
   ///
   /// For definitions for coordinate spaces, see [TestWidgetsFlutterBinding].
-  Offset globalToLocal(Offset point) => point;
+  Offset globalToLocal(Offset point, RenderView view) => point;
 
   /// Convert the given point from the local coordinate space to the global
-  /// one.
+  /// coordinate space of the [RenderView].
   ///
-  /// It translates the point from the local coordinate space of the test (in
-  /// logical pixels) to the global coordinate space of the device (also in
-  /// logical pixels). It does not apply the device pixel ratio to translate
-  /// to physical pixels.
+  /// This method operates in logical pixels for both coordinate spaces. It does
+  /// not apply the device pixel ratio to translate to physical pixels.
   ///
   /// For definitions for coordinate spaces, see [TestWidgetsFlutterBinding].
-  Offset localToGlobal(Offset point) => point;
+  Offset localToGlobal(Offset point, RenderView view) => point;
 
   /// The source of the current pointer event.
   ///
@@ -1854,7 +1851,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
           // The pointer events received with this source has a global position
           // (see [handlePointerEventForSource]). Transform it to the local
           // coordinate space used by the testing widgets.
-          final PointerEvent localEvent = event.copyWith(position: globalToLocal(event.position));
+          final PointerEvent localEvent = event.copyWith(position: globalToLocal(event.position, renderView));
           withPointerEventSource(TestBindingEventSource.device,
             () => super.handlePointerEvent(localEvent)
           );
@@ -1989,34 +1986,34 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
-  Offset globalToLocal(Offset point) {
+  Offset globalToLocal(Offset point, RenderView view) {
     // The method is expected to translate the given point expressed in logical
     // pixels in the global coordinate space to the local coordinate space (also
     // expressed in logical pixels).
     // The inverted transform translates from the global coordinate space in
     // physical pixels to the local coordinate space in logical pixels.
-    final Matrix4 transform = _liveTestRenderView.configuration.toMatrix();
+    final Matrix4 transform = view.configuration.toMatrix();
     final double det = transform.invert();
     assert(det != 0.0);
     // In order to use the transform, we need to translate the point first into
     // the physical coordinate space by applying the device pixel ratio.
     return MatrixUtils.transformPoint(
       transform,
-      point * _liveTestRenderView.configuration.devicePixelRatio,
+      point * view.configuration.devicePixelRatio,
     );
   }
 
   @override
-  Offset localToGlobal(Offset point) {
+  Offset localToGlobal(Offset point, RenderView view) {
     // The method is expected to translate the given point expressed in logical
     // pixels in the local coordinate space to the global coordinate space (also
     // expressed in logical pixels).
     // The transform translates from the local coordinate space in logical
     // pixels to the global coordinate space in physical pixels.
-    final Matrix4 transform = _liveTestRenderView.configuration.toMatrix();
+    final Matrix4 transform = view.configuration.toMatrix();
     final Offset pointInPhysicalPixels = MatrixUtils.transformPoint(transform, point);
     // We need to apply the device pixel ratio to get back to logical pixels.
-    return pointInPhysicalPixels / _liveTestRenderView.configuration.devicePixelRatio;
+    return pointInPhysicalPixels / view.configuration.devicePixelRatio;
   }
 }
 

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -566,11 +566,21 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// Convert the given point from the global coordinate space to the local
   /// one.
   ///
+  /// It translates the point from the global coordinate space of the device (in
+  /// logical pixels) to the local coordinate space of the test (also in logical
+  /// pixels). It does not apply the device pixel ratio (used to translate
+  /// to/from physical pixels).
+  ///
   /// For definitions for coordinate spaces, see [TestWidgetsFlutterBinding].
   Offset globalToLocal(Offset point) => point;
 
   /// Convert the given point from the local coordinate space to the global
   /// one.
+  ///
+  /// It translates the point from the local coordinate space of the test (in
+  /// logical pixels) to the global coordinate space of the device (also in
+  /// logical pixels). It does not apply the device pixel ratio to translate
+  /// to physical pixels.
   ///
   /// For definitions for coordinate spaces, see [TestWidgetsFlutterBinding].
   Offset localToGlobal(Offset point) => point;
@@ -1994,9 +2004,11 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 }
 
-/// A [ViewConfiguration] that pretends the display is of a particular size. The
-/// size is in logical pixels. The resulting ViewConfiguration maps the given
-/// size onto the actual display using the [BoxFit.contain] algorithm.
+/// A [ViewConfiguration] that pretends the display is of a particular size (in
+/// logical pixels).
+///
+/// The resulting ViewConfiguration maps the given size onto the actual display
+/// using the [BoxFit.contain] algorithm.
 class TestViewConfiguration extends ViewConfiguration {
   /// Deprecated. Will be removed in a future version of Flutter.
   ///

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -564,7 +564,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   }
 
   /// Convert the given point from the global coordinate space of the provided
-  /// [RenderView] to its local one (both expressed in logical pixels).
+  /// [RenderView] to its local one.
   ///
   /// This method operates in logical pixels for both coordinate spaces. It does
   /// not apply the device pixel ratio (used to translate to/from physical

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -832,7 +832,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
   @override
   HitTestResult hitTestOnBinding(Offset location) {
-    location = binding.localToGlobal(location);
+    location = binding.localToGlobal(location, binding.renderView);
     return super.hitTestOnBinding(location);
   }
 

--- a/packages/flutter_test/test/coordinate_translation_test.dart
+++ b/packages/flutter_test/test/coordinate_translation_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final LiveTestWidgetsFlutterBinding binding = LiveTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('localToGlobal and globalToLocal calculate correct results', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(2400, 1800);
+    tester.view.devicePixelRatio = 3.0;
+    tester.binding.renderView.configuration = TestViewConfiguration.fromView(
+      view: tester.view,
+      size: const Size(400, 200),
+    );
+
+    // The configuration above defines a view with a resolution of 2400x1800
+    // physical pixels. With a device pixel ratio of 3x, this yields a
+    // resolution of 800x600 logical pixels. In this view, a RenderView sized
+    // 400x200 (in logical pixels) is fitted using the BoxFit.contain
+    // algorithm (as documented on TestViewConfiguration. To fit 400x200 into
+    // 800x600 the RenderView is scaled up by 2 to fill the full width and then
+    // vertically positioned in the middle. The origin of the RenderView is
+    // located at (0, 100) in the logical coordinate space of the view:
+    //
+    //           View: 800 logical pixels wide (or 2400 physical pixels)
+    // +---------------------------------------+
+    // |                                       |
+    // | 100px                                 |
+    // |                                       |
+    // +---------------------------------------+
+    // |                                       |
+    // |     RenderView (400x200px)            |
+    // | 400px          scaled to 800x400px    | View: 600 logical pixels high (or 1800 physical pixels)
+    // |                                       |
+    // |                                       |
+    // +---------------------------------------+
+    // |                                       |
+    // | 200px                                 |
+    // |                                       |
+    // +---------------------------------------+
+    //
+    // All values in logical pixels until otherwise noted.
+    //
+    // A point  can be translated from the local coordinate space of the
+    // RenderView (in logical pixels) to the global coordinate space of the View
+    // (in logical pixels) by multiplying each coordinate by 2 and adding 100 to
+    // the y coordinate. This is what the localToGlobal/globalToLocal methods
+    // do:
+
+    expect(binding.localToGlobal(const Offset(0, -50)), Offset.zero);
+    expect(binding.localToGlobal(Offset.zero), const Offset(0, 100));
+    expect(binding.localToGlobal(const Offset(200, 100)), const Offset(400, 300));
+    expect(binding.localToGlobal(const Offset(150, 75)), const Offset(300, 250));
+    expect(binding.localToGlobal(const Offset(400, 200)), const Offset(800, 500));
+    expect(binding.localToGlobal(const Offset(400, 400)), const Offset(800, 900));
+
+    expect(binding.globalToLocal(Offset.zero), const Offset(0, -50));
+    expect(binding.globalToLocal(const Offset(0, 100)), Offset.zero);
+    expect(binding.globalToLocal(const Offset(400, 300)), const Offset(200, 100));
+    expect(binding.globalToLocal(const Offset(300, 250)), const Offset(150, 75));
+    expect(binding.globalToLocal(const Offset(800, 500)), const Offset(400, 200));
+    expect(binding.globalToLocal(const Offset(800, 900)), const Offset(400, 400));
+  });
+}

--- a/packages/flutter_test/test/coordinate_translation_test.dart
+++ b/packages/flutter_test/test/coordinate_translation_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -11,9 +11,12 @@ void main() {
   testWidgets('localToGlobal and globalToLocal calculate correct results', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(2400, 1800);
     tester.view.devicePixelRatio = 3.0;
-    tester.binding.renderView.configuration = TestViewConfiguration.fromView(
+    final RenderView renderView = RenderView(
       view: tester.view,
-      size: const Size(400, 200),
+      configuration: TestViewConfiguration.fromView(
+        view: tester.view,
+        size: const Size(400, 200),
+      )
     );
 
     // The configuration above defines a view with a resolution of 2400x1800
@@ -50,18 +53,18 @@ void main() {
     // the y coordinate. This is what the localToGlobal/globalToLocal methods
     // do:
 
-    expect(binding.localToGlobal(const Offset(0, -50)), Offset.zero);
-    expect(binding.localToGlobal(Offset.zero), const Offset(0, 100));
-    expect(binding.localToGlobal(const Offset(200, 100)), const Offset(400, 300));
-    expect(binding.localToGlobal(const Offset(150, 75)), const Offset(300, 250));
-    expect(binding.localToGlobal(const Offset(400, 200)), const Offset(800, 500));
-    expect(binding.localToGlobal(const Offset(400, 400)), const Offset(800, 900));
+    expect(binding.localToGlobal(const Offset(0, -50), renderView), Offset.zero);
+    expect(binding.localToGlobal(Offset.zero, renderView), const Offset(0, 100));
+    expect(binding.localToGlobal(const Offset(200, 100), renderView), const Offset(400, 300));
+    expect(binding.localToGlobal(const Offset(150, 75), renderView), const Offset(300, 250));
+    expect(binding.localToGlobal(const Offset(400, 200), renderView), const Offset(800, 500));
+    expect(binding.localToGlobal(const Offset(400, 400), renderView), const Offset(800, 900));
 
-    expect(binding.globalToLocal(Offset.zero), const Offset(0, -50));
-    expect(binding.globalToLocal(const Offset(0, 100)), Offset.zero);
-    expect(binding.globalToLocal(const Offset(400, 300)), const Offset(200, 100));
-    expect(binding.globalToLocal(const Offset(300, 250)), const Offset(150, 75));
-    expect(binding.globalToLocal(const Offset(800, 500)), const Offset(400, 200));
-    expect(binding.globalToLocal(const Offset(800, 900)), const Offset(400, 400));
+    expect(binding.globalToLocal(Offset.zero, renderView), const Offset(0, -50));
+    expect(binding.globalToLocal(const Offset(0, 100), renderView), Offset.zero);
+    expect(binding.globalToLocal(const Offset(400, 300), renderView), const Offset(200, 100));
+    expect(binding.globalToLocal(const Offset(300, 250), renderView), const Offset(150, 75));
+    expect(binding.globalToLocal(const Offset(800, 500), renderView), const Offset(400, 200));
+    expect(binding.globalToLocal(const Offset(800, 900), renderView), const Offset(400, 400));
   });
 }

--- a/packages/flutter_test/test/widget_tester_live_device_test.dart
+++ b/packages/flutter_test/test/widget_tester_live_device_test.dart
@@ -126,7 +126,7 @@ class _MockLiveTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
     // real devices touches sends event in the global coordinate system.
     // See the documentation of [handlePointerEventForSource] for details.
     if (source == TestBindingEventSource.test) {
-      final PointerEvent globalEvent = event.copyWith(position: localToGlobal(event.position));
+      final PointerEvent globalEvent = event.copyWith(position: localToGlobal(event.position, renderView));
       return super.handlePointerEventForSource(globalEvent);
     }
     return super.handlePointerEventForSource(event, source: source);


### PR DESCRIPTION
In the multi view world, `RenderViews` are created by the `View` widget and no longer owned by the binding. Prior to this change, the `LiveTestWidgetsFlutterBinding` owned and managed a special subclass of `RenderView`, the `_LiveTestRenderView`. In the new world, where `RenderView`s can be created anywhere in the widget tree where a `View` widget is used, this setup is no longer feasible. This change removes this special `_LiveTestRenderView` and instead adds debug hocks to `RenderView` to allow the `LiveTestWidgetsFlutterBinding` to draw a debug overlay on top of the content of any `RenderView`.