### PR TITLE
Add oriol_33 firebaselab configuration.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -420,6 +420,24 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Linux firebase_oriol33_abstract_method_smoke_test
+    bringup: true
+    recipe: firebaselab/firebaselab
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:33v6"}
+        ]
+      tags: >
+        ["firebaselab"]
+      task_name: abstract_method_smoke_test
+      physical_devices: >-
+        ["--device", "model=oriole,version=33"]
+      virtual_device: >-
+        []
+
+
   - name: Linux firebase_abstract_method_smoke_test
     bringup: true # Flaky https://github.com/flutter/flutter/issues/124691
     recipe: firebaselab/firebaselab

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -437,7 +437,6 @@ targets:
       virtual_device: >-
         []
 
-
   - name: Linux firebase_abstract_method_smoke_test
     bringup: true # Flaky https://github.com/flutter/flutter/issues/124691
     recipe: firebaselab/firebaselab


### PR DESCRIPTION
This allows to run the api 33 as a separate build.

Bug: https://github.com/flutter/flutter/issues/127884
Bug: https://github.com/flutter/flutter/issues/118736


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
