### PR TITLE
Super tiny MediaQuery doc update

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -759,7 +759,7 @@ class MediaQueryData {
 /// containing your app), you can use [MediaQuery.sizeOf]:
 /// `MediaQuery.sizeOf(context)`.
 ///
-/// Querying the current media using specific methods (for example:
+/// Querying the current media using specific methods (for example,
 /// [MediaQuery.sizeOf] and [MediaQuery.paddingOf]) will cause your widget to
 /// rebuild automatically whenever the property you query changes.
 ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -756,18 +756,24 @@ class MediaQueryData {
 /// Establishes a subtree in which media queries resolve to the given data.
 ///
 /// For example, to learn the size of the current media (e.g., the window
-/// containing your app), you can use [MediaQuery.sizeOf]: 
-/// `MediaQuery.sizeOf(context)`. Alternatively, with less performance,
-/// you can read the [MediaQueryData.size] property from
-/// the [MediaQueryData] returned by [MediaQuery.of]:
-/// `MediaQuery.of(context).size`.
+/// containing your app), you can use [MediaQuery.sizeOf]:
+/// `MediaQuery.sizeOf(context)`.
 ///
-/// Querying the current media using [MediaQuery.of] will cause your widget to
-/// rebuild automatically whenever the [MediaQueryData] changes (e.g., if the
-/// user rotates their device).
+/// Querying the current media using specific methods (for example:
+/// [MediaQuery.sizeOf] and [MediaQuery.paddingOf]) will cause your widget to
+/// rebuild automatically whenever the property you query changes.
 ///
-/// If no [MediaQuery] is in scope then the [MediaQuery.of] method will throw an
-/// exception. Alternatively, [MediaQuery.maybeOf] may be used, which returns
+/// On the other hand, querying using [MediaQuery.of] will cause your widget to
+/// rebuild automatically whenever any field of the [MediaQueryData] changes
+/// (e.g., if the user rotates their device). Therefore, if you are only
+/// concerned with one or a few fields of [MediaQueryData], prefer using
+/// the specific methods (for example: [MediaQuery.sizeOf] and
+/// [MediaQuery.paddingOf]).
+///
+/// If no [MediaQuery] is in scope then the series of methods like
+/// [MediaQuery.of] and [MediaQuery.sizeOf] will throw an exception.
+/// Alternatively, the "maybe-" variant methods (such as [MediaQuery.maybeOf]
+/// and [MediaQuery.maybeSizeOf]) can be used, which returns
 /// null instead of throwing if no [MediaQuery] is in scope.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=A3WrA4zAaPw}

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -756,7 +756,9 @@ class MediaQueryData {
 /// Establishes a subtree in which media queries resolve to the given data.
 ///
 /// For example, to learn the size of the current media (e.g., the window
-/// containing your app), you can read the [MediaQueryData.size] property from
+/// containing your app), you can use [MediaQuery.sizeOf]: 
+/// `MediaQuery.sizeOf(context)`. Alternatively, with less performance,
+/// you can read the [MediaQueryData.size] property from
 /// the [MediaQueryData] returned by [MediaQuery.of]:
 /// `MediaQuery.of(context).size`.
 ///


### PR DESCRIPTION
Just now I see some good news: https://www.reddit.com/r/FlutterDev/comments/13vo5a2/the_most_important_flutter_310_feature_that/ (ignore the title though...). It was a performance problem in the old days, so it was great that the problem disappears. However, it seems that the doc is not updated yet, so everyone reading MediaQuery page will still use the old way. Thus I create this super-tiny PR :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
