### PR TITLE
[CP] BETA AGP 8.0 minification support when using integration_test package

### DIFF
--- a/packages/integration_test/android/build.gradle
+++ b/packages/integration_test/android/build.gradle
@@ -40,6 +40,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'lib-proguard-rules.txt'
     }
 
     dependencies {

--- a/packages/integration_test/android/lib-proguard-rules.txt
+++ b/packages/integration_test/android/lib-proguard-rules.txt
@@ -1,0 +1,5 @@
+# For some reason org.kxml2.io.KXmlParser and org.kxml2.io.KXmlSerializer
+# are missing and not marked correctly by dependencies.
+# Possibly related to https://github.com/flutter/flutter/issues/56591
+# See https://github.com/flutter/flutter/issues/127388 for more context.
+-dontwarn org.kxml2.io.KXmlParser**,org.kxml2.io.KXmlSerializer**

--- a/packages/integration_test/example/android/app/build.gradle
+++ b/packages/integration_test/example/android/app/build.gradle
@@ -55,6 +55,7 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/integration_test/example/android/app/proguard-rules.pro
+++ b/packages/integration_test/example/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Intentionally empty. Validation is that apps can set their own proguard files.


### PR DESCRIPTION
- Support minification for apps that depend on AGP 8 and integration_test (#127628)
Fixes #127967 #127969


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
