### PR TITLE
Sync Lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -110,7 +110,6 @@ linter:
     - implicit_call_tearoffs
     - implicit_reopen
     - invalid_case_patterns
-    - iterable_contains_unrelated_type
     # - join_return_with_assignment # not required by flutter style
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -118,7 +117,6 @@ linter:
     - library_prefixes
     - library_private_types_in_public_api
     # - lines_longer_than_80_chars # not required by flutter style
-    - list_remove_unrelated_type
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/linter/issues/453
     # - matching_super_parameters # blocked on https://github.com/dart-lang/language/issues/2509
     - missing_whitespace_between_adjacent_strings
@@ -130,6 +128,7 @@ linter:
     - no_literal_bool_comparisons
     - no_logic_in_create_state
     # - no_runtimeType_toString # ok in tests; we enable this only in packages/
+    - no_self_assignments
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2106,7 +2106,7 @@ abstract class RenderBox extends RenderObject {
   @override
   void debugResetSize() {
     // updates the value of size._canBeUsedByParent if necessary
-    size = size;
+    size = size; // ignore: no_self_assignments
   }
 
   Map<TextBaseline, double?>? _cachedBaselines;

--- a/packages/flutter/test/rendering/image_test.dart
+++ b/packages/flutter/test/rendering/image_test.dart
@@ -200,7 +200,8 @@ Future<void> main() async {
     final RenderImage renderImage = RenderImage(image: image.clone());
     expect(image.debugGetOpenHandleStackTraces()!.length, 2);
 
-    renderImage.image = renderImage.image;
+    // Testing short-circuit logic of setter.
+    renderImage.image = renderImage.image; // ignore: no_self_assignments
     expect(image.debugGetOpenHandleStackTraces()!.length, 2);
 
     renderImage.image = null;

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -161,10 +161,8 @@ class FakeVM extends Fake implements vm.VmService {
     return vm.Timestamp(timestamp: lastTimeStamp);
   }
 
-  List<String> recordedStreams = <String>[];
   @override
   Future<vm.Success> setVMTimelineFlags(List<String> recordedStreams) async {
-    recordedStreams = recordedStreams;
     return vm.Success();
   }
 


### PR DESCRIPTION
Syncs our lints with https://github.com/dart-lang/linter/blob/master/example/all.yaml:
* removed the deprecated `iterable_contains_unrelated_type` and `list_remove_unrelated_type` lints (their replacement `collection_methods_unrelated_type` was already enabled for us)
* enabled the new `no_self_assignments` and fixed one issue triggered by the lint. 