### PR TITLE
Fix handling of AppLifecycleState.hidden

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -376,6 +376,13 @@ mixin SchedulerBinding on BindingBase {
   AppLifecycleState? get lifecycleState => _lifecycleState;
   AppLifecycleState? _lifecycleState;
 
+  /// Allows the test framework to reset the lifecycle state back to its
+  /// initial value.
+  @visibleForTesting
+  void resetLifecycleState() {
+    _lifecycleState = null;
+  }
+
   /// Called when the application lifecycle state changes.
   ///
   /// Notifies all the observers using

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -285,6 +285,8 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
         return AppLifecycleState.resumed;
       case 'AppLifecycleState.inactive':
         return AppLifecycleState.inactive;
+      case 'AppLifecycleState.hidden':
+        return AppLifecycleState.hidden;
       case 'AppLifecycleState.paused':
         return AppLifecycleState.paused;
       case 'AppLifecycleState.detached':

--- a/packages/flutter/test/services/lifecycle_test.dart
+++ b/packages/flutter/test/services/lifecycle_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -19,5 +21,14 @@ void main() {
     // The lifecycleState should now be the state we passed above,
     // even though no lifecycle event was fired from the platform.
     expect(ServicesBinding.instance.lifecycleState.toString(), equals('AppLifecycleState.paused'));
+  });
+  testWidgets('Handles all of the allowed states of AppLifecycleState', (WidgetTester tester) async {
+    final TestWidgetsFlutterBinding binding = tester.binding;
+    for (final AppLifecycleState state in AppLifecycleState.values) {
+      binding.resetLifecycleState();
+      binding.platformDispatcher.initialLifecycleStateTestValue = state.toString();
+      binding.readTestInitialLifecycleStateFromNativeWindow();
+      expect(ServicesBinding.instance.lifecycleState.toString(), equals(state.toString()));
+    }
   });
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1150,6 +1150,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     keyEventManager.clearState();
     // ignore: invalid_use_of_visible_for_testing_member
     RendererBinding.instance.initMouseTracker();
+    // ignore: invalid_use_of_visible_for_testing_member
+    ServicesBinding.instance.resetLifecycleState();
   }
 }
 


### PR DESCRIPTION
## Description

This fixes the parsing of `AppLifecycleState` in the services binding so that it knows what it is.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/127974

## Tests
 - Added a test that causes parsing of all the different app lifecycle states.