### PR TITLE
[Windows] Address feedback for show window comment

### DIFF
--- a/dev/integration_tests/flutter_gallery/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/flutter_window.cpp
@@ -36,8 +36,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/dev/integration_tests/ui/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/ui/windows/runner/flutter_window.cpp
@@ -36,8 +36,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
@@ -64,8 +64,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   // Create a method channel to check the window's visibility.

--- a/dev/manual_tests/windows/runner/flutter_window.cpp
+++ b/dev/manual_tests/windows/runner/flutter_window.cpp
@@ -36,8 +36,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/examples/flutter_view/windows/runner/flutter_window.cpp
+++ b/examples/flutter_view/windows/runner/flutter_window.cpp
@@ -36,8 +36,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/examples/hello_world/windows/runner/flutter_window.cpp
+++ b/examples/hello_world/windows/runner/flutter_window.cpp
@@ -36,8 +36,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/examples/layers/windows/runner/flutter_window.cpp
+++ b/examples/layers/windows/runner/flutter_window.cpp
@@ -36,8 +36,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/examples/platform_channel/windows/runner/flutter_window.cpp
+++ b/examples/platform_channel/windows/runner/flutter_window.cpp
@@ -99,8 +99,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/packages/flutter_tools/lib/src/windows/migrations/show_window_migration.dart
+++ b/packages/flutter_tools/lib/src/windows/migrations/show_window_migration.dart
@@ -20,8 +20,8 @@ const String _after = r'''
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/flutter_window.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/flutter_window.cpp
@@ -32,8 +32,8 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Flutter can complete the first frame before the "show window" callback is
-  // registered. Ensure a frame is pending to ensure the window is shown.
-  // This no-ops if the first frame hasn't completed yet.
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/packages/flutter_tools/test/general.shard/windows/migrations/show_window_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/migrations/show_window_migration_test.dart
@@ -75,8 +75,8 @@ void main () {
         '  });\n'
         '\n'
         '  // Flutter can complete the first frame before the "show window" callback is\n'
-        '  // registered. Ensure a frame is pending to ensure the window is shown.\n'
-        "  // This no-ops if the first frame hasn't completed yet.\n"
+        '  // registered. The following call ensures a frame is pending to ensure the\n'
+        "  // window is shown. It is a no-op if the first frame hasn't completed yet.\n"
         '  flutter_controller_->ForceRedraw();\n'
         '\n'
         '  return true;\n';
@@ -103,8 +103,8 @@ void main () {
         '  });\r\n'
         '\r\n'
         '  // Flutter can complete the first frame before the "show window" callback is\r\n'
-        '  // registered. Ensure a frame is pending to ensure the window is shown.\r\n'
-        "  // This no-ops if the first frame hasn't completed yet.\r\n"
+        '  // registered. The following call ensures a frame is pending to ensure the\r\n'
+        "  // window is shown. It is a no-op if the first frame hasn't completed yet.\r\n"
         '  flutter_controller_->ForceRedraw();\r\n'
         '\r\n'
         '  return true;\r\n';
@@ -145,8 +145,8 @@ void main () {
         '  });\n'
         '\n'
         '  // Flutter can complete the first frame before the "show window" callback is\n'
-        '  // registered. Ensure a frame is pending to ensure the window is shown.\n'
-        "  // This no-ops if the first frame hasn't completed yet.\n"
+        '  // registered. The following call ensures a frame is pending to ensure the\n'
+        "  // window is shown. It is a no-op if the first frame hasn't completed yet.\n"
         '  flutter_controller_->ForceRedraw();\n'
         '\n'
         '  return true;\n'
@@ -176,8 +176,8 @@ void main () {
         '  });\r\n'
         '\r\n'
         '  // Flutter can complete the first frame before the "show window" callback is\r\n'
-        '  // registered. Ensure a frame is pending to ensure the window is shown.\r\n'
-        "  // This no-ops if the first frame hasn't completed yet.\r\n"
+        '  // registered. The following call ensures a frame is pending to ensure the\r\n'
+        "  // window is shown. It is a no-op if the first frame hasn't completed yet.\r\n"
         '  flutter_controller_->ForceRedraw();\r\n'
         '\r\n'
         '  return true;\r\n'


### PR DESCRIPTION
Address Tong's feedback here: https://github.com/flutter/flutter/issues/127695#issuecomment-1564884872

Follow-up to: https://github.com/flutter/flutter/pull/127046

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
