### PR TITLE
Updated Menu examples

### DIFF
--- a/examples/api/lib/material/menu_anchor/menu_accelerator_label.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_accelerator_label.0.dart
@@ -103,6 +103,7 @@ class MenuAcceleratorApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
       home: Shortcuts(
         shortcuts: <ShortcutActivator, Intent>{
           const SingleActivator(LogicalKeyboardKey.keyT, control: true): VoidCallbackIntent(() {

--- a/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
@@ -202,8 +202,9 @@ class MenuApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(body: MyCascadingMenu(message: kMessage)),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const Scaffold(body: MyCascadingMenu(message: kMessage)),
     );
   }
 }

--- a/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
@@ -201,8 +201,9 @@ class ContextMenuApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(body: MyContextMenu(message: kMessage)),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const Scaffold(body: MyContextMenu(message: kMessage)),
     );
   }
 }

--- a/examples/api/test/material/menu_anchor/menu_accelerator_label.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_accelerator_label.0_test.dart
@@ -29,7 +29,7 @@ void main() {
     expect(find.text('About', findRichText: true), findsOneWidget);
     expect(
       tester.getRect(findMenu('About')),
-      equals(const Rect.fromLTRB(4.0, 48.0, 98.0, 208.0)),
+      equals(const Rect.fromLTRB(4.0, 48.0, 111.0, 208.0)),
     );
     expect(find.text('Save', findRichText: true), findsOneWidget);
     expect(find.text('Quit', findRichText: true), findsOneWidget);
@@ -45,10 +45,10 @@ void main() {
     expect(find.text('Quit', findRichText: true), findsNothing);
     expect(find.text('Magnify', findRichText: true), findsNothing);
     expect(find.text('Minify', findRichText: true), findsNothing);
-    expect(find.text('CLOSE'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
 
-    await tester.tap(find.text('CLOSE'));
+    await tester.tap(find.text('Close'));
     await tester.pumpAndSettle();
-    expect(find.text('CLOSE'), findsNothing);
+    expect(find.text('Close'), findsNothing);
   });
 }

--- a/examples/api/test/material/menu_anchor/menu_anchor.1_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_anchor.1_test.dart
@@ -21,14 +21,14 @@ void main() {
     await tester.sendKeyDownEvent(LogicalKeyboardKey.controlRight);
     await tester.tapAt(const Offset(100, 200));
     await tester.pump();
-    expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(100.0, 200.0, 388.0, 360.0)));
+    expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(100.0, 200.0, 433.0, 360.0)));
 
     // Make sure tapping in a different place causes the menu to move.
     await tester.tapAt(const Offset(200, 100));
     await tester.pump();
     await tester.sendKeyUpEvent(LogicalKeyboardKey.controlRight);
 
-    expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(200.0, 100.0, 488.0, 260.0)));
+    expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(200.0, 100.0, 533.0, 260.0)));
 
     expect(find.text(example.MenuEntry.about.label), findsOneWidget);
     expect(find.text(example.MenuEntry.showMessage.label), findsOneWidget);


### PR DESCRIPTION
Migrated the examples to M3. In a few cases that required changing the expected bounds for menu items a little because the default font is a little bigger. Most of the menu examples include an about box and in M3 the "CLOSE" button has become "Close" - so that required a small change in a test.