### PR TITLE
Updated TabBar and ToggleButtons examples

### DIFF
--- a/examples/api/lib/material/toggle_buttons/toggle_buttons.0.dart
+++ b/examples/api/lib/material/toggle_buttons/toggle_buttons.0.dart
@@ -23,8 +23,9 @@ class ToggleButtonsExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: ToggleButtonsSample(title: 'ToggleButtons Sample'),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const ToggleButtonsSample(title: 'ToggleButtons Sample'),
     );
   }
 }

--- a/examples/api/test/material/tabs/tab_bar.2_test.dart
+++ b/examples/api/test/material/tabs/tab_bar.2_test.dart
@@ -24,45 +24,40 @@ void main() {
     final TabBar secondaryTabBar = tester.widget<TabBar>(find.byType(TabBar).first);
     expect(secondaryTabBar.tabs.length, 2);
 
-    final Finder primaryTab1 = find.widgetWithText(Tab, primaryTabLabel1);
-    final Finder primaryTab2 = find.widgetWithText(Tab, primaryTabLabel2);
-    final Finder primaryTab3 = find.widgetWithText(Tab, primaryTabLabel3);
-    final Finder secondaryTab2 = find.widgetWithText(Tab, secondaryTabLabel2);
-
     String tabBarViewText = '$primaryTabLabel2: $secondaryTabLabel1 tab';
     expect(find.text(tabBarViewText), findsOneWidget);
 
-    await tester.tap(primaryTab1);
+    await tester.tap(find.text(primaryTabLabel1));
     await tester.pumpAndSettle();
 
     tabBarViewText = '$primaryTabLabel1: $secondaryTabLabel1 tab';
     expect(find.text(tabBarViewText), findsOneWidget);
 
-    await tester.tap(secondaryTab2);
+    await tester.tap(find.text(secondaryTabLabel2));
     await tester.pumpAndSettle();
 
     tabBarViewText = '$primaryTabLabel1: $secondaryTabLabel2 tab';
     expect(find.text(tabBarViewText), findsOneWidget);
 
-    await tester.tap(primaryTab2);
+    await tester.tap(find.text(primaryTabLabel2));
     await tester.pumpAndSettle();
 
     tabBarViewText = '$primaryTabLabel2: $secondaryTabLabel1 tab';
     expect(find.text(tabBarViewText), findsOneWidget);
 
-    await tester.tap(secondaryTab2);
+    await tester.tap(find.text(secondaryTabLabel2));
     await tester.pumpAndSettle();
 
     tabBarViewText = '$primaryTabLabel2: $secondaryTabLabel2 tab';
     expect(find.text(tabBarViewText), findsOneWidget);
 
-    await tester.tap(primaryTab3);
+    await tester.tap(find.text(primaryTabLabel3));
     await tester.pumpAndSettle();
 
     tabBarViewText = '$primaryTabLabel3: $secondaryTabLabel1 tab';
     expect(find.text(tabBarViewText), findsOneWidget);
 
-    await tester.tap(secondaryTab2);
+    await tester.tap(find.text(secondaryTabLabel2));
     await tester.pumpAndSettle();
 
     tabBarViewText = '$primaryTabLabel3: $secondaryTabLabel2 tab';

--- a/examples/api/test/material/toggle_buttons/toggle_buttons.0_test.dart
+++ b/examples/api/test/material/toggle_buttons/toggle_buttons.0_test.dart
@@ -24,10 +24,13 @@ void main() {
     TextButton secondButton = findButton('Banana');
     TextButton thirdButton = findButton('Orange');
 
+    const Color selectedColor = Color(0xffef9a9a);
+    const Color unselectedColor = Color(0x00fffbfe);
+
     /// First button is selected.
-    expect(firstButton.style!.backgroundColor!.resolve(enabled), const Color(0xffef9a9a));
-    expect(secondButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
-    expect(thirdButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
+    expect(firstButton.style!.backgroundColor!.resolve(enabled), selectedColor);
+    expect(secondButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
+    expect(thirdButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
 
     /// Tap on second button.
     await tester.tap(find.widgetWithText(TextButton, 'Banana'));
@@ -38,9 +41,9 @@ void main() {
     thirdButton = findButton('Orange');
 
     /// Only second button is selected.
-    expect(firstButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
-    expect(secondButton.style!.backgroundColor!.resolve(enabled), const Color(0xffef9a9a));
-    expect(thirdButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
+    expect(firstButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
+    expect(secondButton.style!.backgroundColor!.resolve(enabled), selectedColor);
+    expect(thirdButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
   });
 
   testWidgets('Multi-select ToggleButtons', (WidgetTester tester) async {
@@ -59,10 +62,13 @@ void main() {
     TextButton secondButton = findButton('Potatoes');
     TextButton thirdButton = findButton('Carrots');
 
+    const Color selectedColor = Color(0xffa5d6a7);
+    const Color unselectedColor = Color(0x00fffbfe);
+
     /// Second button is selected.
-    expect(firstButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
-    expect(secondButton.style!.backgroundColor!.resolve(enabled), const Color(0xffa5d6a7));
-    expect(thirdButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
+    expect(firstButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
+    expect(secondButton.style!.backgroundColor!.resolve(enabled), selectedColor);
+    expect(thirdButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
 
     /// Tap on other two buttons.
     await tester.tap(find.widgetWithText(TextButton, 'Tomatoes'));
@@ -74,9 +80,9 @@ void main() {
     thirdButton = findButton('Carrots');
 
     /// All buttons are selected.
-    expect(firstButton.style!.backgroundColor!.resolve(enabled), const Color(0xffa5d6a7));
-    expect(secondButton.style!.backgroundColor!.resolve(enabled), const Color(0xffa5d6a7));
-    expect(thirdButton.style!.backgroundColor!.resolve(enabled), const Color(0xffa5d6a7));
+    expect(firstButton.style!.backgroundColor!.resolve(enabled), selectedColor);
+    expect(secondButton.style!.backgroundColor!.resolve(enabled), selectedColor);
+    expect(thirdButton.style!.backgroundColor!.resolve(enabled), selectedColor);
   });
 
   testWidgets('Icon-only ToggleButtons', (WidgetTester tester) async {
@@ -95,10 +101,14 @@ void main() {
     TextButton secondButton = findButton(Icons.cloud);
     TextButton thirdButton = findButton(Icons.ac_unit);
 
+    const Color selectedColor =  Color(0xff90caf9);
+    const Color unselectedColor = Color(0x00fffbfe);
+
+
     /// Third button is selected.
-    expect(firstButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
-    expect(secondButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
-    expect(thirdButton.style!.backgroundColor!.resolve(enabled), const Color(0xff90caf9));
+    expect(firstButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
+    expect(secondButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
+    expect(thirdButton.style!.backgroundColor!.resolve(enabled), selectedColor);
 
     /// Tap on the first button.
     await tester.tap(find.widgetWithIcon(TextButton, Icons.sunny));
@@ -109,9 +119,9 @@ void main() {
     thirdButton = findButton(Icons.ac_unit);
 
     /// First button os selected.
-    expect(firstButton.style!.backgroundColor!.resolve(enabled), const Color(0xff90caf9));
-    expect(secondButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
-    expect(thirdButton.style!.backgroundColor!.resolve(enabled), const Color(0x00ffffff));
+    expect(firstButton.style!.backgroundColor!.resolve(enabled), selectedColor);
+    expect(secondButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
+    expect(thirdButton.style!.backgroundColor!.resolve(enabled), unselectedColor);
   });
 }
 


### PR DESCRIPTION
Updated the ToggleButtons example and test to M3.

Updated the nested tabs test to avoid warnings like:
```
Warning: A call to tap() with finder "exactly one widget with type "Tab" which is an ancestor of text "Explore": Tab(text: "Explore", icon: Icon)" derived an Offset (Offset(666.7, 92.0)) that would not hit test on the specified widget.
```
