### PR TITLE
Tiny improvement on performance when ui.Image and ui.Picture is created/disposed

### DIFF
--- a/packages/flutter/lib/src/foundation/memory_allocations.dart
+++ b/packages/flutter/lib/src/foundation/memory_allocations.dart
@@ -309,30 +309,30 @@ class MemoryAllocations {
   }
 
   void _imageOnCreate(ui.Image image) {
-    dispatchObjectEvent(ObjectCreated(
+    dispatchObjectCreated(
       library: _dartUiLibrary,
       className: '${ui.Image}',
       object: image,
-    ));
+    );
   }
 
   void _pictureOnCreate(ui.Picture picture) {
-    dispatchObjectEvent(ObjectCreated(
+    dispatchObjectCreated(
       library: _dartUiLibrary,
       className: '${ui.Picture}',
       object: picture,
-    ));
+    );
   }
 
   void _imageOnDispose(ui.Image image) {
-    dispatchObjectEvent(ObjectDisposed(
+    dispatchObjectDisposed(
       object: image,
-    ));
+    );
   }
 
   void _pictureOnDispose(ui.Picture picture) {
-    dispatchObjectEvent(ObjectDisposed(
+    dispatchObjectDisposed(
       object: picture,
-    ));
+    );
   }
 }


### PR DESCRIPTION
When learning the `MemoryAllocations` by glancing through the source code, I realize `dispatchObjectCreated` says `This method is more efficient than [dispatchObjectEvent] if the event object is not created yet`, and the code agree with that because we can save one object creation and a few lines of code if there are no listeners. On the other hand, _imageOnCreate and its friends uses the aforementioned slower `dispatchObjectEvent`. Thus this super tiny PR simply improves this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
