### PR TITLE
Do not try to load main/default asset image if only higher-res variants exist

### DIFF
--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -327,12 +327,8 @@ class AssetImage extends AssetBundleImageProvider {
   }
 
   AssetMetadata _chooseVariant(String mainAssetKey, ImageConfiguration config, Iterable<AssetMetadata>? candidateVariants) {
-    if (candidateVariants == null) {
+    if (candidateVariants == null || candidateVariants.isEmpty || config.devicePixelRatio == null) {
       return AssetMetadata(key: mainAssetKey, targetDevicePixelRatio: null, main: true);
-    }
-
-    if (config.devicePixelRatio == null) {
-      return candidateVariants.firstWhere((AssetMetadata variant) => variant.main);
     }
 
     final SplayTreeMap<double, AssetMetadata> candidatesByDevicePixelRatio =

--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -33,8 +33,8 @@ abstract class AssetManifest {
   /// Retrieves metadata about an asset and its variants. Returns null if the
   /// key was not found in the asset manifest.
   ///
-  /// This method considers a main asset to be a variant of itself and
-  /// includes it in the returned list.
+  /// This method considers a main asset to be a variant of itself. The returned
+  /// list will include it if it exists.
   List<AssetMetadata>? getAssetVariants(String key);
 }
 
@@ -83,12 +83,7 @@ class _AssetManifestBin implements AssetManifest {
       _data.remove(key);
     }
 
-    final AssetMetadata mainAsset = AssetMetadata(key: key,
-      targetDevicePixelRatio: null,
-      main: true
-    );
-
-    return <AssetMetadata>[mainAsset, ..._typeCastedData[key]!];
+    return _typeCastedData[key]!;
   }
 
   @override

--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -73,11 +73,15 @@ class _AssetManifestBin implements AssetManifest {
       }
       _typeCastedData[key] = ((_data[key] ?? <Object?>[]) as Iterable<Object?>)
         .cast<Map<Object?, Object?>>()
-        .map((Map<Object?, Object?> data) => AssetMetadata(
+        .map((Map<Object?, Object?> data) {
+          final String asset = data['asset']! as String;
+          final Object? dpr = data['dpr'];
+          return AssetMetadata(
             key: data['asset']! as String,
-            targetDevicePixelRatio: data['dpr']! as double,
-            main: false,
-        ))
+            targetDevicePixelRatio: dpr == null ? null : dpr as double,
+            main: key == asset,
+          );
+        })
         .toList();
 
       _data.remove(key);

--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -78,7 +78,7 @@ class _AssetManifestBin implements AssetManifest {
           final Object? dpr = data['dpr'];
           return AssetMetadata(
             key: data['asset']! as String,
-            targetDevicePixelRatio: dpr == null ? null : dpr as double,
+            targetDevicePixelRatio: dpr as double?,
             main: key == asset,
           );
         })

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -43,8 +43,6 @@ void main() {
       final Map<String, List<Map<Object?, Object?>>> assetBundleMap =
         <String, List<Map<Object?, Object?>>>{};
 
-      assetBundleMap[mainAssetPath] = <Map<Object?, Object?>>[];
-
       final AssetImage assetImage = AssetImage(
         mainAssetPath,
         bundle: TestAssetBundle(assetBundleMap),

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -160,15 +160,17 @@ void main() {
       double chosenAssetRatio,
       String expectedAssetPath,
     ) {
-      final Map<String, List<Map<Object?, Object?>>> assetBundleMap =
-        <String, List<Map<Object?, Object?>>>{};
-
-      final Map<Object?, Object?> mainAssetVariantManifestEntry = <Object?, Object?>{};
-      mainAssetVariantManifestEntry['asset'] = variantPath;
-      mainAssetVariantManifestEntry['dpr'] = 3.0;
-      assetBundleMap[mainAssetPath] = <Map<Object?, Object?>>[mainAssetVariantManifestEntry];
-
-      final TestAssetBundle testAssetBundle = TestAssetBundle(assetBundleMap);
+      const Map<String, List<Map<Object?, Object?>>> assetManifest =
+          <String, List<Map<Object?, Object?>>>{
+        'assets/normalFolder/normalFile.png': <Map<Object?, Object?>>[
+          <Object?, Object?>{'asset': 'assets/normalFolder/normalFile.png'},
+          <Object?, Object?>{
+            'asset': 'assets/normalFolder/3.0x/normalFile.png',
+            'dpr': 3.0
+          },
+        ]
+      };
+      final TestAssetBundle testAssetBundle = TestAssetBundle(assetManifest);
 
       final AssetImage assetImage = AssetImage(
         mainAssetPath,

--- a/packages/flutter/test/services/asset_manifest_test.dart
+++ b/packages/flutter/test/services/asset_manifest_test.dart
@@ -12,11 +12,18 @@ class TestAssetBundle extends AssetBundle {
       final Map<String, List<Object>> binManifestData = <String, List<Object>>{
         'assets/foo.png': <Object>[
           <String, Object>{
+            'asset': 'assets/foo.png',
+          },
+          <String, Object>{
             'asset': 'assets/2x/foo.png',
             'dpr': 2.0
-          }
+          },
         ],
-        'assets/bar.png': <Object>[],
+        'assets/bar.png': <Object>[
+          <String, Object>{
+            'asset': 'assets/bar.png',
+          },
+        ],
       };
 
       final ByteData data = const StandardMessageCodec().encodeMessage(binManifestData)!;

--- a/packages/flutter/test/services/asset_manifest_test.dart
+++ b/packages/flutter/test/services/asset_manifest_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -39,7 +41,6 @@ class TestAssetBundle extends AssetBundle {
   }
 }
 
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -71,4 +72,30 @@ void main() {
     final AssetManifest manifest = await AssetManifest.loadFromAssetBundle(TestAssetBundle());
     expect(manifest.getAssetVariants('invalid asset key'), isNull);
   });
+}
+
+String createAssetManifestJson(Map<String, List<AssetMetadata>> manifest) {
+  final Map<Object, Object> jsonObject = manifest.map(
+    (String key, List<AssetMetadata> value) {
+      final List<String> variants = value.map((AssetMetadata e) => e.key).toList();
+      return MapEntry<String, List<String>>(key, variants);
+    }
+  );
+
+  return json.encode(jsonObject);
+}
+
+ByteData createAssetManifestSmcBin(Map<String, List<AssetMetadata>> manifest) {
+  final Map<Object, Object> smcObject  = manifest.map(
+    (String key, List<AssetMetadata> value) {
+      final List<Object> variants = value.map((AssetMetadata variant) => <String, Object?>{
+        'asset': variant.key,
+        'dpr': variant.targetDevicePixelRatio,
+      }).toList();
+
+      return MapEntry<String, List<Object>>(key, variants);
+    }
+  );
+
+  return const StandardMessageCodec().encodeMessage(smcObject)!;
 }

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -19,16 +19,15 @@ import '../image_data.dart';
 ByteData testByteData(double scale) => ByteData(8)..setFloat64(0, scale);
 double scaleOf(ByteData data) => data.getFloat64(0);
 
-final Map<Object?, Object?> testManifest = json.decode('''
-{
-  "assets/image.png" : [
-    {"asset": "assets/1.5x/image.png", "dpr": 1.5},
-    {"asset": "assets/2.0x/image.png", "dpr": 2.0},
-    {"asset": "assets/3.0x/image.png", "dpr": 3.0},
-    {"asset": "assets/4.0x/image.png", "dpr": 4.0}
-  ]
-}
-''') as Map<Object?, Object?>;
+final Map<Object?, Object?> testManifest = <Object?, Object?>{
+  'assets/image.png' : <Map<String, Object>>[
+    <String, String>{'asset': 'assets/image.png'},
+    <String, Object>{'asset': 'assets/1.5x/image.png', 'dpr': 1.5},
+    <String, Object>{'asset': 'assets/2.0x/image.png', 'dpr': 2.0},
+    <String, Object>{'asset': 'assets/3.0x/image.png', 'dpr': 3.0},
+    <String, Object>{'asset': 'assets/4.0x/image.png', 'dpr': 4.0}
+  ],
+};
 
 class TestAssetBundle extends CachingAssetBundle {
   TestAssetBundle({ required Map<Object?, Object?> manifest }) {
@@ -303,13 +302,12 @@ void main() {
   // if higher resolution assets are not available we will pick the best
   // available.
   testWidgets('Low-resolution assets', (WidgetTester tester) async {
-    final Map<Object?, Object?> manifest = json.decode('''
-      {
-        "assets/image.png" : [
-          {"asset": "assets/1.5x/image.png", "dpr": 1.5}
-        ]
-      }
-    ''') as Map<Object?, Object?>;
+    const Map<Object?, Object?> manifest = <Object?, Object?>{
+      'assets/image.png': <Map<String, Object>>[
+        <String, Object>{'asset': 'assets/image.png'},
+        <String, Object>{'asset': 'assets/1.5x/image.png', 'dpr': 1.5},
+      ],
+    };
     final AssetBundle bundle = TestAssetBundle(manifest: manifest);
 
     Future<void> testRatio({required double ratio, required double expectedScale}) async {

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -166,7 +166,6 @@ class ManifestAssetBundle implements AssetBundle {
   DateTime? _lastBuildTimestamp;
 
   // We assume the main asset is designed for a device pixel ratio of 1.0.
-  static const double _defaultResolution = 1.0;
   static const String _kAssetManifestJsonFilename = 'AssetManifest.json';
   static const String _kAssetManifestBinFilename = 'AssetManifest.smcbin';
 
@@ -688,7 +687,7 @@ class ManifestAssetBundle implements AssetBundle {
   DevFSByteContent _createAssetManifestBinary(
     Map<String, List<String>> assetManifest
   ) {
-    double parseScale(String key) {
+    double? parseScale(String key) {
       final Uri assetUri = Uri.parse(key);
       String directoryPath = '';
       if (assetUri.pathSegments.length > 1) {
@@ -699,7 +698,8 @@ class ManifestAssetBundle implements AssetBundle {
       if (match != null && match.groupCount > 0) {
         return double.parse(match.group(1)!);
       }
-      return _defaultResolution;
+
+      return null;
     }
 
     final Map<String, dynamic> result = <String, dynamic>{};
@@ -708,15 +708,12 @@ class ManifestAssetBundle implements AssetBundle {
       final List<dynamic> resultVariants = <dynamic>[];
       final List<String> entries = (manifestEntry.value as List<dynamic>).cast<String>();
       for (final String variant in entries) {
-        if (variant == manifestEntry.key) {
-          // With the newer binary format, don't include the main asset in it's
-          // list of variants. This reduces parsing time at runtime.
-          continue;
-        }
         final Map<String, dynamic> resultVariant = <String, dynamic>{};
-        final double variantDevicePixelRatio = parseScale(variant);
+        final double? variantDevicePixelRatio = parseScale(variant);
         resultVariant['asset'] = variant;
-        resultVariant['dpr'] = variantDevicePixelRatio;
+        if (variantDevicePixelRatio != null) {
+          resultVariant['dpr'] = variantDevicePixelRatio;
+        }
         resultVariants.add(resultVariant);
       }
       result[manifestEntry.key] = resultVariants;

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -16,7 +16,6 @@ import 'package:standard_message_codec/standard_message_codec.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import 'asset_bundle_variant_test.dart';
 
 void main() {
   String fixPath(String path) {
@@ -64,6 +63,14 @@ $assetsSection
       ..writeAsStringSync(packages);
   }
 
+  Map<Object, Object> assetManifestBinToJson(Map<Object, Object> manifest) {
+    List<Object> convertList(List<Object> variants) => variants
+      .map((Object variant) => (variant as Map<Object?, Object?>)['asset']!)
+      .toList();
+
+    return manifest.map((Object key, Object value) => MapEntry<Object, Object>(key, convertList(value as List<Object>)));
+  }
+
   Future<void> buildAndVerifyAssets(
     List<String> assets,
     List<String> packages,
@@ -85,24 +92,23 @@ $assetsSection
       }
     }
 
-    final Map<Object?, Object?> assetManifest =
-      const StandardMessageCodec().decodeMessage(
-        ByteData.sublistView(
-          Uint8List.fromList(
-            await bundle.entries['AssetManifest.smcbin']!.contentsAsBytes()
-          )
+    final Map<Object?, Object?> assetManifest = const StandardMessageCodec().decodeMessage(
+      ByteData.sublistView(
+        Uint8List.fromList(
+          await bundle.entries['AssetManifest.smcbin']!.contentsAsBytes()
         )
-      ) as Map<Object?, Object?>;
+      )
+    ) as Map<Object?, Object?>;
 
-      expect(
-        json.decode(utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes())),
-        assetManifestBinToJson(expectedAssetManifest),
-      );
-      expect(
-        assetManifest,
-        expectedAssetManifest
-      );
-    }
+    expect(
+      json.decode(utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes())),
+      assetManifestBinToJson(expectedAssetManifest),
+    );
+    expect(
+      assetManifest,
+      expectedAssetManifest
+    );
+  }
 
   void writeAssets(String path, List<String> assets) {
     for (final String asset in assets) {

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -122,7 +122,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       };
 
       expect(smcBinManifest, equals(expectedAssetManifest));
-      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(jsonManifest, equals(_assetManifestBinToJson(expectedAssetManifest)));
     });
 
     testWithoutContext('Asset directories have their subdirectories searched for asset variants', () async {
@@ -178,7 +178,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
           },
         ],
       };
-      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(jsonManifest, equals(_assetManifestBinToJson(expectedAssetManifest)));
       expect(smcBinManifest, equals(expectedAssetManifest));
     });
 
@@ -225,7 +225,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         ],
       };
 
-      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(jsonManifest, equals(_assetManifestBinToJson(expectedAssetManifest)));
       expect(smcBinManifest, equals(expectedAssetManifest));
     });
 
@@ -266,7 +266,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
 
-      expect(jsonManifest, equals(assetManifestBinToJson(expectedManifest)));
+      expect(jsonManifest, equals(_assetManifestBinToJson(expectedManifest)));
       expect(smcBinManifest, equals(expectedManifest));
     });
   });
@@ -349,13 +349,13 @@ flutter:
       final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
 
-      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(jsonManifest, equals(_assetManifestBinToJson(expectedAssetManifest)));
       expect(smcBinManifest, equals(expectedAssetManifest));
     });
   });
 }
 
-Map<Object, Object> assetManifestBinToJson(Map<Object, Object> manifest) {
+Map<Object, Object> _assetManifestBinToJson(Map<Object, Object> manifest) {
   List<Object> convertList(List<Object> variants) => variants
     .map((Object variant) => (variant as Map<Object?, Object?>)['asset']!)
     .toList();

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -96,7 +96,7 @@ flutter:
       expect(manifest[imageNonVariant], equals(<String>[imageNonVariant]));
     });
 
-    testWithoutContext('Asset directories are recursively searched for assets', () async {
+    testWithoutContext('Asset directories have their subdirectories searched for asset variants', () async {
       const String topLevelImage = 'assets/image.jpg';
       const String secondLevelImage = 'assets/folder/secondLevel.jpg';
       const String secondLevel2xVariant = 'assets/folder/2x/secondLevel.jpg';

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -102,32 +102,27 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       );
 
       final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
-
-      expect(jsonManifest, hasLength(2));
-      expect(jsonManifest[image], equals(<String>[image, image2xVariant]));
-      expect(jsonManifest[imageNonVariant], equals(<String>[imageNonVariant]));
-
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
 
-      expect(smcBinManifest, equals(
-          <String, List<Map<String, Object>>>{
-            image: <Map<String, Object>>[
-              <String, String>{
-                'asset': image,
-              },
-              <String, Object>{
-                'asset': image2xVariant,
-                'dpr': 2.0,
-              }
-            ],
-            imageNonVariant: <Map<String, String>>[
-              <String, String>{
-                'asset': imageNonVariant,
-              }
-            ],
+      final Map<String, List<Map<String, Object>>> expectedAssetManifest = <String, List<Map<String, Object>>>{
+        image: <Map<String, Object>>[
+          <String, String>{
+            'asset': image,
+          },
+          <String, Object>{
+            'asset': image2xVariant,
+            'dpr': 2.0,
           }
-        )
-      );
+        ],
+        imageNonVariant: <Map<String, String>>[
+          <String, String>{
+            'asset': imageNonVariant,
+          }
+        ],
+      };
+
+      expect(smcBinManifest, equals(expectedAssetManifest));
+      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
     });
 
     testWithoutContext('Asset directories have their subdirectories searched for asset variants', () async {
@@ -160,32 +155,31 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
-      final Map<String, List<String>> manifest = await extractAssetManifestJsonFromBundle(bundle);
-      expect(manifest, hasLength(2));
-      expect(manifest[topLevelImage], equals(<String>[topLevelImage]));
-      expect(manifest[secondLevelImage], equals(<String>[secondLevelImage, secondLevel2xVariant]));
+      final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
+      expect(jsonManifest, hasLength(2));
+      expect(jsonManifest[topLevelImage], equals(<String>[topLevelImage]));
+      expect(jsonManifest[secondLevelImage], equals(<String>[secondLevelImage, secondLevel2xVariant]));
 
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
 
-      expect(smcBinManifest, equals(
-          <String, List<Map<String, Object>>>{
-            topLevelImage: <Map<String, Object>>[
-              <String, String>{
-                'asset': topLevelImage,
-              },
-            ],
-            secondLevelImage: <Map<String, Object>>[
-              <String, String>{
-                'asset': secondLevelImage,
-              },
-              <String, Object>{
-                'asset': secondLevel2xVariant,
-                'dpr': 2.0,
-              },
-            ],
-          }
-        )
-      );
+      final Map<String, List<Map<String, Object>>> expectedAssetManifest = <String, List<Map<String, Object>>>{
+        topLevelImage: <Map<String, Object>>[
+          <String, String>{
+            'asset': topLevelImage,
+          },
+        ],
+        secondLevelImage: <Map<String, Object>>[
+          <String, String>{
+            'asset': secondLevelImage,
+          },
+          <String, Object>{
+            'asset': secondLevel2xVariant,
+            'dpr': 2.0,
+          },
+        ],
+      };
+      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(smcBinManifest, equals(expectedAssetManifest));
     });
 
     testWithoutContext('Asset paths should never be URI-encoded', () async {
@@ -216,26 +210,23 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
-      final Map<String, List<String>> manifest = await extractAssetManifestJsonFromBundle(bundle);
-      expect(manifest, hasLength(1));
-      expect(manifest[image], equals(<String>[image, imageVariant]));
-
+      final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
 
-      expect(smcBinManifest, equals(
-          <String, List<Map<String, Object>>>{
-            image: <Map<String, Object>>[
-              <String, Object>{
-                'asset': image,
-              },
-              <String, Object>{
-                'asset': imageVariant,
-                'dpr': 3.0
-              },
-            ],
-          }
-        )
-      );
+      final Map<String, List<Map<String, Object>>> expectedAssetManifest = <String, List<Map<String, Object>>>{
+        image: <Map<String, Object>>[
+          <String, Object>{
+            'asset': image,
+          },
+          <String, Object>{
+            'asset': imageVariant,
+            'dpr': 3.0
+          },
+        ],
+      };
+
+      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(smcBinManifest, equals(expectedAssetManifest));
     });
 
     testWithoutContext('Main assets are not included if the file does not exist', () async {
@@ -264,22 +255,19 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
-      final Map<String, List<String>> manifest = await extractAssetManifestJsonFromBundle(bundle);
-      expect(manifest, hasLength(1));
-      expect(manifest['assets/image.png'], equals(<String>[imageVariant]));
-
+      final Map<String, List<Map<String, Object>>> expectedManifest = <String, List<Map<String, Object>>>{
+        'assets/image.png': <Map<String, Object>>[
+          <String, Object>{
+            'asset': imageVariant,
+            'dpr': 2.0
+          },
+        ],
+      };
+      final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
-      expect(smcBinManifest, equals(
-          <String, List<Map<String, Object>>>{
-            'assets/image.png': <Map<String, Object>>[
-              <String, Object>{
-                'asset': imageVariant,
-                'dpr': 2.0
-              },
-            ],
-          }
-        )
-      );
+
+      expect(jsonManifest, equals(assetManifestBinToJson(expectedManifest)));
+      expect(smcBinManifest, equals(expectedManifest));
     });
   });
 
@@ -337,36 +325,40 @@ flutter:
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
-      final Map<String, List<String>> manifest = await extractAssetManifestJsonFromBundle(bundle);
+      final Map<String, List<Map<String, Object>>> expectedAssetManifest = <String, List<Map<String, Object>>>{
+        'assets/foo.jpg': <Map<String, Object>>[
+          <String, Object>{
+            'asset': 'assets/foo.jpg',
+          },
+          <String, Object>{
+            'asset': 'assets/2x/foo.jpg',
+            'dpr': 2.0,
+          },
+        ],
+        'assets/somewhereElse/bar.jpg': <Map<String, Object>>[
+          <String, Object>{
+            'asset': 'assets/somewhereElse/bar.jpg',
+          },
+          <String, Object>{
+            'asset': 'assets/somewhereElse/2x/bar.jpg',
+            'dpr': 2.0,
+          },
+        ],
+      };
 
-      expect(manifest, hasLength(2));
-      expect(manifest['assets/foo.jpg'], equals(<String>['assets/foo.jpg', 'assets/2x/foo.jpg']));
-      expect(manifest['assets/somewhereElse/bar.jpg'], equals(<String>['assets/somewhereElse/bar.jpg', 'assets/somewhereElse/2x/bar.jpg']));
-
+      final Map<String, List<String>> jsonManifest = await extractAssetManifestJsonFromBundle(bundle);
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(bundle);
-      expect(smcBinManifest, equals(
-          <String, List<Map<String, Object>>>{
-            'assets/foo.jpg': <Map<String, Object>>[
-              <String, Object>{
-                'asset': 'assets/foo.jpg',
-              },
-              <String, Object>{
-                'asset': 'assets/2x/foo.jpg',
-                'dpr': 2.0,
-              },
-            ],
-            'assets/somewhereElse/bar.jpg': <Map<String, Object>>[
-              <String, Object>{
-                'asset': 'assets/somewhereElse/bar.jpg',
-              },
-              <String, Object>{
-                'asset': 'assets/somewhereElse/2x/bar.jpg',
-                'dpr': 2.0,
-              },
-            ],
-          }
-        )
-      );
+
+      expect(jsonManifest, equals(assetManifestBinToJson(expectedAssetManifest)));
+      expect(smcBinManifest, equals(expectedAssetManifest));
     });
   });
+}
+
+Map<Object, Object> assetManifestBinToJson(Map<Object, Object> manifest) {
+  List<Object> convertList(List<Object> variants) => variants
+    .map((Object variant) => (variant as Map<Object?, Object?>)['asset']!)
+    .toList();
+
+  return manifest.map((Object key, Object value) => MapEntry<Object, Object>(key, convertList(value as List<Object>)));
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/127090.

https://github.com/flutter/flutter/pull/122505 did a few things to speed up the first asset load that a flutter app performs. One of those things was to not include the main asset in its own list of variants in the asset manifest. The idea was that we know that the main asset always exists, so including it in its list of variants is a waste of storage space and loading time (even if the cost was tiny).

However, the assumption that the main asset always exists is wrong. From [Declaring resolution-aware image assets](https://docs.flutter.dev/ui/assets-and-images#resolution-aware), which predates https://github.com/flutter/flutter/pull/122505:

> Each entry in the asset section of the pubspec.yaml should correspond to a real file, with the exception of the main asset entry. If the main asset entry doesn’t correspond to a real file, then the asset with the lowest resolution is used as the fallback for devices with device pixel ratios below that resolution. The entry should still be included in the pubspec.yaml manifest, however.

For example, it's valid to declare `assets/image.png` as an asset even if only `assets/3x/image.png` exists on disk.

This fix restores older behavior of including a main asset as a variant of itself in the manifest if it exists.

This fix also includes a non-user-visible behavior change:
* `"dpr"` is no longer a required field in the asset manifest's underlying structure. For the main asset entry, we do not include `"dpr"`. It makes less sense for the tool to decide what the default target dpr for an image should be. This should be left to the framework.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
