### PR TITLE
Use Material3 in the 2D viewport tests

### DIFF
--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -283,6 +283,7 @@ Widget simpleListTest({
   Clip? clipBehavior,
 }) {
   return MaterialApp(
+    theme: ThemeData(useMaterial3: true),
     home: Scaffold(
       body: SimpleListTableView(
         mainAxis: mainAxis,

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -192,7 +192,7 @@ void main() {
 
         switch (defaultTargetPlatform) {
           case TargetPlatform.fuchsia:
-            // Includes a scrollbar and and overscroll indicator
+            // Includes a scrollbar and and overscroll glow
             expect(find.byType(RepaintBoundary), findsNWidgets(6));
 
           case TargetPlatform.android:

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -161,10 +161,18 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
+        // In the tests below the number of RepaintBoundary depends on:
+        // TwoDimensionalChildListDelegate - builds 1 unless addRepaintBoundaries is false
+        // ModalRoute - builds 2
+        // GlowingOverscrollIndicator - builds 2
+        // RawScrollbar - builds 2
+
         switch (defaultTargetPlatform) {
-          case TargetPlatform.android:
           case TargetPlatform.fuchsia:
+            // Includes a scrollbar and an overscroll glow
             expect(find.byType(RepaintBoundary), findsNWidgets(7));
+
+          case TargetPlatform.android:
           case TargetPlatform.iOS:
           case TargetPlatform.linux:
           case TargetPlatform.macOS:
@@ -183,9 +191,11 @@ void main() {
         await tester.pumpAndSettle();
 
         switch (defaultTargetPlatform) {
-          case TargetPlatform.android:
           case TargetPlatform.fuchsia:
+            // Includes a scrollbar and and overscroll indicator
             expect(find.byType(RepaintBoundary), findsNWidgets(6));
+
+          case TargetPlatform.android:
           case TargetPlatform.iOS:
           case TargetPlatform.linux:
           case TargetPlatform.macOS:

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -161,7 +161,7 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
-        // In the tests below the number of RepaintBoundary depends on:
+        // In the tests below the number of RepaintBoundary widgets depends on:
         // TwoDimensionalChildListDelegate - builds 1 unless addRepaintBoundaries is false
         // ModalRoute - builds 2
         // GlowingOverscrollIndicator - builds 2

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -162,14 +162,18 @@ void main() {
         await tester.pumpAndSettle();
 
         // In the tests below the number of RepaintBoundary widgets depends on:
-        // TwoDimensionalChildListDelegate - builds 1 unless addRepaintBoundaries is false
         // ModalRoute - builds 2
         // GlowingOverscrollIndicator - builds 2
-        // RawScrollbar - builds 2
+        // TwoDimensionalChildListDelegate - builds 1 unless addRepaintBoundaries is false
+
+        void expectModalRoute() {
+          expect(ModalRoute.of(tester.element(find.byType(SimpleListTableViewport))), isA<MaterialPageRoute<void>>());
+        }
 
         switch (defaultTargetPlatform) {
           case TargetPlatform.fuchsia:
-            // Includes a scrollbar and an overscroll glow
+            expectModalRoute();
+            expect(find.byType(GlowingOverscrollIndicator), findsNWidgets(2));
             expect(find.byType(RepaintBoundary), findsNWidgets(7));
 
           case TargetPlatform.android:
@@ -177,6 +181,7 @@ void main() {
           case TargetPlatform.linux:
           case TargetPlatform.macOS:
           case TargetPlatform.windows:
+            expectModalRoute();
             expect(find.byType(RepaintBoundary), findsNWidgets(3));
         }
 
@@ -192,7 +197,8 @@ void main() {
 
         switch (defaultTargetPlatform) {
           case TargetPlatform.fuchsia:
-            // Includes a scrollbar and and overscroll glow
+            expectModalRoute();
+            expect(find.byType(GlowingOverscrollIndicator), findsNWidgets(2));
             expect(find.byType(RepaintBoundary), findsNWidgets(6));
 
           case TargetPlatform.android:
@@ -200,6 +206,7 @@ void main() {
           case TargetPlatform.linux:
           case TargetPlatform.macOS:
           case TargetPlatform.windows:
+            expectModalRoute();
             expect(find.byType(RepaintBoundary), findsNWidgets(2));
         }
       }, variant: TargetPlatformVariant.all());


### PR DESCRIPTION
Set `useMaterial3: true' for the MaterialApp used in the 2D tests to enable making  `useMaterial3: true' the default for ThemeData in a future PR.
