### PR TITLE
Selection area right click behavior should match native

### DIFF
--- a/examples/api/lib/material/selectable_region/selectable_region.0.dart
+++ b/examples/api/lib/material/selectable_region/selectable_region.0.dart
@@ -157,6 +157,7 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
         hasContent: true,
         startSelectionPoint: isReversed ? secondSelectionPoint : firstSelectionPoint,
         endSelectionPoint: isReversed ? firstSelectionPoint : secondSelectionPoint,
+        selectionRects: <Rect>[selectionRect],
       );
     }
   }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1335,6 +1335,14 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
       : paragraph._getOffsetForPosition(TextPosition(offset: selectionEnd));
     final bool flipHandles = isReversed != (TextDirection.rtl == paragraph.textDirection);
     final Matrix4 paragraphToFragmentTransform = getTransformToParagraph()..invert();
+    final TextSelection selection = TextSelection(
+      baseOffset: selectionStart,
+      extentOffset: selectionEnd,
+    );
+    final List<Rect> selectionRects = <Rect>[];
+    for (final TextBox textBox in paragraph.getBoxesForSelection(selection)) {
+      selectionRects.add(textBox.toRect());
+    }
     return SelectionGeometry(
       startSelectionPoint: SelectionPoint(
         localPosition: MatrixUtils.transformPoint(paragraphToFragmentTransform, startOffsetInParagraphCoordinates),
@@ -1346,6 +1354,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         lineHeight: paragraph._textPainter.preferredLineHeight,
         handleType: flipHandles ? TextSelectionHandleType.left : TextSelectionHandleType.right,
       ),
+      selectionRects: selectionRects,
       status: _textSelectionStart!.offset == _textSelectionEnd!.offset
         ? SelectionStatus.collapsed
         : SelectionStatus.uncollapsed,

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -628,7 +628,8 @@ class SelectionGeometry {
   /// The status of ongoing selection in the [Selectable] or [SelectionHandler].
   final SelectionStatus status;
 
-  /// The rects that represent the selection if there is any.
+  /// The rects in the local coordinates of the containing [Selectable] that
+  /// represent the selection if there is any.
   final List<Rect>? selectionRects;
 
   /// Whether there is any selectable content in the [Selectable] or

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -593,7 +593,8 @@ class SelectionGeometry {
     this.selectionRects = const <Rect>[],
     required this.status,
     required this.hasContent,
-  }) : assert((startSelectionPoint == null && endSelectionPoint == null) || status != SelectionStatus.none);
+  }) : assert((startSelectionPoint == null && endSelectionPoint == null) || status != SelectionStatus.none),
+       assert(status == SelectionStatus.uncollapsed || selectionRects.isEmpty);
 
   /// The geometry information at the selection start.
   ///

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -593,8 +593,7 @@ class SelectionGeometry {
     this.selectionRects = const <Rect>[],
     required this.status,
     required this.hasContent,
-  }) : assert((startSelectionPoint == null && endSelectionPoint == null) || status != SelectionStatus.none),
-       assert(status == SelectionStatus.uncollapsed || selectionRects.isEmpty);
+  }) : assert((startSelectionPoint == null && endSelectionPoint == null) || status != SelectionStatus.none);
 
   /// The geometry information at the selection start.
   ///

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -590,7 +590,7 @@ class SelectionGeometry {
   const SelectionGeometry({
     this.startSelectionPoint,
     this.endSelectionPoint,
-    this.selectionRects,
+    this.selectionRects = const <Rect>[],
     required this.status,
     required this.hasContent,
   }) : assert((startSelectionPoint == null && endSelectionPoint == null) || status != SelectionStatus.none);
@@ -630,7 +630,7 @@ class SelectionGeometry {
 
   /// The rects in the local coordinates of the containing [Selectable] that
   /// represent the selection if there is any.
-  final List<Rect>? selectionRects;
+  final List<Rect> selectionRects;
 
   /// Whether there is any selectable content in the [Selectable] or
   /// [SelectionHandler].
@@ -643,12 +643,14 @@ class SelectionGeometry {
   SelectionGeometry copyWith({
     SelectionPoint? startSelectionPoint,
     SelectionPoint? endSelectionPoint,
+    List<Rect>? selectionRects,
     SelectionStatus? status,
     bool? hasContent,
   }) {
     return SelectionGeometry(
       startSelectionPoint: startSelectionPoint ?? this.startSelectionPoint,
       endSelectionPoint: endSelectionPoint ?? this.endSelectionPoint,
+      selectionRects: selectionRects ?? this.selectionRects,
       status: status ?? this.status,
       hasContent: hasContent ?? this.hasContent,
     );
@@ -665,6 +667,7 @@ class SelectionGeometry {
     return other is SelectionGeometry
         && other.startSelectionPoint == startSelectionPoint
         && other.endSelectionPoint == endSelectionPoint
+        && other.selectionRects == selectionRects
         && other.status == status
         && other.hasContent == hasContent;
   }
@@ -674,6 +677,7 @@ class SelectionGeometry {
     return Object.hash(
       startSelectionPoint,
       endSelectionPoint,
+      selectionRects,
       status,
       hasContent,
     );

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -576,8 +576,8 @@ enum SelectionStatus {
 /// The geometry of the current selection.
 ///
 /// This includes details such as the locations of the selection start and end,
-/// line height, etc. This information is used for drawing selection controls
-/// for mobile platforms.
+/// line height, the rects that encompass the selection, etc. This information
+/// is used for drawing selection controls for mobile platforms.
 ///
 /// The positions in geometry are in local coordinates of the [SelectionHandler]
 /// or [Selectable].

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -590,6 +590,7 @@ class SelectionGeometry {
   const SelectionGeometry({
     this.startSelectionPoint,
     this.endSelectionPoint,
+    this.selectionRects,
     required this.status,
     required this.hasContent,
   }) : assert((startSelectionPoint == null && endSelectionPoint == null) || status != SelectionStatus.none);
@@ -626,6 +627,9 @@ class SelectionGeometry {
 
   /// The status of ongoing selection in the [Selectable] or [SelectionHandler].
   final SelectionStatus status;
+
+  /// The rects that represent the selection if there is any.
+  final List<Rect>? selectionRects;
 
   /// Whether there is any selectable content in the [Selectable] or
   /// [SelectionHandler].

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -514,15 +514,11 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.windows:
-        if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
-          // If lastSecondaryTapDownPosition is within the current selection then
-          // keep the current selection, if not then collapse it.
-          final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
-          if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-            _selectStartTo(offset: lastSecondaryTapDownPosition!);
-            _selectEndTo(offset: lastSecondaryTapDownPosition!);
-          }
-        } else {
+        // If lastSecondaryTapDownPosition is within the current selection then
+        // keep the current selection, if not then collapse it.
+        final bool uncollapsedSelectionExists = _selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed;
+        final bool lastSecondaryTapDownPositionWasOnActiveSelection = uncollapsedSelectionExists && _positionIsOnActiveSelection(globalPosition: details.globalPosition);
+        if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
           _selectStartTo(offset: lastSecondaryTapDownPosition!);
           _selectEndTo(offset: lastSecondaryTapDownPosition!);
         }
@@ -545,15 +541,11 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           hideToolbar();
           return;
         }
-        if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
-          // If lastSecondaryTapDownPosition is within the current selection then
-          // keep the current selection, if not then collapse it.
-          final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
-          if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-            _selectStartTo(offset: lastSecondaryTapDownPosition!);
-            _selectEndTo(offset: lastSecondaryTapDownPosition!);
-          }
-        } else {
+        // If lastSecondaryTapDownPosition is within the current selection then
+        // keep the current selection, if not then collapse it.
+        final bool uncollapsedSelectionExists = _selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed;
+        final bool lastSecondaryTapDownPositionWasOnActiveSelection = uncollapsedSelectionExists && _positionIsOnActiveSelection(globalPosition: details.globalPosition);
+        if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
           _selectStartTo(offset: lastSecondaryTapDownPosition!);
           _selectEndTo(offset: lastSecondaryTapDownPosition!);
         }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -500,6 +500,22 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.windows:
         if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
           // If lastSecondaryTapDownPosition is within the current selection then keep the current selection, else collapse it.
+          bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
+          for (final Selectable selectable in _selectionDelegate.selectables) {
+            if (selectable.value.hasSelection && selectable.value.status == SelectionStatus.uncollapsed) {
+              final Rect localRect = Rect.fromLTWH(0, 0, selectable.size.width, selectable.size.height);
+              final Matrix4 transform = selectable.getTransformTo(null);
+              final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
+              if (globalRect.contains(details.globalPosition)) {
+                lastSecondaryTapDownPositionWasOnActiveSelection = true;
+                break;
+              }
+            }
+          }
+          if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
+            _selectStartTo(offset: lastSecondaryTapDownPosition);
+            _selectEndTo(offset: lastSecondaryTapDownPosition);
+          }
         } else {
           _selectStartTo(offset: lastSecondaryTapDownPosition);
           _selectEndTo(offset: lastSecondaryTapDownPosition);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -490,6 +490,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleRightClickDown(TapDownDetails details) {
+    final Offset? previousSecondaryTapDownPosition = lastSecondaryTapDownPosition;
+    final bool toolbarIsVisible = _selectionOverlay?.toolbarIsVisible ?? false;
     lastSecondaryTapDownPosition = details.globalPosition;
     widget.focusNode.requestFocus();
     switch (defaultTargetPlatform) {
@@ -501,12 +503,19 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         _showHandles();
         _showToolbar(location: details.globalPosition);
       case TargetPlatform.iOS:
+        _selectWordAt(offset: details.globalPosition);
+        _showHandles();
+        _showToolbar(location: details.globalPosition);
       case TargetPlatform.macOS:
+        if (previousSecondaryTapDownPosition == lastSecondaryTapDownPosition && toolbarIsVisible) {
+          hideToolbar();
+          return;
+        }
         _selectWordAt(offset: details.globalPosition);
         _showHandles();
         _showToolbar(location: details.globalPosition);
       case TargetPlatform.linux:
-        if (_selectionOverlay?.toolbarIsVisible ?? false) {
+        if (toolbarIsVisible) {
           hideToolbar();
           return;
         }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -263,7 +263,7 @@ class SelectableRegion extends StatefulWidget {
     required final VoidCallback onCopy,
     required final VoidCallback onSelectAll,
   }) {
-    final bool canCopy = selectionGeometry.hasSelection && selectionGeometry.startSelectionPoint?.localPosition != selectionGeometry.endSelectionPoint?.localPosition;
+    final bool canCopy = selectionGeometry.hasSelection && selectionGeometry.status == SelectionStatus.uncollapsed;
     final bool canSelectAll = selectionGeometry.hasContent;
 
     // Determine which buttons will appear so that the order and total number is
@@ -498,31 +498,39 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.windows:
-        _selectStartTo(offset: details.globalPosition);
-        _selectEndTo(offset: details.globalPosition);
+        if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
+          // If lastSecondaryTapDownPosition is within the current selection then keep the current selection, else collapse it.
+        } else {
+          _selectStartTo(offset: lastSecondaryTapDownPosition);
+          _selectEndTo(offset: lastSecondaryTapDownPosition);
+        }
         _showHandles();
-        _showToolbar(location: details.globalPosition);
+        _showToolbar(location: lastSecondaryTapDownPosition);
       case TargetPlatform.iOS:
-        _selectWordAt(offset: details.globalPosition);
+        _selectWordAt(offset: lastSecondaryTapDownPosition);
         _showHandles();
-        _showToolbar(location: details.globalPosition);
+        _showToolbar(location: lastSecondaryTapDownPosition);
       case TargetPlatform.macOS:
         if (previousSecondaryTapDownPosition == lastSecondaryTapDownPosition && toolbarIsVisible) {
           hideToolbar();
           return;
         }
-        _selectWordAt(offset: details.globalPosition);
+        _selectWordAt(offset: lastSecondaryTapDownPosition);
         _showHandles();
-        _showToolbar(location: details.globalPosition);
+        _showToolbar(location: lastSecondaryTapDownPosition);
       case TargetPlatform.linux:
         if (toolbarIsVisible) {
           hideToolbar();
           return;
         }
-        _selectStartTo(offset: details.globalPosition);
-        _selectEndTo(offset: details.globalPosition);
+        if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
+          // If lastSecondaryTapDownPosition is within the current selection then keep the current selection, else collapse it.
+        } else {
+          _selectStartTo(offset: lastSecondaryTapDownPosition);
+          _selectEndTo(offset: lastSecondaryTapDownPosition);
+        }
         _showHandles();
-        _showToolbar(location: details.globalPosition);
+        _showToolbar(location: lastSecondaryTapDownPosition);
     }
     _updateSelectedContentIfNeeded();
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -499,7 +499,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.fuchsia:
       case TargetPlatform.windows:
         if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
-          // If lastSecondaryTapDownPosition is within the current selection then keep the current selection, else collapse it.
+          // If lastSecondaryTapDownPosition is within the current selection then
+          // keep the current selection, if not then collapse it.
           bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
           for (final Rect selectionRect in _selectionDelegate.value.selectionRects!) {
             final Matrix4 transform = _selectionDelegate.getTransformTo(null);
@@ -536,7 +537,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           return;
         }
         if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
-          // If lastSecondaryTapDownPosition is within the current selection then keep the current selection, else collapse it.
+          // If lastSecondaryTapDownPosition is within the current selection then
+          // keep the current selection, if not then collapse it.
           bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
           for (final Rect selectionRect in _selectionDelegate.value.selectionRects!) {
             final Matrix4 transform = _selectionDelegate.getTransformTo(null);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -502,11 +502,17 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           // If lastSecondaryTapDownPosition is within the current selection then
           // keep the current selection, if not then collapse it.
           bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
-          for (final Rect selectionRect in _selectionDelegate.value.selectionRects!) {
-            final Matrix4 transform = _selectionDelegate.getTransformTo(null);
-            final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
-            if (globalRect.contains(details.globalPosition)) {
-              lastSecondaryTapDownPositionWasOnActiveSelection = true;
+          for (final Selectable selectable in _selectionDelegate.selectables) {
+            if (!selectable.value.hasSelection || (selectable.value.status != SelectionStatus.uncollapsed)) {
+              continue;
+            }
+            for (final Rect selectionRect in selectable.value.selectionRects!) {
+              final Matrix4 transform = selectable.getTransformTo(null);
+              final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
+              if (globalRect.contains(details.globalPosition)) {
+                lastSecondaryTapDownPositionWasOnActiveSelection = true;
+                break;
+              }
             }
           }
           if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
@@ -540,11 +546,17 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           // If lastSecondaryTapDownPosition is within the current selection then
           // keep the current selection, if not then collapse it.
           bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
-          for (final Rect selectionRect in _selectionDelegate.value.selectionRects!) {
-            final Matrix4 transform = _selectionDelegate.getTransformTo(null);
-            final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
-            if (globalRect.contains(details.globalPosition)) {
-              lastSecondaryTapDownPositionWasOnActiveSelection = true;
+          for (final Selectable selectable in _selectionDelegate.selectables) {
+            if (!selectable.value.hasSelection || (selectable.value.status != SelectionStatus.uncollapsed)) {
+              continue;
+            }
+            for (final Rect selectionRect in selectable.value.selectionRects!) {
+              final Matrix4 transform = selectable.getTransformTo(null);
+              final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
+              if (globalRect.contains(details.globalPosition)) {
+                lastSecondaryTapDownPositionWasOnActiveSelection = true;
+                break;
+              }
             }
           }
           if (!lastSecondaryTapDownPositionWasOnActiveSelection) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1823,13 +1823,21 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     // Need to collect selection rects from selectables ranging from the
     // currentSelectionStartIndex to the currentSelectionEndIndex.
     final List<Rect> selectionRects = <Rect>[];
+    final Rect? drawableArea = hasSize ? Rect
+      .fromLTWH(0, 0, containerSize.width, containerSize.height) : null;
     for (int index = currentSelectionStartIndex; index <= currentSelectionEndIndex; index++) {
       final List<Rect> currSelectableSelectionRects = selectables[index].value.selectionRects;
-      selectionRects.addAll(currSelectableSelectionRects.map((Rect selectionRect) {
+      final List<Rect> finiteSelectionRects = currSelectableSelectionRects.map((Rect selectionRect) {
         final Matrix4 transform = getTransformFrom(selectables[index]);
         final Rect localRect = MatrixUtils.transformRect(transform, selectionRect);
+        if (drawableArea != null) {
+          return drawableArea.intersect(localRect);
+        }
         return localRect;
-      }));
+      }).where((Rect selectionRect) {
+        return selectionRect.isFinite && !selectionRect.isEmpty;
+      }).toList();
+      selectionRects.addAll(finiteSelectionRects);
     }
 
     return SelectionGeometry(

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -489,6 +489,22 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     _updateSelectedContentIfNeeded();
   }
 
+  bool _positionIsOnActiveSelection({required Offset globalPosition}) {
+    for (final Selectable selectable in _selectionDelegate.selectables) {
+      if (!selectable.value.hasSelection || (selectable.value.status != SelectionStatus.uncollapsed)) {
+        continue;
+      }
+      for (final Rect selectionRect in selectable.value.selectionRects!) {
+        final Matrix4 transform = selectable.getTransformTo(null);
+        final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
+        if (globalRect.contains(globalPosition)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   void _handleRightClickDown(TapDownDetails details) {
     final Offset? previousSecondaryTapDownPosition = lastSecondaryTapDownPosition;
     final bool toolbarIsVisible = _selectionOverlay?.toolbarIsVisible ?? false;
@@ -501,20 +517,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
           // If lastSecondaryTapDownPosition is within the current selection then
           // keep the current selection, if not then collapse it.
-          bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
-          for (final Selectable selectable in _selectionDelegate.selectables) {
-            if (!selectable.value.hasSelection || (selectable.value.status != SelectionStatus.uncollapsed)) {
-              continue;
-            }
-            for (final Rect selectionRect in selectable.value.selectionRects!) {
-              final Matrix4 transform = selectable.getTransformTo(null);
-              final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
-              if (globalRect.contains(details.globalPosition)) {
-                lastSecondaryTapDownPositionWasOnActiveSelection = true;
-                break;
-              }
-            }
-          }
+          final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
           if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
             _selectStartTo(offset: lastSecondaryTapDownPosition!);
             _selectEndTo(offset: lastSecondaryTapDownPosition!);
@@ -545,20 +548,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         if (_selectionDelegate.value.hasSelection && _selectionDelegate.value.status == SelectionStatus.uncollapsed) {
           // If lastSecondaryTapDownPosition is within the current selection then
           // keep the current selection, if not then collapse it.
-          bool lastSecondaryTapDownPositionWasOnActiveSelection = false;
-          for (final Selectable selectable in _selectionDelegate.selectables) {
-            if (!selectable.value.hasSelection || (selectable.value.status != SelectionStatus.uncollapsed)) {
-              continue;
-            }
-            for (final Rect selectionRect in selectable.value.selectionRects!) {
-              final Matrix4 transform = selectable.getTransformTo(null);
-              final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
-              if (globalRect.contains(details.globalPosition)) {
-                lastSecondaryTapDownPositionWasOnActiveSelection = true;
-                break;
-              }
-            }
-          }
+          final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
           if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
             _selectStartTo(offset: lastSecondaryTapDownPosition!);
             _selectEndTo(offset: lastSecondaryTapDownPosition!);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1827,7 +1827,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       .fromLTWH(0, 0, containerSize.width, containerSize.height) : null;
     for (int index = currentSelectionStartIndex; index <= currentSelectionEndIndex; index++) {
       final List<Rect> currSelectableSelectionRects = selectables[index].value.selectionRects;
-      final List<Rect> finiteSelectionRects = currSelectableSelectionRects.map((Rect selectionRect) {
+      final List<Rect> selectionRectsWithinDrawableArea = currSelectableSelectionRects.map((Rect selectionRect) {
         final Matrix4 transform = getTransformFrom(selectables[index]);
         final Rect localRect = MatrixUtils.transformRect(transform, selectionRect);
         if (drawableArea != null) {
@@ -1837,7 +1837,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       }).where((Rect selectionRect) {
         return selectionRect.isFinite && !selectionRect.isEmpty;
       }).toList();
-      selectionRects.addAll(finiteSelectionRects);
+      selectionRects.addAll(selectionRectsWithinDrawableArea);
     }
 
     return SelectionGeometry(

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -517,19 +517,19 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           _selectEndTo(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
-        _showToolbar(location: lastSecondaryTapDownPosition!);
+        _showToolbar(location: lastSecondaryTapDownPosition);
       case TargetPlatform.iOS:
         _selectWordAt(offset: lastSecondaryTapDownPosition!);
         _showHandles();
-        _showToolbar(location: lastSecondaryTapDownPosition!);
+        _showToolbar(location: lastSecondaryTapDownPosition);
       case TargetPlatform.macOS:
-        // if (previousSecondaryTapDownPosition == lastSecondaryTapDownPosition && toolbarIsVisible) {
-        //   hideToolbar();
-        //   return;
-        // }
-        // _selectWordAt(offset: lastSecondaryTapDownPosition!);
-        // _showHandles();
-        // _showToolbar(location: lastSecondaryTapDownPosition!);
+        if (previousSecondaryTapDownPosition == lastSecondaryTapDownPosition && toolbarIsVisible) {
+          hideToolbar();
+          return;
+        }
+        _selectWordAt(offset: lastSecondaryTapDownPosition!);
+        _showHandles();
+        _showToolbar(location: lastSecondaryTapDownPosition);
       case TargetPlatform.linux:
         if (toolbarIsVisible) {
           hideToolbar();
@@ -554,7 +554,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           _selectEndTo(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
-        _showToolbar(location: lastSecondaryTapDownPosition!);
+        _showToolbar(location: lastSecondaryTapDownPosition);
     }
     _updateSelectedContentIfNeeded();
   }
@@ -1833,9 +1833,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
     // Need to collect selection rects from selectables ranging from the
     // currentSelectionStartIndex to the currentSelectionEndIndex.
-    List<Rect> selectionRects = <Rect>[];
+    final List<Rect> selectionRects = <Rect>[];
     for (int index = currentSelectionStartIndex; index <= currentSelectionEndIndex; index++) {
-      List<Rect>? currSelectableSelectionRects = selectables[index].value.selectionRects;
+      final List<Rect>? currSelectableSelectionRects = selectables[index].value.selectionRects;
       if (currSelectableSelectionRects != null) {
         selectionRects.addAll(currSelectableSelectionRects);
       }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -491,7 +491,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
 
   bool _positionIsOnActiveSelection({required Offset globalPosition}) {
     for (final Selectable selectable in _selectionDelegate.selectables) {
-      if (!selectable.value.hasSelection || (selectable.value.status != SelectionStatus.uncollapsed)) {
+      if (!selectable.value.hasSelection || selectable.value.status != SelectionStatus.uncollapsed) {
         continue;
       }
       for (final Rect selectionRect in selectable.value.selectionRects!) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -490,16 +490,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   bool _positionIsOnActiveSelection({required Offset globalPosition}) {
-    for (final Selectable selectable in _selectionDelegate.selectables) {
-      if (!selectable.value.hasSelection || selectable.value.status != SelectionStatus.uncollapsed) {
-        continue;
-      }
-      for (final Rect selectionRect in selectable.value.selectionRects!) {
-        final Matrix4 transform = selectable.getTransformTo(null);
-        final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
-        if (globalRect.contains(globalPosition)) {
-          return true;
-        }
+    for (final Rect selectionRect in _selectionDelegate.value.selectionRects!) {
+      if (selectionRect.contains(globalPosition)) {
+        return true;
       }
     }
     return false;
@@ -1833,7 +1826,11 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     for (int index = currentSelectionStartIndex; index <= currentSelectionEndIndex; index++) {
       final List<Rect>? currSelectableSelectionRects = selectables[index].value.selectionRects;
       if (currSelectableSelectionRects != null) {
-        selectionRects.addAll(currSelectableSelectionRects);
+        selectionRects.addAll(currSelectableSelectionRects.map((Rect selectionRect) {
+          final Matrix4 transform = selectables[index].getTransformTo(null);
+          final Rect globalRect = MatrixUtils.transformRect(transform, selectionRect);
+          return globalRect;
+        }));
       }
     }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -562,15 +562,8 @@ class TextSelectionOverlay {
   /// Whether the handles are currently visible.
   bool get handlesAreVisible => _selectionOverlay._handles != null && handlesVisible;
 
-  /// Whether the toolbar is currently visible.
-  ///
-  /// Includes both the text selection toolbar and the spell check menu.
-  ///
-  /// See also:
-  ///
-  ///   * [spellCheckToolbarIsVisible], which is only whether the spell check menu
-  ///     specifically is visible.
-  bool get toolbarIsVisible => _selectionOverlay._toolbarIsVisible;
+  /// {@macro flutter.widgets.SelectionOverlay.toolbarIsVisible}
+  bool get toolbarIsVisible => _selectionOverlay.toolbarIsVisible;
 
   /// Whether the magnifier is currently visible.
   bool get magnifierIsVisible => _selectionOverlay._magnifierController.shown;
@@ -984,7 +977,17 @@ class SelectionOverlay {
   /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   final TextMagnifierConfiguration magnifierConfiguration;
 
-  bool get _toolbarIsVisible {
+  /// {@template flutter.widgets.SelectionOverlay.toolbarIsVisible}
+  /// Whether the toolbar is currently visible.
+  ///
+  /// Includes both the text selection toolbar and the spell check menu.
+  ///
+  /// See also:
+  ///
+  ///   * [spellCheckToolbarIsVisible], which is only whether the spell check menu
+  ///     specifically is visible.
+  /// {@endtemplate}
+  bool get toolbarIsVisible {
     return selectionControls is TextSelectionHandleControls
         ? _contextMenuController.isShown || _spellCheckToolbarController.isShown
         : _toolbar != null || _spellCheckToolbarController.isShown;
@@ -1001,7 +1004,7 @@ class SelectionOverlay {
   /// [MagnifierController.shown].
   /// {@endtemplate}
   void showMagnifier(MagnifierInfo initialMagnifierInfo) {
-    if (_toolbarIsVisible) {
+    if (toolbarIsVisible) {
       hideToolbar();
     }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -563,6 +563,11 @@ class TextSelectionOverlay {
   bool get handlesAreVisible => _selectionOverlay._handles != null && handlesVisible;
 
   /// {@macro flutter.widgets.SelectionOverlay.toolbarIsVisible}
+  ///
+  /// See also:
+  ///
+  ///   * [spellCheckToolbarIsVisible], which is only whether the spell check menu
+  ///     specifically is visible.
   bool get toolbarIsVisible => _selectionOverlay.toolbarIsVisible;
 
   /// Whether the magnifier is currently visible.
@@ -981,11 +986,6 @@ class SelectionOverlay {
   /// Whether the toolbar is currently visible.
   ///
   /// Includes both the text selection toolbar and the spell check menu.
-  ///
-  /// See also:
-  ///
-  ///   * [spellCheckToolbarIsVisible], which is only whether the spell check menu
-  ///     specifically is visible.
   /// {@endtemplate}
   bool get toolbarIsVisible {
     return selectionControls is TextSelectionHandleControls

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1131,6 +1131,7 @@ void main() {
       // Should select "Hello".
       expect(paragraph.selections[0], const TextSelection(baseOffset: 124, extentOffset: 129));
     },
+      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
       skip: isBrowser, // https://github.com/flutter/flutter/issues/61020
     );
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -635,6 +635,104 @@ void main() {
     );
 
     testWidgets(
+      'right-click mouse at the same position as previous right-click toggles the context menu on macOS',
+      (WidgetTester tester) async {
+        Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+        final UniqueKey toolbarKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              focusNode: FocusNode(),
+              selectionControls: materialTextSelectionHandleControls,
+              contextMenuBuilder: (
+                BuildContext context,
+                SelectableRegionState selectableRegionState,
+              ) {
+                buttonTypes = selectableRegionState.contextMenuButtonItems
+                  .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                  .toSet();
+                return SizedBox.shrink(key: toolbarKey);
+              },
+              child: const Center(
+                child: Text('How are you'),
+              ),
+            ),
+          ),
+        );
+
+        expect(buttonTypes.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
+
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+        final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        addTearDown(gesture.removePointer);
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+        await gesture.up();
+        await tester.pump();
+
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        await gesture.down(textOffsetToPosition(paragraph, 2));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+        await gesture.up();
+        await tester.pump();
+
+        // Right-click at same position will toggle the context menu off.
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsNothing);
+
+        await gesture.down(textOffsetToPosition(paragraph, 9));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 11));
+
+        await gesture.up();
+        await tester.pump();
+
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        await gesture.down(textOffsetToPosition(paragraph, 9));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 11));
+
+        await gesture.up();
+        await tester.pump();
+
+        // Right-click at same position will toggle the context menu off.
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsNothing);
+
+        await gesture.down(textOffsetToPosition(paragraph, 6));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+
+        await gesture.up();
+        await tester.pump();
+
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        // Clear selection.
+        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
+      skip: kIsWeb, // [intended] Web uses its native context menu.
+    );
+
+    testWidgets(
       'right-click mouse shows the context menu at position on Android, Fucshia, and Windows',
       (WidgetTester tester) async {
         Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -562,6 +562,7 @@ void main() {
 
     testWidgets('right-click mouse can select word at position on Apple platforms', (WidgetTester tester) async {
       Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+      final UniqueKey toolbarKey = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(
@@ -574,7 +575,7 @@ void main() {
               buttonTypes = selectableRegionState.contextMenuButtonItems
                 .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
                 .toSet();
-              return const SizedBox.shrink();
+              return SizedBox.shrink(key: toolbarKey);
             },
             child: const Center(
               child: Text('How are you'),
@@ -584,6 +585,7 @@ void main() {
       );
 
       expect(buttonTypes.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
 
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
@@ -592,10 +594,11 @@ void main() {
       expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
 
       await gesture.up();
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(buttonTypes, contains(ContextMenuButtonType.copy));
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
 
       await gesture.down(textOffsetToPosition(paragraph, 6));
       await tester.pump();
@@ -606,6 +609,7 @@ void main() {
 
       expect(buttonTypes, contains(ContextMenuButtonType.copy));
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
 
       await gesture.down(textOffsetToPosition(paragraph, 9));
       await tester.pump();
@@ -616,10 +620,18 @@ void main() {
 
       expect(buttonTypes, contains(ContextMenuButtonType.copy));
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
+
+      // Clear selection.
+      await tester.tapAt(textOffsetToPosition(paragraph, 1));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
     testWidgets('right-click mouse shows the context menu at position on Android, Fucshia, and Windows', (WidgetTester tester) async {
       Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+      final UniqueKey toolbarKey = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(
@@ -632,7 +644,7 @@ void main() {
               buttonTypes = selectableRegionState.contextMenuButtonItems
                 .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
                 .toSet();
-              return const SizedBox.shrink();
+              return SizedBox.shrink(key: toolbarKey);
             },
             child: const Center(
               child: Text('How are you'),
@@ -642,6 +654,7 @@ void main() {
       );
 
       expect(buttonTypes.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
 
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
@@ -655,6 +668,7 @@ void main() {
 
       expect(buttonTypes.length, 1);
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
 
       await gesture.down(textOffsetToPosition(paragraph, 6));
       await tester.pump();
@@ -665,6 +679,7 @@ void main() {
 
       expect(buttonTypes.length, 1);
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
 
       await gesture.down(textOffsetToPosition(paragraph, 9));
       await tester.pump();
@@ -675,10 +690,18 @@ void main() {
 
       expect(buttonTypes.length, 1);
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
+
+      // Clear selection.
+      await tester.tapAt(textOffsetToPosition(paragraph, 1));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
 
     testWidgets('right-click mouse toggles the context menu on Linux', (WidgetTester tester) async {
       Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+      final UniqueKey toolbarKey = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(
@@ -691,7 +714,7 @@ void main() {
               buttonTypes = selectableRegionState.contextMenuButtonItems
                 .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
                 .toSet();
-              return const SizedBox.shrink();
+              return SizedBox.shrink(key: toolbarKey);
             },
             child: const Center(
               child: Text('How are you'),
@@ -701,6 +724,7 @@ void main() {
       );
 
       expect(buttonTypes.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
 
       final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
       final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
@@ -714,6 +738,7 @@ void main() {
 
       expect(buttonTypes.length, 1);
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
 
       await gesture.down(textOffsetToPosition(paragraph, 6));
       await tester.pump();
@@ -722,7 +747,7 @@ void main() {
       await gesture.up();
       await tester.pump();
 
-      expect(buttonTypes.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
 
       await gesture.down(textOffsetToPosition(paragraph, 9));
       await tester.pump();
@@ -733,6 +758,13 @@ void main() {
 
       expect(buttonTypes.length, 1);
       expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+      expect(find.byKey(toolbarKey), findsOneWidget);
+
+      // Clear selection.
+      await tester.tapAt(textOffsetToPosition(paragraph, 1));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+      expect(find.byKey(toolbarKey), findsNothing);
     }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
     testWidgets('can copy a selection made with the mouse', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -560,212 +560,230 @@ void main() {
       await gesture.up();
     });
 
-    testWidgets('right-click mouse can select word at position on Apple platforms', (WidgetTester tester) async {
-      Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
-      final UniqueKey toolbarKey = UniqueKey();
-      await tester.pumpWidget(
-        MaterialApp(
-          home: SelectableRegion(
-            focusNode: FocusNode(),
-            selectionControls: materialTextSelectionHandleControls,
-            contextMenuBuilder: (
-              BuildContext context,
-              SelectableRegionState selectableRegionState,
-            ) {
-              buttonTypes = selectableRegionState.contextMenuButtonItems
-                .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
-                .toSet();
-              return SizedBox.shrink(key: toolbarKey);
-            },
-            child: const Center(
-              child: Text('How are you'),
+    testWidgets(
+      'right-click mouse can select word at position on Apple platforms',
+      (WidgetTester tester) async {
+        Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+        final UniqueKey toolbarKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              focusNode: FocusNode(),
+              selectionControls: materialTextSelectionHandleControls,
+              contextMenuBuilder: (
+                BuildContext context,
+                SelectableRegionState selectableRegionState,
+              ) {
+                buttonTypes = selectableRegionState.contextMenuButtonItems
+                  .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                  .toSet();
+                return SizedBox.shrink(key: toolbarKey);
+              },
+              child: const Center(
+                child: Text('How are you'),
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(buttonTypes.isEmpty, true);
-      expect(find.byKey(toolbarKey), findsNothing);
+        expect(buttonTypes.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
 
-      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
-      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
-      addTearDown(gesture.removePointer);
-      await tester.pump();
-      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+        final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        addTearDown(gesture.removePointer);
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes, contains(ContextMenuButtonType.copy));
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      await gesture.down(textOffsetToPosition(paragraph, 6));
-      await tester.pump();
-      expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+        await gesture.down(textOffsetToPosition(paragraph, 6));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes, contains(ContextMenuButtonType.copy));
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      await gesture.down(textOffsetToPosition(paragraph, 9));
-      await tester.pump();
-      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 11));
+        await gesture.down(textOffsetToPosition(paragraph, 9));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 11));
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes, contains(ContextMenuButtonType.copy));
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        expect(buttonTypes, contains(ContextMenuButtonType.copy));
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      // Clear selection.
-      await tester.tapAt(textOffsetToPosition(paragraph, 1));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
-      expect(find.byKey(toolbarKey), findsNothing);
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+        // Clear selection.
+        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
+      skip: kIsWeb, // Web handles its own context menu.
+    );
 
-    testWidgets('right-click mouse shows the context menu at position on Android, Fucshia, and Windows', (WidgetTester tester) async {
-      Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
-      final UniqueKey toolbarKey = UniqueKey();
-      await tester.pumpWidget(
-        MaterialApp(
-          home: SelectableRegion(
-            focusNode: FocusNode(),
-            selectionControls: materialTextSelectionHandleControls,
-            contextMenuBuilder: (
-              BuildContext context,
-              SelectableRegionState selectableRegionState,
-            ) {
-              buttonTypes = selectableRegionState.contextMenuButtonItems
-                .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
-                .toSet();
-              return SizedBox.shrink(key: toolbarKey);
-            },
-            child: const Center(
-              child: Text('How are you'),
+    testWidgets(
+      'right-click mouse shows the context menu at position on Android, Fucshia, and Windows',
+      (WidgetTester tester) async {
+        Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+        final UniqueKey toolbarKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              focusNode: FocusNode(),
+              selectionControls: materialTextSelectionHandleControls,
+              contextMenuBuilder: (
+                BuildContext context,
+                SelectableRegionState selectableRegionState,
+              ) {
+                buttonTypes = selectableRegionState.contextMenuButtonItems
+                  .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                  .toSet();
+                return SizedBox.shrink(key: toolbarKey);
+              },
+              child: const Center(
+                child: Text('How are you'),
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(buttonTypes.isEmpty, true);
-      expect(find.byKey(toolbarKey), findsNothing);
+        expect(buttonTypes.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
 
-      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
-      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
-      addTearDown(gesture.removePointer);
-      await tester.pump();
-      // Selection is collapsed so none is reported.
-      expect(paragraph.selections.isEmpty, true);
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+        final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        addTearDown(gesture.removePointer);
+        await tester.pump();
+        // Selection is collapsed so none is reported.
+        expect(paragraph.selections.isEmpty, true);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes.length, 1);
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        expect(buttonTypes.length, 1);
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      await gesture.down(textOffsetToPosition(paragraph, 6));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
+        await gesture.down(textOffsetToPosition(paragraph, 6));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes.length, 1);
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        expect(buttonTypes.length, 1);
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      await gesture.down(textOffsetToPosition(paragraph, 9));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
+        await gesture.down(textOffsetToPosition(paragraph, 9));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes.length, 1);
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        expect(buttonTypes.length, 1);
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      // Clear selection.
-      await tester.tapAt(textOffsetToPosition(paragraph, 1));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
-      expect(find.byKey(toolbarKey), findsNothing);
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
+        // Clear selection.
+        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }),
+      skip: kIsWeb, // Web handles its own context menu.
+    );
 
-    testWidgets('right-click mouse toggles the context menu on Linux', (WidgetTester tester) async {
-      Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
-      final UniqueKey toolbarKey = UniqueKey();
-      await tester.pumpWidget(
-        MaterialApp(
-          home: SelectableRegion(
-            focusNode: FocusNode(),
-            selectionControls: materialTextSelectionHandleControls,
-            contextMenuBuilder: (
-              BuildContext context,
-              SelectableRegionState selectableRegionState,
-            ) {
-              buttonTypes = selectableRegionState.contextMenuButtonItems
-                .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
-                .toSet();
-              return SizedBox.shrink(key: toolbarKey);
-            },
-            child: const Center(
-              child: Text('How are you'),
+    testWidgets(
+      'right-click mouse toggles the context menu on Linux',
+      (WidgetTester tester) async {
+        Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+        final UniqueKey toolbarKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              focusNode: FocusNode(),
+              selectionControls: materialTextSelectionHandleControls,
+              contextMenuBuilder: (
+                BuildContext context,
+                SelectableRegionState selectableRegionState,
+              ) {
+                buttonTypes = selectableRegionState.contextMenuButtonItems
+                  .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                  .toSet();
+                return SizedBox.shrink(key: toolbarKey);
+              },
+              child: const Center(
+                child: Text('How are you'),
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(buttonTypes.isEmpty, true);
-      expect(find.byKey(toolbarKey), findsNothing);
+        expect(buttonTypes.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
 
-      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
-      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
-      addTearDown(gesture.removePointer);
-      await tester.pump();
-      // Selection is collapsed so none is reported.
-      expect(paragraph.selections.isEmpty, true);
+        final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+        final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        addTearDown(gesture.removePointer);
+        await tester.pump();
+        // Selection is collapsed so none is reported.
+        expect(paragraph.selections.isEmpty, true);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes.length, 1);
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        // Context menu toggled on.
+        expect(buttonTypes.length, 1);
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      await gesture.down(textOffsetToPosition(paragraph, 6));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
+        await gesture.down(textOffsetToPosition(paragraph, 6));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(find.byKey(toolbarKey), findsNothing);
+        // Context menu toggled off.
+        expect(find.byKey(toolbarKey), findsNothing);
 
-      await gesture.down(textOffsetToPosition(paragraph, 9));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
+        await gesture.down(textOffsetToPosition(paragraph, 9));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
 
-      await gesture.up();
-      await tester.pump();
+        await gesture.up();
+        await tester.pump();
 
-      expect(buttonTypes.length, 1);
-      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
-      expect(find.byKey(toolbarKey), findsOneWidget);
+        // Context menu toggled on.
+        expect(buttonTypes.length, 1);
+        expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
 
-      // Clear selection.
-      await tester.tapAt(textOffsetToPosition(paragraph, 1));
-      await tester.pump();
-      expect(paragraph.selections.isEmpty, true);
-      expect(find.byKey(toolbarKey), findsNothing);
-    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+        // Clear selection.
+        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.linux),
+      skip: kIsWeb, // Web handles its own context menu.
+    );
 
     testWidgets('can copy a selection made with the mouse', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -802,6 +802,39 @@ void main() {
         await tester.pump();
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
+
+        // Create an uncollapsed selection by dragging.
+        final TestGesture dragGesture = await tester.startGesture(textOffsetToPosition(paragraph, 0), kind: PointerDeviceKind.mouse);
+        addTearDown(dragGesture.removePointer);
+        await tester.pump();
+        await dragGesture.moveTo(textOffsetToPosition(paragraph, 5));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
+        await dragGesture.up();
+        await tester.pump();
+
+        // Right click on previous selection should not collapse the selection.
+        await gesture.down(textOffsetToPosition(paragraph, 2));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        // Right click anywhere outside previous selection should collapse the
+        // selection.
+        await gesture.down(textOffsetToPosition(paragraph, 7));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        // Clear selection.
+        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }),
       skip: kIsWeb, // [intended] Web uses its native context menu.
@@ -871,6 +904,47 @@ void main() {
         // Context menu toggled on.
         expect(buttonTypes.length, 1);
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        // Clear selection.
+        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
+        expect(find.byKey(toolbarKey), findsNothing);
+
+        final TestGesture dragGesture = await tester.startGesture(textOffsetToPosition(paragraph, 0), kind: PointerDeviceKind.mouse);
+        addTearDown(dragGesture.removePointer);
+        await tester.pump();
+        await dragGesture.moveTo(textOffsetToPosition(paragraph, 5));
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
+        await dragGesture.up();
+        await tester.pump();
+
+        // Right click on previous selection should not collapse the selection.
+        await gesture.down(textOffsetToPosition(paragraph, 2));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
+        expect(find.byKey(toolbarKey), findsOneWidget);
+
+        // Right click anywhere outside previous selection should first toggle the context
+        // menu off.
+        await gesture.down(textOffsetToPosition(paragraph, 7));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
+        expect(find.byKey(toolbarKey), findsNothing);
+
+        // Right click again should collapse the selection and toggle the context
+        // menu on.
+        await gesture.down(textOffsetToPosition(paragraph, 7));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+        expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsOneWidget);
 
         // Clear selection.

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -631,7 +631,7 @@ void main() {
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
-      skip: kIsWeb, // Web handles its own context menu.
+      skip: kIsWeb, // [intended] Web uses its native context menu.
     );
 
     testWidgets(
@@ -706,7 +706,7 @@ void main() {
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }),
-      skip: kIsWeb, // Web handles its own context menu.
+      skip: kIsWeb, // [intended] Web uses its native context menu.
     );
 
     testWidgets(
@@ -782,7 +782,7 @@ void main() {
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.linux),
-      skip: kIsWeb, // Web handles its own context menu.
+      skip: kIsWeb, // [intended] Web uses its native context menu.
     );
 
     testWidgets('can copy a selection made with the mouse', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -560,6 +560,181 @@ void main() {
       await gesture.up();
     });
 
+    testWidgets('right-click mouse can select word at position on Apple platforms', (WidgetTester tester) async {
+      Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionHandleControls,
+            contextMenuBuilder: (
+              BuildContext context,
+              SelectableRegionState selectableRegionState,
+            ) {
+              buttonTypes = selectableRegionState.contextMenuButtonItems
+                .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                .toSet();
+              return const SizedBox.shrink();
+            },
+            child: const Center(
+              child: Text('How are you'),
+            ),
+          ),
+        ),
+      );
+
+      expect(buttonTypes.isEmpty, true);
+
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(buttonTypes, contains(ContextMenuButtonType.copy));
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+
+      await gesture.down(textOffsetToPosition(paragraph, 6));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes, contains(ContextMenuButtonType.copy));
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+
+      await gesture.down(textOffsetToPosition(paragraph, 9));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 8, extentOffset: 11));
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes, contains(ContextMenuButtonType.copy));
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+
+    testWidgets('right-click mouse shows the context menu at position on Android, Fucshia, and Windows', (WidgetTester tester) async {
+      Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionHandleControls,
+            contextMenuBuilder: (
+              BuildContext context,
+              SelectableRegionState selectableRegionState,
+            ) {
+              buttonTypes = selectableRegionState.contextMenuButtonItems
+                .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                .toSet();
+              return const SizedBox.shrink();
+            },
+            child: const Center(
+              child: Text('How are you'),
+            ),
+          ),
+        ),
+      );
+
+      expect(buttonTypes.isEmpty, true);
+
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      // Selection is collapsed so none is reported.
+      expect(paragraph.selections.isEmpty, true);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes.length, 1);
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+
+      await gesture.down(textOffsetToPosition(paragraph, 6));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes.length, 1);
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+
+      await gesture.down(textOffsetToPosition(paragraph, 9));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes.length, 1);
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
+
+    testWidgets('right-click mouse toggles the context menu on Linux', (WidgetTester tester) async {
+      Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionHandleControls,
+            contextMenuBuilder: (
+              BuildContext context,
+              SelectableRegionState selectableRegionState,
+            ) {
+              buttonTypes = selectableRegionState.contextMenuButtonItems
+                .map((ContextMenuButtonItem buttonItem) => buttonItem.type)
+                .toSet();
+              return const SizedBox.shrink();
+            },
+            child: const Center(
+              child: Text('How are you'),
+            ),
+          ),
+        ),
+      );
+
+      expect(buttonTypes.isEmpty, true);
+
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      // Selection is collapsed so none is reported.
+      expect(paragraph.selections.isEmpty, true);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes.length, 1);
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+
+      await gesture.down(textOffsetToPosition(paragraph, 6));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes.isEmpty, true);
+
+      await gesture.down(textOffsetToPosition(paragraph, 9));
+      await tester.pump();
+      expect(paragraph.selections.isEmpty, true);
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(buttonTypes.length, 1);
+      expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
     testWidgets('can copy a selection made with the mouse', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
This change updates `SelectableRegion`s right-click gesture to match native platform behavior.

Before: Right-click gesture selects word at position and opens context menu (All Platforms)
After: 
- Linux, toggles context menu on/off, and collapses selection when click was not on an active selection (uncollapsed).
- Windows, Android, Fuchsia, shows context menu at right-clicked position (unless the click is at an active selection).
- macOS, toggles the context menu if right click was at the same position as the previous / or selects word at position and opens context menu.
- iOS, selects word at position and opens context menu.

This change also prevents the `copy` menu button from being shown when there is a collapsed selection (nothing to copy).

Fixes #117561

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.