### PR TITLE
[flutter_tools] [DAP] Don't try to restart/reload if app hasn't started yet

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -663,6 +663,12 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     bool fullRestart, [
     String? reason,
   ]) async {
+    // Don't do anything if the app hasn't started yet, as restarts and reloads
+    // can only operate on a running app.
+    if (_appId == null) {
+      return;
+    }
+
     final String progressId = fullRestart ? 'hotRestart' : 'hotReload';
     final String progressMessage = fullRestart ? 'Hot restarting…' : 'Hot reloading…';
     final DapProgressReporter progress = startProgressNotification(

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -186,6 +186,30 @@ void main() {
         expect(adapter.dapToFlutterRequests, isNot(contains('app.stop')));
       });
 
+      test('does not call "app.restart" before app has been started', () async {
+        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+          simulateAppStarted: false,
+        );
+
+        final Completer<void> launchCompleter = Completer<void>();
+         final FlutterLaunchRequestArguments launchArgs = FlutterLaunchRequestArguments(
+          cwd: '/project',
+          program: 'foo.dart',
+        );
+        final Completer<void> restartCompleter = Completer<void>();
+        final RestartArguments restartArgs = RestartArguments();
+
+        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.launchRequest(MockRequest(), launchArgs, launchCompleter.complete);
+        await launchCompleter.future;
+        await adapter.restartRequest(MockRequest(), restartArgs, restartCompleter.complete);
+        await restartCompleter.future;
+
+        expect(adapter.dapToFlutterRequests, isNot(contains('app.restart')));
+      });
+
       test('includes Dart Debug extension progress update', () async {
         final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),


### PR DESCRIPTION
The editor is set to hot-reload-on-save by default so saving while the debug session is starting currently prints an error:

Failed to Hot Reload: app 'null' not found

![image](https://github.com/flutter/flutter/assets/1078012/a125b455-a46d-4993-98d8-5d8ae7237a00)

This change skips the call to `app.restart` if the app hasn't started yet to avoid printing an error.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
