### PR TITLE
Use a `show` over a `hide` for `test_api` exports

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -47,7 +47,20 @@ export 'package:matcher/expect.dart' hide expect, isInstanceOf;
 // that doesn't apply here.
 export 'package:test_api/hooks.dart' show TestFailure;
 export 'package:test_api/scaffolding.dart'
-    hide group, setUp, setUpAll, tearDown, tearDownAll, test;
+    show
+        OnPlatform,
+        Retry,
+        Skip,
+        Tags,
+        TestOn,
+        Timeout,
+        addTearDown,
+        markTestSkipped,
+        printOnFailure,
+        pumpEventQueue,
+        registerException,
+        spawnHybridCode,
+        spawnHybridUri;
 
 /// Signature for callback to [testWidgets] and [benchmarkWidgets].
 typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);


### PR DESCRIPTION
The members which are currently hidden may get removed from `package:test_api` because they have no uses.
https://github.com/dart-lang/test/pull/2030

Switch to a `show` and list all the exported APIs. This is currently a no-op change, and is forward compatible with the breaking change when it lands.

A `show` is also safer than a `hide` when exporting across package boundaries. Adding a new member to a library _can be_ breaking, but is often treated as non-breaking. If a new member is added to `package:test_api/scaffolding.dart` it will need to be manually added to the list to be usable from `package:flutter_test`, but we anyways want to add a CHANGELOG entry for user facing changes.
