### PR TITLE
[testing] Make the FLUTTER_STORAGE_BASE_URL warning non-fatal.

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -519,10 +519,15 @@ class Cache {
     if (_hasWarnedAboutStorageOverride) {
       return;
     }
+    // Automated testing of Flutter builds using non-released artifacts
+    // need to be able to use the --fatal-warnings flag without failing
+    // due to their custom artifact download location.
+    final bool oldWarnings = _logger.hadWarningOutput;
     _logger.printWarning(
       'Flutter assets will be downloaded from $overrideUrl. Make sure you trust this source!',
       emphasis: true,
     );
+    _logger.hadWarningOutput = oldWarnings;
     _hasWarnedAboutStorageOverride = true;
   }
 


### PR DESCRIPTION
Presubmit testing and CI testing of Flutter using a custom storage location for engine artifacts must be able to use the --fatal-warnings flag without failing due to the custom artifact location.

This change makes this warning always non-fatal.
An alternative change that only makes the warning non-fatal if a command-line flag is passed to the flutter tool will also be uploaded for review.

Bug: https://github.com/flutter/flutter/issues/127683

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.