### PR TITLE
apply base to Route and SelectionContainerDelegate subclass

### DIFF
--- a/examples/api/lib/material/selection_container/selection_container.0.dart
+++ b/examples/api/lib/material/selection_container/selection_container.0.dart
@@ -63,7 +63,7 @@ class _SelectionAllOrNoneContainerState extends State<SelectionAllOrNoneContaine
   }
 }
 
-class SelectAllOrNoneContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+final class SelectAllOrNoneContainerDelegate extends MultiSelectableSelectionContainerDelegate {
   Offset? _adjustedStartEdge;
   Offset? _adjustedEndEdge;
   bool _isSelected = false;

--- a/examples/api/lib/widgets/routes/popup_route.0.dart
+++ b/examples/api/lib/widgets/routes/popup_route.0.dart
@@ -38,7 +38,7 @@ class PopupRouteExample extends StatelessWidget {
   }
 }
 
-class DismissibleDialog<T> extends PopupRoute<T> {
+final class DismissibleDialog<T> extends PopupRoute<T> {
   @override
   Color? get barrierColor => Colors.black.withAlpha(0x50);
 

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -806,7 +806,7 @@ class _DecoyChildState extends State<_DecoyChild> with TickerProviderStateMixin 
 }
 
 // The open CupertinoContextMenu modal.
-class _ContextMenuRoute<T> extends PopupRoute<T> {
+final class _ContextMenuRoute<T> extends PopupRoute<T> {
   // Build a _ContextMenuRoute.
   _ContextMenuRoute({
     required List<Widget> actions,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -83,7 +83,7 @@ final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
 ///  * [MaterialRouteTransitionMixin], which is a mixin that provides
 ///    platform-appropriate transitions for a [PageRoute].
 ///  * [CupertinoPageRoute], which is a [PageRoute] that leverages this mixin.
-mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
+base mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -321,7 +321,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
 ///  * [CupertinoTabScaffold], for applications that have a tab bar at the
 ///    bottom with multiple pages.
 ///  * [CupertinoPage], for a [Page] version of this class.
-class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T> {
+base class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T> {
   /// Creates a page route for use in an iOS designed app.
   ///
   /// The [builder], [maintainState], and [fullscreenDialog] arguments must not
@@ -357,7 +357,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
 //
 // This route uses the builder from the page to build its content. This ensures
 // the content is up to date after page updates.
-class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T> {
+final class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T> {
   _PageBasedCupertinoPageRoute({
     required CupertinoPage<T> page,
     super.allowSnapshotting = true,
@@ -994,7 +994,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
 ///  * [CupertinoActionSheet], which is the widget usually returned by the
 ///    `builder` argument.
 ///  * <https://developer.apple.com/design/human-interface-guidelines/ios/views/action-sheets/>
-class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
+base class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
   /// A route that shows a modal iOS-style popup that slides up from the
   /// bottom of the screen.
   CupertinoModalPopupRoute({
@@ -1314,7 +1314,7 @@ Future<T?> showCupertinoDialog<T>({
 ///  * [showDialog], which displays a Material dialog.
 ///  * [DisplayFeatureSubScreen], which documents the specifics of how
 ///    [DisplayFeature]s can split the screen into sub-screens.
-class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
+base class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
   /// A dialog route that shows an iOS-style dialog.
   CupertinoDialogRoute({
     required WidgetBuilder builder,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -798,7 +798,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 ///    [DisplayFeature]s can split the screen into sub-screens.
 ///  * The Material 2 spec at <https://m2.material.io/components/sheets-bottom>.
 ///  * The Material 3 spec at <https://m3.material.io/components/bottom-sheets/overview>.
-class ModalBottomSheetRoute<T> extends PopupRoute<T> {
+base class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   /// A modal bottom sheet route.
   ModalBottomSheetRoute({
     required this.builder,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -1550,7 +1550,7 @@ bool _debugIsActive(BuildContext context) {
 ///  * [showCupertinoDialog], which displays an iOS-style dialog.
 ///  * [DisplayFeatureSubScreen], which documents the specifics of how
 ///    [DisplayFeature]s can split the screen into sub-screens.
-class DialogRoute<T> extends RawDialogRoute<T> {
+base class DialogRoute<T> extends RawDialogRoute<T> {
   /// A dialog route with Material entrance and exit animations,
   /// modal barrier color, and modal barrier behavior (dialog is dismissible
   /// with a tap on the barrier).

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -415,7 +415,7 @@ class _MenuLimits {
   final double scrollOffset;
 }
 
-class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
+final class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   _DropdownRoute({
     required this.items,
     required this.padding,

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -29,7 +29,7 @@ import 'theme.dart';
 ///  * [MaterialRouteTransitionMixin], which provides the material transition
 ///    for this route.
 ///  * [MaterialPage], which is a [Page] of this class.
-class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
+base class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
   /// Construct a MaterialPageRoute whose contents are defined by [builder].
   ///
   /// The values of [builder], [maintainState], and [PageRoute.fullscreenDialog]
@@ -79,7 +79,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 ///    by the [PageTransitionsTheme].
 ///  * [CupertinoPageTransitionsBuilder], which is the default page transition
 ///    for iOS and macOS.
-mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
+base mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -176,7 +176,7 @@ class MaterialPage<T> extends Page<T> {
 //
 // This route uses the builder from the page to build its content. This ensures
 // the content is up to date after page updates.
-class _PageBasedMaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
+final class _PageBasedMaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
   _PageBasedMaterialPageRoute({
     required MaterialPage<T> page,
     super.allowSnapshotting,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -774,7 +774,7 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
   }
 }
 
-class _PopupMenuRoute<T> extends PopupRoute<T> {
+final class _PopupMenuRoute<T> extends PopupRoute<T> {
   _PopupMenuRoute({
     required this.position,
     required this.items,

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -384,7 +384,7 @@ enum _SearchBody {
   results,
 }
 
-class _SearchPageRoute<T> extends PageRoute<T> {
+final class _SearchPageRoute<T> extends PageRoute<T> {
   _SearchPageRoute({
     required this.delegate,
   }) {

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -396,7 +396,7 @@ class _SearchAnchorState extends State<SearchAnchor> {
   }
 }
 
-class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
+final class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
   _SearchViewRoute({
     this.toggleVisibility,
     this.textDirection,

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -128,7 +128,7 @@ enum RoutePopDisposition {
 /// The type argument `T` is the route's return type, as used by
 /// [currentResult], [popped], and [didPop]. The type `void` may be used if the
 /// route does not return a value.
-abstract class Route<T> {
+abstract base class Route<T> {
   /// Initialize the [Route].
   ///
   /// If the [settings] are not provided, an empty [RouteSettings] object is
@@ -2830,7 +2830,7 @@ enum _RouteLifecycle {
 
 typedef _RouteEntryPredicate = bool Function(_RouteEntry entry);
 
-class _NotAnnounced extends Route<void> {
+final class _NotAnnounced extends Route<void> {
   // A placeholder for the lastAnnouncedPreviousRoute, the
   // lastAnnouncedPoppedNextRoute, and the lastAnnouncedNextRoute before any
   // change has been announced.

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -14,7 +14,7 @@ import 'routes.dart';
 /// See also:
 ///
 ///  * [Route], which documents the meaning of the `T` generic type argument.
-abstract class PageRoute<T> extends ModalRoute<T> {
+abstract base class PageRoute<T> extends ModalRoute<T> {
   /// Creates a modal route that replaces the entire screen.
   PageRoute({
     super.settings,
@@ -63,7 +63,7 @@ Widget _defaultTransitionsBuilder(BuildContext context, Animation<double> animat
 /// See also:
 ///
 ///  * [Route], which documents the meaning of the `T` generic type argument.
-class PageRouteBuilder<T> extends PageRoute<T> {
+base class PageRouteBuilder<T> extends PageRoute<T> {
   /// Creates a route that delegates to builder callbacks.
   ///
   /// The [pageBuilder], [transitionsBuilder], [opaque], [barrierDismissible],

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -39,7 +39,7 @@ import 'transitions.dart';
 /// See also:
 ///
 ///  * [Route], which documents the meaning of the `T` generic type argument.
-abstract class OverlayRoute<T> extends Route<T> {
+abstract base class OverlayRoute<T> extends Route<T> {
   /// Creates a route that knows how to interact with an [Overlay].
   OverlayRoute({
     super.settings,
@@ -97,7 +97,7 @@ abstract class OverlayRoute<T> extends Route<T> {
 /// See also:
 ///
 ///  * [Route], which documents the meaning of the `T` generic type argument.
-abstract class TransitionRoute<T> extends OverlayRoute<T> {
+abstract base class TransitionRoute<T> extends OverlayRoute<T> {
   /// Creates a route that animates itself when it is pushed or popped.
   TransitionRoute({
     super.settings,
@@ -536,7 +536,7 @@ class LocalHistoryEntry {
 /// See also:
 ///
 ///  * [Route], which documents the meaning of the `T` generic type argument.
-mixin LocalHistoryRoute<T> on Route<T> {
+base mixin LocalHistoryRoute<T> on Route<T> {
   List<LocalHistoryEntry>? _localHistory;
   int _entriesImpliesAppBarDismissal = 0;
   /// Adds a local history entry to this route.
@@ -987,7 +987,7 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
 /// See also:
 ///
 ///  * [Route], which further documents the meaning of the `T` generic type argument.
-abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T> {
+abstract base class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T> {
   /// Creates a route that blocks interaction with previous routes.
   ModalRoute({
     super.settings,
@@ -1781,7 +1781,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 ///
 ///   * [ModalRoute], which is the base class for this class.
 ///   * [Navigator.pop], which is used to dismiss the route.
-abstract class PopupRoute<T> extends ModalRoute<T> {
+abstract base class PopupRoute<T> extends ModalRoute<T> {
   /// Initializes the [PopupRoute].
   PopupRoute({
     super.settings,
@@ -2020,7 +2020,7 @@ abstract mixin class RouteAware {
 ///  * [showGeneralDialog], which is a way to display a RawDialogRoute.
 ///  * [showDialog], which is a way to display a DialogRoute.
 ///  * [showCupertinoDialog], which displays an iOS-style dialog.
-class RawDialogRoute<T> extends PopupRoute<T> {
+base class RawDialogRoute<T> extends PopupRoute<T> {
   /// A general dialog route which allows for customization of the dialog popup.
   RawDialogRoute({
     required RoutePageBuilder pageBuilder,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1064,7 +1064,7 @@ class _ScrollableSelectionHandlerState extends State<_ScrollableSelectionHandler
 /// selectable. The records are used to determine whether the selection is up to
 /// date with the scroll position when it sends the drag update event to a
 /// selectable.
-class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+final class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
   _ScrollableSelectionContainerDelegate({
     required this.state,
     required ScrollPosition position

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1287,7 +1287,7 @@ class _DirectionallyExtendCaretSelectionAction<T extends DirectionalCaretMovemen
   }
 }
 
-class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+final class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
   final Set<Selectable> _hasReceivedStartEvent = <Selectable>{};
   final Set<Selectable> _hasReceivedEndEvent = <Selectable>{};
 
@@ -1447,7 +1447,7 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
 ///
 /// This class optimize the selection update by keeping track of the
 /// [Selectable]s that currently contain the selection edges.
-abstract class MultiSelectableSelectionContainerDelegate extends SelectionContainerDelegate with ChangeNotifier {
+abstract base class MultiSelectableSelectionContainerDelegate extends SelectionContainerDelegate with ChangeNotifier {
   /// Gets the list of selectables this delegate is managing.
   List<Selectable> selectables = <Selectable>[];
 

--- a/packages/flutter/lib/src/widgets/selection_container.dart
+++ b/packages/flutter/lib/src/widgets/selection_container.dart
@@ -261,7 +261,7 @@ class SelectionRegistrarScope extends InheritedWidget {
 ///
 /// This delegate needs to implement [SelectionRegistrar] to register
 /// [Selectable]s in the [SelectionContainer] subtree.
-abstract class SelectionContainerDelegate implements SelectionHandler, SelectionRegistrar {
+abstract base class SelectionContainerDelegate implements SelectionHandler, SelectionRegistrar {
   BuildContext? _selectionContainerContext;
 
   /// Gets the paint transform from the [Selectable] child to

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2841,7 +2841,7 @@ class _GeometryCachePainter extends CustomPainter {
   }
 }
 
-class _CustomPageRoute<T> extends PageRoute<T> {
+final class _CustomPageRoute<T> extends PageRoute<T> {
   _CustomPageRoute({
     required this.builder,
     RouteSettings super.settings = const RouteSettings(),

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -65,7 +65,7 @@ class SampleForm extends StatelessWidget {
 }
 
 // Expose the protected hasScopedWillPopCallback getter
-class _TestPageRoute<T> extends MaterialPageRoute<T> {
+final class _TestPageRoute<T> extends MaterialPageRoute<T> {
   _TestPageRoute({
     super.settings,
     required super.builder,

--- a/packages/flutter/test/widgets/app_overrides_test.dart
+++ b/packages/flutter/test/widgets/app_overrides_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestRoute<T> extends PageRoute<T> {
+final class TestRoute<T> extends PageRoute<T> {
   TestRoute({ required this.child, super.settings });
 
   final Widget child;

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3090,7 +3090,7 @@ void main() {
   });
 }
 
-class TestRoute extends PageRouteBuilder<void> {
+final class TestRoute extends PageRouteBuilder<void> {
   TestRoute({required Widget child})
       : super(
           pageBuilder: (BuildContext _, Animation<double> __, Animation<double> ___) {

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -129,7 +129,7 @@ final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
   ),
 };
 
-class ThreeRoute extends MaterialPageRoute<void> {
+final class ThreeRoute extends MaterialPageRoute<void> {
   ThreeRoute()
     : super(builder: (BuildContext context) {
         return Material(
@@ -145,7 +145,7 @@ class ThreeRoute extends MaterialPageRoute<void> {
       });
 }
 
-class MutatingRoute extends MaterialPageRoute<void> {
+final class MutatingRoute extends MaterialPageRoute<void> {
   MutatingRoute()
     : super(builder: (BuildContext context) {
         return Hero(tag: 'a', key: UniqueKey(), child: const Text('MutatingRoute'));

--- a/packages/flutter/test/widgets/inherited_theme_test.dart
+++ b/packages/flutter/test/widgets/inherited_theme_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestRoute extends PageRouteBuilder<void> {
+final class TestRoute extends PageRouteBuilder<void> {
   TestRoute(Widget child) : super(
     pageBuilder: (BuildContext _, Animation<double> __, Animation<double> ___) => child,
   );

--- a/packages/flutter/test/widgets/navigator_restoration_test.dart
+++ b/packages/flutter/test/widgets/navigator_restoration_test.dart
@@ -1338,4 +1338,6 @@ class _RouteFinder extends MatchFinder {
   }
 }
 
-class FakeRoute extends Fake implements Route<void> { }
+final class FakeRoute extends MaterialPageRoute<void> {
+  FakeRoute() : super(builder: (_) => const Placeholder());
+ }

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -92,7 +92,7 @@ class OnTapPage extends StatelessWidget {
   }
 }
 
-class SlideInOutPageRoute<T> extends PageRouteBuilder<T> {
+final class SlideInOutPageRoute<T> extends PageRouteBuilder<T> {
   SlideInOutPageRoute({required WidgetBuilder bodyBuilder, super.settings}) : super(
     pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) => bodyBuilder(context),
     transitionsBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
@@ -4157,9 +4157,9 @@ void main() {
 
 typedef AnnouncementCallBack = void Function(Route<dynamic>?);
 
-class NotAnnounced extends Route<void> { /* A place holder for not announced route*/ }
+final class NotAnnounced extends Route<void> { /* A place holder for not announced route*/ }
 
-class RouteAnnouncementSpy extends Route<void> {
+final class RouteAnnouncementSpy extends Route<void> {
   RouteAnnouncementSpy({
     this.onDidChangePrevious,
     this.onDidChangeNext,
@@ -4302,7 +4302,7 @@ class TestPage extends Page<void> {
   }
 }
 
-class NoAnimationPageRoute extends PageRouteBuilder<void> {
+final class NoAnimationPageRoute extends PageRouteBuilder<void> {
   NoAnimationPageRoute({
     super.settings,
     required WidgetBuilder pageBuilder
@@ -4375,7 +4375,7 @@ class ZeroDurationPage extends Page<void> {
   }
 }
 
-class ZeroDurationPageRoute extends PageRoute<void> {
+final class ZeroDurationPageRoute extends PageRoute<void> {
   ZeroDurationPageRoute({required ZeroDurationPage page})
       : super(settings: page, allowSnapshotting: false);
 

--- a/packages/flutter/test/widgets/page_forward_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_forward_transitions_test.dart
@@ -26,7 +26,7 @@ class TestTransition extends AnimatedWidget {
   }
 }
 
-class TestRoute<T> extends PageRoute<T> {
+final class TestRoute<T> extends PageRoute<T> {
   TestRoute({
     required this.child,
     required RouteSettings settings,

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class TestOverlayRoute extends OverlayRoute<void> {
+final class TestOverlayRoute extends OverlayRoute<void> {
   TestOverlayRoute({ super.settings });
   @override
   Iterable<OverlayEntry> createOverlayEntries() sync* {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -15,7 +15,7 @@ final List<String> results = <String>[];
 
 Set<TestRoute> routes = HashSet<TestRoute>();
 
-class TestRoute extends Route<String?> with LocalHistoryRoute<String?> {
+final class TestRoute extends Route<String?> with LocalHistoryRoute<String?> {
   TestRoute(this.name);
   final String name;
 
@@ -1978,7 +1978,7 @@ double _getOpacity(GlobalKey key, WidgetTester tester) {
   });
 }
 
-class ModifiedReverseTransitionDurationRoute<T> extends MaterialPageRoute<T> {
+final class ModifiedReverseTransitionDurationRoute<T> extends MaterialPageRoute<T> {
   ModifiedReverseTransitionDurationRoute({
     required super.builder,
     super.settings,
@@ -1990,9 +1990,22 @@ class ModifiedReverseTransitionDurationRoute<T> extends MaterialPageRoute<T> {
   final Duration reverseTransitionDuration;
 }
 
-class MockPageRoute extends Fake implements PageRoute<dynamic> { }
+final class MockPageRoute extends PageRoute<dynamic> {
+  @override
+  Color? get barrierColor => throw UnimplementedError();
+  @override
+  String? get barrierLabel => throw UnimplementedError();
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    throw UnimplementedError();
+  }
+  @override
+  bool get maintainState => throw UnimplementedError();
+  @override
+  Duration get transitionDuration => throw UnimplementedError();
+ }
 
-class MockRoute extends Fake implements Route<dynamic> { }
+final class MockRoute extends Route<dynamic> { }
 
 class MockRouteAware extends Fake implements RouteAware {
   int didPushCount = 0;
@@ -2021,7 +2034,7 @@ class MockRouteAware extends Fake implements RouteAware {
   }
 }
 
-class TestPageRouteBuilder extends PageRouteBuilder<void> {
+final class TestPageRouteBuilder extends PageRouteBuilder<void> {
   TestPageRouteBuilder({required super.pageBuilder});
 
   @override
@@ -2053,7 +2066,7 @@ class DialogObserver extends NavigatorObserver {
   }
 }
 
-class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
+final class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
   _TestDialogRouteWithCustomBarrierCurve({
     required Widget child,
     this.barrierLabel,

--- a/packages/flutter/test/widgets/selection_container_test.dart
+++ b/packages/flutter/test/widgets/selection_container_test.dart
@@ -204,7 +204,7 @@ void main() {
   });
 }
 
-class TestContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+final class TestContainerDelegate extends MultiSelectableSelectionContainerDelegate {
   @override
   SelectionResult dispatchSelectionEventToChild(Selectable selectable, SelectionEvent event) {
     throw UnimplementedError();


### PR DESCRIPTION
both class can't be `implements` without breaking the framework since they contain private state and methods

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
