### PR TITLE
Disable context menu

### DIFF
--- a/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -98,16 +97,22 @@ class _MyContextMenuState extends State<MyContextMenu> {
   }
 
   Future<void> _disableContextMenu() async {
+    if (!kIsWeb) {
+      // Does nothing on non-web platforms.
+      return;
+    }
     _menuWasEnabled = BrowserContextMenu.enabled;
     if (_menuWasEnabled) {
-      // Does nothing on non-web platforms.
       await BrowserContextMenu.disableContextMenu();
     }
   }
 
   void _reenableContextMenu() {
-    if (_menuWasEnabled && !BrowserContextMenu.enabled) {
+    if (!kIsWeb) {
       // Does nothing on non-web platforms.
+      return;
+    }
+    if (_menuWasEnabled && !BrowserContextMenu.enabled) {
       BrowserContextMenu.enableContextMenu();
     }
   }
@@ -168,7 +173,7 @@ class _MyContextMenuState extends State<MyContextMenu> {
               children: <Widget>[
                 const Padding(
                   padding: EdgeInsets.all(8.0),
-                  child: Text('Ctrl-click anywhere on the background to show the menu.'),
+                  child: Text('Right-click anywhere on the background to show the menu.'),
                 ),
                 Padding(
                   padding: const EdgeInsets.all(12.0),

--- a/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/examples/api/test/material/menu_anchor/menu_anchor.1_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_anchor.1_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_api_samples/material/menu_anchor/menu_anchor.1.dart' as example;
@@ -18,15 +19,13 @@ void main() {
 
     await tester.pumpWidget(const example.ContextMenuApp());
 
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlRight);
-    await tester.tapAt(const Offset(100, 200));
+    await tester.tapAt(const Offset(100, 200), buttons: kSecondaryButton);
     await tester.pump();
     expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(100.0, 200.0, 433.0, 360.0)));
 
     // Make sure tapping in a different place causes the menu to move.
-    await tester.tapAt(const Offset(200, 100));
+    await tester.tapAt(const Offset(200, 100), buttons: kSecondaryButton);
     await tester.pump();
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlRight);
 
     expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(200.0, 100.0, 533.0, 260.0)));
 
@@ -67,8 +66,7 @@ void main() {
     );
 
     // Open the menu so we can look for state changes reflected in the menu.
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlRight);
-    await tester.tapAt(const Offset(100, 200));
+    await tester.tapAt(const Offset(100, 200), buttons: kSecondaryButton);
     await tester.pump();
 
     expect(find.text(example.MenuEntry.showMessage.label), findsOneWidget);


### PR DESCRIPTION
## Description

Changes the context menu example for `MenuAnchor` so that it uses right-click, or (on macOS and iOS only) ctrl-left-click, for the context menu. Also disables the browser context menu on web platforms.

## Tests
 - Updated test to reflect new triggers.