### PR TITLE
Fix typos 'wether' -> 'whether'

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -202,7 +202,7 @@ class _ZoomPageTransition extends StatelessWidget {
   ///
   /// See also:
   ///
-  ///  * [TransitionRoute.allowSnapshotting], which defines wether the route
+  ///  * [TransitionRoute.allowSnapshotting], which defines whether the route
   ///    transition will prefer to animate a snapshot of the entering and exiting
   ///    routes.
   final bool allowSnapshotting;

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -437,8 +437,7 @@ class RadioListTile<T> extends StatelessWidget {
 
   final _RadioType _radioType;
 
-  /// Determines wether or not to use the checkbox style for the [CupertinoRadio]
-  /// control.
+  /// Whether to use the checkbox style for the [CupertinoRadio] control.
   ///
   /// Only usable under the [RadioListTile.adaptive] constructor. If set to
   /// true, on Apple platforms the radio button will appear as an iOS styled


### PR DESCRIPTION
## Description

Fix two typos where 'wether' was used instead of 'whether'.

## Tests

Documentation only.


