### PR TITLE
Reland: Provide default constraints for M3 dialogs

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -24,6 +24,8 @@ import 'theme_data.dart';
 
 const EdgeInsets _defaultInsetPadding = EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
 
+const BoxConstraints _dialogConstraints = BoxConstraints(minWidth: 280.0, maxWidth: 560.0, maxHeight: 560.0);
+
 /// A Material Design dialog.
 ///
 /// This dialog widget does not have any opinion about the contents of the
@@ -232,7 +234,7 @@ class Dialog extends StatelessWidget {
       dialogChild = Align(
         alignment: alignment ?? dialogTheme.alignment ?? defaults.alignment!,
         child: ConstrainedBox(
-          constraints: const BoxConstraints(minWidth: 280.0),
+          constraints: _constraintsScaleFactor(MediaQuery.of(context).textScaleFactor, theme.useMaterial3),
           child: Material(
             color: backgroundColor ?? dialogTheme.backgroundColor ?? Theme.of(context).dialogBackgroundColor,
             elevation: elevation ?? dialogTheme.elevation ?? defaults.elevation!,
@@ -1261,7 +1263,7 @@ class SimpleDialog extends StatelessWidget {
     Widget dialogChild = IntrinsicWidth(
       stepWidth: 56.0,
       child: ConstrainedBox(
-        constraints: const BoxConstraints(minWidth: 280.0),
+        constraints: _constraintsScaleFactor(MediaQuery.of(context).textScaleFactor, theme.useMaterial3),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1585,6 +1587,17 @@ double _paddingScaleFactor(double textScaleFactor) {
   // The final padding scale factor is clamped between 1/3 and 1. For example,
   // a non-scaled padding of 24 will produce a padding between 24 and 8.
   return lerpDouble(1.0, 1.0 / 3.0, clampedTextScaleFactor - 1.0)!;
+}
+
+BoxConstraints _constraintsScaleFactor(double textScaleFactor, bool useMaterial3) {
+  if (!useMaterial3) {
+    return const BoxConstraints(minWidth: 280.0);
+  } else {
+    return textScaleFactor == 1.0
+      ? _dialogConstraints
+      // Scale the max height of the dialog by the text scale factor to aid in readability.
+      : _dialogConstraints.copyWith(maxHeight: _dialogConstraints.maxHeight * textScaleFactor);
+  }
 }
 
 // Hand coded defaults based on Material Design 2.

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
@@ -1595,8 +1596,10 @@ BoxConstraints _constraintsScaleFactor(double textScaleFactor, bool useMaterial3
   } else {
     return textScaleFactor == 1.0
       ? _dialogConstraints
-      // Scale the max height of the dialog by the text scale factor to aid in readability.
-      : _dialogConstraints.copyWith(maxHeight: _dialogConstraints.maxHeight * textScaleFactor);
+      // Scale the max height of the dialog by the text scale factor to aid in
+      // readability. To handle extreme cases, limit the text scale factor to
+      // 2.0.
+      : _dialogConstraints.copyWith(maxHeight: _dialogConstraints.maxHeight * min(2.0, textScaleFactor));
   }
 }
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -5,6 +5,7 @@
 @TestOn('!chrome')
 library;
 
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -426,7 +427,7 @@ void main() {
             tester.view.devicePixelRatio = 1;
             await mediaQueryBoilerplate(tester, materialType: materialType);
 
-            width = timePickerPortraitSize.width + padding.horizontal;
+            width = min(timePickerPortraitSize.width + padding.horizontal, 560); // width is limited to 560
             height = timePickerPortraitSize.height + padding.vertical;
             expect(
               tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
@@ -445,7 +446,7 @@ void main() {
               materialType: materialType,
             );
 
-            width =  timePickerLandscapeSize.width + padding.horizontal;
+            width =  min(timePickerLandscapeSize.width + padding.horizontal, 560); // width is limited to 560
             height = timePickerLandscapeSize.height + padding.vertical;
             expect(
               tester.getSize(find.byWidget(getMaterialFromDialog(tester))),
@@ -751,10 +752,10 @@ void main() {
             expect(tester.getBottomLeft(find.text(okString)).dx, 616);
             expect(tester.getBottomRight(find.text(cancelString)).dx, 582);
           case MaterialType.material3:
-            expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(138, 129)));
-            expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(292.0, 143.0)));
-            expect(tester.getBottomLeft(find.text(okString)).dx, 616);
-            expect(tester.getBottomRight(find.text(cancelString)).dx, 578);
+            expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(144, 129)));
+            expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(298.0, 143.0)));
+            expect(tester.getBottomLeft(find.text(okString)).dx, 610);
+            expect(tester.getBottomRight(find.text(cancelString)).dx, 572);
         }
 
         await tester.tap(find.text(okString));
@@ -774,11 +775,11 @@ void main() {
             expect(tester.getBottomRight(find.text(okString)).dx, 184);
             expect(tester.getBottomLeft(find.text(cancelString)).dx, 218);
           case MaterialType.material3:
-            expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(508, 129)));
-            expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(662, 143)));
-            expect(tester.getBottomLeft(find.text(okString)).dx, 156);
-            expect(tester.getBottomRight(find.text(okString)).dx, 184);
-            expect(tester.getBottomLeft(find.text(cancelString)).dx, 222);
+            expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(502, 129)));
+            expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(656, 143)));
+            expect(tester.getBottomLeft(find.text(okString)).dx, 162);
+            expect(tester.getBottomRight(find.text(okString)).dx, 190);
+            expect(tester.getBottomLeft(find.text(cancelString)).dx, 228);
         }
 
         await tester.tap(find.text(okString));


### PR DESCRIPTION
Reland of https://github.com/flutter/flutter/pull/120082, which was reverted in https://github.com/flutter/flutter/pull/126355.

One additional [commit](https://github.com/flutter/flutter/commit/e166cbd0bac8619835237908bc066ad15de2730f) was made to handle extreme text scaling cases.

---

This PR constrains M3 dialogs to 560dp max width and height.

This is not a breaking change per the breaking change policy.

Part of https://github.com/flutter/flutter/issues/118619

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
