### PR TITLE
[labeler] Set sync labels to false to stop removing labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,3 +18,5 @@ jobs:
     steps:
     # Source available at https://github.com/actions/labeler/blob/main/README.md
     - uses: actions/labeler@9fcb2c2f5584144ca754f8bfe8c6f81e77753375
+      with:
+        sync-labels: false


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/128440

The current version of the action has a bug where the sync-labels default value is not read correctly. Explicitly setting to see if that stops the removals.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
