### PR TITLE
Replace `MaterialButton` from test classes

### DIFF
--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1402,9 +1402,9 @@ void main() {
                     reverseDuration: const Duration(seconds: 2),
                   ),
                   builder: (BuildContext context) {
-                    return MaterialButton(
-                      onPressed: () => Navigator.pop(context),
+                    return ElevatedButton(
                       key: tapTargetToClose,
+                      onPressed: () => Navigator.pop(context),
                       child: const Text('BottomSheet'),
                     );
                   },
@@ -1551,9 +1551,9 @@ void main() {
                   context: context,
                   transitionAnimationController: controller,
                   builder: (BuildContext context) {
-                    return MaterialButton(
-                      onPressed: () => Navigator.pop(context),
+                    return ElevatedButton(
                       key: tapTargetToClose,
+                      onPressed: () => Navigator.pop(context),
                       child: const Text('BottomSheet'),
                     );
                   },

--- a/packages/flutter/test/material/card_test.dart
+++ b/packages/flutter/test/material/card_test.dart
@@ -22,9 +22,9 @@ void main() {
                 children: <Widget>[
                   const Text('I am text!'),
                   const Text('Moar text!!1'),
-                  MaterialButton(
-                    child: const Text('Button'),
+                  ElevatedButton(
                     onPressed: () { },
+                    child: const Text('Button'),
                   ),
                 ],
               ),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -1029,7 +1029,7 @@ class _TestSearchDelegate extends SearchDelegate<String> {
   @override
   Widget buildSuggestions(BuildContext context) {
     queriesForSuggestions.add(query);
-    return MaterialButton(
+    return ElevatedButton(
       onPressed: () {
         showResults(context);
       },
@@ -1066,7 +1066,7 @@ class _TestEmptySearchDelegate extends SearchDelegate<String> {
 
   @override
   Widget buildSuggestions(BuildContext context) {
-    return MaterialButton(
+    return ElevatedButton(
       onPressed: () {
         showResults(context);
       },

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -1345,9 +1345,13 @@ void main() {
                   Text('Second child', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 8.0)),
                 ],
               ),
-              const MaterialButton(
+              ElevatedButton(
                 onPressed: null,
-                child: Text('Material Button', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 20.0)),
+                style: ElevatedButton.styleFrom(textStyle: const TextStyle(
+                  fontFamily: 'FlutterTest',
+                  fontSize: 20.0,
+                )),
+                child: const Text('Elevated Button'),
               ),
               const Text('Text', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 28.0)),
             ],
@@ -1366,11 +1370,11 @@ void main() {
 
     final double firstToggleButtonDy = tester.getBottomLeft(find.text('First child')).dy;
     final double secondToggleButtonDy = tester.getBottomLeft(find.text('Second child')).dy;
-    final double materialButtonDy = tester.getBottomLeft(find.text('Material Button')).dy;
+    final double elevatedButtonDy = tester.getBottomLeft(find.text('Elevated Button')).dy;
     final double textDy = tester.getBottomLeft(find.text('Text')).dy;
 
     expect(firstToggleButtonDy, secondToggleButtonDy);
-    expect(firstToggleButtonDy, materialButtonDy - 3.0);
+    expect(firstToggleButtonDy, elevatedButtonDy - 3.0);
     expect(firstToggleButtonDy, textDy - 5.0);
   });
 

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -863,10 +863,10 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: FocusableActionDetector(
-              child: MaterialButton(
+              child: ElevatedButton(
+                onPressed: () {},
                 focusNode: buttonNode,
                 child: const Text('Test'),
-                onPressed: () {},
               ),
             ),
           ),
@@ -882,10 +882,10 @@ void main() {
           MaterialApp(
             home: FocusableActionDetector(
               descendantsAreFocusable: false,
-              child: MaterialButton(
+              child: ElevatedButton(
+                onPressed: () {},
                 focusNode: buttonNode,
                 child: const Text('Test'),
-                onPressed: () {},
               ),
             ),
           ),
@@ -910,15 +910,15 @@ void main() {
             home: FocusableActionDetector(
               child: Column(
                 children: <Widget>[
-                  MaterialButton(
+                  ElevatedButton(
+                    onPressed: () {},
                     focusNode: buttonNode1,
                     child: const Text('Node 1'),
-                    onPressed: () {},
                   ),
-                  MaterialButton(
+                  ElevatedButton(
+                    onPressed: () {},
                     focusNode: buttonNode2,
                     child: const Text('Node 2'),
-                    onPressed: () {},
                   ),
                 ],
               ),
@@ -941,15 +941,15 @@ void main() {
               descendantsAreTraversable: false,
               child: Column(
                 children: <Widget>[
-                  MaterialButton(
+                  ElevatedButton(
+                    onPressed: () {},
                     focusNode: buttonNode1,
                     child: const Text('Node 1'),
-                    onPressed: () {},
                   ),
-                  MaterialButton(
+                  ElevatedButton(
+                    onPressed: () {},
                     focusNode: buttonNode2,
                     child: const Text('Node 2'),
-                    onPressed: () {},
                   ),
                 ],
               ),

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -331,7 +331,7 @@ void main() {
             policy: WidgetOrderTraversalPolicy(),
             child: Center(
               child: Builder(builder: (BuildContext context) {
-                return MaterialButton(
+                return ElevatedButton(
                   key: key1,
                   focusNode: testNode1,
                   autofocus: true,
@@ -340,7 +340,7 @@ void main() {
                       MaterialPageRoute<void>(
                         builder: (BuildContext context) {
                           return Center(
-                            child: MaterialButton(
+                            child: ElevatedButton(
                               key: key2,
                               focusNode: testNode2,
                               autofocus: true,
@@ -1218,7 +1218,7 @@ void main() {
               child: Builder(builder: (BuildContext context) {
                 return FocusTraversalOrder(
                   order: const NumericFocusOrder(0),
-                  child: MaterialButton(
+                  child: ElevatedButton(
                     key: key1,
                     focusNode: testNode1,
                     autofocus: true,
@@ -1229,7 +1229,7 @@ void main() {
                             return Center(
                               child: FocusTraversalOrder(
                                 order: const NumericFocusOrder(0),
-                                child: MaterialButton(
+                                child: ElevatedButton(
                                   key: key2,
                                   focusNode: testNode2,
                                   autofocus: true,


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/128465

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
