### PR TITLE
[flutter_tools] Add support for vmServiceFileInfo when attaching

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -40,7 +40,10 @@ Arguments specific to `launchRequest` are:
 
 Arguments specific to `attachRequest` are:
 
-- `String? vmServiceUri` - the VM Service URI to attach to (if not supplied, Flutter will try to discover it from the device)
+- `String vmServiceInfoFile` - the file to read the VM Service info from \*
+- `String vmServiceUri` - the VM Service URI to attach to \*
+
+\* Only one of `vmServiceInfoFile` or `vmServiceUri` may be supplied.
 
 ## Custom Requests
 

--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -40,10 +40,10 @@ Arguments specific to `launchRequest` are:
 
 Arguments specific to `attachRequest` are:
 
-- `String vmServiceInfoFile` - the file to read the VM Service info from \*
-- `String vmServiceUri` - the VM Service URI to attach to \*
+- `String? vmServiceInfoFile` - the file to read the VM Service info from \*
+- `String? vmServiceUri` - the VM Service URI to attach to \*
 
-\* Only one of `vmServiceInfoFile` or `vmServiceUri` may be supplied.
+\* Only one of `vmServiceInfoFile` or `vmServiceUri` may be supplied. If neither are supplied, Flutter will try to discover it from the device.
 
 ## Custom Requests
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -126,7 +126,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
 
     if (vmServiceUri != null && vmServiceInfoFile != null) {
       sendConsoleOutput(
-        'To attach, provide only one of vmServiceUri/vmServiceInfoFile',
+        'To attach, provide only one (or neither) of vmServiceUri/vmServiceInfoFile',
       );
       handleSessionTerminate();
       return;

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -11,7 +11,7 @@ import 'package:vm_service/vm_service.dart' as vm;
 import '../base/io.dart';
 import '../cache.dart';
 import '../convert.dart';
-import '../globals.dart' show fs;
+import '../globals.dart' as globals show fs;
 import 'flutter_adapter_args.dart';
 import 'flutter_base_adapter.dart';
 
@@ -139,7 +139,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
     );
 
     if (vmServiceUri == null && vmServiceInfoFile != null) {
-      final Uri uriFromFile = await waitForVmServiceInfoFile(logger, fs.file(vmServiceInfoFile));
+      final Uri uriFromFile = await waitForVmServiceInfoFile(logger, globals.fs.file(vmServiceInfoFile));
       vmServiceUri = uriFromFile.toString();
     }
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:dds/dap.dart' hide PidTracker;
@@ -12,6 +11,7 @@ import 'package:vm_service/vm_service.dart' as vm;
 import '../base/io.dart';
 import '../cache.dart';
 import '../convert.dart';
+import '../globals.dart' show fs;
 import 'flutter_adapter_args.dart';
 import 'flutter_base_adapter.dart';
 
@@ -139,7 +139,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
     );
 
     if (vmServiceUri == null && vmServiceInfoFile != null) {
-      final Uri uriFromFile = await waitForVmServiceInfoFile(logger, File(vmServiceInfoFile));
+      final Uri uriFromFile = await waitForVmServiceInfoFile(logger, fs.file(vmServiceInfoFile));
       vmServiceUri = uriFromFile.toString();
     }
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -17,6 +17,7 @@ class FlutterAttachRequestArguments
     this.customTool,
     this.customToolReplacesArgs,
     this.vmServiceUri,
+    this.vmServiceInfoFile,
     this.program,
     super.restart,
     super.name,
@@ -36,6 +37,7 @@ class FlutterAttachRequestArguments
         customTool = obj['customTool'] as String?,
         customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
         vmServiceUri = obj['vmServiceUri'] as String?,
+        vmServiceInfoFile = obj['vmServiceInfoFile'] as String?,
         program = obj['program'] as String?,
         super.fromMap();
 
@@ -64,7 +66,14 @@ class FlutterAttachRequestArguments
   final int? customToolReplacesArgs;
 
   /// The VM Service URI of the running Flutter app to connect to.
+  ///
+  /// Only one of this or [vmServiceInfoFile] (or neither) can be supplied.
   final String? vmServiceUri;
+
+  /// The VM Service info file to extract the VM Service URI from to attach to.
+  ///
+  /// Only one of this or [vmServiceUri] (or neither) can be supplied.
+  final String? vmServiceInfoFile;
 
   /// The program/Flutter app to be run.
   final String? program;

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/debug_adapters/flutter_adapter.dart';
 import 'package:flutter_tools/src/debug_adapters/flutter_adapter_args.dart';
-import 'package:flutter_tools/src/globals.dart' as globals show platform;
+import 'package:flutter_tools/src/globals.dart' as globals show fs, platform;
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
@@ -272,6 +272,107 @@ void main() {
               '--machine',
               '--target',
               'program/main.dart'
+            ]));
+      });
+
+      test('runs "flutter attach" with --debug-uri if vmServiceUri is passed', () async {
+        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+        final Completer<void> responseCompleter = Completer<void>();
+
+        final FlutterAttachRequestArguments args =
+            FlutterAttachRequestArguments(
+          cwd: '/project',
+          program: 'program/main.dart',
+          vmServiceUri: 'ws://1.2.3.4/ws'
+        );
+
+        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.attachRequest(
+            MockRequest(), args, responseCompleter.complete);
+        await responseCompleter.future;
+
+        expect(
+            adapter.processArgs,
+            containsAllInOrder(<String>[
+              'attach',
+              '--machine',
+              '--debug-uri',
+              'ws://1.2.3.4/ws',
+              '--target',
+              'program/main.dart',
+            ]));
+      });
+
+      test('runs "flutter attach" with --debug-uri if vmServiceInfoFile exists', () async {
+        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+        final Completer<void> responseCompleter = Completer<void>();
+        final File serviceInfoFile = globals.fs.systemTempDirectory.createTempSync('dap_flutter_attach_vmServiceInfoFile').childFile('vmServiceInfo.json');
+
+        final FlutterAttachRequestArguments args =
+            FlutterAttachRequestArguments(
+          cwd: '/project',
+          program: 'program/main.dart',
+          vmServiceInfoFile: serviceInfoFile.path,
+        );
+
+        // Write the service info file before trying to attach:
+        serviceInfoFile.writeAsStringSync('{ "uri": "ws://1.2.3.4/ws" }');
+
+        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        await responseCompleter.future;
+
+        expect(
+            adapter.processArgs,
+            containsAllInOrder(<String>[
+              'attach',
+              '--machine',
+              '--debug-uri',
+              'ws://1.2.3.4/ws',
+              '--target',
+              'program/main.dart',
+            ]));
+      });
+
+      test('runs "flutter attach" with --debug-uri if vmServiceInfoFile is created later', () async {
+        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+        final Completer<void> responseCompleter = Completer<void>();
+        final File serviceInfoFile = globals.fs.systemTempDirectory.createTempSync('dap_flutter_attach_vmServiceInfoFile').childFile('vmServiceInfo.json');
+
+        final FlutterAttachRequestArguments args =
+            FlutterAttachRequestArguments(
+          cwd: '/project',
+          program: 'program/main.dart',
+          vmServiceInfoFile: serviceInfoFile.path,
+        );
+
+
+        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        final Future<void> attachResponseFuture = adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        // Write the service info file a little later to ensure we detect it:
+        await pumpEventQueue(times:5000);
+        serviceInfoFile.writeAsStringSync('{ "uri": "ws://1.2.3.4/ws" }');
+        await attachResponseFuture;
+        await responseCompleter.future;
+
+        expect(
+            adapter.processArgs,
+            containsAllInOrder(<String>[
+              'attach',
+              '--machine',
+              '--debug-uri',
+              'ws://1.2.3.4/ws',
+              '--target',
+              'program/main.dart',
             ]));
       });
 


### PR DESCRIPTION
When building the new SDK DAPs, this functionality was missed from the Flutter adapter (but added to the Dart CLI adapter).

As well as passing a VM Service URI directly, we support passing a file that can be polled for it.

This uses the same mechanism we use to obtain the VM Service URI from a Dart debug session (we run `dart --write-service-info=foo.json my_file.dart` and then poll that file which the VM will write) and is useful for users that have their own mechanism for launching an app (for example using custom Flutter embedders - see https://github.com/Dart-Code/Dart-Code/issues/3353) to provide a VM Service URI once the app is up and running.

Fixes https://github.com/Dart-Code/Dart-Code/issues/4577.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
