### PR TITLE
Updated flutter_localizations tests for Material3;

### DIFF
--- a/packages/flutter_localizations/test/basics_test.dart
+++ b/packages/flutter_localizations/test/basics_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Nested Localizations', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp( // Creates the outer Localizations widget.
+      theme: ThemeData(useMaterial3: true),
       home: ListView(
         children: <Widget>[
           const LocalizationTracker(key: ValueKey<String>('outer')),
@@ -20,11 +21,12 @@ void main() {
         ],
       ),
     ));
-
+    // Most localized aspects of the TextTheme text styles are the same for the default US local and
+    // for Chinese for Material3. The baselines for all text styles differ.
     final LocalizationTrackerState outerTracker = tester.state(find.byKey(const ValueKey<String>('outer'), skipOffstage: false));
-    expect(outerTracker.bodySmallFontSize, 12.0);
+    expect(outerTracker.textBaseline, TextBaseline.alphabetic);
     final LocalizationTrackerState innerTracker = tester.state(find.byKey(const ValueKey<String>('inner'), skipOffstage: false));
-    expect(innerTracker.bodySmallFontSize, 13.0);
+    expect(innerTracker.textBaseline, TextBaseline.ideographic);
   });
 
   testWidgets('Localizations is compatible with ChangeNotifier.dispose() called during didChangeDependencies', (WidgetTester tester) async {
@@ -92,11 +94,11 @@ class LocalizationTracker extends StatefulWidget {
 }
 
 class LocalizationTrackerState extends State<LocalizationTracker> {
-  late double bodySmallFontSize;
+  late TextBaseline textBaseline;
 
   @override
   Widget build(BuildContext context) {
-    bodySmallFontSize = Theme.of(context).textTheme.bodySmall!.fontSize!;
+    textBaseline = Theme.of(context).textTheme.bodySmall!.textBaseline!;
     return Container();
   }
 }

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -93,79 +93,123 @@ void main() {
   });
 
   testWidgets('locale parameter overrides ambient locale', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      locale: const Locale('en', 'US'),
-      supportedLocales: const <Locale>[
-        Locale('en', 'US'),
-        Locale('fr', 'CA'),
-      ],
-      localizationsDelegates: GlobalMaterialLocalizations.delegates,
-      home: Material(
-        child: Builder(
-          builder: (BuildContext context) {
-            return TextButton(
-              onPressed: () async {
-                await showDatePicker(
-                  context: context,
-                  initialDate: initialDate,
-                  firstDate: firstDate,
-                  lastDate: lastDate,
-                  locale: const Locale('fr', 'CA'),
-                );
-              },
-              child: const Text('X'),
-            );
-          },
+    Widget buildFrame(bool useMaterial3) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: useMaterial3),
+        locale: const Locale('en', 'US'),
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('fr', 'CA'),
+        ],
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                    locale: const Locale('fr', 'CA'),
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
         ),
-      ),
-    ));
+      );
+    }
 
+    Element getPicker() => tester.element(find.byType(CalendarDatePicker));
+
+    await tester.pumpWidget(buildFrame(true));
     await tester.tap(find.text('X'));
-    await tester.pumpAndSettle(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final Element picker = tester.element(find.byType(CalendarDatePicker));
     expect(
-      Localizations.localeOf(picker),
+      Localizations.localeOf(getPicker()),
       const Locale('fr', 'CA'),
     );
+    expect(
+      Directionality.of(getPicker()),
+      TextDirection.ltr,
+    );
+
+    await tester.tap(find.text('Annuler'));
+
+    // The tests below are only relevant for Material 2. Once Material 2
+    // support is deprecated and the APIs are removed, these tests
+    // can be deleted.
+
+    await tester.pumpWidget(buildFrame(false));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
 
     expect(
-      Directionality.of(picker),
+      Localizations.localeOf(getPicker()),
+      const Locale('fr', 'CA'),
+    );
+    expect(
+      Directionality.of(getPicker()),
       TextDirection.ltr,
     );
 
     await tester.tap(find.text('ANNULER'));
+
   });
 
   testWidgets('textDirection parameter overrides ambient textDirection', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      locale: const Locale('en', 'US'),
-      home: Material(
-        child: Builder(
-          builder: (BuildContext context) {
-            return TextButton(
-              onPressed: () async {
-                await showDatePicker(
-                  context: context,
-                  initialDate: initialDate,
-                  firstDate: firstDate,
-                  lastDate: lastDate,
-                  textDirection: TextDirection.rtl,
-                );
-              },
-              child: const Text('X'),
-            );
-          },
+    Widget buildFrame(bool useMaterial3) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: useMaterial3),
+        locale: const Locale('en', 'US'),
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                    textDirection: TextDirection.rtl,
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
         ),
-      ),
-    ));
+      );
+    }
 
+    Element getPicker() => tester.element(find.byType(CalendarDatePicker));
+
+    await tester.pumpWidget(buildFrame(true));
     await tester.tap(find.text('X'));
-    await tester.pumpAndSettle(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    final Element picker = tester.element(find.byType(CalendarDatePicker));
     expect(
-      Directionality.of(picker),
+      Directionality.of(getPicker()),
+      TextDirection.rtl,
+    );
+
+    await tester.tap(find.text('Cancel'));
+
+    // The tests below are only relevant for Material 2. Once Material 2
+    // support is deprecated and the APIs are removed, these tests
+    // can be deleted.
+
+    await tester.pumpWidget(buildFrame(false));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    expect(
+      Directionality.of(getPicker()),
       TextDirection.rtl,
     );
 
@@ -173,45 +217,70 @@ void main() {
   });
 
   testWidgets('textDirection parameter takes precedence over locale parameter', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      locale: const Locale('en', 'US'),
-      supportedLocales: const <Locale>[
-        Locale('en', 'US'),
-        Locale('fr', 'CA'),
-      ],
-      localizationsDelegates: GlobalMaterialLocalizations.delegates,
-      home: Material(
-        child: Builder(
-          builder: (BuildContext context) {
-            return TextButton(
-              onPressed: () async {
-                await showDatePicker(
-                  context: context,
-                  initialDate: initialDate,
-                  firstDate: firstDate,
-                  lastDate: lastDate,
-                  locale: const Locale('fr', 'CA'),
-                  textDirection: TextDirection.rtl,
-                );
-              },
-              child: const Text('X'),
-            );
-          },
+    Widget buildFrame(bool useMaterial3) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: useMaterial3),
+        locale: const Locale('en', 'US'),
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('fr', 'CA'),
+        ],
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                    locale: const Locale('fr', 'CA'),
+                    textDirection: TextDirection.rtl,
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
         ),
-      ),
-    ));
+      );
+    }
 
+    Element getPicker() => tester.element(find.byType(CalendarDatePicker));
+
+    await tester.pumpWidget(buildFrame(true));
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle(const Duration(seconds: 1));
 
-    final Element picker = tester.element(find.byType(CalendarDatePicker));
     expect(
-      Localizations.localeOf(picker),
+      Localizations.localeOf(getPicker()),
       const Locale('fr', 'CA'),
     );
 
     expect(
-      Directionality.of(picker),
+      Directionality.of(getPicker()),
+      TextDirection.rtl,
+    );
+
+    await tester.tap(find.text('Annuler'));
+
+    // The tests below are only relevant for Material 2. Once Material 2
+    // support is deprecated and the APIs are removed, these tests
+    // can be deleted.
+
+    await tester.pumpWidget(buildFrame(false));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    expect(
+      Localizations.localeOf(getPicker()),
+      const Locale('fr', 'CA'),
+    );
+
+    expect(
+      Directionality.of(getPicker()),
       TextDirection.rtl,
     );
 

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -17,6 +17,7 @@ void main() {
     final Key targetKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: true),
         routes: <String, WidgetBuilder>{
           '/next': (BuildContext context) {
             return const Text('Next');
@@ -75,20 +76,20 @@ void main() {
     Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
-    expect(topLeft, const Offset(392.0, 299.5));
-    expect(topRight, const Offset(596.0, 299.5));
-    expect(bottomLeft, const Offset(392.0, 316.5));
-    expect(bottomRight, const Offset(596.0, 316.5));
+    expect(topLeft, const Offset(392.0, 298.0));
+    expect(topRight, const Offset(562.0, 298.0));
+    expect(bottomLeft, const Offset(392.0, 318.0));
+    expect(bottomRight, const Offset(562.0, 318.0));
 
     topLeft = tester.getTopLeft(find.text('你好，世界'));
     topRight = tester.getTopRight(find.text('你好，世界'));
     bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
     bottomRight = tester.getBottomRight(find.text('你好，世界'));
 
-    expect(topLeft, const Offset(392.0, 347.5));
-    expect(topRight, const Offset(477.0, 347.5));
-    expect(bottomLeft, const Offset(392.0, 364.5));
-    expect(bottomRight, const Offset(477.0, 364.5));
+    expect(topLeft, const Offset(392.0, 346.0));
+    expect(topRight, const Offset(463.0, 346.0));
+    expect(bottomLeft, const Offset(392.0, 366.0));
+    expect(bottomRight, const Offset(463.0, 366.0));
   });
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
@@ -101,6 +102,7 @@ void main() {
     final Key targetKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: true),
         routes: <String, WidgetBuilder>{
           '/next': (BuildContext context) {
             return const Text('Next');
@@ -159,19 +161,19 @@ void main() {
     Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
     Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
 
-    expect(topLeft, const Offset(392.0, 300.0));
-    expect(topRight, const Offset(584.0, 300.0));
-    expect(bottomLeft, const Offset(392.0, 316));
-    expect(bottomRight, const Offset(584.0, 316));
+    expect(topLeft, const Offset(392.0, 298.0));
+    expect(topRight, const Offset(562.0, 298.0));
+    expect(bottomLeft, const Offset(392.0, 318.0));
+    expect(bottomRight, const Offset(562.0, 318.0));
 
     topLeft = tester.getTopLeft(find.text('你好，世界'));
     topRight = tester.getTopRight(find.text('你好，世界'));
     bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
     bottomRight = tester.getBottomRight(find.text('你好，世界'));
 
-    expect(topLeft, const Offset(392.0, 348.0));
-    expect(topRight, const Offset(472.0, 348.0));
-    expect(bottomLeft, const Offset(392.0, 364.0));
-    expect(bottomRight, const Offset(472.0, 364.0));
+    expect(topLeft, const Offset(392.0, 346.0));
+    expect(topRight, const Offset(463.0, 346.0));
+    expect(bottomLeft, const Offset(392.0, 366.0));
+    expect(bottomRight, const Offset(463.0, 366.0));
   });
 }


### PR DESCRIPTION
Updated the localization tests so that they'll DTRT when useMaterial3:true becomes the default for ThemeData. In a few cases there are M2 and M3 tests now, to check features that are significantly different in Material3, notably the double ring for the 24  hour input dial. 

| Material 2 | Material 3|
|---------|---------|
|   <img width="250" alt="Screenshot 2023-06-08 at 10 47 37 AM" src="https://github.com/flutter/flutter/assets/1377460/6ca95e22-b3f1-4f6b-9e39-79c888ba58f1"> | <img width="257" alt="Screenshot 2023-06-08 at 10 47 13 AM" src="https://github.com/flutter/flutter/assets/1377460/19b685bf-c812-4c87-baed-70fa56efaad8"> | 

In M3, most aspects of the ideographic text styles are the same as for alphabetic styles, so there are some tweaks here to account for that. 


