### PR TITLE
[WIP][POC] TextField can be used in SelectionArea

### DIFF
--- a/packages/flutter/lib/src/material/selection_area.dart
+++ b/packages/flutter/lib/src/material/selection_area.dart
@@ -47,6 +47,7 @@ class SelectionArea extends StatefulWidget {
     this.contextMenuBuilder = _defaultContextMenuBuilder,
     this.magnifierConfiguration,
     this.onSelectionChanged,
+    this.readOnly = true,
     required this.child,
   });
 
@@ -86,6 +87,11 @@ class SelectionArea extends StatefulWidget {
 
   /// Called when the selected content changes.
   final ValueChanged<SelectedContent?>? onSelectionChanged;
+
+  /// Whether the contents of this [SelectionArea] are read only.
+  ///
+  /// Defaults to true.
+  final bool readOnly;
 
   /// The child widget this selection area applies to.
   ///
@@ -127,6 +133,7 @@ class _SelectionAreaState extends State<SelectionArea> {
       contextMenuBuilder: widget.contextMenuBuilder,
       magnifierConfiguration: widget.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,
       onSelectionChanged: widget.onSelectionChanged,
+      readOnly: widget.readOnly,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1461,7 +1461,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     }
 
     Widget selectionAreaBuilder = SelectionArea(
-      readOnly: false,
+      readOnly: widget.readOnly || !_isEnabled,
+      // focusNode: focusNode,
       child: Builder(
         builder: (BuildContext context) {
           final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1460,10 +1460,86 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         };
     }
 
+    Widget selectionAreaBuilder = SelectionArea(
+      child: Builder(
+        builder: (BuildContext context) {
+          final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);
+          return EditableText(
+            key: editableTextKey,
+            readOnly: widget.readOnly || !_isEnabled,
+            toolbarOptions: widget.toolbarOptions,
+            showCursor: widget.showCursor,
+            showSelectionHandles: _showSelectionHandles,
+            controller: controller,
+            focusNode: focusNode,
+            undoController: widget.undoController,
+            keyboardType: widget.keyboardType,
+            textInputAction: widget.textInputAction,
+            textCapitalization: widget.textCapitalization,
+            style: style,
+            strutStyle: widget.strutStyle,
+            textAlign: widget.textAlign,
+            textDirection: widget.textDirection,
+            autofocus: widget.autofocus,
+            obscuringCharacter: widget.obscuringCharacter,
+            obscureText: widget.obscureText,
+            autocorrect: widget.autocorrect,
+            smartDashesType: widget.smartDashesType,
+            smartQuotesType: widget.smartQuotesType,
+            enableSuggestions: widget.enableSuggestions,
+            maxLines: widget.maxLines,
+            minLines: widget.minLines,
+            expands: widget.expands,
+            // Only show the selection highlight when the text field is focused.
+            selectionRegistrar: registrar,
+            selectionColor: selectionColor,
+            // selectionColor: focusNode.hasFocus ? selectionColor,
+            selectionControls: widget.selectionEnabled ? textSelectionControls : null,
+            onChanged: widget.onChanged,
+            onSelectionChanged: _handleSelectionChanged,
+            onEditingComplete: widget.onEditingComplete,
+            onSubmitted: widget.onSubmitted,
+            onAppPrivateCommand: widget.onAppPrivateCommand,
+            onSelectionHandleTapped: _handleSelectionHandleTapped,
+            onTapOutside: widget.onTapOutside,
+            inputFormatters: formatters,
+            rendererIgnoresPointer: true,
+            mouseCursor: MouseCursor.defer, // TextField will handle the cursor
+            cursorWidth: widget.cursorWidth,
+            cursorHeight: widget.cursorHeight,
+            cursorRadius: cursorRadius,
+            cursorColor: cursorColor,
+            selectionHeightStyle: widget.selectionHeightStyle,
+            selectionWidthStyle: widget.selectionWidthStyle,
+            cursorOpacityAnimates: cursorOpacityAnimates ?? false,
+            cursorOffset: cursorOffset,
+            paintCursorAboveText: paintCursorAboveText,
+            backgroundCursorColor: CupertinoColors.inactiveGray,
+            scrollPadding: widget.scrollPadding,
+            keyboardAppearance: keyboardAppearance,
+            enableInteractiveSelection: widget.enableInteractiveSelection,
+            dragStartBehavior: widget.dragStartBehavior,
+            scrollController: widget.scrollController,
+            scrollPhysics: widget.scrollPhysics,
+            autofillClient: this,
+            autocorrectionTextRectColor: autocorrectionTextRectColor,
+            clipBehavior: widget.clipBehavior,
+            restorationId: 'editable',
+            scribbleEnabled: widget.scribbleEnabled,
+            enableIMEPersonalizedLearning: widget.enableIMEPersonalizedLearning,
+            contentInsertionConfiguration: widget.contentInsertionConfiguration,
+            contextMenuBuilder: widget.contextMenuBuilder,
+            spellCheckConfiguration: spellCheckConfiguration,
+            magnifierConfiguration: widget.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,
+          );
+        },
+      ),
+    );
+
     Widget child = RepaintBoundary(
       child: UnmanagedRestorationScope(
         bucket: bucket,
-        child: EditableText(
+        child: registrar == null ? selectionAreaBuilder : EditableText(
           key: editableTextKey,
           readOnly: widget.readOnly || !_isEnabled,
           toolbarOptions: widget.toolbarOptions,
@@ -1593,9 +1669,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
               );
             },
             child: child,
-            // child: SelectionArea(
-            //   child: child,
-            // ),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -20,8 +20,8 @@ import 'input_decorator.dart';
 import 'magnifier.dart';
 import 'material_localizations.dart';
 import 'material_state.dart';
-import 'selection_area.dart';
 import 'selectable_text.dart' show iOSHorizontalOffset;
+import 'selection_area.dart';
 import 'spell_check_suggestions_toolbar.dart';
 import 'text_selection.dart';
 import 'theme.dart';
@@ -1460,7 +1460,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         };
     }
 
-    Widget selectionAreaBuilder = SelectionArea(
+    final Widget selectionAreaBuilder = SelectionArea(
       readOnly: widget.readOnly || !_isEnabled,
       // focusNode: focusNode,
       child: Builder(

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1461,6 +1461,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     }
 
     Widget selectionAreaBuilder = SelectionArea(
+      readOnly: false,
       child: Builder(
         builder: (BuildContext context) {
           final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -20,6 +20,7 @@ import 'input_decorator.dart';
 import 'magnifier.dart';
 import 'material_localizations.dart';
 import 'material_state.dart';
+import 'selection_area.dart';
 import 'selectable_text.dart' show iOSHorizontalOffset;
 import 'spell_check_suggestions_toolbar.dart';
 import 'text_selection.dart';
@@ -1333,6 +1334,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         (widget.style!.fontSize == null || widget.style!.textBaseline == null)),
       'inherit false style must supply fontSize and textBaseline',
     );
+    final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);
 
     final ThemeData theme = Theme.of(context);
     final DefaultSelectionStyle selectionStyle = DefaultSelectionStyle.of(context);
@@ -1488,7 +1490,9 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           minLines: widget.minLines,
           expands: widget.expands,
           // Only show the selection highlight when the text field is focused.
-          selectionColor: focusNode.hasFocus ? selectionColor : null,
+          selectionRegistrar: registrar,
+          selectionColor: selectionColor,
+          // selectionColor: focusNode.hasFocus ? selectionColor,
           selectionControls: widget.selectionEnabled ? textSelectionControls : null,
           onChanged: widget.onChanged,
           onSelectionChanged: _handleSelectionChanged,
@@ -1588,10 +1592,10 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
                 child: child,
               );
             },
-            child: _selectionGestureDetectorBuilder.buildGestureDetector(
-              behavior: HitTestBehavior.translucent,
-              child: child,
-            ),
+            child: child,
+            // child: SelectionArea(
+            //   child: child,
+            // ),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1824,7 +1824,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   bool get _hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
 
   Offset _getOffsetForPosition(TextPosition position) {
-    return _textPainter.getOffsetForCaret(position, Rect.zero) + Offset(0, _textPainter.getFullHeightForCaret(position, Rect.zero) ?? 0.0);
+    return _textPainter.getOffsetForCaret(position, Rect.zero) + Offset(0, _textPainter.getFullHeightForCaret(position, _caretPrototype) ?? 0.0);
   }
 
   /// Returns the local coordinates of the endpoints of the given selection.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -799,12 +799,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
 
   void _updateSelectionRegistrarSubscription() {
     if (_registrar == null) {
-      debugPrint('registar null');
       return;
     }
-    debugPrint('updating registrar');
     _lastSelectableFragments ??= _getSelectableFragments();
-    debugPrint('$_lastSelectableFragments');
     _lastSelectableFragments!.forEach(_registrar!.add);
   }
 
@@ -892,7 +889,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     if (_textPainter.text == value) {
       return;
     }
-    debugPrint('set text');
     _cachedLineBreakCount = null;
     _textPainter.text = value;
     _cachedAttributedValue = null;
@@ -1899,6 +1895,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     _computeTextMetricsIfNeeded();
     globalPosition += -_paintOffset;
     return _textPainter.getPositionForOffset(globalToLocal(globalPosition));
+  }
+
+  TextPosition _getPositionForOffset(Offset offset) {
+    assert(!debugNeedsLayout);
+    _computeTextMetricsIfNeeded();
+    return _textPainter.getPositionForOffset(offset);
   }
 
   /// Returns the [Rect] in local coordinates for the caret at the given text
@@ -3224,7 +3226,7 @@ class _EditableSelectableFragment with Selectable, ChangeNotifier {
 
   @override
   SelectionResult dispatchSelectionEvent(SelectionEvent event) {
-    debugPrint('dispatchSelectionEvent $fullText $event');
+    debugPrint('dispatchSelectionEvent ${range.textInside(fullText)} separator $fullText $event');
     late final SelectionResult result;
     final TextPosition? existingSelectionStart = _textSelectionStart;
     final TextPosition? existingSelectionEnd = _textSelectionEnd;
@@ -3310,7 +3312,7 @@ class _EditableSelectableFragment with Selectable, ChangeNotifier {
       direction: editable.textDirection,
     );
 
-    final TextPosition position = _clampTextPosition(editable.getPositionForPoint(adjustedOffset));
+    final TextPosition position = _clampTextPosition(editable._getPositionForOffset(adjustedOffset));
     _setSelectionPosition(position, isEnd: isEnd);
     if (position.offset == range.end) {
       return SelectionResult.next;
@@ -3346,7 +3348,7 @@ class _EditableSelectableFragment with Selectable, ChangeNotifier {
   }
 
   SelectionResult _handleSelectWord(Offset globalPosition) {
-    final TextPosition position = editable.getPositionForPoint(editable.globalToLocal(globalPosition));
+    final TextPosition position = editable._getPositionForOffset(editable.globalToLocal(globalPosition));
     if (_positionIsWithinCurrentSelection(position)) {
       return SelectionResult.end;
     }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3333,7 +3333,7 @@ class _EditableSelectableFragment with Selectable, ChangeNotifier {
             extentOffset: _textSelectionEnd?.offset,
           ),
         ),
-        SelectionChangedCause.tap,
+        SelectionChangedCause.tap, // Is SelectionChangedCause necessary? If so we will need to add it to SelectionEvent.
       );
     }
     return result;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3326,18 +3326,15 @@ class _EditableSelectableFragment with Selectable, ChangeNotifier {
     if (existingSelectionStart != _textSelectionStart ||
         existingSelectionEnd != _textSelectionEnd) {
       _didChangeSelection();
-      if (_textSelectionStart != null && _textSelectionEnd != null) {
-        debugPrint('woah');
-        editable.textSelectionDelegate.userUpdateTextEditingValue(
-          editable.textSelectionDelegate.textEditingValue.copyWith(
-            selection: editable.textSelectionDelegate.textEditingValue.selection.copyWith(
-              baseOffset: _textSelectionStart!.offset,
-              extentOffset: _textSelectionEnd!.offset,
-            ),
+      editable.textSelectionDelegate.userUpdateTextEditingValue(
+        editable.textSelectionDelegate.textEditingValue.copyWith(
+          selection: editable.textSelectionDelegate.textEditingValue.selection.copyWith(
+            baseOffset: _textSelectionStart?.offset,
+            extentOffset: _textSelectionEnd?.offset,
           ),
-          SelectionChangedCause.tap,
-        );
-      }
+        ),
+        SelectionChangedCause.tap,
+      );
     }
     return result;
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3197,8 +3197,8 @@ class _CompositeRenderEditablePainter extends RenderEditablePainter {
 /// A continuous, selectable piece of paragraph.
 ///
 /// Since the selections in [PlaceHolderSpan] are handled independently in its
-/// subtree, a selection in [RenderParagraph] can't continue across a
-/// [PlaceHolderSpan]. The [RenderParagraph] splits itself on [PlaceHolderSpan]
+/// subtree, a selection in [RenderEditable] can't continue across a
+/// [PlaceHolderSpan]. The [RenderEditable] splits itself on [PlaceHolderSpan]
 /// to create multiple `_SelectableFragment`s so that they can be selected
 /// separately.
 class _EditableSelectableFragment with Selectable, ChangeNotifier {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1819,10 +1819,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   // the text may position outside the visible region even when the text fits.
   bool get _hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
 
-  Offset _getOffsetForPosition(TextPosition position) {
-    return _textPainter.getOffsetForCaret(position, Rect.zero) + Offset(0, _textPainter.getFullHeightForCaret(position, _caretPrototype) ?? 0.0);
-  }
-
   /// Returns the local coordinates of the endpoints of the given selection.
   ///
   /// If the selection is collapsed (and therefore occupies a single point), the
@@ -1901,6 +1897,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     assert(!debugNeedsLayout);
     _computeTextMetricsIfNeeded();
     return _textPainter.getPositionForOffset(offset);
+  }
+
+  Offset _getOffsetForPosition(TextPosition position) {
+    return _textPainter.getOffsetForCaret(position, Rect.zero) + Offset(0, _textPainter.getFullHeightForCaret(position, _caretPrototype) ?? 0.0);
   }
 
   /// Returns the [Rect] in local coordinates for the caret at the given text

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3326,6 +3326,18 @@ class _EditableSelectableFragment with Selectable, ChangeNotifier {
     if (existingSelectionStart != _textSelectionStart ||
         existingSelectionEnd != _textSelectionEnd) {
       _didChangeSelection();
+      if (_textSelectionStart != null && _textSelectionEnd != null) {
+        debugPrint('woah');
+        editable.textSelectionDelegate.userUpdateTextEditingValue(
+          editable.textSelectionDelegate.textEditingValue.copyWith(
+            selection: editable.textSelectionDelegate.textEditingValue.selection.copyWith(
+              baseOffset: _textSelectionStart!.offset,
+              extentOffset: _textSelectionEnd!.offset,
+            ),
+          ),
+          SelectionChangedCause.tap,
+        );
+      }
     }
     return result;
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2691,31 +2691,31 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
 
   final LayerHandle<LeaderLayer> _leaderLayerHandler = LayerHandle<LeaderLayer>();
 
-  void _paintHandleLayers(PaintingContext context, List<TextSelectionPoint> endpoints, Offset offset) {
-    Offset startPoint = endpoints[0].point;
-    startPoint = Offset(
-      clampDouble(startPoint.dx, 0.0, size.width),
-      clampDouble(startPoint.dy, 0.0, size.height),
-    );
-    _leaderLayerHandler.layer = LeaderLayer(link: startHandleLayerLink, offset: startPoint + offset);
-    context.pushLayer(
-      _leaderLayerHandler.layer!,
-      super.paint,
-      Offset.zero,
-    );
-    if (endpoints.length == 2) {
-      Offset endPoint = endpoints[1].point;
-      endPoint = Offset(
-        clampDouble(endPoint.dx, 0.0, size.width),
-        clampDouble(endPoint.dy, 0.0, size.height),
-      );
-      context.pushLayer(
-        LeaderLayer(link: endHandleLayerLink, offset: endPoint + offset),
-        super.paint,
-        Offset.zero,
-      );
-    }
-  }
+  // void _paintHandleLayers(PaintingContext context, List<TextSelectionPoint> endpoints, Offset offset) {
+  //   Offset startPoint = endpoints[0].point;
+  //   startPoint = Offset(
+  //     clampDouble(startPoint.dx, 0.0, size.width),
+  //     clampDouble(startPoint.dy, 0.0, size.height),
+  //   );
+  //   _leaderLayerHandler.layer = LeaderLayer(link: startHandleLayerLink, offset: startPoint + offset);
+  //   context.pushLayer(
+  //     _leaderLayerHandler.layer!,
+  //     super.paint,
+  //     Offset.zero,
+  //   );
+  //   if (endpoints.length == 2) {
+  //     Offset endPoint = endpoints[1].point;
+  //     endPoint = Offset(
+  //       clampDouble(endPoint.dx, 0.0, size.width),
+  //       clampDouble(endPoint.dy, 0.0, size.height),
+  //     );
+  //     context.pushLayer(
+  //       LeaderLayer(link: endHandleLayerLink, offset: endPoint + offset),
+  //       super.paint,
+  //       Offset.zero,
+  //     );
+  //   }
+  // }
 
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -429,6 +429,7 @@ class GranularlyExtendSelectionEvent extends SelectionEvent {
     required this.forward,
     required this.isEnd,
     required this.granularity,
+    required this.collapseSelection,
   }) : super._(SelectionEventType.granularlyExtendSelection);
 
   /// Whether to extend the selection forward.
@@ -436,6 +437,9 @@ class GranularlyExtendSelectionEvent extends SelectionEvent {
 
   /// Whether this event is updating the end selection edge.
   final bool isEnd;
+
+  /// Whether this event should collapse the selection.
+  final bool collapseSelection;
 
   /// The granularity for which the selection extend.
   final TextGranularity granularity;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -827,6 +827,7 @@ class EditableText extends StatefulWidget {
     this.autofocus = false,
     bool? showCursor,
     this.showSelectionHandles = false,
+    this.selectionRegistrar,
     this.selectionColor,
     this.selectionControls,
     TextInputType? keyboardType,
@@ -877,6 +878,7 @@ class EditableText extends StatefulWidget {
   }) : assert(obscuringCharacter.length == 1),
        smartDashesType = smartDashesType ?? (obscureText ? SmartDashesType.disabled : SmartDashesType.enabled),
        smartQuotesType = smartQuotesType ?? (obscureText ? SmartQuotesType.disabled : SmartQuotesType.enabled),
+       assert(selectionRegistrar == null || selectionColor != null),
        assert(minLines == null || minLines > 0),
        assert(
          (maxLines == null) || (minLines == null) || (maxLines >= minLines),
@@ -1304,6 +1306,11 @@ class EditableText extends StatefulWidget {
   // See https://github.com/flutter/flutter/issues/7035 for the rationale for this
   // keyboard behavior.
   final bool autofocus;
+
+  /// The [SelectionRegistrar] this editable is subscribed to.
+  ///
+  /// If this is set, [selectionColor] must be non-null.
+  final SelectionRegistrar? selectionRegistrar;
 
   /// The color to use when painting the selection.
   ///
@@ -5256,6 +5263,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                                 minLines: widget.minLines,
                                 expands: widget.expands,
                                 strutStyle: widget.strutStyle,
+                                selectionRegistrar: widget.selectionRegistrar,
                                 selectionColor: _selectionOverlay?.spellCheckToolbarIsVisible ?? false
                                     ? _spellCheckConfiguration.misspelledSelectionColor ?? widget.selectionColor
                                     : widget.selectionColor,
@@ -5386,6 +5394,7 @@ class _Editable extends MultiChildRenderObjectWidget {
     this.minLines,
     required this.expands,
     this.strutStyle,
+    this.selectionRegistrar,
     this.selectionColor,
     required this.textScaler,
     required this.textAlign,
@@ -5424,6 +5433,7 @@ class _Editable extends MultiChildRenderObjectWidget {
   final int? minLines;
   final bool expands;
   final StrutStyle? strutStyle;
+  final SelectionRegistrar? selectionRegistrar;
   final Color? selectionColor;
   final TextScaler textScaler;
   final TextAlign textAlign;
@@ -5465,6 +5475,7 @@ class _Editable extends MultiChildRenderObjectWidget {
       minLines: minLines,
       expands: expands,
       strutStyle: strutStyle,
+      registrar: selectionRegistrar,
       selectionColor: selectionColor,
       textScaler: textScaler,
       textAlign: textAlign,
@@ -5509,6 +5520,7 @@ class _Editable extends MultiChildRenderObjectWidget {
       ..minLines = minLines
       ..expands = expands
       ..strutStyle = strutStyle
+      ..registrar = selectionRegistrar
       ..selectionColor = selectionColor
       ..textScaler = textScaler
       ..textAlign = textAlign

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4535,6 +4535,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       ? _value.selection != value.selection
       : _value != value;
     if (shouldShowCaret) {
+      debugPrint('showing caret');
       _scheduleShowCaretOnScreen(withAnimation: true);
     }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -696,6 +696,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       _showHandles();
     }
     _longPressStartedWithoutFocus = false;
+    _hideMagnifier();
   }
 
   bool _positionIsOnActiveSelection({required Offset globalPosition}) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -546,7 +546,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _startNewMouseSelectionGesture(TapDragDownDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
-        widget.focusNode.requestFocus();
+        // widget.focusNode.requestFocus();
         hideToolbar();
         switch (defaultTargetPlatform) {
           case TargetPlatform.android:

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -577,8 +577,8 @@ class TextSelectionOverlay {
   ///     specifically is visible.
   bool get toolbarIsVisible => _selectionOverlay.toolbarIsVisible;
 
-  /// Whether the magnifier is currently visible.
-  bool get magnifierIsVisible => _selectionOverlay._magnifierController.shown;
+  /// {@macro flutter.widgets.SelectionOverlay.magnifierIsVisible}
+  bool get magnifierIsVisible => _selectionOverlay.magnifierIsVisible;
 
   /// Whether the spell check menu is currently visible.
   ///
@@ -1010,6 +1010,13 @@ class SelectionOverlay {
     return selectionControls is TextSelectionHandleControls
         ? _contextMenuController.isShown || _spellCheckToolbarController.isShown
         : _toolbar != null || _spellCheckToolbarController.isShown;
+  }
+
+  /// {@template flutter.widgets.SelectionOverlay.magnifierIsVisible}
+  /// Whether the magnifier is currently visible.
+  /// {@endtemplate}
+  bool get magnifierIsVisible {
+    return _magnifierController.shown;
   }
 
   /// {@template flutter.widgets.SelectionOverlay.showMagnifier}


### PR DESCRIPTION
This PR enables `TextField` to be used inside of a `SelectionArea` and to be selectable along with other selectables in a selection tree. `TextField`s dependency on `TextSelectionGestureDetector` is removed as a result.

Goals:
* `TextField` can be placed in a `SelectionArea` and still be selectable.
* `TextField` is selectable even when not explicitly wrapped with a `SelectionArea`.
* `EditableText` with `ignorePointer` set to `enabled` can be wrapped with a `SelectionArea` to achieve native text input gesture support like double click to select a word and triple click to select a paragraph.

Current Blockers:
https://github.com/flutter/flutter/issues/129583 , `SelectionArea` should have feature parity with `TextSelectionGestureDetector` before this PR is merged.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.