### PR TITLE
Reduce `_DoubleClampVisitor` false positives

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -239,7 +239,15 @@ class _DoubleClampVisitor extends RecursiveAstVisitor<CompilationUnit> {
 
   @override
   CompilationUnit? visitMethodInvocation(MethodInvocation node) {
-    if (node.methodName.name == 'clamp') {
+    final NodeList<Expression> arguments = node.argumentList.arguments;
+    // This may produce false positives when the receiver of the method
+    // invocation is not a subtype of num. The ast of the receiver isn't
+    // guaranteed to be resolved at this time. Check whether the argument list
+    // consists of 2 positional args to reduce false positives.
+    final bool isNumClampInvocatoin = node.methodName.name == 'clamp'
+                                   && arguments.length == 2
+                                   && !arguments.any((Expression exp) => exp is NamedExpression);
+    if (isNumClampInvocatoin) {
       final _Line line = _getLine(parseResult, node.function.offset);
       if (!line.content.contains('// ignore_clamp_double_lint')) {
         clamps.add(line);

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -240,14 +240,14 @@ class _DoubleClampVisitor extends RecursiveAstVisitor<CompilationUnit> {
   @override
   CompilationUnit? visitMethodInvocation(MethodInvocation node) {
     final NodeList<Expression> arguments = node.argumentList.arguments;
-    // This may produce false positives when the receiver of the method
-    // invocation is not a subtype of num. The ast of the receiver isn't
-    // guaranteed to be resolved at this time. Check whether the argument list
-    // consists of 2 positional args to reduce false positives.
-    final bool isNumClampInvocatoin = node.methodName.name == 'clamp'
+    // This may produce false positives when `node.target` is not a subtype of
+    // num. The static type of `node.target` isn't guaranteed to be resolved at
+    // this time. Check whether the argument list consists of 2 positional args
+    // to reduce false positives.
+    final bool isNumClampInvocation = node.methodName.name == 'clamp'
                                    && arguments.length == 2
                                    && !arguments.any((Expression exp) => exp is NamedExpression);
-    if (isNumClampInvocatoin) {
+    if (isNumClampInvocation) {
       final _Line line = _getLine(parseResult, node.function.offset);
       if (!line.content.contains('// ignore_clamp_double_lint')) {
         clamps.add(line);


### PR DESCRIPTION
I'm getting a few false positives in https://github.com/flutter/flutter/pull/128522/checks from the `num.clamp` checker since I introduced a class with a `clamp` method.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
