### PR TITLE
Ignore app.stop events received before the app.detach response in attach integration tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -757,7 +757,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     // to throw if it sees an app.stop event before the response to this request.
     final Future<Map<String, Object?>> responseFuture = _waitFor(
       id: requestId,
-      ignoreAppStopEvent: method == 'app.stop',
+      ignoreAppStopEvent: method == 'app.stop' || method == 'app.detach',
     );
     _process?.stdin.writeln(jsonEncoded);
     final Map<String, Object?> response = await responseFuture;


### PR DESCRIPTION
The app.detach command will close the VM service connection, which yields an app.stop event in the daemon protocol.  The daemon does not guarantee any ordering between this event and the response to the app.detach.

See https://github.com/flutter/flutter/issues/128546
