### PR TITLE
[CP] rename generated asset manifest file back to `AssetManifest.bin` (from `AssetManifest.smcbin`) 

### DIFF
--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -7,7 +7,12 @@ import 'package:flutter/foundation.dart';
 import 'asset_bundle.dart';
 import 'message_codecs.dart';
 
-const String _kAssetManifestFilename = 'AssetManifest.smcbin';
+// We use .bin as the extension since it is well-known to represent
+// data in some arbitrary binary format. Using a well-known extension here
+// is important for web, because some web servers will not serve files with
+// unrecognized file extensions by default.
+// See https://github.com/flutter/flutter/issues/128456.
+const String _kAssetManifestFilename = 'AssetManifest.bin';
 
 /// Contains details about available assets and their variants.
 /// See [Asset variants](https://docs.flutter.dev/development/ui/assets-and-images#asset-variants)

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -18,7 +18,7 @@ class TestAssetBundle extends CachingAssetBundle {
 
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.smcbin') {
+    if (key == 'AssetManifest.bin') {
       return const StandardMessageCodec().encodeMessage(_assetBundleMap)!;
     }
 

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -19,7 +19,7 @@ class TestAssetBundle extends CachingAssetBundle {
       return ByteData.view(Uint8List.fromList(const Utf8Encoder().convert('{"one": ["one"]}')).buffer);
     }
 
-    if (key == 'AssetManifest.smcbin') {
+    if (key == 'AssetManifest.bin') {
       return const StandardMessageCodec().encodeMessage(<String, Object>{
         'one': <Object>[]
       })!;
@@ -76,8 +76,8 @@ void main() {
       expect(firstLoadStructuredDataResult, 'one');
       expect(secondLoadStructuredDataResult, 'one');
 
-      final String firstLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData value) => Future<String>.value('one'));
-      final String secondLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData value) => Future<String>.value('two'));
+      final String firstLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.value('one'));
+      final String secondLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.value('two'));
       expect(firstLoadStructuredBinaryDataResult, 'one');
       expect(secondLoadStructuredBinaryDataResult, 'one');
     });
@@ -95,9 +95,9 @@ void main() {
       final String secondLoadStructuredDataResult = await bundle.loadStructuredData('AssetManifest.json', (String value) => Future<String>.value('two'));
       expect(secondLoadStructuredDataResult, 'two');
 
-      await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData value) => Future<String>.value('one'));
+      await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.value('one'));
       bundle.clear();
-      final String secondLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData value) => Future<String>.value('two'));
+      final String secondLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.value('two'));
       expect(secondLoadStructuredBinaryDataResult, 'two');
     });
 
@@ -114,9 +114,9 @@ void main() {
       final String secondLoadStructuredDataResult = await bundle.loadStructuredData('AssetManifest.json', (String value) => Future<String>.value('two'));
       expect(secondLoadStructuredDataResult, 'two');
 
-      await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData value) => Future<String>.value('one'));
-      bundle.evict('AssetManifest.smcbin');
-      final String secondLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData value) => Future<String>.value('two'));
+      await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.value('one'));
+      bundle.evict('AssetManifest.bin');
+      final String secondLoadStructuredBinaryDataResult = await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.value('two'));
       expect(secondLoadStructuredBinaryDataResult, 'two');
     });
 
@@ -191,7 +191,7 @@ void main() {
   test('loadStructuredBinaryData correctly loads ByteData', () async {
     final TestAssetBundle bundle = TestAssetBundle();
     final Map<Object?, Object?> assetManifest =
-      await bundle.loadStructuredBinaryData('AssetManifest.smcbin', (ByteData data) => const StandardMessageCodec().decodeMessage(data) as Map<Object?, Object?>);
+      await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData data) => const StandardMessageCodec().decodeMessage(data) as Map<Object?, Object?>);
     expect(assetManifest.keys.toList(), equals(<String>['one']));
     expect(assetManifest['one'], <Object>[]);
   });

--- a/packages/flutter/test/services/asset_manifest_test.dart
+++ b/packages/flutter/test/services/asset_manifest_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 class TestAssetBundle extends AssetBundle {
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.smcbin') {
+    if (key == 'AssetManifest.bin') {
       final Map<String, List<Object>> binManifestData = <String, List<Object>>{
         'assets/foo.png': <Object>[
           <String, Object>{

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -40,7 +40,7 @@ class TestAssetBundle extends CachingAssetBundle {
   Future<ByteData> load(String key) {
     late ByteData data;
     switch (key) {
-      case 'AssetManifest.smcbin':
+      case 'AssetManifest.bin':
         data = manifest;
       case 'assets/image.png':
         data = testByteData(1.0);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -167,7 +167,7 @@ class ManifestAssetBundle implements AssetBundle {
 
   // We assume the main asset is designed for a device pixel ratio of 1.0.
   static const String _kAssetManifestJsonFilename = 'AssetManifest.json';
-  static const String _kAssetManifestBinFilename = 'AssetManifest.smcbin';
+  static const String _kAssetManifestBinFilename = 'AssetManifest.bin';
 
   static const String _kNoticeFile = 'NOTICES';
   // Comically, this can't be name with the more common .gz file extension

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -539,7 +539,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
   }
 
   bool _needRebuild(Map<String, DevFSContent> entries) {
-    final File manifest = globals.fs.file(globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.json'));
+    // TODO(andrewkolos): This logic might fail in the future if we change the
+    // schema of the contents of the asset manifest file and the user does not
+    // perform a `flutter clean` after upgrading.
+    // See https://github.com/flutter/flutter/issues/128563.
+    final File manifest = globals.fs.file(globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.bin'));
     if (!manifest.existsSync()) {
       return true;
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -723,7 +723,7 @@ dev_dependencies:
       '--no-pub',
     ]);
 
-    final bool fileExists = await fs.isFile(globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.json'));
+    final bool fileExists = await fs.isFile(globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.bin'));
     expect(fileExists, true);
 
   }, overrides: <Type, Generator>{
@@ -744,7 +744,7 @@ dev_dependencies:
       '--no-test-assets',
     ]);
 
-    final bool fileExists = await fs.isFile(globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.json'));
+    final bool fileExists = await fs.isFile(globals.fs.path.join('build', 'unit_test_assets', 'AssetManifest.bin'));
     expect(fileExists, false);
 
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
@@ -111,7 +111,7 @@ $fontsSection
 
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
-      expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.smcbin',
+      expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.bin',
         'AssetManifest.json', 'FontManifest.json', 'NOTICES.Z']));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -95,7 +95,7 @@ $assetsSection
     final Map<Object?, Object?> assetManifest = const StandardMessageCodec().decodeMessage(
       ByteData.sublistView(
         Uint8List.fromList(
-          await bundle.entries['AssetManifest.smcbin']!.contentsAsBytes()
+          await bundle.entries['AssetManifest.bin']!.contentsAsBytes()
         )
       )
     ) as Map<Object?, Object?>;
@@ -140,7 +140,7 @@ $assetsSection
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(
-        <String>['NOTICES.Z', 'AssetManifest.json', 'AssetManifest.smcbin', 'FontManifest.json']));
+        <String>['NOTICES.Z', 'AssetManifest.json', 'AssetManifest.bin', 'FontManifest.json']));
       const String expectedAssetManifest = '{}';
       expect(
         utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes()),
@@ -166,7 +166,7 @@ $assetsSection
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(
-        <String>['NOTICES.Z', 'AssetManifest.json', 'AssetManifest.smcbin', 'FontManifest.json']));
+        <String>['NOTICES.Z', 'AssetManifest.json', 'AssetManifest.bin', 'FontManifest.json']));
       const String expectedAssetManifest = '{}';
       expect(
         utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes()),

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -51,7 +51,7 @@ void main() {
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys,
-        unorderedEquals(<String>['AssetManifest.json', 'AssetManifest.smcbin'])
+        unorderedEquals(<String>['AssetManifest.json', 'AssetManifest.bin'])
       );
       const String expectedJsonAssetManifest = '{}';
       const Map<Object, Object> expectedBinAssetManifest = <Object, Object>{};
@@ -60,7 +60,7 @@ void main() {
         expectedJsonAssetManifest,
       );
       expect(
-        const StandardMessageCodec().decodeMessage(ByteData.sublistView(Uint8List.fromList(await bundle.entries['AssetManifest.smcbin']!.contentsAsBytes()))),
+        const StandardMessageCodec().decodeMessage(ByteData.sublistView(Uint8List.fromList(await bundle.entries['AssetManifest.bin']!.contentsAsBytes()))),
         expectedBinAssetManifest
       );
 
@@ -103,7 +103,7 @@ flutter:
 
       expect(bundle.entries.keys, unorderedEquals(<String>[
         'AssetManifest.json',
-        'AssetManifest.smcbin',
+        'AssetManifest.bin',
         'FontManifest.json',
         'NOTICES.Z',
         'assets/foo/dog.png',
@@ -128,7 +128,7 @@ flutter:
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.json',
-        'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
+        'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
       // Simulate modifying the files by updating the filestat time manually.
       globals.fs.file(globals.fs.path.join('assets', 'foo', 'fizz.txt'))
         ..createSync(recursive: true)
@@ -137,7 +137,7 @@ flutter:
       expect(bundle.needsBuild(), true);
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.json',
-          'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt',
+          'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt',
           'assets/foo/fizz.txt']));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
@@ -158,7 +158,7 @@ flutter:
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.json',
-        'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
+        'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
       expect(bundle.needsBuild(), false);
 
       // Delete the wildcard directory and update pubspec file.
@@ -180,7 +180,7 @@ name: example''')
       expect(bundle.needsBuild(), true);
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.json',
-        'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
+        'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -204,7 +204,7 @@ flutter:
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.json',
-        'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
+        'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
       expect(bundle.needsBuild(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
@@ -237,7 +237,7 @@ flutter:
       ).createBundle();
       await bundle.build(packagesPath: '.packages', deferredComponentsEnabled: true);
       expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.json',
-        'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
+        'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
       expect(bundle.deferredComponentsEntries.length, 1);
       expect(bundle.deferredComponentsEntries['component1']!.length, 2);
       expect(bundle.needsBuild(), false);
@@ -268,7 +268,7 @@ flutter:
       await bundle.build(packagesPath: '.packages');
       expect(bundle.entries.keys, unorderedEquals(<String>['assets/foo/bar.txt',
         'assets/bar/barbie.txt', 'assets/wild/dash.txt', 'AssetManifest.json',
-        'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z']));
+        'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']));
       expect(bundle.deferredComponentsEntries.isEmpty, true);
       expect(bundle.needsBuild(), false);
     }, overrides: <Type, Generator>{
@@ -302,7 +302,7 @@ flutter:
       ).createBundle();
       await bundle.build(packagesPath: '.packages', deferredComponentsEnabled: true);
       expect(bundle.entries.keys, unorderedEquals(<String>['assets/foo/bar.txt',
-        'AssetManifest.json', 'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z']));
+        'AssetManifest.json', 'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']));
       expect(bundle.deferredComponentsEntries.length, 1);
       expect(bundle.deferredComponentsEntries['component1']!.length, 2);
       expect(bundle.needsBuild(), false);
@@ -316,7 +316,7 @@ flutter:
       await bundle.build(packagesPath: '.packages', deferredComponentsEnabled: true);
 
       expect(bundle.entries.keys, unorderedEquals(<String>['assets/foo/bar.txt',
-        'AssetManifest.json', 'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z']));
+        'AssetManifest.json', 'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']));
       expect(bundle.deferredComponentsEntries.length, 1);
       expect(bundle.deferredComponentsEntries['component1']!.length, 3);
     }, overrides: <Type, Generator>{
@@ -663,7 +663,7 @@ flutter:
     await bundle.build(packagesPath: '.packages');
 
       expect(bundle.entries.keys, unorderedEquals(<String>['packages/foo/bar/fizz.txt',
-        'AssetManifest.json', 'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z']));
+        'AssetManifest.json', 'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']));
     expect(bundle.needsBuild(), false);
 
     // Does not track dependency's wildcard directories.
@@ -799,7 +799,7 @@ flutter:
 
     expect(await bundle.build(packagesPath: '.packages'), 0);
     expect(bundle.entries.keys, unorderedEquals(<String>['assets/foo.txt',
-      'AssetManifest.json', 'AssetManifest.smcbin', 'FontManifest.json', 'NOTICES.Z']));
+      'AssetManifest.json', 'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']));
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -33,7 +33,7 @@ void main() {
   }
 
   Future<Map<Object?, Object?>> extractAssetManifestSmcBinFromBundle(ManifestAssetBundle bundle) async {
-    final List<int> manifest = await bundle.entries['AssetManifest.smcbin']!.contentsAsBytes();
+    final List<int> manifest = await bundle.entries['AssetManifest.bin']!.contentsAsBytes();
     final ByteData asByteData = ByteData.view(Uint8List.fromList(manifest).buffer);
     final Map<Object?, Object?> decoded = const StandardMessageCodec().decodeMessage(asByteData)! as Map<Object?, Object?>;
     return decoded;


### PR DESCRIPTION
Cherry-picks https://github.com/flutter/flutter/pull/128529 onto stable.
Fixes https://github.com/flutter/flutter/issues/128230

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
