### PR TITLE
Update button tests for Material 3 by default

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -439,7 +439,7 @@ class ThemeData with Diagnosticable {
     pageTransitionsTheme ??= const PageTransitionsTheme();
     scrollbarTheme ??= const ScrollbarThemeData();
     visualDensity ??= VisualDensity.defaultDensityForPlatform(platform);
-    useMaterial3 ??= false;
+    useMaterial3 ??= true;
     final bool useInkSparkle = platform == TargetPlatform.android && !kIsWeb;
     splashFactory ??= useMaterial3
       ? useInkSparkle ? InkSparkle.splashFactory : InkRipple.splashFactory

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -439,7 +439,7 @@ class ThemeData with Diagnosticable {
     pageTransitionsTheme ??= const PageTransitionsTheme();
     scrollbarTheme ??= const ScrollbarThemeData();
     visualDensity ??= VisualDensity.defaultDensityForPlatform(platform);
-    useMaterial3 ??= true;
+    useMaterial3 ??= false;
     final bool useInkSparkle = platform == TargetPlatform.android && !kIsWeb;
     splashFactory ??= useMaterial3
       ? useInkSparkle ? InkSparkle.splashFactory : InkRipple.splashFactory

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -738,18 +738,21 @@ void main() {
   testWidgets('Does ElevatedButton contribute semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: ElevatedButton(
-            style: const ButtonStyle(
-              // Specifying minimumSize to mimic the original minimumSize for
-              // RaisedButton so that the semantics tree's rect and transform
-              // match the original version of this test.
-              minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: ElevatedButton(
+              style: const ButtonStyle(
+                // Specifying minimumSize to mimic the original minimumSize for
+                // RaisedButton so that the semantics tree's rect and transform
+                // match the original version of this test.
+                minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+              ),
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
-            onPressed: () { },
-            child: const Text('ABC'),
           ),
         ),
       ),
@@ -790,7 +793,7 @@ void main() {
 
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
       return Theme(
-        data: ThemeData(materialTapTargetSize: tapTargetSize),
+        data: ThemeData(useMaterial3: false, materialTapTargetSize: tapTargetSize),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
@@ -838,9 +841,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return tester.pumpWidget(
         MaterialApp(
-          // Test was setup using fonts from Material 2, so make sure we always
-          // test against englishLike2014.
-          theme: ThemeData(textTheme: Typography.englishLike2014),
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(
@@ -1033,10 +1034,8 @@ void main() {
             await tester.pumpWidget(
               MaterialApp(
                 theme: ThemeData(
+                  useMaterial3: false,
                   colorScheme: const ColorScheme.light(),
-                  // Force Material 2 defaults for the typography and size
-                  // default values as the test was designed against these settings.
-                  textTheme: Typography.englishLike2014,
                   elevatedButtonTheme: ElevatedButtonThemeData(
                     style: ElevatedButton.styleFrom(minimumSize: const Size(64, 36)),
                   ),

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -14,7 +14,7 @@ import '../widgets/semantics_tester.dart';
 void main() {
   testWidgets('FilledButton, FilledButton.icon defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
-    final ThemeData theme = ThemeData.from(colorScheme: colorScheme);
+    final ThemeData theme = ThemeData.from(useMaterial3: false, colorScheme: colorScheme);
 
     // Enabled FilledButton
     await tester.pumpWidget(
@@ -884,18 +884,21 @@ void main() {
   testWidgets('Does FilledButton contribute semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: FilledButton(
-            style: const ButtonStyle(
-              // Specifying minimumSize to mimic the original minimumSize for
-              // RaisedButton so that the semantics tree's rect and transform
-              // match the original version of this test.
-              minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: FilledButton(
+              style: const ButtonStyle(
+                // Specifying minimumSize to mimic the original minimumSize for
+                // RaisedButton so that the semantics tree's rect and transform
+                // match the original version of this test.
+                minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+              ),
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
-            onPressed: () { },
-            child: const Text('ABC'),
           ),
         ),
       ),
@@ -936,7 +939,7 @@ void main() {
 
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
       return Theme(
-        data: ThemeData(materialTapTargetSize: tapTargetSize),
+        data: ThemeData(useMaterial3: false, materialTapTargetSize: tapTargetSize),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
@@ -984,9 +987,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return tester.pumpWidget(
         MaterialApp(
-          // Test was setup using fonts from Material 2, so make sure we always
-          // test against englishLike2014.
-          theme: ThemeData(textTheme: Typography.englishLike2014),
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(
@@ -1179,10 +1180,7 @@ void main() {
             await tester.pumpWidget(
               MaterialApp(
                 theme: ThemeData(
-                  colorScheme: const ColorScheme.light(),
-                  // Force Material 2 defaults for the typography and size
-                  // default values as the test was designed against these settings.
-                  textTheme: Typography.englishLike2014,
+                  useMaterial3: false,
                   filledButtonTheme: FilledButtonThemeData(
                     style: FilledButton.styleFrom(minimumSize: const Size(64, 36)),
                   ),
@@ -1410,7 +1408,7 @@ void main() {
     const Color borderColor = Color(0xff4caf50);
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(colorScheme: const ColorScheme.light(), textTheme: Typography.englishLike2014),
+        theme: ThemeData(useMaterial3: false),
         home: Center(
           child: FilledButton(
             style: FilledButton.styleFrom(
@@ -1599,7 +1597,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(textTheme: Typography.englishLike2014),
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: Column(

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -693,6 +693,7 @@ void main() {
       bool resizeToAvoidBottomInset = true,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: MediaQuery(
           data: data,
           child: Scaffold(
@@ -1640,15 +1641,14 @@ const double _dockedOffsetY = 544.0;
 const double _containedOffsetY = 544.0 + 56.0 / 2;
 const double _miniFloatOffsetY = _floatOffsetY + kMiniButtonOffsetAdjustment;
 
-Widget _singleFabScaffold(
-  FloatingActionButtonLocation location,
-  {
-    FloatingActionButtonAnimator? animator,
-    bool mini = false,
-    TextDirection textDirection = TextDirection.ltr,
-  }
-) {
+Widget _singleFabScaffold(FloatingActionButtonLocation location, {
+  bool useMaterial3 = false,
+  FloatingActionButtonAnimator? animator,
+  bool mini = false,
+  TextDirection textDirection = TextDirection.ltr,
+}) {
   return MaterialApp(
+    theme: ThemeData(useMaterial3: useMaterial3),
     home: Directionality(
       textDirection: textDirection,
       child: Scaffold(

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -19,10 +19,6 @@ import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
 void main() {
-
-  //final ThemeData material3Theme = ThemeData.light().copyWith(useMaterial3: true);
-  //final ThemeData material2Theme = ThemeData.light().copyWith(useMaterial3: false);
-
   final ThemeData material3Theme = ThemeData(useMaterial3: true);
   final ThemeData material2Theme = ThemeData(useMaterial3: false);
 

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -20,8 +20,11 @@ import 'feedback_tester.dart';
 
 void main() {
 
-  final ThemeData material3Theme = ThemeData.light().copyWith(useMaterial3: true);
-  final ThemeData material2Theme = ThemeData.light().copyWith(useMaterial3: false);
+  //final ThemeData material3Theme = ThemeData.light().copyWith(useMaterial3: true);
+  //final ThemeData material2Theme = ThemeData.light().copyWith(useMaterial3: false);
+
+  final ThemeData material3Theme = ThemeData(useMaterial3: true);
+  final ThemeData material2Theme = ThemeData(useMaterial3: false);
 
   testWidgets('Floating Action Button control test', (WidgetTester tester) async {
     bool didPressButton = false;
@@ -950,6 +953,7 @@ void main() {
     const Color splashColor = Color(0xcafefeed);
 
     await tester.pumpWidget(MaterialApp(
+      theme: material2Theme,
       home: FloatingActionButton(
         onPressed: () {},
         splashColor: splashColor,
@@ -1051,6 +1055,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: material2Theme,
         home: Scaffold(
           floatingActionButton: FloatingActionButton.extended(
             label: const Text('', key: labelKey),

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -23,11 +23,14 @@ void main() {
 
     // Enabled MaterialButton
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MaterialButton(
-          onPressed: () { },
-          child: const Text('button'),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MaterialButton(
+            onPressed: () { },
+            child: const Text('button'),
+          ),
         ),
       ),
     );
@@ -68,11 +71,14 @@ void main() {
 
     // Disabled MaterialButton
     await tester.pumpWidget(
-      const Directionality(
-        textDirection: TextDirection.ltr,
-        child: MaterialButton(
-          onPressed: null,
-          child: Text('button'),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: MaterialButton(
+            onPressed: null,
+            child: Text('button'),
+          ),
         ),
       ),
     );
@@ -442,6 +448,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Theme(
           data: ThemeData(
+            useMaterial3: false,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
           child: buttonWidget,
@@ -488,6 +495,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Theme(
           data: ThemeData(
+            useMaterial3: false,
             highlightColor: themeHighlightColor1,
             splashColor: themeSplashColor1,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -516,6 +524,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Theme(
           data: ThemeData(
+            useMaterial3: false,
             highlightColor: themeHighlightColor2,
             splashColor: themeSplashColor2,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -574,15 +583,20 @@ void main() {
       );
 
     // enabled button
-    await tester.pumpWidget(Directionality(
-      textDirection: TextDirection.ltr,
-      child: Center(
-        child: MaterialButton(
-          child: const Text('Button'),
-          onPressed: () { /* to make sure the button is enabled */ },
+    await tester.pumpWidget(
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: MaterialButton(
+              child: const Text('Button'),
+              onPressed: () { /* to make sure the button is enabled */ },
+            ),
+          ),
         ),
       ),
-    ));
+    );
 
     expect(semantics, hasSemantics(
       TestSemantics.root(
@@ -607,15 +621,20 @@ void main() {
     ));
 
     // disabled button
-    await tester.pumpWidget(const Directionality(
-      textDirection: TextDirection.ltr,
-      child: Center(
-        child: MaterialButton(
-          onPressed: null, // button is disabled
-          child: Text('Button'),
+    await tester.pumpWidget(
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: MaterialButton(
+              onPressed: null, // button is disabled
+              child: Text('Button'),
+            ),
+          ),
         ),
       ),
-    ));
+    );
 
     expect(semantics, hasSemantics(
       TestSemantics.root(
@@ -773,6 +792,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
 
     expect(material.shape, material3
       ? StadiumBorder(side: BorderSide(color: colorScheme.outline))
@@ -82,7 +82,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
 
     expect(material.shape, material3
       ? StadiumBorder(side: BorderSide(color: colorScheme.outline))
@@ -125,7 +125,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
 
     expect(material.shape, material3
         ? StadiumBorder(side: BorderSide(color: colorScheme.outline))
@@ -160,7 +160,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
 
     expect(material.shape, material3
         ? StadiumBorder(side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)))
@@ -966,18 +966,21 @@ void main() {
   testWidgets('OutlinedButton contributes semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: OutlinedButton(
-            style: const ButtonStyle(
-              // Specifying minimumSize to mimic the original minimumSize for
-              // RaisedButton so that the corresponding button size matches
-              // the original version of this test.
-              minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: OutlinedButton(
+              style: const ButtonStyle(
+                // Specifying minimumSize to mimic the original minimumSize for
+                // RaisedButton so that the corresponding button size matches
+                // the original version of this test.
+                minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
+              ),
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
-            onPressed: () {},
-            child: const Text('ABC'),
           ),
         ),
       ),
@@ -1011,8 +1014,7 @@ void main() {
   testWidgets('OutlinedButton scales textScaleFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       Theme(
-        // Force Material 2 typography.
-        data: ThemeData(textTheme: Typography.englishLike2014),
+        data: ThemeData(useMaterial3: false),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
@@ -1041,7 +1043,7 @@ void main() {
     await tester.pumpWidget(
       Theme(
         // Force Material 2 typography.
-        data: ThemeData(textTheme: Typography.englishLike2014),
+        data: ThemeData(useMaterial3: false),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
@@ -1072,8 +1074,7 @@ void main() {
     // Set text scale large enough to expand text and button.
     await tester.pumpWidget(
       Theme(
-        // Force Material 2 typography.
-        data: ThemeData(textTheme: Typography.englishLike2014),
+        data: ThemeData(useMaterial3: false),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
@@ -1131,7 +1132,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(textTheme: Typography.englishLike2014),
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(
@@ -1261,10 +1262,7 @@ void main() {
             await tester.pumpWidget(
               MaterialApp(
                 theme: ThemeData(
-                  colorScheme: const ColorScheme.light(),
-                  // Force Material 2 defaults for the typography and size
-                  // default values as the test was designed against these settings.
-                  textTheme: Typography.englishLike2014,
+                  useMaterial3: false,
                   outlinedButtonTheme: OutlinedButtonThemeData(
                     style: OutlinedButton.styleFrom(minimumSize: const Size(64, 36)),
                   ),
@@ -1407,7 +1405,7 @@ void main() {
   testWidgets('Override OutlinedButton default padding', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: const ColorScheme.light()),
+        theme: ThemeData(useMaterial3: false),
         home: Builder(
           builder: (BuildContext context) {
             return MediaQuery(
@@ -1677,7 +1675,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(textTheme: Typography.englishLike2014),
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: Column(

--- a/packages/flutter/test/material/raw_material_button_test.dart
+++ b/packages/flutter/test/material/raw_material_button_test.dart
@@ -17,13 +17,16 @@ void main() {
     bool pressed = false;
     const Color splashColor = Color(0xff00ff00);
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: RawMaterialButton(
-            splashColor: splashColor,
-            onPressed: () { pressed = true; },
-            child: const Text('BUTTON'),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: RawMaterialButton(
+              splashColor: splashColor,
+              onPressed: () { pressed = true; },
+              child: const Text('BUTTON'),
+            ),
           ),
         ),
       ),
@@ -45,19 +48,22 @@ void main() {
     final FocusNode focusNode = FocusNode(debugLabel: 'Test Button');
     const Color splashColor = Color(0xff00ff00);
     await tester.pumpWidget(
-      Shortcuts(
-        shortcuts: const <ShortcutActivator, Intent>{
-          SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
-          SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
-        },
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: RawMaterialButton(
-              splashColor: splashColor,
-              focusNode: focusNode,
-              onPressed: () { pressed = true; },
-              child: const Text('BUTTON'),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Shortcuts(
+          shortcuts: const <ShortcutActivator, Intent>{
+            SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+            SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+          },
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: RawMaterialButton(
+                splashColor: splashColor,
+                focusNode: focusNode,
+                onPressed: () { pressed = true; },
+                child: const Text('BUTTON'),
+              ),
             ),
           ),
         ),
@@ -175,16 +181,19 @@ void main() {
     const Color fillColor = Color(0xFFEF5350);
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: RawMaterialButton(
-            materialTapTargetSize: MaterialTapTargetSize.padded,
-            onPressed: () { },
-            fillColor: fillColor,
-            highlightColor: highlightColor,
-            splashColor: splashColor,
-            child: const SizedBox(),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: RawMaterialButton(
+              materialTapTargetSize: MaterialTapTargetSize.padded,
+              onPressed: () { },
+              fillColor: fillColor,
+              highlightColor: highlightColor,
+              splashColor: splashColor,
+              child: const SizedBox(),
+            ),
           ),
         ),
       ),
@@ -207,16 +216,19 @@ void main() {
     const Color fillColor = Color(0xFFEF5350);
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: RawMaterialButton(
-            materialTapTargetSize: MaterialTapTargetSize.padded,
-            onPressed: () { },
-            fillColor: fillColor,
-            highlightColor: highlightColor,
-            splashColor: splashColor,
-            child: const SizedBox(),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: RawMaterialButton(
+              materialTapTargetSize: MaterialTapTargetSize.padded,
+              onPressed: () { },
+              fillColor: fillColor,
+              highlightColor: highlightColor,
+              splashColor: splashColor,
+              child: const SizedBox(),
+            ),
           ),
         ),
       ),
@@ -520,6 +532,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
     expect(material.shape, material3
       ? const StadiumBorder()
       : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
@@ -77,7 +77,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
     expect(material.shape, material3
       ? const StadiumBorder()
       : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
@@ -115,7 +115,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
     expect(material.shape, material3
       ? const StadiumBorder()
       : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
@@ -145,7 +145,7 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shadowColor, material3 ? Colors.transparent : const Color(0xff000000));
     expect(material.shape, material3
       ? const StadiumBorder()
       : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
@@ -580,8 +580,7 @@ void main() {
   testWidgets('Does TextButton scale with font scale changes', (WidgetTester tester) async {
     await tester.pumpWidget(
       Theme(
-        // Force Material 2 typography.
-        data: ThemeData(textTheme: Typography.englishLike2014),
+        data: ThemeData(useMaterial3: false),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
@@ -603,8 +602,7 @@ void main() {
     // textScaleFactor expands text, but not button.
     await tester.pumpWidget(
       Theme(
-        // Force Material 2 typography.
-        data: ThemeData(textTheme: Typography.englishLike2014),
+        data: ThemeData(useMaterial3: false),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
@@ -632,8 +630,7 @@ void main() {
     // Set text scale large enough to expand text and button.
     await tester.pumpWidget(
       Theme(
-        // Force Material 2 typography.
-        data: ThemeData(textTheme: Typography.englishLike2014),
+        data: ThemeData(useMaterial3: false),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
@@ -656,7 +653,7 @@ void main() {
   testWidgets('TextButton size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
       return Theme(
-        data: ThemeData(materialTapTargetSize: tapTargetSize),
+        data: ThemeData(useMaterial3: false, materialTapTargetSize: tapTargetSize),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
@@ -925,7 +922,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, { bool useText = false }) async {
       return tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(textTheme: Typography.englishLike2014),
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(
@@ -1065,10 +1062,8 @@ void main() {
             await tester.pumpWidget(
               MaterialApp(
                 theme: ThemeData(
+                  useMaterial3: false,
                   colorScheme: const ColorScheme.light(),
-                  // Force Material 2 defaults for the typography and size
-                  // default values as the test was designed against these settings.
-                  textTheme: Typography.englishLike2014,
                   textButtonTheme: TextButtonThemeData(
                     style: TextButton.styleFrom(minimumSize: const Size(64, 36)),
                   ),
@@ -1484,7 +1479,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(textTheme: Typography.englishLike2014),
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: Column(

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -17,10 +17,22 @@ import '../widgets/semantics_tester.dart';
 
 const double _defaultBorderWidth = 1.0;
 
-Widget boilerplate({required Widget child}) {
-  return Directionality(
-    textDirection: TextDirection.ltr,
-    child: Center(child: child),
+Widget boilerplate({
+  bool? useMaterial3,
+  MaterialTapTargetSize? tapTargetSize,
+  required Widget child,
+}) {
+  return Theme(
+    data: ThemeData(
+      useMaterial3: useMaterial3,
+      materialTapTargetSize: tapTargetSize,
+    ),
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: Material(child: child),
+      ),
+    ),
   );
 }
 
@@ -34,16 +46,14 @@ void main() {
     }
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            onPressed: (int index) {},
-            isSelected: const <bool>[false, true],
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          onPressed: (int index) {},
+          isSelected: const <bool>[false, true],
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -70,25 +80,23 @@ void main() {
       final List<bool> isSelected = <bool>[false, true];
       final ThemeData theme = ThemeData();
       await tester.pumpWidget(
-        Material(
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return boilerplate(
-                child: ToggleButtons(
-                  onPressed: (int index) {
-                    setState(() {
-                      isSelected[index] = !isSelected[index];
-                    });
-                  },
-                  isSelected: isSelected,
-                  children: const <Widget>[
-                    Text('First child'),
-                    Text('Second child'),
-                  ],
-                ),
-              );
-            },
-          ),
+        StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return boilerplate(
+              child: ToggleButtons(
+                onPressed: (int index) {
+                  setState(() {
+                    isSelected[index] = !isSelected[index];
+                  });
+                },
+                isSelected: isSelected,
+                children: const <Widget>[
+                  Text('First child'),
+                  Text('Second child'),
+                ],
+              ),
+            );
+          },
         ),
       );
 
@@ -132,15 +140,13 @@ void main() {
       final ThemeData theme = ThemeData();
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: isSelected,
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: isSelected,
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+            ],
           ),
         ),
       );
@@ -178,15 +184,13 @@ void main() {
     (WidgetTester tester) async {
       await expectLater(
         () => tester.pumpWidget(
-          Material(
-            child: boilerplate(
-              child: ToggleButtons(
-                isSelected: const <bool>[false],
-                children: const <Widget>[
-                  Text('First child'),
-                  Text('Second child'),
-                ],
-              ),
+          boilerplate(
+            child: ToggleButtons(
+              isSelected: const <bool>[false],
+              children: const <Widget>[
+                Text('First child'),
+                Text('Second child'),
+              ],
             ),
           ),
         ),
@@ -205,16 +209,14 @@ void main() {
   testWidgets('Default text style is applied', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, true],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, true],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -237,21 +239,19 @@ void main() {
 
   testWidgets('Custom text style except color is applied', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, true],
-            onPressed: (int index) {},
-            textStyle: const TextStyle(
-              textBaseline: TextBaseline.ideographic,
-              fontSize: 20.0,
-              color: Colors.orange,
-            ),
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, true],
+          onPressed: (int index) {},
+          textStyle: const TextStyle(
+            textBaseline: TextBaseline.ideographic,
+            fontSize: 20.0,
+            color: Colors.orange,
           ),
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -276,17 +276,15 @@ void main() {
 
   testWidgets('Default BoxConstraints', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, false, false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Icon(Icons.check),
-              Icon(Icons.access_alarm),
-              Icon(Icons.cake),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, false, false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Icon(Icons.check),
+            Icon(Icons.access_alarm),
+            Icon(Icons.cake),
+          ],
         ),
       ),
     );
@@ -305,21 +303,19 @@ void main() {
   testWidgets('Custom BoxConstraints', (WidgetTester tester) async {
     // Test for minimum constraints
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            constraints: const BoxConstraints(
-              minWidth: 50.0,
-              minHeight: 60.0,
-            ),
-            isSelected: const <bool>[false, false, false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Icon(Icons.check),
-              Icon(Icons.access_alarm),
-              Icon(Icons.cake),
-            ],
+      boilerplate(
+        child: ToggleButtons(
+          constraints: const BoxConstraints(
+            minWidth: 50.0,
+            minHeight: 60.0,
           ),
+          isSelected: const <bool>[false, false, false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Icon(Icons.check),
+            Icon(Icons.access_alarm),
+            Icon(Icons.cake),
+          ],
         ),
       ),
     );
@@ -336,22 +332,20 @@ void main() {
 
     // Test for maximum constraints
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            constraints: const BoxConstraints(
-              maxWidth: 20.0,
-              maxHeight: 10.0,
-            ),
-            isSelected: const <bool>[false, false, false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Icon(Icons.check),
-              Icon(Icons.access_alarm),
-              Icon(Icons.cake),
-            ],
+      boilerplate(
+        child: ToggleButtons(
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          constraints: const BoxConstraints(
+            maxWidth: 20.0,
+            maxHeight: 10.0,
           ),
+          isSelected: const <bool>[false, false, false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Icon(Icons.check),
+            Icon(Icons.access_alarm),
+            Icon(Icons.cake),
+          ],
         ),
       ),
     );
@@ -384,18 +378,16 @@ void main() {
       }
       final ThemeData theme = ThemeData();
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Row(children: <Widget>[
-                  Text('First child'),
-                  Icon(Icons.check),
-                ]),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Row(children: <Widget>[
+                Text('First child'),
+                Icon(Icons.check),
+              ]),
+            ],
           ),
         ),
       );
@@ -411,18 +403,16 @@ void main() {
       );
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[true],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Row(children: <Widget>[
-                  Text('First child'),
-                  Icon(Icons.check),
-                ]),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[true],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Row(children: <Widget>[
+                Text('First child'),
+                Icon(Icons.check),
+              ]),
+            ],
           ),
         ),
       );
@@ -438,17 +428,15 @@ void main() {
       );
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[true],
-              children: const <Widget>[
-                Row(children: <Widget>[
-                  Text('First child'),
-                  Icon(Icons.check),
-                ]),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[true],
+            children: const <Widget>[
+              Row(children: <Widget>[
+                Text('First child'),
+                Icon(Icons.check),
+              ]),
+            ],
           ),
         ),
       );
@@ -491,19 +479,17 @@ void main() {
       expect(theme.colorScheme.onSurface.withOpacity(0.38), isNot(disabledColor));
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              color: enabledColor,
-              isSelected: const <bool>[false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Row(children: <Widget>[
-                  Text('First child'),
-                  Icon(Icons.check),
-                ]),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            color: enabledColor,
+            isSelected: const <bool>[false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Row(children: <Widget>[
+                Text('First child'),
+                Icon(Icons.check),
+              ]),
+            ],
           ),
         ),
       );
@@ -513,19 +499,17 @@ void main() {
       expect(iconTheme(Icons.check).data.color, enabledColor);
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              selectedColor: selectedColor,
-              isSelected: const <bool>[true],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Row(children: <Widget>[
-                  Text('First child'),
-                  Icon(Icons.check),
-                ]),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            selectedColor: selectedColor,
+            isSelected: const <bool>[true],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Row(children: <Widget>[
+                Text('First child'),
+                Icon(Icons.check),
+              ]),
+            ],
           ),
         ),
       );
@@ -535,18 +519,16 @@ void main() {
       expect(iconTheme(Icons.check).data.color, selectedColor);
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              disabledColor: disabledColor,
-              isSelected: const <bool>[true],
-              children: const <Widget>[
-                Row(children: <Widget>[
-                  Text('First child'),
-                  Icon(Icons.check),
-                ]),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            disabledColor: disabledColor,
+            isSelected: const <bool>[true],
+            children: const <Widget>[
+              Row(children: <Widget>[
+                Text('First child'),
+                Icon(Icons.check),
+              ]),
+            ],
           ),
         ),
       );
@@ -560,17 +542,15 @@ void main() {
   testWidgets('Default button fillColor - unselected', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Row(children: <Widget>[
-                Text('First child'),
-              ]),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Row(children: <Widget>[
+              Text('First child'),
+            ]),
+          ],
         ),
       ),
     );
@@ -589,17 +569,15 @@ void main() {
   testWidgets('Default button fillColor - selected', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[true],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Row(children: <Widget>[
-                Text('First child'),
-              ]),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[true],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Row(children: <Widget>[
+              Text('First child'),
+            ]),
+          ],
         ),
       ),
     );
@@ -618,16 +596,14 @@ void main() {
   testWidgets('Default button fillColor - disabled', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[true],
-            children: const <Widget>[
-              Row(children: <Widget>[
-                Text('First child'),
-              ]),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[true],
+          children: const <Widget>[
+            Row(children: <Widget>[
+              Text('First child'),
+            ]),
+          ],
         ),
       ),
     );
@@ -646,18 +622,16 @@ void main() {
   testWidgets('Custom button fillColor', (WidgetTester tester) async {
     const Color customFillColor = Colors.green;
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            fillColor: customFillColor,
-            isSelected: const <bool>[true],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Row(children: <Widget>[
-                Text('First child'),
-              ]),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          fillColor: customFillColor,
+          isSelected: const <bool>[true],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Row(children: <Widget>[
+              Text('First child'),
+            ]),
+          ],
         ),
       ),
     );
@@ -684,17 +658,15 @@ void main() {
     const Color selectedFillColor = Colors.yellow;
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            fillColor: selectedFillColor,
-            isSelected: const <bool>[false, true],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          fillColor: selectedFillColor,
+          isSelected: const <bool>[false, true],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -705,16 +677,14 @@ void main() {
     expect(buttonColor('Second child').color, selectedFillColor);
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            fillColor: selectedFillColor,
-            isSelected: const <bool>[false, true],
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          fillColor: selectedFillColor,
+          isSelected: const <bool>[false, true],
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -746,17 +716,15 @@ void main() {
     }
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            fillColor: MaterialStateColor.resolveWith(getFillColor),
-            isSelected: const <bool>[false, true],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          fillColor: MaterialStateColor.resolveWith(getFillColor),
+          isSelected: const <bool>[false, true],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -768,16 +736,14 @@ void main() {
 
     // disabled
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            fillColor: MaterialStateColor.resolveWith(getFillColor),
-            isSelected: const <bool>[false, true],
-            children: const <Widget>[
-              Text('First child'),
-              Text('Second child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          fillColor: MaterialStateColor.resolveWith(getFillColor),
+          isSelected: const <bool>[false, true],
+          children: const <Widget>[
+            Text('First child'),
+            Text('Second child'),
+          ],
         ),
       ),
     );
@@ -792,16 +758,14 @@ void main() {
     final ThemeData theme = ThemeData();
     final FocusNode focusNode = FocusNode();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false],
-            onPressed: (int index) {},
-            focusNodes: <FocusNode>[focusNode],
-            children: const <Widget>[
-              Text('First child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false],
+          onPressed: (int index) {},
+          focusNodes: <FocusNode>[focusNode],
+          children: const <Widget>[
+            Text('First child'),
+          ],
         ),
       ),
     );
@@ -859,16 +823,14 @@ void main() {
     final ThemeData theme = ThemeData();
     final FocusNode focusNode = FocusNode();
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[true],
-            onPressed: (int index) {},
-            focusNodes: <FocusNode>[focusNode],
-            children: const <Widget>[
-              Text('First child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[true],
+          onPressed: (int index) {},
+          focusNodes: <FocusNode>[focusNode],
+          children: const <Widget>[
+            Text('First child'),
+          ],
         ),
       ),
     );
@@ -930,20 +892,18 @@ void main() {
     final FocusNode focusNode = FocusNode();
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            splashColor: splashColor,
-            highlightColor: highlightColor,
-            hoverColor: hoverColor,
-            focusColor: focusColor,
-            isSelected: const <bool>[true],
-            onPressed: (int index) {},
-            focusNodes: <FocusNode>[focusNode],
-            children: const <Widget>[
-              Text('First child'),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          splashColor: splashColor,
+          highlightColor: highlightColor,
+          hoverColor: hoverColor,
+          focusColor: focusColor,
+          isSelected: const <bool>[true],
+          onPressed: (int index) {},
+          focusNodes: <FocusNode>[focusNode],
+          children: const <Widget>[
+            Text('First child'),
+          ],
         ),
       ),
     );
@@ -999,15 +959,13 @@ void main() {
       final ThemeData theme = ThemeData();
       const double defaultBorderWidth = 1.0;
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       );
@@ -1029,15 +987,13 @@ void main() {
       );
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[true],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[true],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       );
@@ -1058,14 +1014,12 @@ void main() {
       );
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[false],
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[false],
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       );
@@ -1096,17 +1050,15 @@ void main() {
       const double customWidth = 2.0;
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              borderColor: borderColor,
-              borderWidth: customWidth,
-              isSelected: const <bool>[false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            borderColor: borderColor,
+            borderWidth: customWidth,
+            isSelected: const <bool>[false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       );
@@ -1128,17 +1080,15 @@ void main() {
       );
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              selectedBorderColor: selectedBorderColor,
-              borderWidth: customWidth,
-              isSelected: const <bool>[true],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            selectedBorderColor: selectedBorderColor,
+            borderWidth: customWidth,
+            isSelected: const <bool>[true],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       );
@@ -1159,16 +1109,14 @@ void main() {
       );
 
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              disabledBorderColor: disabledBorderColor,
-              borderWidth: customWidth,
-              isSelected: const <bool>[false],
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            disabledBorderColor: disabledBorderColor,
+            borderWidth: customWidth,
+            isSelected: const <bool>[false],
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       );
@@ -1204,12 +1152,10 @@ void main() {
     ];
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, true, false],
-            children: children,
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, true, false],
+          children: children,
         ),
       ),
     );
@@ -1247,12 +1193,10 @@ void main() {
     ];
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, true, false],
-            children: children,
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, true, false],
+          children: children,
         ),
       ),
     );
@@ -1299,13 +1243,11 @@ void main() {
     // Update border width and widget sized to verify layout updates correctly
     const double customBorderWidth = 5.0;
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            borderWidth: customBorderWidth,
-            isSelected: const <bool>[false, true, false],
-            children: childrenRebuilt,
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          borderWidth: customBorderWidth,
+          isSelected: const <bool>[false, true, false],
+          children: childrenRebuilt,
         ),
       ),
     );
@@ -1331,31 +1273,30 @@ void main() {
     // The point size of the fonts must be a multiple of 4 until
     // https://github.com/flutter/flutter/issues/122066 is resolved.
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: <Widget>[
-              ToggleButtons(
-                borderWidth: 5.0,
-                isSelected: const <bool>[false, true],
-                children: const <Widget>[
-                  Text('First child', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 8.0)),
-                  Text('Second child', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 8.0)),
-                ],
-              ),
-              ElevatedButton(
-                onPressed: null,
-                style: ElevatedButton.styleFrom(textStyle: const TextStyle(
-                  fontFamily: 'FlutterTest',
-                  fontSize: 20.0,
-                )),
-                child: const Text('Elevated Button'),
-              ),
-              const Text('Text', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 28.0)),
-            ],
-          ),
+      boilerplate(
+        useMaterial3: false,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: <Widget>[
+            ToggleButtons(
+              borderWidth: 5.0,
+              isSelected: const <bool>[false, true],
+              children: const <Widget>[
+                Text('First child', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 8.0)),
+                Text('Second child', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 8.0)),
+              ],
+            ),
+            ElevatedButton(
+              onPressed: null,
+              style: ElevatedButton.styleFrom(textStyle: const TextStyle(
+                fontFamily: 'FlutterTest',
+                fontSize: 20.0,
+              )),
+              child: const Text('Elevated Button'),
+            ),
+            const Text('Text', style: TextStyle(fontFamily: 'FlutterTest', fontSize: 28.0)),
+          ],
         ),
       ),
     );
@@ -1431,17 +1372,15 @@ void main() {
     (WidgetTester tester) async {
       final ThemeData theme = ThemeData();
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              isSelected: const <bool>[false, true, false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-                Text('Third child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            isSelected: const <bool>[false, true, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+              Text('Third child'),
+            ],
           ),
         ),
       );
@@ -1513,18 +1452,16 @@ void main() {
         (WidgetTester tester) async {
       final ThemeData theme = ThemeData();
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              direction: Axis.vertical,
-              isSelected: const <bool>[false, true, false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-                Text('Third child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            direction: Axis.vertical,
+            isSelected: const <bool>[false, true, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+              Text('Third child'),
+            ],
           ),
         ),
       );
@@ -1601,19 +1538,17 @@ void main() {
     'VerticalDirection test when direction is vertical.',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              direction: Axis.vertical,
-              verticalDirection: VerticalDirection.up,
-              isSelected: const <bool>[false, true, false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-                Text('Third child'),
-              ],
-            ),
+        boilerplate(
+          child: ToggleButtons(
+            direction: Axis.vertical,
+            verticalDirection: VerticalDirection.up,
+            isSelected: const <bool>[false, true, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+              Text('Third child'),
+            ],
           ),
         ),
       );
@@ -1627,22 +1562,19 @@ void main() {
 
   testWidgets('Tap target size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
-      return Theme(
-        data: ThemeData(materialTapTargetSize: tapTargetSize),
-        child: Material(
-          child: boilerplate(
-            child: ToggleButtons(
-              key: key,
-              constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
-              isSelected: const <bool>[false, true, false],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First'),
-                Text('Second'),
-                Text('Third'),
-              ],
-            ),
-          ),
+      return boilerplate(
+        useMaterial3: false,
+        tapTargetSize: tapTargetSize,
+        child: ToggleButtons(
+          key: key,
+          constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+          isSelected: const <bool>[false, true, false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Text('First'),
+            Text('Second'),
+            Text('Third'),
+          ],
         ),
       );
     }
@@ -1658,20 +1590,19 @@ void main() {
 
   testWidgets('Tap target size is configurable', (WidgetTester tester) async {
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
-      return Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            key: key,
-            tapTargetSize: tapTargetSize,
-            constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
-            isSelected: const <bool>[false, true, false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Text('First'),
-              Text('Second'),
-              Text('Third'),
-            ],
-          ),
+      return boilerplate(
+        useMaterial3: false,
+        child: ToggleButtons(
+          key: key,
+          tapTargetSize: tapTargetSize,
+          constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+          isSelected: const <bool>[false, true, false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Text('First'),
+            Text('Second'),
+            Text('Third'),
+          ],
         ),
       );
     }
@@ -1687,22 +1618,20 @@ void main() {
 
   testWidgets('Tap target size is configurable for vertical axis', (WidgetTester tester) async {
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
-      return Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            key: key,
-            tapTargetSize: tapTargetSize,
-            constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
-            direction: Axis.vertical,
-            isSelected: const <bool>[false, true, false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Text('1'),
-              Text('2'),
-              Text('3'),
-            ],
-          ),
-        ),
+     return boilerplate(
+       child: ToggleButtons(
+         key: key,
+         tapTargetSize: tapTargetSize,
+         constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+         direction: Axis.vertical,
+         isSelected: const <bool>[false, true, false],
+         onPressed: (int index) {},
+         children: const <Widget>[
+           Text('1'),
+           Text('2'),
+           Text('3'),
+         ],
+       ),
       );
     }
 
@@ -1717,19 +1646,18 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/73725
   testWidgets('Border radius paint test when there is only one button', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData();
+    final ThemeData theme = ThemeData(useMaterial3: false);
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: RepaintBoundary(
-            child: ToggleButtons(
-              borderRadius: const BorderRadius.all(Radius.circular(7.0)),
-              isSelected: const <bool>[true],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-              ],
-            ),
+      boilerplate(
+        useMaterial3: false,
+        child: RepaintBoundary(
+          child: ToggleButtons(
+            borderRadius: const BorderRadius.all(Radius.circular(7.0)),
+            isSelected: const <bool>[true],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       ),
@@ -1764,22 +1692,21 @@ void main() {
 
   testWidgets('Border radius paint test when Radius.x or Radius.y equal 0.0', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: RepaintBoundary(
-            child: ToggleButtons(
-              borderRadius: const BorderRadius.only(
-                topRight: Radius.elliptical(10, 0),
-                topLeft: Radius.elliptical(0, 10),
-                bottomRight: Radius.elliptical(0, 10),
-                bottomLeft: Radius.elliptical(10, 0),
-              ),
-              isSelected: const <bool>[true],
-              onPressed: (int index) {},
-              children: const <Widget>[
-                Text('First child'),
-              ],
+      boilerplate(
+        useMaterial3: false,
+        child: RepaintBoundary(
+          child: ToggleButtons(
+            borderRadius: const BorderRadius.only(
+              topRight: Radius.elliptical(10, 0),
+              topLeft: Radius.elliptical(0, 10),
+              bottomRight: Radius.elliptical(0, 10),
+              bottomLeft: Radius.elliptical(10, 0),
             ),
+            isSelected: const <bool>[true],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First child'),
+            ],
           ),
         ),
       ),
@@ -1831,19 +1758,17 @@ void main() {
 
   testWidgets('ToggleButtons changes mouse cursor when the button is hovered', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: MouseRegion(
-            cursor: SystemMouseCursors.forbidden,
-            child: ToggleButtons(
-              mouseCursor: SystemMouseCursors.text,
-              onPressed: (int index) {},
-              isSelected: const <bool>[false, true],
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-              ],
-            ),
+      boilerplate(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.forbidden,
+          child: ToggleButtons(
+            mouseCursor: SystemMouseCursors.text,
+            onPressed: (int index) {},
+            isSelected: const <bool>[false, true],
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+            ],
           ),
         ),
       ),
@@ -1858,18 +1783,16 @@ void main() {
 
     // Test default cursor
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: MouseRegion(
-            cursor: SystemMouseCursors.forbidden,
-            child: ToggleButtons(
-              onPressed: (int index) {},
-              isSelected: const <bool>[false, true],
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-              ],
-            ),
+      boilerplate(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.forbidden,
+          child: ToggleButtons(
+            onPressed: (int index) {},
+            isSelected: const <bool>[false, true],
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+            ],
           ),
         ),
       ),
@@ -1879,17 +1802,15 @@ void main() {
 
     // Test default cursor when disabled
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: MouseRegion(
-            cursor: SystemMouseCursors.forbidden,
-            child: ToggleButtons(
-              isSelected: const <bool>[false, true],
-              children: const <Widget>[
-                Text('First child'),
-                Text('Second child'),
-              ],
-            ),
+      boilerplate(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.forbidden,
+          child: ToggleButtons(
+            isSelected: const <bool>[false, true],
+            children: const <Widget>[
+              Text('First child'),
+              Text('Second child'),
+            ],
           ),
         ),
       ),
@@ -1901,14 +1822,12 @@ void main() {
   testWidgets('ToggleButtons focus, hover, and highlight elevations are 0', (WidgetTester tester) async {
     final List<FocusNode> focusNodes = <FocusNode>[FocusNode(), FocusNode()];
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[true, false],
-            onPressed: (int index) { },
-            focusNodes: focusNodes,
-            children: const <Widget>[Text('one'), Text('two')],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[true, false],
+          onPressed: (int index) { },
+          focusNodes: focusNodes,
+          children: const <Widget>[Text('one'), Text('two')],
         ),
       ),
     );
@@ -1948,17 +1867,15 @@ void main() {
 
   testWidgets('Toggle buttons height matches MaterialTapTargetSize.padded height', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, false, false],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Icon(Icons.check),
-              Icon(Icons.access_alarm),
-              Icon(Icons.cake),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, false, false],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Icon(Icons.check),
+            Icon(Icons.access_alarm),
+            Icon(Icons.cake),
+          ],
         ),
       ),
     );
@@ -1976,21 +1893,19 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, false, false],
-            onPressed: (int index) {},
-            constraints: const BoxConstraints.tightFor(
-              width: 86,
-              height: 32,
-            ),
-            children: const <Widget>[
-              Icon(Icons.check),
-              Icon(Icons.access_alarm),
-              Icon(Icons.cake),
-            ],
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, false, false],
+          onPressed: (int index) {},
+          constraints: const BoxConstraints.tightFor(
+            width: 86,
+            height: 32,
           ),
+          children: const <Widget>[
+            Icon(Icons.check),
+            Icon(Icons.access_alarm),
+            Icon(Icons.cake),
+          ],
         ),
       ),
     );
@@ -2064,16 +1979,14 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      Material(
-        child: boilerplate(
-          child: ToggleButtons(
-            isSelected: const <bool>[false, true],
-            onPressed: (int index) {},
-            children: const <Widget>[
-              Icon(Icons.check),
-              Icon(Icons.access_alarm),
-            ],
-          ),
+      boilerplate(
+        child: ToggleButtons(
+          isSelected: const <bool>[false, true],
+          onPressed: (int index) {},
+          children: const <Widget>[
+            Icon(Icons.check),
+            Icon(Icons.access_alarm),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Updates all of the button tests so that they'll pass if ThemeData.useMaterial3 defaults to true.

The extensive changes to the toggle_buttons_test.dart was to refactor the `boilerplate` function to include the Material widget every use of the boilerplate function started with.

Most of the tests that have wired `useMaterial3` to false will need to be updated with a M3 version.