### PR TITLE
Add .env file support for  option `--dart-define-from-file`

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -612,17 +612,17 @@ abstract class FlutterCommand extends Command<void> {
       valueHelp: 'foo=bar',
       splitCommas: false,
     );
-    useDartDefineConfigJsonFileOption();
+    useDartDefineFromFileOption();
   }
 
-  void useDartDefineConfigJsonFileOption() {
+  void useDartDefineFromFileOption() {
     argParser.addMultiOption(
       FlutterOptions.kDartDefineFromFileOption,
-      help: 'The path of a json format file where flutter define a global constant pool. '
-          'Json entry will be available as constants from the String.fromEnvironment, bool.fromEnvironment, '
-          'and int.fromEnvironment constructors; the key and field are json values.\n'
+      help:
+          'The path of a .json or .env file containing key-value pairs that will be available as environment variables.\n'
+          'These can be accessed using the String.fromEnvironment, bool.fromEnvironment, and int.fromEnvironment constructors.\n'
           'Multiple defines can be passed by repeating "--${FlutterOptions.kDartDefineFromFileOption}" multiple times.',
-      valueHelp: 'use-define-config.json',
+      valueHelp: 'use-define-config.json|.env',
       splitCommas: false,
     );
   }
@@ -1341,18 +1341,29 @@ abstract class FlutterCommand extends Command<void> {
     final Map<String, Object?> dartDefineConfigJsonMap = <String, Object?>{};
 
     if (argParser.options.containsKey(FlutterOptions.kDartDefineFromFileOption)) {
-      final List<String> configJsonPaths = stringsArg(
+      final List<String> configFilePaths = stringsArg(
         FlutterOptions.kDartDefineFromFileOption,
       );
 
-      for (final String path in configJsonPaths) {
+      for (final String path in configFilePaths) {
         if (!globals.fs.isFileSync(path)) {
           throwToolExit('Json config define file "--${FlutterOptions
               .kDartDefineFromFileOption}=$path" is not a file, '
               'please fix first!');
         }
 
-        final String configJsonRaw = globals.fs.file(path).readAsStringSync();
+        final String configRaw = globals.fs.file(path).readAsStringSync();
+
+        // Determine whether the file content is JSON or .env format.
+        String configJsonRaw;
+        if (configRaw.trim().startsWith('{')) {
+          configJsonRaw = configRaw;
+        } else {
+
+          // Convert env file to JSON.
+          configJsonRaw = convertEnvFileToJsonRaw(configRaw);
+        }
+
         try {
           // Fix json convert Object value :type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, Object>' in type cast
           (json.decode(configJsonRaw) as Map<String, dynamic>)
@@ -1368,6 +1379,88 @@ abstract class FlutterCommand extends Command<void> {
     }
 
     return dartDefineConfigJsonMap;
+  }
+
+  /// Parse a property line from an env file.
+  /// Supposed property structure should be:
+  ///   key=value
+  ///
+  /// Where: key is a string without spaces and value is a string.
+  /// Value can also contain '=' char.
+  ///
+  /// Returns a record of key and value as strings.
+  MapEntry<String, String> _parseProperty(String line) {
+    final RegExp blockRegExp = RegExp(r'^\s*([a-zA-Z_]+[a-zA-Z0-9_]*)\s*=\s*"""\s*(.*)$');
+    if (blockRegExp.hasMatch(line)) {
+      throwToolExit('Multi-line value is not supported: $line');
+    }
+
+    final RegExp propertyRegExp = RegExp(r'^\s*([a-zA-Z_]+[a-zA-Z0-9_]*)\s*=\s*(.*)?$');
+    final Match? match = propertyRegExp.firstMatch(line);
+    if (match == null) {
+      throwToolExit('Unable to parse file provided for '
+        '--${FlutterOptions.kDartDefineFromFileOption}.\n'
+        'Invalid property line: $line');
+    }
+
+    final String key = match.group(1)!;
+    final String value = match.group(2) ?? '';
+
+    // Remove wrapping quotes and trailing line comment.
+    final RegExp doubleQuoteValueRegExp = RegExp(r'^"(.*)"\s*(\#\s*.*)?$');
+    final Match? doubleQuoteValue = doubleQuoteValueRegExp.firstMatch(value);
+    if (doubleQuoteValue != null) {
+      return MapEntry<String, String>(key, doubleQuoteValue.group(1)!);
+    }
+
+    final RegExp quoteValueRegExp = RegExp(r"^'(.*)'\s*(\#\s*.*)?$");
+    final Match? quoteValue = quoteValueRegExp.firstMatch(value);
+    if (quoteValue != null) {
+      return MapEntry<String, String>(key, quoteValue.group(1)!);
+    }
+
+    final RegExp backQuoteValueRegExp = RegExp(r'^`(.*)`\s*(\#\s*.*)?$');
+    final Match? backQuoteValue = backQuoteValueRegExp.firstMatch(value);
+    if (backQuoteValue != null) {
+      return MapEntry<String, String>(key, backQuoteValue.group(1)!);
+    }
+
+    final RegExp noQuoteValueRegExp = RegExp(r'^([^#\n\s]*)\s*(?:\s*#\s*(.*))?$');
+    final Match? noQuoteValue = noQuoteValueRegExp.firstMatch(value);
+    if (noQuoteValue != null) {
+      return MapEntry<String, String>(key, noQuoteValue.group(1)!);
+    }
+
+    return MapEntry<String, String>(key, value);
+  }
+
+  /// Converts an .env file string to its equivalent JSON string.
+  ///
+  /// For example, the .env file string
+  ///   key=value # comment
+  ///   complexKey="foo#bar=baz"
+  /// would be converted to a JSON string equivalent to:
+  ///   {
+  ///     "key": "value",
+  ///     "complexKey": "foo#bar=baz"
+  ///   }
+  ///
+  /// Multiline values are not supported.
+  String convertEnvFileToJsonRaw(String configRaw) {
+    final List<String> lines = configRaw
+        .split('\n')
+        .map((String line) => line.trim())
+        .where((String line) => line.isNotEmpty)
+        .where((String line) => !line.startsWith('#')) // Remove comment lines.
+        .toList();
+
+    final Map<String, String> propertyMap = <String, String>{};
+    for (final String line in lines) {
+      final MapEntry<String, String> property = _parseProperty(line);
+      propertyMap[property.key] = property.value;
+    }
+
+    return jsonEncode(propertyMap);
   }
 
   /// Updates dart-defines based on [webRenderer].


### PR DESCRIPTION
# Proposal

I suggest to make possible to specify .env files to the --dart-define-from-file in addition to the Json format.

# Issue

Close #128667

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.