### PR TITLE
Fix paint offset in reverse for 2D

### DIFF
--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1243,7 +1243,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     RenderBox child, {
     required Offset layoutOffset,
   }) {
-    // This is only usable once we have a sizes
+    // This is only usable once we have sizes.
     assert(hasSize);
     assert(child.hasSize);
     final double xOffset;

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1149,7 +1149,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     childParentData.paintOffset = computeAbsolutePaintOffsetFor(
       child,
       layoutOffset: childParentData.layoutOffset!,
-      paintExtent: childParentData._paintExtent!,
     );
     // If the child is partially visible, or not visible at all, there is
     // visual overflow.
@@ -1243,14 +1242,15 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   Offset computeAbsolutePaintOffsetFor(
     RenderBox child, {
     required Offset layoutOffset,
-    required Size paintExtent,
   }) {
-    assert(hasSize); // this is only usable once we have a size
+    // This is only usable once we have a sizes
+    assert(hasSize);
+    assert(child.hasSize);
     final double xOffset;
     final double yOffset;
     switch (verticalAxisDirection) {
       case AxisDirection.up:
-        yOffset = viewportDimension.height - (layoutOffset.dy + paintExtent.height);
+        yOffset = viewportDimension.height - (layoutOffset.dy + child.size.height);
       case AxisDirection.down:
         yOffset = layoutOffset.dy;
       case AxisDirection.right:
@@ -1261,7 +1261,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       case AxisDirection.right:
         xOffset = layoutOffset.dx;
       case AxisDirection.left:
-        xOffset = viewportDimension.width - (layoutOffset.dx + paintExtent.width);
+        xOffset = viewportDimension.width - (layoutOffset.dx + child.size.width);
       case AxisDirection.up:
       case AxisDirection.down:
         throw Exception('This should not happen');

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -1189,7 +1189,8 @@ void main() {
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('sets up parent data', (WidgetTester tester) async {
-      // Also tests computeChildPaintOffset & computeChildPaintExtent
+      // Also tests computeAbsolutePaintOffsetFor & computeChildPaintExtent
+      // Regression test for https://github.com/flutter/flutter/issues/128723
       final Map<ChildVicinity, UniqueKey> childKeys = <ChildVicinity, UniqueKey>{};
       final TwoDimensionalChildBuilderDelegate delegate = TwoDimensionalChildBuilderDelegate(
         maxXIndex: 5,
@@ -1250,7 +1251,7 @@ void main() {
       childParentData = parentDataOf(viewport.lastChild!);
       expect(childParentData.vicinity, const ChildVicinity(xIndex: 5, yIndex: 5));
       expect(childParentData.isVisible, isFalse);
-      expect(childParentData.paintOffset, const Offset(1000.0, -400.0));
+      expect(childParentData.paintOffset, const Offset(1000.0, -600.0));
       expect(childParentData.layoutOffset, const Offset(1000.0, 1000.0));
 
       // - horizontal reverse
@@ -1271,7 +1272,7 @@ void main() {
       childParentData = parentDataOf(viewport.lastChild!);
       expect(childParentData.vicinity, const ChildVicinity(xIndex: 5, yIndex: 5));
       expect(childParentData.isVisible, isFalse);
-      expect(childParentData.paintOffset, const Offset(-200.0, 1000.0));
+      expect(childParentData.paintOffset, const Offset(-400.0, 1000.0));
       expect(childParentData.layoutOffset, const Offset(1000.0, 1000.0));
 
       // - both reverse
@@ -1293,7 +1294,7 @@ void main() {
       childParentData = parentDataOf(viewport.lastChild!);
       expect(childParentData.vicinity, const ChildVicinity(xIndex: 5, yIndex: 5));
       expect(childParentData.isVisible, isFalse);
-      expect(childParentData.paintOffset, const Offset(-200.0, -400.0));
+      expect(childParentData.paintOffset, const Offset(-400.0, -600.0));
       expect(childParentData.layoutOffset, const Offset(1000.0, 1000.0));
 
       // Change the scroll positions to test partially visible.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128723

The paint offset was incorrectly being computed when one or both axis was in the reverse direction. Instead of using the paint extent, the child's size should be used.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
