### PR TITLE
Update unit tests in material library for Material 3

### DIFF
--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -63,6 +63,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         title: 'Pirate app',
         home: Scaffold(
           appBar: AppBar(
@@ -167,8 +168,9 @@ void main() {
     });
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Center(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Center(
           child: LicensePage(),
         ),
       ),
@@ -220,9 +222,10 @@ void main() {
     });
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         title: 'Pirate app',
-        home: Center(
+        home: const Center(
           child: LicensePage(
             applicationName: 'LicensePage test app',
             applicationVersion: '0.1.2',
@@ -298,6 +301,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           primaryTextTheme: const TextTheme(
             titleLarge: titleTextStyle,
             titleSmall: subtitleTextStyle,
@@ -384,8 +388,9 @@ void main() {
     });
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: MediaQuery(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const MediaQuery(
           data: MediaQueryData(
             padding: EdgeInsets.all(safeareaPadding),
           ),
@@ -830,7 +835,7 @@ void main() {
     const Color cardColor = Color(0xFF654321);
 
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData.light().copyWith(
+      theme: ThemeData.light(useMaterial3: false).copyWith(
         scaffoldBackgroundColor: scaffoldColor,
         cardColor: cardColor,
       ),
@@ -1051,7 +1056,12 @@ void main() {
 
   testWidgetsWithLeakTracking('Error handling test', (WidgetTester tester) async {
     LicenseRegistry.addLicense(() => Stream<LicenseEntry>.error(Exception('Injected failure')));
-    await tester.pumpWidget(const MaterialApp(home: Material(child: AboutListTile())));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Material(child: AboutListTile())
+      )
+    );
     await tester.tap(find.byType(ListTile));
     await tester.pump();
     await tester.pump(const Duration(seconds: 2));
@@ -1082,9 +1092,10 @@ void main() {
     await tester.binding.setSurfaceSize(defaultSize);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         title: title,
-        home: Scaffold(
+        home: const Scaffold(
           body: Directionality(
             textDirection: textDirection,
             child: LicensePage(),
@@ -1145,9 +1156,10 @@ void main() {
     await tester.binding.setSurfaceSize(defaultSize);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         title: title,
-        home: Scaffold(
+        home: const Scaffold(
           body: Directionality(
             textDirection: textDirection,
             child: LicensePage(),

--- a/packages/flutter/test/material/app_builder_test.dart
+++ b/packages/flutter/test/material/app_builder_test.dart
@@ -10,6 +10,7 @@ void main() {
     final List<String> log = <String>[];
     final Widget app = MaterialApp(
       theme: ThemeData(
+        useMaterial3: false,
         primarySwatch: Colors.green,
       ),
       home: const Placeholder(),
@@ -42,6 +43,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           primarySwatch: Colors.yellow,
         ),
         home: Builder(

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -995,6 +995,7 @@ void main() {
     const Color secondaryColor = Color(0xff008800);
     final Color glowSecondaryColor = secondaryColor.withOpacity(0.05);
     final ThemeData theme = ThemeData.from(
+      useMaterial3: false,
       colorScheme: const ColorScheme.light().copyWith(secondary: secondaryColor),
     );
     await tester.pumpWidget(
@@ -1264,6 +1265,7 @@ void main() {
 
   testWidgets('ScrollBehavior default android overscroll indicator', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       scrollBehavior: const MaterialScrollBehavior(),
       home: ListView(
         children: const <Widget>[

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -459,7 +459,7 @@ void main() {
     const Color highlightColor = Color(0xFF112233);
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.light().copyWith(
+        theme: ThemeData.light(useMaterial3: false).copyWith(
           focusColor: highlightColor,
         ),
         home: Scaffold(

--- a/packages/flutter/test/material/banner_theme_test.dart
+++ b/packages/flutter/test/material/banner_theme_test.dart
@@ -457,6 +457,7 @@ void main() {
       const String contentText = 'Content';
 
       await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: MaterialBanner(
             content: const Text(contentText),
@@ -503,6 +504,7 @@ void main() {
       const Key tapTarget = Key('tap-target');
 
       await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Builder(
             builder: (BuildContext context) {

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -120,6 +120,7 @@ void main() {
           child: RepaintBoundary(
             key: key,
             child: MaterialApp(
+              theme: ThemeData(useMaterial3: false),
               home: Scaffold(
                 floatingActionButton: FloatingActionButton(
                   onPressed: () { },
@@ -217,9 +218,10 @@ void main() {
     expect(babRect, const Rect.fromLTRB(240, 520, 560, 600));
   });
 
-  testWidgets('color defaults to Theme.bottomAppBarColor', (WidgetTester tester) async {
+  testWidgets('color defaults to Theme.bottomAppBarColor in M2', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Builder(
           builder: (BuildContext context) {
             return Theme(
@@ -245,6 +247,7 @@ void main() {
   testWidgets('color overrides theme color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Builder(
           builder: (BuildContext context) {
             return Theme(
@@ -324,7 +327,7 @@ void main() {
   testWidgets('dark theme applies an elevation overlay color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: const ColorScheme.dark()),
+        theme: ThemeData.from(useMaterial3: false, colorScheme: const ColorScheme.dark()),
         home: Scaffold(
           bottomNavigationBar: BottomAppBar(
             color: const ColorScheme.dark().surface,
@@ -508,8 +511,9 @@ void main() {
 
   testWidgets('observes safe area', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: MediaQuery(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const MediaQuery(
           data: MediaQueryData(
             padding: EdgeInsets.all(50.0),
           ),
@@ -566,8 +570,10 @@ void main() {
 
   testWidgets('BottomAppBar with shape when Scaffold.bottomNavigationBar == null', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/80878
+    final ThemeData theme = ThemeData();
     await tester.pumpWidget(
       MaterialApp(
+        theme: theme,
         home: Scaffold(
           floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
           floatingActionButton: FloatingActionButton(
@@ -595,7 +601,7 @@ void main() {
     );
 
     expect(tester.getRect(find.byType(FloatingActionButton)), const Rect.fromLTRB(372, 528, 428, 584));
-    expect(tester.getSize(find.byType(BottomAppBar)), const Size(800, 50));
+    expect(tester.getSize(find.byType(BottomAppBar)), theme.useMaterial3 ? const Size(800, 80) : const Size(800, 50));
   });
 
   testWidgets('notch with margin and top padding, home safe area', (WidgetTester tester) async {

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -36,6 +36,7 @@ void main() {
 
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomAppBarTheme: theme,
           bottomAppBarColor: themeColor
         ),
@@ -53,6 +54,7 @@ void main() {
 
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomAppBarTheme: theme,
           bottomAppBarColor: themeColor
         ),
@@ -67,7 +69,7 @@ void main() {
       const Color themeColor = Colors.white10;
 
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(bottomAppBarColor: themeColor),
+        theme: ThemeData(useMaterial3: false, bottomAppBarColor: themeColor),
         home: const Scaffold(body: BottomAppBar()),
       ));
 
@@ -77,7 +79,7 @@ void main() {
 
     testWidgets('BAB color - Default', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(),
+        theme: ThemeData(useMaterial3: false),
         home: const Scaffold(body: BottomAppBar()),
       ));
 
@@ -102,8 +104,9 @@ void main() {
     });
 
     testWidgets('BAB theme does not affect defaults', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(
-        home: Scaffold(body: BottomAppBar()),
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(body: BottomAppBar()),
       ));
 
       final PhysicalShape widget = _getBabRenderObject(tester);

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -52,6 +52,7 @@ void main() {
   testWidgets('BottomNavigationBar content test', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           bottomNavigationBar: BottomNavigationBar(
             items: const <BottomNavigationBarItem>[
@@ -81,7 +82,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.light().copyWith(
+        theme: ThemeData.light(useMaterial3: false).copyWith(
           colorScheme: const ColorScheme.light().copyWith(primary: primaryColor),
           unselectedWidgetColor: unselectedWidgetColor,
         ),
@@ -413,6 +414,7 @@ void main() {
   testWidgets('Shifting BottomNavigationBar defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           bottomNavigationBar: BottomNavigationBar(
             type: BottomNavigationBarType.shifting,
@@ -991,6 +993,7 @@ void main() {
   testWidgets('BottomNavigationBar adds bottom padding to height', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: MediaQuery(
           data: const MediaQueryData(viewPadding: EdgeInsets.only(bottom: 40.0)),
           child: Scaffold(
@@ -1323,6 +1326,7 @@ void main() {
   testWidgets('BottomNavigationBar responds to textScaleFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           bottomNavigationBar: BottomNavigationBar(
             type: BottomNavigationBarType.fixed,
@@ -1396,6 +1400,7 @@ void main() {
   testWidgets('BottomNavigationBar does not grow with textScaleFactor when labels are provided', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           bottomNavigationBar: BottomNavigationBar(
             type: BottomNavigationBarType.fixed,
@@ -1484,19 +1489,22 @@ void main() {
               onGenerateRoute: (RouteSettings settings) {
                 return MaterialPageRoute<void>(
                   builder: (BuildContext context) {
-                    return Scaffold(
-                      bottomNavigationBar: BottomNavigationBar(
-                        items: const <BottomNavigationBarItem>[
-                          BottomNavigationBarItem(
-                            label: label,
-                            icon: Icon(Icons.ac_unit),
-                            tooltip: label,
-                          ),
-                          BottomNavigationBarItem(
-                            label: 'B',
-                            icon: Icon(Icons.battery_alert),
-                          ),
-                        ],
+                    return MaterialApp(
+                      theme: ThemeData(useMaterial3: false),
+                      home: Scaffold(
+                        bottomNavigationBar: BottomNavigationBar(
+                          items: const <BottomNavigationBarItem>[
+                            BottomNavigationBarItem(
+                              label: label,
+                              icon: Icon(Icons.ac_unit),
+                              tooltip: label,
+                            ),
+                            BottomNavigationBarItem(
+                              label: 'B',
+                              icon: Icon(Icons.battery_alert),
+                            ),
+                          ],
+                        ),
                       ),
                     );
                   },
@@ -1566,6 +1574,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           bottomNavigationBar: BottomNavigationBar(
             items: <BottomNavigationBarItem>[
@@ -1924,6 +1933,7 @@ void main() {
     Widget runTest() {
       int currentIndex = 0;
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(
@@ -2363,6 +2373,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Builder(
           builder: (BuildContext context) {
             return Scaffold(
@@ -2410,6 +2421,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Builder(
           builder: (BuildContext context) {
             return Scaffold(
@@ -2455,6 +2467,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Builder(
           builder: (BuildContext context) {
             return Scaffold(
@@ -2492,6 +2505,7 @@ void main() {
 
 Widget boilerplate({ Widget? bottomNavigationBar, required TextDirection textDirection }) {
   return MaterialApp(
+    theme: ThemeData(useMaterial3: false),
     home: Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1604,6 +1604,7 @@ void main() {
   testWidgets('BottomNavigationBar paints circles', (WidgetTester tester) async {
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         textDirection: TextDirection.ltr,
         bottomNavigationBar: BottomNavigationBar(
           items: const <BottomNavigationBarItem>[
@@ -2503,9 +2504,9 @@ void main() {
   });
 }
 
-Widget boilerplate({ Widget? bottomNavigationBar, required TextDirection textDirection }) {
+Widget boilerplate({ Widget? bottomNavigationBar, required TextDirection textDirection, bool? useMaterial3 }) {
   return MaterialApp(
-    theme: ThemeData(useMaterial3: false),
+    theme: ThemeData(useMaterial3: useMaterial3),
     home: Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -979,6 +979,7 @@ void main() {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         key: scaffoldKey,
         body: const Center(child: Text('body')),
@@ -1180,6 +1181,7 @@ void main() {
 
   testWidgets('showModalBottomSheet does not use root Navigator by default', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: Navigator(onGenerateRoute: (RouteSettings settings) => MaterialPageRoute<void>(builder: (_) {
           return const _TestPage();
@@ -1804,8 +1806,9 @@ void main() {
     });
 
     testWidgets('No constraints by default for bottomSheet property', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(
-        home: Scaffold(
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(
           body: Center(child: Text('body')),
           bottomSheet: Text('BottomSheet'),
         ),
@@ -1819,6 +1822,7 @@ void main() {
 
     testWidgets('No constraints by default for showBottomSheet', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Builder(builder: (BuildContext context) {
             return Center(
@@ -1846,6 +1850,7 @@ void main() {
 
     testWidgets('No constraints by default for showModalBottomSheet', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Builder(builder: (BuildContext context) {
             return Center(
@@ -1875,6 +1880,7 @@ void main() {
     testWidgets('Theme constraints used for bottomSheet property', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomSheetTheme: const BottomSheetThemeData(
             constraints: BoxConstraints(maxWidth: 80),
           ),
@@ -1902,6 +1908,7 @@ void main() {
     testWidgets('Theme constraints used for showBottomSheet', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomSheetTheme: const BottomSheetThemeData(
             constraints: BoxConstraints(maxWidth: 80),
           ),
@@ -1935,6 +1942,7 @@ void main() {
     testWidgets('Theme constraints used for showModalBottomSheet', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomSheetTheme: const BottomSheetThemeData(
             constraints: BoxConstraints(maxWidth: 80),
           ),
@@ -1969,6 +1977,7 @@ void main() {
     testWidgets('constraints param overrides theme for showBottomSheet', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomSheetTheme: const BottomSheetThemeData(
             constraints: BoxConstraints(maxWidth: 80),
           ),
@@ -2003,6 +2012,7 @@ void main() {
     testWidgets('constraints param overrides theme for showModalBottomSheet', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           bottomSheetTheme: const BottomSheetThemeData(
             constraints: BoxConstraints(maxWidth: 80),
           ),

--- a/packages/flutter/test/material/bottom_sheet_theme_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_theme_test.dart
@@ -80,6 +80,7 @@ void main() {
 
   testWidgets('Passing no BottomSheetThemeData returns defaults', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: BottomSheet(
           onClosing: () {},
@@ -256,14 +257,14 @@ void main() {
     const Color darkShadowColor = Colors.purple;
 
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData.light().copyWith(
+      theme: ThemeData.light(useMaterial3: false).copyWith(
         bottomSheetTheme: const BottomSheetThemeData(
           elevation: lightElevation,
           backgroundColor: lightBackgroundColor,
           shadowColor: lightShadowColor,
         ),
       ),
-      darkTheme: ThemeData.dark().copyWith(
+      darkTheme: ThemeData.dark(useMaterial3: false).copyWith(
         bottomSheetTheme: const BottomSheetThemeData(
           elevation: darkElevation,
           backgroundColor: darkBackgroundColor,
@@ -323,7 +324,7 @@ void main() {
 
 Widget bottomSheetWithElevations(BottomSheetThemeData bottomSheetTheme) {
   return MaterialApp(
-    theme: ThemeData(bottomSheetTheme: bottomSheetTheme),
+    theme: ThemeData(bottomSheetTheme: bottomSheetTheme, useMaterial3: false),
     home: Scaffold(
       body: Builder(
         builder: (BuildContext context) {

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -28,6 +28,7 @@ void main() {
     TextDirection textDirection = TextDirection.ltr,
   }) {
     return MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Material(
         child: Directionality(
           textDirection: textDirection,

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -42,11 +42,14 @@ void main() {
     Color checkBoxCheckColor = const Color(0xffFFFFFF);
 
     Widget buildFrame(Color? color) {
-      return wrap(
-        child: CheckboxListTile(
-          value: true,
-          checkColor: color,
-          onChanged: (bool? value) {},
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: CheckboxListTile(
+            value: true,
+            checkColor: color,
+            onChanged: (bool? value) {},
+          ),
         ),
       );
     }
@@ -730,14 +733,17 @@ void main() {
     const double splashRadius = 24.0;
 
     Widget buildCheckbox({bool active = false, bool useOverlay = true}) {
-      return wrap(
-        child: CheckboxListTile(
-          value: active,
-          onChanged: (_) { },
-          fillColor: const MaterialStatePropertyAll<Color>(fillColor),
-          overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
-          hoverColor: hoverColor,
-          splashRadius: splashRadius,
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: CheckboxListTile(
+            value: active,
+            onChanged: (_) { },
+            fillColor: const MaterialStatePropertyAll<Color>(fillColor),
+            overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
+            hoverColor: hoverColor,
+            splashRadius: splashRadius,
+          ),
         ),
       );
     }

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -76,7 +76,7 @@ Widget wrapForChip({
   Brightness brightness = Brightness.light,
 }) {
   return MaterialApp(
-    theme: ThemeData(brightness: brightness),
+    theme: ThemeData(brightness: brightness, useMaterial3: false),
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
@@ -220,7 +220,7 @@ void main() {
 
     Widget buildFrame(Brightness brightness) {
       return MaterialApp(
-        theme: ThemeData(brightness: brightness),
+        theme: ThemeData(brightness: brightness, useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: Builder(
@@ -1689,6 +1689,7 @@ void main() {
 
   testWidgets('Chip uses ThemeData chip theme if present', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(
+      useMaterial3: false,
       platform: TargetPlatform.android,
       primarySwatch: Colors.red,
     );
@@ -1792,7 +1793,7 @@ void main() {
     await tester.pumpWidget(
       wrapForChip(
         child: Theme(
-          data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.padded),
+          data: ThemeData(useMaterial3: false, materialTapTargetSize: MaterialTapTargetSize.padded),
           child: Center(
             child: RawChip(
               key: key1,
@@ -1809,7 +1810,7 @@ void main() {
     await tester.pumpWidget(
       wrapForChip(
         child: Theme(
-          data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
+          data: ThemeData(useMaterial3: false, materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
           child: Center(
             child: RawChip(
               key: key2,
@@ -2466,6 +2467,7 @@ void main() {
 
   testWidgets('Chip elevation and shadow color work correctly', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(
+      useMaterial3: false,
       platform: TargetPlatform.android,
       primarySwatch: Colors.red,
     );
@@ -2725,6 +2727,7 @@ void main() {
 
     Widget chipWidget({ bool enabled = true, bool selected = false }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Focus(
             focusNode: focusNode,
@@ -2804,6 +2807,7 @@ void main() {
 
     Widget chipWidget({ bool enabled = true, bool selected = false }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Focus(
             focusNode: focusNode,
@@ -2886,6 +2890,7 @@ void main() {
 
     Widget chipWidget({ bool enabled = true, bool selected = false }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Focus(
             focusNode: focusNode,
@@ -2963,6 +2968,7 @@ void main() {
 
     Widget chipWidget({ bool enabled = true, bool selected = false }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Focus(
             focusNode: focusNode,
@@ -3035,6 +3041,7 @@ void main() {
     Widget chipWidget({ bool enabled = true, bool selected = false }) {
       return MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           chipTheme: ThemeData.light().chipTheme.copyWith(
             shape: themeShape,
             side: themeBorderSide,
@@ -3071,6 +3078,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity) async {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Center(
               child: Column(

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -147,7 +147,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.light().copyWith(
+        theme: ThemeData.light(useMaterial3: false).copyWith(
           chipTheme: chipTheme,
         ),
         home: Directionality(
@@ -193,7 +193,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.light().copyWith(
+        theme: ThemeData.light(useMaterial3: false).copyWith(
           chipTheme: shadowedChipTheme,
         ),
         home: ChipTheme(
@@ -242,6 +242,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: ChipTheme(
           data: shadowedChipTheme,
           child: Builder(
@@ -654,6 +655,7 @@ void main() {
     Widget chipWidget({ bool selected = false }) {
       return MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           chipTheme: ThemeData.light().chipTheme.copyWith(
             side: MaterialStateBorderSide.resolveWith(getBorderSide),
           ),
@@ -699,7 +701,7 @@ void main() {
 
     Widget chipWidget({ bool selected = false }) {
       return MaterialApp(
-        theme: ThemeData(chipTheme: chipTheme),
+        theme: ThemeData(useMaterial3: false, chipTheme: chipTheme),
         home: Scaffold(
           body: ChoiceChip(
             label: const Text('Chip'),
@@ -739,7 +741,7 @@ void main() {
 
     Widget chipWidget({ bool selected = false }) {
       return MaterialApp(
-        theme: ThemeData(chipTheme: chipTheme),
+        theme: ThemeData(useMaterial3: false, chipTheme: chipTheme),
         home: Scaffold(
           body: ChoiceChip(
             label: const Text('Chip'),

--- a/packages/flutter/test/material/choice_chip_test.dart
+++ b/packages/flutter/test/material/choice_chip_test.dart
@@ -403,7 +403,7 @@ void main() {
     testWidgets('ChoiceChip defaults', (WidgetTester tester) async {
       Widget buildFrame(Brightness brightness) {
         return MaterialApp(
-          theme: ThemeData(brightness: brightness),
+          theme: ThemeData(useMaterial3: false, brightness: brightness),
           home: const Scaffold(
             body: Center(
               child: ChoiceChip(

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -287,7 +287,7 @@ void main() {
     // can be deleted.
 
     testWidgets('CircleAvatar default colors with light theme', (WidgetTester tester) async {
-      final ThemeData theme = ThemeData(primaryColor: Colors.grey.shade100);
+      final ThemeData theme = ThemeData(useMaterial3: false, primaryColor: Colors.grey.shade100);
       await tester.pumpWidget(
         wrap(
           child: Theme(
@@ -309,7 +309,7 @@ void main() {
     });
 
     testWidgets('CircleAvatar default colors with dark theme', (WidgetTester tester) async {
-      final ThemeData theme = ThemeData(primaryColor: Colors.grey.shade800);
+      final ThemeData theme = ThemeData(useMaterial3: false, primaryColor: Colors.grey.shade800);
       await tester.pumpWidget(
         wrap(
           child: Theme(
@@ -337,7 +337,9 @@ Widget wrap({ required Widget child }) {
     textDirection: TextDirection.ltr,
     child: MediaQuery(
       data: const MediaQueryData(),
-      child: Center(child: child),
+      child: MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Center(child: child)),
     ),
   );
 }

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1680,6 +1680,7 @@ void main() {
     }
 
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Material(child: buildTable()),
     ));
 

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -382,6 +382,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Center(
             child: Builder(
               builder: (BuildContext context) {
@@ -417,7 +418,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData.fallback().copyWith(dialogTheme: customDialogTheme),
+          theme: ThemeData.fallback(useMaterial3: false).copyWith(dialogTheme: customDialogTheme),
           home: Center(
             child: Builder(
               builder: (BuildContext context) {
@@ -447,6 +448,7 @@ void main() {
     testWidgets('OK Cancel button layout', (WidgetTester tester) async {
        Widget buildFrame(TextDirection textDirection) {
          return MaterialApp(
+           theme: ThemeData(useMaterial3: false),
            home: Material(
              child: Center(
                child: Builder(

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -504,6 +504,7 @@ void main() {
   testWidgets('OK Cancel button layout', (WidgetTester tester) async {
      Widget buildFrame(TextDirection textDirection) {
        return MaterialApp(
+         theme: ThemeData(useMaterial3: false),
          home: Material(
            child: Center(
              child: Builder(
@@ -1062,9 +1063,10 @@ void main() {
 
   testWidgets('DatePickerDialog is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         restorationScopeId: 'app',
-        home: _RestorableDateRangePickerDialogTestWidget(),
+        home: const _RestorableDateRangePickerDialogTestWidget(),
       ),
     );
 

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -171,7 +171,7 @@ void main() {
       actions: <Widget>[ ],
       alignment: Alignment.topRight,
     );
-    final ThemeData theme = ThemeData(dialogTheme: const DialogTheme(alignment: Alignment.bottomLeft));
+    final ThemeData theme = ThemeData(useMaterial3: false, dialogTheme: const DialogTheme(alignment: Alignment.bottomLeft));
 
     await tester.pumpWidget(
       _appWithDialog(tester, dialog, theme: theme),
@@ -193,7 +193,7 @@ void main() {
       title: Text('Title'),
       actions: <Widget>[ ],
     );
-    final ThemeData theme = ThemeData(dialogTheme: const DialogTheme(shape: customBorder));
+    final ThemeData theme = ThemeData(useMaterial3: false, dialogTheme: const DialogTheme(shape: customBorder));
 
     await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
     await tester.tap(find.text('X'));
@@ -248,7 +248,7 @@ void main() {
 
   testWidgets('Custom Icon Color - Theme - lowest preference', (WidgetTester tester) async {
     const Color iconThemeColor = Colors.yellow;
-    final ThemeData theme = ThemeData(iconTheme: const IconThemeData(color: iconThemeColor));
+    final ThemeData theme = ThemeData(useMaterial3: false, iconTheme: const IconThemeData(color: iconThemeColor));
     const AlertDialog dialog = AlertDialog(
       icon: Icon(Icons.ac_unit),
       actions: <Widget>[ ],
@@ -320,7 +320,7 @@ void main() {
       title: Text(titleText),
       actions: <Widget>[ ],
     );
-    final ThemeData theme = ThemeData(textTheme: const TextTheme(titleLarge: titleTextStyle));
+    final ThemeData theme = ThemeData(useMaterial3: false, textTheme: const TextTheme(titleLarge: titleTextStyle));
 
     await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
     await tester.tap(find.text('X'));
@@ -419,7 +419,7 @@ void main() {
       content: Text(contentText),
       actions: <Widget>[ ],
     );
-    final ThemeData theme = ThemeData(textTheme: const TextTheme(titleMedium: contentTextStyle));
+    final ThemeData theme = ThemeData(useMaterial3: false, textTheme: const TextTheme(titleMedium: contentTextStyle));
 
     await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
     await tester.tap(find.text('X'));

--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -9,9 +9,9 @@ import '../rendering/mock_canvas.dart';
 void main() {
   testWidgets('Divider control test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Center(
           child: Divider(),
         ),
       ),
@@ -94,9 +94,9 @@ void main() {
 
   testWidgets('Vertical Divider Test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Center(
           child: VerticalDivider(),
         ),
       ),

--- a/packages/flutter/test/material/divider_theme_test.dart
+++ b/packages/flutter/test/material/divider_theme_test.dart
@@ -272,8 +272,9 @@ void main() {
 
     group('Horizontal Divider', () {
       testWidgets('Passing no DividerThemeData returns defaults', (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(
-          home: Scaffold(
+        await tester.pumpWidget(MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: const Scaffold(
             body: Divider(),
           ),
         ));
@@ -285,7 +286,7 @@ void main() {
         final BoxDecoration decoration = container.decoration! as BoxDecoration;
         expect(decoration.border!.bottom.width, 0.0);
 
-        final ThemeData theme = ThemeData();
+        final ThemeData theme = ThemeData(useMaterial3: false);
         expect(decoration.border!.bottom.color, theme.dividerColor);
 
         final Rect dividerRect = tester.getRect(find.byType(Divider));
@@ -314,8 +315,9 @@ void main() {
 
     group('Vertical Divider', () {
       testWidgets('Passing no DividerThemeData returns defaults', (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(
-          home: Scaffold(
+        await tester.pumpWidget(MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: const Scaffold(
             body: VerticalDivider(),
           ),
         ));
@@ -328,7 +330,7 @@ void main() {
         final Border border = decoration.border! as Border;
         expect(border.left.width, 0.0);
 
-        final ThemeData theme = ThemeData();
+        final ThemeData theme = ThemeData(useMaterial3: false);
         expect(border.left.color, theme.dividerColor);
 
         final Rect dividerRect = tester.getRect(find.byType(VerticalDivider));

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -14,6 +14,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           drawer: Drawer(
             child: ListView(

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -16,6 +16,7 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -161,39 +162,43 @@ Widget buildFrame({
   double? menuMaxHeight,
   EdgeInsetsGeometry? padding,
   Alignment dropdownAlignment = Alignment.center,
+  bool? useMaterial3,
 }) {
-  return TestApp(
-    textDirection: textDirection,
-    mediaSize: mediaSize,
-    child: Material(
-      child: Align(
-        alignment: dropdownAlignment,
-        child: RepaintBoundary(
-          child: buildDropdown(
-            isFormField: isFormField,
-            buttonKey: buttonKey,
-            value: value,
-            hint: hint,
-            disabledHint: disabledHint,
-            onChanged: onChanged,
-            onTap: onTap,
-            icon: icon,
-            iconSize: iconSize,
-            iconDisabledColor: iconDisabledColor,
-            iconEnabledColor: iconEnabledColor,
-            isDense: isDense,
-            isExpanded: isExpanded,
-            underline: underline,
-            focusNode: focusNode,
-            autofocus: autofocus,
-            focusColor: focusColor,
-            dropdownColor: dropdownColor,
-            items: items,
-            selectedItemBuilder: selectedItemBuilder,
-            itemHeight: itemHeight,
-            alignment: alignment,
-            menuMaxHeight: menuMaxHeight,
-            padding: padding,
+  return Theme(
+    data: ThemeData(useMaterial3: useMaterial3),
+    child: TestApp(
+      textDirection: textDirection,
+      mediaSize: mediaSize,
+      child: Material(
+        child: Align(
+          alignment: dropdownAlignment,
+          child: RepaintBoundary(
+            child: buildDropdown(
+              isFormField: isFormField,
+              buttonKey: buttonKey,
+              value: value,
+              hint: hint,
+              disabledHint: disabledHint,
+              onChanged: onChanged,
+              onTap: onTap,
+              icon: icon,
+              iconSize: iconSize,
+              iconDisabledColor: iconDisabledColor,
+              iconEnabledColor: iconEnabledColor,
+              isDense: isDense,
+              isExpanded: isExpanded,
+              underline: underline,
+              focusNode: focusNode,
+              autofocus: autofocus,
+              focusColor: focusColor,
+              dropdownColor: dropdownColor,
+              items: items,
+              selectedItemBuilder: selectedItemBuilder,
+              itemHeight: itemHeight,
+              alignment: alignment,
+              menuMaxHeight: menuMaxHeight,
+              padding: padding,
+            ),
           ),
         ),
       ),
@@ -207,6 +212,7 @@ Widget buildDropdownWithHint({
   bool enableSelectedItemBuilder = false,
 }){
   return buildFrame(
+    useMaterial3: false,
     mediaSize: const Size(800, 600),
     itemHeight: 100.0,
     alignment: alignment,
@@ -286,6 +292,7 @@ Future<void> checkDropdownColor(WidgetTester tester, {Color? color, bool isFormF
   const String text = 'foo';
   await tester.pumpWidget(
     MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Material(
         child: isFormField
             ? Form(
@@ -335,7 +342,7 @@ Future<void> checkDropdownColor(WidgetTester tester, {Color? color, bool isFormF
 void main() {
   testWidgets('Default dropdown golden', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
-    Widget build() => buildFrame(buttonKey: buttonKey, onChanged: onChanged);
+    Widget build() => buildFrame(buttonKey: buttonKey, onChanged: onChanged, useMaterial3: false);
     await tester.pumpWidget(build());
     final Finder buttonFinder = find.byKey(buttonKey);
     assert(tester.renderObject(buttonFinder).attached);
@@ -347,7 +354,7 @@ void main() {
 
   testWidgets('Expanded dropdown golden', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
-    Widget build() => buildFrame(buttonKey: buttonKey, isExpanded: true, onChanged: onChanged);
+    Widget build() => buildFrame(buttonKey: buttonKey, isExpanded: true, onChanged: onChanged, useMaterial3: false);
     await tester.pumpWidget(build());
     final Finder buttonFinder = find.byKey(buttonKey);
     assert(tester.renderObject(buttonFinder).attached);
@@ -609,6 +616,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/66870
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(),
           body: Column(
@@ -697,7 +705,7 @@ void main() {
     testWidgets('Dropdown button aligns selected menu item ($textDirection)', (WidgetTester tester) async {
       final Key buttonKey = UniqueKey();
 
-      Widget build() => buildFrame(buttonKey: buttonKey, textDirection: textDirection, onChanged: onChanged);
+      Widget build() => buildFrame(buttonKey: buttonKey, textDirection: textDirection, onChanged: onChanged, useMaterial3: false);
 
       await tester.pumpWidget(build());
       final RenderBox buttonBox = tester.renderObject<RenderBox>(find.byKey(buttonKey));
@@ -2382,12 +2390,12 @@ void main() {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     final UniqueKey buttonKey = UniqueKey();
     final FocusNode focusNode = FocusNode(debugLabel: 'DropdownButton');
-    await tester.pumpWidget(buildFrame(buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, autofocus: true));
+    await tester.pumpWidget(buildFrame(buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, autofocus: true, useMaterial3: false));
     await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
     expect(focusNode.hasPrimaryFocus, isTrue);
     expect(find.byType(Material), paints..rect(rect: const Rect.fromLTRB(348.0, 276.0, 452.0, 324.0), color: const Color(0x1f000000)));
 
-    await tester.pumpWidget(buildFrame(buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, focusColor: const Color(0xff00ff00)));
+    await tester.pumpWidget(buildFrame(buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, focusColor: const Color(0xff00ff00), useMaterial3: false));
     await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
     expect(find.byType(Material), paints..rect(rect: const Rect.fromLTRB(348.0, 276.0, 452.0, 324.0), color: const Color(0x1f00ff00)));
   });
@@ -2696,6 +2704,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: StatefulBuilder(
@@ -3169,6 +3178,7 @@ void main() {
     final UniqueKey itemKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: DropdownButton<String>(
@@ -3504,8 +3514,9 @@ void main() {
     await tester.pumpAndSettle(); // finish the menu animation
 
     // The inherited ScrollBehavior should not apply Scrollbars since they are
-    // already built in to the widget.
-    expect(find.byType(CupertinoScrollbar), findsNothing);
+    // already built in to the widget. For iOS platform, ScrollBar directly returns
+    // CupertinoScrollbar
+    expect(find.byType(CupertinoScrollbar), debugDefaultTargetPlatformOverride == TargetPlatform.iOS ? findsOneWidget : findsNothing);
     expect(find.byType(Scrollbar), findsOneWidget);
     expect(find.byType(RawScrollbar), findsNothing);
 
@@ -3516,6 +3527,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: DropdownButton<String>(

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -77,6 +77,7 @@ void main() {
     IconTheme iconTheme;
     // Light mode test
     await tester.pumpWidget(wrap(
+      theme: ThemeData(useMaterial3: false),
       child: const ExpandIcon(onPressed: null),
     ));
     await tester.pumpAndSettle();
@@ -87,7 +88,7 @@ void main() {
     // Dark mode test
     await tester.pumpWidget(wrap(
       child: const ExpandIcon(onPressed: null),
-      theme: ThemeData(brightness: Brightness.dark),
+      theme: ThemeData(useMaterial3: false, brightness: Brightness.dark),
     ));
     await tester.pumpAndSettle();
 
@@ -176,6 +177,7 @@ void main() {
     final SemanticsHandle handle = tester.ensureSemantics();
     const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
     await tester.pumpWidget(wrap(
+      theme: ThemeData(useMaterial3: false),
       child: ExpandIcon(
         isExpanded: true,
         onPressed: (bool _) { },

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -183,6 +183,7 @@ void main() {
     final Key headerKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: ExpansionPanelListSemanticsTest(headerKey: headerKey),
       ),
     );
@@ -1024,6 +1025,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: SingleChildScrollView(
           child: expansionList,
         ),

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -167,6 +167,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           colorScheme: ColorScheme.fromSwatch().copyWith(primary: foregroundColor),
           unselectedWidgetColor: unselectedWidgetColor,
           textTheme: const TextTheme(titleMedium: TextStyle(color: headerColor)),

--- a/packages/flutter/test/material/filter_chip_test.dart
+++ b/packages/flutter/test/material/filter_chip_test.dart
@@ -13,9 +13,10 @@ Widget wrapForChip({
   TextDirection textDirection = TextDirection.ltr,
   double textScaleFactor = 1.0,
   Brightness brightness = Brightness.light,
+  bool? useMaterial3,
 }) {
   return MaterialApp(
-    theme: ThemeData(brightness: brightness),
+    theme: ThemeData(brightness: brightness, useMaterial3: useMaterial3),
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
@@ -31,9 +32,11 @@ Future<void> pumpCheckmarkChip(
   required Widget chip,
   Color? themeColor,
   Brightness brightness = Brightness.light,
+  ThemeData? theme,
 }) async {
   await tester.pumpWidget(
     wrapForChip(
+      useMaterial3: false,
       brightness: brightness,
       child: Builder(
         builder: (BuildContext context) {
@@ -385,6 +388,7 @@ void main() {
 
   testWidgets('Filter chip check mark color is determined by platform brightness when light', (WidgetTester tester) async {
     await pumpCheckmarkChip(
+      theme: ThemeData(useMaterial3: false),
       tester,
       chip: selectedFilterChip(),
     );
@@ -400,6 +404,7 @@ void main() {
       tester,
       chip: selectedFilterChip(),
       brightness: Brightness.dark,
+      theme: ThemeData(useMaterial3: false),
     );
 
     expectCheckmarkColor(

--- a/packages/flutter/test/material/flexible_space_bar_stretch_mode_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_stretch_mode_test.dart
@@ -53,6 +53,7 @@ void main() {
   testWidgets('FlexibleSpaceBar stretch mode blurBackground', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
             physics: const BouncingScrollPhysics(),

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -81,6 +81,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
             key: dragTarget,
@@ -172,6 +173,7 @@ void main() {
     const double expandedHeight = 200;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
             slivers: <Widget>[
@@ -438,6 +440,7 @@ void main() {
     late double width;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Builder(
             builder: (BuildContext context) {
@@ -486,6 +489,7 @@ void main() {
     const double expandedTitleScale = 3.0;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
             slivers: <Widget>[
@@ -555,6 +559,7 @@ void main() {
     const double height = 300.0;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
             slivers: <Widget>[
@@ -615,6 +620,7 @@ void main() {
     const double expandedTitleScale = 3.0;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
             slivers: <Widget>[
@@ -674,7 +680,7 @@ void main() {
   testWidgets('FlexibleSpaceBar test titlePadding defaults', (WidgetTester tester) async {
     Widget buildFrame(TargetPlatform platform, bool? centerTitle) {
       return MaterialApp(
-        theme: ThemeData(platform: platform),
+        theme: ThemeData(platform: platform, useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(
             flexibleSpace: FlexibleSpaceBar(
@@ -724,7 +730,7 @@ void main() {
   testWidgets('FlexibleSpaceBar test titlePadding override', (WidgetTester tester) async {
     Widget buildFrame(TargetPlatform platform, bool? centerTitle) {
       return MaterialApp(
-        theme: ThemeData(platform: platform),
+        theme: ThemeData(platform: platform, useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(
             flexibleSpace: FlexibleSpaceBar(

--- a/packages/flutter/test/material/inherited_theme_test.dart
+++ b/packages/flutter/test/material/inherited_theme_test.dart
@@ -99,6 +99,7 @@ void main() {
 
     Widget buildFrame() {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: PopupMenuTheme(
             data: const PopupMenuThemeData(

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -59,9 +59,9 @@ void main() {
     const BorderRadius borderRadius = BorderRadius.all(Radius.circular(6.0));
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Material(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
           child: Center(
             child: SizedBox(
               width: 200.0,
@@ -190,9 +190,9 @@ void main() {
 
   testWidgets('Does the Ink widget render anything', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Material(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
           child: Center(
             child: Ink(
               color: Colors.blue,
@@ -222,9 +222,9 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Material(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
           child: Center(
             child: Ink(
               color: Colors.red,
@@ -250,9 +250,9 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Material(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
           child: Center(
             child: InkWell( // this is at a different depth in the tree so it's now a new InkWell
               splashColor: Colors.green,
@@ -518,9 +518,9 @@ void main() {
     const Color splashColor = Color(0xff00ff00);
 
     Widget buildWidget({InteractiveInkFeatureFactory? splashFactory}) {
-      return Directionality(
-        textDirection: TextDirection.ltr,
-        child: Material(
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
           child: Center(
             child: SizedBox(
               width: 100.0,

--- a/packages/flutter/test/material/ink_splash_test.dart
+++ b/packages/flutter/test/material/ink_splash_test.dart
@@ -30,6 +30,7 @@ void main() {
   testWidgets('InkWell with NoSplash splashFactory paints nothing', (WidgetTester tester) async {
     Widget buildFrame({ InteractiveInkFeatureFactory? splashFactory }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: Material(

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -338,23 +338,26 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTouch;
     final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');
     const Color splashColor = Color(0xffff0000);
-    await tester.pumpWidget(Material(
-      child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: Focus(
-            focusNode: focusNode,
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: InkWell(
-                hoverColor: const Color(0xff00ff00),
-                splashColor: splashColor,
-                focusColor: const Color(0xff0000ff),
-                highlightColor: const Color(0xf00fffff),
-                onTap: () { },
-                onLongPress: () { },
-                onHover: (bool hover) { },
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
+      home: Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Focus(
+              focusNode: focusNode,
+              child: SizedBox(
+                width: 100,
+                height: 100,
+                child: InkWell(
+                  hoverColor: const Color(0xff00ff00),
+                  splashColor: splashColor,
+                  focusColor: const Color(0xff0000ff),
+                  highlightColor: const Color(0xf00fffff),
+                  onTap: () { },
+                  onLongPress: () { },
+                  onHover: (bool hover) { },
+                ),
               ),
             ),
           ),
@@ -376,31 +379,34 @@ void main() {
     FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTouch;
     final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');
     const Color splashColor = Color(0xffff0000);
-    await tester.pumpWidget(Material(
-      child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: Center(
-          child: Focus(
-            focusNode: focusNode,
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: InkWell(
-                overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
-                  if (states.contains(MaterialState.hovered)) {
-                    return const Color(0xff00ff00);
-                  }
-                  if (states.contains(MaterialState.focused)) {
-                    return const Color(0xff0000ff);
-                  }
-                  if (states.contains(MaterialState.pressed)) {
-                    return splashColor;
-                  }
-                  return const Color(0xffbadbad); // Shouldn't happen.
-                }),
-                onTap: () { },
-                onLongPress: () { },
-                onHover: (bool hover) { },
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
+      home: Material(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Focus(
+              focusNode: focusNode,
+              child: SizedBox(
+                width: 100,
+                height: 100,
+                child: InkWell(
+                  overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                    if (states.contains(MaterialState.hovered)) {
+                      return const Color(0xff00ff00);
+                    }
+                    if (states.contains(MaterialState.focused)) {
+                      return const Color(0xff0000ff);
+                    }
+                    if (states.contains(MaterialState.pressed)) {
+                      return splashColor;
+                    }
+                    return const Color(0xffbadbad); // Shouldn't happen.
+                  }),
+                  onTap: () { },
+                  onLongPress: () { },
+                  onHover: (bool hover) { },
+                ),
               ),
             ),
           ),
@@ -820,19 +826,22 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/121626.
     final FocusNode focusNode = FocusNode(debugLabel: 'Ink Focus');
     Widget boilerplate(BorderRadius borderRadius) {
-      return Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: MouseRegion(
-                child: InkWell(
-                  focusNode: focusNode,
-                  customBorder: RoundedRectangleBorder(borderRadius: borderRadius),
-                  onTap: () { },
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 100,
+                height: 100,
+                child: MouseRegion(
+                  child: InkWell(
+                    focusNode: focusNode,
+                    customBorder: RoundedRectangleBorder(borderRadius: borderRadius),
+                    onTap: () { },
+                  ),
                 ),
               ),
             ),
@@ -1108,9 +1117,9 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
   testWidgets('splashing survives scrolling when keep-alive is enabled', (WidgetTester tester) async {
     Future<void> runTest(bool keepAlive) async {
       await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Material(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Material(
             child: CompositedTransformFollower(
               // forces a layer, which makes the paints easier to separate out
               link: LayerLink(),
@@ -1325,16 +1334,19 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
     }
 
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: paddedInkWell(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
               child: paddedInkWell(
-                key: middleKey,
                 child: paddedInkWell(
-                  key: innerKey,
-                  child: const SizedBox(width: 50, height: 50),
+                  key: middleKey,
+                  child: paddedInkWell(
+                    key: innerKey,
+                    child: const SizedBox(width: 50, height: 50),
+                  ),
                 ),
               ),
             ),
@@ -1391,24 +1403,27 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
     }
 
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: 200,
-              height: 100,
-              child: Row(
-                children: <Widget>[
-                  paddedInkWell(
-                    key: middleKey,
-                    child: paddedInkWell(
-                      key: innerKey,
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 200,
+                height: 100,
+                child: Row(
+                  children: <Widget>[
+                    paddedInkWell(
+                      key: middleKey,
+                      child: paddedInkWell(
+                        key: innerKey,
+                      ),
                     ),
-                  ),
-                  const SizedBox(),
-                ],
+                    const SizedBox(),
+                  ],
+                ),
               ),
             ),
           ),
@@ -1424,23 +1439,26 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
 
     // Reparent parent
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: 200,
-              height: 100,
-              child: Row(
-                children: <Widget>[
-                  paddedInkWell(
-                    key: innerKey,
-                  ),
-                  paddedInkWell(
-                    key: middleKey,
-                  ),
-                ],
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 200,
+                height: 100,
+                child: Row(
+                  children: <Widget>[
+                    paddedInkWell(
+                      key: innerKey,
+                    ),
+                    paddedInkWell(
+                      key: middleKey,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -1479,16 +1497,19 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
     }
 
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: paddedInkWell(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
               child: paddedInkWell(
-                key: middleKey,
                 child: paddedInkWell(
-                  key: innerKey,
-                  child: const SizedBox(width: 50, height: 50),
+                  key: middleKey,
+                  child: paddedInkWell(
+                    key: innerKey,
+                    child: const SizedBox(width: 50, height: 50),
+                  ),
                 ),
               ),
             ),
@@ -1514,39 +1535,42 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
     final GlobalKey leftKey = GlobalKey();
     final GlobalKey rightKey = GlobalKey();
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: InkWell(
-                key: parentKey,
-                onTap: () {},
-                child: Center(
-                  child: SizedBox(
-                    width: 100,
-                    height: 50,
-                    child: Row(
-                      children: <Widget>[
-                        SizedBox(
-                          width: 50,
-                          height: 50,
-                          child: InkWell(
-                            key: leftKey,
-                            onTap: () {},
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: SizedBox(
+                width: 100,
+                height: 100,
+                child: InkWell(
+                  key: parentKey,
+                  onTap: () {},
+                  child: Center(
+                    child: SizedBox(
+                      width: 100,
+                      height: 50,
+                      child: Row(
+                        children: <Widget>[
+                          SizedBox(
+                            width: 50,
+                            height: 50,
+                            child: InkWell(
+                              key: leftKey,
+                              onTap: () {},
+                            ),
                           ),
-                        ),
-                        SizedBox(
-                          width: 50,
-                          height: 50,
-                          child: InkWell(
-                            key: rightKey,
-                            onTap: () {},
+                          SizedBox(
+                            width: 50,
+                            height: 50,
+                            child: InkWell(
+                              key: rightKey,
+                              onTap: () {},
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -1610,47 +1634,50 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
       Widget? leftChild,
       Widget? rightChild,
     }) {
-      return Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: leftWidth+rightWidth,
-              height: 100,
-              child: Row(
-                children: <Widget>[
-                  SizedBox(
-                    width: leftWidth,
-                    height: 100,
-                    child: InkWell(
-                      key: leftKey,
-                      onTap: () {},
-                      child: Center(
-                        child: SizedBox(
-                          width: leftWidth,
-                          height: 50,
-                          child: leftChild,
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: leftWidth+rightWidth,
+                height: 100,
+                child: Row(
+                  children: <Widget>[
+                    SizedBox(
+                      width: leftWidth,
+                      height: 100,
+                      child: InkWell(
+                        key: leftKey,
+                        onTap: () {},
+                        child: Center(
+                          child: SizedBox(
+                            width: leftWidth,
+                            height: 50,
+                            child: leftChild,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  SizedBox(
-                    width: rightWidth,
-                    height: 100,
-                    child: InkWell(
-                      key: rightKey,
-                      onTap: () {},
-                      child: Center(
-                        child: SizedBox(
-                          width: leftWidth,
-                          height: 50,
-                          child: rightChild,
+                    SizedBox(
+                      width: rightWidth,
+                      height: 100,
+                      child: InkWell(
+                        key: rightKey,
+                        onTap: () {},
+                        child: Center(
+                          child: SizedBox(
+                            width: leftWidth,
+                            height: 50,
+                            child: rightChild,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -1714,24 +1741,27 @@ testWidgets('InkResponse radius can be updated', (WidgetTester tester) async {
   testWidgets("Ink wells's splash starts before tap is confirmed and disappear after tap is canceled", (WidgetTester tester) async {
     final GlobalKey innerKey = GlobalKey();
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: GestureDetector(
-            onHorizontalDragStart: (_) {},
-            child: Center(
-              child: SizedBox(
-                width: 100,
-                height: 100,
-                child: InkWell(
-                  onTap: () {},
-                  child: Center(
-                    child: SizedBox(
-                      width: 50,
-                      height: 50,
-                      child: InkWell(
-                        key: innerKey,
-                        onTap: () {},
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: GestureDetector(
+              onHorizontalDragStart: (_) {},
+              child: Center(
+                child: SizedBox(
+                  width: 100,
+                  height: 100,
+                  child: InkWell(
+                    onTap: () {},
+                    child: Center(
+                      child: SizedBox(
+                        width: 50,
+                        height: 50,
+                        child: InkWell(
+                          key: innerKey,
+                          onTap: () {},
+                        ),
                       ),
                     ),
                   ),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -36,6 +36,7 @@ Widget buildInputDecorator({
   ),
 }) {
   return MaterialApp(
+    theme: ThemeData(useMaterial3: false),
     home: Material(
       child: Builder(
         builder: (BuildContext context) {
@@ -787,6 +788,7 @@ void main() {
         final TextEditingController controller = TextEditingController();
         Widget buildFrame(bool alignLabelWithHint) {
           return MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Directionality(
                 textDirection: TextDirection.ltr,
@@ -837,6 +839,7 @@ void main() {
         final TextEditingController controller = TextEditingController();
         Widget buildFrame(bool alignLabelWithHint) {
           return MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Directionality(
                 textDirection: TextDirection.ltr,
@@ -888,6 +891,7 @@ void main() {
         final TextEditingController controller = TextEditingController();
         Widget buildFrame(bool alignLabelWithHint) {
           return MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Directionality(
                 textDirection: TextDirection.ltr,
@@ -939,6 +943,7 @@ void main() {
         final TextEditingController controller = TextEditingController();
         Widget buildFrame(bool alignLabelWithHint) {
           return MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Directionality(
                 textDirection: TextDirection.ltr,
@@ -5714,6 +5719,7 @@ void main() {
     late StateSetter setState;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: StatefulBuilder(
           builder: (BuildContext context, StateSetter setter) {
             setState = setter;

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -991,6 +991,7 @@ void main() {
 
   testWidgets('ListTile can be splashed and has correct splash color', (WidgetTester tester) async {
     final Widget buildApp = MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Material(
         child: Center(
           child: SizedBox(
@@ -1279,6 +1280,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: ListTile(
@@ -1807,6 +1809,7 @@ void main() {
       bool selected = false,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: Builder(
@@ -3571,6 +3574,7 @@ void main() {
     });
 
     testWidgets('ListTile text color', (WidgetTester tester) async {
+      final ThemeData theme = ThemeData(useMaterial3: false);
       Widget buildFrame({
         bool dense = false,
         bool enabled = true,
@@ -3578,7 +3582,7 @@ void main() {
         ListTileStyle? style,
       }) {
         return MaterialApp(
-          theme: ThemeData(useMaterial3: false),
+          theme: theme,
           home: Material(
             child: Center(
               child: Builder(
@@ -3599,8 +3603,6 @@ void main() {
           ),
         );
       }
-
-      final ThemeData theme = ThemeData();
 
       // ListTile - ListTileStyle.list (default).
       await tester.pumpWidget(buildFrame());

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -215,6 +215,7 @@ void main() {
       Color? textColor,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: ListTileTheme(

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -82,6 +82,7 @@ void main() {
   }) {
     final FocusNode focusNode = FocusNode();
     return MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Material(
         child: Directionality(
           textDirection: textDirection,
@@ -145,7 +146,7 @@ void main() {
   testWidgets('Menu responds to density changes', (WidgetTester tester) async {
     Widget buildMenu({VisualDensity? visualDensity = VisualDensity.standard}) {
       return MaterialApp(
-        theme: ThemeData(visualDensity: visualDensity),
+        theme: ThemeData(visualDensity: visualDensity, useMaterial3: false),
         home: Material(
           child: Column(
             children: <Widget>[
@@ -542,6 +543,7 @@ void main() {
     testWidgets('geometry', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Column(
               children: <Widget>[
@@ -606,6 +608,7 @@ void main() {
     testWidgets('geometry with RTL direction', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Directionality(
               textDirection: TextDirection.rtl,
@@ -815,6 +818,7 @@ void main() {
         Padding(
           padding: const EdgeInsets.all(10.0),
           child: MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Column(
                 children: <Widget>[
@@ -867,6 +871,7 @@ void main() {
         Padding(
           padding: const EdgeInsets.all(10.0),
           child: MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Directionality(
                 textDirection: TextDirection.rtl,
@@ -2295,6 +2300,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Column(
               children: <Widget>[
@@ -2338,6 +2344,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Material(
@@ -2384,6 +2391,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(300, 300));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Builder(
             builder: (BuildContext context) {
               return Directionality(
@@ -2428,6 +2436,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(300, 300));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Builder(
             builder: (BuildContext context) {
               return Directionality(
@@ -2472,6 +2481,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Builder(
             builder: (BuildContext context) {
               return Directionality(
@@ -2548,6 +2558,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Builder(
             builder: (BuildContext context) {
               return Directionality(
@@ -2624,6 +2635,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Builder(
             builder: (BuildContext context) {
               return Directionality(
@@ -2675,6 +2687,7 @@ void main() {
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Builder(
             builder: (BuildContext context) {
               return Directionality(
@@ -2730,7 +2743,7 @@ void main() {
     }) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData.light().copyWith(visualDensity: visualDensity),
+          theme: ThemeData.light(useMaterial3: false).copyWith(visualDensity: visualDensity),
           home: Directionality(
             textDirection: textDirection,
             child: Material(

--- a/packages/flutter/test/material/menu_bar_theme_test.dart
+++ b/packages/flutter/test/material/menu_bar_theme_test.dart
@@ -55,6 +55,7 @@ void main() {
   testWidgets('theme is honored', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Builder(builder: (BuildContext context) {
             return MenuTheme(
@@ -107,6 +108,7 @@ void main() {
   testWidgets('Constructor parameters override theme parameters', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Builder(
             builder: (BuildContext context) {

--- a/packages/flutter/test/material/menu_style_test.dart
+++ b/packages/flutter/test/material/menu_style_test.dart
@@ -239,6 +239,7 @@ void main() {
     testWidgets('visual density', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Column(
               children: <Widget>[

--- a/packages/flutter/test/material/menu_theme_test.dart
+++ b/packages/flutter/test/material/menu_theme_test.dart
@@ -55,6 +55,7 @@ void main() {
   testWidgets('theme is honored', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Builder(builder: (BuildContext context) {
             return MenuBarTheme(
@@ -107,6 +108,7 @@ void main() {
   testWidgets('Constructor parameters override theme parameters', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Builder(
             builder: (BuildContext context) {

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -202,8 +202,9 @@ void main() {
   testWidgets('MergeableMaterial paints shadows', (WidgetTester tester) async {
     debugDisableShadows = false;
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(
           body: SingleChildScrollView(
             child: MergeableMaterial(
               children: <MergeableMaterialItem>[
@@ -1100,8 +1101,9 @@ void main() {
 
   testWidgets('MergeableMaterial dividers', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(
           body: SingleChildScrollView(
             child: MergeableMaterial(
               hasDividers: true,
@@ -1157,8 +1159,9 @@ void main() {
     expect(isDivider(boxes[offset + 3], true, false), isTrue);
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(
           body: SingleChildScrollView(
             child: MergeableMaterial(
               hasDividers: true,

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -534,6 +534,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: const Placeholder(),
           bottomSheet: Container(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1560,6 +1560,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: PopupMenuButton<String>(
@@ -1774,6 +1775,7 @@ void main() {
       double fontSize = 24,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         builder: (BuildContext context, Widget? child) {
           return Directionality(
             textDirection: textDirection,
@@ -2363,6 +2365,7 @@ void main() {
 
     Widget buildFrame(double width, double height) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         builder: (BuildContext context, Widget? child) {
           return MediaQuery(
             data: const MediaQueryData(
@@ -2422,6 +2425,7 @@ void main() {
 
     Widget buildFrame(double width, double height) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         builder: (BuildContext context, Widget? child) {
           return MediaQuery(
             data: const MediaQueryData(
@@ -2710,6 +2714,7 @@ void main() {
     Future<void> buildFrameWithoutChild({double? splashRadius}) {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: Center(
               child: PopupMenuButton<String>(

--- a/packages/flutter/test/material/popup_menu_theme_test.dart
+++ b/packages/flutter/test/material/popup_menu_theme_test.dart
@@ -409,7 +409,7 @@ void main() {
       final Key popupButtonApp = UniqueKey();
       final Key enabledPopupItemKey = UniqueKey();
       final Key disabledPopupItemKey = UniqueKey();
-      final ThemeData theme = ThemeData();
+      final ThemeData theme = ThemeData(useMaterial3: false);
 
       await tester.pumpWidget(MaterialApp(
         theme: theme,
@@ -511,7 +511,7 @@ void main() {
       final Key disabledPopupItemKey = UniqueKey();
 
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(popupMenuTheme: popupMenuTheme),
+        theme: ThemeData(popupMenuTheme: popupMenuTheme, useMaterial3: false),
         key: popupButtonApp,
         home: Material(
           child: Column(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1407,6 +1407,7 @@ void main() {
         values = newValues;
       }
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           // The builder is used to pass the context from the MaterialApp widget
           // to the [Navigator]. This context is required in order for the

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -959,6 +959,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: RefreshIndicator(
           onRefresh: refresh,
           child: Builder(

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -581,7 +581,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(platform: TargetPlatform.android),
+        theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(
             title: const Text('Title'),
@@ -746,6 +746,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/pull/92039
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: MediaQuery(
           data: const MediaQueryData(
             // Representing a navigational notch at the bottom of the screen
@@ -991,9 +992,9 @@ void main() {
       late double mediaQueryBottom;
 
       Widget buildFrame({ required bool extendBody, bool? resizeToAvoidBottomInset, double viewInsetBottom = 0.0 }) {
-        return Directionality(
-          textDirection: TextDirection.ltr,
-          child: MediaQuery(
+        return MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: MediaQuery(
             data: MediaQueryData(
               viewInsets: EdgeInsets.only(bottom: viewInsetBottom),
             ),

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -851,6 +851,7 @@ void main() {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: PrimaryScrollController(
           controller: scrollController,
           child: Scrollbar(
@@ -942,6 +943,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(thumbVisibility: MaterialStateProperty.all(true)),
         ),
         home: const SingleChildScrollView(
@@ -988,7 +990,9 @@ void main() {
   testWidgets('Hover animation is not triggered by tap gestures', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: ScrollbarThemeData(
           thumbVisibility: MaterialStateProperty.all(true),
           showTrackOnHover: true,
         )),
@@ -1060,7 +1064,9 @@ void main() {
   testWidgets('ScrollbarThemeData.thickness replaces hoverThickness', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: ScrollbarThemeData(
           thumbVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) => true),
           trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
             return states.contains(MaterialState.hovered);
@@ -1129,7 +1135,9 @@ void main() {
   testWidgets('ScrollbarThemeData.trackVisibility replaces showTrackOnHover', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: ScrollbarThemeData(
           thumbVisibility: MaterialStateProperty.all(true),
           trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
             if (states.contains(MaterialState.hovered)) {
@@ -1194,7 +1202,9 @@ void main() {
   testWidgets('Scrollbar showTrackOnHover', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: ScrollbarThemeData(
           thumbVisibility: MaterialStateProperty.all(true),
           showTrackOnHover: true,
         )),
@@ -1387,6 +1397,7 @@ void main() {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: PrimaryScrollController(
           controller: scrollController,
           child: Scrollbar(
@@ -1550,6 +1561,7 @@ void main() {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: PrimaryScrollController(
           controller: scrollController,
           child: Scrollbar(

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -993,9 +993,10 @@ void main() {
         theme: ThemeData(
           useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(
-          thumbVisibility: MaterialStateProperty.all(true),
-          showTrackOnHover: true,
-        )),
+            thumbVisibility: MaterialStateProperty.all(true),
+            showTrackOnHover: true,
+          ),
+        ),
         home: const SingleChildScrollView(
           child: SizedBox(width: 4000.0, height: 4000.0),
         ),
@@ -1067,18 +1068,19 @@ void main() {
         theme: ThemeData(
           useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(
-          thumbVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) => true),
-          trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-            return states.contains(MaterialState.hovered);
-          }),
-          thickness: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-            if (states.contains(MaterialState.hovered)) {
-              return 40.0;
-            }
-            // Default thickness
-            return 8.0;
-          }),
-        )),
+            thumbVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) => true),
+            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              return states.contains(MaterialState.hovered);
+            }),
+            thickness: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.hovered)) {
+                return 40.0;
+              }
+              // Default thickness
+              return 8.0;
+            }),
+          ),
+        ),
         home: const SingleChildScrollView(
           child: SizedBox(width: 4000.0, height: 4000.0),
         ),
@@ -1138,14 +1140,15 @@ void main() {
         theme: ThemeData(
           useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(
-          thumbVisibility: MaterialStateProperty.all(true),
-          trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-            if (states.contains(MaterialState.hovered)) {
-              return true;
-            }
-            return false;
-          }),
-        )),
+            thumbVisibility: MaterialStateProperty.all(true),
+            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.hovered)) {
+                return true;
+              }
+              return false;
+            }),
+          ),
+        ),
         home: const SingleChildScrollView(
           child: SizedBox(width: 4000.0, height: 4000.0),
         ),
@@ -1205,9 +1208,10 @@ void main() {
         theme: ThemeData(
           useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(
-          thumbVisibility: MaterialStateProperty.all(true),
-          showTrackOnHover: true,
-        )),
+            thumbVisibility: MaterialStateProperty.all(true),
+            showTrackOnHover: true,
+          ),
+        ),
         home: const SingleChildScrollView(
           child: SizedBox(width: 4000.0, height: 4000.0),
         ),

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -35,6 +35,7 @@ void main() {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: ScrollConfiguration(
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
@@ -259,7 +260,7 @@ void main() {
   testWidgets('ScrollbarTheme can disable gestures', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(interactive: false)),
+      theme: ThemeData(useMaterial3: false, scrollbarTheme: const ScrollbarThemeData(interactive: false)),
       home: Scrollbar(
         thumbVisibility: true,
         controller: scrollController,
@@ -306,7 +307,7 @@ void main() {
   testWidgets('Scrollbar.interactive takes priority over ScrollbarTheme', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(scrollbarTheme: const ScrollbarThemeData(interactive: false)),
+      theme: ThemeData(useMaterial3: false, scrollbarTheme: const ScrollbarThemeData(interactive: false)),
       home: Scrollbar(
         interactive: true,
         thumbVisibility: true,
@@ -625,7 +626,7 @@ void main() {
     }
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData().copyWith(
+        theme: ThemeData(useMaterial3: false).copyWith(
           scrollbarTheme: _scrollbarTheme(
             trackVisibility: MaterialStateProperty.resolveWith(getTrackVisibility),
           ),

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -734,7 +734,7 @@ void main() {
 
   // Regression test for: https://github.com/flutter/flutter/issues/66781
   testWidgets('text in search bar contrasts background (light mode)', (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData.light();
+    final ThemeData themeData = ThemeData(useMaterial3: false);
     final _TestSearchDelegate delegate = _TestSearchDelegate(
       defaultAppBarTheme: true,
     );
@@ -762,7 +762,7 @@ void main() {
 
   // Regression test for: https://github.com/flutter/flutter/issues/66781
   testWidgets('text in search bar contrasts background (dark mode)', (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData.dark();
+    final ThemeData themeData = ThemeData.dark(useMaterial3: false);
     final _TestSearchDelegate delegate = _TestSearchDelegate(
       defaultAppBarTheme: true,
     );

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -167,6 +167,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/119314
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Padding(
             padding: const EdgeInsets.only(top: 64),

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -829,6 +829,7 @@ void main() {
         ShowValueIndicator show = ShowValueIndicator.onlyForDiscrete,
       }) {
         return MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: StatefulBuilder(
@@ -2670,6 +2671,7 @@ void main() {
       bool enabled = true,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Builder(
             // The builder is used to pass the context from the MaterialApp widget
@@ -3638,10 +3640,11 @@ void main() {
 
     testWidgets('Slider can be hovered and has correct hover color', (WidgetTester tester) async {
       tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
-      final ThemeData theme = ThemeData();
+      final ThemeData theme = ThemeData(useMaterial3: false);
       double value = 0.5;
       Widget buildApp({bool enabled = true}) {
         return MaterialApp(
+          theme: theme,
           home: Material(
             child: Center(
               child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -242,6 +242,7 @@ void main() {
       const Color customColor2 = Color(0xdeadbeef);
       const Color customColor3 = Color(0xdecaface);
       final ThemeData theme = ThemeData(
+        useMaterial3: false,
         platform: TargetPlatform.android,
         primarySwatch: Colors.blue,
         sliderTheme: const SliderThemeData(
@@ -276,6 +277,7 @@ void main() {
               value = d;
             };
         return MaterialApp(
+          theme: theme,
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: Material(
@@ -894,6 +896,7 @@ void main() {
     debugDisableShadows = false;
     try {
       final ThemeData theme = ThemeData(
+        useMaterial3: false,
         platform: TargetPlatform.android,
         primarySwatch: Colors.blue,
       );
@@ -904,6 +907,7 @@ void main() {
       );
       Widget buildApp(String value, { double sliderValue = 0.5, double textScale = 1.0 }) {
         return MaterialApp(
+          theme: theme,
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: MediaQuery(
@@ -1076,6 +1080,7 @@ void main() {
     debugDisableShadows = false;
     try {
       final ThemeData theme = ThemeData(
+        useMaterial3: false,
         platform: TargetPlatform.android,
         primarySwatch: Colors.blue,
       );
@@ -1086,6 +1091,7 @@ void main() {
       );
       Widget buildApp(String value, { double sliderValue = 0.5, double textScale = 1.0 }) {
         return MaterialApp(
+          theme: theme,
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: MediaQuery(
@@ -2081,7 +2087,7 @@ void main() {
 
     testWidgets('Slider defaults', (WidgetTester tester) async {
       debugDisableShadows = false;
-      final ThemeData theme  = ThemeData();
+      final ThemeData theme  = ThemeData(useMaterial3: false);
       const double trackHeight = 4.0;
       final ColorScheme colorScheme = theme.colorScheme;
       final Color activeTrackColor = Color(colorScheme.primary.value);
@@ -2111,6 +2117,7 @@ void main() {
                 value = d;
               };
           return MaterialApp(
+            theme: theme,
             home: Directionality(
               textDirection: TextDirection.ltr,
               child: Material(
@@ -2232,6 +2239,7 @@ void main() {
       debugDisableShadows = false;
       try {
         final ThemeData theme = ThemeData(
+          useMaterial3: false,
           platform: TargetPlatform.android,
         );
         Widget buildApp(String value, { double sliderValue = 0.5, double textScale = 1.0 }) {

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -302,7 +302,7 @@ void main() {
   });
 
   testWidgets('Light theme SnackBar has dark background', (WidgetTester tester) async {
-    final ThemeData lightTheme = ThemeData.light();
+    final ThemeData lightTheme = ThemeData.light(useMaterial3: false);
     await tester.pumpWidget(
       MaterialApp(
         theme: lightTheme,
@@ -383,7 +383,7 @@ void main() {
   });
 
   testWidgets('Dark theme SnackBar has primary text buttons', (WidgetTester tester) async {
-    final ThemeData darkTheme = ThemeData.dark();
+    final ThemeData darkTheme = ThemeData.dark(useMaterial3: false);
     await tester.pumpWidget(
       MaterialApp(
         theme: darkTheme,
@@ -961,6 +961,7 @@ void main() {
 
   testWidgets('SnackBar button text alignment', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: MediaQuery(
         data: const MediaQueryData(
           padding: EdgeInsets.only(
@@ -1010,6 +1011,7 @@ void main() {
     'Custom padding between SnackBar and its contents when set to SnackBarBehavior.fixed',
     (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: MediaQuery(
           data: const MediaQueryData(
             padding: EdgeInsets.only(
@@ -1120,6 +1122,7 @@ void main() {
   testWidgets('Floating SnackBar button text alignment', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(
+        useMaterial3: false,
         snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating),
       ),
       home: MediaQuery(
@@ -1172,6 +1175,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           snackBarTheme: const SnackBarThemeData(behavior: SnackBarBehavior.floating),
         ),
         home: MediaQuery(
@@ -1902,8 +1906,9 @@ void main() {
     testWidgets('Snackbar with SnackBarBehavior.floating will assert when offset too high by a large Scaffold.persistentFooterButtons', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/84263
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: const Scaffold(
             persistentFooterButtons: <Widget>[SizedBox(height: 1000)],
           ),
         ),
@@ -1917,8 +1922,9 @@ void main() {
     testWidgets('Snackbar with SnackBarBehavior.floating will assert when offset too high by a large Scaffold.bottomNavigationBar', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/84263
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: const Scaffold(
             bottomNavigationBar: SizedBox(height: 1000),
           ),
         ),

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -13,17 +13,20 @@ import '../rendering/recording_canvas.dart';
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
-Widget boilerplate({ Widget? child, TextDirection textDirection = TextDirection.ltr }) {
-  return Localizations(
-    locale: const Locale('en', 'US'),
-    delegates: const <LocalizationsDelegate<dynamic>>[
-      DefaultMaterialLocalizations.delegate,
-      DefaultWidgetsLocalizations.delegate,
-    ],
-    child: Directionality(
-      textDirection: textDirection,
-      child: Material(
-        child: child,
+Widget boilerplate({ Widget? child, TextDirection textDirection = TextDirection.ltr, bool? useMaterial3, TabBarTheme? tabBarTheme }) {
+  return Theme(
+    data: ThemeData(useMaterial3: useMaterial3, tabBarTheme: tabBarTheme),
+    child: Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      child: Directionality(
+        textDirection: textDirection,
+        child: Material(
+          child: child,
+        ),
       ),
     ),
   );
@@ -115,9 +118,13 @@ Widget buildFrame({
   EdgeInsetsGeometry? padding,
   TextDirection textDirection = TextDirection.ltr,
   TabAlignment? tabAlignment,
+  TabBarTheme? tabBarTheme,
+  bool? useMaterial3,
 }) {
   if (secondaryTabBar) {
     return boilerplate(
+      useMaterial3: useMaterial3,
+      tabBarTheme: tabBarTheme,
       textDirection: textDirection,
       child: DefaultTabController(
         animationDuration: animationDuration,
@@ -136,6 +143,8 @@ Widget buildFrame({
   }
 
   return boilerplate(
+    useMaterial3: useMaterial3,
+    tabBarTheme: tabBarTheme,
     textDirection: textDirection,
     child: DefaultTabController(
       animationDuration: animationDuration,
@@ -196,9 +205,9 @@ class TabControllerFrameState extends State<TabControllerFrame> with SingleTicke
   }
 }
 
-Widget buildLeftRightApp({required List<String> tabs, required String value, bool automaticIndicatorColorAdjustment = true}) {
+Widget buildLeftRightApp({required List<String> tabs, required String value, bool automaticIndicatorColorAdjustment = true, ThemeData? themeData}) {
   return MaterialApp(
-    theme: ThemeData(platform: TargetPlatform.android),
+    theme: themeData ?? ThemeData(platform: TargetPlatform.android),
     home: DefaultTabController(
       initialIndex: tabs.indexOf(value),
       length: tabs.length,
@@ -313,19 +322,23 @@ void main() {
   });
 
   testWidgets('Tab sizing - text', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(fontFamily: 'FlutterTest');
+    final bool material3 = theme.useMaterial3;
     await tester.pumpWidget(
-      MaterialApp(theme: ThemeData(fontFamily: 'FlutterTest'), home: const Center(child: Material(child: Tab(text: 'x')))),
+      MaterialApp(theme: theme, home: const Center(child: Material(child: Tab(text: 'x')))),
     );
     expect(tester.renderObject<RenderParagraph>(find.byType(RichText)).text.style!.fontFamily, 'FlutterTest');
-    expect(tester.getSize(find.byType(Tab)), const Size(14.0, 46.0));
+    expect(tester.getSize(find.byType(Tab)), material3 ? const Size(15.0, 46.0) : const Size(14.0, 46.0));
   });
 
   testWidgets('Tab sizing - icon and text', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(fontFamily: 'FlutterTest');
+    final bool material3 = theme.useMaterial3;
     await tester.pumpWidget(
-      MaterialApp(theme: ThemeData(fontFamily: 'FlutterTest'), home: const Center(child: Material(child: Tab(icon: SizedBox(width: 10.0, height: 10.0), text: 'x')))),
+      MaterialApp(theme: theme, home: const Center(child: Material(child: Tab(icon: SizedBox(width: 10.0, height: 10.0), text: 'x')))),
     );
     expect(tester.renderObject<RenderParagraph>(find.byType(RichText)).text.style!.fontFamily, 'FlutterTest');
-    expect(tester.getSize(find.byType(Tab)), const Size(14.0, 72.0));
+    expect(tester.getSize(find.byType(Tab)), material3 ? const Size(15.0, 72.0) : const Size(14.0, 72.0));
   });
 
   testWidgets('Tab sizing - icon, iconMargin and text', (WidgetTester tester) async {
@@ -353,35 +366,43 @@ void main() {
   });
 
   testWidgets('Tab sizing - icon and child', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(fontFamily: 'FlutterTest');
+    final bool material3 = theme.useMaterial3;
     await tester.pumpWidget(
-      MaterialApp(theme: ThemeData(fontFamily: 'FlutterTest'), home: const Center(child: Material(child: Tab(icon: SizedBox(width: 10.0, height: 10.0), child: Text('x'))))),
+      MaterialApp(theme: theme, home: const Center(child: Material(child: Tab(icon: SizedBox(width: 10.0, height: 10.0), child: Text('x'))))),
     );
     expect(tester.renderObject<RenderParagraph>(find.byType(RichText)).text.style!.fontFamily, 'FlutterTest');
-    expect(tester.getSize(find.byType(Tab)), const Size(14.0, 72.0));
+    expect(tester.getSize(find.byType(Tab)), material3 ? const Size(15.0, 72.0) : const Size(14.0, 72.0));
   });
 
   testWidgets('Tab color - normal', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(fontFamily: 'FlutterTest');
+    final bool material3 = theme.useMaterial3;
     final Widget tabBar = TabBar(tabs: const <Widget>[SizedBox.shrink()], controller: TabController(length: 1, vsync: tester));
     await tester.pumpWidget(
-      MaterialApp(home: Material(child: tabBar)),
+      MaterialApp(theme: theme, home: Material(child: tabBar)),
     );
-    expect(find.byType(TabBar), paints..line(color: Colors.blue[500]));
+    expect(find.byType(TabBar), paints..line(color: material3 ? theme.colorScheme.surfaceVariant : Colors.blue[500]));
   });
 
   testWidgets('Tab color - match', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    final bool material3 = theme.useMaterial3;
     final Widget tabBar = TabBar(tabs: const <Widget>[SizedBox.shrink()], controller: TabController(length: 1, vsync: tester));
     await tester.pumpWidget(
-      MaterialApp(home: Material(color: const Color(0xff2196f3), child: tabBar)),
+      MaterialApp(theme: theme, home: Material(color: const Color(0xff2196f3), child: tabBar)),
     );
-    expect(find.byType(TabBar), paints..line(color: Colors.white));
+    expect(find.byType(TabBar), paints..line(color: material3 ? theme.colorScheme.surfaceVariant : Colors.white));
   });
 
   testWidgets('Tab color - transparency', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    final bool material3 = theme.useMaterial3;
     final Widget tabBar = TabBar(tabs: const <Widget>[SizedBox.shrink()], controller: TabController(length: 1, vsync: tester));
     await tester.pumpWidget(
-      MaterialApp(home: Material(type: MaterialType.transparency, child: tabBar)),
+      MaterialApp(theme: theme, home: Material(type: MaterialType.transparency, child: tabBar)),
     );
-    expect(find.byType(TabBar), paints..line(color: Colors.blue[500]));
+    expect(find.byType(TabBar), paints..line(color: material3 ? theme.colorScheme.surfaceVariant : Colors.blue[500]));
   });
 
   testWidgets('TabBar default selected/unselected label style (primary)', (WidgetTester tester) async {
@@ -391,10 +412,7 @@ void main() {
     const String selectedValue = 'A';
     const String unselectedValue = 'C';
     await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: buildFrame(tabs: tabs, value: selectedValue),
-      ),
+      buildFrame(tabs: tabs, value: selectedValue, useMaterial3: theme.useMaterial3),
     );
     expect(find.text('A'), findsOneWidget);
     expect(find.text('B'), findsOneWidget);
@@ -420,10 +438,7 @@ void main() {
     const String selectedValue = 'A';
     const String unselectedValue = 'C';
     await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: buildFrame(tabs: tabs, value: selectedValue, secondaryTabBar: true),
-      ),
+      buildFrame(tabs: tabs, value: selectedValue, secondaryTabBar: true, useMaterial3: theme.useMaterial3),
     );
     expect(find.text('A'), findsOneWidget);
     expect(find.text('B'), findsOneWidget);
@@ -455,8 +470,8 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme,
         home: boilerplate(
+          useMaterial3: theme.useMaterial3,
           child: Container(
             alignment: Alignment.topLeft,
             child: TabBar(
@@ -514,8 +529,8 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme,
         home: boilerplate(
+          useMaterial3: theme.useMaterial3,
           child: Container(
             alignment: Alignment.topLeft,
             child: TabBar.secondary(
@@ -559,10 +574,7 @@ void main() {
     const String selectedValue = 'A';
     const String unselectedValue = 'B';
     await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: buildFrame(tabs: tabs, value: selectedValue),
-      ),
+      buildFrame(tabs: tabs, value: selectedValue, useMaterial3: theme.useMaterial3),
     );
 
     RenderObject overlayColor() {
@@ -599,10 +611,7 @@ void main() {
     const String selectedValue = 'A';
     const String unselectedValue = 'B';
     await tester.pumpWidget(
-      Theme(
-        data: theme,
-        child: buildFrame(tabs: tabs, value: selectedValue, secondaryTabBar: true),
-      ),
+      buildFrame(tabs: tabs, value: selectedValue, secondaryTabBar: true, useMaterial3: theme.useMaterial3),
     );
 
     RenderObject overlayColor() {
@@ -1548,7 +1557,7 @@ void main() {
     final List<String> tabs = <String>['A', 'B'];
 
     const Color indicatorColor = Color(0xFFFF0000);
-    await tester.pumpWidget(buildFrame(tabs: tabs, value: 'A', indicatorColor: indicatorColor, animationDuration: Duration.zero));
+    await tester.pumpWidget(buildFrame(useMaterial3: false, tabs: tabs, value: 'A', indicatorColor: indicatorColor, animationDuration: Duration.zero));
 
     final RenderBox box = tester.renderObject(find.byType(TabBar));
     final TabIndicatorRecordingCanvas canvas = TabIndicatorRecordingCanvas(indicatorColor);
@@ -1882,7 +1891,7 @@ void main() {
     final List<String> tabs = <String>['A', 'B'];
 
     const Color indicatorColor = Color(0xFFFF0000);
-    await tester.pumpWidget(buildFrame(tabs: tabs, value: 'A', indicatorColor: indicatorColor));
+    await tester.pumpWidget(buildFrame(useMaterial3: false, tabs: tabs, value: 'A', indicatorColor: indicatorColor));
 
     final RenderBox box = tester.renderObject(find.byType(TabBar));
     final TabIndicatorRecordingCanvas canvas = TabIndicatorRecordingCanvas(indicatorColor);
@@ -2301,6 +2310,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -2360,6 +2370,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         textDirection: TextDirection.rtl,
         child: Container(
           alignment: Alignment.topLeft,
@@ -2421,6 +2432,7 @@ void main() {
 
     Widget buildFrame() {
       return boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -2487,6 +2499,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -2556,6 +2569,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         textDirection: TextDirection.rtl,
         child: Container(
           alignment: Alignment.topLeft,
@@ -2627,6 +2641,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -2697,6 +2712,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         textDirection: TextDirection.rtl,
         child: Container(
           alignment: Alignment.topLeft,
@@ -2769,6 +2785,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -2847,6 +2864,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         textDirection: TextDirection.rtl,
         child: Container(
           alignment: Alignment.topLeft,
@@ -3041,6 +3059,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -3111,6 +3130,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -3180,6 +3200,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         textDirection: TextDirection.rtl,
         child: Container(
           alignment: Alignment.topLeft,
@@ -3242,6 +3263,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -3318,6 +3340,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Semantics(
           container: true,
           child: TabBar(
@@ -3584,6 +3607,7 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
+        useMaterial3: false,
         child: Semantics(
           container: true,
           child: TabBar(
@@ -3772,6 +3796,7 @@ void main() {
 
     Widget buildFrame(TabController controller) {
       return boilerplate(
+        useMaterial3: false,
         child: Container(
           alignment: Alignment.topLeft,
           child: TabBar(
@@ -3975,23 +4000,27 @@ void main() {
     expect(tester.takeException(), null);
   });
 
-  testWidgets('Default tab indicator color is white', (WidgetTester tester) async {
+  testWidgets('Default tab indicator color is white in M2 and surfaceVariant in M3', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/15958
     final List<String> tabs = <String>['LEFT', 'RIGHT'];
-    await tester.pumpWidget(buildLeftRightApp(tabs: tabs, value: 'LEFT'));
+    final ThemeData theme = ThemeData(platform: TargetPlatform.android);
+    final bool material3 = theme.useMaterial3;
+    await tester.pumpWidget(buildLeftRightApp(themeData: theme, tabs: tabs, value: 'LEFT'));
     final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
     expect(tabBarBox, paints..line(
-      color: Colors.white,
+      color: material3 ? theme.colorScheme.surfaceVariant : Colors.white,
     ));
   });
 
   testWidgets('Tab indicator color should not be adjusted when disable [automaticIndicatorColorAdjustment]', (WidgetTester tester) async {
      // Regression test for https://github.com/flutter/flutter/issues/68077
      final List<String> tabs = <String>['LEFT', 'RIGHT'];
-     await tester.pumpWidget(buildLeftRightApp(tabs: tabs, value: 'LEFT', automaticIndicatorColorAdjustment: false));
+     final ThemeData theme = ThemeData(platform: TargetPlatform.android);
+     final bool material3 = theme.useMaterial3;
+     await tester.pumpWidget(buildLeftRightApp(themeData: theme, tabs: tabs, value: 'LEFT', automaticIndicatorColorAdjustment: false));
      final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
      expect(tabBarBox, paints..line(
-       color: const Color(0xff2196f3),
+       color: material3 ? theme.colorScheme.surfaceVariant : const Color(0xff2196f3),
      ));
   });
 
@@ -4095,6 +4124,7 @@ void main() {
         const Color splashColor = Color(0xf00fffff);
         await tester.pumpWidget(
           boilerplate(
+            useMaterial3: false,
             child: DefaultTabController(
               length: 1,
               child: TabBar(
@@ -4360,12 +4390,12 @@ void main() {
   testWidgets('TabBar colors labels correctly', (WidgetTester tester) async {
     MaterialStateColor buildMSC(Color selectedColor, Color unselectedColor) {
       return MaterialStateColor
-          .resolveWith((Set<MaterialState> states) {
-            if (states.contains(MaterialState.selected)) {
-              return selectedColor;
-            }
-            return unselectedColor;
-          });
+        .resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return selectedColor;
+          }
+          return unselectedColor;
+        });
     }
 
     final Color materialLabelColor = buildMSC(const Color(0x00000000), const Color(0x00000001));
@@ -4394,7 +4424,7 @@ void main() {
       labelStyle: TextStyle(color: Color(0x00000017)),
       unselectedLabelStyle: TextStyle(color: Color(0x00000018)),
     );
-
+    final ThemeData theme = ThemeData(useMaterial3: false);
     Widget buildTabBar({
       bool isLabelColorMSC = false,
       bool isLabelColorNull = false,
@@ -4411,7 +4441,7 @@ void main() {
               : tabBarTheme;
       return boilerplate(
         child: Theme(
-          data: ThemeData(tabBarTheme: effectiveTheme),
+          data: theme.copyWith(tabBarTheme: effectiveTheme),
           child: DefaultTabController(
             length: 2,
             child: TabBar(
@@ -4488,8 +4518,8 @@ void main() {
       isUnselectedLabelColorNull: true,
       isTabBarThemeNull: true,
     ));
-    expect(getTab1Color(), equals(ThemeData().primaryTextTheme.bodyText1!.color!.value));
-    expect(getTab2Color(), equals(ThemeData().primaryTextTheme.bodyText1!.color!.withAlpha(0xB2).value));
+    expect(getTab1Color(), equals(theme.primaryTextTheme.bodyText1!.color!.value));
+    expect(getTab2Color(), equals(theme.primaryTextTheme.bodyText1!.color!.withAlpha(0xB2).value));
   });
 
   testWidgets('Replacing the tabController after disposing the old one', (WidgetTester tester) async {
@@ -4779,6 +4809,7 @@ void main() {
     Widget buildTabControllerFrame(BuildContext context, TabController controller) {
       tabController = controller;
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(
             bottom: TabBar(
@@ -5263,6 +5294,7 @@ void main() {
 
   testWidgets('Change tab bar height', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: DefaultTabController(
         length: 4,
         child: Scaffold(
@@ -5775,9 +5807,7 @@ void main() {
     final ThemeData theme = ThemeData(useMaterial3: true);
     final List<String> tabs = <String>['A', 'B', 'C'];
 
-    await tester.pumpWidget(Theme(
-      data: theme,
-      child: buildFrame(tabs: tabs, value: 'C')),
+    await tester.pumpWidget(buildFrame(tabs: tabs, value: 'C', useMaterial3: theme.useMaterial3),
     );
 
     await tester.pumpAndSettle();
@@ -5828,8 +5858,7 @@ void main() {
     final List<String> tabs = <String>['A', 'B', 'C'];
 
     await tester.pumpWidget(MaterialApp(
-        theme: theme,
-        home: buildFrame(tabs: tabs, value: 'B'),
+        home: buildFrame(tabs: tabs, value: 'B', useMaterial3: theme.useMaterial3),
       ),
     );
 
@@ -5878,8 +5907,7 @@ void main() {
     final List<String> tabs = <String>['A', 'B', 'C'];
 
     await tester.pumpWidget(MaterialApp(
-        theme: theme,
-        home: buildFrame(tabs: tabs, value: 'B'),
+        home: buildFrame(tabs: tabs, value: 'B', useMaterial3: theme.useMaterial3),
       ),
     );
 
@@ -6025,7 +6053,7 @@ void main() {
 
       const String selectedValue = 'A';
       const String unSelectedValue = 'C';
-      await tester.pumpWidget(buildFrame(tabs: tabs, value: selectedValue));
+      await tester.pumpWidget(buildFrame(useMaterial3: false, tabs: tabs, value: selectedValue));
       expect(find.text('A'), findsOneWidget);
       expect(find.text('B'), findsOneWidget);
       expect(find.text('C'), findsOneWidget);
@@ -6055,13 +6083,7 @@ void main() {
       const String unSelectedValue = 'C';
       const Color labelColor = Color(0xff0000ff);
       await tester.pumpWidget(
-        Theme(
-          data: ThemeData(
-            tabBarTheme: const TabBarTheme(labelColor: labelColor),
-            useMaterial3: false,
-          ),
-          child: buildFrame(tabs: tabs, value: selectedValue),
-        ),
+        buildFrame(tabs: tabs, value: selectedValue, useMaterial3: false, tabBarTheme: const TabBarTheme(labelColor: labelColor)),
       );
       expect(find.text('A'), findsOneWidget);
       expect(find.text('B'), findsOneWidget);
@@ -6159,8 +6181,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: theme,
           home: boilerplate(
+            useMaterial3: theme.useMaterial3,
             child: Container(
               alignment: Alignment.topLeft,
               child: TabBar(
@@ -6205,8 +6227,8 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: theme,
           home: boilerplate(
+            useMaterial3: theme.useMaterial3,
             child: Container(
               alignment: Alignment.topLeft,
               child: TabBar.secondary(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -839,19 +839,22 @@ void main() {
   });
 
   testWidgets('Overflow clipBehavior none golden', (WidgetTester tester) async {
-    final Widget widget = overlay(
-      child: RepaintBoundary(
-        key: const ValueKey<int>(1),
-        child: SizedBox(
-          height: 200,
-          width: 200,
-          child: Center(
-            child: SizedBox(
-              // Make sure the input field is not high enough for the WidgetSpan.
-              height: 50,
-              child: TextField(
-                controller: OverflowWidgetTextEditingController(),
-                clipBehavior: Clip.none,
+    final Widget widget = Theme(
+      data: ThemeData(useMaterial3: false),
+      child: overlay(
+        child: RepaintBoundary(
+          key: const ValueKey<int>(1),
+          child: SizedBox(
+            height: 200,
+            width: 200,
+            child: Center(
+              child: SizedBox(
+                // Make sure the input field is not high enough for the WidgetSpan.
+                height: 50,
+                child: TextField(
+                  controller: OverflowWidgetTextEditingController(),
+                  clipBehavior: Clip.none,
+                ),
               ),
             ),
           ),
@@ -873,13 +876,16 @@ void main() {
   });
 
   testWidgets('Material cursor android golden', (WidgetTester tester) async {
-    final Widget widget = overlay(
-      child: const RepaintBoundary(
-        key: ValueKey<int>(1),
-        child: TextField(
-          cursorColor: Colors.blue,
-          cursorWidth: 15,
-          cursorRadius: Radius.circular(3.0),
+    final Widget widget = Theme(
+      data: ThemeData(useMaterial3: false),
+      child: overlay(
+        child: const RepaintBoundary(
+          key: ValueKey<int>(1),
+          child: TextField(
+            cursorColor: Colors.blue,
+            cursorWidth: 15,
+            cursorRadius: Radius.circular(3.0),
+          ),
         ),
       ),
     );
@@ -899,13 +905,19 @@ void main() {
   });
 
   testWidgets('Material cursor golden', (WidgetTester tester) async {
-    final Widget widget = overlay(
-      child: const RepaintBoundary(
-        key: ValueKey<int>(1),
-        child: TextField(
-          cursorColor: Colors.blue,
-          cursorWidth: 15,
-          cursorRadius: Radius.circular(3.0),
+    final Widget widget = Theme(
+      data: ThemeData(useMaterial3: false),
+      child: overlay(
+        child: Theme(
+          data: ThemeData(useMaterial3: false),
+          child: const RepaintBoundary(
+            key: ValueKey<int>(1),
+            child: TextField(
+              cursorColor: Colors.blue,
+              cursorWidth: 15,
+              cursorRadius: Radius.circular(3.0),
+            ),
+          ),
         ),
       ),
     );
@@ -969,8 +981,9 @@ void main() {
 
   testWidgets('text field selection toolbar renders correctly inside opacity', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Scaffold(
           body: Center(
             child: SizedBox(
               width: 100,
@@ -1230,12 +1243,15 @@ void main() {
     final FocusNode focusNode = FocusNode();
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
-      overlay(
-        child: RepaintBoundary(
-          child: TextField(
-            cursorWidth: 15.0,
-            controller: controller,
-            focusNode: focusNode,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: RepaintBoundary(
+            child: TextField(
+              cursorWidth: 15.0,
+              controller: controller,
+              focusNode: focusNode,
+            ),
           ),
         ),
       ),
@@ -1257,13 +1273,16 @@ void main() {
     final FocusNode focusNode = FocusNode();
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
-      overlay(
-        child: RepaintBoundary(
-          child: TextField(
-            cursorWidth: 15.0,
-            cursorRadius: const Radius.circular(3.0),
-            controller: controller,
-            focusNode: focusNode,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: RepaintBoundary(
+            child: TextField(
+              cursorWidth: 15.0,
+              cursorRadius: const Radius.circular(3.0),
+              controller: controller,
+              focusNode: focusNode,
+            ),
           ),
         ),
       ),
@@ -1285,13 +1304,16 @@ void main() {
     final FocusNode focusNode = FocusNode();
     EditableText.debugDeterministicCursor = true;
     await tester.pumpWidget(
-      overlay(
-        child: RepaintBoundary(
-          child: TextField(
-            cursorWidth: 15.0,
-            cursorHeight: 30.0,
-            controller: controller,
-            focusNode: focusNode,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: RepaintBoundary(
+            child: TextField(
+              cursorWidth: 15.0,
+              cursorHeight: 30.0,
+              controller: controller,
+              focusNode: focusNode,
+            ),
           ),
         ),
       ),
@@ -1310,11 +1332,14 @@ void main() {
     final TextEditingController controller = TextEditingController();
 
     await tester.pumpWidget(
-      overlay(
-        child: TextField(
-          key: textFieldKey,
-          controller: controller,
-          maxLines: null,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: TextField(
+            key: textFieldKey,
+            controller: controller,
+            maxLines: null,
+          ),
         ),
       ),
     );
@@ -3861,6 +3886,7 @@ void main() {
       final TextEditingController controller = TextEditingController();
 
       await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Padding(
             padding: const EdgeInsets.all(30.0),
@@ -4410,6 +4436,7 @@ void main() {
       Widget? prefix,
     }) {
       return boilerplate(
+        theme: ThemeData(useMaterial3: false),
         child: SizedBox(
           height: height,
           child: TextField(
@@ -4548,12 +4575,15 @@ void main() {
     final TextEditingController controller = TextEditingController();
 
     await tester.pumpWidget(
-      overlay(
-        child: TextField(
-          dragStartBehavior: DragStartBehavior.down,
-          controller: controller,
-          style: const TextStyle(color: Colors.black, fontSize: 34.0),
-          maxLines: 3,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: TextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            style: const TextStyle(color: Colors.black, fontSize: 34.0),
+            maxLines: 3,
+          ),
         ),
       ),
     );
@@ -4796,11 +4826,14 @@ void main() {
 
   testWidgets('TextField errorText trumps helperText', (WidgetTester tester) async {
     await tester.pumpWidget(
-      overlay(
-        child: const TextField(
-          decoration: InputDecoration(
-            errorText: 'error text',
-            helperText: 'helper text',
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: const TextField(
+            decoration: InputDecoration(
+              errorText: 'error text',
+              helperText: 'helper text',
+            ),
           ),
         ),
       ),
@@ -4810,7 +4843,7 @@ void main() {
   });
 
   testWidgets('TextField with default helperStyle', (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData(hintColor: Colors.blue[500]);
+    final ThemeData themeData = ThemeData(hintColor: Colors.blue[500], useMaterial3: false);
     await tester.pumpWidget(
       overlay(
         child: Theme(
@@ -5214,12 +5247,15 @@ void main() {
 
   testWidgets('Collapsed hint text placement', (WidgetTester tester) async {
     await tester.pumpWidget(
-      overlay(
-        child: const TextField(
-          decoration: InputDecoration.collapsed(
-            hintText: 'hint',
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: const TextField(
+            decoration: InputDecoration.collapsed(
+              hintText: 'hint',
+            ),
+            strutStyle: StrutStyle.disabled,
           ),
-          strutStyle: StrutStyle.disabled,
         ),
       ),
     );
@@ -5585,11 +5621,14 @@ void main() {
     final TextEditingController controller = TextEditingController();
 
     await tester.pumpWidget(
-      overlay(
-        child: SizedBox(
-          width: 100.0,
-          child: TextField(
-            controller: controller,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: SizedBox(
+            width: 100.0,
+            child: TextField(
+              controller: controller,
+            ),
           ),
         ),
       ),
@@ -6358,6 +6397,7 @@ void main() {
     const String errorText = 'error text';
     Widget buildFrame(bool enabled, bool hasError) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextField(
@@ -6405,6 +6445,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextField(
@@ -7251,40 +7292,43 @@ void main() {
     final Key keyB = UniqueKey();
 
     await tester.pumpWidget(
-      overlay(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          textBaseline: TextBaseline.alphabetic,
-          children: <Widget>[
-            Expanded(
-              child: TextField(
-                key: keyA,
-                decoration: null,
-                controller: controllerA,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: <Widget>[
+              Expanded(
+                child: TextField(
+                  key: keyA,
+                  decoration: null,
+                  controller: controllerA,
+                  // The point size of the font must be a multiple of 4 until
+                  // https://github.com/flutter/flutter/issues/122066 is resolved.
+                  style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 12.0),
+                  strutStyle: StrutStyle.disabled,
+                ),
+              ),
+              const Text(
+                'abc',
                 // The point size of the font must be a multiple of 4 until
                 // https://github.com/flutter/flutter/issues/122066 is resolved.
-                style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 12.0),
-                strutStyle: StrutStyle.disabled,
+                style: TextStyle(fontFamily: 'FlutterTest', fontSize: 24.0),
               ),
-            ),
-            const Text(
-              'abc',
-              // The point size of the font must be a multiple of 4 until
-              // https://github.com/flutter/flutter/issues/122066 is resolved.
-              style: TextStyle(fontFamily: 'FlutterTest', fontSize: 24.0),
-            ),
-            Expanded(
-              child: TextField(
-                key: keyB,
-                decoration: null,
-                controller: controllerB,
-                // The point size of the font must be a multiple of 4 until
-                // https://github.com/flutter/flutter/issues/122066 is resolved.
-                style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 36.0),
-                strutStyle: StrutStyle.disabled,
+              Expanded(
+                child: TextField(
+                  key: keyB,
+                  decoration: null,
+                  controller: controllerB,
+                  // The point size of the font must be a multiple of 4 until
+                  // https://github.com/flutter/flutter/issues/122066 is resolved.
+                  style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 36.0),
+                  strutStyle: StrutStyle.disabled,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -7310,38 +7354,41 @@ void main() {
     final Key keyB = UniqueKey();
 
     await tester.pumpWidget(
-      overlay(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          textBaseline: TextBaseline.alphabetic,
-          children: <Widget>[
-            Expanded(
-              child: TextField(
-                key: keyA,
-                decoration: null,
-                controller: controllerA,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: <Widget>[
+              Expanded(
+                child: TextField(
+                  key: keyA,
+                  decoration: null,
+                  controller: controllerA,
+                  // The point size of the font must be a multiple of 4 until
+                  // https://github.com/flutter/flutter/issues/122066 is resolved.
+                  style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 12.0),
+                ),
+              ),
+              const Text(
+                'abc',
                 // The point size of the font must be a multiple of 4 until
                 // https://github.com/flutter/flutter/issues/122066 is resolved.
-                style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 12.0),
+                style: TextStyle(fontFamily: 'FlutterTest', fontSize: 24.0),
               ),
-            ),
-            const Text(
-              'abc',
-              // The point size of the font must be a multiple of 4 until
-              // https://github.com/flutter/flutter/issues/122066 is resolved.
-              style: TextStyle(fontFamily: 'FlutterTest', fontSize: 24.0),
-            ),
-            Expanded(
-              child: TextField(
-                key: keyB,
-                decoration: null,
-                controller: controllerB,
-                // The point size of the font must be a multiple of 4 until
-                // https://github.com/flutter/flutter/issues/122066 is resolved.
-                style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 36.0),
+              Expanded(
+                child: TextField(
+                  key: keyB,
+                  decoration: null,
+                  controller: controllerB,
+                  // The point size of the font must be a multiple of 4 until
+                  // https://github.com/flutter/flutter/issues/122066 is resolved.
+                  style: const TextStyle(fontFamily: 'FlutterTest', fontSize: 36.0),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -8138,8 +8185,9 @@ void main() {
 
   testWidgets('TextField displays text with text direction', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Material(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Material(
           child: TextField(
             textDirection: TextDirection.rtl,
           ),
@@ -8158,8 +8206,9 @@ void main() {
     expect(topLeft.dx, equals(701));
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Material(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const Material(
           child: TextField(
             textDirection: TextDirection.ltr,
           ),
@@ -8366,6 +8415,7 @@ void main() {
     final TextEditingController controller = TextEditingController(text: 'Just some text');
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: MediaQuery(
             data: const MediaQueryData(textScaleFactor: 4.0),
@@ -8582,6 +8632,7 @@ void main() {
       required TextAlign textAlign,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: Center(
             child: Column(
@@ -8652,6 +8703,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/23994
 
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       textTheme: TextTheme(
         titleMedium: TextStyle(
           color: Colors.blue[500],
@@ -9471,6 +9523,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: TextField(
                 dragStartBehavior: DragStartBehavior.down,
@@ -9583,6 +9636,7 @@ void main() {
         );
         await tester.pumpWidget(
           MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Center(
                 child: TextField(
@@ -9673,6 +9727,7 @@ void main() {
         );
         await tester.pumpWidget(
           MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: Center(
                 child: TextField(
@@ -10185,6 +10240,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: TextField(
                 dragStartBehavior: DragStartBehavior.down,
@@ -10285,6 +10341,7 @@ void main() {
 
         await tester.pumpWidget(
           MaterialApp(
+            theme: ThemeData(useMaterial3: false),
             home: Material(
               child: TextField(
                 dragStartBehavior: DragStartBehavior.down,
@@ -11418,6 +11475,7 @@ void main() {
     );
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextField(
@@ -11506,6 +11564,7 @@ void main() {
     );
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextField(
@@ -11594,6 +11653,7 @@ void main() {
     );
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextField(
@@ -11759,6 +11819,7 @@ void main() {
     );
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextField(
@@ -12119,6 +12180,7 @@ void main() {
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Center(
               child: TextField(
@@ -12232,6 +12294,7 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Material(
             child: Center(
               child: TextField(
@@ -12878,7 +12941,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: TextField(
@@ -12923,7 +12986,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: TextField(
@@ -12947,7 +13010,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: TextField(
@@ -12978,7 +13041,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: TextField(
@@ -13007,7 +13070,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: TextField(
@@ -13036,7 +13099,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: TextField(
@@ -13065,11 +13128,14 @@ void main() {
   testWidgets('Caret center position', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const SizedBox(
-          width: 300.0,
-          child: TextField(
-            textAlign: TextAlign.center,
-            decoration: null,
+        child: Theme(
+          data: ThemeData(useMaterial3: false),
+          child: const SizedBox(
+            width: 300.0,
+            child: TextField(
+              textAlign: TextAlign.center,
+              decoration: null,
+            ),
           ),
         ),
       ),
@@ -13105,11 +13171,14 @@ void main() {
   testWidgets('Caret indexes into trailing whitespace center align', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const SizedBox(
-          width: 300.0,
-          child: TextField(
-            textAlign: TextAlign.center,
-            decoration: null,
+        child: Theme(
+          data: ThemeData(useMaterial3: false),
+          child: const SizedBox(
+            width: 300.0,
+            child: TextField(
+              textAlign: TextAlign.center,
+              decoration: null,
+            ),
           ),
         ),
       ),
@@ -13573,7 +13642,7 @@ void main() {
     final ScrollController scrollController = ScrollController();
 
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(),
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: Center(
           child: ListView(
@@ -13604,7 +13673,7 @@ void main() {
     final ScrollController textFieldScrollController = ScrollController();
 
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(),
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: Center(
           child: ListView(
@@ -14291,6 +14360,7 @@ void main() {
     Widget textFieldBuilder({ FloatingLabelBehavior behavior = FloatingLabelBehavior.auto }) {
       return MaterialApp(
         theme: ThemeData(
+          useMaterial3: false,
           inputDecorationTheme: InputDecorationTheme(
             floatingLabelBehavior: behavior,
           ),
@@ -14872,6 +14942,7 @@ void main() {
     final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home:  Material(
           child: Center(
             child: TextField(controller: controller),
@@ -14977,6 +15048,7 @@ void main() {
         || defaultTargetPlatform == TargetPlatform.fuchsia;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home:  Material(
           child: Center(
             child: TextField(controller: controller),
@@ -15083,6 +15155,7 @@ void main() {
     final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home:  Material(
           child: Center(
             child: TextField(controller: controller),
@@ -15187,6 +15260,7 @@ void main() {
         || defaultTargetPlatform == TargetPlatform.fuchsia;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home:  Material(
           child: Center(
             child: TextField(controller: controller),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -34,6 +34,18 @@ typedef FormatEditUpdateCallback = void Function(TextEditingValue, TextEditingVa
 // On web, key events in text fields are handled by the browser.
 const bool areKeyEventsHandledByPlatform = isBrowser;
 
+class CupertinoLocalizationsDelegate extends LocalizationsDelegate<CupertinoLocalizations> {
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<CupertinoLocalizations> load(Locale locale) =>
+    DefaultCupertinoLocalizations.load(locale);
+
+  @override
+  bool shouldReload(CupertinoLocalizationsDelegate old) => false;
+}
+
 class MaterialLocalizationsDelegate extends LocalizationsDelegate<MaterialLocalizations> {
   @override
   bool isSupported(Locale locale) => true;
@@ -75,6 +87,7 @@ Widget overlayWithEntry(OverlayEntry entry) {
     delegates: <LocalizationsDelegate<dynamic>>[
       WidgetsLocalizationsDelegate(),
       MaterialLocalizationsDelegate(),
+      CupertinoLocalizationsDelegate(),
     ],
     child: DefaultTextEditingShortcuts(
       child: Directionality(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3411,12 +3411,15 @@ void main() {
     );
 
     await tester.pumpWidget(
-      overlay(
-        child: TextField(
-          dragStartBehavior: DragStartBehavior.down,
-          controller: controller,
-          maxLines: 3,
-          minLines: 3,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: overlay(
+          child: TextField(
+            dragStartBehavior: DragStartBehavior.down,
+            controller: controller,
+            maxLines: 3,
+            minLines: 3,
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -905,19 +905,13 @@ void main() {
   });
 
   testWidgets('Material cursor golden', (WidgetTester tester) async {
-    final Widget widget = Theme(
-      data: ThemeData(useMaterial3: false),
-      child: overlay(
-        child: Theme(
-          data: ThemeData(useMaterial3: false),
-          child: const RepaintBoundary(
-            key: ValueKey<int>(1),
-            child: TextField(
-              cursorColor: Colors.blue,
-              cursorWidth: 15,
-              cursorRadius: Radius.circular(3.0),
-            ),
-          ),
+    final Widget widget = overlay(
+      child: const RepaintBoundary(
+        key: ValueKey<int>(1),
+        child: TextField(
+          cursorColor: Colors.blue,
+          cursorWidth: 15,
+          cursorRadius: Radius.circular(3.0),
         ),
       ),
     );

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -591,12 +591,13 @@ void main() {
   });
 
 
-  testWidgets('Disabled field hides helper and counter', (WidgetTester tester) async {
+  testWidgets('Disabled field hides helper and counter in M2', (WidgetTester tester) async {
     const String helperText = 'helper text';
     const String counterText = 'counter text';
     const String errorText = 'error text';
     Widget buildFrame(bool enabled, bool hasError) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: TextFormField(

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -376,7 +376,7 @@ void main() {
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(platform: TargetPlatform.android),
+        theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
         home: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   test('Defaults to the default typography for the platform', () {
     for (final TargetPlatform platform in TargetPlatform.values) {
-      final ThemeData theme = ThemeData(platform: platform);
+      final ThemeData theme = ThemeData(platform: platform, useMaterial3: false);
       final Typography typography = Typography.material2018(platform: platform);
       expect(
         theme.textTheme,
@@ -34,8 +34,8 @@ void main() {
   });
 
   test('Default text theme contrasts with brightness', () {
-    final ThemeData lightTheme = ThemeData(brightness: Brightness.light);
-    final ThemeData darkTheme = ThemeData(brightness: Brightness.dark);
+    final ThemeData lightTheme = ThemeData(brightness: Brightness.light, useMaterial3: false);
+    final ThemeData darkTheme = ThemeData(brightness: Brightness.dark, useMaterial3: false);
     final Typography typography = Typography.material2018(platform: lightTheme.platform);
 
     expect(lightTheme.textTheme.titleLarge!.color, typography.black.titleLarge!.color);
@@ -43,8 +43,8 @@ void main() {
   });
 
   test('Default primary text theme contrasts with primary brightness', () {
-    final ThemeData lightTheme = ThemeData(primaryColor: Colors.white);
-    final ThemeData darkTheme = ThemeData(primaryColor: Colors.black);
+    final ThemeData lightTheme = ThemeData(primaryColor: Colors.white, useMaterial3: false);
+    final ThemeData darkTheme = ThemeData(primaryColor: Colors.black, useMaterial3: false);
     final Typography typography = Typography.material2018(platform: lightTheme.platform);
 
     expect(lightTheme.primaryTextTheme.titleLarge!.color, typography.black.titleLarge!.color);
@@ -52,8 +52,8 @@ void main() {
   });
 
   test('Default icon theme contrasts with brightness', () {
-    final ThemeData lightTheme = ThemeData(brightness: Brightness.light);
-    final ThemeData darkTheme = ThemeData(brightness: Brightness.dark);
+    final ThemeData lightTheme = ThemeData(brightness: Brightness.light, useMaterial3: false);
+    final ThemeData darkTheme = ThemeData(brightness: Brightness.dark, useMaterial3: false);
     final Typography typography = Typography.material2018(platform: lightTheme.platform);
 
     expect(lightTheme.textTheme.titleLarge!.color, typography.black.titleLarge!.color);
@@ -61,8 +61,8 @@ void main() {
   });
 
   test('Default primary icon theme contrasts with primary brightness', () {
-    final ThemeData lightTheme = ThemeData(primaryColor: Colors.white);
-    final ThemeData darkTheme = ThemeData(primaryColor: Colors.black);
+    final ThemeData lightTheme = ThemeData(primaryColor: Colors.white, useMaterial3: false);
+    final ThemeData darkTheme = ThemeData(primaryColor: Colors.black, useMaterial3: false);
     final Typography typography = Typography.material2018(platform: lightTheme.platform);
 
     expect(lightTheme.primaryTextTheme.titleLarge!.color, typography.black.titleLarge!.color);

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -142,32 +142,35 @@ void main() {
   testWidgetsWithLeakTracking('Does tooltip end up in the right place - top left', (WidgetTester tester) async {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            OverlayEntry(
-              builder: (BuildContext context) {
-                return Stack(
-                  children: <Widget>[
-                    Positioned(
-                      left: 0.0,
-                      top: 0.0,
-                      child: Tooltip(
-                        key: tooltipKey,
-                        message: tooltipText,
-                        height: 20.0,
-                        padding: const EdgeInsets.all(5.0),
-                        verticalOffset: 20.0,
-                        preferBelow: false,
-                        child: const SizedBox.shrink(),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 0.0,
+                        top: 0.0,
+                        child: Tooltip(
+                          key: tooltipKey,
+                          message: tooltipText,
+                          height: 20.0,
+                          padding: const EdgeInsets.all(5.0),
+                          verticalOffset: 20.0,
+                          preferBelow: false,
+                          child: const SizedBox.shrink(),
+                        ),
                       ),
-                    ),
-                  ],
-                );
-              },
-            ),
-          ],
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -362,32 +365,35 @@ void main() {
   testWidgetsWithLeakTracking('Does tooltip end up in the right place - way off to the right', (WidgetTester tester) async {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            OverlayEntry(
-              builder: (BuildContext context) {
-                return Stack(
-                  children: <Widget>[
-                    Positioned(
-                      left: 1600.0,
-                      top: 300.0,
-                      child: Tooltip(
-                        key: tooltipKey,
-                        message: tooltipText,
-                        height: 10.0,
-                        padding: EdgeInsets.zero,
-                        verticalOffset: 10.0,
-                        preferBelow: true,
-                        child: const SizedBox.shrink(),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 1600.0,
+                        top: 300.0,
+                        child: Tooltip(
+                          key: tooltipKey,
+                          message: tooltipText,
+                          height: 10.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 10.0,
+                          preferBelow: true,
+                          child: const SizedBox.shrink(),
+                        ),
                       ),
-                    ),
-                  ],
-                );
-              },
-            ),
-          ],
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -416,32 +422,35 @@ void main() {
   testWidgetsWithLeakTracking('Does tooltip end up in the right place - near the edge', (WidgetTester tester) async {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            OverlayEntry(
-              builder: (BuildContext context) {
-                return Stack(
-                  children: <Widget>[
-                    Positioned(
-                      left: 780.0,
-                      top: 300.0,
-                      child: Tooltip(
-                        key: tooltipKey,
-                        message: tooltipText,
-                        height: 10.0,
-                        padding: EdgeInsets.zero,
-                        verticalOffset: 10.0,
-                        preferBelow: true,
-                        child: const SizedBox.shrink(),
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 780.0,
+                        top: 300.0,
+                        child: Tooltip(
+                          key: tooltipKey,
+                          message: tooltipText,
+                          height: 10.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 10.0,
+                          preferBelow: true,
+                          child: const SizedBox.shrink(),
+                        ),
                       ),
-                    ),
-                  ],
-                );
-              },
-            ),
-          ],
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -580,6 +589,7 @@ void main() {
   testWidgetsWithLeakTracking('Default tooltip message textStyle - light', (WidgetTester tester) async {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Tooltip(
         key: tooltipKey,
         message: tooltipText,
@@ -604,6 +614,7 @@ void main() {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(
+        useMaterial3: false,
         brightness: Brightness.dark,
       ),
       home: Tooltip(
@@ -760,20 +771,23 @@ void main() {
   testWidgetsWithLeakTracking('Does tooltip end up with the right default size, shape, and color', (WidgetTester tester) async {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            OverlayEntry(
-              builder: (BuildContext context) {
-                return Tooltip(
-                  key: tooltipKey,
-                  message: tooltipText,
-                  child: const SizedBox.shrink(),
-                );
-              },
-            ),
-          ],
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Tooltip(
+                    key: tooltipKey,
+                    message: tooltipText,
+                    child: const SizedBox.shrink(),
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -797,6 +811,7 @@ void main() {
     final GlobalKey<TooltipState> tooltipKey = GlobalKey<TooltipState>();
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Tooltip(
           key: tooltipKey,
           message: tooltipText,
@@ -828,21 +843,24 @@ void main() {
       color: Color(0x80800000),
     );
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            OverlayEntry(
-              builder: (BuildContext context) {
-                return Tooltip(
-                  key: tooltipKey,
-                  decoration: customDecoration,
-                  message: tooltipText,
-                  child: const SizedBox.shrink(),
-                );
-              },
-            ),
-          ],
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Tooltip(
+                    key: tooltipKey,
+                    decoration: customDecoration,
+                    message: tooltipText,
+                    child: const SizedBox.shrink(),
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1431,27 +1449,30 @@ void main() {
 
   testWidgetsWithLeakTracking('Tooltip text scales with textScaleFactor', (WidgetTester tester) async {
     Widget buildApp(String text, { required double textScaleFactor }) {
-      return MediaQuery(
-        data: MediaQueryData(textScaleFactor: textScaleFactor),
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Navigator(
-            onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<void>(
-                builder: (BuildContext context) {
-                  return Center(
-                    child: Tooltip(
-                      message: text,
-                      child: Container(
-                        width: 100.0,
-                        height: 100.0,
-                        color: Colors.green[500],
+      return Theme(
+        data: ThemeData(useMaterial3: false),
+        child: MediaQuery(
+          data: MediaQueryData(textScaleFactor: textScaleFactor),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Navigator(
+              onGenerateRoute: (RouteSettings settings) {
+                return MaterialPageRoute<void>(
+                  builder: (BuildContext context) {
+                    return Center(
+                      child: Tooltip(
+                        message: text,
+                        child: Container(
+                          width: 100.0,
+                          height: 100.0,
+                          color: Colors.green[500],
+                        ),
                       ),
-                    ),
-                  );
-                },
-              );
-            },
+                    );
+                  },
+                );
+              },
+            ),
           ),
         ),
       );

--- a/packages/flutter/test/material/tooltip_theme_test.dart
+++ b/packages/flutter/test/material/tooltip_theme_test.dart
@@ -686,6 +686,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Theme(
           data: ThemeData(
+            useMaterial3: false,
             tooltipTheme: const TooltipThemeData(
               decoration: customDecoration,
             ),
@@ -723,22 +724,25 @@ void main() {
       color: Color(0x80800000),
     );
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: TooltipTheme(
-          data: const TooltipThemeData(decoration: customDecoration),
-          child: Overlay(
-            initialEntries: <OverlayEntry>[
-              OverlayEntry(
-                builder: (BuildContext context) {
-                  return Tooltip(
-                    key: key,
-                    message: tooltipText,
-                    child: const SizedBox.shrink(),
-                  );
-                },
-              ),
-            ],
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: TooltipTheme(
+            data: const TooltipThemeData(decoration: customDecoration),
+            child: Overlay(
+              initialEntries: <OverlayEntry>[
+                OverlayEntry(
+                  builder: (BuildContext context) {
+                    return Tooltip(
+                      key: key,
+                      message: tooltipText,
+                      child: const SizedBox.shrink(),
+                    );
+                  },
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Updates most of the unit tests in the packages/flutter/test/material folder so that they'll pass if ThemeData.useMaterial3 defaults to true.

All of the tests have wired useMaterial3 to false and will need to be updated with a M3 version.

related to #127064

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.