### PR TITLE
Update rest of the unit tests in material library for Material 3

### DIFF
--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -709,6 +709,7 @@ void main() {
         theme: themeData,
         home: Scaffold(
           appBar: AppBar(
+            leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {}),
             title: const Text('X'),
           ),
           drawer: const Column(), // Doesn't really matter. Triggers a hamburger regardless.
@@ -1383,13 +1384,19 @@ void main() {
   group('SliverAppBar elevation', () {
     Widget buildSliverAppBar(bool forceElevated, {double? elevation, double? themeElevation}) {
       return MaterialApp(
-        theme: ThemeData(appBarTheme: AppBarTheme(elevation: themeElevation)),
+        theme: ThemeData(
+          appBarTheme: AppBarTheme(
+            elevation: themeElevation,
+            scrolledUnderElevation: themeElevation,
+          ),
+        ),
         home: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
               title: const Text('Title'),
               forceElevated: forceElevated,
               elevation: elevation,
+              scrolledUnderElevation: elevation,
             ),
           ],
         ),
@@ -1408,8 +1415,10 @@ void main() {
 
       // Default elevation should be used by the material, but
       // the AppBar's elevation should not be specified by SliverAppBar.
+      // When useMaterial3 is true, and forceElevated is true, the default elevation
+      // should be the value of `scrolledUnderElevation` which is 3.0
       await tester.pumpWidget(buildSliverAppBar(true));
-      expect(getMaterial().elevation, useMaterial3 ? 0.0 : 4.0);
+      expect(getMaterial().elevation, useMaterial3 ? 3.0 : 4.0);
       expect(getAppBar().elevation, null);
 
       // SliverAppBar should use the specified elevation.
@@ -1807,7 +1816,10 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         // Test was designed against InkSplash so need to make sure that is used.
-        theme: ThemeData(splashFactory: InkSplash.splashFactory),
+        theme: ThemeData(
+          useMaterial3: false,
+          splashFactory: InkSplash.splashFactory
+        ),
         home: Center(
           child: AppBar(
             title: const Text('Abc'),
@@ -2462,7 +2474,7 @@ void main() {
   });
 
   testWidgets('AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
-    final ThemeData darkTheme = ThemeData.dark();
+    final ThemeData darkTheme = ThemeData.dark(useMaterial3: false);
     await tester.pumpWidget(MaterialApp(
       theme: darkTheme,
       home: Scaffold(
@@ -2480,7 +2492,7 @@ void main() {
   });
 
   testWidgets('AppBar draws a dark system bar for a light background', (WidgetTester tester) async {
-    final ThemeData lightTheme = ThemeData(primarySwatch: Colors.lightBlue);
+    final ThemeData lightTheme = ThemeData(primarySwatch: Colors.lightBlue, useMaterial3: false);
     await tester.pumpWidget(
       MaterialApp(
         theme: lightTheme,
@@ -2511,7 +2523,7 @@ void main() {
 
     // Using a light theme.
     {
-      await tester.pumpWidget(buildAppBar(ThemeData.from(colorScheme: const ColorScheme.light())));
+      await tester.pumpWidget(buildAppBar(ThemeData(useMaterial3: false)));
       final Material appBarMaterial = tester.widget<Material>(
         find.descendant(
           of: find.byType(AppBar),
@@ -2531,7 +2543,7 @@ void main() {
 
     // Using a dark theme.
     {
-      await tester.pumpWidget(buildAppBar(ThemeData.from(colorScheme: const ColorScheme.dark())));
+      await tester.pumpWidget(buildAppBar(ThemeData.dark(useMaterial3: false)));
       final Material appBarMaterial = tester.widget<Material>(
         find.descendant(
           of: find.byType(AppBar),
@@ -4255,7 +4267,7 @@ void main() {
     // By default, title widget should be to the right of the
     // leading widget and title spacing should be respected.
     Offset titleOffset = tester.getTopLeft(collapsedTitle);
-    Offset iconButtonOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    Offset iconButtonOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconButtonOffset.dx + titleSpacing);
 
     await tester.pumpWidget(buildWidget(centerTitle: true));
@@ -4280,7 +4292,7 @@ void main() {
     // The title widget should be to the right of the leading
     // widget with no spacing.
     titleOffset = tester.getTopLeft(collapsedTitle);
-    iconButtonOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    iconButtonOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconButtonOffset.dx);
 
     // Set centerTitle to true so the end of the title can reach
@@ -4348,7 +4360,7 @@ void main() {
     // By default, title widget should be to the right of the leading
     // widget and title spacing should be respected.
     Offset titleOffset = tester.getTopLeft(collapsedTitle);
-    Offset iconButtonOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    Offset iconButtonOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconButtonOffset.dx + titleSpacing);
 
     await tester.pumpWidget(buildWidget(centerTitle: true));
@@ -4372,7 +4384,7 @@ void main() {
     // The title widget should be to the right of the leading
     // widget with no spacing.
     titleOffset = tester.getTopLeft(collapsedTitle);
-    iconButtonOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    iconButtonOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconButtonOffset.dx);
 
     // Set centerTitle to true so the end of the title can reach

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -44,6 +44,7 @@ void main() {
 
   testWidgets('Passing no AppBarTheme returns defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
+    final bool material3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
@@ -67,13 +68,15 @@ void main() {
       expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.light);
       expect(widget.color, theme.colorScheme.surface);
       expect(widget.elevation, 0);
-      expect(widget.shadowColor, null);
+      expect(widget.shadowColor, material3 ? Colors.transparent : null);
       expect(widget.surfaceTintColor, theme.colorScheme.surfaceTint);
       expect(widget.shape, null);
       expect(iconTheme.data, IconThemeData(color: theme.colorScheme.onSurface, size: 24));
       expect(actionsIconTheme.data, IconThemeData(color: theme.colorScheme.onSurfaceVariant, size: 24));
-      expect(actionIconText.text.style!.color, Colors.black);
-      expect(text.style, Typography.material2021().englishLike.bodyMedium!.merge(Typography.material2021().black.bodyMedium).copyWith(color: theme.colorScheme.onSurface));
+      expect(actionIconText.text.style!.color, material3 ? theme.colorScheme.onSurfaceVariant : Colors.black);
+      expect(text.style, material3
+        ? Typography.material2021().englishLike.bodyMedium!.merge(Typography.material2021().black.bodyMedium).copyWith(color: theme.colorScheme.onSurface, decorationColor: theme.colorScheme.onSurface)
+        : Typography.material2021().englishLike.bodyMedium!.merge(Typography.material2021().black.bodyMedium).copyWith(color: theme.colorScheme.onSurface));
       expect(tester.getSize(find.byType(AppBar)).height, kToolbarHeight);
       expect(tester.getSize(find.byType(AppBar)).width, 800);
     } else {
@@ -262,7 +265,7 @@ void main() {
     if (lightTheme.useMaterial3) {
       // M3 AppBar defaults for light themes:
       // - elevation: 0
-      // - shadow color: null
+      // - shadow color: Colors.transparent
       // - surface tint color: ColorScheme.surfaceTint
       // - background color: ColorScheme.surface
       // - foreground color: ColorScheme.onSurface
@@ -280,7 +283,7 @@ void main() {
         expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.light);
         expect(widget.color, lightTheme.colorScheme.surface);
         expect(widget.elevation, 0);
-        expect(widget.shadowColor, null);
+        expect(widget.shadowColor, Colors.transparent);
         expect(widget.surfaceTintColor, lightTheme.colorScheme.surfaceTint);
         expect(iconTheme.data.color, lightTheme.colorScheme.onSurface);
         expect(actionsIconTheme.data.color, lightTheme.colorScheme.onSurface);
@@ -290,14 +293,14 @@ void main() {
 
       // M3 AppBar defaults for dark themes:
       // - elevation: 0
-      // - shadow color: null
+      // - shadow color: Colors.transparent
       // - surface tint color: ColorScheme.surfaceTint
       // - background color: ColorScheme.surface
       // - foreground color: ColorScheme.onSurface
       // - actions text: style bodyMedium, foreground color
       // - status bar brightness: dark (based on background color)
       {
-        await tester.pumpWidget(buildFrame(ThemeData.from(colorScheme: const ColorScheme.dark())));
+        await tester.pumpWidget(buildFrame(darkTheme));
         await tester.pumpAndSettle(); // Theme change animation
 
         final Material widget = _getAppBarMaterial(tester);
@@ -309,15 +312,15 @@ void main() {
         expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.dark);
         expect(widget.color, darkTheme.colorScheme.surface);
         expect(widget.elevation, 0);
-        expect(widget.shadowColor, null);
+        expect(widget.shadowColor, Colors.transparent);
         expect(widget.surfaceTintColor, darkTheme.colorScheme.surfaceTint);
         expect(iconTheme.data.color, darkTheme.colorScheme.onSurface);
         expect(actionsIconTheme.data.color, darkTheme.colorScheme.onSurface);
         expect(actionIconText.text.style!.color, darkTheme.colorScheme.onSurface);
-        expect(text.style, Typography.material2021().englishLike.bodyMedium!.merge(Typography.material2021().black.bodyMedium).copyWith(color: darkTheme.colorScheme.onSurface));
+        expect(text.style, Typography.material2021().englishLike.bodyMedium!.merge(Typography.material2021().black.bodyMedium).copyWith(color: darkTheme.colorScheme.onSurface, decorationColor: darkTheme.colorScheme.onSurface));
       }
     } else {
-      // AppBar defaults for light themes:
+      // AppBar M2 defaults for light themes:
       // - elevation: 4
       // - shadow color: black
       // - surface tint color: null
@@ -345,7 +348,7 @@ void main() {
         expect(text.style, Typography.material2014().englishLike.bodyMedium!.merge(Typography.material2014().black.bodyMedium).copyWith(color: lightTheme.colorScheme.onPrimary));
       }
 
-      // AppBar defaults for dark themes:
+      // AppBar M2 defaults for dark themes:
       // - elevation: 4
       // - shadow color: black
       // - surface tint color: null
@@ -751,7 +754,7 @@ void main() {
     // Test title spacing.
     final Finder collapsedTitle = find.text(title).last;
     final Offset titleOffset = tester.getTopLeft(collapsedTitle);
-    final Offset iconOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    final Offset iconOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconOffset.dx + appBarTheme.titleSpacing!);
   });
 
@@ -828,7 +831,7 @@ void main() {
     // Test title spacing.
     final Finder collapsedTitle = find.text(title).last;
     final Offset titleOffset = tester.getTopLeft(collapsedTitle);
-    final Offset iconOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    final Offset iconOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconOffset.dx + titleSpacing);
   });
 
@@ -884,7 +887,7 @@ void main() {
     // Test title spacing.
     final Finder collapsedTitle = find.text(title).last;
     final Offset titleOffset = tester.getTopLeft(collapsedTitle);
-    final Offset iconOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    final Offset iconOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconOffset.dx + appBarTheme.titleSpacing!);
   });
 
@@ -961,7 +964,7 @@ void main() {
     // Test title spacing.
     final Finder collapsedTitle = find.text(title).last;
     final Offset titleOffset = tester.getTopLeft(collapsedTitle);
-    final Offset iconOffset = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.menu));
+    final Offset iconOffset = tester.getTopRight(find.ancestor(of: find.widgetWithIcon(IconButton, Icons.menu), matching: find.byType(ConstrainedBox)));
     expect(titleOffset.dx, iconOffset.dx + titleSpacing);
   });
 
@@ -1082,7 +1085,7 @@ Material _getAppBarMaterial(WidgetTester tester) {
     find.descendant(
       of: find.byType(AppBar),
       matching: find.byType(Material),
-    ),
+    ).first,
   );
 }
 

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -293,16 +293,17 @@ void main() {
   });
 
   testWidgets('Null dialog shape', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
     const AlertDialog dialog = AlertDialog(
       actions: <Widget>[ ],
     );
-    await tester.pumpWidget(_buildAppWithDialog(dialog));
+    await tester.pumpWidget(_buildAppWithDialog(dialog, theme: theme));
 
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 
     final Material materialWidget = _getMaterialFromDialog(tester);
-    expect(materialWidget.shape, _defaultM2DialogShape);
+    expect(materialWidget.shape, theme.useMaterial3 ? _defaultM3DialogShape : _defaultM2DialogShape);
   });
 
   testWidgets('Rectangular dialog shape', (WidgetTester tester) async {
@@ -767,7 +768,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      _buildAppWithDialog(dialog),
+      _buildAppWithDialog(dialog, theme: ThemeData(useMaterial3: false)),
     );
 
     await tester.tap(find.text('X'));
@@ -2544,6 +2545,7 @@ void main() {
 
     Widget buildFrame(MainAxisAlignment? alignment) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: AlertDialog(
             content: const SizedBox(width: 800),


### PR DESCRIPTION
Updates the rest of the unit tests in the packages/flutter/test/material folder so that they'll pass if ThemeData.useMaterial3 defaults to true.

Most of the tests have wired useMaterial3 to false and will need to be updated with a M3 version, only a few of the tests have the `useMaterial3` check.

related to https://github.com/flutter/flutter/issues/127064

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
