### PR TITLE
MergeableMaterial: Fix adding a slice and separating it

### DIFF
--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -470,7 +470,12 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
       _removeChild(j);
     }
     while (i < newChildren.length) {
-      _insertChild(j, newChildren[i]);
+      final MergeableMaterialItem newChild = newChildren[i];
+      _insertChild(j, newChild);
+
+      if (newChild is MaterialGap) {
+        _animationTuples[newChild.key]!.controller.forward();
+      }
 
       i += 1;
       j += 1;

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -1110,7 +1110,6 @@ void main() {
     );
 
     final RenderBox box = tester.renderObject(find.byType(MergeableMaterial));
-
     expect(box.size.height, equals(100));
 
     matches(getBorderRadius(tester, 0), RadiusType.Round, RadiusType.Round);
@@ -1150,7 +1149,6 @@ void main() {
 
     matches(getBorderRadius(tester, 0), RadiusType.Round, RadiusType.Shifting);
     matches(getBorderRadius(tester, 1), RadiusType.Shifting, RadiusType.Round);
-
 
     await tester.pump(const Duration(milliseconds: 100));
     expect(box.size.height, equals(216));

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -1088,6 +1088,77 @@ void main() {
     matches(getBorderRadius(tester, 1), RadiusType.Round, RadiusType.Round);
   });
 
+  testWidgets('MergeableMaterial insert and separate slice', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: MergeableMaterial(
+              children: <MergeableMaterialItem>[
+                MaterialSlice(
+                  key: ValueKey<String>('A'),
+                  child: SizedBox(
+                    width: 100.0,
+                    height: 100.0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(MergeableMaterial));
+
+    expect(box.size.height, equals(100));
+
+    matches(getBorderRadius(tester, 0), RadiusType.Round, RadiusType.Round);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: MergeableMaterial(
+              children: <MergeableMaterialItem>[
+                MaterialSlice(
+                  key: ValueKey<String>('A'),
+                  child: SizedBox(
+                    width: 100.0,
+                    height: 100.0,
+                  ),
+                ),
+                MaterialGap(
+                  key: ValueKey<String>('x'),
+                ),
+                MaterialSlice(
+                  key: ValueKey<String>('B'),
+                  child: SizedBox(
+                    width: 100.0,
+                    height: 100.0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(box.size.height, lessThan(216));
+
+    matches(getBorderRadius(tester, 0), RadiusType.Round, RadiusType.Shifting);
+    matches(getBorderRadius(tester, 1), RadiusType.Shifting, RadiusType.Round);
+
+
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(box.size.height, equals(216));
+
+    matches(getBorderRadius(tester, 0), RadiusType.Round, RadiusType.Round);
+    matches(getBorderRadius(tester, 1), RadiusType.Round, RadiusType.Round);
+  });
+
   bool isDivider(BoxDecoration decoration, bool top, bool bottom) {
     const BorderSide side = BorderSide(color: Color(0x1F000000), width: 0.5);
 


### PR DESCRIPTION
Fixes #128646

It is possible to add a `MaterialGap` to a `MergeableMaterial` without its `AnimationController` for the separation animation being kicked off.
This leads to the gap instantly being removed again by [`_removeEmptyGaps()`](https://github.com/flutter/flutter/blob/682aa387cfe4fbd71ccd5418b2c2a075729a1c66/packages/flutter/lib/src/material/mergeable_material.dart#L539) during the next build.

The fix adds an `AnimationController.forward()` call where the `MaterialGap` [insertion happens](https://github.com/Snonky/flutter/blob/24ce235d0bff8201ccdf4e7da5d7cb43f9be0173/packages/flutter/lib/src/material/mergeable_material.dart#L476-L478).

I found this bug while using `ExpansionPanelList` as the issue describes. Here is a video of an `ExpansionPanelList` before and after the fix. Note the gaps between the panels:

<details>
<summary>Before</summary>

https://github.com/flutter/flutter/assets/47639380/9b20a0ac-ca13-47f0-b0bb-ee3c5c10bab0

</details>


<details>
<summary>After</summary>

https://github.com/flutter/flutter/assets/47639380/2f348a54-f9e0-4abb-bb95-622b3b72beaa

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
