### PR TITLE
Adding ScrollController support for Stepper widget

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -202,6 +202,7 @@ class Stepper extends StatefulWidget {
   const Stepper({
     super.key,
     required this.steps,
+    this.controller,
     this.physics,
     this.type = StepperType.vertical,
     this.currentStep = 0,
@@ -229,6 +230,10 @@ class Stepper extends StatefulWidget {
   /// If the stepper is contained within another scrollable it
   /// can be helpful to set this property to [ClampingScrollPhysics].
   final ScrollPhysics? physics;
+
+  /// To control the initial scroll offset of the scroll view, provide a
+  /// [controller] with its [ScrollController.initialScrollOffset] property set.
+  final ScrollController? controller;
 
   /// The type of stepper that determines the layout. In the case of
   /// [StepperType.horizontal], the content of the current step is displayed
@@ -765,6 +770,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
 
   Widget _buildVertical() {
     return ListView(
+      controller: widget.controller,
       shrinkWrap: true,
       physics: widget.physics,
       children: <Widget>[
@@ -858,6 +864,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         ),
         Expanded(
           child: ListView(
+            controller: widget.controller,
             physics: widget.physics,
             padding: const EdgeInsets.all(24.0),
             children: <Widget>[

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -231,6 +231,9 @@ class Stepper extends StatefulWidget {
   /// can be helpful to set this property to [ClampingScrollPhysics].
   final ScrollPhysics? physics;
 
+  /// An object that can be used to control the position to which this scroll
+  /// view is scrolled.
+  ///
   /// To control the initial scroll offset of the scroll view, provide a
   /// [controller] with its [ScrollController.initialScrollOffset] property set.
   final ScrollController? controller;

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -972,6 +972,34 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     }
   });
 
+  testWidgets('Vertical and Horizontal Stepper controller test', (WidgetTester tester) async {
+      ScrollController controller = ScrollController();
+      for (final StepperType type in StepperType.values) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: Stepper(
+                controller: controller,
+                type: type,
+                steps: const <Step>[
+                  Step(
+                    title: Text('Step 1'),
+                    content: SizedBox(
+                      width: 100.0,
+                      height: 100.0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final ListView listView = tester.widget<ListView>(find.descendant(of: find.byType(Stepper), matching: find.byType(ListView)));
+        expect(listView.controller, controller);
+      }
+    });
+
   testWidgets('Stepper horizontal size test', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/pull/77732
     Widget buildFrame({ bool isActive = true, Brightness? brightness }) {

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -972,8 +972,8 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     }
   });
 
-  testWidgets('Vertical and Horizontal Stepper controller test', (WidgetTester tester) async {
-      ScrollController controller = ScrollController();
+  testWidgets('ScrollController is passed to the stepper listview', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
       for (final StepperType type in StepperType.values) {
         await tester.pumpWidget(
           MaterialApp(
@@ -995,7 +995,10 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
           ),
         );
 
-        final ListView listView = tester.widget<ListView>(find.descendant(of: find.byType(Stepper), matching: find.byType(ListView)));
+        final ListView listView = tester.widget<ListView>(
+          find.descendant(of: find.byType(Stepper),
+          matching: find.byType(ListView),
+        ));
         expect(listView.controller, controller);
       }
     });


### PR DESCRIPTION
This PR is to add **controller** property to the **Stepper** widget, so that user has the flexibility to control the scroll offset for various purposes(especially in case of scroll animations)!

Fixes #61207 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
