### PR TITLE
add .pub-cache back to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ analysis_benchmark.json
 **/generated_plugin_registrant.dart
 .packages
 .pub-preload-cache/
+.pub-cache/
 .pub/
 build/
 flutter_*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Do not remove or rename entries in this file, only add new ones
+# See https://github.com/flutter/flutter/issues/128635 for more context
+
 # Miscellaneous
 *.class
 *.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Do not remove or rename entries in this file, only add new ones
-# See https://github.com/flutter/flutter/issues/128635 for more context
+# See https://github.com/flutter/flutter/issues/128635 for more context.
 
 # Miscellaneous
 *.class


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128635

In https://github.com/flutter/flutter/commit/1fd84f88e915427c88fb1d38c052150c76e27b4f, we renamed the `.pub-cache` entry in the `.gitignore` file to `.pub-preload-cache`, and ensured the packaging script was now populating that directory. However, for users who already had this directory from downloading an earlier archive but used `flutter upgrade` to get the latest code, they now had a `.gitignore` file that was no longer ignoring their `.pub-cache` directory.

Now, when these users try to `flutter upgrade` again, the tool tries to verify if their checkout is clean, and will exit early if not directing the user to either stash or commit these changes, or do `flutter upgrade --force` which will try to update their branch anyway (and which would succeed since there would be no git conflict). These change adds back the `.pub-cache` entry to `.gitignore`, which won't retroactively fix broken releases, but will at least ensure if they `flutter upgrade --force` once to get this fix, they won't need to again.