### PR TITLE
Add simple unit tests for annotations.dart file

### DIFF
--- a/packages/flutter/test/foundation/annotations_test.dart
+++ b/packages/flutter/test/foundation/annotations_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('test Category constructor', () {
-    const List<String> sections = [
+    const List<String> sections = <String>[
        'First section',
        'Second section',
        'Third section'

--- a/packages/flutter/test/foundation/annotations_test.dart
+++ b/packages/flutter/test/foundation/annotations_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/foundation/annotations_test.dart
+++ b/packages/flutter/test/foundation/annotations_test.dart
@@ -2,12 +2,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('test DocumentationIcon object', () {
+  test('test DocumentationIcon constructor', () {
     const DocumentationIcon docIcon = DocumentationIcon('Test String');
     expect(docIcon.url, contains('Test String'));
   });
 
-  test('test Summary object', () {
+  test('test Summary constructor', () {
     const Summary summary = Summary('Test String');
     expect(summary.text, contains('Test String'));
   });

--- a/packages/flutter/test/foundation/annotations_test.dart
+++ b/packages/flutter/test/foundation/annotations_test.dart
@@ -2,6 +2,15 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('test Category constructor', () {
+    const List<String> sections = [
+       'First section',
+       'Second section',
+       'Third section'
+      ];
+    const Category category = Category(sections);
+    expect(category.sections, sections);
+  });
   test('test DocumentationIcon constructor', () {
     const DocumentationIcon docIcon = DocumentationIcon('Test String');
     expect(docIcon.url, contains('Test String'));

--- a/packages/flutter/test/foundation/annotations_test.dart
+++ b/packages/flutter/test/foundation/annotations_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('test DocumentationIcon object', () {
+    const DocumentationIcon docIcon = DocumentationIcon('Test String');
+    expect(docIcon.url, contains('Test String'));
+  });
+
+  test('test Summary object', () {
+    const Summary summary = Summary('Test String');
+    expect(summary.text, contains('Test String'));
+  });
+}


### PR DESCRIPTION
This PR is adding a file of two simple unit tests in order to improve code coverage (covering two simple classes within the annotations.dart file).

The issue this is fixing is the lack of complete test coverage for the annotations.dart file.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
