### PR TITLE
Revert "[flutter_tools] cache flutter sdk version to disk"

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -128,7 +128,6 @@ GOTO :after_subroutine
 
   :do_snapshot
     IF EXIST "%FLUTTER_ROOT%\version" DEL "%FLUTTER_ROOT%\version"
-    IF EXIST "%FLUTTER_ROOT%\bin\cache\flutter.version.json" DEL "%FLUTTER_ROOT%\bin\cache\flutter.version.json"
     ECHO: > "%cache_dir%\.dartignore"
     ECHO Building flutter tool... 1>&2
     PUSHD "%flutter_tools_dir%"

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -123,10 +123,7 @@ function upgrade_flutter () (
   #  * STAMP_PATH is an empty file, or
   #  * Contents of STAMP_PATH is not what we are going to compile, or
   #  * pubspec.yaml last modified after pubspec.lock
-  if [[ ! -f "$SNAPSHOT_PATH" || \
-        ! -s "$STAMP_PATH" || \
-        "$(cat "$STAMP_PATH")" != "$compilekey" || \
-        "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]]; then
+  if [[ ! -f "$SNAPSHOT_PATH" || ! -s "$STAMP_PATH" || "$(cat "$STAMP_PATH")" != "$compilekey" || "$FLUTTER_TOOLS_DIR/pubspec.yaml" -nt "$FLUTTER_TOOLS_DIR/pubspec.lock" ]]; then
     # Waits for the update lock to be acquired. Placing this check inside the
     # conditional allows the majority of flutter/dart installations to bypass
     # the lock entirely, but as a result this required a second verification that
@@ -140,7 +137,6 @@ function upgrade_flutter () (
 
     # Fetch Dart...
     rm -f "$FLUTTER_ROOT/version"
-    rm -f "$FLUTTER_ROOT/bin/cache/flutter.version.json"
     touch "$FLUTTER_ROOT/bin/cache/.dartignore"
     "$FLUTTER_ROOT/bin/internal/update_dart_sdk.sh"
 

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -33,6 +33,7 @@ class DoctorCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    globals.flutterVersion.fetchTagsAndUpdate();
     if (argResults?.wasParsed('check-for-remote-artifacts') ?? false) {
       final String engineRevision = stringArg('check-for-remote-artifacts')!;
       if (engineRevision.startsWith(RegExp(r'[a-f0-9]{1,40}'))) {

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -92,10 +92,7 @@ class DowngradeCommand extends FlutterCommand {
     String workingDirectory = Cache.flutterRoot!;
     if (argResults!.wasParsed('working-directory')) {
       workingDirectory = stringArg('working-directory')!;
-      _flutterVersion = FlutterVersion(
-        fs: _fileSystem!,
-        flutterRoot: workingDirectory,
-      );
+      _flutterVersion = FlutterVersion(workingDirectory: workingDirectory);
     }
 
     final String currentChannel = _flutterVersion!.channel;

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -80,7 +80,7 @@ class UpgradeCommand extends FlutterCommand {
       gitTagVersion: GitTagVersion.determine(globals.processUtils, globals.platform),
       flutterVersion: stringArg('working-directory') == null
         ? globals.flutterVersion
-        : FlutterVersion(flutterRoot: _commandRunner.workingDirectory!, fs: globals.fs),
+        : FlutterVersion(workingDirectory: _commandRunner.workingDirectory),
       verifyOnly: boolArg('verify-only'),
     );
   }
@@ -297,11 +297,7 @@ class UpgradeCommandRunner {
         'for instructions.'
       );
     }
-    return FlutterVersion.fromRevision(
-      flutterRoot: workingDirectory!,
-      frameworkRevision: revision,
-      fs: globals.fs,
-    );
+    return FlutterVersion(workingDirectory: workingDirectory, frameworkRevision: revision);
   }
 
   /// Attempts a hard reset to the given revision.

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -226,10 +226,7 @@ Future<T> runInContext<T>(
         config: globals.config,
         platform: globals.platform,
       ),
-      FlutterVersion: () => FlutterVersion(
-        fs: globals.fs,
-        flutterRoot: Cache.flutterRoot!,
-      ),
+      FlutterVersion: () => FlutterVersion(),
       FuchsiaArtifacts: () => FuchsiaArtifacts.find(),
       FuchsiaDeviceTools: () => FuchsiaDeviceTools(),
       FuchsiaSdk: () => FuchsiaSdk(),

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -123,7 +123,7 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
       FlutterValidator(
         fileSystem: globals.fs,
         platform: globals.platform,
-        flutterVersion: () => globals.flutterVersion.fetchTagsAndGetVersion(clock: globals.systemClock),
+        flutterVersion: () => globals.flutterVersion,
         devToolsVersion: () => globals.cache.devToolsVersion,
         processManager: globals.processManager,
         userMessages: userMessages,

--- a/packages/flutter_tools/lib/src/project_validator.dart
+++ b/packages/flutter_tools/lib/src/project_validator.dart
@@ -136,10 +136,7 @@ class VariableDumpMachineProjectValidator extends MachineProjectValidator {
     ));
 
     // FlutterVersion
-    final FlutterVersion version = FlutterVersion(
-      flutterRoot: Cache.flutterRoot!,
-      fs: fileSystem,
-    );
+    final FlutterVersion version = FlutterVersion(workingDirectory: project.directory.absolute.path);
     result.add(ProjectValidatorResult(
       name: 'FlutterVersion.frameworkRevision',
       value: _toJsonValue(version.frameworkRevision),

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -18,7 +18,6 @@ import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../tester/flutter_tester.dart';
-import '../version.dart';
 import '../web/web_device.dart';
 
 /// Common flutter command line options.
@@ -319,16 +318,14 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
         if ((topLevelResults[FlutterGlobalOptions.kVersionFlag] as bool?) ?? false) {
           globals.flutterUsage.sendCommand(FlutterGlobalOptions.kVersionFlag);
-          final FlutterVersion version = globals.flutterVersion.fetchTagsAndGetVersion(
-            clock: globals.systemClock,
-          );
-          final String status;
+          globals.flutterVersion.fetchTagsAndUpdate();
+          String status;
           if (machineFlag) {
-            final Map<String, Object> jsonOut = version.toJson();
+            final Map<String, Object> jsonOut = globals.flutterVersion.toJson();
             jsonOut['flutterRoot'] = Cache.flutterRoot!;
             status = const JsonEncoder.withIndent('  ').convert(jsonOut);
           } else {
-            status = version.toString();
+            status = globals.flutterVersion.toString();
           }
           globals.printStatus(status);
           return;

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -13,10 +13,8 @@ import 'base/context.dart';
 import 'base/io.dart' as io;
 import 'base/logger.dart';
 import 'base/utils.dart';
-import 'cache.dart';
 import 'convert.dart';
 import 'device.dart';
-import 'globals.dart' as globals;
 import 'ios/xcodeproj.dart';
 import 'project.dart';
 import 'version.dart';
@@ -246,10 +244,7 @@ Future<vm_service.VmService> setUpVmService({
   }
 
   vmService.registerServiceCallback(kFlutterVersionServiceName, (Map<String, Object?> params) async {
-    final FlutterVersion version = context.get<FlutterVersion>() ?? FlutterVersion(
-      fs: globals.fs,
-      flutterRoot: Cache.flutterRoot!,
-    );
+    final FlutterVersion version = context.get<FlutterVersion>() ?? FlutterVersion();
     final Map<String, Object> versionJson = version.toJson();
     versionJson['frameworkRevisionShort'] = version.frameworkRevisionShort;
     versionJson['engineRevisionShort'] = version.engineRevisionShort;

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:args/command_runner.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_studio_validator.dart';
@@ -15,6 +16,7 @@ import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/custom_devices/custom_device_workflow.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
@@ -30,16 +32,17 @@ import 'package:test/fake.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/test_flutter_command_runner.dart';
 
 void main() {
+  late FakeFlutterVersion flutterVersion;
   late BufferLogger logger;
   late FakeProcessManager fakeProcessManager;
-  late MemoryFileSystem fs;
 
   setUp(() {
+    flutterVersion = FakeFlutterVersion();
     logger = BufferLogger.test();
     fakeProcessManager = FakeProcessManager.empty();
-    fs = MemoryFileSystem.test();
   });
 
   testWithoutContext('ValidationMessage equality and hashCode includes contextUrl', () {
@@ -758,55 +761,27 @@ void main() {
       contains(isA<CustomDeviceWorkflow>()),
     );
   }, overrides: <Type, Generator>{
-    FileSystem: () => fs,
+    FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => fakeProcessManager,
   });
 
-  group('FlutterValidator', () {
-    late FakeFlutterVersion initialVersion;
-    late FakeFlutterVersion secondVersion;
-    late TestFeatureFlags featureFlags;
+  testUsingContext('Fetches tags to get the right version', () async {
+    Cache.disableLocking();
 
-    setUp(() {
-      secondVersion = FakeFlutterVersion(frameworkRevisionShort: '222');
-      initialVersion = FakeFlutterVersion(
-        frameworkRevisionShort: '111',
-        nextFlutterVersion: secondVersion,
-      );
-      featureFlags = TestFeatureFlags();
-    });
+    final DoctorCommand doctorCommand = DoctorCommand();
+    final CommandRunner<void> commandRunner = createTestCommandRunner(doctorCommand);
 
-    testUsingContext('FlutterValidator fetches tags and gets fresh version', () async {
-      final Directory devtoolsDir = fs.directory('/path/to/flutter/bin/cache/dart-sdk/bin/resources/devtools')
-          ..createSync(recursive: true);
-      fs.directory('/path/to/flutter/bin/cache/artifacts').createSync(recursive: true);
-      devtoolsDir.childFile('version.json').writeAsStringSync('{"version": "123"}');
-      fakeProcessManager.addCommands(const <FakeCommand>[
-        FakeCommand(command: <String>['which', 'java']),
-      ]);
-      final List<DoctorValidator> validators = DoctorValidatorsProvider.test(
-        featureFlags: featureFlags,
-        platform: FakePlatform(),
-      ).validators;
-      final FlutterValidator flutterValidator = validators.whereType<FlutterValidator>().first;
-      final ValidationResult result = await flutterValidator.validate();
-      expect(
-        result.messages.map((ValidationMessage msg) => msg.message),
-        contains(contains('Framework revision 222')),
-      );
-    }, overrides: <Type, Generator>{
-      Cache: () => Cache.test(
-        rootOverride: fs.directory('/path/to/flutter'),
-        fileSystem: fs,
-        processManager: fakeProcessManager,
-      ),
-      FileSystem: () => fs,
-      FlutterVersion: () => initialVersion,
-      Platform: () => FakePlatform(),
-      ProcessManager: () => fakeProcessManager,
-      TestFeatureFlags: () => featureFlags,
-    });
-  });
+    await commandRunner.run(<String>['doctor']);
+
+    expect(flutterVersion.didFetchTagsAndUpdate, true);
+    Cache.enableLocking();
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => FakeProcessManager.any(),
+    FileSystem: () => MemoryFileSystem.test(),
+    FlutterVersion: () => flutterVersion,
+    Doctor: () => NoOpDoctor(),
+  }, initializeFlutterRoot: false);
+
   testUsingContext('If android workflow is disabled, AndroidStudio validator is not included', () {
     final DoctorValidatorsProvider provider = DoctorValidatorsProvider.test(
       featureFlags: TestFeatureFlags(isAndroidEnabled: false),
@@ -850,7 +825,6 @@ class NoOpDoctor implements Doctor {
     bool showPii = true,
     List<ValidatorTask>? startedValidatorTasks,
     bool sendEvent = true,
-    FlutterVersion? version,
   }) async => true;
 
   @override

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -37,8 +37,7 @@ void main() {
 
     setUp(() {
       fakeCommandRunner = FakeUpgradeCommandRunner();
-      realCommandRunner = UpgradeCommandRunner()
-          ..workingDirectory = Cache.flutterRoot;
+      realCommandRunner = UpgradeCommandRunner();
       processManager = FakeProcessManager.empty();
       fakeCommandRunner.willHaveUncommittedChanges = false;
       fakePlatform = FakePlatform()..environment = Map<String, String>.unmodifiable(<String, String>{

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -41,14 +41,11 @@ void main() {
   group('analytics', () {
     late Directory tempDir;
     late Config testConfig;
-    late FileSystem fs;
-    const String flutterRoot = '/path/to/flutter';
 
     setUp(() {
-      Cache.flutterRoot = flutterRoot;
+      Cache.flutterRoot = '../..';
       tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_analytics_test.');
       testConfig = Config.test();
-      fs = MemoryFileSystem.test();
     });
 
     tearDown(() {
@@ -80,7 +77,7 @@ void main() {
 
       expect(count, 0);
     }, overrides: <Type, Generator>{
-      FlutterVersion: () => FakeFlutterVersion(),
+      FlutterVersion: () => FlutterVersion(),
       Usage: () => Usage(
         configDirOverride: tempDir.path,
         logFile: tempDir.childFile('analytics.log').path,
@@ -104,7 +101,7 @@ void main() {
 
       expect(count, 0);
     }, overrides: <Type, Generator>{
-      FlutterVersion: () => FakeFlutterVersion(),
+      FlutterVersion: () => FlutterVersion(),
       Usage: () => Usage(
         configDirOverride: tempDir.path,
         logFile: tempDir.childFile('analytics.log').path,
@@ -121,12 +118,12 @@ void main() {
 
       expect(globals.fs.file('test').readAsStringSync(), contains('$featuresKey: enable-web'));
     }, overrides: <Type, Generator>{
-      FlutterVersion: () => FakeFlutterVersion(),
+      FlutterVersion: () => FlutterVersion(),
       Config: () => testConfig,
       Platform: () => FakePlatform(environment: <String, String>{
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
       }),
-      FileSystem: () => fs,
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -144,12 +141,12 @@ void main() {
         contains('$featuresKey: enable-web,enable-linux-desktop,enable-macos-desktop'),
       );
     }, overrides: <Type, Generator>{
-      FlutterVersion: () => FakeFlutterVersion(),
+      FlutterVersion: () => FlutterVersion(),
       Config: () => testConfig,
       Platform: () => FakePlatform(environment: <String, String>{
         'FLUTTER_ANALYTICS_LOG_FILE': 'test',
       }),
-      FileSystem: () => fs,
+      FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -387,7 +384,6 @@ class FakeDoctor extends Fake implements Doctor {
     bool showPii = true,
     List<ValidatorTask>? startedValidatorTasks,
     bool sendEvent = true,
-    FlutterVersion? version,
   }) async {
     return diagnoseSucceeds;
   }

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -4,13 +4,12 @@
 
 import 'dart:convert';
 
-import 'package:file/file.dart';
-import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 import 'package:test/fake.dart';
 
@@ -19,7 +18,7 @@ import '../src/context.dart';
 import '../src/fake_process_manager.dart';
 import '../src/fakes.dart' show FakeFlutterVersion;
 
-final SystemClock _testClock = SystemClock.fixed(DateTime.utc(2015));
+final SystemClock _testClock = SystemClock.fixed(DateTime(2015));
 final DateTime _stampUpToDate = _testClock.ago(VersionFreshnessValidator.checkAgeConsideredUpToDate ~/ 2);
 final DateTime _stampOutOfDate = _testClock.ago(VersionFreshnessValidator.checkAgeConsideredUpToDate * 2);
 
@@ -50,11 +49,7 @@ void main() {
     }
 
     group('$FlutterVersion for $channel', () {
-      late FileSystem fs;
-      const String flutterRoot = '/path/to/flutter';
-
       setUpAll(() {
-        fs = MemoryFileSystem.test();
         Cache.disableLocking();
         VersionFreshnessValidator.timeToPauseToLetUserReadTheMessage = Duration.zero;
       });
@@ -106,7 +101,7 @@ void main() {
           ),
         ]);
 
-        final FlutterVersion flutterVersion = FlutterVersion(clock: _testClock, fs: fs, flutterRoot: flutterRoot);
+        final FlutterVersion flutterVersion = globals.flutterVersion;
         await flutterVersion.checkFlutterVersionFreshness();
         expect(flutterVersion.channel, channel);
         expect(flutterVersion.repositoryUrl, flutterUpstreamUrl);
@@ -129,6 +124,7 @@ void main() {
         expect(testLogger.statusText, isEmpty);
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
+        FlutterVersion: () => FlutterVersion(clock: _testClock),
         ProcessManager: () => processManager,
         Cache: () => cache,
       });
@@ -423,197 +419,15 @@ void main() {
       ),
     ]);
 
-    final MemoryFileSystem fs = MemoryFileSystem.test();
-    final FlutterVersion flutterVersion = FlutterVersion(
-      clock: _testClock,
-      fs: fs,
-      flutterRoot: '/path/to/flutter',
-    );
+    final FlutterVersion flutterVersion = globals.flutterVersion;
     expect(flutterVersion.channel, '[user-branch]');
     expect(flutterVersion.getVersionString(), 'feature-branch/1234abcd');
     expect(flutterVersion.getBranchName(), 'feature-branch');
     expect(flutterVersion.getVersionString(redactUnknownBranches: true), '[user-branch]/1234abcd');
     expect(flutterVersion.getBranchName(redactUnknownBranches: true), '[user-branch]');
-
     expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-    Cache: () => cache,
-  });
-
-  testUsingContext('ensureVersionFile() writes version information to disk', () async {
-    processManager.addCommands(<FakeCommand>[
-      const FakeCommand(
-        command: <String>['git', '-c', 'log.showSignature=false', 'log', '-n', '1', '--pretty=format:%H'],
-        stdout: '1234abcd',
-      ),
-      const FakeCommand(
-        command: <String>['git', 'tag', '--points-at', '1234abcd'],
-      ),
-      const FakeCommand(
-        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', '1234abcd'],
-        stdout: '0.1.2-3-1234abcd',
-      ),
-      const FakeCommand(
-        command: <String>['git', 'symbolic-ref', '--short', 'HEAD'],
-        stdout: 'feature-branch',
-      ),
-      const FakeCommand(
-        command: <String>['git', 'rev-parse', '--abbrev-ref', '--symbolic', '@{upstream}'],
-      ),
-      FakeCommand(
-        command: const <String>[
-          'git',
-          '-c',
-          'log.showSignature=false',
-          'log',
-          'HEAD',
-          '-n',
-          '1',
-          '--pretty=format:%ad',
-          '--date=iso',
-        ],
-        stdout: _testClock.ago(VersionFreshnessValidator.versionAgeConsideredUpToDate('stable') ~/ 2).toString(),
-      ),
-    ]);
-
-    final MemoryFileSystem fs = MemoryFileSystem.test();
-    final Directory flutterRoot = fs.directory('/path/to/flutter');
-    flutterRoot.childDirectory('bin').childDirectory('cache').createSync(recursive: true);
-    final FlutterVersion flutterVersion = FlutterVersion(
-      clock: _testClock,
-      fs: fs,
-      flutterRoot: flutterRoot.path,
-    );
-
-    final File versionFile = fs.file('/path/to/flutter/bin/cache/flutter.version.json');
-    expect(versionFile.existsSync(), isFalse);
-
-    flutterVersion.ensureVersionFile();
-    expect(versionFile.existsSync(), isTrue);
-    expect(versionFile.readAsStringSync(), '''
-{
-  "frameworkVersion": "0.0.0-unknown",
-  "channel": "[user-branch]",
-  "repositoryUrl": "unknown source",
-  "frameworkRevision": "1234abcd",
-  "frameworkCommitDate": "2014-10-02 00:00:00.000Z",
-  "engineRevision": "abcdefg",
-  "dartSdkVersion": "2.12.0",
-  "devToolsVersion": "2.8.0",
-  "flutterVersion": "0.0.0-unknown"
-}''');
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-    Cache: () => cache,
-  });
-
-  testUsingContext('version does not call git if a .version.json file exists', () async {
-    final MemoryFileSystem fs = MemoryFileSystem.test();
-    final Directory flutterRoot = fs.directory('/path/to/flutter');
-    final Directory cacheDir = flutterRoot
-        .childDirectory('bin')
-        .childDirectory('cache')
-        ..createSync(recursive: true);
-    const String devToolsVersion = '0000000';
-    const Map<String, Object> versionJson = <String, Object>{
-      'channel': 'stable',
-      'frameworkVersion': '1.2.3',
-      'repositoryUrl': 'https://github.com/flutter/flutter.git',
-      'frameworkRevision': '1234abcd',
-      'frameworkCommitDate': '2023-04-28 12:34:56 -0400',
-      'engineRevision': 'deadbeef',
-      'dartSdkVersion': 'deadbeef2',
-      'devToolsVersion': devToolsVersion,
-      'flutterVersion': 'foo',
-    };
-    cacheDir.childFile('flutter.version.json').writeAsStringSync(
-      jsonEncode(versionJson),
-    );
-    final FlutterVersion flutterVersion = FlutterVersion(
-      clock: _testClock,
-      fs: fs,
-      flutterRoot: flutterRoot.path,
-    );
-    expect(flutterVersion.channel, 'stable');
-    expect(flutterVersion.getVersionString(), 'stable/1.2.3');
-    expect(flutterVersion.getBranchName(), 'stable');
-    expect(flutterVersion.dartSdkVersion, 'deadbeef2');
-    expect(flutterVersion.devToolsVersion, devToolsVersion);
-    expect(flutterVersion.engineRevision, 'deadbeef');
-
-    expect(processManager, hasNoRemainingExpectations);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-    Cache: () => cache,
-  });
-
-  testUsingContext('FlutterVersion() falls back to git if .version.json is malformed', () async {
-    final MemoryFileSystem fs = MemoryFileSystem.test();
-    final Directory flutterRoot = fs.directory(fs.path.join('path', 'to', 'flutter'));
-    final Directory cacheDir = flutterRoot
-        .childDirectory('bin')
-        .childDirectory('cache')
-        ..createSync(recursive: true);
-    final File legacyVersionFile = flutterRoot.childFile('version');
-    final File versionFile = cacheDir.childFile('flutter.version.json')..writeAsStringSync(
-      '{',
-    );
-
-    processManager.addCommands(<FakeCommand>[
-      const FakeCommand(
-        command: <String>['git', '-c', 'log.showSignature=false', 'log', '-n', '1', '--pretty=format:%H'],
-        stdout: '1234abcd',
-      ),
-      const FakeCommand(
-        command: <String>['git', 'tag', '--points-at', '1234abcd'],
-      ),
-      const FakeCommand(
-        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', '1234abcd'],
-        stdout: '0.1.2-3-1234abcd',
-      ),
-      const FakeCommand(
-        command: <String>['git', 'symbolic-ref', '--short', 'HEAD'],
-        stdout: 'feature-branch',
-      ),
-      const FakeCommand(
-        command: <String>['git', 'rev-parse', '--abbrev-ref', '--symbolic', '@{upstream}'],
-        stdout: 'feature-branch',
-      ),
-      FakeCommand(
-        command: const <String>[
-          'git',
-          '-c',
-          'log.showSignature=false',
-          'log',
-          'HEAD',
-          '-n',
-          '1',
-          '--pretty=format:%ad',
-          '--date=iso',
-        ],
-        stdout: _testClock.ago(VersionFreshnessValidator.versionAgeConsideredUpToDate('stable') ~/ 2).toString(),
-      ),
-    ]);
-
-    // version file exists in a malformed state
-    expect(versionFile.existsSync(), isTrue);
-    final FlutterVersion flutterVersion = FlutterVersion(
-      clock: _testClock,
-      fs: fs,
-      flutterRoot: flutterRoot.path,
-    );
-
-    // version file was deleted because it couldn't be parsed
-    expect(versionFile.existsSync(), isFalse);
-    expect(legacyVersionFile.existsSync(), isFalse);
-    // version file was written to disk
-    flutterVersion.ensureVersionFile();
-    expect(processManager, hasNoRemainingExpectations);
-    expect(versionFile.existsSync(), isTrue);
-    expect(legacyVersionFile.existsSync(), isTrue);
-  }, overrides: <Type, Generator>{
+    FlutterVersion: () => FlutterVersion(clock: _testClock),
     ProcessManager: () => processManager,
     Cache: () => cache,
   });

--- a/packages/flutter_tools/test/integration.shard/analyze_suggestions_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_suggestions_integration_test.dart
@@ -158,6 +158,7 @@ void main() {
       expect(decoded['FlutterProject.isModule'], false);
       expect(decoded['FlutterProject.isPlugin'], false);
       expect(decoded['FlutterProject.manifest.appname'], 'test_project');
+      expect(decoded['FlutterVersion.frameworkRevision'], '');
 
       expect(decoded['Platform.isAndroid'], false);
       expect(decoded['Platform.isIOS'], false);

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -43,6 +43,8 @@ void main() {
     final Directory testDirectory = parentDirectory.childDirectory('flutter');
     testDirectory.createSync(recursive: true);
 
+    int exitCode = 0;
+
     // Enable longpaths for windows integration test.
     await processManager.run(<String>[
       'git', 'config', '--system', 'core.longpaths', 'true',

--- a/packages/flutter_tools/test/integration.shard/flutter_build_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_config_only_test.dart
@@ -24,18 +24,14 @@ void main() {
     );
     exampleAppDir = tempDir.childDirectory('bbb').childDirectory('example');
 
-    processManager.runSync(
-      <String>[
-        flutterBin,
-        ...getLocalEngineArguments(),
-        'create',
-        '--template=plugin',
-        '--platforms=android',
-        'bbb',
-        '-v',
-      ],
-      workingDirectory: tempDir.path,
-    );
+    processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'create',
+      '--template=plugin',
+      '--platforms=android',
+      'bbb',
+    ], workingDirectory: tempDir.path);
   });
 
   tearDown(() async {
@@ -52,17 +48,14 @@ void main() {
       // Ensure file is gone prior to configOnly running.
       await gradleFile.delete();
 
-      final ProcessResult result = processManager.runSync(
-        <String>[
-          flutterBin,
-          ...getLocalEngineArguments(),
-          'build',
-          'apk',
-          '--target-platform=android-arm',
-          '--config-only',
-        ],
-        workingDirectory: exampleAppDir.path,
-      );
+      final ProcessResult result = processManager.runSync(<String>[
+        flutterBin,
+        ...getLocalEngineArguments(),
+        'build',
+        'apk',
+        '--target-platform=android-arm',
+        '--config-only',
+      ], workingDirectory: exampleAppDir.path);
 
       expect(gradleFile, exists);
       expect(result.stdout, contains(RegExp(r'Config complete')));

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -13,7 +13,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
-import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -338,25 +337,12 @@ class FakeFlutterVersion implements FlutterVersion {
     this.frameworkAge = '0 hours ago',
     this.frameworkCommitDate = '12/01/01',
     this.gitTagVersion = const GitTagVersion.unknown(),
-    this.flutterRoot = '/path/to/flutter',
-    this.nextFlutterVersion,
   });
 
   final String branch;
 
   bool get didFetchTagsAndUpdate => _didFetchTagsAndUpdate;
   bool _didFetchTagsAndUpdate = false;
-
-  /// Will be returned by [fetchTagsAndGetVersion] if not null.
-  final FlutterVersion? nextFlutterVersion;
-
-  @override
-    FlutterVersion fetchTagsAndGetVersion({
-      SystemClock clock = const SystemClock(),
-    }) {
-    _didFetchTagsAndUpdate = true;
-    return nextFlutterVersion ?? this;
-  }
 
   bool get didCheckFlutterVersionFreshness => _didCheckFlutterVersionFreshness;
   bool _didCheckFlutterVersionFreshness = false;
@@ -368,9 +354,6 @@ class FakeFlutterVersion implements FlutterVersion {
     }
     return kUserBranch;
   }
-
-  @override
-  final String flutterRoot;
 
   @override
   final String devToolsVersion;
@@ -403,10 +386,15 @@ class FakeFlutterVersion implements FlutterVersion {
   final String frameworkCommitDate;
 
   @override
+  String get frameworkDate => frameworkCommitDate;
+
+  @override
   final GitTagVersion gitTagVersion;
 
   @override
-  FileSystem get fs => throw UnimplementedError('FakeFlutterVersion.fs is not implemented');
+  void fetchTagsAndUpdate() {
+    _didFetchTagsAndUpdate = true;
+  }
 
   @override
   Future<void> checkFlutterVersionFreshness() async {


### PR DESCRIPTION
Reverts flutter/flutter#124558

This causes a reproducible failure of packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart.
The failure of 

 'UpgradeCommandRunner fetchLatestVersion returns version if git succeeds'

 with a failing null check in 

#0      UpgradeCommandRunner.fetchLatestVersion (package:flutter_tools/src/commands/upgrade.dart:301:36)

disappears if the commit is reverted.
