### PR TITLE
Fix an ordering dependency in the flutter_tools upgrade test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -38,7 +38,7 @@ void main() {
     setUp(() {
       fakeCommandRunner = FakeUpgradeCommandRunner();
       realCommandRunner = UpgradeCommandRunner()
-          ..workingDirectory = Cache.flutterRoot;
+          ..workingDirectory = getFlutterRoot();
       processManager = FakeProcessManager.empty();
       fakeCommandRunner.willHaveUncommittedChanges = false;
       fakePlatform = FakePlatform()..environment = Map<String, String>.unmodifiable(<String, String>{


### PR DESCRIPTION
Cache.flutterRoot is set within testUsingContext and will be uninitialized the first time test suite setup is invoked.
