### PR TITLE
Fix detection that tests are running on monorepo bots

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -277,7 +277,8 @@ Future<void> main(List<String> args) async {
 }
 
 final String _luciBotId = Platform.environment['SWARMING_BOT_ID'] ?? '';
-final bool _runningInDartHHHBot = _luciBotId.startsWith('luci-dart-');
+final bool _runningInDartHHHBot =
+    _luciBotId.startsWith('luci-dart-') || _luciBotId.startsWith('dart-tests-');
 
 /// Verify the Flutter Engine is the revision in
 /// bin/cache/internal/engine.version.


### PR DESCRIPTION
Automatic CI testing runs on monorepo bots that tests the heads
of the Dart SDK, Flutter engine, and Flutter framework together.
These tests previously ran on bots called HHH (triple-headed),
and the logic for detecting this used the machine name of the test machine.

Extend that detection logic to cover the test machine hostnames that
run monorepo testing, that start with either 'dart-tests-' or 'luci-dart-'.

None of the machines used to run Flutter release builds have names
like this, even though they are in an internal Dart luci project.

Bug: b/231927187