### PR TITLE
Refactor `Analytics` global getter to point to context only

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 
 import 'package:process/process.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import 'android/android_builder.dart';
 import 'android/android_sdk.dart';
@@ -87,6 +88,12 @@ Future<T> runInContext<T>(
     body: runnerWrapper,
     overrides: overrides,
     fallbacks: <Type, Generator>{
+      Analytics: () => Analytics(
+        tool: DashTool.flutterTool,
+        flutterChannel: globals.flutterVersion.channel,
+        flutterVersion: globals.flutterVersion.frameworkVersion,
+        dartVersion: globals.flutterVersion.dartSdkVersion,
+      ),
       AndroidBuilder: () => AndroidGradleBuilder(
         java: globals.java,
         logger: globals.logger,

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -91,19 +91,7 @@ Future<bool> get isRunningOnBot => botDetector.isRunningOnBot;
 
 // Analytics instance for package:unified_analytics for telemetry
 // reporting for all Flutter and Dart related tooling
-Analytics get analytics => context.get<Analytics>() ?? getDefaultAnalytics();
-Analytics getDefaultAnalytics() {
-
-  initializeDateFormatting();
-  final Analytics defaultAnalytics = Analytics(
-    tool: DashTool.flutterTool,
-    flutterChannel: flutterVersion.channel,
-    flutterVersion: flutterVersion.frameworkVersion,
-    dartVersion: flutterVersion.dartSdkVersion,
-  );
-
-  return defaultAnalytics;
-}
+Analytics get analytics => context.get<Analytics>()!;
 
 /// Currently active implementation of the file system.
 ///

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:intl/date_symbol_data_local.dart';
 import 'package:process/process.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 


### PR DESCRIPTION
Refactor the globals getter for `Analytics` to be in the context instead of having a default fallback. The current state of the tool creates a new instance every time `globals.analytics` was called

Addresses issue:
- https://github.com/flutter/flutter/issues/128535

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
