### PR TITLE
[flutter_tools] add a gradle error handler for could not open cache directory

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -83,6 +83,7 @@ final List<GradleHandledError> gradleErrors = <GradleHandledError>[
   zipExceptionHandler,
   incompatibleJavaAndGradleVersionsHandler,
   remoteTerminatedHandshakeHandler,
+  couldNotOpenCacheDirectoryHandler,
 ];
 
 const String _boxTitle = 'Flutter Fix';
@@ -714,4 +715,23 @@ final GradleHandledError remoteTerminatedHandshakeHandler = GradleHandledError(
     return GradleBuildStatus.retry;
   },
   eventLabel: 'remote-terminated-handshake',
+);
+
+@visibleForTesting
+final GradleHandledError couldNotOpenCacheDirectoryHandler = GradleHandledError(
+  test: (String line) => line.contains('> Could not open cache directory '),
+  handler: ({
+    required String line,
+    required FlutterProject project,
+    required bool usesAndroidX,
+    required bool multidexEnabled,
+  }) async {
+    globals.printError(
+      '${globals.logger.terminal.warningMark} '
+      'Gradle threw an error while resolving dependencies.'
+    );
+
+    return GradleBuildStatus.retry;
+  },
+  eventLabel: 'could-not-open-cache-directory',
 );

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -134,6 +134,7 @@ Caused by: java.io.EOFException: SSL peer shut down incorrectly
         )
       );
     });
+
     testUsingContext('retries if gradle fails downloading with proxy error', () async {
       const String errorMessage = r'''
 Exception in thread "main" java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 400 Bad Request"
@@ -627,9 +628,7 @@ Command: /home/android/gradlew assembleRelease
         )
       );
     });
-  });
 
-  group('permission errors', () {
     testUsingContext('pattern', () async {
       const String errorMessage = '''
 Permission denied
@@ -1385,6 +1384,32 @@ Could not compile build file '…/example/android/build.gradle'.
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
     });
+  });
+
+  testUsingContext('couldNotOpenCacheDirectoryHandler', () async {
+    final GradleBuildStatus status = await couldNotOpenCacheDirectoryHandler.handler(
+      line: '''
+FAILURE: Build failed with an exception.
+
+* Where:
+Script '/Volumes/Work/s/w/ir/x/w/flutter/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy' line: 276
+
+* What went wrong:
+A problem occurred evaluating script.
+> Failed to apply plugin class 'FlutterPlugin'.
+   > Could not open cache directory 41rl0ui7kgmsyfwn97o2jypl6 (/Volumes/Work/s/w/ir/cache/gradle/caches/6.7/gradle-kotlin-dsl/41rl0ui7kgmsyfwn97o2jypl6).
+      > Failed to create Jar file /Volumes/Work/s/w/ir/cache/gradle/caches/6.7/generated-gradle-jars/gradle-api-6.7.jar.''',
+      project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      usesAndroidX: true,
+      multidexEnabled: true,
+    );
+    expect(testLogger.errorText, contains('Gradle threw an error while resolving dependencies'));
+    expect(status, GradleBuildStatus.retry);
+  }, overrides: <Type, Generator>{
+    GradleUtils: () => FakeGradleUtils(),
+    Platform: () => fakePlatform('android'),
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -51,6 +51,7 @@ void main() {
           zipExceptionHandler,
           incompatibleJavaAndGradleVersionsHandler,
           remoteTerminatedHandshakeHandler,
+          couldNotOpenCacheDirectoryHandler,
         ])
       );
     });


### PR DESCRIPTION
Works around part of https://github.com/flutter/flutter/issues/128866