### PR TITLE
Stop accepting DiagnosticsNode as input from Devtools (closed).

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1722,8 +1722,8 @@ mixin WidgetInspectorService {
     return _safeJsonEncode(_getProperties(diagnosticsNodeId, groupName));
   }
 
-  List<Object>  _getProperties(String? diagnosticableId, String groupName) {
-    final DiagnosticsNode? node = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
+  List<Object>  _getProperties(String? diagnosticsOrDiagnosticableId, String groupName) {
+    final DiagnosticsNode? node = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
     if (node == null) {
       return const <Object>[];
     }
@@ -1760,22 +1760,27 @@ mixin WidgetInspectorService {
     return _safeJsonEncode(_getChildrenSummaryTree(diagnosticsNodeId, groupName));
   }
 
-  DiagnosticsNode? _diagnosticableIdToDiagnosticsNode(String? diagnosticableId) {
-    final Object? object = toObject(diagnosticableId);
+  DiagnosticsNode? _idToDiagnosticsNode(String? diagnosticsOrDiagnosticableId) {
+    // TODO(polina-c): start always assuming Diagnosticable, when DevTools stops sending DiagnosticsNode to
+    // APIs that invoke this method.
+    final Object? object = toObject(diagnosticsOrDiagnosticableId);
     return objectToDiagnosticsNode(object);
   }
 
   /// If posiible, returns [DiagnosticsNode] for the object.
   @visibleForTesting
   static DiagnosticsNode? objectToDiagnosticsNode(Object? object) {
+    if (object is DiagnosticsNode) {
+      return object;
+    }
     if (object is Diagnosticable) {
       return object.toDiagnosticsNode();
     }
     return null;
   }
 
-  List<Object> _getChildrenSummaryTree(String? diagnosticableId, String groupName) {
-    final DiagnosticsNode? node = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
+  List<Object> _getChildrenSummaryTree(String? diagnosticsOrDiagnosticableId, String groupName) {
+    final DiagnosticsNode? node = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
     if (node == null) {
       return <Object>[];
     }
@@ -1785,17 +1790,17 @@ mixin WidgetInspectorService {
   }
 
   /// Returns a JSON representation of the children of the [DiagnosticsNode]
-  /// object that [diagnosticableId] references providing information needed
+  /// object that [diagnosticsOrDiagnosticableId] references providing information needed
   /// for the details subtree view.
   ///
   /// The details subtree shows properties inline and includes all children
   /// rather than a filtered set of important children.
-  String getChildrenDetailsSubtree(String diagnosticableId, String groupName) {
-    return _safeJsonEncode(_getChildrenDetailsSubtree(diagnosticableId, groupName));
+  String getChildrenDetailsSubtree(String diagnosticsOrDiagnosticableId, String groupName) {
+    return _safeJsonEncode(_getChildrenDetailsSubtree(diagnosticsOrDiagnosticableId, groupName));
   }
 
-  List<Object> _getChildrenDetailsSubtree(String? diagnosticableId, String groupName) {
-    final DiagnosticsNode? node = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
+  List<Object> _getChildrenDetailsSubtree(String? diagnosticsOrDiagnosticableId, String groupName) {
+    final DiagnosticsNode? node = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
     // With this value of minDepth we only expand one extra level of important nodes.
     final InspectorSerializationDelegate delegate = InspectorSerializationDelegate(groupName: groupName, includeProperties: true, service: this);
     return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenFiltered(node, delegate), delegate, parent: node);
@@ -1907,19 +1912,19 @@ mixin WidgetInspectorService {
   ///  * [getChildrenDetailsSubtree], a method to get children of a node
   ///    in the details subtree.
   String getDetailsSubtree(
-    String diagnosticableId,
+    String diagnosticsOrDiagnosticableId,
     String groupName, {
     int subtreeDepth = 2,
   }) {
-    return _safeJsonEncode(_getDetailsSubtree(diagnosticableId, groupName, subtreeDepth));
+    return _safeJsonEncode(_getDetailsSubtree(diagnosticsOrDiagnosticableId, groupName, subtreeDepth));
   }
 
   Map<String, Object?>? _getDetailsSubtree(
-    String? diagnosticableId,
+    String? diagnosticsOrDiagnosticableId,
     String? groupName,
     int subtreeDepth,
   ) {
-    final DiagnosticsNode? root = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
+    final DiagnosticsNode? root = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
     if (root == null) {
       return null;
     }
@@ -1935,9 +1940,15 @@ mixin WidgetInspectorService {
   }
 
   /// Returns a [DiagnosticsNode] representing the currently selected [Element].
+  ///
+  /// If the currently selected [Element] is identical to the [Element]
+  /// referenced by `previousSelectionId` then the previous [DiagnosticsNode] is
+  /// reused.
+  // TODO(polina-c): delete [previousSelectionId] when it is not used in DevTools
+  // https://github.com/flutter/devtools/issues/3951
   @protected
-  String getSelectedWidget(String groupName) {
-    return _safeJsonEncode(_getSelectedWidget(groupName));
+  String getSelectedWidget(String? previousSelectionId, String groupName) {
+    return _safeJsonEncode(_getSelectedWidget(previousSelectionId, groupName));
   }
 
   /// Captures an image of the current state of an [object] that is a
@@ -2013,11 +2024,11 @@ mixin WidgetInspectorService {
   Future<Map<String, Object?>> _getLayoutExplorerNode(
     Map<String, String> parameters,
   ) {
-    final String? diagnosticableId = parameters['id'];
+    final String? diagnosticsOrDiagnosticableId = parameters['id'];
     final int subtreeDepth = int.parse(parameters['subtreeDepth']!);
     final String? groupName = parameters['groupName'];
     Map<String, dynamic>? result = <String, dynamic>{};
-    final DiagnosticsNode? root = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
+    final DiagnosticsNode? root = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
     if (root == null) {
       return Future<Map<String, dynamic>>.value(<String, dynamic>{
         'result': result,
@@ -2204,33 +2215,42 @@ mixin WidgetInspectorService {
     throw Exception('Enum value $name not found');
   }
 
-  Map<String, Object?>? _getSelectedWidget(String groupName) {
+  Map<String, Object?>? _getSelectedWidget(String? previousSelectionId, String groupName) {
     return _nodeToJson(
-      _getSelectedWidgetDiagnosticsNode(),
+      _getSelectedWidgetDiagnosticsNode(previousSelectionId),
       InspectorSerializationDelegate(groupName: groupName, service: this),
     );
   }
 
-  DiagnosticsNode? _getSelectedWidgetDiagnosticsNode() {
-    return selection.currentElement?.toDiagnosticsNode();
+  DiagnosticsNode? _getSelectedWidgetDiagnosticsNode(String? previousSelectionId) {
+    final DiagnosticsNode? previousSelection = toObject(previousSelectionId) as DiagnosticsNode?;
+    final Element? current = selection.currentElement;
+    return current == previousSelection?.value ? previousSelection : current?.toDiagnosticsNode();
   }
 
   /// Returns a [DiagnosticsNode] representing the currently selected [Element]
   /// if the selected [Element] should be shown in the summary tree otherwise
   /// returns the first ancestor of the selected [Element] shown in the summary
   /// tree.
-  String getSelectedSummaryWidget(String groupName) {
-    return _safeJsonEncode(_getSelectedSummaryWidget(groupName));
+  ///
+  /// If the currently selected [Element] is identical to the [Element]
+  /// referenced by `previousSelectionId` then the previous [DiagnosticsNode] is
+  /// reused.
+  // TODO(polina-c): delete paramater [previousSelectionId] when it is not used in DevTools
+  // https://github.com/flutter/devtools/issues/3951
+  String getSelectedSummaryWidget(String previousSelectionId, String groupName) {
+    return _safeJsonEncode(_getSelectedSummaryWidget(previousSelectionId, groupName));
   }
 
-  _Location? _getSelectedSummaryWidgetLocation() {
-     return _getCreationLocation(_getSelectedSummaryDiagnosticsNode()?.value);
+  _Location? _getSelectedSummaryWidgetLocation(String? previousSelectionId) {
+     return _getCreationLocation(_getSelectedSummaryDiagnosticsNode(previousSelectionId)?.value);
   }
 
-  DiagnosticsNode? _getSelectedSummaryDiagnosticsNode() {
+  DiagnosticsNode? _getSelectedSummaryDiagnosticsNode(String? previousSelectionId) {
     if (!isWidgetCreationTracked()) {
-      return _getSelectedWidgetDiagnosticsNode();
+      return _getSelectedWidgetDiagnosticsNode(previousSelectionId);
     }
+    final DiagnosticsNode? previousSelection = toObject(previousSelectionId) as DiagnosticsNode?;
     Element? current = selection.currentElement;
     if (current != null && !_isValueCreatedByLocalProject(current)) {
       Element? firstLocal;
@@ -2242,11 +2262,11 @@ mixin WidgetInspectorService {
       }
       current = firstLocal;
     }
-    return current?.toDiagnosticsNode();
+    return current == previousSelection?.value ? previousSelection : current?.toDiagnosticsNode();
   }
 
-  Map<String, Object?>? _getSelectedSummaryWidget(String groupName) {
-    return _nodeToJson(_getSelectedSummaryDiagnosticsNode(), InspectorSerializationDelegate(groupName: groupName, service: this));
+  Map<String, Object?>? _getSelectedSummaryWidget(String? previousSelectionId, String groupName) {
+    return _nodeToJson(_getSelectedSummaryDiagnosticsNode(previousSelectionId), InspectorSerializationDelegate(groupName: groupName, service: this));
   }
 
   /// Returns whether [Widget] creation locations are available.

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1722,8 +1722,8 @@ mixin WidgetInspectorService {
     return _safeJsonEncode(_getProperties(diagnosticsNodeId, groupName));
   }
 
-  List<Object>  _getProperties(String? diagnosticsOrDiagnosticableId, String groupName) {
-    final DiagnosticsNode? node = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
+  List<Object>  _getProperties(String? diagnosticableId, String groupName) {
+    final DiagnosticsNode? node = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
     if (node == null) {
       return const <Object>[];
     }
@@ -1760,27 +1760,22 @@ mixin WidgetInspectorService {
     return _safeJsonEncode(_getChildrenSummaryTree(diagnosticsNodeId, groupName));
   }
 
-  DiagnosticsNode? _idToDiagnosticsNode(String? diagnosticsOrDiagnosticableId) {
-    // TODO(polina-c): start always assuming Diagnosticable, when DevTools stops sending DiagnosticsNode to
-    // APIs that invoke this method.
-    final Object? object = toObject(diagnosticsOrDiagnosticableId);
+  DiagnosticsNode? _diagnosticableIdToDiagnosticsNode(String? diagnosticableId) {
+    final Object? object = toObject(diagnosticableId);
     return objectToDiagnosticsNode(object);
   }
 
   /// If posiible, returns [DiagnosticsNode] for the object.
   @visibleForTesting
   static DiagnosticsNode? objectToDiagnosticsNode(Object? object) {
-    if (object is DiagnosticsNode) {
-      return object;
-    }
     if (object is Diagnosticable) {
       return object.toDiagnosticsNode();
     }
     return null;
   }
 
-  List<Object> _getChildrenSummaryTree(String? diagnosticsOrDiagnosticableId, String groupName) {
-    final DiagnosticsNode? node = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
+  List<Object> _getChildrenSummaryTree(String? diagnosticableId, String groupName) {
+    final DiagnosticsNode? node = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
     if (node == null) {
       return <Object>[];
     }
@@ -1790,17 +1785,17 @@ mixin WidgetInspectorService {
   }
 
   /// Returns a JSON representation of the children of the [DiagnosticsNode]
-  /// object that [diagnosticsOrDiagnosticableId] references providing information needed
+  /// object that [diagnosticableId] references providing information needed
   /// for the details subtree view.
   ///
   /// The details subtree shows properties inline and includes all children
   /// rather than a filtered set of important children.
-  String getChildrenDetailsSubtree(String diagnosticsOrDiagnosticableId, String groupName) {
-    return _safeJsonEncode(_getChildrenDetailsSubtree(diagnosticsOrDiagnosticableId, groupName));
+  String getChildrenDetailsSubtree(String diagnosticableId, String groupName) {
+    return _safeJsonEncode(_getChildrenDetailsSubtree(diagnosticableId, groupName));
   }
 
-  List<Object> _getChildrenDetailsSubtree(String? diagnosticsOrDiagnosticableId, String groupName) {
-    final DiagnosticsNode? node = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
+  List<Object> _getChildrenDetailsSubtree(String? diagnosticableId, String groupName) {
+    final DiagnosticsNode? node = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
     // With this value of minDepth we only expand one extra level of important nodes.
     final InspectorSerializationDelegate delegate = InspectorSerializationDelegate(groupName: groupName, includeProperties: true, service: this);
     return _nodesToJson(node == null ? const <DiagnosticsNode>[] : _getChildrenFiltered(node, delegate), delegate, parent: node);
@@ -1912,19 +1907,19 @@ mixin WidgetInspectorService {
   ///  * [getChildrenDetailsSubtree], a method to get children of a node
   ///    in the details subtree.
   String getDetailsSubtree(
-    String diagnosticsOrDiagnosticableId,
+    String diagnosticableId,
     String groupName, {
     int subtreeDepth = 2,
   }) {
-    return _safeJsonEncode(_getDetailsSubtree(diagnosticsOrDiagnosticableId, groupName, subtreeDepth));
+    return _safeJsonEncode(_getDetailsSubtree(diagnosticableId, groupName, subtreeDepth));
   }
 
   Map<String, Object?>? _getDetailsSubtree(
-    String? diagnosticsOrDiagnosticableId,
+    String? diagnosticableId,
     String? groupName,
     int subtreeDepth,
   ) {
-    final DiagnosticsNode? root = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
+    final DiagnosticsNode? root = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
     if (root == null) {
       return null;
     }
@@ -2024,11 +2019,11 @@ mixin WidgetInspectorService {
   Future<Map<String, Object?>> _getLayoutExplorerNode(
     Map<String, String> parameters,
   ) {
-    final String? diagnosticsOrDiagnosticableId = parameters['id'];
+    final String? diagnosticableId = parameters['id'];
     final int subtreeDepth = int.parse(parameters['subtreeDepth']!);
     final String? groupName = parameters['groupName'];
     Map<String, dynamic>? result = <String, dynamic>{};
-    final DiagnosticsNode? root = _idToDiagnosticsNode(diagnosticsOrDiagnosticableId);
+    final DiagnosticsNode? root = _diagnosticableIdToDiagnosticsNode(diagnosticableId);
     if (root == null) {
       return Future<Map<String, dynamic>>.value(<String, dynamic>{
         'result': result,

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1763,7 +1763,6 @@ mixin WidgetInspectorService {
   DiagnosticsNode? _idToDiagnosticsNode(String? diagnosticsOrDiagnosticableId) {
     // TODO(polina-c): start always assuming Diagnosticable, when DevTools stops sending DiagnosticsNode to
     // APIs that invoke this method.
-    // https://github.com/flutter/devtools/issues/3951
     final Object? object = toObject(diagnosticsOrDiagnosticableId);
     return objectToDiagnosticsNode(object);
   }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1513,7 +1513,7 @@ mixin WidgetInspectorService {
   void _sendInspectEvent(Object? object){
     inspect(object);
 
-    final _Location? location = _getSelectedSummaryWidgetLocation(null);
+    final _Location? location = _getSelectedSummaryWidgetLocation();
     if (location != null) {
       postEvent(
         'navigate',
@@ -1939,11 +1939,10 @@ mixin WidgetInspectorService {
   /// If the currently selected [Element] is identical to the [Element]
   /// referenced by `previousSelectionId` then the previous [DiagnosticsNode] is
   /// reused.
-  // TODO(polina-c): delete [previousSelectionId] when it is not used in DevTools
-  // https://github.com/flutter/devtools/issues/3951
   @protected
   String getSelectedWidget(String? previousSelectionId, String groupName) {
-    return _safeJsonEncode(_getSelectedWidget(previousSelectionId, groupName));
+    assert(previousSelectionId == null, 'previousSelectionId is deprecated');
+    return _safeJsonEncode(_getSelectedWidget(null, groupName));
   }
 
   /// Captures an image of the current state of an [object] that is a
@@ -2211,16 +2210,15 @@ mixin WidgetInspectorService {
   }
 
   Map<String, Object?>? _getSelectedWidget(String? previousSelectionId, String groupName) {
+    assert(previousSelectionId == null, 'previousSelectionId is deprecated');
     return _nodeToJson(
-      _getSelectedWidgetDiagnosticsNode(previousSelectionId),
+      _getSelectedWidgetDiagnosticsNode(),
       InspectorSerializationDelegate(groupName: groupName, service: this),
     );
   }
 
-  DiagnosticsNode? _getSelectedWidgetDiagnosticsNode(String? previousSelectionId) {
-    final DiagnosticsNode? previousSelection = toObject(previousSelectionId) as DiagnosticsNode?;
-    final Element? current = selection.currentElement;
-    return current == previousSelection?.value ? previousSelection : current?.toDiagnosticsNode();
+  DiagnosticsNode? _getSelectedWidgetDiagnosticsNode() {
+    return selection.currentElement?.toDiagnosticsNode();
   }
 
   /// Returns a [DiagnosticsNode] representing the currently selected [Element]
@@ -2231,21 +2229,18 @@ mixin WidgetInspectorService {
   /// If the currently selected [Element] is identical to the [Element]
   /// referenced by `previousSelectionId` then the previous [DiagnosticsNode] is
   /// reused.
-  // TODO(polina-c): delete paramater [previousSelectionId] when it is not used in DevTools
-  // https://github.com/flutter/devtools/issues/3951
-  String getSelectedSummaryWidget(String previousSelectionId, String groupName) {
+  String getSelectedSummaryWidget(String? previousSelectionId, String groupName) {
     return _safeJsonEncode(_getSelectedSummaryWidget(previousSelectionId, groupName));
   }
 
-  _Location? _getSelectedSummaryWidgetLocation(String? previousSelectionId) {
-     return _getCreationLocation(_getSelectedSummaryDiagnosticsNode(previousSelectionId)?.value);
+  _Location? _getSelectedSummaryWidgetLocation() {
+     return _getCreationLocation(_getSelectedSummaryDiagnosticsNode()?.value);
   }
 
-  DiagnosticsNode? _getSelectedSummaryDiagnosticsNode(String? previousSelectionId) {
+  DiagnosticsNode? _getSelectedSummaryDiagnosticsNode() {
     if (!isWidgetCreationTracked()) {
-      return _getSelectedWidgetDiagnosticsNode(previousSelectionId);
+      return _getSelectedWidgetDiagnosticsNode();
     }
-    final DiagnosticsNode? previousSelection = toObject(previousSelectionId) as DiagnosticsNode?;
     Element? current = selection.currentElement;
     if (current != null && !_isValueCreatedByLocalProject(current)) {
       Element? firstLocal;
@@ -2257,11 +2252,12 @@ mixin WidgetInspectorService {
       }
       current = firstLocal;
     }
-    return current == previousSelection?.value ? previousSelection : current?.toDiagnosticsNode();
+    return current?.toDiagnosticsNode();
   }
 
   Map<String, Object?>? _getSelectedSummaryWidget(String? previousSelectionId, String groupName) {
-    return _nodeToJson(_getSelectedSummaryDiagnosticsNode(previousSelectionId), InspectorSerializationDelegate(groupName: groupName, service: this));
+    assert(previousSelectionId == null, 'previousSelectionId is deprecated');
+    return _nodeToJson(_getSelectedSummaryDiagnosticsNode(), InspectorSerializationDelegate(groupName: groupName, service: this));
   }
 
   /// Returns whether [Widget] creation locations are available.

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -903,25 +903,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       }
     });
 
-    test('WidgetInspectorService getProperties for $DiagnosticsNode', () {
-      // TODO(polina-c): delete this test once getChildrenDetailsSubtree stops accepting DiagnosticsNode.
-      // https://github.com/flutter/devtools/issues/3951
-      final DiagnosticsNode diagnostic = const Text('a', textDirection: TextDirection.ltr).toDiagnosticsNode();
-      const String group = 'group';
-      service.disposeAllGroups();
-      final String id = service.toId(diagnostic, group)!;
-      final List<Object?> propertiesJson = json.decode(service.getProperties(id, group)) as List<Object?>;
-      final List<DiagnosticsNode> properties = diagnostic.getProperties();
-      expect(properties, isNotEmpty);
-      expect(propertiesJson.length, equals(properties.length));
-      for (int i = 0; i < propertiesJson.length; ++i) {
-        final Map<String, Object?> propertyJson = propertiesJson[i]! as Map<String, Object?>;
-        expect(service.toObject(propertyJson['valueId'] as String?), equals(properties[i].value));
-        expect(service.toObject(propertyJson['objectId']! as String), isA<DiagnosticsNode>());
-      }
-    });
-
-    test('WidgetInspectorService getProperties for $Diagnosticable', () {
+    test('WidgetInspectorService getProperties', () {
       const Diagnosticable diagnosticable = Text('a', textDirection: TextDirection.ltr);
       const String group = 'group';
       service.disposeAllGroups();
@@ -2129,27 +2111,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       }
     });
 
-    test('ext.flutter.inspector.getProperties for $DiagnosticsNode', () async {
-      // TODO(polina-c): delete this test once getChildrenDetailsSubtree stops accepting DiagnosticsNode.
-      // https://github.com/flutter/devtools/issues/3951
-      final DiagnosticsNode diagnostic = const Text('a', textDirection: TextDirection.ltr).toDiagnosticsNode();
-      const String group = 'group';
-      final String id = service.toId(diagnostic, group)!;
-      final List<Object?> propertiesJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getProperties.name,
-        <String, String>{'arg': id, 'objectGroup': group},
-      ))! as List<Object?>;
-      final List<DiagnosticsNode> properties = diagnostic.getProperties();
-      expect(properties, isNotEmpty);
-      expect(propertiesJson.length, equals(properties.length));
-      for (int i = 0; i < propertiesJson.length; ++i) {
-        final Map<String, Object?> propertyJson = propertiesJson[i]! as Map<String, Object?>;
-        expect(service.toObject(propertyJson['valueId'] as String?), equals(properties[i].value));
-        expect(service.toObject(propertyJson['objectId']! as String), isA<DiagnosticsNode>());
-      }
-    });
-
-    test('ext.flutter.inspector.getProperties for $Diagnosticable', () async {
+    test('ext.flutter.inspector.getProperties', () async {
       const Diagnosticable diagnosticable = Text('a', textDirection: TextDirection.ltr);
       const String group = 'group';
       final String id = service.toId(diagnosticable, group)!;
@@ -2330,118 +2292,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(nestedRelatedProperty, isNot(contains('children')));
     });
 
-    testWidgets('ext.flutter.inspector.getRootWidgetSummaryTree on $DiagnosticsNode', (WidgetTester tester) async {
-      // TODO(polina-c): delete this test once getChildrenSummaryTree stops accepting DiagnosticsNode.
-      // https://github.com/flutter/devtools/issues/3951
-      const String group = 'test-group';
 
-      await tester.pumpWidget(
-        const Directionality(
-          textDirection: TextDirection.ltr,
-          child: Stack(
-            children: <Widget>[
-              Text('a', textDirection: TextDirection.ltr),
-              Text('b', textDirection: TextDirection.ltr),
-              Text('c', textDirection: TextDirection.ltr),
-            ],
-          ),
-        ),
-      );
-      final Element elementA = find.text('a').evaluate().first;
-
-      service.disposeAllGroups();
-      service.resetPubRootDirectories();
-      service.setSelection(elementA, 'my-group');
-      final Map<String, dynamic> jsonA = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getSelectedWidget.name,
-        <String, String>{'objectGroup': 'my-group'},
-      ))! as Map<String, dynamic>;
-
-      service.resetPubRootDirectories();
-      Map<String, Object?> rootJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getRootWidgetSummaryTree.name,
-        <String, String>{'objectGroup': group},
-      ))! as Map<String, Object?>;
-      // We haven't yet properly specified which directories are summary tree
-      // directories so we get an empty tree other than the root that is always
-      // included.
-      final Object? rootWidget = service.toObject(rootJson['valueId']! as String);
-      expect(rootWidget, equals(WidgetsBinding.instance.rootElement));
-      List<Object?> childrenJson = rootJson['children']! as List<Object?>;
-      // There are no summary tree children.
-      expect(childrenJson.length, equals(0));
-
-      final Map<String, Object?> creationLocation = jsonA['creationLocation']! as Map<String, Object?>;
-      expect(creationLocation, isNotNull);
-      final String testFile = creationLocation['file']! as String;
-      expect(testFile, endsWith('widget_inspector_test.dart'));
-      final List<String> segments = Uri.parse(testFile).pathSegments;
-      // Strip a couple subdirectories away to generate a plausible pub root
-      // directory.
-      final String pubRootTest = '/${segments.take(segments.length - 2).join('/')}';
-      service.resetPubRootDirectories();
-      await service.testExtension(
-        WidgetInspectorServiceExtensions.addPubRootDirectories.name,
-        <String, String>{'arg0': pubRootTest},
-      );
-
-      rootJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getRootWidgetSummaryTree.name,
-        <String, String>{'objectGroup': group},
-      ))! as Map<String, Object?>;
-      childrenJson = rootJson['children']! as List<Object?>;
-      // The tree of nodes returned contains all widgets created directly by the
-      // test.
-      childrenJson = rootJson['children']! as List<Object?>;
-      expect(childrenJson.length, equals(1));
-
-      List<Object?> alternateChildrenJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getChildrenSummaryTree.name,
-        <String, String>{'arg': rootJson['objectId']! as String, 'objectGroup': group},
-      ))! as List<Object?>;
-      expect(alternateChildrenJson.length, equals(1));
-      Map<String, Object?> childJson = childrenJson[0]! as Map<String, Object?>;
-      Map<String, Object?> alternateChildJson = alternateChildrenJson[0]! as Map<String, Object?>;
-      expect(childJson['description'], startsWith('Directionality'));
-      expect(alternateChildJson['description'], startsWith('Directionality'));
-      expect(alternateChildJson['valueId'], equals(childJson['valueId']));
-
-      childrenJson = childJson['children']! as List<Object?>;
-      alternateChildrenJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getChildrenSummaryTree.name,
-        <String, String>{'arg': childJson['objectId']! as String, 'objectGroup': group},
-      ))! as List<Object?>;
-      expect(alternateChildrenJson.length, equals(1));
-      expect(childrenJson.length, equals(1));
-      alternateChildJson = alternateChildrenJson[0]! as Map<String, Object?>;
-      childJson = childrenJson[0]! as Map<String, Object?>;
-      expect(childJson['description'], startsWith('Stack'));
-      expect(alternateChildJson['description'], startsWith('Stack'));
-      expect(alternateChildJson['valueId'], equals(childJson['valueId']));
-      childrenJson = childJson['children']! as List<Object?>;
-
-      childrenJson = childJson['children']! as List<Object?>;
-      alternateChildrenJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getChildrenSummaryTree.name,
-        <String, String>{'arg': childJson['objectId']! as String, 'objectGroup': group},
-      ))! as List<Object?>;
-      expect(alternateChildrenJson.length, equals(3));
-      expect(childrenJson.length, equals(3));
-      alternateChildJson = alternateChildrenJson[2]! as Map<String, Object?>;
-      childJson = childrenJson[2]! as Map<String, Object?>;
-      expect(childJson['description'], startsWith('Text'));
-      expect(alternateChildJson['description'], startsWith('Text'));
-      expect(alternateChildJson['valueId'], equals(childJson['valueId']));
-      alternateChildrenJson = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getChildrenSummaryTree.name,
-        <String, String>{'arg': childJson['objectId']! as String, 'objectGroup': group},
-      ))! as List<Object?>;
-      expect(alternateChildrenJson.length , equals(0));
-      // Tests are failing when this typo is fixed.
-      expect(childJson['chidlren'], isNull);
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
-
-    testWidgets('ext.flutter.inspector.getRootWidgetSummaryTree on $Diagnosticable', (WidgetTester tester) async {
+    testWidgets('ext.flutter.inspector.getRootWidgetSummaryTree', (WidgetTester tester) async {
       const String group = 'test-group';
 
       await tester.pumpWidget(
@@ -5098,69 +4950,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(box2.localToGlobal(Offset.zero), equals(position2));
     });
 
-    testWidgets('getChildrenDetailsSubtree with $DiagnosticsNode', (WidgetTester tester) async {
-      // TODO(polina-c): delete this test once getChildrenDetailsSubtree stops accepting DiagnosticsNode.
-      // https://github.com/flutter/devtools/issues/3951
-      await tester.pumpWidget(
-        MaterialApp(
-          title: 'Hello, World',
-          theme: ThemeData(
-            primarySwatch: Colors.blue,
-          ),
-          home: Scaffold(
-            appBar: AppBar(
-              title: const Text('Hello, World'),
-            ),
-            body: const Center(
-              child: Text('Hello, World!'),
-            ),
-          ),
-        ),
-      );
-      service.setSelection(find.text('Hello, World!').evaluate().first, 'my-group');
-
-      // Figure out the pubRootDirectory
-      final Map<String, Object?> jsonObject = (await service.testExtension(
-        WidgetInspectorServiceExtensions.getSelectedWidget.name,
-        <String, String>{'objectGroup': 'my-group'},
-      ))! as Map<String, Object?>;
-      final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
-      expect(creationLocation, isNotNull);
-      final String file = creationLocation['file']! as String;
-      expect(file, endsWith('widget_inspector_test.dart'));
-      final List<String> segments = Uri.parse(file).pathSegments;
-      // Strip a couple subdirectories away to generate a plausible pub rootdirectory.
-      final String pubRootTest = '/${segments.take(segments.length - 2).join('/')}';
-      service.resetPubRootDirectories();
-      service.addPubRootDirectories(<String>[pubRootTest]);
-
-      final String summary = service.getRootWidgetSummaryTree('foo1');
-      // ignore: avoid_dynamic_calls
-      final List<Object?> childrenOfRoot = json.decode(summary)['children'] as List<Object?>;
-      final List<Object?> childrenOfMaterialApp = (childrenOfRoot.first! as Map<String, Object?>)['children']! as List<Object?>;
-      final Map<String, Object?> scaffold = childrenOfMaterialApp.first! as Map<String, Object?>;
-      expect(scaffold['description'], 'Scaffold');
-      final String objectId = scaffold['objectId']! as String;
-      final String details = service.getDetailsSubtree(objectId, 'foo2');
-      // ignore: avoid_dynamic_calls
-      final List<Object?> detailedChildren = json.decode(details)['children'] as List<Object?>;
-
-      final List<Map<String, Object?>> appBars = <Map<String, Object?>>[];
-      void visitChildren(List<Object?> children) {
-        for (final Map<String, Object?> child in children.cast<Map<String, Object?>>()) {
-          if (child['description'] == 'AppBar') {
-            appBars.add(child);
-          }
-          if (child.containsKey('children')) {
-            visitChildren(child['children']! as List<Object?>);
-          }
-        }
-      }
-      visitChildren(detailedChildren);
-      expect(appBars.single, isNot(contains('children')));
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
-
-    testWidgets('getChildrenDetailsSubtree with $Diagnosticable', (WidgetTester tester) async {
+    testWidgets('getChildrenDetailsSubtree', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           title: 'Hello, World',


### PR DESCRIPTION
This PR should merge after DevTools 2.25.0, that does not pass DiagnosticsNode any more, is released.
