### PR TITLE
Use devicectl to check for iOS 17 device connection

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -368,6 +368,7 @@ Future<T> runInContext<T>(
           processManager: globals.processManager,
           dyLdLibEntry: globals.cache.dyLdLibEntry,
         ),
+        fileSystem: globals.fs,
       ),
       XcodeProjectInterpreter: () => XcodeProjectInterpreter(
         logger: globals.logger,

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -24,10 +24,10 @@ class IOSCoreDeviceControl {
     required ProcessUtils processUtils,
     required Xcode xcode,
     required FileSystem fileSystem,
-  }) : _logger = logger,
-      _processUtils = processUtils,
-      _xcode = xcode,
-      _fileSystem = fileSystem;
+  })  : _logger = logger,
+        _processUtils = processUtils,
+        _xcode = xcode,
+        _fileSystem = fileSystem;
 
   final Logger _logger;
   final ProcessUtils _processUtils;
@@ -54,9 +54,8 @@ class IOSCoreDeviceControl {
     Duration validTimeout = timeout;
     if (timeout.inSeconds < _minimumTimeoutInSeconds) {
       _logger.printTrace(
-        'Timeout of ${timeout.inSeconds} seconds is below the minimum timeout value '
-        'for devicectl. Changing the timeout to the minimum value of $_minimumTimeoutInSeconds.'
-      );
+          'Timeout of ${timeout.inSeconds} seconds is below the minimum timeout value '
+          'for devicectl. Changing the timeout to the minimum value of $_minimumTimeoutInSeconds.');
       validTimeout = const Duration(seconds: _minimumTimeoutInSeconds);
     }
 
@@ -121,8 +120,8 @@ class IOSCoreDevice {
   IOSCoreDevice(
     Map<String, Object?> data, {
     required Logger logger,
-  }) : _data = data,
-      _logger = logger;
+  })  : _data = data,
+        _logger = logger;
 
   /// Example:
   /// {
@@ -157,8 +156,8 @@ class IOSCoreDevice {
   @visibleForTesting
   List<IOSCoreDeviceCapability> get capabilities {
     final List<IOSCoreDeviceCapability> capabilitiesList = <IOSCoreDeviceCapability>[];
-    final Object? capabilitiesData = _data['capabilities'];
-    if (capabilitiesData != null && capabilitiesData is List<Object?>) {
+    if (_data['capabilities'] is List<Object?>) {
+      final List<Object?> capabilitiesData = _data['capabilities']! as List<Object?>;
       for (final Object? capabilityData in capabilitiesData) {
         if (capabilityData != null && capabilityData is Map<String, Object?>) {
           capabilitiesList.add(IOSCoreDeviceCapability(capabilityData));
@@ -170,17 +169,20 @@ class IOSCoreDevice {
 
   @visibleForTesting
   IOSCoreDeviceConnectionProperties? get connectionProperties {
-    final Object? connectionPropertiesData = _data['connectionProperties'];
-    if (connectionPropertiesData != null && connectionPropertiesData is Map<String, Object?>) {
-      return IOSCoreDeviceConnectionProperties(connectionPropertiesData, logger: _logger);
+    if (_data['connectionProperties'] is Map<String, Object?>) {
+      final Map<String, Object?> connectionPropertiesData = _data['connectionProperties']! as Map<String, Object?>;
+      return IOSCoreDeviceConnectionProperties(
+        connectionPropertiesData,
+        logger: _logger,
+      );
     }
     return null;
   }
 
   @visibleForTesting
   IOSCoreDeviceProperties? get deviceProperties {
-    final Object? devicePropertiesData = _data['deviceProperties'];
-    if (devicePropertiesData != null && devicePropertiesData is Map<String, Object?>) {
+    if (_data['deviceProperties'] is Map<String, Object?>) {
+      final Map<String, Object?> devicePropertiesData = _data['deviceProperties']! as Map<String, Object?>;
       return IOSCoreDeviceProperties(devicePropertiesData);
     }
     return null;
@@ -188,9 +190,12 @@ class IOSCoreDevice {
 
   @visibleForTesting
   IOSCoreDeviceHardwareProperties? get hardwareProperties {
-    final Object? hardwarePropertiesData = _data['hardwareProperties'];
-    if (hardwarePropertiesData != null && hardwarePropertiesData is Map<String, Object?>) {
-      return IOSCoreDeviceHardwareProperties(hardwarePropertiesData, logger: _logger);
+    if (_data['hardwareProperties'] is Map<String, Object?>) {
+      final Map<String, Object?> hardwarePropertiesData = _data['hardwareProperties']! as Map<String, Object?>;
+      return IOSCoreDeviceHardwareProperties(
+        hardwarePropertiesData,
+        logger: _logger,
+      );
     }
     return null;
   }
@@ -227,8 +232,8 @@ class IOSCoreDeviceConnectionProperties {
   IOSCoreDeviceConnectionProperties(
     Map<String, Object?> data, {
     required Logger logger,
-  }) : _data = data,
-      _logger = logger;
+  })  : _data = data,
+        _logger = logger;
 
   /// Example:
   /// "connectionProperties" : {
@@ -260,6 +265,7 @@ class IOSCoreDeviceConnectionProperties {
     }
     return null;
   }
+
   String? get lastConnectionDate => _data['lastConnectionDate']?.toString();
   List<String>? get localHostnames {
     if (_data['localHostnames'] is List<Object?>) {
@@ -272,6 +278,7 @@ class IOSCoreDeviceConnectionProperties {
     }
     return null;
   }
+
   String? get pairingState => _data['pairingState']?.toString();
   List<String>? get potentialHostnames {
     if (_data['potentialHostnames'] is List<Object?>) {
@@ -284,6 +291,7 @@ class IOSCoreDeviceConnectionProperties {
     }
     return null;
   }
+
   /// When [transportType] is not null, values may be `wired` or `localNetwork`.
   String? get transportType => _data['transportType']?.toString();
   String? get tunnelIPAddress => _data['tunnelIPAddress']?.toString();
@@ -318,6 +326,7 @@ class IOSCoreDeviceProperties {
     }
     return null;
   }
+
   String? get bootedSnapshotName => _data['bootedSnapshotName']?.toString();
   String? get bootState => _data['bootState']?.toString();
   bool? get ddiServicesAvailable {
@@ -326,6 +335,7 @@ class IOSCoreDeviceProperties {
     }
     return null;
   }
+
   String? get developerModeStatus => _data['developerModeStatus']?.toString();
   bool? get hasInternalOSBuild {
     if (_data['hasInternalOSBuild'] is bool?) {
@@ -333,6 +343,7 @@ class IOSCoreDeviceProperties {
     }
     return null;
   }
+
   String? get name => _data['name']?.toString();
   String? get osBuildUpdate => _data['osBuildUpdate']?.toString();
   String? get osVersionNumber => _data['osVersionNumber']?.toString();
@@ -342,6 +353,7 @@ class IOSCoreDeviceProperties {
     }
     return null;
   }
+
   String? get screenViewingURL => _data['screenViewingURL']?.toString();
 }
 
@@ -349,8 +361,8 @@ class IOSCoreDeviceHardwareProperties {
   IOSCoreDeviceHardwareProperties(
     Map<String, Object?> data, {
     required Logger logger,
-  }) : _data = data,
-      _logger = logger;
+  })  : _data = data,
+        _logger = logger;
 
   /// Example:
   /// "hardwareProperties" : {
@@ -395,6 +407,7 @@ class IOSCoreDeviceHardwareProperties {
     }
     return null;
   }
+
   String? get deviceType => _data['deviceType']?.toString();
   int? get ecid {
     if (_data['ecid'] is int?) {
@@ -402,6 +415,7 @@ class IOSCoreDeviceHardwareProperties {
     }
     return null;
   }
+
   String? get hardwareModel => _data['hardwareModel']?.toString();
   int? get internalStorageCapacity {
     if (_data['internalStorageCapacity'] is int?) {
@@ -409,6 +423,7 @@ class IOSCoreDeviceHardwareProperties {
     }
     return null;
   }
+
   String? get marketingName => _data['marketingName']?.toString();
   String? get platform => _data['platform']?.toString();
   String? get productType => _data['productType']?.toString();
@@ -426,6 +441,7 @@ class IOSCoreDeviceHardwareProperties {
     }
     return null;
   }
+
   List<int>? get supportedDeviceFamilies {
     if (_data['supportedDeviceFamilies'] is List<Object?>) {
       final List<Object?> values = _data['supportedDeviceFamilies']! as List<Object?>;
@@ -437,6 +453,7 @@ class IOSCoreDeviceHardwareProperties {
     }
     return null;
   }
+
   String? get thinningProductType => _data['thinningProductType']?.toString();
   String? get udid => _data['udid']?.toString();
 }
@@ -461,6 +478,7 @@ class IOSCoreDeviceCPUType {
     }
     return null;
   }
+
   int? get cpuType {
     if (_data['type'] is int?) {
       return _data['type'] as int?;

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -1,0 +1,470 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/process.dart';
+import '../convert.dart';
+import '../device.dart';
+import '../macos/xcode.dart';
+
+/// A wrapper around the `devicectl` command line tool.
+///
+/// CoreDevice is a device connectivity stack introduced in Xcode 15. Devices
+/// with iOS 17 or greater are CoreDevices.
+///
+/// `devicectl` (CoreDevice Device Control) is an Xcode CLI tool used for
+/// interacting with CoreDevices.
+class IOSCoreDeviceControl {
+  IOSCoreDeviceControl({
+    required Logger logger,
+    required ProcessUtils processUtils,
+    required Xcode xcode,
+    required FileSystem fileSystem,
+  }) : _logger = logger,
+      _processUtils = processUtils,
+      _xcode = xcode,
+      _fileSystem = fileSystem;
+
+  final Logger _logger;
+  final ProcessUtils _processUtils;
+  final Xcode _xcode;
+  final FileSystem _fileSystem;
+
+  /// When the `--timeout` flag is used with `devicectl`, it must be at
+  /// least 5 seconds. If lower than 5 seconds, `devicectl` will error and not
+  /// run the command.
+  static const int _minimumTimeoutInSeconds = 5;
+
+  /// Executes `devicectl` command to get list of devices. The command will
+  /// likely complete before [timeout] is reached. If [timeout] is reached,
+  /// the command will be stopped as a failure.
+  Future<List<Object?>> _listCoreDevices({
+    Duration timeout = const Duration(seconds: _minimumTimeoutInSeconds),
+  }) async {
+    if (!_xcode.isDevicectlInstalled) {
+      _logger.printTrace('devicectl is not installed.');
+      return <Object?>[];
+    }
+
+    // Default to minimum timeout if needed to prevent error.
+    Duration validTimeout = timeout;
+    if (timeout.inSeconds < _minimumTimeoutInSeconds) {
+      _logger.printTrace(
+        'Timeout of ${timeout.inSeconds} seconds is below the minimum timeout value '
+        'for devicectl. Changing the timeout to the minimum value of $_minimumTimeoutInSeconds.'
+      );
+      validTimeout = const Duration(seconds: _minimumTimeoutInSeconds);
+    }
+
+    final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync('core_devices.');
+    final File output = tempDirectory.childFile('core_device_list.json');
+    output.createSync();
+
+    final List<String> command = <String>[
+      ..._xcode.xcrunCommand(),
+      'devicectl',
+      'list',
+      'devices',
+      '--timeout',
+      validTimeout.inSeconds.toString(),
+      '--json-output',
+      output.path,
+    ];
+
+    final RunResult results = await _processUtils.run(command);
+    if (results.exitCode != 0) {
+      _logger.printTrace('Error executing devicectl: ${results.exitCode}\n${results.stderr}');
+      return <Object?>[];
+    }
+
+    final String stringOutput = output.readAsStringSync();
+
+    try {
+      final Object? decodeResult = (json.decode(stringOutput) as Map<String, Object?>)['result'];
+      if (decodeResult is Map<String, Object?>) {
+        final Object? decodeDevices = decodeResult['devices'];
+        if (decodeDevices is List<Object?>) {
+          return decodeDevices;
+        }
+      }
+      _logger.printTrace('devicectl returned unexpected JSON response: $stringOutput');
+      return <Object?>[];
+    } on FormatException {
+      // We failed to parse the devicectl output, or it returned junk.
+      _logger.printTrace('devicectl returned non-JSON response: $stringOutput');
+      return <Object?>[];
+    } finally {
+      tempDirectory.deleteSync(recursive: true);
+    }
+  }
+
+  Future<List<IOSCoreDevice>> getCoreDevices({
+    Duration timeout = const Duration(seconds: _minimumTimeoutInSeconds),
+  }) async {
+    final List<IOSCoreDevice> devices = <IOSCoreDevice>[];
+
+    final List<Object?> devicesSection = await _listCoreDevices(timeout: timeout);
+    for (final Object? deviceObject in devicesSection) {
+      if (deviceObject is Map<String, Object?>) {
+        devices.add(IOSCoreDevice(deviceObject, logger: _logger));
+      }
+    }
+    return devices;
+  }
+}
+
+class IOSCoreDevice {
+  IOSCoreDevice(
+    Map<String, Object?> data, {
+    required Logger logger,
+  }) : _data = data,
+      _logger = logger;
+
+  /// Example:
+  /// {
+  ///   "capabilities" : [
+  ///   ],
+  ///   "connectionProperties" : {
+  ///   },
+  ///   "deviceProperties" : {
+  ///   },
+  ///   "hardwareProperties" : {
+  ///   },
+  ///   "identifier" : "123456BB5-AEDE-7A22-B890-1234567890DD",
+  ///   "visibilityClass" : "default"
+  /// }
+  final Map<String, Object?> _data;
+  final Logger _logger;
+
+  String? get udid => hardwareProperties?.udid;
+
+  DeviceConnectionInterface? get connectionInterface {
+    final String? transportType = connectionProperties?.transportType;
+    if (transportType != null) {
+      if (transportType.toLowerCase() == 'localnetwork') {
+        return DeviceConnectionInterface.wireless;
+      } else if (transportType.toLowerCase() == 'wired') {
+        return DeviceConnectionInterface.attached;
+      }
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  List<IOSCoreDeviceCapability> get capabilities {
+    final List<IOSCoreDeviceCapability> capabilitiesList = <IOSCoreDeviceCapability>[];
+    final Object? capabilitiesData = _data['capabilities'];
+    if (capabilitiesData != null && capabilitiesData is List<Object?>) {
+      for (final Object? capabilityData in capabilitiesData) {
+        if (capabilityData != null && capabilityData is Map<String, Object?>) {
+          capabilitiesList.add(IOSCoreDeviceCapability(capabilityData));
+        }
+      }
+    }
+    return capabilitiesList;
+  }
+
+  @visibleForTesting
+  IOSCoreDeviceConnectionProperties? get connectionProperties {
+    final Object? connectionPropertiesData = _data['connectionProperties'];
+    if (connectionPropertiesData != null && connectionPropertiesData is Map<String, Object?>) {
+      return IOSCoreDeviceConnectionProperties(connectionPropertiesData, logger: _logger);
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  IOSCoreDeviceProperties? get deviceProperties {
+    final Object? devicePropertiesData = _data['deviceProperties'];
+    if (devicePropertiesData != null && devicePropertiesData is Map<String, Object?>) {
+      return IOSCoreDeviceProperties(devicePropertiesData);
+    }
+    return null;
+  }
+
+  @visibleForTesting
+  IOSCoreDeviceHardwareProperties? get hardwareProperties {
+    final Object? hardwarePropertiesData = _data['hardwareProperties'];
+    if (hardwarePropertiesData != null && hardwarePropertiesData is Map<String, Object?>) {
+      return IOSCoreDeviceHardwareProperties(hardwarePropertiesData, logger: _logger);
+    }
+    return null;
+  }
+
+  /// This is not the UDID of the device.
+  String? get coreDeviceIdentifer => _data['identifier']?.toString();
+
+  String? get visibilityClass => _data['visibilityClass']?.toString();
+}
+
+class IOSCoreDeviceCapability {
+  IOSCoreDeviceCapability(
+    Map<String, Object?> data,
+  ) : _data = data;
+
+  /// Example:
+  /// "capabilities" : [
+  ///   {
+  ///     "featureIdentifier" : "com.apple.coredevice.feature.spawnexecutable",
+  ///     "name" : "Spawn Executable"
+  ///   },
+  ///   {
+  ///     "featureIdentifier" : "com.apple.coredevice.feature.launchapplication",
+  ///     "name" : "Launch Application"
+  ///   }
+  /// ]
+  final Map<String, Object?> _data;
+
+  String? get featureIdentifier => _data['featureIdentifier']?.toString();
+  String? get name => _data['name']?.toString();
+}
+
+class IOSCoreDeviceConnectionProperties {
+  IOSCoreDeviceConnectionProperties(
+    Map<String, Object?> data, {
+    required Logger logger,
+  }) : _data = data,
+      _logger = logger;
+
+  /// Example:
+  /// "connectionProperties" : {
+  ///   "authenticationType" : "manualPairing",
+  ///   "isMobileDeviceOnly" : false,
+  ///   "lastConnectionDate" : "2023-06-15T15:29:00.082Z",
+  ///   "localHostnames" : [
+  ///     "iPadName.coredevice.local",
+  ///     "00001234-0001234A3C03401E.coredevice.local",
+  ///     "12345BB5-AEDE-4A22-B653-6037262550DD.coredevice.local"
+  ///   ],
+  ///   "pairingState" : "paired",
+  ///   "potentialHostnames" : [
+  ///     "00001234-0001234A3C03401E.coredevice.local",
+  ///     "12345BB5-AEDE-4A22-B653-6037262550DD.coredevice.local"
+  ///   ],
+  ///   "transportType" : "wired",
+  ///   "tunnelIPAddress" : "fdf1:23c4:cd56::1",
+  ///   "tunnelState" : "connected",
+  ///   "tunnelTransportProtocol" : "tcp"
+  /// }
+  final Map<String, Object?> _data;
+  final Logger _logger;
+
+  String? get authenticationType => _data['authenticationType']?.toString();
+  bool? get isMobileDeviceOnly {
+    if (_data['isMobileDeviceOnly'] is bool?) {
+      return _data['isMobileDeviceOnly'] as bool?;
+    }
+    return null;
+  }
+  String? get lastConnectionDate => _data['lastConnectionDate']?.toString();
+  List<String>? get localHostnames {
+    if (_data['localHostnames'] is List<Object?>) {
+      final List<Object?> values = _data['localHostnames']! as List<Object?>;
+      try {
+        return List<String>.from(values);
+      } on TypeError {
+        _logger.printTrace('Error parsing localHostnames value: $values');
+      }
+    }
+    return null;
+  }
+  String? get pairingState => _data['pairingState']?.toString();
+  List<String>? get potentialHostnames {
+    if (_data['potentialHostnames'] is List<Object?>) {
+      final List<Object?> values = _data['potentialHostnames']! as List<Object?>;
+      try {
+        return List<String>.from(values);
+      } on TypeError {
+        _logger.printTrace('Error parsing potentialHostnames value: $values');
+      }
+    }
+    return null;
+  }
+  /// When [transportType] is not null, values may be `wired` or `localNetwork`.
+  String? get transportType => _data['transportType']?.toString();
+  String? get tunnelIPAddress => _data['tunnelIPAddress']?.toString();
+  String? get tunnelState => _data['tunnelState']?.toString();
+  String? get tunnelTransportProtocol => _data['tunnelTransportProtocol']?.toString();
+}
+
+class IOSCoreDeviceProperties {
+  IOSCoreDeviceProperties(
+    Map<String, Object?> data,
+  ) : _data = data;
+
+  /// Example:
+  /// "deviceProperties" : {
+  ///   "bootedFromSnapshot" : true,
+  ///   "bootedSnapshotName" : "com.apple.os.update-B5336980824124F599FD39FE91016493A74331B09F475250BB010B276FE2439E3DE3537349A3A957D3FF2A4B623B4ECC",
+  ///   "bootState" : "booted",
+  ///   "ddiServicesAvailable" : true,
+  ///   "developerModeStatus" : "enabled",
+  ///   "hasInternalOSBuild" : false,
+  ///   "name" : "iPadName",
+  ///   "osBuildUpdate" : "21A5248v",
+  ///   "osVersionNumber" : "17.0",
+  ///   "rootFileSystemIsWritable" : false,
+  ///   "screenViewingURL" : "coredevice-devices:/viewDeviceByUUID?uuid=123456BB5-AEDE-7A22-B890-1234567890DD"
+  /// }
+  final Map<String, Object?> _data;
+
+  bool? get bootedFromSnapshot {
+    if (_data['bootedFromSnapshot'] is bool?) {
+      return _data['bootedFromSnapshot'] as bool?;
+    }
+    return null;
+  }
+  String? get bootedSnapshotName => _data['bootedSnapshotName']?.toString();
+  String? get bootState => _data['bootState']?.toString();
+  bool? get ddiServicesAvailable {
+    if (_data['ddiServicesAvailable'] is bool?) {
+      return _data['ddiServicesAvailable'] as bool?;
+    }
+    return null;
+  }
+  String? get developerModeStatus => _data['developerModeStatus']?.toString();
+  bool? get hasInternalOSBuild {
+    if (_data['hasInternalOSBuild'] is bool?) {
+      return _data['hasInternalOSBuild'] as bool?;
+    }
+    return null;
+  }
+  String? get name => _data['name']?.toString();
+  String? get osBuildUpdate => _data['osBuildUpdate']?.toString();
+  String? get osVersionNumber => _data['osVersionNumber']?.toString();
+  bool? get rootFileSystemIsWritable {
+    if (_data['rootFileSystemIsWritable'] is bool?) {
+      return _data['rootFileSystemIsWritable'] as bool?;
+    }
+    return null;
+  }
+  String? get screenViewingURL => _data['screenViewingURL']?.toString();
+}
+
+class IOSCoreDeviceHardwareProperties {
+  IOSCoreDeviceHardwareProperties(
+    Map<String, Object?> data, {
+    required Logger logger,
+  }) : _data = data,
+      _logger = logger;
+
+  /// Example:
+  /// "hardwareProperties" : {
+  ///   "cpuType" : {
+  ///     "name" : "arm64e",
+  ///     "subType" : 2,
+  ///     "type" : 16777228
+  ///   },
+  ///   "deviceType" : "iPad",
+  ///   "ecid" : 12345678903408542,
+  ///   "hardwareModel" : "J617AP",
+  ///   "internalStorageCapacity" : 128000000000,
+  ///   "marketingName" : "iPad Pro (11-inch) (4th generation)\"",
+  ///   "platform" : "iOS",
+  ///   "productType" : "iPad14,3",
+  ///   "serialNumber" : "HC123DHCQV",
+  ///   "supportedCPUTypes" : [
+  ///     {
+  ///       "name" : "arm64e",
+  ///       "subType" : 2,
+  ///       "type" : 16777228
+  ///     },
+  ///     {
+  ///       "name" : "arm64",
+  ///       "subType" : 0,
+  ///       "type" : 16777228
+  ///     }
+  ///   ],
+  ///   "supportedDeviceFamilies" : [
+  ///     1,
+  ///     2
+  ///   ],
+  ///   "thinningProductType" : "iPad14,3-A",
+  ///   "udid" : "00001234-0001234A3C03401E"
+  /// }
+  final Map<String, Object?> _data;
+  final Logger _logger;
+
+  IOSCoreDeviceCPUType? get cpuType {
+    if (_data['cpuType'] is Map<String, Object?>) {
+      return IOSCoreDeviceCPUType(_data['cpuType']! as Map<String, Object?>);
+    }
+    return null;
+  }
+  String? get deviceType => _data['deviceType']?.toString();
+  int? get ecid {
+    if (_data['ecid'] is int?) {
+      return _data['ecid'] as int?;
+    }
+    return null;
+  }
+  String? get hardwareModel => _data['hardwareModel']?.toString();
+  int? get internalStorageCapacity {
+    if (_data['internalStorageCapacity'] is int?) {
+      return _data['internalStorageCapacity'] as int?;
+    }
+    return null;
+  }
+  String? get marketingName => _data['marketingName']?.toString();
+  String? get platform => _data['platform']?.toString();
+  String? get productType => _data['productType']?.toString();
+  String? get serialNumber => _data['serialNumber']?.toString();
+  List<IOSCoreDeviceCPUType>? get supportedCPUTypes {
+    if (_data['supportedCPUTypes'] is List<Object?>) {
+      final List<Object?> values = _data['supportedCPUTypes']! as List<Object?>;
+      final List<IOSCoreDeviceCPUType> cpuTypes = <IOSCoreDeviceCPUType>[];
+      for (final Object? cpuTypeData in values) {
+        if (cpuTypeData is Map<String, Object?>) {
+          cpuTypes.add(IOSCoreDeviceCPUType(cpuTypeData));
+        }
+      }
+      return cpuTypes;
+    }
+    return null;
+  }
+  List<int>? get supportedDeviceFamilies {
+    if (_data['supportedDeviceFamilies'] is List<Object?>) {
+      final List<Object?> values = _data['supportedDeviceFamilies']! as List<Object?>;
+      try {
+        return List<int>.from(values);
+      } on TypeError {
+        _logger.printTrace('Error parsing supportedDeviceFamilies value: $values');
+      }
+    }
+    return null;
+  }
+  String? get thinningProductType => _data['thinningProductType']?.toString();
+  String? get udid => _data['udid']?.toString();
+}
+
+class IOSCoreDeviceCPUType {
+  IOSCoreDeviceCPUType(
+    Map<String, Object?> data,
+  ) : _data = data;
+
+  /// Example:
+  /// "cpuType" : {
+  ///   "name" : "arm64e",
+  ///   "subType" : 2,
+  ///   "type" : 16777228
+  /// }
+  final Map<String, Object?> _data;
+
+  String? get name => _data['name']?.toString();
+  int? get subType {
+    if (_data['subType'] is int?) {
+      return _data['subType'] as int?;
+    }
+    return null;
+  }
+  int? get cpuType {
+    if (_data['type'] is int?) {
+      return _data['type'] as int?;
+    }
+    return null;
+  }
+}

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -146,6 +146,28 @@ class Xcode {
     return _isSimctlInstalled ?? false;
   }
 
+  bool? _isDevicectlInstalled;
+
+  /// Verifies that `devicectl` is installed by checking Xcode version and trying
+  /// to run it. `devicectl` is made available in Xcode 15.
+  bool get isDevicectlInstalled {
+    if (_isDevicectlInstalled == null) {
+      try {
+        if (currentVersion == null || currentVersion!.major < 15) {
+          _isDevicectlInstalled = false;
+          return _isDevicectlInstalled!;
+        }
+        final RunResult result = _processUtils.runSync(
+          <String>[...xcrunCommand(), 'devicectl', '--version'],
+        );
+        _isDevicectlInstalled = result.exitCode == 0;
+      } on ProcessException {
+        _isDevicectlInstalled = false;
+      }
+    }
+    return _isDevicectlInstalled ?? false;
+  }
+
   bool get isRequiredVersionSatisfactory {
     final Version? version = currentVersion;
     if (version == null) {

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -5,17 +5,12 @@
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/version.dart';
-import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
-import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
-import 'package:flutter_tools/src/project.dart';
-import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -37,7 +32,10 @@ void main() {
     setUp(() {
       logger = BufferLogger.test();
       fakeProcessManager = FakeProcessManager.empty();
-      processUtils = ProcessUtils(processManager: fakeProcessManager, logger: logger);
+      processUtils = ProcessUtils(
+        processManager: fakeProcessManager,
+        logger: logger,
+      );
       final XcodeProjectInterpreter xcodeProjectInterpreter = XcodeProjectInterpreter.test(
         processManager: fakeProcessManager,
         version: Version(14, 0, 0),
@@ -72,7 +70,10 @@ void main() {
     setUp(() {
       logger = BufferLogger.test();
       fakeProcessManager = FakeProcessManager.empty();
-      processUtils = ProcessUtils(processManager: fakeProcessManager, logger: logger);
+      processUtils = ProcessUtils(
+        processManager: fakeProcessManager,
+        logger: logger,
+      );
       xcode = Xcode.test(processManager: FakeProcessManager.any());
       deviceControl = IOSCoreDeviceControl(
         logger: logger,
@@ -108,7 +109,9 @@ void main() {
 }
     ''';
 
-      final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -168,7 +171,9 @@ void main() {
 }
     ''';
 
-    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -229,7 +234,9 @@ void main() {
 }
     ''';
 
-    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -254,7 +261,8 @@ void main() {
       expect(devices[0].connectionProperties, isNull);
       expect(devices[0].deviceProperties, isNull);
       expect(devices[0].hardwareProperties, isNull);
-
+      expect(devices[0].coreDeviceIdentifer, '123456BB5-AEDE-7A22-B890-1234567890DD');
+      expect(devices[0].visibilityClass, 'default');
 
       expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(tempFile, isNot(exists));
@@ -282,7 +290,9 @@ void main() {
 }
     ''';
 
-    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -344,7 +354,9 @@ void main() {
 }
     ''';
 
-    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -377,13 +389,10 @@ void main() {
         ],
       );
       expect(devices[0].connectionProperties?.pairingState, 'paired');
-      expect(
-        devices[0].connectionProperties?.potentialHostnames,
-        <String>[
-          '00001234-0001234A3C03401E.coredevice.local',
-          '123456BB5-AEDE-7A22-B890-1234567890DD.coredevice.local',
-        ]
-      );
+      expect(devices[0].connectionProperties?.potentialHostnames, <String>[
+        '00001234-0001234A3C03401E.coredevice.local',
+        '123456BB5-AEDE-7A22-B890-1234567890DD.coredevice.local',
+      ]);
       expect(devices[0].connectionProperties?.transportType, 'wired');
       expect(devices[0].connectionProperties?.tunnelIPAddress, 'fdf1:23c4:cd56::1');
       expect(devices[0].connectionProperties?.tunnelState, 'connected');
@@ -418,7 +427,9 @@ void main() {
 }
     ''';
 
-    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -500,7 +511,9 @@ void main() {
 }
     ''';
 
-    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      final File tempFile = fileSystem.systemTempDirectory
+          .childDirectory('core_devices.rand0')
+          .childFile('core_device_list.json');
       fakeProcessManager.addCommand(FakeCommand(
         command: <String>[
           'xcrun',
@@ -525,7 +538,6 @@ void main() {
       expect(devices[0].hardwareProperties?.cpuType?.name, 'arm64e');
       expect(devices[0].hardwareProperties?.cpuType?.subType, 2);
       expect(devices[0].hardwareProperties?.cpuType?.cpuType, 16777228);
-
       expect(devices[0].hardwareProperties?.deviceType, 'iPad');
       expect(devices[0].hardwareProperties?.ecid, 12345678903408542);
       expect(devices[0].hardwareProperties?.hardwareModel, 'J617AP');
@@ -534,8 +546,7 @@ void main() {
       expect(devices[0].hardwareProperties?.platform, 'iOS');
       expect(devices[0].hardwareProperties?.productType, 'iPad14,3');
       expect(devices[0].hardwareProperties?.serialNumber, 'HC123DHCQV');
-
-
+      expect(devices[0].hardwareProperties?.supportedCPUTypes, isNotNull);
       expect(devices[0].hardwareProperties?.supportedCPUTypes?[0].name, 'arm64e');
       expect(devices[0].hardwareProperties?.supportedCPUTypes?[0].subType, 2);
       expect(devices[0].hardwareProperties?.supportedCPUTypes?[0].cpuType, 16777228);
@@ -555,7 +566,9 @@ void main() {
       testWithoutContext('invalid json', () async {
         const String deviceControlOutput = '''Invalid JSON''';
 
-        final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('core_device_list.json');
         fakeProcessManager.addCommand(FakeCommand(
           command: <String>[
             'xcrun',
@@ -603,7 +616,9 @@ void main() {
 }
     ''';
 
-        final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('core_device_list.json');
         fakeProcessManager.addCommand(FakeCommand(
           command: <String>[
             'xcrun',
@@ -656,7 +671,9 @@ void main() {
 }
     ''';
 
-        final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+        final File tempFile = fileSystem.systemTempDirectory
+            .childDirectory('core_devices.rand0')
+            .childFile('core_device_list.json');
         fakeProcessManager.addCommand(FakeCommand(
           command: <String>[
             'xcrun',
@@ -674,52 +691,17 @@ void main() {
           },
         ));
 
-        final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices(timeout: const Duration(seconds: 2));
+        final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices(
+          timeout: const Duration(seconds: 2),
+        );
         expect(devices.isNotEmpty, isTrue);
         expect(fakeProcessManager, hasNoRemainingExpectations);
         expect(
           logger.traceText,
-          contains(
-            'Timeout of 2 seconds is below the minimum timeout value '
-            'for devicectl. Changing the timeout to the minimum value of 5.'
-          ),
+          contains('Timeout of 2 seconds is below the minimum timeout value '
+              'for devicectl. Changing the timeout to the minimum value of 5.'),
         );
       });
-
     });
-
-
   });
-
-}
-
-class FakeIosProject extends Fake implements IosProject {
-  @override
-  Future<String> productBundleIdentifier(BuildInfo? buildInfo) async => 'com.example.test';
-
-  @override
-  Future<String> hostAppBundleName(BuildInfo? buildInfo) async => 'My Super Awesome App.app';
-}
-
-class FakeSimControl extends Fake implements SimControl {
-  final List<LaunchRequest> requests = <LaunchRequest>[];
-
-  @override
-  Future<RunResult> launch(String deviceId, String appIdentifier, [ List<String>? launchArgs ]) async {
-    requests.add(LaunchRequest(deviceId, appIdentifier, launchArgs));
-    return RunResult(ProcessResult(0, 0, '', ''), <String>['test']);
-  }
-
-  @override
-  Future<RunResult> install(String deviceId, String appPath) async {
-    return RunResult(ProcessResult(0, 0, '', ''), <String>['test']);
-  }
-}
-
-class LaunchRequest {
-  const LaunchRequest(this.deviceId, this.appIdentifier, this.launchArgs);
-
-  final String deviceId;
-  final String appIdentifier;
-  final List<String>? launchArgs;
 }

--- a/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/core_devices_test.dart
@@ -1,0 +1,725 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/version.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/ios/core_devices.dart';
+import 'package:flutter_tools/src/ios/simulators.dart';
+import 'package:flutter_tools/src/ios/xcodeproj.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+
+void main() {
+  late MemoryFileSystem fileSystem;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+  });
+
+  group('Xcode prior to Core Device Control/Xcode 15', () {
+    late BufferLogger logger;
+    late FakeProcessManager fakeProcessManager;
+    late ProcessUtils processUtils;
+    late Xcode xcode;
+    late IOSCoreDeviceControl deviceControl;
+
+    setUp(() {
+      logger = BufferLogger.test();
+      fakeProcessManager = FakeProcessManager.empty();
+      processUtils = ProcessUtils(processManager: fakeProcessManager, logger: logger);
+      final XcodeProjectInterpreter xcodeProjectInterpreter = XcodeProjectInterpreter.test(
+        processManager: fakeProcessManager,
+        version: Version(14, 0, 0),
+      );
+      xcode = Xcode.test(
+        processManager: FakeProcessManager.any(),
+        xcodeProjectInterpreter: xcodeProjectInterpreter,
+      );
+      deviceControl = IOSCoreDeviceControl(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: xcode,
+        fileSystem: fileSystem,
+      );
+    });
+
+    testWithoutContext('devicectl is not installed', () async {
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.isEmpty, isTrue);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(logger.traceText, contains('devicectl is not installed.'));
+    });
+  });
+
+  group('Core Device Control', () {
+    late BufferLogger logger;
+    late FakeProcessManager fakeProcessManager;
+    late ProcessUtils processUtils;
+    late Xcode xcode;
+    late IOSCoreDeviceControl deviceControl;
+
+    setUp(() {
+      logger = BufferLogger.test();
+      fakeProcessManager = FakeProcessManager.empty();
+      processUtils = ProcessUtils(processManager: fakeProcessManager, logger: logger);
+      xcode = Xcode.test(processManager: FakeProcessManager.any());
+      deviceControl = IOSCoreDeviceControl(
+        logger: logger,
+        processUtils: processUtils,
+        xcode: xcode,
+        fileSystem: fileSystem,
+      );
+    });
+
+    testWithoutContext('No devices', () async {
+      const String deviceControlOutput = '''
+{
+  "info" : {
+    "arguments" : [
+      "devicectl",
+      "list",
+      "devices",
+      "--json-output",
+      "core_device_list.json"
+    ],
+    "commandType" : "devicectl.list.devices",
+    "environment" : {
+      "TERM" : "xterm-256color"
+    },
+    "outcome" : "success",
+    "version" : "325.3"
+  },
+  "result" : {
+    "devices" : [
+
+    ]
+  }
+}
+    ''';
+
+      final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.isEmpty, isTrue);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+    });
+
+    testWithoutContext('All sections parsed', () async {
+      const String deviceControlOutput = '''
+{
+  "info" : {
+    "arguments" : [
+      "devicectl",
+      "list",
+      "devices",
+      "--json-output",
+      "core_device_list.json"
+    ],
+    "commandType" : "devicectl.list.devices",
+    "environment" : {
+      "TERM" : "xterm-256color"
+    },
+    "outcome" : "success",
+    "version" : "325.3"
+  },
+  "result" : {
+    "devices" : [
+      {
+        "capabilities" : [
+        ],
+        "connectionProperties" : {
+        },
+        "deviceProperties" : {
+        },
+        "hardwareProperties" : {
+        },
+        "identifier" : "123456BB5-AEDE-7A22-B890-1234567890DD",
+        "visibilityClass" : "default"
+      }
+    ]
+  }
+}
+    ''';
+
+    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.length, 1);
+
+      expect(devices[0].capabilities, isNotNull);
+      expect(devices[0].connectionProperties, isNotNull);
+      expect(devices[0].deviceProperties, isNotNull);
+      expect(devices[0].hardwareProperties, isNotNull);
+      expect(devices[0].coreDeviceIdentifer, '123456BB5-AEDE-7A22-B890-1234567890DD');
+      expect(devices[0].visibilityClass, 'default');
+
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempFile, isNot(exists));
+    });
+
+    testWithoutContext('All sections parsed, device missing sections', () async {
+      const String deviceControlOutput = '''
+{
+  "info" : {
+    "arguments" : [
+      "devicectl",
+      "list",
+      "devices",
+      "--json-output",
+      "core_device_list.json"
+    ],
+    "commandType" : "devicectl.list.devices",
+    "environment" : {
+      "TERM" : "xterm-256color"
+    },
+    "outcome" : "success",
+    "version" : "325.3"
+  },
+  "result" : {
+    "devices" : [
+      {
+        "identifier" : "123456BB5-AEDE-7A22-B890-1234567890DD",
+        "visibilityClass" : "default"
+      }
+    ]
+  }
+}
+    ''';
+
+    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.length, 1);
+
+      expect(devices[0].capabilities, isEmpty);
+      expect(devices[0].connectionProperties, isNull);
+      expect(devices[0].deviceProperties, isNull);
+      expect(devices[0].hardwareProperties, isNull);
+
+
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempFile, isNot(exists));
+    });
+
+    testWithoutContext('capabilities parsed', () async {
+      const String deviceControlOutput = '''
+{
+  "result" : {
+    "devices" : [
+      {
+        "capabilities" : [
+          {
+            "featureIdentifier" : "com.apple.coredevice.feature.spawnexecutable",
+            "name" : "Spawn Executable"
+          },
+          {
+            "featureIdentifier" : "com.apple.coredevice.feature.launchapplication",
+            "name" : "Launch Application"
+          }
+        ]
+      }
+    ]
+  }
+}
+    ''';
+
+    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.length, 1);
+
+      expect(devices[0].capabilities.length, 2);
+      expect(devices[0].capabilities[0].featureIdentifier, 'com.apple.coredevice.feature.spawnexecutable');
+      expect(devices[0].capabilities[0].name, 'Spawn Executable');
+      expect(devices[0].capabilities[1].featureIdentifier, 'com.apple.coredevice.feature.launchapplication');
+      expect(devices[0].capabilities[1].name, 'Launch Application');
+
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempFile, isNot(exists));
+    });
+
+    testWithoutContext('connectionProperties parsed', () async {
+      const String deviceControlOutput = '''
+{
+  "result" : {
+    "devices" : [
+      {
+        "connectionProperties" : {
+          "authenticationType" : "manualPairing",
+          "isMobileDeviceOnly" : false,
+          "lastConnectionDate" : "2023-06-15T15:29:00.082Z",
+          "localHostnames" : [
+            "Victorias-iPad.coredevice.local",
+            "00001234-0001234A3C03401E.coredevice.local",
+            "123456BB5-AEDE-7A22-B890-1234567890DD.coredevice.local"
+          ],
+          "pairingState" : "paired",
+          "potentialHostnames" : [
+            "00001234-0001234A3C03401E.coredevice.local",
+            "123456BB5-AEDE-7A22-B890-1234567890DD.coredevice.local"
+          ],
+          "transportType" : "wired",
+          "tunnelIPAddress" : "fdf1:23c4:cd56::1",
+          "tunnelState" : "connected",
+          "tunnelTransportProtocol" : "tcp"
+        }
+      }
+    ]
+  }
+}
+    ''';
+
+    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.length, 1);
+
+      expect(devices[0].connectionProperties?.authenticationType, 'manualPairing');
+      expect(devices[0].connectionProperties?.isMobileDeviceOnly, false);
+      expect(devices[0].connectionProperties?.lastConnectionDate, '2023-06-15T15:29:00.082Z');
+      expect(
+        devices[0].connectionProperties?.localHostnames,
+        <String>[
+          'Victorias-iPad.coredevice.local',
+          '00001234-0001234A3C03401E.coredevice.local',
+          '123456BB5-AEDE-7A22-B890-1234567890DD.coredevice.local',
+        ],
+      );
+      expect(devices[0].connectionProperties?.pairingState, 'paired');
+      expect(
+        devices[0].connectionProperties?.potentialHostnames,
+        <String>[
+          '00001234-0001234A3C03401E.coredevice.local',
+          '123456BB5-AEDE-7A22-B890-1234567890DD.coredevice.local',
+        ]
+      );
+      expect(devices[0].connectionProperties?.transportType, 'wired');
+      expect(devices[0].connectionProperties?.tunnelIPAddress, 'fdf1:23c4:cd56::1');
+      expect(devices[0].connectionProperties?.tunnelState, 'connected');
+      expect(devices[0].connectionProperties?.tunnelTransportProtocol, 'tcp');
+
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempFile, isNot(exists));
+    });
+
+    testWithoutContext('deviceProperties parsed', () async {
+      const String deviceControlOutput = '''
+{
+  "result" : {
+    "devices" : [
+      {
+        "deviceProperties" : {
+          "bootedFromSnapshot" : true,
+          "bootedSnapshotName" : "com.apple.os.update-123456",
+          "bootState" : "booted",
+          "ddiServicesAvailable" : true,
+          "developerModeStatus" : "enabled",
+          "hasInternalOSBuild" : false,
+          "name" : "iPadName",
+          "osBuildUpdate" : "21A5248v",
+          "osVersionNumber" : "17.0",
+          "rootFileSystemIsWritable" : false,
+          "screenViewingURL" : "coredevice-devices:/viewDeviceByUUID?uuid=123456BB5-AEDE-7A22-B890-1234567890DD"
+        }
+      }
+    ]
+  }
+}
+    ''';
+
+    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.length, 1);
+
+      expect(devices[0].deviceProperties?.bootedFromSnapshot, true);
+      expect(devices[0].deviceProperties?.bootedSnapshotName, 'com.apple.os.update-123456');
+      expect(devices[0].deviceProperties?.bootState, 'booted');
+      expect(devices[0].deviceProperties?.ddiServicesAvailable, true);
+      expect(devices[0].deviceProperties?.developerModeStatus, 'enabled');
+      expect(devices[0].deviceProperties?.hasInternalOSBuild, false);
+      expect(devices[0].deviceProperties?.name, 'iPadName');
+      expect(devices[0].deviceProperties?.osBuildUpdate, '21A5248v');
+      expect(devices[0].deviceProperties?.osVersionNumber, '17.0');
+      expect(devices[0].deviceProperties?.rootFileSystemIsWritable, false);
+      expect(devices[0].deviceProperties?.screenViewingURL, 'coredevice-devices:/viewDeviceByUUID?uuid=123456BB5-AEDE-7A22-B890-1234567890DD');
+
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempFile, isNot(exists));
+    });
+
+    testWithoutContext('hardwareProperties parsed', () async {
+      const String deviceControlOutput = r'''
+{
+  "result" : {
+    "devices" : [
+      {
+        "hardwareProperties" : {
+          "cpuType" : {
+            "name" : "arm64e",
+            "subType" : 2,
+            "type" : 16777228
+          },
+          "deviceType" : "iPad",
+          "ecid" : 12345678903408542,
+          "hardwareModel" : "J617AP",
+          "internalStorageCapacity" : 128000000000,
+          "marketingName" : "iPad Pro (11-inch) (4th generation)\"",
+          "platform" : "iOS",
+          "productType" : "iPad14,3",
+          "serialNumber" : "HC123DHCQV",
+          "supportedCPUTypes" : [
+            {
+              "name" : "arm64e",
+              "subType" : 2,
+              "type" : 16777228
+            },
+            {
+              "name" : "arm64",
+              "subType" : 0,
+              "type" : 16777228
+            }
+          ],
+          "supportedDeviceFamilies" : [
+            1,
+            2
+          ],
+          "thinningProductType" : "iPad14,3-A",
+          "udid" : "00001234-0001234A3C03401E"
+        }
+      }
+    ]
+  }
+}
+    ''';
+
+    final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>[
+          'xcrun',
+          'devicectl',
+          'list',
+          'devices',
+          '--timeout',
+          '5',
+          '--json-output',
+          tempFile.path,
+        ],
+        onRun: () {
+          expect(tempFile, exists);
+          tempFile.writeAsStringSync(deviceControlOutput);
+        },
+      ));
+
+      final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+      expect(devices.length, 1);
+
+      expect(devices[0].hardwareProperties?.cpuType, isNotNull);
+      expect(devices[0].hardwareProperties?.cpuType?.name, 'arm64e');
+      expect(devices[0].hardwareProperties?.cpuType?.subType, 2);
+      expect(devices[0].hardwareProperties?.cpuType?.cpuType, 16777228);
+
+      expect(devices[0].hardwareProperties?.deviceType, 'iPad');
+      expect(devices[0].hardwareProperties?.ecid, 12345678903408542);
+      expect(devices[0].hardwareProperties?.hardwareModel, 'J617AP');
+      expect(devices[0].hardwareProperties?.internalStorageCapacity, 128000000000);
+      expect(devices[0].hardwareProperties?.marketingName, 'iPad Pro (11-inch) (4th generation)"');
+      expect(devices[0].hardwareProperties?.platform, 'iOS');
+      expect(devices[0].hardwareProperties?.productType, 'iPad14,3');
+      expect(devices[0].hardwareProperties?.serialNumber, 'HC123DHCQV');
+
+
+      expect(devices[0].hardwareProperties?.supportedCPUTypes?[0].name, 'arm64e');
+      expect(devices[0].hardwareProperties?.supportedCPUTypes?[0].subType, 2);
+      expect(devices[0].hardwareProperties?.supportedCPUTypes?[0].cpuType, 16777228);
+      expect(devices[0].hardwareProperties?.supportedCPUTypes?[1].name, 'arm64');
+      expect(devices[0].hardwareProperties?.supportedCPUTypes?[1].subType, 0);
+      expect(devices[0].hardwareProperties?.supportedCPUTypes?[1].cpuType, 16777228);
+      expect(devices[0].hardwareProperties?.supportedDeviceFamilies, <int>[1, 2]);
+      expect(devices[0].hardwareProperties?.thinningProductType, 'iPad14,3-A');
+
+      expect(devices[0].hardwareProperties?.udid, '00001234-0001234A3C03401E');
+
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempFile, isNot(exists));
+    });
+
+    group('Handles errors quietly', () {
+      testWithoutContext('invalid json', () async {
+        const String deviceControlOutput = '''Invalid JSON''';
+
+        final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+        fakeProcessManager.addCommand(FakeCommand(
+          command: <String>[
+            'xcrun',
+            'devicectl',
+            'list',
+            'devices',
+            '--timeout',
+            '5',
+            '--json-output',
+            tempFile.path,
+          ],
+          onRun: () {
+            expect(tempFile, exists);
+            tempFile.writeAsStringSync(deviceControlOutput);
+          },
+        ));
+
+        final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+        expect(devices.isEmpty, isTrue);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('devicectl returned non-JSON response: Invalid JSON'));
+      });
+
+      testWithoutContext('unexpected json', () async {
+        const String deviceControlOutput = '''
+{
+  "info" : {
+    "arguments" : [
+      "devicectl",
+      "list",
+      "devices",
+      "--json-output",
+      "device_list.json"
+    ],
+    "commandType" : "devicectl.list.devices",
+    "environment" : {
+      "TERM" : "xterm-256color"
+    },
+    "outcome" : "success",
+    "version" : "325.3"
+  },
+  "result" : [
+
+  ]
+}
+    ''';
+
+        final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+        fakeProcessManager.addCommand(FakeCommand(
+          command: <String>[
+            'xcrun',
+            'devicectl',
+            'list',
+            'devices',
+            '--timeout',
+            '5',
+            '--json-output',
+            tempFile.path,
+          ],
+          onRun: () {
+            expect(tempFile, exists);
+            tempFile.writeAsStringSync(deviceControlOutput);
+          },
+        ));
+
+        final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices();
+        expect(devices.isEmpty, isTrue);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(logger.traceText, contains('devicectl returned unexpected JSON response:'));
+      });
+
+      testWithoutContext('When timeout is below minimum, default to minimum', () async {
+        const String deviceControlOutput = '''
+{
+  "info" : {
+    "arguments" : [
+      "devicectl",
+      "list",
+      "devices",
+      "--json-output",
+      "core_device_list.json"
+    ],
+    "commandType" : "devicectl.list.devices",
+    "environment" : {
+      "TERM" : "xterm-256color"
+    },
+    "outcome" : "success",
+    "version" : "325.3"
+  },
+  "result" : {
+    "devices" : [
+      {
+        "identifier" : "123456BB5-AEDE-7A22-B890-1234567890DD",
+        "visibilityClass" : "default"
+      }
+    ]
+  }
+}
+    ''';
+
+        final File tempFile = fileSystem.systemTempDirectory.childDirectory('core_devices.rand0').childFile('core_device_list.json');
+        fakeProcessManager.addCommand(FakeCommand(
+          command: <String>[
+            'xcrun',
+            'devicectl',
+            'list',
+            'devices',
+            '--timeout',
+            '5',
+            '--json-output',
+            tempFile.path,
+          ],
+          onRun: () {
+            expect(tempFile, exists);
+            tempFile.writeAsStringSync(deviceControlOutput);
+          },
+        ));
+
+        final List<IOSCoreDevice> devices = await deviceControl.getCoreDevices(timeout: const Duration(seconds: 2));
+        expect(devices.isNotEmpty, isTrue);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
+        expect(
+          logger.traceText,
+          contains(
+            'Timeout of 2 seconds is below the minimum timeout value '
+            'for devicectl. Changing the timeout to the minimum value of 5.'
+          ),
+        );
+      });
+
+    });
+
+
+  });
+
+}
+
+class FakeIosProject extends Fake implements IosProject {
+  @override
+  Future<String> productBundleIdentifier(BuildInfo? buildInfo) async => 'com.example.test';
+
+  @override
+  Future<String> hostAppBundleName(BuildInfo? buildInfo) async => 'My Super Awesome App.app';
+}
+
+class FakeSimControl extends Fake implements SimControl {
+  final List<LaunchRequest> requests = <LaunchRequest>[];
+
+  @override
+  Future<RunResult> launch(String deviceId, String appIdentifier, [ List<String>? launchArgs ]) async {
+    requests.add(LaunchRequest(deviceId, appIdentifier, launchArgs));
+    return RunResult(ProcessResult(0, 0, '', ''), <String>['test']);
+  }
+
+  @override
+  Future<RunResult> install(String deviceId, String appPath) async {
+    return RunResult(ProcessResult(0, 0, '', ''), <String>['test']);
+  }
+}
+
+class LaunchRequest {
+  const LaunchRequest(this.deviceId, this.appIdentifier, this.launchArgs);
+
+  final String deviceId;
+  final String appIdentifier;
+  final List<String>? launchArgs;
+}


### PR DESCRIPTION
`xcdevice` (the Xcode CLI tool we use to get iOS physical device information) does not show the correct connection interface ('usb' vs 'network') for iOS 17 devices. Xcode 15 introduced a device connectivity stack called CoreDevice and new tool called `devicectl` to interact with it. This PR adopts usage of `devicectl` to get connection information for iOS 17 devices.

Note: `devicectl` is currently in preview and may change in the future. As a result, this PR is very defensive about errors and only prints them using printTrace, to minimize visibility to users.

Fixes https://github.com/flutter/flutter/issues/128827.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
