### PR TITLE
Prevent crashes on range errors when selecting device

### DIFF
--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -774,7 +774,7 @@ class TargetDeviceSelection {
         throwToolExit('');
       }
       final int deviceIndex = int.parse(userInputString) - 1;
-      if (deviceIndex < devices.length) {
+      if (deviceIndex > -1 && deviceIndex < devices.length) {
         chosenDevice = devices[deviceIndex];
       }
     }

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -345,19 +345,11 @@ class TargetDevices {
 
   Future<Device> _chooseOneOfAvailableDevices(List<Device> devices) async {
     _displayDeviceOptions(devices);
-
-    Device? chosenDevice;
-    while (chosenDevice == null) {
-      final String userInputString = await _readUserInput(devices.length);
-      if (userInputString.toLowerCase() == 'q') {
-        throwToolExit('');
-      }
-      final int deviceIndex = int.parse(userInputString) - 1;
-      if (deviceIndex > -1 && deviceIndex < devices.length) {
-        chosenDevice = devices[deviceIndex];
-      }
+    final String userInput =  await _readUserInput(devices.length);
+    if (userInput.toLowerCase() == 'q') {
+      throwToolExit('');
     }
-    return chosenDevice;
+    return devices[int.parse(userInput) - 1];
   }
 
   void _displayDeviceOptions(List<Device> devices) {

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -345,11 +345,19 @@ class TargetDevices {
 
   Future<Device> _chooseOneOfAvailableDevices(List<Device> devices) async {
     _displayDeviceOptions(devices);
-    final String userInput =  await _readUserInput(devices.length);
-    if (userInput.toLowerCase() == 'q') {
-      throwToolExit('');
+
+    Device? chosenDevice;
+    while (chosenDevice == null) {
+      final String userInputString = await _readUserInput(devices.length);
+      if (userInputString.toLowerCase() == 'q') {
+        throwToolExit('');
+      }
+      final int deviceIndex = int.parse(userInputString) - 1;
+      if (deviceIndex > -1 && deviceIndex < devices.length) {
+        chosenDevice = devices[deviceIndex];
+      }
     }
-    return devices[int.parse(userInput) - 1];
+    return chosenDevice;
   }
 
   void _displayDeviceOptions(List<Device> devices) {

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -1830,11 +1830,6 @@ Please choose one (or "q" to quit): '''));
             targetDevices.waitForWirelessBeforeInput = true;
             targetDevices.deviceSelection.input = '2';
 
-            // Adding this additional prompt demonstrates that selecting
-            // `0` for the first option won't crash the tool, we will instead
-            // need to simulate typing into stdin again with the correct value
-            // which is `1` in this case
-            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '0');
             terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
 
             final List<Device>? devices = await targetDevices.findAllTargetDevices();

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -1497,10 +1497,15 @@ Please choose one (or "q" to quit): '''));
             );
             targetDevices.waitForWirelessBeforeInput = true;
 
-            // Having the `0` first is an invalid choice for a device, the second
-            // item in the list, `1` is a valid option though which will return a
-            // valid device
-            targetDevices.deviceSelection.input = <String>['0', '1'];
+            // Having the '0' first is an invalid choice for a device, the second
+            // item in the list is a '2' which is out of range since we only have
+            // one item in the deviceList. The final item in the list, is '1'
+            // which is a valid option though which will return a valid device
+            //
+            // Important: if none of the values in the list are valid, the test will
+            // hang indefinitely since the [userSelectDevice()] method uses a while
+            // loop to listen for valid devices
+            targetDevices.deviceSelection.input = <String>['0', '2', '1'];
             logger.originalStatusText = '''
 Connected devices:
 target-device-9 (mobile) • xxx • ios • iOS 16

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -1829,6 +1829,12 @@ Please choose one (or "q" to quit): '''));
 
             targetDevices.waitForWirelessBeforeInput = true;
             targetDevices.deviceSelection.input = '2';
+
+            // Adding this additional prompt demonstrates that selecting
+            // `0` for the first option won't crash the tool, we will instead
+            // need to simulate typing into stdin again with the correct value
+            // which is `1` in this case
+            terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '0');
             terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
 
             final List<Device>? devices = await targetDevices.findAllTargetDevices();

--- a/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/target_devices_test.dart
@@ -1829,7 +1829,6 @@ Please choose one (or "q" to quit): '''));
 
             targetDevices.waitForWirelessBeforeInput = true;
             targetDevices.deviceSelection.input = '2';
-
             terminal.setPrompt(<String>['1', '2', 'q', 'Q'], '1');
 
             final List<Device>? devices = await targetDevices.findAllTargetDevices();


### PR DESCRIPTION
Prevent the cli from crashing when a user selects a number that is not valid for `flutter run` device selection

Fixes issue:
- https://github.com/flutter/flutter/issues/129191

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
