### PR TITLE
Reorders menu item button shortcuts on Mac-like platforms

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -3577,12 +3577,8 @@ bool _debugMenuInfo(String message, [Iterable<String>? details]) {
   return true;
 }
 
-/// Whether [defaultTargetPlatform] is one that uses symbolic shortcuts.
-///
-/// Mac and iOS use special symbols for modifier keys instead of their names,
-/// render them in a particular order defined by Apple's human interface
-/// guidelines, and format them so that the modifier keys always align.
-bool get _usesSymbolicModifiers {
+/// Whether [defaultTargetPlatform] is an Apple platform (Mac or iOS).
+bool get _isApple {
   switch (defaultTargetPlatform) {
     case TargetPlatform.iOS:
     case TargetPlatform.macOS:
@@ -3595,22 +3591,22 @@ bool get _usesSymbolicModifiers {
   }
 }
 
+/// Whether [defaultTargetPlatform] is one that uses symbolic shortcuts.
+///
+/// Mac and iOS use special symbols for modifier keys instead of their names,
+/// render them in a particular order defined by Apple's human interface
+/// guidelines, and format them so that the modifier keys always align.
+bool get _usesSymbolicModifiers {
+  return _isApple;
+}
+
 
 bool get _platformSupportsAccelerators {
-  switch (defaultTargetPlatform) {
-    case TargetPlatform.android:
-    case TargetPlatform.fuchsia:
-    case TargetPlatform.linux:
-    case TargetPlatform.windows:
-      return true;
-    case TargetPlatform.iOS:
-    case TargetPlatform.macOS:
-      // On iOS and macOS, pressing the Option key (a.k.a. the Alt key) causes a
-      // different set of characters to be generated, and the native menus don't
-      // support accelerators anyhow, so we just disable accelerators on these
-      // platforms.
-      return false;
-  }
+  // On iOS and macOS, pressing the Option key (a.k.a. the Alt key) causes a
+  // different set of characters to be generated, and the native menus don't
+  // support accelerators anyhow, so we just disable accelerators on these
+  // platforms.
+  return !_isApple;
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - Menu

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2944,7 +2944,17 @@ void main() {
         shift: true,
         alt: true,
       );
-      final String allExpected = <String>[expectedAlt, expectedCtrl, expectedMeta, expectedShift, 'A'].join(expectedSeparator);
+      late String allExpected;
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          allExpected = <String>[expectedAlt, expectedCtrl, expectedMeta, expectedShift, 'A'].join(expectedSeparator);
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          allExpected = <String>[expectedCtrl, expectedAlt, expectedShift, expectedMeta, 'A'].join(expectedSeparator);
+      }
       const CharacterActivator charShortcuts = CharacterActivator('ñ');
       const String charExpected = 'ñ';
       await tester.pumpWidget(


### PR DESCRIPTION
The Apple Human Interface Guidelines give a specific ordering of the symbols
used as modifier keys in menu shortcuts.  These guidelines are encoded into
the native Cocoa or UIKit menu classes, and are intended to ensure that symbols
are always aligned into columns of like symbols and do not move around in the
case of dynamic menu items (for example, holding Option will transform certain
menu items into different versions that take the Option key, so the Option key
symbol appears to the left of most other symbols to avoid reordering).

The Material spec says to use symbols for modifier keys on Mac and iOS, as this
is what users there are familiar with.  It stands to reason that we should
follow the platform guidelines fully, so this changes the MenuItemButton class
to honor the HIG-compliant symbol ordering on Mac and iOS.

Fixed: #129308

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
