### PR TITLE
`_TapStatusTrackerMixin` should wait until the next `PointerDownEvent` before resetting its state when the tap timer has elapsed

### DIFF
--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -896,6 +896,8 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
   bool _pastSlopTolerance = false;
   bool _sentTapDown = false;
   bool _wonArenaForPrimaryPointer = false;
+  PointerDownEvent? _localDown;
+  PointerUpEvent? _localUp;
 
   // Primary pointer being tracked by this recognizer.
   int? _primaryPointer;
@@ -966,6 +968,7 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
+    _localDown = event;
     if (_dragState == _DragState.ready) {
       super.addAllowedPointer(event);
       _primaryPointer = event.pointer;
@@ -999,8 +1002,8 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
     _acceptedActivePointers.add(pointer);
 
     // Called when this recognizer is accepted by the [GestureArena].
-    if (currentDown != null) {
-      _checkTapDown(currentDown!);
+    if (_localDown != null) {
+      _checkTapDown(_localDown!);
     }
 
     _wonArenaForPrimaryPointer = true;

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -542,7 +542,6 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
     super.addAllowedPointer(event);
     if (_consecutiveTapTimerHasElapsed) {
       _tapTrackerReset();
-      _consecutiveTapTimerHasElapsed = false;
     }
     if (maxConsecutiveTap == _consecutiveTapCount) {
       _tapTrackerReset();
@@ -659,6 +658,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
     _keysPressedOnDown = null;
     _down = null;
     _up = null;
+    _consecutiveTapTimerHasElapsed = false;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -491,7 +491,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   PointerUpEvent? get currentUp => _up;
 
   // The number of consecutive taps that the most recently tracked [PointerDownEvent]
-  // in [_down] represents.
+  // in [currentDown] represents.
   //
   // This value defaults to zero, meaning a tap series is not currently being tracked.
   //

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -471,7 +471,7 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   // Public state available to [OneSequenceGestureRecognizer].
 
   // The number of consecutive taps that the most recently tracked [PointerDownEvent]
-  // in [currentDown] represents.
+  // in [_down] represents.
   //
   // This value defaults to zero, meaning a tap series is not currently being tracked.
   //
@@ -948,9 +948,9 @@ sealed class BaseTapAndDragGestureRecognizer extends OneSequenceGestureRecognize
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
-    _localDown = event;
     if (_dragState == _DragState.ready) {
       super.addAllowedPointer(event);
+      _localDown = event;
       _primaryPointer = event.pointer;
       _globalDistanceMoved = 0.0;
       _globalDistanceMovedAllAxes = 0.0;

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -533,14 +533,13 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   // For timing taps.
   Timer? _consecutiveTapTimer;
   Offset? _lastTapOffset;
-  bool _consecutiveTapTimerHasElapsed = false;
 
   // When tracking a tap, the [consecutiveTapCount] is incremented if the given tap
   // falls under the tolerance specifications and reset to 1 if not.
   @override
   void addAllowedPointer(PointerDownEvent event) {
     super.addAllowedPointer(event);
-    if (_consecutiveTapTimerHasElapsed) {
+    if (_consecutiveTapTimer != null && !_consecutiveTapTimer!.isActive) {
       _tapTrackerReset();
     }
     if (maxConsecutiveTap == _consecutiveTapCount) {
@@ -638,11 +637,10 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
   }
 
   void _consecutiveTapTimerTimeout() {
-    // The consecutive tap timer may time out before a tap down/tap up event
-    // is fired. In this case we should not reset the tap tracker state immediately.
-    // Instead the `_consecutiveTapTimerHasElapsed` flag is used to determine
-    // if we should reset the tap tracker on the next call to [addAllowedPointer].
-    _consecutiveTapTimerHasElapsed = true;
+    // The consecutive tap timer may time out before a tap down/tap up event is
+    // fired. In this case we should not reset the tap tracker state immediately.
+    // Instead we should reset the tap tracker on the next call to [addAllowedPointer],
+    // if the timer is no longer active.
   }
 
   void _tapTrackerReset() {
@@ -658,7 +656,6 @@ mixin _TapStatusTrackerMixin on OneSequenceGestureRecognizer {
     _keysPressedOnDown = null;
     _down = null;
     _up = null;
-    _consecutiveTapTimerHasElapsed = false;
   }
 }
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2178,7 +2178,7 @@ void main() {
     await gesture.up();
     // This is to allow the GestureArena to decide a winner between TapGestureRecognizer,
     // DoubleTapGestureRecognizer, and BaseTapAndDragGestureRecognizer.
-    await tester.pumpAndSettle(Duration(milliseconds: 500));
+    await tester.pumpAndSettle(Duration(milliseconds: 300));
     expect(controller.selection.isCollapsed, true);
     expect(controller.selection.baseOffset, testValue.indexOf('e'));
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2178,7 +2178,7 @@ void main() {
     await gesture.up();
     // This is to allow the GestureArena to decide a winner between TapGestureRecognizer,
     // DoubleTapGestureRecognizer, and BaseTapAndDragGestureRecognizer.
-    await tester.pumpAndSettle(Duration(milliseconds: 300));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
     expect(controller.selection.isCollapsed, true);
     expect(controller.selection.baseOffset, testValue.indexOf('e'));
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2178,7 +2178,7 @@ void main() {
     await gesture.up();
     // This is to allow the GestureArena to decide a winner between TapGestureRecognizer,
     // DoubleTapGestureRecognizer, and BaseTapAndDragGestureRecognizer.
-    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle(kDoubleTapTimeout);
     expect(controller.selection.isCollapsed, true);
     expect(controller.selection.baseOffset, testValue.indexOf('e'));
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -2147,6 +2147,52 @@ void main() {
       variant: TargetPlatformVariant.mobile(),
   );
 
+  testWidgets('Can select text with a mouse when wrapped in a GestureDetector with tap/double tap callbacks', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/129161.
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: GestureDetector(
+            onTap: () {},
+            onDoubleTap: () {},
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    const String testValue = 'abc def ghi';
+    await tester.enterText(find.byType(TextField), testValue);
+    await skipPastScrollingAnimation(tester);
+
+    final Offset ePos = textOffsetToPosition(tester, testValue.indexOf('e'));
+    final Offset gPos = textOffsetToPosition(tester, testValue.indexOf('g'));
+
+    final TestGesture gesture = await tester.startGesture(ePos, kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    await gesture.up();
+    // This is to allow the GestureArena to decide a winner between TapGestureRecognizer,
+    // DoubleTapGestureRecognizer, and BaseTapAndDragGestureRecognizer.
+    await tester.pumpAndSettle(Duration(milliseconds: 500));
+    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.baseOffset, testValue.indexOf('e'));
+
+    await gesture.down(ePos);
+    await tester.pump();
+    await gesture.moveTo(gPos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(controller.selection.baseOffset, testValue.indexOf('e'));
+    expect(controller.selection.extentOffset, testValue.indexOf('g'));
+  }, variant: TargetPlatformVariant.desktop());
+
   testWidgets('Can select text by dragging with a mouse', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
 

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -694,6 +694,44 @@ void main() {
       'panend#2']);
   });
 
+  // This is a regression test for https://github.com/flutter/flutter/issues/129161.
+  testGesture('Beats TapGestureRecognizer and DoubleTapGestureRecognizer when the pointer has not moved and this recognizer is the first in the arena', (GestureTester tester) {
+    debugPrintGestureArenaDiagnostics = true;
+    setUpTapAndPanGestureRecognizer();
+
+    final TapGestureRecognizer taps = TapGestureRecognizer()
+      ..onTapDown = (TapDownDetails details) {
+        events.add('tapdown');
+      }
+      ..onTapUp =  (TapUpDetails details) {
+        events.add('tapup');
+      }
+      ..onTapCancel = () {
+        events.add('tapscancel');
+      };
+
+    final DoubleTapGestureRecognizer doubleTaps = DoubleTapGestureRecognizer()
+      ..onDoubleTapDown = (TapDownDetails details) {
+        events.add('doubletapdown');
+      }
+      ..onDoubleTap =  () {
+        events.add('doubletapup');
+      }
+      ..onDoubleTapCancel = () {
+        events.add('doubletapcancel');
+      };
+
+    tapAndDrag.addPointer(down1);
+    taps.addPointer(down1);
+    doubleTaps.addPointer(down1);
+    tester.closeArena(1);
+    tester.route(down1);
+    tester.route(up1);
+    GestureBinding.instance.gestureArena.sweep(1);
+    GestureBinding.instance.gestureArena.release(1);
+    expect(events, <String>['down#1', 'up#1']);
+  });
+
   testGesture('Beats TapGestureRecognizer when the pointer has not moved and this recognizer is the first in the arena', (GestureTester tester) {
     setUpTapAndPanGestureRecognizer();
 

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -728,7 +728,7 @@ void main() {
     tester.route(up1);
     GestureBinding.instance.gestureArena.sweep(1);
     // Wait for GestureArena to resolve itself.
-    tester.async.elapse(const Duration(milliseconds: 300));
+    tester.async.elapse(kDoubleTapTimeout);
     expect(events, <String>['down#1', 'up#1']);
   });
 

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -696,7 +696,6 @@ void main() {
 
   // This is a regression test for https://github.com/flutter/flutter/issues/129161.
   testGesture('Beats TapGestureRecognizer and DoubleTapGestureRecognizer when the pointer has not moved and this recognizer is the first in the arena', (GestureTester tester) {
-    debugPrintGestureArenaDiagnostics = true;
     setUpTapAndPanGestureRecognizer();
 
     final TapGestureRecognizer taps = TapGestureRecognizer()

--- a/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
+++ b/packages/flutter/test/widgets/tap_and_drag_gestures_test.dart
@@ -727,7 +727,8 @@ void main() {
     tester.route(down1);
     tester.route(up1);
     GestureBinding.instance.gestureArena.sweep(1);
-    GestureBinding.instance.gestureArena.release(1);
+    // Wait for GestureArena to resolve itself.
+    tester.async.elapse(const Duration(milliseconds: 300));
     expect(events, <String>['down#1', 'up#1']);
   });
 


### PR DESCRIPTION
`_TapStatusTrackerMixin` used by `BaseTapAndDragGestureRecognizer` should wait until the next tap down before resetting its state when the `_consecutiveTapTimer` times out. This is because `BaseTapAndDragGestureRecognizer` may not have fired its tap down/tap up event before the state has been reset preventing it from firing the tap down/tap up callbacks at all because `currentDown` and `currentUp` are reset to `null`.

Fixes #129161 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.