### PR TITLE
Add `onSubmitted` property to `SearchBar`

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1045,7 +1045,8 @@ class SearchBar extends StatefulWidget {
   /// Invoked upon user input.
   final ValueChanged<String>? onChanged;
 
-  /// {@macro flutter.widgets.editableText.onSubmitted}
+  /// Called when the user indicates that they are done editing the text in the
+  /// field.
   final ValueChanged<String>? onSubmitted;
 
   /// Optional size constraints for the search bar.

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -996,6 +996,7 @@ class SearchBar extends StatefulWidget {
     this.trailing,
     this.onTap,
     this.onChanged,
+    this.onSubmitted,
     this.constraints,
     this.elevation,
     this.backgroundColor,
@@ -1043,6 +1044,9 @@ class SearchBar extends StatefulWidget {
 
   /// Invoked upon user input.
   final ValueChanged<String>? onChanged;
+
+  /// {@macro flutter.widgets.editableText.onSubmitted}
+  final ValueChanged<String>? onSubmitted;
 
   /// Optional size constraints for the search bar.
   ///
@@ -1236,6 +1240,7 @@ class _SearchBarState extends State<SearchBar> {
                       child: TextField(
                         focusNode: _focusNode,
                         onChanged: widget.onChanged,
+                        onSubmitted: widget.onSubmitted,
                         controller: widget.controller,
                         style: effectiveTextStyle,
                         decoration: InputDecoration(

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -274,16 +274,12 @@ void main() {
     String submittedQuery = '';
     await tester.pumpWidget(
       MaterialApp(
-        home: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Material(
-                child: SearchBar(
-                  onSubmitted: (String text) {
-                    submittedQuery = text;
-                  },
-                ),
-              );
-            }
+        home: Material(
+          child: SearchBar(
+            onSubmitted: (String text) {
+              submittedQuery = text;
+            },
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -270,6 +270,30 @@ void main() {
     expect(changeCount, 2);
   });
 
+  testWidgets('SearchBar respects onSubmitted property', (WidgetTester tester) async {
+    String submittedQuery = '';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Material(
+                child: SearchBar(
+                  onSubmitted: (String text) {
+                    submittedQuery = text;
+                  },
+                ),
+              );
+            }
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(SearchBar), 'query');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+
+    expect(submittedQuery, equals('query'));
+  });
+
   testWidgets('SearchBar respects constraints property', (WidgetTester tester) async {
     const BoxConstraints constraints = BoxConstraints(maxWidth: 350.0, minHeight: 80);
     await tester.pumpWidget(


### PR DESCRIPTION
Fixes #126551

This PR is to add `onSubmitted` property to `SearchBar`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
