### PR TITLE
Updated TextMagnifierExampleApp to M3

### DIFF
--- a/examples/api/lib/widgets/text_magnifier/text_magnifier.0.dart
+++ b/examples/api/lib/widgets/text_magnifier/text_magnifier.0.dart
@@ -20,7 +20,7 @@ class TextMagnifierExampleApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(useMaterial3: false),
+      theme: ThemeData(useMaterial3: true),
       home: Scaffold(
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 48.0),


### PR DESCRIPTION
This change is part of "step 3" in https://github.com/flutter/flutter/issues/127064. 

Updated the TextMagnifierExampleApp to use Material3.
