### PR TITLE
Add r: timeout label to bugs/pr closed by no response bot.

### DIFF
--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -36,6 +36,7 @@ jobs:
           # Number of days of inactivity before an issue is closed for lack of response.
           days-before-stale: -1
           days-before-close: 21
+          close-issue-label: r: timeout
           # Label requiring a response.
           stale-issue-label: "waiting for customer response"
           stale-pr-label: "needs-info"
@@ -43,3 +44,4 @@ jobs:
             Without additional information we're not able to resolve this PR.
             Feel free to add more info or respond to any questions above.
             Thanks for your contribution!
+          close-pr-label: r: timeout

--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -36,7 +36,7 @@ jobs:
           # Number of days of inactivity before an issue is closed for lack of response.
           days-before-stale: -1
           days-before-close: 21
-          close-issue-label: r: timeout
+          close-issue-label: "r: timeout"
           # Label requiring a response.
           stale-issue-label: "waiting for customer response"
           stale-pr-label: "needs-info"
@@ -44,4 +44,4 @@ jobs:
             Without additional information we're not able to resolve this PR.
             Feel free to add more info or respond to any questions above.
             Thanks for your contribution!
-          close-pr-label: r: timeout
+          close-pr-label: "r: timeout"


### PR DESCRIPTION
Adds r: timeout to bugs closed by inactivity.

Bug: https://github.com/flutter/flutter/issues/104962


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
