### PR TITLE
Refactor JSNumber.toDart and Object.toJS

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -1336,9 +1336,7 @@ void registerEngineBenchmarkValueListener(String name, EngineBenchmarkValueListe
   if (_engineBenchmarkListeners.isEmpty) {
     // The first listener is being registered. Register the global listener.
     web.window['_flutter_internal_on_benchmark'.toJS] =
-        // Upcast to [Object] to export.
-        // ignore: unnecessary_cast
-        (_dispatchEngineBenchmarkValue as Object).toJS;
+        _dispatchEngineBenchmarkValue.toJS;
   }
   _engineBenchmarkListeners[name] = listener;
 }

--- a/packages/flutter/lib/src/services/dom.dart
+++ b/packages/flutter/lib/src/services/dom.dart
@@ -117,7 +117,7 @@ extension DomXMLHttpRequestExtension on DomXMLHttpRequest {
   external JSNumber? get _status;
 
   /// Gets the status.
-  int? get status => _status?.toDart.toInt();
+  int? get status => _status?.toDartInt;
 
   @JS('responseType')
   external set _responseType(JSString value);
@@ -184,13 +184,13 @@ extension DomProgressEventExtension on DomProgressEvent {
   external JSNumber? get _loaded;
 
   /// Amount of work done.
-  int? get loaded => _loaded?.toDart.toInt();
+  int? get loaded => _loaded?.toDartInt;
 
   @JS('total')
   external JSNumber? get _total;
 
   /// Total amount of work.
-  int? get total => _total?.toDart.toInt();
+  int? get total => _total?.toDartInt;
 }
 
 /// The underlying DOM document.
@@ -291,19 +291,19 @@ extension DomMouseEventExtension on DomMouseEvent {
   external JSNumber get _offsetX;
 
   /// Returns the current x offset.
-  num get offsetX => _offsetX.toDart;
+  num get offsetX => _offsetX.toDartDouble;
 
   @JS('offsetY')
   external JSNumber get _offsetY;
 
   /// Returns the current y offset.
-  num get offsetY => _offsetY.toDart;
+  num get offsetY => _offsetY.toDartDouble;
 
   @JS('button')
   external JSNumber get _button;
 
   /// Returns the current button.
-  int get button => _button.toDart.toInt();
+  int get button => _button.toDartInt;
 }
 
 /// A DOM selection.
@@ -394,9 +394,9 @@ extension DomCSSStyleSheetExtension on DomCSSStyleSheet {
   /// Inserts a rule into this style sheet.
   int insertRule(String rule, [int? index]) {
     if (index == null) {
-      return _insertRule1(rule.toJS).toDart.toInt();
+      return _insertRule1(rule.toJS).toDartInt;
     } else {
-      return _insertRule2(rule.toJS, index.toDouble().toJS).toDart.toInt();
+      return _insertRule2(rule.toJS, index.toJS).toDartInt;
     }
   }
 }

--- a/packages/flutter/test/painting/_test_http_request.dart
+++ b/packages/flutter/test/painting/_test_http_request.dart
@@ -43,8 +43,6 @@ class TestHttpRequest {
         setRequestHeader: setRequestHeader.toJS,
         addEventListener: addEventListener.toJS,
     );
-    // TODO(srujzs): This is needed for when we reify JS types. Right now, JSAny
-    // is a typedef for Object?, but when we reify, it'll be its own type.
     final JSAny mock = _mock as JSAny;
     createGetter(mock, 'headers', () => headers.jsify());
     createGetter(mock,


### PR DESCRIPTION
JSNumber.toDart will now be two functions: toDartDouble and toDartInt.

There was code that did an Object.toJS. This has been changed to
use Function.toJS as well to make it consistent with the code
in flutter/packages: https://github.com/flutter/packages/blob/0ef393811d0c2653e68ac135733353fcad8fffa9/packages/web_benchmarks/lib/src/recorder.dart#L1223

This is to help land this CL: https://dart-review.googlesource.com/c/sdk/+/309082

https://dart-review.googlesource.com/c/sdk/+/309081 is the CL that added the new methods.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
