### PR TITLE
Make bug templates more consistent

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_performance_others.md
+++ b/.github/ISSUE_TEMPLATE/4_performance_others.md
@@ -1,5 +1,5 @@
 ---
-name: My app has some non-speed performance issues.
+name: My app has some non-speed performance issues
 about: You are writing an application but have discovered that it uses too much memory, too much energy (e.g., CPU/GPU usage is high), or its app size is too large.
 title: ''
 labels: 'created via performance template'

--- a/.github/ISSUE_TEMPLATE/5_performance_speed.md
+++ b/.github/ISSUE_TEMPLATE/5_performance_speed.md
@@ -1,5 +1,5 @@
 ---
-name: My app is slow or missing frames.
+name: My app is slow or missing frames
 about: You are writing an application but have discovered that it is slow, you are
   not hitting 60Hz, or you are getting jank (missed frames).
 title: ''

--- a/.github/ISSUE_TEMPLATE/7_cherry_pick.yml
+++ b/.github/ISSUE_TEMPLATE/7_cherry_pick.yml
@@ -1,4 +1,4 @@
-name: Request a cherry-pick.
+name: Request a cherry-pick
 description: As a contributor, you would like to request that a feature be cherry-picked into a release.
 title: '[CP] <title>'
 labels: ['cp: review']

--- a/.github/ISSUE_TEMPLATE/8_design_doc.yml
+++ b/.github/ISSUE_TEMPLATE/8_design_doc.yml
@@ -1,4 +1,4 @@
-name: Share a Flutter design document.
+name: Share a Flutter design document
 description: As a contributor, I would like to share a design document.
 title: '[Design Document] <title>'
 labels: ['design doc']

--- a/.github/ISSUE_TEMPLATE/8_design_doc.yml
+++ b/.github/ISSUE_TEMPLATE/8_design_doc.yml
@@ -1,6 +1,5 @@
 name: Share a Flutter design document
 description: As a contributor, I would like to share a design document.
-title: '[Design Document] <title>'
 labels: ['design doc']
 body:
   - type: markdown
@@ -18,7 +17,8 @@ body:
     attributes:
       label: Document Link
       description: |
-        Insert the 'flutter.dev/go' for your document here, as referenced in
+        Insert the "https://flutter.dev/go" link for your document here.
+        For details on creating a link, see the instructions in
         https://flutter.dev/go/template
     validations:
       required: true


### PR DESCRIPTION
* remove trailing periods in template titles
* tweak the design doc template a little based on testing it out