### PR TITLE
Automatically migrate ClipboardData.text to non-null

### DIFF
--- a/packages/flutter/lib/fix_data/fix_services.yaml
+++ b/packages/flutter/lib/fix_data/fix_services.yaml
@@ -18,6 +18,20 @@
 # * Fixes in this file are from the Services library. *
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/122446
+  - title: "Migrate to empty 'text' string"
+    date: 2023-06-26
+    element:
+      uris: [ 'services.dart' ]
+      constructor: ''
+      inClass: 'ClipboardData'
+    changes:
+      - kind: 'changeParameterType'
+        name: 'text'
+        nullability: 'non_null'
+        argumentValue:
+          expression: "''"
+
   # Changes made in https://github.com/flutter/flutter/pull/60320
   - title: "Migrate to 'viewId'"
     date: 2020-07-05

--- a/packages/flutter/test_fixes/services/services.dart
+++ b/packages/flutter/test_fixes/services/services.dart
@@ -5,6 +5,10 @@
 import 'package:flutter/services.dart';
 
 void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/122446
+  final clipboardData1 = ClipboardData();
+  final clipboardData2 = ClipboardData(text: null);
+
   // Changes made in https://github.com/flutter/flutter/pull/60320
   final SurfaceAndroidViewController surfaceController = SurfaceAndroidViewController(
       viewId: 10,

--- a/packages/flutter/test_fixes/services/services.dart.expect
+++ b/packages/flutter/test_fixes/services/services.dart.expect
@@ -5,6 +5,10 @@
 import 'package:flutter/services.dart';
 
 void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/122446
+  final clipboardData1 = ClipboardData(text: '');
+  final clipboardData2 = ClipboardData(text: '');
+
   // Changes made in https://github.com/flutter/flutter/pull/60320
   final SurfaceAndroidViewController surfaceController = SurfaceAndroidViewController(
       viewId: 10,


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/122446 was a breaking change in Flutter 3.10 that made the `ClipboardData` constructor's `text` argument a required non-nullable argument. This leverages `dart fix`'s new automatic migration to, well, automatically migrate affected users.

Manual migration docs: https://docs.flutter.dev/release/breaking-changes/clipboard-data-required

Follow-up to https://github.com/flutter/flutter/pull/122446
Part of https://github.com/flutter/flutter/issues/121976

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
