### PR TITLE
Dev, examples/api, etc updated for Material 3 by default

### DIFF
--- a/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
+++ b/dev/automated_tests/flutter_test/print_correct_local_widget_test.dart
@@ -10,6 +10,7 @@ void main() {
     // This should fail with user created widget = Row.
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(
             title: const Text('RenderFlex OverFlow'),

--- a/dev/benchmarks/test_apps/stocks/lib/main.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/main.dart
@@ -50,11 +50,13 @@ class StocksAppState extends State<StocksApp> {
     switch (_configuration.stockMode) {
       case StockMode.optimistic:
         return ThemeData(
+          useMaterial3: false,
           brightness: Brightness.light,
           primarySwatch: Colors.purple,
         );
       case StockMode.pessimistic:
         return ThemeData(
+          useMaterial3: false,
           brightness: Brightness.dark,
           primarySwatch: Colors.purple,
         );

--- a/dev/integration_tests/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/contacts_demo.dart
@@ -104,6 +104,7 @@ class ContactsDemoState extends State<ContactsDemo> {
   Widget build(BuildContext context) {
     return Theme(
       data: ThemeData(
+        useMaterial3: false,
         brightness: Brightness.light,
         primarySwatch: Colors.indigo,
         platform: Theme.of(context).platform,

--- a/dev/integration_tests/flutter_gallery/lib/gallery/themes.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/themes.dart
@@ -26,6 +26,7 @@ ThemeData _buildDarkTheme() {
     background: const Color(0xFF202124),
   );
   final ThemeData base = ThemeData(
+    useMaterial3: false,
     brightness: Brightness.dark,
     colorScheme: colorScheme,
     primaryColor: primaryColor,
@@ -50,6 +51,7 @@ ThemeData _buildLightTheme() {
     error: const Color(0xFFB00020),
   );
   final ThemeData base = ThemeData(
+    useMaterial3: false,
     brightness: Brightness.light,
     colorScheme: colorScheme,
     primaryColor: primaryColor,

--- a/dev/integration_tests/flutter_gallery/test/accessibility_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/accessibility_test.dart
@@ -8,235 +8,249 @@ import 'package:flutter_gallery/gallery/app.dart';
 import 'package:flutter_gallery/gallery/themes.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+class TestMaterialApp extends StatelessWidget {
+  const TestMaterialApp({ super.key, required this.home });
+
+  final Widget home;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: false),
+      home: home,
+    );
+  }
+}
+
 void main() {
   group('All material demos meet recommended tap target sizes', () {
     testWidgets('backdrop_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: BackdropDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: BackdropDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('bottom_app_bar_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: BottomAppBarDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: BottomAppBarDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('bottom_navigation_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: BottomNavigationDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: BottomNavigationDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('buttons_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ButtonsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ButtonsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('cards_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: CardsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: CardsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('chip_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ChipDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ChipDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     }, skip: true); // https://github.com/flutter/flutter/issues/42455
 
     testWidgets('data_table_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DataTableDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DataTableDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('date_and_time_picker_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DateAndTimePickerDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DateAndTimePickerDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('dialog_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DialogDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DialogDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('drawer_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DrawerDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DrawerDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('elevation_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ElevationDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ElevationDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('expansion_panels_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ExpansionPanelsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ExpansionPanelsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('grid_list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: GridListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: GridListDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('icons_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: IconsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: IconsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('leave_behind_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: LeaveBehindDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: LeaveBehindDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ListDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('menu_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: MenuDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: MenuDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('modal_bottom_sheet_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ModalBottomSheetDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ModalBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('overscroll_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: OverscrollDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: OverscrollDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('page_selector_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: PageSelectorDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: PageSelectorDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('persistent_bottom_sheet_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: PersistentBottomSheetDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: PersistentBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('progress_indicator_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ProgressIndicatorDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ProgressIndicatorDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('reorderable_list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ReorderableListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ReorderableListDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('scrollable_tabs_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ScrollableTabsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ScrollableTabsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('search_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SearchDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SearchDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('selection_controls_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SelectionControlsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SelectionControlsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('slider_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SliderDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SliderDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('snack_bar_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SnackBarDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SnackBarDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('tabs_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TabsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TabsDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('tabs_fab_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TabsFabDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TabsFabDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('text_form_field_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TextFormFieldDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TextFormFieldDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('tooltip_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TooltipDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TooltipDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('expansion_tile_list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ExpansionTileListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ExpansionTileListDemo()));
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       handle.dispose();
     });
@@ -245,231 +259,231 @@ void main() {
   group('All material demos have labeled tap targets', () {
     testWidgets('backdrop_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: BackdropDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: BackdropDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('bottom_app_bar_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: BottomAppBarDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: BottomAppBarDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('bottom_navigation_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: BottomNavigationDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: BottomNavigationDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('buttons_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ButtonsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ButtonsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('cards_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: CardsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: CardsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('chip_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ChipDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ChipDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('data_table_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DataTableDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DataTableDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     }, skip: true); // DataTables are not accessible, https://github.com/flutter/flutter/issues/10830
 
     testWidgets('date_and_time_picker_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DateAndTimePickerDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DateAndTimePickerDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('dialog_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DialogDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DialogDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('drawer_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: DrawerDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: DrawerDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('elevation_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ElevationDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ElevationDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('expansion_panels_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ExpansionPanelsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ExpansionPanelsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('grid_list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: GridListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: GridListDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('icons_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: IconsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: IconsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('leave_behind_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: LeaveBehindDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: LeaveBehindDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ListDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('menu_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: MenuDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: MenuDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('modal_bottom_sheet_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ModalBottomSheetDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ModalBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('overscroll_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: OverscrollDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: OverscrollDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('page_selector_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: PageSelectorDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: PageSelectorDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('persistent_bottom_sheet_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: PersistentBottomSheetDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: PersistentBottomSheetDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('progress_indicator_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ProgressIndicatorDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ProgressIndicatorDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('reorderable_list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ReorderableListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ReorderableListDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('scrollable_tabs_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ScrollableTabsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ScrollableTabsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('search_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SearchDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SearchDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('selection_controls_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SelectionControlsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SelectionControlsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('slider_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SliderDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SliderDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('snack_bar_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: SnackBarDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: SnackBarDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('tabs_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TabsDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TabsDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('tabs_fab_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TabsFabDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TabsFabDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('text_form_field_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TextFormFieldDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TextFormFieldDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('tooltip_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: TooltipDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: TooltipDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });
 
     testWidgets('expansion_tile_list_demo', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(const MaterialApp(home: ExpansionTileListDemo()));
+      await tester.pumpWidget(const TestMaterialApp(home: ExpansionTileListDemo()));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       handle.dispose();
     });

--- a/dev/integration_tests/flutter_gallery/test/demo/material/buttons_demo_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/demo/material/buttons_demo_test.dart
@@ -10,7 +10,7 @@ void main() {
   testWidgets('Button locations are OK', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/pull/85351
     {
-      await tester.pumpWidget(const MaterialApp(home: ButtonsDemo()));
+      await tester.pumpWidget(MaterialApp(theme: ThemeData(useMaterial3: false), home: const ButtonsDemo()));
       expect(find.byType(ElevatedButton).evaluate().length, 2);
       final Offset topLeft1 = tester.getTopLeft(find.byType(ElevatedButton).first);
       final Offset topLeft2 = tester.getTopLeft(find.byType(ElevatedButton).last);

--- a/examples/api/lib/services/binding/handle_request_app_exit.0.dart
+++ b/examples/api/lib/services/binding/handle_request_app_exit.0.dart
@@ -79,30 +79,29 @@ class _BodyState extends State<Body> with WidgetsBindingObserver {
     return Center(
       child: SizedBox(
         width: 300,
-        child: IntrinsicHeight(
-          child: Column(
-            children: <Widget>[
-              RadioListTile<bool>(
-                title: const Text('Do Not Allow Exit'),
-                groupValue: _shouldExit,
-                value: false,
-                onChanged: _radioChanged,
-              ),
-              RadioListTile<bool>(
-                title: const Text('Allow Exit'),
-                groupValue: _shouldExit,
-                value: true,
-                onChanged: _radioChanged,
-              ),
-              const SizedBox(height: 30),
-              ElevatedButton(
-                onPressed: _quit,
-                child: const Text('Quit'),
-              ),
-              const SizedBox(height: 30),
-              Text(lastResponse),
-            ],
-          ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            RadioListTile<bool>(
+              title: const Text('Do Not Allow Exit'),
+              groupValue: _shouldExit,
+              value: false,
+              onChanged: _radioChanged,
+            ),
+            RadioListTile<bool>(
+              title: const Text('Allow Exit'),
+              groupValue: _shouldExit,
+              value: true,
+              onChanged: _radioChanged,
+            ),
+            const SizedBox(height: 30),
+            ElevatedButton(
+              onPressed: _quit,
+              child: const Text('Quit'),
+            ),
+            const SizedBox(height: 30),
+            Text(lastResponse),
+          ],
         ),
       ),
     );

--- a/examples/api/lib/widgets/heroes/hero.1.dart
+++ b/examples/api/lib/widgets/heroes/hero.1.dart
@@ -18,8 +18,9 @@ class HeroApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: HeroExample(),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const HeroExample(),
     );
   }
 }

--- a/examples/api/lib/widgets/implicit_animations/animated_slide.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_slide.0.dart
@@ -13,8 +13,9 @@ class AnimatedSlideApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: AnimatedSlideExample(),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const AnimatedSlideExample(),
     );
   }
 }

--- a/examples/api/test/widgets/heroes/hero.1_test.dart
+++ b/examples/api/test/widgets/heroes/hero.1_test.dart
@@ -22,7 +22,7 @@ void main() {
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
     heroSize = tester.getSize(find.byType(Container).first);
-    expect(heroSize.width.roundToDouble(), 171.0);
+    expect(heroSize.width.roundToDouble(), 170.0);
     expect(heroSize.height.roundToDouble(), 73.0);
 
     // Jump to 50% into the transition.
@@ -61,7 +61,7 @@ void main() {
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
     heroSize = tester.getSize(find.byType(Container).first);
-    expect(heroSize.width.roundToDouble(), 171.0);
+    expect(heroSize.width.roundToDouble(), 170.0);
     expect(heroSize.height.roundToDouble(), 73.0);
 
     // Jump to 100% into the transition.

--- a/examples/api/test/widgets/implicit_animations/animated_slide.0_test.dart
+++ b/examples/api/test/widgets/implicit_animations/animated_slide.0_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     logoOffset = tester.getCenter(find.byType(FlutterLogo));
     expect(logoOffset.dx.roundToDouble(), 376.0);
-    expect(logoOffset.dy.roundToDouble(), 140.0);
+    expect(logoOffset.dy.roundToDouble(), 137.0);
 
     // Test X axis slider.
     final Offset x = tester.getCenter(find.text('X'));
@@ -32,6 +32,6 @@ void main() {
 
     logoOffset = tester.getCenter(find.byType(FlutterLogo));
     expect(logoOffset.dx.roundToDouble(), 178.0);
-    expect(logoOffset.dy.roundToDouble(), 140.0);
+    expect(logoOffset.dy.roundToDouble(), 137.0);
   });
 }

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -439,7 +439,7 @@ class ThemeData with Diagnosticable {
     pageTransitionsTheme ??= const PageTransitionsTheme();
     scrollbarTheme ??= const ScrollbarThemeData();
     visualDensity ??= VisualDensity.defaultDensityForPlatform(platform);
-    useMaterial3 ??= false;
+    useMaterial3 ??= true;
     final bool useInkSparkle = platform == TargetPlatform.android && !kIsWeb;
     splashFactory ??= useMaterial3
       ? useInkSparkle ? InkSparkle.splashFactory : InkRipple.splashFactory

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -439,7 +439,7 @@ class ThemeData with Diagnosticable {
     pageTransitionsTheme ??= const PageTransitionsTheme();
     scrollbarTheme ??= const ScrollbarThemeData();
     visualDensity ??= VisualDensity.defaultDensityForPlatform(platform);
-    useMaterial3 ??= true;
+    useMaterial3 ??= false;
     final bool useInkSparkle = platform == TargetPlatform.android && !kIsWeb;
     splashFactory ??= useMaterial3
       ? useInkSparkle ? InkSparkle.splashFactory : InkRipple.splashFactory

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -463,6 +463,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: Row(
               crossAxisAlignment: CrossAxisAlignment.baseline,
@@ -517,6 +518,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: Row(
               crossAxisAlignment: CrossAxisAlignment.baseline,

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -41,7 +41,7 @@ void main() {
           colorFilter: sepia,
           child: MaterialApp(
             title: 'Flutter Demo',
-            theme: ThemeData(primarySwatch: Colors.blue),
+            theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: false),
             home: Scaffold(
               appBar: AppBar(
                 title: const Text('Sepia ColorFilter Test'),

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -927,6 +927,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Padding(
           padding: const EdgeInsets.only(top: 0.25),
           child: Material(

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -95,7 +95,7 @@ void main() {
           imageFilter: matrix,
           child: MaterialApp(
             title: 'Flutter Demo',
-            theme: ThemeData(primarySwatch: Colors.blue),
+            theme: ThemeData(useMaterial3: false, primarySwatch: Colors.blue),
             home: Scaffold(
               appBar: AppBar(
                 title: const Text('Matrix ImageFilter Test'),
@@ -132,7 +132,7 @@ void main() {
             imageFilter: matrixFilter,
             child: MaterialApp(
               title: 'Flutter Demo',
-              theme: ThemeData(primarySwatch: Colors.blue),
+              theme: ThemeData(useMaterial3: false, primarySwatch: Colors.blue),
               home: Scaffold(
                 appBar: AppBar(
                   title: const Text('Matrix ImageFilter Test'),

--- a/packages/flutter/test/widgets/list_view_viewporting_test.dart
+++ b/packages/flutter/test/widgets/list_view_viewporting_test.dart
@@ -231,7 +231,7 @@ void main() {
 
   testWidgets('ListView reinvoke builders', (WidgetTester tester) async {
     late StateSetter setState;
-    ThemeData themeData = ThemeData.light();
+    ThemeData themeData = ThemeData.light(useMaterial3: false);
 
     Widget itemBuilder(BuildContext context, int index) {
       return Container(
@@ -263,7 +263,7 @@ void main() {
     expect(widget.color, equals(Colors.blue));
 
     setState(() {
-      themeData = ThemeData(primarySwatch: Colors.green);
+      themeData = ThemeData(primarySwatch: Colors.green, useMaterial3: false);
     });
 
     await tester.pump();

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -32,17 +32,8 @@ Widget buildTest({
   Key? key,
   bool expanded = true,
 }) {
-  return Localizations(
-    locale: const Locale('en', 'US'),
-    delegates: const <LocalizationsDelegate<dynamic>>[
-      DefaultMaterialLocalizations.delegate,
-      DefaultWidgetsLocalizations.delegate,
-    ],
-    child: Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(),
-        child: Scaffold(
+  return MaterialApp(
+        home: Scaffold(
           drawerDragStartBehavior: DragStartBehavior.down,
           body: DefaultTabController(
             length: 4,
@@ -114,8 +105,6 @@ Widget buildTest({
             ),
           ),
         ),
-      ),
-    ),
   );
 }
 
@@ -577,7 +566,7 @@ void main() {
     const List<String> tabs = <String>['Hello', 'World'];
     int buildCount = 0;
     await tester.pumpWidget(
-      MaterialApp(home: Material(child:
+      MaterialApp(theme: ThemeData(useMaterial3: false), home: Material(child:
         // THE FOLLOWING SECTION IS FROM THE NestedScrollView DOCUMENTATION
         // (EXCEPT FOR THE CHANGES TO THE buildCount COUNTER)
         DefaultTabController(
@@ -2274,6 +2263,7 @@ void main() {
     // Regression tests for https://github.com/flutter/flutter/issues/17096
     Widget buildBallisticTest(ScrollController controller) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: NestedScrollView(
             controller: controller,

--- a/packages/flutter/test/widgets/opacity_test.dart
+++ b/packages/flutter/test/widgets/opacity_test.dart
@@ -155,6 +155,7 @@ void main() {
   testWidgets('offset is correctly handled in Opacity', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: SingleChildScrollView(
             child: RepaintBoundary(

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -47,20 +47,23 @@ void main() {
   testWidgets('PhysicalModel - clips when overflows and elevation is 0', (WidgetTester tester) async {
     const Key key = Key('test');
     await tester.pumpWidget(
-      const MediaQuery(
-        key: key,
-        data: MediaQueryData(),
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Padding(
-            padding: EdgeInsets.all(50),
-            child: Row(
-              children: <Widget>[
-                Material(child: Text('A long long long long long long long string')),
-                Material(child: Text('A long long long long long long long string')),
-                Material(child: Text('A long long long long long long long string')),
-                Material(child: Text('A long long long long long long long string')),
-              ],
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: const MediaQuery(
+          key: key,
+          data: MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Padding(
+              padding: EdgeInsets.all(50),
+              child: Row(
+                children: <Widget>[
+                  Material(child: Text('A long long long long long long long string')),
+                  Material(child: Text('A long long long long long long long string')),
+                  Material(child: Text('A long long long long long long long string')),
+                  Material(child: Text('A long long long long long long long string')),
+                ],
+              ),
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -158,6 +158,7 @@ void main() {
   testWidgets('select to scroll works for small scrollable', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: SelectionArea(
         selectionControls: materialTextSelectionControls,
         child: Scaffold(

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -947,6 +947,7 @@ void main() {
     final ScrollController outerController = ScrollController();
     final ScrollController innerController = ScrollController();
     await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: false),
       home: Scaffold(
         body: SingleChildScrollView(
           controller: outerController,

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1248,6 +1248,7 @@ void main() {
       final UniqueKey outerText = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: SelectableRegion(
             focusNode: FocusNode(),
             selectionControls: materialTextSelectionControls,

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -59,20 +59,23 @@ Widget overlay({ Widget? child }) {
 }
 
 Widget overlayWithEntry(OverlayEntry entry) {
-  return Localizations(
-    locale: const Locale('en', 'US'),
-    delegates: <LocalizationsDelegate<dynamic>>[
-      WidgetsLocalizationsDelegate(),
-      MaterialLocalizationsDelegate(),
-    ],
-    child: Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(size: Size(800.0, 600.0)),
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            entry,
-          ],
+  return Theme(
+    data: ThemeData(useMaterial3: false),
+    child: Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: <LocalizationsDelegate<dynamic>>[
+        WidgetsLocalizationsDelegate(),
+        MaterialLocalizationsDelegate(),
+      ],
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(800.0, 600.0)),
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              entry,
+            ],
+          ),
         ),
       ),
     ),
@@ -80,25 +83,29 @@ Widget overlayWithEntry(OverlayEntry entry) {
 }
 
 Widget boilerplate({ Widget? child }) {
-  return Localizations(
-    locale: const Locale('en', 'US'),
-    delegates: <LocalizationsDelegate<dynamic>>[
-      WidgetsLocalizationsDelegate(),
-      MaterialLocalizationsDelegate(),
-    ],
-    child: Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(size: Size(800.0, 600.0)),
-        child: Center(
-          child: Material(
-            child: child,
+  return Theme(
+    data: ThemeData(useMaterial3: false),
+    child:Localizations(
+      locale: const Locale('en', 'US'),
+      delegates: <LocalizationsDelegate<dynamic>>[
+        WidgetsLocalizationsDelegate(),
+        MaterialLocalizationsDelegate(),
+      ],
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(800.0, 600.0)),
+          child: Center(
+            child: Material(
+              child: child,
+            ),
           ),
         ),
       ),
     ),
   );
 }
+
 
 Future<void> skipPastScrollingAnimation(WidgetTester tester) async {
   await tester.pump();
@@ -4130,7 +4137,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText('something'),
@@ -4153,7 +4160,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -4174,7 +4181,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -4200,7 +4207,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -4224,7 +4231,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -4256,7 +4263,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -4285,7 +4292,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -4314,7 +4321,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
           home: const Material(
             child: Center(
               child: SelectableText(
@@ -5019,6 +5026,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Center(
             child: SelectableText(
@@ -5186,6 +5194,7 @@ void main() {
   testWidgets('keeps alive when has focus', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: DefaultTabController(
           length: 2,
           child: Scaffold(
@@ -5349,8 +5358,9 @@ void main() {
     const TextStyle textStyle = TextStyle(color: Color(0xff00ff00), fontSize: 12.0);
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: SelectableText.rich(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: const SelectableText.rich(
           TextSpan(
             text: 'Abcd',
             style: textStyle,
@@ -5369,6 +5379,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: SelectableText(
           'I love Flutter!',
           onSelectionChanged: (TextSelection s, _) {
@@ -5408,6 +5419,7 @@ void main() {
     TextSelection? selection;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: Builder(
             builder: (BuildContext context) {

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -24,6 +24,7 @@ void main() {
     }) {
     return MaterialApp(
       theme:  ThemeData(
+        useMaterial3: false,
         materialTapTargetSize: MaterialTapTargetSize.padded,
       ),
       home: Scaffold(

--- a/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
@@ -244,35 +244,25 @@ void main() {
   testWidgets('Sliver appbars - floating and pinned - second app bar stacks below', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
-      Localizations(
-        locale: const Locale('en', 'us'),
-        delegates: const <LocalizationsDelegate<dynamic>>[
-          DefaultWidgetsLocalizations.delegate,
-          DefaultMaterialLocalizations.delegate,
-        ],
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: CustomScrollView(
-              controller: controller,
-              slivers: <Widget>[
-                const SliverAppBar(floating: true, pinned: true, expandedHeight: 200.0, title: Text('A')),
-                const SliverAppBar(primary: false, pinned: true, title: Text('B')),
-                SliverList(
-                  delegate: SliverChildListDelegate(
-                    const <Widget>[
-                      Text('C'),
-                      Text('D'),
-                      SizedBox(height: 500.0),
-                      Text('E'),
-                      SizedBox(height: 500.0),
-                    ],
-                  ),
-                ),
-              ],
+      MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: CustomScrollView(
+          controller: controller,
+          slivers: <Widget>[
+            const SliverAppBar(floating: true, pinned: true, expandedHeight: 200.0, title: Text('A')),
+            const SliverAppBar(primary: false, pinned: true, title: Text('B')),
+            SliverList(
+              delegate: SliverChildListDelegate(
+                const <Widget>[
+                  Text('C'),
+                  Text('D'),
+                  SizedBox(height: 500.0),
+                  Text('E'),
+                  SizedBox(height: 500.0),
+                ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -426,6 +426,7 @@ void main() {
       }
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: CustomScrollView(
               slivers: <Widget> [

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -520,7 +520,7 @@ void main() {
 
   testWidgets('Text Inline widget', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Center(
+      Theme(data: ThemeData(useMaterial3: false), child: Center(
         child: RepaintBoundary(
           child: Material(
             child: Directionality(
@@ -604,7 +604,7 @@ void main() {
             ),
           ),
         ),
-      ),
+      )),
     );
     await expectLater(
       find.byType(Container),

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -191,6 +191,7 @@ void main() {
   testWidgets('Text Fade', (WidgetTester tester) async {
     await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             backgroundColor: Colors.transparent,
             body: RepaintBoundary(
@@ -616,6 +617,7 @@ void main() {
     await tester.pumpWidget(
       Center(
         child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: RepaintBoundary(
             child: Material(
               child: Container(
@@ -662,6 +664,7 @@ void main() {
     await tester.pumpWidget(
       Center(
         child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: RepaintBoundary(
             child: Material(
               child: Container(

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -208,6 +208,7 @@ void main() {
     double textScaleFactor = 1.0;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(title: const Text('title')),
           body: Center(
@@ -236,6 +237,7 @@ void main() {
     textScaleFactor = textScaleFactor * 5;
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           appBar: AppBar(title: const Text('title')),
           body: Center(
@@ -1132,6 +1134,7 @@ void main() {
     Future<void> createText(TextWidthBasis textWidthBasis) {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: Center(
               // Each word takes up more than a half of a line. Together they

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -46,6 +46,7 @@ Widget simpleBuilderTest({
   bool setLayoutOffset = true,
 }) {
   return MaterialApp(
+    theme: ThemeData(useMaterial3: false),
     restorationScopeId: restorationID,
     home: Scaffold(
       body: SimpleBuilderTableView(


### PR DESCRIPTION
Updated tests in dev, examples/api, and tests/widgets to ensure that they continue to pass when the default for `ThemeData.useMaterial3` is changed to true.

This is the final set of changes required for https://github.com/flutter/flutter/issues/127064.

Based on https://github.com/flutter/flutter/pull/127501, which was presubmit tested with `useMaterial3: true`.