### PR TITLE
Make `DropdownMenu` be able to scroll to the highlighted item when searching.

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -132,6 +132,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.selectedTrailingIcon,
     this.enableFilter = false,
     this.enableSearch = true,
+    this.enableScrollToHighlight = true,
     this.textStyle,
     this.inputDecorationTheme,
     this.menuStyle,
@@ -139,7 +140,6 @@ class DropdownMenu<T> extends StatefulWidget {
     this.initialSelection,
     this.onSelected,
     this.requestFocusOnTap,
-    this.enableScrollToHighlight = true,
     required this.dropdownMenuEntries,
   });
 

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -132,7 +132,6 @@ class DropdownMenu<T> extends StatefulWidget {
     this.selectedTrailingIcon,
     this.enableFilter = false,
     this.enableSearch = true,
-    this.enableScrollToHighlight = true,
     this.textStyle,
     this.inputDecorationTheme,
     this.menuStyle,
@@ -226,12 +225,6 @@ class DropdownMenu<T> extends StatefulWidget {
   ///
   /// Defaults to true as the search function could be commonly used.
   final bool enableSearch;
-
-  /// Determine whether the scrollable menu list can automatically scroll to the first
-  /// matching item. This will be ignored if [enableSearch] is false.
-  ///
-  /// Defaults to true.
-  final bool enableScrollToHighlight;
 
   /// The text style for the [TextField] of the [DropdownMenu];
   ///
@@ -522,9 +515,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
     if (widget.enableSearch) {
       currentHighlight = search(filteredEntries, _textEditingController);
-      if (widget.enableScrollToHighlight) {
-        scrollToHighlight();
-      }
+      scrollToHighlight();
     }
 
     final List<Widget> menu = _buildButtons(filteredEntries, _textEditingController, textDirection, focusedIndex: currentHighlight);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -139,7 +139,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.initialSelection,
     this.onSelected,
     this.requestFocusOnTap,
-    this.isScrollableToHighlight = true,
+    this.enableScrollToHighlight = true,
     required this.dropdownMenuEntries,
   });
 
@@ -227,6 +227,12 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Defaults to true as the search function could be commonly used.
   final bool enableSearch;
 
+  /// Determine whether the menu list can automatically scroll to the first
+  /// matching item. This will be ignored if [enableSearch] is false.
+  ///
+  /// Defaults to true.
+  final bool enableScrollToHighlight;
+
   /// The text style for the [TextField] of the [DropdownMenu];
   ///
   /// Defaults to the overall theme's [TextTheme.labelLarge]
@@ -277,9 +283,6 @@ class DropdownMenu<T> extends StatefulWidget {
   /// is provided. If this is an empty list, the menu will be empty and only
   /// contain space for padding.
   final List<DropdownMenuEntry<T>> dropdownMenuEntries;
-
-  ///
-  final bool isScrollableToHighlight;
 
   @override
   State<DropdownMenu<T>> createState() => _DropdownMenuState<T>();
@@ -519,7 +522,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
     if (widget.enableSearch) {
       currentHighlight = search(filteredEntries, _textEditingController);
-      if (widget.isScrollableToHighlight) {
+      if (widget.enableScrollToHighlight) {
         scrollToHighlight();
       }
     }

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -315,7 +315,13 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   @override
   void didUpdateWidget(DropdownMenu<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.enableSearch != widget.enableSearch) {
+      if (!widget.enableSearch) {
+        currentHighlight = null;
+      }
+    }
     if (oldWidget.dropdownMenuEntries != widget.dropdownMenuEntries) {
+      currentHighlight = null;
       filteredEntries = widget.dropdownMenuEntries;
       buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
       _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
@@ -360,10 +366,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
   void scrollToHighlight() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (currentHighlight != null && buttonItemKeys[currentHighlight!].currentContext != null) {
-        Scrollable.ensureVisible(
-          buttonItemKeys[currentHighlight!].currentContext!
-        );
+      final BuildContext? highlightContext = buttonItemKeys[currentHighlight!].currentContext;
+      if (highlightContext != null) {
+        Scrollable.ensureVisible(highlightContext);
       }
     });
   }
@@ -515,7 +520,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
     if (widget.enableSearch) {
       currentHighlight = search(filteredEntries, _textEditingController);
-      scrollToHighlight();
+      if (currentHighlight != null) {
+        scrollToHighlight();
+      }
     }
 
     final List<Widget> menu = _buildButtons(filteredEntries, _textEditingController, textDirection, focusedIndex: currentHighlight);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -139,6 +139,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.initialSelection,
     this.onSelected,
     this.requestFocusOnTap,
+    this.isScrollableToHighlight = true,
     required this.dropdownMenuEntries,
   });
 
@@ -277,6 +278,8 @@ class DropdownMenu<T> extends StatefulWidget {
   /// contain space for padding.
   final List<DropdownMenuEntry<T>> dropdownMenuEntries;
 
+  final bool isScrollableToHighlight;
+
   @override
   State<DropdownMenu<T>> createState() => _DropdownMenuState<T>();
 }
@@ -284,6 +287,7 @@ class DropdownMenu<T> extends StatefulWidget {
 class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   final GlobalKey _anchorKey = GlobalKey();
   final GlobalKey _leadingKey = GlobalKey();
+  late List<GlobalKey> buttonItemKeys;
   final MenuController _controller = MenuController();
   late final TextEditingController _textEditingController;
   late bool _enableFilter;
@@ -299,6 +303,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     _textEditingController = widget.controller ?? TextEditingController();
     _enableFilter = widget.enableFilter;
     filteredEntries = widget.dropdownMenuEntries;
+    buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
     _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
 
     final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
@@ -314,6 +319,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   void didUpdateWidget(DropdownMenu<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.dropdownMenuEntries != widget.dropdownMenuEntries) {
+      filteredEntries = widget.dropdownMenuEntries;
+      buttonItemKeys = List<GlobalKey>.generate(filteredEntries.length, (int index) => GlobalKey());
       _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
     }
     if (oldWidget.leadingIcon != widget.leadingIcon) {
@@ -354,11 +361,23 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     });
   }
 
+  void scrollToHighlight() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (currentHighlight != null && buttonItemKeys[currentHighlight!].currentContext != null) {
+        Scrollable.ensureVisible(
+          buttonItemKeys[currentHighlight!].currentContext!,
+          // duration: const Duration(milliseconds: 100),
+          // alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd
+        );
+      }
+    });
+  }
+
   double? getWidth(GlobalKey key) {
     final BuildContext? context = key.currentContext;
     if (context != null) {
       final RenderBox box = context.findRenderObject()! as RenderBox;
-      return box.size.width;
+      return box.hasSize ? box.size.width : null;
     }
     return null;
   }
@@ -384,7 +403,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     List<DropdownMenuEntry<T>> filteredEntries,
     TextEditingController textEditingController,
     TextDirection textDirection,
-    { int? focusedIndex }
+    { int? focusedIndex, bool enableScrollToHighlight = true}
   ) {
     final List<Widget> result = <Widget>[];
     final double padding = leadingPadding ?? _kDefaultHorizontalPadding;
@@ -416,6 +435,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         : effectiveStyle;
 
       final MenuItemButton menuItemButton = MenuItemButton(
+        key: enableScrollToHighlight ? buttonItemKeys[i] : null,
         style: effectiveStyle,
         leadingIcon: entry.leadingIcon,
         trailingIcon: entry.trailingIcon,
@@ -490,7 +510,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
   @override
   Widget build(BuildContext context) {
     final TextDirection textDirection = Directionality.of(context);
-    _initialMenu ??= _buildButtons(widget.dropdownMenuEntries, _textEditingController, textDirection);
+    _initialMenu ??= _buildButtons(widget.dropdownMenuEntries, _textEditingController, textDirection, enableScrollToHighlight: false);
     final DropdownMenuThemeData theme = DropdownMenuTheme.of(context);
     final DropdownMenuThemeData defaults = _DropdownMenuDefaultsM3(context);
 
@@ -500,6 +520,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
     if (widget.enableSearch) {
       currentHighlight = search(filteredEntries, _textEditingController);
+      if (widget.isScrollableToHighlight) {
+        scrollToHighlight();
+      }
     }
 
     final List<Widget> menu = _buildButtons(filteredEntries, _textEditingController, textDirection, focusedIndex: currentHighlight);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -227,7 +227,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Defaults to true as the search function could be commonly used.
   final bool enableSearch;
 
-  /// Determine whether the menu list can automatically scroll to the first
+  /// Determine whether the scrollable menu list can automatically scroll to the first
   /// matching item. This will be ignored if [enableSearch] is false.
   ///
   /// Defaults to true.

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -278,6 +278,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// contain space for padding.
   final List<DropdownMenuEntry<T>> dropdownMenuEntries;
 
+  ///
   final bool isScrollableToHighlight;
 
   @override
@@ -365,9 +366,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (currentHighlight != null && buttonItemKeys[currentHighlight!].currentContext != null) {
         Scrollable.ensureVisible(
-          buttonItemKeys[currentHighlight!].currentContext!,
-          // duration: const Duration(milliseconds: 100),
-          // alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd
+          buttonItemKeys[currentHighlight!].currentContext!
         );
       }
     });

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1316,12 +1316,12 @@ void main() {
     expect(find.text(errorText), findsOneWidget);
   });
 
-  testWidgets('Can scroll to highlighted item', (WidgetTester tester) async {
+  testWidgets('Can scroll to the highlighted item', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: DropdownMenu<TestMenu>(
           requestFocusOnTap: true,
-          menuHeight: 100,
+          menuHeight: 100, // Give a small number so the list can only show 2 or 3 items.
           dropdownMenuEntries: menuChildren,
         ),
       ),
@@ -1331,7 +1331,6 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
-    // The menu is not long enough to show Item 5.
     expect(find.text('Item 5').hitTestable(), findsNothing);
     await tester.enterText(find.byType(TextField), '5');
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1315,6 +1315,30 @@ void main() {
     await tester.pumpWidget(buildFrame());
     expect(find.text(errorText), findsOneWidget);
   });
+
+  testWidgets('Can scroll to highlighted item', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DropdownMenu<TestMenu>(
+          requestFocusOnTap: true,
+          menuHeight: 100,
+          dropdownMenuEntries: menuChildren,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pumpAndSettle();
+
+    // The menu is not long enough to show Item 5.
+    expect(find.text('Item 5').hitTestable(), findsNothing);
+    await tester.enterText(find.byType(TextField), '5');
+    await tester.pumpAndSettle();
+    // Item 5 should show up.
+    expect(find.text('Item 5').hitTestable(), findsOneWidget);
+  });
+
 }
 
 enum TestMenu {


### PR DESCRIPTION
Fixes #120349

This PR enables `DropdownMenu` to automatically scroll to the first matching item when `enableSearch` is true.

<details><summary>video example</summary>

https://github.com/flutter/flutter/assets/36861262/1a7a956c-c186-44ca-9a52-d94dc21cac8a

</details>



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.