### PR TITLE
Prepare for utf8.encode() to return more precise Uint8List type

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -493,7 +493,7 @@ class WebAssetServer implements AssetReader {
 
   /// Write a single file into the in-memory cache.
   void writeFile(String filePath, String contents) {
-    writeBytes(filePath, utf8.encode(contents) as Uint8List);
+    writeBytes(filePath, const Utf8Encoder().convert(contents));
   }
 
   void writeBytes(String filePath, Uint8List contents) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/symbolize_test.dart
@@ -39,7 +39,7 @@ void main() {
 
     unawaited(symbolizationService.decode(
       input: Stream<Uint8List>.fromIterable(<Uint8List>[
-        utf8.encode('Hello, World\n') as Uint8List,
+        const Utf8Encoder().convert('Hello, World\n'),
       ]),
       symbols: Uint8List(0),
       output: IOSink(output.sink),


### PR DESCRIPTION
To avoid analyzer warnings when utf8.encode() will return the more precise Uint8List type, we use const Utf8Encoder().convert() which already returns Uint8List

See https://github.com/dart-lang/sdk/issues/52801