### PR TITLE
Remove an unnecessary assert

### DIFF
--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -167,7 +167,6 @@ class _BufferedStreamController<T> {
     final StreamController<T> streamControllerInstance = StreamController<T>.broadcast();
       streamControllerInstance.onListen = () {
       for (final dynamic event in _events) {
-        assert(T is! List);
         if (event is T) {
           streamControllerInstance.add(event);
         } else {


### PR DESCRIPTION
The type variable `T`, when used as an expression, will always be a
`Type`. The type test `T is! List` is always true (as is `T is Type`).

This expression will become a warning in the analyzer in some upcoming
release of the Dart SDK.

This `assert` was added in a PR which reapplied an earlier PR, however
the earlier PR did not include this assert. I do not see any discussion
indicating the intent of this assert.

The impact of testing this `T` in any way is low - this is a private
class so we can see all the uses and know that the only type bound to
`T` is `Uri`. Avoid the upcoming diagnostic and remove the assert
entirely. This maintains existing behavior but ignores the potential
intent for the check.
