### PR TITLE
Update `SwitchTheme` tests for M2/M3

### DIFF
--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -86,7 +86,7 @@ void main() {
     expect(description[8], 'thumbIcon: MaterialStatePropertyAll(Icon(IconData(U+0007B)))');
   });
 
-  testWidgets('Switch is themeable', (WidgetTester tester) async {
+  testWidgets('Material2 - Switch is themeable', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
 
     const Color defaultThumbColor = Color(0xfffffff0);
@@ -106,6 +106,7 @@ void main() {
     const Icon icon2 = Icon(Icons.close);
 
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       switchTheme: SwitchThemeData(
         thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
@@ -151,7 +152,6 @@ void main() {
         }),
       ),
     );
-    final bool material3 = themeData.useMaterial3;
     Widget buildSwitch({bool selected = false, bool autofocus = false}) {
       return MaterialApp(
         theme: themeData,
@@ -171,42 +171,29 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? (paints
-        ..rrect(color: defaultTrackColor)
-        ..rrect(color: defaultTrackOutlineColor, strokeWidth: defaultTrackOutlineWidth)
-        ..rrect(color: defaultThumbColor)
-        ..paragraph()
-      )
-      : (paints
+      paints
         ..rrect(color: defaultTrackColor)
         ..rrect(color: defaultTrackOutlineColor, strokeWidth: defaultTrackOutlineWidth)
         ..rrect()
         ..rrect()
         ..rrect()
         ..rrect(color: defaultThumbColor)
-      )
     );
     // Size from MaterialTapTargetSize.shrinkWrap.
-    expect(tester.getSize(find.byType(Switch)), material3 ? const Size(60.0, 40.0) : const Size(59.0, 40.0));
+    expect(tester.getSize(find.byType(Switch)), const Size(59.0, 40.0));
 
     // Selected switch.
     await tester.pumpWidget(buildSwitch(selected: true));
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? (paints
-        ..rrect(color: selectedTrackColor)
-        ..rrect(color: selectedTrackOutlineColor, strokeWidth: selectedTrackOutlineWidth)
-        ..rrect(color: selectedThumbColor)..paragraph())
-      : (paints
+      paints
         ..rrect(color: selectedTrackColor)
         ..rrect(color: selectedTrackOutlineColor, strokeWidth: selectedTrackOutlineWidth)
         ..rrect()
         ..rrect()
         ..rrect()
-        ..rrect(color: selectedThumbColor))
+        ..rrect(color: selectedThumbColor)
     );
 
     // Switch with hover.
@@ -222,7 +209,125 @@ void main() {
     expect(_getSwitchMaterial(tester), paints..circle(color: focusOverlayColor, radius: splashRadius));
   });
 
-  testWidgets('Switch properties are taken over the theme values', (WidgetTester tester) async {
+  testWidgets('Material3 - Switch is themeable', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+
+    const Color defaultThumbColor = Color(0xfffffff0);
+    const Color selectedThumbColor = Color(0xfffffff1);
+    const Color defaultTrackColor = Color(0xfffffff2);
+    const Color selectedTrackColor = Color(0xfffffff3);
+    const Color defaultTrackOutlineColor = Color(0xfffffff4);
+    const Color selectedTrackOutlineColor = Color(0xfffffff5);
+    const double defaultTrackOutlineWidth = 3.0;
+    const double selectedTrackOutlineWidth = 6.0;
+    const MouseCursor mouseCursor = SystemMouseCursors.text;
+    const MaterialTapTargetSize materialTapTargetSize = MaterialTapTargetSize.shrinkWrap;
+    const Color focusOverlayColor = Color(0xfffffff4);
+    const Color hoverOverlayColor = Color(0xfffffff5);
+    const double splashRadius = 1.0;
+    const Icon icon1 = Icon(Icons.check);
+    const Icon icon2 = Icon(Icons.close);
+
+    final ThemeData themeData = ThemeData(
+      useMaterial3: true,
+      switchTheme: SwitchThemeData(
+        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return selectedThumbColor;
+          }
+          return defaultThumbColor;
+        }),
+        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return selectedTrackColor;
+          }
+          return defaultTrackColor;
+        }),
+        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return selectedTrackOutlineColor;
+          }
+          return defaultTrackOutlineColor;
+        }),
+        trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return selectedTrackOutlineWidth;
+          }
+          return defaultTrackOutlineWidth;
+        }),
+        mouseCursor: const MaterialStatePropertyAll<MouseCursor>(mouseCursor),
+        materialTapTargetSize: materialTapTargetSize,
+        overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.focused)) {
+            return focusOverlayColor;
+          }
+          if (states.contains(MaterialState.hovered)) {
+            return hoverOverlayColor;
+          }
+          return null;
+        }),
+        splashRadius: splashRadius,
+        thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return icon1;
+          }
+          return icon2;
+        }),
+      ),
+    );
+    Widget buildSwitch({bool selected = false, bool autofocus = false}) {
+      return MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          body: Switch(
+            dragStartBehavior: DragStartBehavior.down,
+            value: selected,
+            onChanged: (bool value) {},
+            autofocus: autofocus,
+          ),
+        ),
+      );
+    }
+
+    // Switch.
+    await tester.pumpWidget(buildSwitch());
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: defaultTrackColor)
+        ..rrect(color: defaultTrackOutlineColor, strokeWidth: defaultTrackOutlineWidth)
+        ..rrect(color: defaultThumbColor)
+        ..paragraph()
+    );
+    // Size from MaterialTapTargetSize.shrinkWrap.
+    expect(tester.getSize(find.byType(Switch)), const Size(60.0, 40.0));
+
+    // Selected switch.
+    await tester.pumpWidget(buildSwitch(selected: true));
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: selectedTrackColor)
+        ..rrect(color: selectedTrackOutlineColor, strokeWidth: selectedTrackOutlineWidth)
+        ..rrect(color: selectedThumbColor)..paragraph()
+    );
+
+    // Switch with hover.
+    await tester.pumpWidget(buildSwitch());
+    await _pointGestureToSwitch(tester);
+    await tester.pumpAndSettle();
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+    expect(_getSwitchMaterial(tester), paints..circle(color: hoverOverlayColor));
+
+    // Switch with focus.
+    await tester.pumpWidget(buildSwitch(autofocus: true));
+    await tester.pumpAndSettle();
+    expect(_getSwitchMaterial(tester), paints..circle(color: focusOverlayColor, radius: splashRadius));
+  });
+
+  testWidgets('Material2 - Switch properties are taken over the theme values', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
 
     const Color themeDefaultThumbColor = Color(0xfffffff0);
@@ -254,6 +359,7 @@ void main() {
     const double splashRadius = 2.0;
 
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       switchTheme: SwitchThemeData(
         thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
@@ -299,7 +405,6 @@ void main() {
         }),
       ),
     );
-    final bool material3 = themeData.useMaterial3;
 
     Widget buildSwitch({bool selected = false, bool autofocus = false}) {
       return MaterialApp(
@@ -354,38 +459,29 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? (paints
-        ..rrect(color: defaultTrackColor)
-        ..rrect(color: defaultOutlineColor, strokeWidth: defaultOutlineWidth)
-        ..rrect(color: defaultThumbColor)..paragraph(offset: const Offset(12, 12)))
-      : (paints
+      paints
         ..rrect(color: defaultTrackColor)
         ..rrect(color: defaultOutlineColor, strokeWidth: defaultOutlineWidth)
         ..rrect()
         ..rrect()
         ..rrect()
-        ..rrect(color: defaultThumbColor))
+        ..rrect(color: defaultThumbColor)
     );
     // Size from MaterialTapTargetSize.shrinkWrap.
-    expect(tester.getSize(find.byType(Switch)), material3 ? const Size(60.0, 40.0) : const Size(59.0, 40.0));
+    expect(tester.getSize(find.byType(Switch)), const Size(59.0, 40.0));
 
     // Selected switch.
     await tester.pumpWidget(buildSwitch(selected: true));
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? (paints
-        ..rrect(color: selectedTrackColor)..rrect(color: selectedOutlineColor, strokeWidth: selectedOutlineWidth)
-        ..rrect(color: selectedThumbColor))
-      : (paints
+      paints
         ..rrect(color: selectedTrackColor)
         ..rrect(color: selectedOutlineColor, strokeWidth: selectedOutlineWidth)
         ..rrect()
         ..rrect()
         ..rrect()
-        ..rrect(color: selectedThumbColor))
+        ..rrect(color: selectedThumbColor)
     );
 
     // Switch with hover.
@@ -401,7 +497,170 @@ void main() {
     expect(_getSwitchMaterial(tester), paints..circle(color: focusColor, radius: splashRadius));
   });
 
-  testWidgets('Switch active and inactive properties are taken over the theme values', (WidgetTester tester) async {
+  testWidgets('Material3 - Switch properties are taken over the theme values', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+
+    const Color themeDefaultThumbColor = Color(0xfffffff0);
+    const Color themeSelectedThumbColor = Color(0xfffffff1);
+    const Color themeDefaultTrackColor = Color(0xfffffff2);
+    const Color themeSelectedTrackColor = Color(0xfffffff3);
+    const Color themeDefaultOutlineColor = Color(0xfffffff6);
+    const Color themeSelectedOutlineColor = Color(0xfffffff7);
+    const double themeDefaultOutlineWidth = 5.0;
+    const double themeSelectedOutlineWidth = 7.0;
+    const MouseCursor themeMouseCursor = SystemMouseCursors.click;
+    const MaterialTapTargetSize themeMaterialTapTargetSize = MaterialTapTargetSize.padded;
+    const Color themeFocusOverlayColor = Color(0xfffffff4);
+    const Color themeHoverOverlayColor = Color(0xfffffff5);
+    const double themeSplashRadius = 1.0;
+
+    const Color defaultThumbColor = Color(0xffffff0f);
+    const Color selectedThumbColor = Color(0xffffff1f);
+    const Color defaultTrackColor = Color(0xffffff2f);
+    const Color selectedTrackColor = Color(0xffffff3f);
+    const Color defaultOutlineColor = Color(0xffffff6f);
+    const Color selectedOutlineColor = Color(0xffffff7f);
+    const double defaultOutlineWidth = 6.0;
+    const double selectedOutlineWidth = 8.0;
+    const MouseCursor mouseCursor = SystemMouseCursors.text;
+    const MaterialTapTargetSize materialTapTargetSize = MaterialTapTargetSize.shrinkWrap;
+    const Color focusColor = Color(0xffffff4f);
+    const Color hoverColor = Color(0xffffff5f);
+    const double splashRadius = 2.0;
+
+    final ThemeData themeData = ThemeData(
+      useMaterial3: true,
+      switchTheme: SwitchThemeData(
+        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedThumbColor;
+          }
+          return themeDefaultThumbColor;
+        }),
+        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedTrackColor;
+          }
+          return themeDefaultTrackColor;
+        }),
+        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedOutlineColor;
+          }
+          return themeDefaultOutlineColor;
+        }),
+        trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedOutlineWidth;
+          }
+          return themeDefaultOutlineWidth;
+        }),
+        mouseCursor: const MaterialStatePropertyAll<MouseCursor>(themeMouseCursor),
+        materialTapTargetSize: themeMaterialTapTargetSize,
+        overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.focused)) {
+            return themeFocusOverlayColor;
+          }
+          if (states.contains(MaterialState.hovered)) {
+            return themeHoverOverlayColor;
+          }
+          return null;
+        }),
+        splashRadius: themeSplashRadius,
+        thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return null;
+          }
+          return null;
+        }),
+      ),
+    );
+
+    Widget buildSwitch({bool selected = false, bool autofocus = false}) {
+      return MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          body: Switch(
+            value: selected,
+            onChanged: (bool value) {},
+            autofocus: autofocus,
+            thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return selectedThumbColor;
+              }
+              return defaultThumbColor;
+            }),
+            trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return selectedTrackColor;
+              }
+              return defaultTrackColor;
+            }),
+            trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return selectedOutlineColor;
+              }
+              return defaultOutlineColor;
+            }),
+            trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return selectedOutlineWidth;
+              }
+              return defaultOutlineWidth;
+            }),
+            mouseCursor: mouseCursor,
+            materialTapTargetSize: materialTapTargetSize,
+            focusColor: focusColor,
+            hoverColor: hoverColor,
+            splashRadius: splashRadius,
+            thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return const Icon(Icons.add);
+              }
+              return const Icon(Icons.access_alarm);
+            }),
+          ),
+        ),
+      );
+    }
+
+    // Switch.
+    await tester.pumpWidget(buildSwitch());
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: defaultTrackColor)
+        ..rrect(color: defaultOutlineColor, strokeWidth: defaultOutlineWidth)
+        ..rrect(color: defaultThumbColor)..paragraph(offset: const Offset(12, 12))
+    );
+    // Size from MaterialTapTargetSize.shrinkWrap.
+    expect(tester.getSize(find.byType(Switch)), const Size(60.0, 40.0));
+
+    // Selected switch.
+    await tester.pumpWidget(buildSwitch(selected: true));
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: selectedTrackColor)..rrect(color: selectedOutlineColor, strokeWidth: selectedOutlineWidth)
+        ..rrect(color: selectedThumbColor)
+    );
+
+    // Switch with hover.
+    await tester.pumpWidget(buildSwitch());
+    await _pointGestureToSwitch(tester);
+    await tester.pumpAndSettle();
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+    expect(_getSwitchMaterial(tester), paints..circle(color: hoverColor));
+
+    // Switch with focus.
+    await tester.pumpWidget(buildSwitch(autofocus: true));
+    await tester.pumpAndSettle();
+    expect(_getSwitchMaterial(tester), paints..circle(color: focusColor, radius: splashRadius));
+  });
+
+  testWidgets('Material2 - Switch active and inactive properties are taken over the theme values', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
 
     const Color themeDefaultThumbColor = Color(0xfffffff0);
@@ -415,6 +674,7 @@ void main() {
     const Color selectedTrackColor = Color(0xffffff3f);
 
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       switchTheme: SwitchThemeData(
         thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
@@ -430,7 +690,6 @@ void main() {
         }),
       ),
     );
-    final bool material3 = themeData.useMaterial3;
 
     Widget buildSwitch({bool selected = false, bool autofocus = false}) {
       return MaterialApp(
@@ -454,17 +713,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-        material3
-        ? (paints
-          ..rrect(color: defaultTrackColor)
-          ..rrect(color: themeData.colorScheme.outline)
-          ..rrect(color: defaultThumbColor))
-        : (paints
-          ..rrect(color: defaultTrackColor)
-          ..rrect()
-          ..rrect()
-          ..rrect()
-          ..rrect(color: defaultThumbColor))
+      paints
+        ..rrect(color: defaultTrackColor)
+        ..rrect()
+        ..rrect()
+        ..rrect()
+        ..rrect(color: defaultThumbColor)
     );
 
     // Selected switch.
@@ -472,21 +726,87 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? (paints
-        ..rrect(color: selectedTrackColor)
-        ..rrect()
-        ..rrect(color: selectedThumbColor))
-      : (paints
+      paints
         ..rrect(color: selectedTrackColor)
         ..rrect()
         ..rrect()
         ..rrect()
-        ..rrect(color: selectedThumbColor))
+        ..rrect(color: selectedThumbColor)
     );
   });
 
-  testWidgets('Switch theme overlay color resolves in active/pressed states', (WidgetTester tester) async {
+  testWidgets('Material3 - Switch active and inactive properties are taken over the theme values', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+
+    const Color themeDefaultThumbColor = Color(0xfffffff0);
+    const Color themeSelectedThumbColor = Color(0xfffffff1);
+    const Color themeDefaultTrackColor = Color(0xfffffff2);
+    const Color themeSelectedTrackColor = Color(0xfffffff3);
+
+    const Color defaultThumbColor = Color(0xffffff0f);
+    const Color selectedThumbColor = Color(0xffffff1f);
+    const Color defaultTrackColor = Color(0xffffff2f);
+    const Color selectedTrackColor = Color(0xffffff3f);
+
+    final ThemeData themeData = ThemeData(
+      useMaterial3: true,
+      switchTheme: SwitchThemeData(
+        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedThumbColor;
+          }
+          return themeDefaultThumbColor;
+        }),
+        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedTrackColor;
+          }
+          return themeDefaultTrackColor;
+        }),
+      ),
+    );
+
+    Widget buildSwitch({bool selected = false, bool autofocus = false}) {
+      return MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          body: Switch(
+            value: selected,
+            onChanged: (bool value) {},
+            autofocus: autofocus,
+            activeColor: selectedThumbColor,
+            inactiveThumbColor: defaultThumbColor,
+            activeTrackColor: selectedTrackColor,
+            inactiveTrackColor: defaultTrackColor,
+          ),
+        ),
+      );
+    }
+
+    // Unselected switch.
+    await tester.pumpWidget(buildSwitch());
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: defaultTrackColor)
+        ..rrect(color: themeData.colorScheme.outline)
+        ..rrect(color: defaultThumbColor)
+    );
+
+    // Selected switch.
+    await tester.pumpWidget(buildSwitch(selected: true));
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: selectedTrackColor)
+        ..rrect()
+        ..rrect(color: selectedThumbColor)
+    );
+  });
+
+  testWidgets('Material2 - Switch theme overlay color resolves in active/pressed states', (WidgetTester tester) async {
     const Color activePressedOverlayColor = Color(0xFF000001);
     const Color inactivePressedOverlayColor = Color(0xFF000002);
 
@@ -501,12 +821,12 @@ void main() {
     }
     const double splashRadius = 24.0;
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       switchTheme: SwitchThemeData(
         overlayColor: MaterialStateProperty.resolveWith(getOverlayColor),
         splashRadius: splashRadius,
       ),
     );
-    final bool material3 = themeData.useMaterial3;
 
     Widget buildSwitch({required bool active}) {
       return MaterialApp(
@@ -526,20 +846,12 @@ void main() {
 
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? ((paints
-        ..rrect()
-        ..rrect())
-        ..circle(
-          color: inactivePressedOverlayColor,
-          radius: splashRadius,
-      ))
-      : (paints
+      paints
         ..rrect()
         ..circle(
           color: inactivePressedOverlayColor,
           radius: splashRadius,
-      )),
+      ),
       reason: 'Inactive pressed Switch should have overlay color: $inactivePressedOverlayColor',
     );
 
@@ -559,7 +871,73 @@ void main() {
     );
   });
 
-  testWidgets('Local SwitchTheme can override global SwitchTheme', (WidgetTester tester) async {
+  testWidgets('Material3 - Switch theme overlay color resolves in active/pressed states', (WidgetTester tester) async {
+    const Color activePressedOverlayColor = Color(0xFF000001);
+    const Color inactivePressedOverlayColor = Color(0xFF000002);
+
+    Color? getOverlayColor(Set<MaterialState> states) {
+      if (states.contains(MaterialState.pressed)) {
+        if (states.contains(MaterialState.selected)) {
+          return activePressedOverlayColor;
+        }
+        return inactivePressedOverlayColor;
+      }
+      return null;
+    }
+    const double splashRadius = 24.0;
+    final ThemeData themeData = ThemeData(
+      useMaterial3: true,
+      switchTheme: SwitchThemeData(
+        overlayColor: MaterialStateProperty.resolveWith(getOverlayColor),
+        splashRadius: splashRadius,
+      ),
+    );
+
+    Widget buildSwitch({required bool active}) {
+      return MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          body: Switch(
+            value: active,
+            onChanged: (_) { },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSwitch(active: false));
+    await tester.press(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(
+      _getSwitchMaterial(tester),
+      (paints
+        ..rrect()
+        ..rrect())
+        ..circle(
+          color: inactivePressedOverlayColor,
+          radius: splashRadius,
+        ),
+      reason: 'Inactive pressed Switch should have overlay color: $inactivePressedOverlayColor',
+    );
+
+    await tester.pumpWidget(buildSwitch(active: true));
+    await tester.press(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect()
+        ..circle(
+          color: activePressedOverlayColor,
+          radius: splashRadius,
+        ),
+      reason: 'Active pressed Switch should have overlay color: $activePressedOverlayColor',
+    );
+  });
+
+  testWidgets('Material2 - Local SwitchTheme can override global SwitchTheme', (WidgetTester tester) async {
     const Color globalThemeThumbColor = Color(0xfffffff1);
     const Color globalThemeTrackColor = Color(0xfffffff2);
     const Color globalThemeOutlineColor = Color(0xfffffff3);
@@ -570,6 +948,7 @@ void main() {
     const double localThemeOutlineWidth = 4.0;
 
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       switchTheme: const SwitchThemeData(
         thumbColor: MaterialStatePropertyAll<Color>(globalThemeThumbColor),
         trackColor: MaterialStatePropertyAll<Color>(globalThemeTrackColor),
@@ -577,7 +956,6 @@ void main() {
         trackOutlineWidth: MaterialStatePropertyAll<double>(globalThemeOutlineWidth),
       ),
     );
-    final bool material3 = themeData.useMaterial3;
     Widget buildSwitch({bool selected = false, bool autofocus = false}) {
       return MaterialApp(
         theme: themeData,
@@ -603,18 +981,64 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       _getSwitchMaterial(tester),
-      material3
-      ? (paints
-        ..rrect(color: localThemeTrackColor)
-        ..rrect(color: localThemeOutlineColor, strokeWidth: localThemeOutlineWidth)
-        ..rrect(color: localThemeThumbColor))
-      : (paints
+      paints
         ..rrect(color: localThemeTrackColor)
         ..rrect(color: localThemeOutlineColor, strokeWidth: localThemeOutlineWidth)
         ..rrect()
         ..rrect()
         ..rrect()
-        ..rrect(color: localThemeThumbColor))
+        ..rrect(color: localThemeThumbColor)
+    );
+  });
+
+  testWidgets('Material3 - Local SwitchTheme can override global SwitchTheme', (WidgetTester tester) async {
+    const Color globalThemeThumbColor = Color(0xfffffff1);
+    const Color globalThemeTrackColor = Color(0xfffffff2);
+    const Color globalThemeOutlineColor = Color(0xfffffff3);
+    const double globalThemeOutlineWidth = 6.0;
+    const Color localThemeThumbColor = Color(0xffff0000);
+    const Color localThemeTrackColor = Color(0xffff0000);
+    const Color localThemeOutlineColor = Color(0xffff0000);
+    const double localThemeOutlineWidth = 4.0;
+
+    final ThemeData themeData = ThemeData(
+      useMaterial3: true,
+      switchTheme: const SwitchThemeData(
+        thumbColor: MaterialStatePropertyAll<Color>(globalThemeThumbColor),
+        trackColor: MaterialStatePropertyAll<Color>(globalThemeTrackColor),
+        trackOutlineColor: MaterialStatePropertyAll<Color>(globalThemeOutlineColor),
+        trackOutlineWidth: MaterialStatePropertyAll<double>(globalThemeOutlineWidth),
+      ),
+    );
+    Widget buildSwitch({bool selected = false, bool autofocus = false}) {
+      return MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          body: SwitchTheme(
+            data: const SwitchThemeData(
+                thumbColor: MaterialStatePropertyAll<Color>(localThemeThumbColor),
+                trackColor: MaterialStatePropertyAll<Color>(localThemeTrackColor),
+                trackOutlineColor: MaterialStatePropertyAll<Color>(localThemeOutlineColor),
+                trackOutlineWidth: MaterialStatePropertyAll<double>(localThemeOutlineWidth)
+            ),
+            child: Switch(
+              value: selected,
+              onChanged: (bool value) {},
+              autofocus: autofocus,
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSwitch(selected: true));
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: localThemeTrackColor)
+        ..rrect(color: localThemeOutlineColor, strokeWidth: localThemeOutlineWidth)
+        ..rrect(color: localThemeThumbColor)
     );
   });
 }


### PR DESCRIPTION
Updated and reorganized unit tests for `SwitchTheme` to have M2 and M3 versions.

More info in https://github.com/flutter/flutter/issues/127064

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.