### PR TITLE
Enable no_wildcard_variable_uses lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -128,6 +128,7 @@ linter:
     - no_logic_in_create_state
     # - no_runtimeType_toString # ok in tests; we enable this only in packages/
     - no_self_assignments
+    - no_wildcard_variable_uses
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter


### PR DESCRIPTION
Wildcard parameters and local variables (e.g. underscore-only names like _, __, ___, etc.) will become non-binding in a future version of the Dart language. Any existing code that uses wildcard parameters or variables will break. In anticipation of this change, and to make adoption easier, this lint disallows wildcard and variable parameter uses.

We had no violations of this in the framework. Let's keep it that way!