### PR TITLE
Fix/select summary widget location exception

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2251,7 +2251,7 @@ mixin WidgetInspectorService {
     if (!isWidgetCreationTracked()) {
       return _getSelectedWidgetDiagnosticsNode(previousSelectionId);
     }
-    final obj = toObject(previousSelectionId);
+    final Object? obj = toObject(previousSelectionId);
     final DiagnosticsNode? previousSelection =
         (obj is RenderObjectElement?) ? obj?.toDiagnosticsNode() : obj as DiagnosticsNode?;
     Element? current = selection.currentElement;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2251,7 +2251,9 @@ mixin WidgetInspectorService {
     if (!isWidgetCreationTracked()) {
       return _getSelectedWidgetDiagnosticsNode(previousSelectionId);
     }
-    final DiagnosticsNode? previousSelection = toObject(previousSelectionId) as DiagnosticsNode?;
+    final obj = toObject(previousSelectionId);
+    final DiagnosticsNode? previousSelection =
+        (obj is RenderObjectElement?) ? obj?.toDiagnosticsNode() : obj as DiagnosticsNode?;
     Element? current = selection.currentElement;
     if (current != null && !_isValueCreatedByLocalProject(current)) {
       Element? firstLocal;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1947,7 +1947,6 @@ mixin WidgetInspectorService {
   /// reused.
   // TODO(polina-c): delete [previousSelectionId] when it is not used in DevTools
   // https://github.com/flutter/devtools/issues/3951
-  @protected
   String getSelectedWidget(String? previousSelectionId, String groupName) {
     return _safeJsonEncode(_getSelectedWidget(previousSelectionId, groupName));
   }

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2759,9 +2759,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       // Column numbers are more stable than line numbers.
       expect(columnA, equals(15));
       expect(columnA, equals(columnB));
-    },
-        skip: !WidgetInspectorService.instance
-            .isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
+    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
 
     testWidgets(
       'ext.flutter.inspector.getSelectedSummaryWidget should not throw "type \'MultiChildRenderObjectElement\' is not a subtype of type \'DiagnosticsNode?\' in type cast',
@@ -2771,11 +2769,9 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           MaterialApp(
             home: WidgetInspector(
               selectButtonBuilder: (BuildContext context, void Function() onPressed) {
-                final selectedWidget =
-                    WidgetInspectorService.instance.getSelectedWidget(null, 'groupName');
+                final selectedWidget = WidgetInspectorService.instance.getSelectedWidget(null, 'groupName');
                 final id = jsonDecode(selectedWidget)['valueId'];
-                final summaryWidget =
-                    WidgetInspectorService.instance.getSelectedSummaryWidget(id, 'groupName');
+                final summaryWidget = WidgetInspectorService.instance.getSelectedSummaryWidget(id, 'groupName');
                 return Text(summaryWidget.toString());
               },
               child: MaterialApp(

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2724,36 +2724,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             ],
           ),
         ),
-    testWidgets(
-      'ext.flutter.inspector.getSelectedSummaryWidget should not throw "type \'MultiChildRenderObjectElement\' is not a subtype of type \'DiagnosticsNode?\' in type cast',
-      (WidgetTester tester) async {
-        // Build our app and trigger a frame.
-        await tester.pumpWidget(
-          MaterialApp(
-            home: WidgetInspector(
-              selectButtonBuilder: (BuildContext context, void Function() onPressed) {
-                final selectedWidget =
-                    WidgetInspectorService.instance.getSelectedWidget(null, 'groupName');
-                final id = jsonDecode(selectedWidget)['valueId'];
-                final summaryWidget =
-                    WidgetInspectorService.instance.getSelectedSummaryWidget(id, 'groupName');
-                return Text(summaryWidget.toString());
-              },
-              child: MaterialApp(
-                title: 'Flutter Demo',
-                theme: ThemeData(
-                  colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-                  useMaterial3: true,
-                ),
-                home: const Placeholder(),
-              ),
-            ),
-          ),
-        );
-
-        await tester.tap(find.byType(Placeholder));
-      },
-    );
       );
       final Element elementA = find.text('a').evaluate().first;
       final Element elementB = find.text('b').evaluate().first;
@@ -2789,7 +2759,40 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       // Column numbers are more stable than line numbers.
       expect(columnA, equals(15));
       expect(columnA, equals(columnB));
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
+    },
+        skip: !WidgetInspectorService.instance
+            .isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
+
+    testWidgets(
+      'ext.flutter.inspector.getSelectedSummaryWidget should not throw "type \'MultiChildRenderObjectElement\' is not a subtype of type \'DiagnosticsNode?\' in type cast',
+      (WidgetTester tester) async {
+        // Build our app and trigger a frame.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WidgetInspector(
+              selectButtonBuilder: (BuildContext context, void Function() onPressed) {
+                final selectedWidget =
+                    WidgetInspectorService.instance.getSelectedWidget(null, 'groupName');
+                final id = jsonDecode(selectedWidget)['valueId'];
+                final summaryWidget =
+                    WidgetInspectorService.instance.getSelectedSummaryWidget(id, 'groupName');
+                return Text(summaryWidget.toString());
+              },
+              child: MaterialApp(
+                title: 'Flutter Demo',
+                theme: ThemeData(
+                  colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+                  useMaterial3: true,
+                ),
+                home: const Placeholder(),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(Placeholder));
+      },
+    );
 
     group(
       'ext.flutter.inspector.addPubRootDirectories group',

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2724,6 +2724,36 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             ],
           ),
         ),
+    testWidgets(
+      'ext.flutter.inspector.getSelectedSummaryWidget should not throw "type \'MultiChildRenderObjectElement\' is not a subtype of type \'DiagnosticsNode?\' in type cast',
+      (WidgetTester tester) async {
+        // Build our app and trigger a frame.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: WidgetInspector(
+              selectButtonBuilder: (BuildContext context, void Function() onPressed) {
+                final selectedWidget =
+                    WidgetInspectorService.instance.getSelectedWidget(null, 'groupName');
+                final id = jsonDecode(selectedWidget)['valueId'];
+                final summaryWidget =
+                    WidgetInspectorService.instance.getSelectedSummaryWidget(id, 'groupName');
+                return Text(summaryWidget.toString());
+              },
+              child: MaterialApp(
+                title: 'Flutter Demo',
+                theme: ThemeData(
+                  colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+                  useMaterial3: true,
+                ),
+                home: const Placeholder(),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(Placeholder));
+      },
+    );
       );
       final Element elementA = find.text('a').evaluate().first;
       final Element elementB = find.text('b').evaluate().first;


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
Using the `WidgetInspectorService.instance.getSelectedWidget(...)` method (which should not be protected just like the `getSelectedSummaryWidget` method) it is possible to retrieve the value id Widget. Using this id to get the `SelectedSummaryWidget` crashes due to `SingleChildRenderObjectElement` and `MultiChildRenderObjectElement` not being of Type `DiagnosticsNode`. 

Both those types contain a toDiagnosticsNode method though and can easly be used to retrieve the widget in question. I made the method (`getSelectedWidget`) unprotected just like `getSelectedSummaryWidget` is, added an additional type check which does not break any existing logic to account for `RenderObjectElement`s as well as a test which fails if the fix is not in place. 

Let me know your thoughts :)

*Steps to reproduce*

1. Wrap some Widget with the WidgetInspector
2. Attempt retrieve the SelectedSummaryWidget inside the selectButtonBuilder callback
3. Depending on the Widget the Exception will complain that SingleChildRenderObjectElement or MulitChildRenderObjectElement is not of Type DiagnosticsNode?

*List which issues are fixed by this PR. You must list at least one issue.*
- #130012

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
