### PR TITLE
Change from "created via performance template" to "from: performance template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_performance_others.md
+++ b/.github/ISSUE_TEMPLATE/4_performance_others.md
@@ -2,7 +2,7 @@
 name: My app has some non-speed performance issues
 about: You are writing an application but have discovered that it uses too much memory, too much energy (e.g., CPU/GPU usage is high), or its app size is too large.
 title: ''
-labels: 'created via performance template'
+labels: 'from: performance template'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/5_performance_speed.md
+++ b/.github/ISSUE_TEMPLATE/5_performance_speed.md
@@ -3,7 +3,7 @@ name: My app is slow or missing frames
 about: You are writing an application but have discovered that it is slow, you are
   not hitting 60Hz, or you are getting jank (missed frames).
 title: ''
-labels: 'created via performance template'
+labels: 'from: performance template'
 assignees: ''
 
 ---


### PR DESCRIPTION
This more closely matches our other conventions.
