### PR TITLE
Add a threshold when comparing screen order for selectables.

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -40,7 +40,7 @@ const Set<PointerDeviceKind> _kLongPressSelectionDevices = <PointerDeviceKind>{
 };
 
 
-const double _kSelectableComparingThreshold = 3.0;
+const double _kSelectableComparingThreshold = 5.0;
 
 /// A widget that introduces an area for user selections.
 ///

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1706,7 +1706,8 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Returns positive if a is lower, negative if a is higher, 0 if their
   /// order can't be determine solely by their vertical position.
   static int _compareVertically(Rect a, Rect b) {
-    if ((a.top - b.top).abs() < _kSelectableComparingThreshold && (a.bottom - b.bottom).abs() < _kSelectableComparingThreshold) {
+    if ((a.top - b.top < _kSelectableComparingThreshold && a.bottom - b.bottom > - _kSelectableComparingThreshold) ||
+        (b.top - a.top < _kSelectableComparingThreshold && b.bottom - a.bottom > - _kSelectableComparingThreshold)) {
       return 0;
     }
     if ((a.top - b.top).abs() > _kSelectableComparingThreshold) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -39,8 +39,10 @@ const Set<PointerDeviceKind> _kLongPressSelectionDevices = <PointerDeviceKind>{
   PointerDeviceKind.invertedStylus,
 };
 
-
-const double _kSelectableComparingThreshold = 5.0;
+// In practice some selectables like widgetspan shift several pixels. So when
+// the vertical position diff is within the threshold, compare the horizontal
+// position to make the compareScreenOrder function more robust.
+const double _kSelectableVerticalComparingThreshold = 3.0;
 
 /// A widget that introduces an area for user selections.
 ///
@@ -1706,11 +1708,11 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Returns positive if a is lower, negative if a is higher, 0 if their
   /// order can't be determine solely by their vertical position.
   static int _compareVertically(Rect a, Rect b) {
-    if ((a.top - b.top < _kSelectableComparingThreshold && a.bottom - b.bottom > - _kSelectableComparingThreshold) ||
-        (b.top - a.top < _kSelectableComparingThreshold && b.bottom - a.bottom > - _kSelectableComparingThreshold)) {
+    if ((a.top - b.top < _kSelectableVerticalComparingThreshold && a.bottom - b.bottom > - _kSelectableVerticalComparingThreshold) ||
+        (b.top - a.top < _kSelectableVerticalComparingThreshold && b.bottom - a.bottom > - _kSelectableVerticalComparingThreshold)) {
       return 0;
     }
-    if ((a.top - b.top).abs() > _kSelectableComparingThreshold) {
+    if ((a.top - b.top).abs() > _kSelectableVerticalComparingThreshold) {
       return a.top > b.top ? 1 : -1;
     }
     return a.bottom > b.bottom ? 1 : -1;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -39,6 +39,9 @@ const Set<PointerDeviceKind> _kLongPressSelectionDevices = <PointerDeviceKind>{
   PointerDeviceKind.invertedStylus,
 };
 
+
+const double _kSelectableComparingThreshold = 3.0;
+
 /// A widget that introduces an area for user selections.
 ///
 /// Flutter widgets are not selectable by default. Wrapping a widget subtree
@@ -1703,11 +1706,10 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Returns positive if a is lower, negative if a is higher, 0 if their
   /// order can't be determine solely by their vertical position.
   static int _compareVertically(Rect a, Rect b) {
-    if ((a.top - b.top < precisionErrorTolerance && a.bottom - b.bottom > - precisionErrorTolerance) ||
-        (b.top - a.top < precisionErrorTolerance && b.bottom - a.bottom > - precisionErrorTolerance)) {
+    if ((a.top - b.top).abs() < _kSelectableComparingThreshold && (a.bottom - b.bottom).abs() < _kSelectableComparingThreshold) {
       return 0;
     }
-    if ((a.top - b.top).abs() > precisionErrorTolerance) {
+    if ((a.top - b.top).abs() > _kSelectableComparingThreshold) {
       return a.top > b.top ? 1 : -1;
     }
     return a.bottom > b.bottom ? 1 : -1;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2471,52 +2471,49 @@ void main() {
   });
 
   testWidgets('Multiple selectables on a single line should be in screen order', (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/127942.
-      final UniqueKey outerText = UniqueKey();
-      const TextStyle textStyle = TextStyle(fontSize: 10);
-      await tester.pumpWidget(
-        MaterialApp(
-          home: SelectableRegion(
-            focusNode: FocusNode(),
-            selectionControls: materialTextSelectionControls,
-            child: Scaffold(
-              body: Center(
-                child: Text.rich(
-                  const TextSpan(
-                    children: <InlineSpan>[
-                      TextSpan(text: 'Hello my name is ', style: textStyle),
-                      WidgetSpan(
-                        child: Text('Dash', style: textStyle),
-                        alignment: PlaceholderAlignment.aboveBaseline,
-                        baseline: TextBaseline.ideographic,
-                      ),
-                      TextSpan(text: '.', style: textStyle),
-                    ],
-                  ),
-                  key: outerText,
+    // Regression test for https://github.com/flutter/flutter/issues/127942.
+    final UniqueKey outerText = UniqueKey();
+    const TextStyle textStyle = TextStyle(fontSize: 10);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectableRegion(
+          focusNode: FocusNode(),
+          selectionControls: materialTextSelectionControls,
+          child: Scaffold(
+            body: Center(
+              child: Text.rich(
+                const TextSpan(
+                  children: <InlineSpan>[
+                    TextSpan(text: 'Hello my name is ', style: textStyle),
+                    WidgetSpan(
+                      child: Text('Dash', style: textStyle),
+                      alignment: PlaceholderAlignment.middle,
+                    ),
+                    TextSpan(text: '.', style: textStyle),
+                  ],
                 ),
+                key: outerText,
               ),
             ),
           ),
         ),
-      );
-      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.byKey(outerText), matching: find.byType(RichText)).first);
-      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 0), kind: PointerDeviceKind.mouse);
-      addTearDown(gesture.removePointer);
-      await tester.pump();
-      await gesture.up();
+      ),
+    );
+    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.byKey(outerText), matching: find.byType(RichText)).first);
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 0), kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.up();
 
-      // Select all.
-      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, control: true));
+    // Select all.
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, control: true));
 
-      // keyboard copy.
-      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyC, control: true));
+    // keyboard copy.
+    await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyC, control: true));
 
-      final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
-      expect(clipboardData['text'], 'Hello my name is Dash.');
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.fuchsia }),
-  );
+    final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
+    expect(clipboardData['text'], 'Hello my name is Dash.');
+  });
 }
 
 class SelectionSpy extends LeafRenderObjectWidget {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2515,8 +2515,8 @@ void main() {
       final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
       expect(clipboardData['text'], 'Hello my name is Dash.');
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.fuchsia })
-    );
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.fuchsia }),
+  );
 }
 
 class SelectionSpy extends LeafRenderObjectWidget {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2473,7 +2473,7 @@ void main() {
   testWidgets('Multiple selectables on a single line should be in screen order', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/127942.
       final UniqueKey outerText = UniqueKey();
-      const TextStyle textStyle=TextStyle(fontSize: 10);
+      const TextStyle textStyle = TextStyle(fontSize: 10);
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2469,6 +2469,54 @@ void main() {
       skip: !kIsWeb, // [intended]
     );
   });
+
+  testWidgets('Multiple selectables on a single line should be in screen order', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/127942.
+      final UniqueKey outerText = UniqueKey();
+      const TextStyle textStyle=TextStyle(fontSize: 10);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: Scaffold(
+              body: Center(
+                child: Text.rich(
+                  const TextSpan(
+                    children: <InlineSpan>[
+                      TextSpan(text: 'Hello my name is ', style: textStyle),
+                      WidgetSpan(
+                        child: Text('Dash', style: textStyle),
+                        alignment: PlaceholderAlignment.aboveBaseline,
+                        baseline: TextBaseline.ideographic,
+                      ),
+                      TextSpan(text: '.', style: textStyle),
+                    ],
+                  ),
+                  key: outerText,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.byKey(outerText), matching: find.byType(RichText)).first);
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 0), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+
+      // Select all.
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, control: true));
+
+      // keyboard copy.
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyC, control: true));
+
+      final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
+      expect(clipboardData['text'], 'Hello my name is Dash.');
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.windows, TargetPlatform.linux, TargetPlatform.fuchsia })
+    );
 }
 
 class SelectionSpy extends LeafRenderObjectWidget {


### PR DESCRIPTION
Add a threshold when comparing screen order for selectables. So when the vertical position diff is within the threshold, will compare the horizontal position.

This fixes https://github.com/flutter/flutter/issues/111021 and https://github.com/flutter/flutter/issues/127942

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
