### PR TITLE
Update `CardTheme`, `DrawerTheme`, `NavigationBar`, and `NavigationRailTheme` tests for M2/M3 

### DIFF
--- a/packages/flutter/test/material/card_theme_test.dart
+++ b/packages/flutter/test/material/card_theme_test.dart
@@ -22,7 +22,7 @@ void main() {
     expect(identical(CardTheme.lerp(theme, theme, 0.5), theme), true);
   });
 
-  testWidgets('Passing no CardTheme returns defaults', (WidgetTester tester) async {
+  testWidgets('Material3 - Passing no CardTheme returns defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(MaterialApp(
       theme: theme,
@@ -117,9 +117,8 @@ void main() {
     expect(material.color, cardTheme.color);
   });
 
-  testWidgets('ThemeData properties are used when no CardTheme is set', (WidgetTester tester) async {
-    final ThemeData themeData = _themeData();
-    final bool material3 = themeData.useMaterial3;
+  testWidgets('Material3 - ThemeData properties are used when no CardTheme is set', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData(useMaterial3: true);
 
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
@@ -129,10 +128,10 @@ void main() {
     ));
 
     final Material material = _getCardMaterial(tester);
-    expect(material.color, material3 ? themeData.colorScheme.surface: themeData.cardColor);
+    expect(material.color, themeData.colorScheme.surface);
   });
 
-  testWidgets('CardTheme customizes shape', (WidgetTester tester) async {
+  testWidgets('Material3 - CardTheme customizes shape', (WidgetTester tester) async {
     const CardTheme cardTheme = CardTheme(
       color: Colors.white,
       shape: BeveledRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(7))),
@@ -166,7 +165,21 @@ void main() {
     // support is deprecated and the APIs are removed, these tests
     // can be deleted.
 
-    testWidgets('Passing no CardTheme returns defaults - M2', (WidgetTester tester) async {
+    testWidgets('Material2 - ThemeData properties are used when no CardTheme is set', (WidgetTester tester) async {
+      final ThemeData themeData = ThemeData(useMaterial3: false);
+
+      await tester.pumpWidget(MaterialApp(
+        theme: themeData,
+        home: const Scaffold(
+          body: Card(),
+        ),
+      ));
+
+      final Material material = _getCardMaterial(tester);
+      expect(material.color, themeData.cardColor);
+    });
+
+    testWidgets('Material2 - Passing no CardTheme returns defaults', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(useMaterial3: false),
         home: const Scaffold(
@@ -188,7 +201,7 @@ void main() {
       ));
     });
 
-    testWidgets('CardTheme customizes shape - M2', (WidgetTester tester) async {
+    testWidgets('Material2 - CardTheme customizes shape', (WidgetTester tester) async {
       const CardTheme cardTheme = CardTheme(
         color: Colors.white,
         shape: BeveledRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(7))),

--- a/packages/flutter/test/material/drawer_theme_test.dart
+++ b/packages/flutter/test/material/drawer_theme_test.dart
@@ -151,7 +151,7 @@ void main() {
     expect(_drawerMaterial(tester).color, theme.colorScheme.surface);
     expect(_drawerMaterial(tester).elevation, 1.0);
     expect(_drawerMaterial(tester).shadowColor, Colors.transparent);
-    expect(_drawerMaterial(tester).surfaceTintColor, ThemeData().colorScheme.surfaceTint);
+    expect(_drawerMaterial(tester).surfaceTintColor, theme.colorScheme.surfaceTint);
     expect(
       _drawerMaterial(tester).shape,
       const RoundedRectangleBorder(borderRadius: BorderRadius.horizontal(left:  Radius.circular(16.0)))

--- a/packages/flutter/test/material/drawer_theme_test.dart
+++ b/packages/flutter/test/material/drawer_theme_test.dart
@@ -58,9 +58,9 @@ void main() {
     ]);
   });
 
-  testWidgets('Default values are used when no Drawer or DrawerThemeData properties are specified', (WidgetTester tester) async {
+  testWidgets('Material2 - Default values are used when no Drawer or DrawerThemeData properties are specified', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-    final ThemeData theme = ThemeData();
+    final ThemeData theme = ThemeData(useMaterial3: false);
     final bool useMaterial3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
@@ -74,23 +74,46 @@ void main() {
     scaffoldKey.currentState!.openDrawer();
     await tester.pumpAndSettle();
 
-    expect(_drawerMaterial(tester).color, useMaterial3 ? theme.colorScheme.surface : null);
-    expect(_drawerMaterial(tester).elevation, useMaterial3 ? 1.0 : 16.0);
-    expect(_drawerMaterial(tester).shadowColor, useMaterial3 ? Colors.transparent : ThemeData().shadowColor);
-    expect(_drawerMaterial(tester).surfaceTintColor, useMaterial3 ? theme.colorScheme.surfaceTint : null);
+    expect(_drawerMaterial(tester).color, null);
+    expect(_drawerMaterial(tester).elevation, 16.0);
+    expect(_drawerMaterial(tester).shadowColor, theme.shadowColor);
+    expect(_drawerMaterial(tester).surfaceTintColor, null);
+    expect(_drawerMaterial(tester).shape, null);
+    expect(_scrim(tester).color, Colors.black54);
+    expect(_drawerRenderBox(tester).size.width, 304.0);
+  });
+
+  testWidgets('Material3 - Default values are used when no Drawer or DrawerThemeData properties are specified', (WidgetTester tester) async {
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    final bool useMaterial3 = theme.useMaterial3;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          key: scaffoldKey,
+          drawer: const Drawer(),
+        ),
+      ),
+    );
+    scaffoldKey.currentState!.openDrawer();
+    await tester.pumpAndSettle();
+
+    expect(_drawerMaterial(tester).color, theme.colorScheme.surface);
+    expect(_drawerMaterial(tester).elevation, 1.0);
+    expect(_drawerMaterial(tester).shadowColor, Colors.transparent);
+    expect(_drawerMaterial(tester).surfaceTintColor, theme.colorScheme.surfaceTint);
     expect(
       _drawerMaterial(tester).shape,
-      useMaterial3
-        ? const RoundedRectangleBorder(borderRadius: BorderRadius.horizontal(right:  Radius.circular(16.0)))
-        : null,
+      const RoundedRectangleBorder(borderRadius: BorderRadius.horizontal(right:  Radius.circular(16.0)))
     );
     expect(_scrim(tester).color, Colors.black54);
     expect(_drawerRenderBox(tester).size.width, 304.0);
   });
 
-  testWidgets('Default values are used when no Drawer or DrawerThemeData properties are specified in end drawer', (WidgetTester tester) async {
+  testWidgets('Material2 - Default values are used when no Drawer or DrawerThemeData properties are specified in end drawer', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-    final ThemeData theme = ThemeData();
+    final ThemeData theme = ThemeData(useMaterial3: false);
     final bool useMaterial3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
@@ -104,15 +127,38 @@ void main() {
     scaffoldKey.currentState!.openEndDrawer();
     await tester.pumpAndSettle();
 
-    expect(_drawerMaterial(tester).color, useMaterial3 ? theme.colorScheme.surface : null);
-    expect(_drawerMaterial(tester).elevation, useMaterial3 ? 1.0 : 16.0);
-    expect(_drawerMaterial(tester).shadowColor, useMaterial3 ? Colors.transparent : ThemeData().shadowColor);
-    expect(_drawerMaterial(tester).surfaceTintColor, useMaterial3 ? ThemeData().colorScheme.surfaceTint : null);
+    expect(_drawerMaterial(tester).color, null);
+    expect(_drawerMaterial(tester).elevation, 16.0);
+    expect(_drawerMaterial(tester).shadowColor, theme.shadowColor);
+    expect(_drawerMaterial(tester).surfaceTintColor, null);
+    expect(_drawerMaterial(tester).shape, null);
+    expect(_scrim(tester).color, Colors.black54);
+    expect(_drawerRenderBox(tester).size.width, 304.0);
+  });
+
+  testWidgets('Material3 - Default values are used when no Drawer or DrawerThemeData properties are specified in end drawer', (WidgetTester tester) async {
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    final bool useMaterial3 = theme.useMaterial3;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          key: scaffoldKey,
+          endDrawer: const Drawer(),
+        ),
+      ),
+    );
+    scaffoldKey.currentState!.openEndDrawer();
+    await tester.pumpAndSettle();
+
+    expect(_drawerMaterial(tester).color, theme.colorScheme.surface);
+    expect(_drawerMaterial(tester).elevation, 1.0);
+    expect(_drawerMaterial(tester).shadowColor, Colors.transparent);
+    expect(_drawerMaterial(tester).surfaceTintColor, ThemeData().colorScheme.surfaceTint);
     expect(
       _drawerMaterial(tester).shape,
-      useMaterial3
-        ? const RoundedRectangleBorder(borderRadius: BorderRadius.horizontal(left:  Radius.circular(16.0)))
-        : null,
+      const RoundedRectangleBorder(borderRadius: BorderRadius.horizontal(left:  Radius.circular(16.0)))
     );
     expect(_scrim(tester).color, Colors.black54);
     expect(_drawerRenderBox(tester).size.width, 304.0);

--- a/packages/flutter/test/material/drawer_theme_test.dart
+++ b/packages/flutter/test/material/drawer_theme_test.dart
@@ -61,7 +61,6 @@ void main() {
   testWidgets('Material2 - Default values are used when no Drawer or DrawerThemeData properties are specified', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     final ThemeData theme = ThemeData(useMaterial3: false);
-    final bool useMaterial3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
@@ -86,7 +85,6 @@ void main() {
   testWidgets('Material3 - Default values are used when no Drawer or DrawerThemeData properties are specified', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     final ThemeData theme = ThemeData(useMaterial3: true);
-    final bool useMaterial3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
@@ -114,7 +112,6 @@ void main() {
   testWidgets('Material2 - Default values are used when no Drawer or DrawerThemeData properties are specified in end drawer', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     final ThemeData theme = ThemeData(useMaterial3: false);
-    final bool useMaterial3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
@@ -139,7 +136,6 @@ void main() {
   testWidgets('Material3 - Default values are used when no Drawer or DrawerThemeData properties are specified in end drawer', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     final ThemeData theme = ThemeData(useMaterial3: true);
-    final bool useMaterial3 = theme.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -246,7 +246,7 @@ void main() {
     );
   });
 
-  testWidgets('NavigationBar uses proper defaults when no parameters are given - M2', (WidgetTester tester) async {
+  testWidgets('Material2 - NavigationBar uses proper defaults when no parameters are given', (WidgetTester tester) async {
     // M2 settings that were hand coded.
     await tester.pumpWidget(
       _buildWidget(
@@ -275,7 +275,7 @@ void main() {
     expect(_getIndicatorDecoration(tester)?.shape, RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)));
   });
 
-  testWidgets('NavigationBar uses proper defaults when no parameters are given - M3', (WidgetTester tester) async {
+  testWidgets('Material3 - NavigationBar uses proper defaults when no parameters are given', (WidgetTester tester) async {
     // M3 settings from the token database.
     final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(
@@ -305,7 +305,7 @@ void main() {
     expect(_getIndicatorDecoration(tester)?.shape, const StadiumBorder());
   });
 
-  testWidgets('NavigationBar shows tooltips with text scaling ', (WidgetTester tester) async {
+  testWidgets('Material2 - NavigationBar shows tooltips with text scaling ', (WidgetTester tester) async {
     const String label = 'A';
 
     Widget buildApp({ required double textScaleFactor }) {
@@ -362,6 +362,65 @@ void main() {
     expect(find.text(label), findsOneWidget);
     await tester.longPress(find.text(label));
     expect(tester.getSize(find.text(label).last), Size(defaultTooltipSize.width * 4, defaultTooltipSize.height * 4));
+  });
+
+  testWidgets('Material3 - NavigationBar shows tooltips with text scaling ', (WidgetTester tester) async {
+    const String label = 'A';
+
+    Widget buildApp({ required double textScaleFactor }) {
+      return MediaQuery(
+        data: MediaQueryData(textScaleFactor: textScaleFactor),
+        child: Localizations(
+          locale: const Locale('en', 'US'),
+          delegates: const <LocalizationsDelegate<dynamic>>[
+            DefaultMaterialLocalizations.delegate,
+            DefaultWidgetsLocalizations.delegate,
+          ],
+          child: MaterialApp(
+            theme: ThemeData(useMaterial3: true),
+            home: Navigator(
+              onGenerateRoute: (RouteSettings settings) {
+                return MaterialPageRoute<void>(
+                  builder: (BuildContext context) {
+                    return Scaffold(
+                      bottomNavigationBar: NavigationBar(
+                        destinations: const <NavigationDestination>[
+                          NavigationDestination(
+                            label: label,
+                            icon: Icon(Icons.ac_unit),
+                            tooltip: label,
+                          ),
+                          NavigationDestination(
+                            label: 'B',
+                            icon: Icon(Icons.battery_alert),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(textScaleFactor: 1.0));
+    expect(find.text(label), findsOneWidget);
+    await tester.longPress(find.text(label));
+    expect(find.text(label), findsNWidgets(2));
+
+    // The default size of a tooltip with the text A.
+    const Size defaultTooltipSize = Size(15.0, 20.0);
+    expect(tester.getSize(find.text(label).last), defaultTooltipSize);
+    // The duration is needed to ensure the tooltip disappears.
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    await tester.pumpWidget(buildApp(textScaleFactor: 4.0));
+    expect(find.text(label), findsOneWidget);
+    await tester.longPress(find.text(label));
+    expect(tester.getSize(find.text(label).last), const Size(57.0, 80.0));
   });
 
   testWidgets('Custom tooltips in NavigationBarDestination', (WidgetTester tester) async {
@@ -566,7 +625,7 @@ void main() {
     expect(newHeight, equals(initialHeight));
   });
 
-  testWidgets('Navigation indicator renders ripple', (WidgetTester tester) async {
+  testWidgets('Material3 - Navigation indicator renders ripple', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/116751.
     int selectedIndex = 0;
 
@@ -767,7 +826,7 @@ void main() {
     );
   });
 
-  testWidgets('Navigation indicator ripple golden test', (WidgetTester tester) async {
+  testWidgets('Material3 - Navigation indicator ripple golden test', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/117420.
 
     Widget buildWidget({ NavigationDestinationLabelBehavior? labelBehavior }) {
@@ -875,7 +934,7 @@ void main() {
     expect(transform.getColumn(0)[0], 1.0);
   });
 
-  testWidgets('Navigation destination updates indicator color and shape', (WidgetTester tester) async {
+  testWidgets('Material3 - Navigation destination updates indicator color and shape', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     const Color color = Color(0xff0000ff);
     const ShapeBorder shape = RoundedRectangleBorder();
@@ -921,7 +980,7 @@ void main() {
     // support is deprecated and the APIs are removed, these tests
     // can be deleted.
 
-    testWidgets('Navigation destination updates indicator color and shape', (WidgetTester tester) async {
+    testWidgets('Material2 - Navigation destination updates indicator color and shape', (WidgetTester tester) async {
       final ThemeData theme = ThemeData(useMaterial3: false);
       const Color color = Color(0xff0000ff);
       const ShapeBorder shape = RoundedRectangleBorder();
@@ -965,7 +1024,7 @@ void main() {
       expect(_getIndicatorDecoration(tester)?.shape, shape);
     });
 
-    testWidgets('Navigation indicator renders ripple', (WidgetTester tester) async {
+    testWidgets('Material2 - Navigation indicator renders ripple', (WidgetTester tester) async {
       // This is a regression test for https://github.com/flutter/flutter/issues/116751.
       int selectedIndex = 0;
 
@@ -1166,7 +1225,7 @@ void main() {
       );
     });
 
-    testWidgets('Navigation indicator ripple golden test', (WidgetTester tester) async {
+    testWidgets('Material2 - Navigation indicator ripple golden test', (WidgetTester tester) async {
       // This is a regression test for https://github.com/flutter/flutter/issues/117420.
 
       Widget buildWidget({ NavigationDestinationLabelBehavior? labelBehavior }) {

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -411,14 +411,23 @@ void main() {
     await tester.longPress(find.text(label));
     expect(find.text(label), findsNWidgets(2));
 
-    expect(tester.getSize(find.text(label).last), const Size(15.0, 20.0));
+    if (!isCanvasKit) {
+      expect(tester.getSize(find.text(label).last), const Size(15.0, 21.0));
+    } else {
+      expect(tester.getSize(find.text(label).last), const Size(15.0, 20.0));
+    }
     // The duration is needed to ensure the tooltip disappears.
     await tester.pumpAndSettle(const Duration(seconds: 2));
 
     await tester.pumpWidget(buildApp(textScaleFactor: 4.0));
     expect(find.text(label), findsOneWidget);
     await tester.longPress(find.text(label));
-    expect(tester.getSize(find.text(label).last), const Size(57.0, 80.0));
+
+    if (!isCanvasKit) {
+      expect(tester.getSize(find.text(label).last), const Size(57.0, 81.0));
+    } else {
+      expect(tester.getSize(find.text(label).last), const Size(57.0, 80.0));
+    }
   });
 
   testWidgets('Custom tooltips in NavigationBarDestination', (WidgetTester tester) async {

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -305,7 +305,7 @@ void main() {
     expect(_getIndicatorDecoration(tester)?.shape, const StadiumBorder());
   });
 
-  testWidgets('Material2 - NavigationBar shows tooltips with text scaling ', (WidgetTester tester) async {
+  testWidgets('Material2 - NavigationBar shows tooltips with text scaling', (WidgetTester tester) async {
     const String label = 'A';
 
     Widget buildApp({ required double textScaleFactor }) {
@@ -364,7 +364,7 @@ void main() {
     expect(tester.getSize(find.text(label).last), Size(defaultTooltipSize.width * 4, defaultTooltipSize.height * 4));
   });
 
-  testWidgets('Material3 - NavigationBar shows tooltips with text scaling ', (WidgetTester tester) async {
+  testWidgets('Material3 - NavigationBar shows tooltips with text scaling', (WidgetTester tester) async {
     const String label = 'A';
 
     Widget buildApp({ required double textScaleFactor }) {

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -411,7 +411,7 @@ void main() {
     await tester.longPress(find.text(label));
     expect(find.text(label), findsNWidgets(2));
 
-    if (!isCanvasKit) {
+    if (kIsWeb && !isCanvasKit) {
       expect(tester.getSize(find.text(label).last), const Size(15.0, 21.0));
     } else {
       expect(tester.getSize(find.text(label).last), const Size(15.0, 20.0));
@@ -423,7 +423,7 @@ void main() {
     expect(find.text(label), findsOneWidget);
     await tester.longPress(find.text(label));
 
-    if (!isCanvasKit) {
+    if (kIsWeb && !isCanvasKit) {
       expect(tester.getSize(find.text(label).last), const Size(57.0, 81.0));
     } else {
       expect(tester.getSize(find.text(label).last), const Size(57.0, 80.0));

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -411,9 +411,7 @@ void main() {
     await tester.longPress(find.text(label));
     expect(find.text(label), findsNWidgets(2));
 
-    // The default size of a tooltip with the text A.
-    const Size defaultTooltipSize = Size(15.0, 20.0);
-    expect(tester.getSize(find.text(label).last), defaultTooltipSize);
+    expect(tester.getSize(find.text(label).last), const Size(15.0, 20.0));
     // The duration is needed to ensure the tooltip disappears.
     await tester.pumpAndSettle(const Duration(seconds: 2));
 

--- a/packages/flutter/test/material/navigation_rail_theme_test.dart
+++ b/packages/flutter/test/material/navigation_rail_theme_test.dart
@@ -12,7 +12,7 @@ void main() {
     expect(const NavigationRailThemeData().hashCode, const NavigationRailThemeData().copyWith().hashCode);
   });
 
-  testWidgets('Default values are used when no NavigationRail or NavigationRailThemeData properties are specified', (WidgetTester tester) async {
+  testWidgets('Material3 - Default values are used when no NavigationRail or NavigationRailThemeData properties are specified', (WidgetTester tester) async {
     final ThemeData theme = ThemeData.light(useMaterial3: true);
     // Material 3 defaults
     await tester.pumpWidget(
@@ -47,7 +47,7 @@ void main() {
     expect(inkResponse.customBorder, const StadiumBorder());
   });
 
-  testWidgets('Default values are used when no NavigationRail or NavigationRailThemeData properties are specified (Material 2)', (WidgetTester tester) async {
+  testWidgets('Material2 - Default values are used when no NavigationRail or NavigationRailThemeData properties are specified', (WidgetTester tester) async {
     // This test can be removed when `useMaterial3` is deprecated.
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Updated unit tests for `CardTheme`, `DrawerTheme`, `NavigationBar`, and `NavigationRailTheme` to have M2 and M3 versions.

More info in https://github.com/flutter/flutter/issues/127064

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
