### PR TITLE
Allow committing text to trigger EditableText.onChanged

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3616,15 +3616,17 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _bringIntoViewBySelectionState(oldTextSelection, value.selection, cause);
     }
     final String currentText = _value.text;
-    try {
-      widget.onChanged?.call(currentText);
-    } catch (exception, stack) {
-      FlutterError.reportError(FlutterErrorDetails(
-        exception: exception,
-        stack: stack,
-        library: 'widgets',
-        context: ErrorDescription('while calling onChanged'),
-      ));
+    if (oldValue.text != currentText || textCommitted) {
+      try {
+        widget.onChanged?.call(currentText);
+      } catch (exception, stack) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: exception,
+          stack: stack,
+          library: 'widgets',
+          context: ErrorDescription('while calling onChanged'),
+        ));
+      }
     }
     endBatchEdit();
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3616,17 +3616,15 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _bringIntoViewBySelectionState(oldTextSelection, value.selection, cause);
     }
     final String currentText = _value.text;
-    if (oldValue.text != currentText) {
-      try {
-        widget.onChanged?.call(currentText);
-      } catch (exception, stack) {
-        FlutterError.reportError(FlutterErrorDetails(
-          exception: exception,
-          stack: stack,
-          library: 'widgets',
-          context: ErrorDescription('while calling onChanged'),
-        ));
-      }
+    try {
+      widget.onChanged?.call(currentText);
+    } catch (exception, stack) {
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: exception,
+        stack: stack,
+        library: 'widgets',
+        context: ErrorDescription('while calling onChanged'),
+      ));
     }
     endBatchEdit();
   }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5042,7 +5042,7 @@ void main() {
     expect(onChangedCount , 2);
     expect(controller.value.isComposingRangeValid , true);
 
-    // Simulate selecting the item that show 'and' on accessory view. 
+    // Simulate selecting the item that show 'and' on accessory view.
     state.updateEditingValue(
       const TextEditingValue(text: 'and'),
     );


### PR DESCRIPTION
Fixes [#128565](https://github.com/flutter/flutter/issues/128565)

If using Android native project to verify, we will find that the issue [#111651](https://github.com/flutter/flutter/issues/111651) is not a bug, and it is the same under iOS.