### PR TITLE
Use platform specific line separator in gen-l10n

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
@@ -49,6 +47,9 @@ Future<LocalizationsGenerator> generateLocalizations({
 
   precacheLanguageAndRegionTags();
 
+  // Use \r\n if project's pubspec file contains \r\n.
+  final bool useCRLF = fileSystem.file('pubspec.yaml').readAsStringSync().contains('\r\n');
+
   LocalizationsGenerator generator;
   try {
     generator = LocalizationsGenerator(
@@ -73,7 +74,7 @@ Future<LocalizationsGenerator> generateLocalizations({
       suppressWarnings: options.suppressWarnings,
     )
       ..loadResources()
-      ..writeOutputFiles(isFromYaml: true);
+      ..writeOutputFiles(isFromYaml: true, useCRLF: useCRLF);
   } on L10nException catch (e) {
     throwToolExit(e.message);
   }
@@ -81,7 +82,6 @@ Future<LocalizationsGenerator> generateLocalizations({
   final List<String> outputFileList = generator.outputFileList;
   final File? untranslatedMessagesFile = generator.untranslatedMessagesFile;
 
-  // All other post processing.
   if (options.format) {
     final List<String> formatFileList = outputFileList.toList();
     if (untranslatedMessagesFile != null) {
@@ -1312,7 +1312,7 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
     }
   }
 
-  List<String> writeOutputFiles({ bool isFromYaml = false }) {
+  List<String> writeOutputFiles({ bool isFromYaml = false, bool useCRLF = false }) {
     // First, generate the string contents of all necessary files.
     final String generatedLocalizationsFile = _generateCode();
 
@@ -1330,7 +1330,9 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
       syntheticPackageDirectory.createSync(recursive: true);
       final File flutterGenPubspec = syntheticPackageDirectory.childFile('pubspec.yaml');
       if (!flutterGenPubspec.existsSync()) {
-        flutterGenPubspec.writeAsStringSync(emptyPubspecTemplate.replaceAll('\n', Platform.lineTerminator));
+        flutterGenPubspec.writeAsStringSync(
+          useCRLF ? emptyPubspecTemplate.replaceAll('\n', '\r\n') : emptyPubspecTemplate
+        );
       }
     }
 
@@ -1349,11 +1351,13 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
 
     // Generate the required files for localizations.
     _languageFileMap.forEach((File file, String contents) {
-      file.writeAsStringSync(contents.replaceAll('\n', Platform.lineTerminator));
+      file.writeAsStringSync(useCRLF ? contents.replaceAll('\n', '\r\n') : contents);
       _outputFileList.add(file.absolute.path);
     });
 
-    baseOutputFile.writeAsStringSync(generatedLocalizationsFile.replaceAll('\n', Platform.lineTerminator));
+    baseOutputFile.writeAsStringSync(
+      useCRLF ? generatedLocalizationsFile.replaceAll('\n', '\r\n') : generatedLocalizationsFile
+    );
     final File? messagesFile = untranslatedMessagesFile;
     if (messagesFile != null) {
       _generateUntranslatedMessagesFile(logger, messagesFile);
@@ -1389,12 +1393,12 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
       if (!inputsAndOutputsListFileLocal.existsSync()) {
         inputsAndOutputsListFileLocal.createSync(recursive: true);
       }
-
+      final String filesListContent = json.encode(<String, Object> {
+        'inputs': _inputFileList,
+        'outputs': _outputFileList,
+      });
       inputsAndOutputsListFileLocal.writeAsStringSync(
-        json.encode(<String, Object> {
-          'inputs': _inputFileList,
-          'outputs': _outputFileList,
-        }).replaceAll('\n', Platform.lineTerminator),
+        useCRLF ? filesListContent.replaceAll('\n', '\r\n') : filesListContent,
       );
     }
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
@@ -1328,7 +1330,7 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
       syntheticPackageDirectory.createSync(recursive: true);
       final File flutterGenPubspec = syntheticPackageDirectory.childFile('pubspec.yaml');
       if (!flutterGenPubspec.existsSync()) {
-        flutterGenPubspec.writeAsStringSync(emptyPubspecTemplate);
+        flutterGenPubspec.writeAsStringSync(emptyPubspecTemplate.replaceAll('\n', Platform.lineTerminator));
       }
     }
 
@@ -1347,11 +1349,11 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
 
     // Generate the required files for localizations.
     _languageFileMap.forEach((File file, String contents) {
-      file.writeAsStringSync(contents);
+      file.writeAsStringSync(contents.replaceAll('\n', Platform.lineTerminator));
       _outputFileList.add(file.absolute.path);
     });
 
-    baseOutputFile.writeAsStringSync(generatedLocalizationsFile);
+    baseOutputFile.writeAsStringSync(generatedLocalizationsFile.replaceAll('\n', Platform.lineTerminator));
     final File? messagesFile = untranslatedMessagesFile;
     if (messagesFile != null) {
       _generateUntranslatedMessagesFile(logger, messagesFile);
@@ -1392,7 +1394,7 @@ The plural cases must be one of "=0", "=1", "=2", "zero", "one", "two", "few", "
         json.encode(<String, Object> {
           'inputs': _inputFileList,
           'outputs': _outputFileList,
-        }),
+        }).replaceAll('\n', Platform.lineTerminator),
       );
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -78,6 +78,11 @@ void main() {
     "description": "Sample description"
   }
 }''');
+    fileSystem
+      .file('pubspec.yaml')
+      .writeAsStringSync('''
+flutter:
+  generate: true''');
 
     final GenerateLocalizationsCommand command = GenerateLocalizationsCommand(
       fileSystem: fileSystem,
@@ -109,7 +114,11 @@ void main() {
   }
 }''');
     fileSystem.file('header.txt').writeAsStringSync('a header file');
-
+    fileSystem
+      .file('pubspec.yaml')
+      .writeAsStringSync('''
+flutter:
+  generate: true''');
     final GenerateLocalizationsCommand command = GenerateLocalizationsCommand(
       fileSystem: fileSystem,
       logger: logger,

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -442,7 +442,7 @@ format: true
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-   testUsingContext('throw when generate: false and uses synthetic package when run via commandline options', () async {
+  testUsingContext('throw when generate: false and uses synthetic package when run via commandline options', () async {
     final File arbFile = fileSystem.file(fileSystem.path.join('lib', 'l10n', 'app_en.arb'))
       ..createSync(recursive: true);
     arbFile.writeAsStringSync('''
@@ -475,7 +475,6 @@ format: true
       () async => createTestCommandRunner(command).run(<String>['gen-l10n', '--synthetic-package']),
       throwsToolExit(message: 'Attempted to generate localizations code without having the flutter: generate flag turned on.')
     );
-
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -799,6 +799,35 @@ flutter:
       );
     });
 
+    testWithoutContext('uses the same line terminator as pubspec.yaml', () async {
+      _standardFlutterDirectoryL10nSetup(fs);
+
+      fs.file('pubspec.yaml')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+flutter:\r
+  generate: true\r
+''');
+
+      final LocalizationOptions options = LocalizationOptions(
+        arbDir: fs.path.join('lib', 'l10n'),
+        outputClass: defaultClassNameString,
+        outputLocalizationFile: defaultOutputFileString,
+      );
+      await generateLocalizations(
+        fileSystem: fs,
+        options: options,
+        logger: BufferLogger.test(),
+        projectDir: fs.currentDirectory,
+        dependenciesDir: fs.currentDirectory,
+        artifacts: artifacts,
+        processManager: processManager,
+      );
+      final String content = getGeneratedFileContent(locale: 'en');
+      expect(content, contains('\r\n'));
+    });
+
+
     testWithoutContext('blank lines generated nicely', () async {
       _standardFlutterDirectoryL10nSetup(fs);
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -827,7 +827,6 @@ flutter:\r
       expect(content, contains('\r\n'));
     });
 
-
     testWithoutContext('blank lines generated nicely', () async {
       _standardFlutterDirectoryL10nSetup(fs);
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -59,6 +59,13 @@ void _standardFlutterDirectoryL10nSetup(FileSystem fs) {
     .writeAsStringSync(singleMessageArbFileString);
   l10nDirectory.childFile(esArbFileName)
     .writeAsStringSync(singleEsMessageArbFileString);
+  fs.file('pubspec.yaml')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+flutter:
+  generate: true
+''');
+
 }
 
 void main() {
@@ -763,7 +770,7 @@ class FooEn extends Foo {
       _standardFlutterDirectoryL10nSetup(fs);
 
       // Missing flutter: generate: true should throw exception.
-      fs.file(fs.path.join(syntheticPackagePath, 'pubspec.yaml'))
+      fs.file('pubspec.yaml')
         ..createSync(recursive: true)
         ..writeAsStringSync('''
 flutter:


### PR DESCRIPTION
Currently files are not generated with `\r\n` in windows. This PR should fix the issue.

Fixes https://github.com/flutter/flutter/issues/109761.