### PR TITLE
Fix unreachable case in `MultiSelectableSelectionContainerDelegate` `handleSelectWord`

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -397,6 +397,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
         if (end == -1) {
           end = plainText.length;
         }
+        debugPrint('_SelectableFragment(paragraph: $this, range: ${TextRange(start: start, end: end)}, fullText: $plainText)');
         result.add(_SelectableFragment(paragraph: this, range: TextRange(start: start, end: end), fullText: plainText));
         start = end;
       }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1980,14 +1980,14 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
+        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
+          return SelectionResult.next;
+        }
         if (lastSelectionResult == SelectionResult.next) {
           continue;
         }
         if (index == 0 && lastSelectionResult == SelectionResult.previous) {
           return SelectionResult.previous;
-        }
-        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
-          return SelectionResult.next;
         }
         if (selectables[index].value != existingGeometry) {
           // Geometry has changed as a result of select word, need to clear the

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1977,7 +1977,14 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       final Rect localRect = Rect.fromLTWH(0, 0, selectables[index].size.width, selectables[index].size.height);
       final Matrix4 transform = selectables[index].getTransformTo(null);
       final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
+      debugPrint('$globalRect');
+    }
+    for (int index = 0; index < selectables.length; index += 1) {
+      final Rect localRect = Rect.fromLTWH(0, 0, selectables[index].size.width, selectables[index].size.height);
+      final Matrix4 transform = selectables[index].getTransformTo(null);
+      final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
       if (globalRect.contains(event.globalPosition)) {
+        debugPrint('$globalRect contains ${event.globalPosition}');
         final SelectionGeometry existingGeometry = selectables[index].value;
         lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
         if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
@@ -1999,6 +2006,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
         }
         return SelectionResult.end;
       } else {
+        debugPrint('$globalRect does not contain ${event.globalPosition}');
         if (lastSelectionResult == SelectionResult.next) {
           currentSelectionStartIndex = currentSelectionEndIndex = index - 1;
           return SelectionResult.end;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1246,9 +1246,10 @@ void main() {
       'can select word when a selectables rect is completely inside of another selectables rect', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/127076.
       final UniqueKey outerText = UniqueKey();
+      const TextStyle textStyle = TextStyle(fontSize: 10);
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: false),
+          theme: ThemeData(useMaterial3: true),
           home: SelectableRegion(
             focusNode: FocusNode(),
             selectionControls: materialTextSelectionControls,
@@ -1260,10 +1261,12 @@ void main() {
                         TextSpan(
                           text:
                               'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                          style: textStyle,
                         ),
-                        WidgetSpan(child: Text('Some text in a WidgetSpan. ')),
-                        TextSpan(text: 'Hello, world.'),
+                        WidgetSpan(child: Text('Some text in a WidgetSpan. ', style: textStyle)),
+                        TextSpan(text: 'Hello, world.', style: textStyle),
                       ],
+                      style: textStyle,
                   ),
                   key: outerText,
                 ),


### PR DESCRIPTION
Fixes an issue in `handleSelectWord` where it can never return `SelectionResult.next` when the last selectable returns with a result of `SelectionResult.next` because a preceding check for `SelectionResult.next` takes precedence. This change moves the case above the preceding one so it can actually be reached.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.