### PR TITLE
Always escape when writing pubspec.yaml's 'description' field.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -389,7 +389,7 @@ abstract class CreateBase extends FlutterCommand {
       'macosIdentifier': appleIdentifier,
       'linuxIdentifier': linuxIdentifier,
       'windowsIdentifier': windowsIdentifier,
-      'description': projectDescription,
+      'description': projectDescription != null ? escapeYamlString(projectDescription) : null,
       'dartSdk': '$flutterRoot/bin/cache/dart-sdk',
       'androidMinApiLevel': android_common.minApiLevel,
       'androidSdkVersion': kAndroidSdkMinVersion,

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3266,6 +3266,24 @@ void main() {
     ),
   });
 
+  testUsingContext('should escape ":" in project description', () async {
+    await _createProject(
+      projectDir,
+      <String>[
+        '--no-pub',
+        '--description',
+        'a: b',
+      ],
+      <String>[
+        'pubspec.yaml',
+      ],
+    );
+
+    final String rawPubspec = await projectDir.childFile('pubspec.yaml').readAsString();
+    final Pubspec pubspec = Pubspec.parse(rawPubspec);
+    expect(pubspec.description, 'a: b');
+  });
+
   testUsingContext('create an FFI plugin with ios, then add macos', () async {
     Cache.flutterRoot = '../..';
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/80013.

**Before**:

```
$ flutter create test1 --description "a: b"
Creating project test1...
Error detected in pubspec.yaml:
Error on line 2, column 15: Mapping values are not allowed here. Did you miss a colon earlier?
  ╷
2 │ description: a: b
  │               ^
  ╵
Please correct the pubspec.yaml file at /Users/matan/Developer/scratch/test1/pubspec.yaml
```

**After**:

```
$ flutter create test1 --description "a: b"
Creating project test1...
Resolving dependencies in test1... 
Got dependencies in test1.
Wrote 129 files.

All done!
You can find general documentation for Flutter at: https://docs.flutter.dev/
Detailed API documentation is available at: https://api.flutter.dev/
If you prefer video documentation, consider: https://www.youtube.com/c/flutterdev

In order to run your application, type:

  $ cd test1
  $ flutter run

Your application code is in test1/lib/main.dart.
```

---

It's worth noting that this _always_ escapes a non-empty project description, which means that descriptions that were not previously wrapped in `"`s' will be. I'm not sure how worth it is to do a _conditional_ escape (i.e. only escape if not escaping would cause a problem), but willing to change.

Side-note: I had no idea where to list this test in the (very large) `create_test.dart`, so I did my best :)