### PR TITLE
Throw error on unexpected positional arguments

### DIFF
--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -219,8 +219,8 @@ class GenerateLocalizationsCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     // Validate the rest of the args.
-    if (argResults?.rest.isNotEmpty ?? false) {
-      throwToolExit('Unrecognized');
+    if (argResults!.rest.isNotEmpty) {
+      throwToolExit('Unexpected positional argument "${argResults!.rest.first}".');
     }
     // Keep in mind that this is also defined in the following locations:
     // 1. flutter_tools/lib/src/build_system/targets/localizations.dart

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -5,6 +5,7 @@
 import 'package:process/process.dart';
 
 import '../artifacts.dart';
+import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../localizations/gen_l10n.dart';
@@ -217,6 +218,10 @@ class GenerateLocalizationsCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    // Validate the rest of the args.
+    if (argResults?.rest.isNotEmpty ?? false) {
+      throwToolExit('Unrecognized');
+    }
     // Keep in mind that this is also defined in the following locations:
     // 1. flutter_tools/lib/src/build_system/targets/localizations.dart
     // 2. flutter_tools/test/general.shard/build_system/targets/localizations_test.dart

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -480,4 +480,17 @@ format: true
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
   });
+
+  testUsingContext('throws error when unexpected positional argument is provided', () {
+    final GenerateLocalizationsCommand command = GenerateLocalizationsCommand(
+      fileSystem: fileSystem,
+      logger: logger,
+      artifacts: artifacts,
+      processManager: processManager,
+    );
+    expect(
+      () async => createTestCommandRunner(command).run(<String>['gen-l10n', '--synthetic-package', 'false']),
+      throwsToolExit(message: 'Unexpected positional argument "false".')
+    );
+  });
 }


### PR DESCRIPTION
This PR fixes ignoring when random positional arguments added to the `flutter gen-l10n`.

So we are no longer able to call `flutter gen-l10n hello world` or `flutter gen-l10n --format false`.

Fixes https://github.com/flutter/flutter/issues/118203