### PR TITLE
Update `Checkbox` tests for M2/M3

### DIFF
--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1802,13 +1802,13 @@ void main() {
     expect(getCheckboxRenderer(), paints..path(color: activeColor)); // checkbox fill
   });
 
-  testWidgets('Checkbox MaterialStateBorderSide applies unconditionally', (WidgetTester tester) async {
+  testWidgets('Material2 - Checkbox MaterialStateBorderSide applies unconditionally', (WidgetTester tester) async {
     const Color borderColor = Color(0xfff44336);
     const BorderSide side = BorderSide(
       width: 4,
       color: borderColor,
     );
-    final bool material3 = theme.useMaterial3;
+    final ThemeData theme = ThemeData(useMaterial3: false);
 
     Widget buildApp({ bool? value, bool enabled = true }) {
       return MaterialApp(
@@ -1832,9 +1832,63 @@ void main() {
         paints
         ..drrect(
           color: borderColor,
-          outer: material3 ? RRect.fromLTRBR(15, 15, 33, 33, const Radius.circular(2)) : RRect.fromLTRBR(15, 15, 33, 33, const Radius.circular(1)),
+          outer: RRect.fromLTRBR(15, 15, 33, 33, const Radius.circular(1)),
           inner: RRect.fromLTRBR(19, 19, 29, 29, Radius.zero),
         ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(value: false));
+    await tester.pumpAndSettle();
+    expectBorder();
+
+
+    await tester.pumpWidget(buildApp(value: false, enabled: false));
+    await tester.pumpAndSettle();
+    expectBorder();
+
+    await tester.pumpWidget(buildApp(value: true));
+    await tester.pumpAndSettle();
+    expectBorder();
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expectBorder();
+  });
+
+  testWidgets('Material3 - Checkbox MaterialStateBorderSide applies unconditionally', (WidgetTester tester) async {
+    const Color borderColor = Color(0xfff44336);
+    const BorderSide side = BorderSide(
+      width: 4,
+      color: borderColor,
+    );
+    final ThemeData theme = ThemeData(useMaterial3: true);
+
+    Widget buildApp({ bool? value, bool enabled = true }) {
+      return MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: Checkbox(
+              value: value,
+              tristate: value == null,
+              onChanged: enabled ? (bool? newValue) { } : null,
+              side: MaterialStateBorderSide.resolveWith((Set<MaterialState> states) => side),
+            ),
+          ),
+        ),
+      );
+    }
+
+    void expectBorder() {
+      expect(
+        tester.renderObject<RenderBox>(find.byType(Checkbox)),
+        paints
+          ..drrect(
+            color: borderColor,
+            outer: RRect.fromLTRBR(15, 15, 33, 33, const Radius.circular(2)),
+            inner: RRect.fromLTRBR(19, 19, 29, 29, Radius.zero),
+          ),
       );
     }
 
@@ -1910,7 +1964,7 @@ void main() {
     expect(find.text(tapTooltip), findsOneWidget);
   });
 
-  testWidgets('Checkbox has default error color when isError is set to true - M3', (WidgetTester tester) async {
+  testWidgets('Checkbox has default error color when isError is set to true - M3 only', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
     final ThemeData themeData = ThemeData(useMaterial3: true);
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
@@ -1982,7 +2036,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('Checkbox MaterialStateBorderSide applies in error states - M3', (WidgetTester tester) async {
+  testWidgets('Checkbox MaterialStateBorderSide applies in error states - M3 only', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
     final ThemeData themeData = ThemeData(useMaterial3: true);
     const Color borderColor = Color(0xffffeb3b);
@@ -2061,7 +2115,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('Checkbox has correct default shape - M3', (WidgetTester tester) async {
+  testWidgets('Checkbox has correct default shape - M3 only', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData(useMaterial3: true);
 
     Widget buildApp() {
@@ -2127,7 +2181,8 @@ void main() {
     }
   });
 
-  testWidgets('Checkbox respects fillColor when it is unchecked', (WidgetTester tester) async {
+  testWidgets('Material2 - Checkbox respects fillColor when it is unchecked', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: false);
     const Color activeBackgroundColor = Color(0xff123456);
     const Color inactiveBackgroundColor = Color(0xff654321);
 
@@ -2163,7 +2218,7 @@ void main() {
       getCheckboxRenderer(),
       paints
         ..drrect(
-          color: theme.useMaterial3 ? theme.colorScheme.onSurfaceVariant : theme.unselectedWidgetColor,
+          color: theme.unselectedWidgetColor,
         ),
     );
     expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
@@ -2174,7 +2229,61 @@ void main() {
       getCheckboxRenderer(),
       paints
         ..drrect(
-          color: theme.useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.38) : theme.disabledColor,
+          color: theme.disabledColor,
+        ),
+    );
+    expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
+  });
+
+  testWidgets('Material3 - Checkbox respects fillColor when it is unchecked', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    const Color activeBackgroundColor = Color(0xff123456);
+    const Color inactiveBackgroundColor = Color(0xff654321);
+
+    Widget buildApp({ bool enabled = true }) {
+      return MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: Checkbox(
+              fillColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                if (states.contains(MaterialState.selected)) {
+                  return activeBackgroundColor;
+                }
+                return inactiveBackgroundColor;
+              }),
+              value: false,
+              onChanged: enabled ? (bool? newValue) { } : null,
+            ),
+          ),
+        ),
+      );
+    }
+
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
+    }
+
+    // Checkbox is unselected, so the default BorderSide appears and fillColor is checkbox's background color.
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      getCheckboxRenderer(),
+      paints
+        ..drrect(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+    );
+    expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));
+
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      getCheckboxRenderer(),
+      paints
+        ..drrect(
+          color: theme.colorScheme.onSurface.withOpacity(0.38),
         ),
     );
     expect(getCheckboxRenderer(), paints..path(color: inactiveBackgroundColor));

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1964,7 +1964,7 @@ void main() {
     expect(find.text(tapTooltip), findsOneWidget);
   });
 
-  testWidgets('Checkbox has default error color when isError is set to true - M3 only', (WidgetTester tester) async {
+  testWidgets('Material3 - Checkbox has default error color when isError is set to true', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
     final ThemeData themeData = ThemeData(useMaterial3: true);
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
@@ -2036,7 +2036,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('Checkbox MaterialStateBorderSide applies in error states - M3 only', (WidgetTester tester) async {
+  testWidgets('Material3 - Checkbox MaterialStateBorderSide applies in error states', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
     final ThemeData themeData = ThemeData(useMaterial3: true);
     const Color borderColor = Color(0xffffeb3b);
@@ -2115,7 +2115,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('Checkbox has correct default shape - M3 only', (WidgetTester tester) async {
+  testWidgets('Material3 - Checkbox has correct default shape', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData(useMaterial3: true);
 
     Widget buildApp() {
@@ -2211,7 +2211,6 @@ void main() {
     }
 
     // Checkbox is unselected, so the default BorderSide appears and fillColor is checkbox's background color.
-
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     expect(
@@ -2265,7 +2264,6 @@ void main() {
     }
 
     // Checkbox is unselected, so the default BorderSide appears and fillColor is checkbox's background color.
-
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     expect(

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -414,7 +414,8 @@ void main() {
     semanticsTester.dispose();
   });
 
-  testWidgets('Checkbox tristate rendering, programmatic transitions', (WidgetTester tester) async {
+  testWidgets('Material2 - Checkbox tristate rendering, programmatic transitions', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: false);
     Widget buildFrame(bool? checkboxValue) {
       return Theme(
         data: theme,
@@ -446,8 +447,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(),
       paints
-        ..path(color: theme.useMaterial3 ? theme.colorScheme.primary : theme.colorScheme.secondary)
-        ..path(color: theme.useMaterial3 ? theme.colorScheme.onPrimary : const Color(0xFFFFFFFF))
+        ..path(color: theme.colorScheme.secondary)
+        ..path(color: const Color(0xFFFFFFFF))
     ); // checkmark is rendered as a path
 
     await tester.pumpWidget(buildFrame(false));
@@ -464,8 +465,8 @@ void main() {
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(),
       paints
-        ..path(color: theme.useMaterial3 ? theme.colorScheme.primary : theme.colorScheme.secondary)
-        ..path(color: theme.useMaterial3 ? theme.colorScheme.onPrimary : const Color(0xFFFFFFFF))
+        ..path(color: theme.colorScheme.secondary)
+        ..path(color: const Color(0xFFFFFFFF))
     ); // checkmark is rendered as a path
 
     await tester.pumpWidget(buildFrame(null));
@@ -473,10 +474,124 @@ void main() {
     expect(getCheckboxRenderer(), paints..line()); // null is rendered as a line (a "dash")
   });
 
-  testWidgets('Checkbox color rendering', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData();
+  testWidgets('Material3 - Checkbox tristate rendering, programmatic transitions', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    Widget buildFrame(bool? checkboxValue) {
+      return Theme(
+        data: theme,
+        child: Material(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                tristate: true,
+                value: checkboxValue,
+                onChanged: (bool? value) { },
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
+    }
+
+    await tester.pumpWidget(buildFrame(false));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: Colors.transparent)); // paint transparent border
+    expect(getCheckboxRenderer(), isNot(paints..line())); // null is rendered as a line (a "dash")
+    expect(getCheckboxRenderer(), paints..drrect()); // empty checkbox
+
+    await tester.pumpWidget(buildFrame(true));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(),
+      paints
+        ..path(color: theme.colorScheme.primary)
+        ..path(color: theme.colorScheme.onPrimary)
+    ); // checkmark is rendered as a path
+
+    await tester.pumpWidget(buildFrame(false));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: Colors.transparent)); // paint transparent border
+    expect(getCheckboxRenderer(), isNot(paints..line())); // null is rendered as a line (a "dash")
+    expect(getCheckboxRenderer(), paints..drrect()); // empty checkbox
+
+    await tester.pumpWidget(buildFrame(null));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..line()); // null is rendered as a line (a "dash")
+
+    await tester.pumpWidget(buildFrame(true));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(),
+      paints
+        ..path(color: theme.colorScheme.primary)
+        ..path(color: theme.colorScheme.onPrimary)
+    ); // checkmark is rendered as a path
+
+    await tester.pumpWidget(buildFrame(null));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..line()); // null is rendered as a line (a "dash")
+  });
+
+  testWidgets('Material2 - Checkbox color rendering', (WidgetTester tester) async {
+    ThemeData theme = ThemeData(useMaterial3: false);
     const Color borderColor = Color(0xff2196f3);
-    const Color m3BorderColor = Color(0xFF6750A4);
+    Color checkColor = const Color(0xffFFFFFF);
+    Color activeColor;
+
+    Widget buildFrame({Color? activeColor, Color? checkColor, ThemeData? themeData}) {
+      return Material(
+        child: Theme(
+          data: theme,
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                value: true,
+                activeColor: activeColor,
+                checkColor: checkColor,
+                onChanged: (bool? value) { },
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
+    }
+
+    await tester.pumpWidget(buildFrame(checkColor: checkColor));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: borderColor)..path(color: checkColor)); // paints's color is 0xFFFFFFFF (default color)
+
+    checkColor = const Color(0xFF000000);
+
+    await tester.pumpWidget(buildFrame(checkColor: checkColor));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: borderColor)..path(color: checkColor)); // paints's color is 0xFF000000 (params)
+
+    activeColor = const Color(0xFF00FF00);
+
+    final ColorScheme colorScheme = const ColorScheme.light().copyWith(secondary: activeColor);
+    theme = theme.copyWith(colorScheme: colorScheme);
+    await tester.pumpWidget(buildFrame(
+      themeData: theme),
+    );
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: activeColor)); // paints's color is 0xFF00FF00 (theme)
+
+    activeColor = const Color(0xFF000000);
+
+    await tester.pumpWidget(buildFrame(activeColor: activeColor));
+    await tester.pumpAndSettle();
+    expect(getCheckboxRenderer(), paints..path(color: activeColor)); // paints's color is 0xFF000000 (params)
+  });
+
+  testWidgets('Material3 - Checkbox color rendering', (WidgetTester tester) async {
+    ThemeData theme = ThemeData(useMaterial3: true);
+    const Color borderColor = Color(0xFF6750A4);
     Color checkColor = const Color(0xffFFFFFF);
     Color activeColor;
 
@@ -504,25 +619,19 @@ void main() {
 
     await tester.pumpWidget(buildFrame(checkColor: checkColor));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: theme.useMaterial3 ? m3BorderColor : borderColor)..path(color: checkColor)); // paints's color is 0xFFFFFFFF (default color)
+    expect(getCheckboxRenderer(), paints..path(color: borderColor)..path(color: checkColor)); // paints's color is 0xFFFFFFFF (default color)
 
     checkColor = const Color(0xFF000000);
 
     await tester.pumpWidget(buildFrame(checkColor: checkColor));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: theme.useMaterial3 ? m3BorderColor : borderColor)..path(color: checkColor)); // paints's color is 0xFF000000 (params)
+    expect(getCheckboxRenderer(), paints..path(color: borderColor)..path(color: checkColor)); // paints's color is 0xFF000000 (params)
 
     activeColor = const Color(0xFF00FF00);
 
-    ThemeData themeData = ThemeData();
-    final bool material3 = themeData.useMaterial3;
-    final ColorScheme colorScheme = material3
-        ? const ColorScheme.light().copyWith(primary: activeColor)
-        : const ColorScheme.light().copyWith(secondary: activeColor);
-    themeData = themeData.copyWith(colorScheme: colorScheme);
-    await tester.pumpWidget(buildFrame(
-      themeData: themeData),
-    );
+    final ColorScheme colorScheme = const ColorScheme.light().copyWith(primary: activeColor);
+    theme = theme.copyWith(colorScheme: colorScheme);
+    await tester.pumpWidget(buildFrame(themeData: theme));
     await tester.pumpAndSettle();
     expect(getCheckboxRenderer(), paints..path(color: activeColor)); // paints's color is 0xFF00FF00 (theme)
 
@@ -533,8 +642,79 @@ void main() {
     expect(getCheckboxRenderer(), paints..path(color: activeColor)); // paints's color is 0xFF000000 (params)
   });
 
-  testWidgets('Checkbox is focusable and has correct focus color', (WidgetTester tester) async {
+  testWidgets('Material2 - Checkbox is focusable and has correct focus color', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool? value = true;
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                value: value,
+                onChanged: enabled ? (bool? newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                focusColor: Colors.orange[500],
+                autofocus: true,
+                focusNode: focusNode,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..circle(color: Colors.orange[500])
+        ..path(color: const Color(0xff2196f3))
+        ..path(color: Colors.white)
+    );
+
+    // Check the false value.
+    value = false;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..circle(color: Colors.orange[500])
+        ..drrect(
+          color: const Color(0x8a000000),
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(1.0)),
+          inner: RRect.fromLTRBR(17.0, 17.0, 31.0, 31.0, Radius.zero),
+        ),
+    );
+
+    // Check what happens when disabled.
+    value = false;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..drrect(
+          color: const Color(0x61000000),
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(1.0)),
+          inner: RRect.fromLTRBR(17.0, 17.0, 31.0, 31.0, Radius.zero),
+        ),
+    );
+  });
+
+  testWidgets('Material3 - Checkbox is focusable and has correct focus color', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
+    final ThemeData theme = ThemeData(useMaterial3: true);
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     bool? value = true;
     Widget buildApp({bool enabled = true}) {
@@ -562,19 +742,13 @@ void main() {
     await tester.pumpWidget(buildApp());
 
     await tester.pumpAndSettle();
-    final bool material3 = theme.useMaterial3;
     expect(focusNode.hasPrimaryFocus, isTrue);
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
-      material3
-        ? (paints
-          ..circle(color: Colors.orange[500])
-          ..path(color: theme.colorScheme.primary)
-          ..path(color: theme.colorScheme.onPrimary))
-        : (paints
-          ..circle(color: Colors.orange[500])
-          ..path(color: const Color(0xff2196f3))
-          ..path(color: Colors.white))
+      paints
+        ..circle(color: Colors.orange[500])
+        ..path(color: theme.colorScheme.primary)
+        ..path(color: theme.colorScheme.onPrimary)
     );
 
     // Check the false value.
@@ -587,8 +761,8 @@ void main() {
       paints
         ..circle(color: Colors.orange[500])
         ..drrect(
-          color: material3 ? theme.colorScheme.onSurface : const Color(0x8a000000),
-          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, material3 ? const Radius.circular(2.0) : const Radius.circular(1.0)),
+          color: theme.colorScheme.onSurface,
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(2.0)),
           inner: RRect.fromLTRBR(17.0, 17.0, 31.0, 31.0, Radius.zero),
         ),
     );
@@ -602,8 +776,8 @@ void main() {
       Material.of(tester.element(find.byType(Checkbox))),
       paints
         ..drrect(
-          color: material3 ? theme.colorScheme.onSurface.withOpacity(0.38) : const Color(0x61000000),
-          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, material3 ? const Radius.circular(2.0) : const Radius.circular(1.0)),
+          color: theme.colorScheme.onSurface.withOpacity(0.38),
+          outer: RRect.fromLTRBR(15.0, 15.0, 33.0, 33.0, const Radius.circular(2.0)),
           inner: RRect.fromLTRBR(17.0, 17.0, 31.0, 31.0, Radius.zero),
         ),
     );
@@ -670,10 +844,10 @@ void main() {
     );
   });
 
-  testWidgets('Checkbox can be hovered and has correct hover color', (WidgetTester tester) async {
+  testWidgets('Material2 - Checkbox can be hovered and has correct hover color', (WidgetTester tester) async {
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
     bool? value = true;
-    final bool material3 = theme.useMaterial3;
+    final ThemeData theme = ThemeData(useMaterial3: false);
     Widget buildApp({bool enabled = true}) {
       return MaterialApp(
         theme: theme,
@@ -699,8 +873,8 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: material3 ? const Color(0xff6750a4) : const Color(0xff2196f3))
-        ..path(color: material3 ? theme.colorScheme.onPrimary : const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+        ..path(color: const Color(0xff2196f3))
+        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
     // Start hovering
@@ -712,8 +886,8 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: material3 ? const Color(0xff6750a4) : const Color(0xff2196f3))
-        ..path(color: material3 ? theme.colorScheme.onPrimary : const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+        ..path(color: const Color(0xff2196f3))
+        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
 
     // Check what happens when disabled.
@@ -722,8 +896,65 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..path(color: material3 ? theme.colorScheme.onSurface.withOpacity(0.38) : const Color(0x61000000))
-        ..path(color: material3 ? theme.colorScheme.surface : const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+        ..path(color: const Color(0x61000000))
+        ..path(color: const Color(0xffffffff), style: PaintingStyle.stroke, strokeWidth: 2.0),
+    );
+  });
+
+  testWidgets('Material3 - Checkbox can be hovered and has correct hover color', (WidgetTester tester) async {
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool? value = true;
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    Widget buildApp({bool enabled = true}) {
+      return MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                value: value,
+                onChanged: enabled ? (bool? newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+                hoverColor: Colors.orange[500],
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..path(color: const Color(0xff6750a4))
+        ..path(color: theme.colorScheme.onPrimary, style: PaintingStyle.stroke, strokeWidth: 2.0),
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(tester.getCenter(find.byType(Checkbox)));
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..path(color: const Color(0xff6750a4))
+        ..path(color: theme.colorScheme.onPrimary, style: PaintingStyle.stroke, strokeWidth: 2.0),
+    );
+
+    // Check what happens when disabled.
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..path(color: theme.colorScheme.onSurface.withOpacity(0.38))
+        ..path(color: theme.colorScheme.surface, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
   });
 
@@ -1108,12 +1339,12 @@ void main() {
     );
   });
 
-  testWidgets('Checkbox default overlay color in active/pressed/focused/hovered states', (WidgetTester tester) async {
+  testWidgets('Material2 - Checkbox default overlay color in active/pressed/focused/hovered states', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
 
+    final ThemeData theme = ThemeData(useMaterial3: false);
     final ColorScheme colors = theme.colorScheme;
-    final bool material3 = theme.useMaterial3;
     Widget buildCheckbox({bool active = false, bool focused = false}) {
       return MaterialApp(
         theme: theme,
@@ -1134,11 +1365,8 @@ void main() {
 
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
-      material3
-        ? (paints..circle(color: colors.primary.withOpacity(0.12)))
-        : (paints
-          ..circle(color: theme.unselectedWidgetColor.withAlpha(kRadialReactionAlpha),)
-        ),
+      paints
+        ..circle(color: theme.unselectedWidgetColor.withAlpha(kRadialReactionAlpha)),
       reason: 'Default inactive pressed Checkbox should have overlay color from default fillColor',
     );
 
@@ -1148,11 +1376,8 @@ void main() {
 
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
-      material3
-        ? (paints..circle(color: colors.onSurface.withOpacity(0.12)))
-        : (paints
-          ..circle(color: colors.secondary.withAlpha(kRadialReactionAlpha),)
-        ),
+      paints
+        ..circle(color: colors.secondary.withAlpha(kRadialReactionAlpha)),
       reason: 'Default active pressed Checkbox should have overlay color from default fillColor',
     );
 
@@ -1163,9 +1388,7 @@ void main() {
     expect(focusNode.hasPrimaryFocus, isTrue);
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
-      material3
-        ? (paints..circle(color: colors.onSurface.withOpacity(0.12)))
-        : (paints..circle(color: theme.focusColor)),
+      paints..circle(color: theme.focusColor),
       reason: 'Focused Checkbox should use default focused overlay color',
     );
 
@@ -1178,9 +1401,72 @@ void main() {
 
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
-      material3
-          ? (paints..circle(color: colors.onSurface.withOpacity(0.08)))
-          : (paints..circle(color: theme.hoverColor)),
+      paints..circle(color: theme.hoverColor),
+      reason: 'Hovered Checkbox should use default hovered overlay color',
+    );
+  });
+
+  testWidgets('Material3 - Checkbox default overlay color in active/pressed/focused/hovered states', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    final ColorScheme colors = theme.colorScheme;
+    Widget buildCheckbox({bool active = false, bool focused = false}) {
+      return MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Checkbox(
+            focusNode: focusNode,
+            autofocus: focused,
+            value: active,
+            onChanged: (_) { },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildCheckbox());
+    await tester.startGesture(tester.getCenter(find.byType(Checkbox)));
+    await tester.pumpAndSettle();
+
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints..circle(color: colors.primary.withOpacity(0.12)),
+      reason: 'Default inactive pressed Checkbox should have overlay color from default fillColor',
+    );
+
+    await tester.pumpWidget(buildCheckbox(active: true));
+    await tester.startGesture(tester.getCenter(find.byType(Checkbox)));
+    await tester.pumpAndSettle();
+
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints..circle(color: colors.onSurface.withOpacity(0.12)),
+      reason: 'Default active pressed Checkbox should have overlay color from default fillColor',
+    );
+
+    await tester.pumpWidget(Container()); // reset test
+    await tester.pumpWidget(buildCheckbox(focused: true));
+    await tester.pumpAndSettle();
+
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints..circle(color: colors.onSurface.withOpacity(0.12)),
+      reason: 'Focused Checkbox should use default focused overlay color',
+    );
+
+    await tester.pumpWidget(Container()); // reset test
+    await tester.pumpWidget(buildCheckbox());
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(tester.getCenter(find.byType(Checkbox)));
+    await tester.pumpAndSettle();
+
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints..circle(color: colors.onSurface.withOpacity(0.08)),
       reason: 'Hovered Checkbox should use default hovered overlay color',
     );
   });

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -543,7 +543,7 @@ void main() {
     Widget buildFrame({Color? activeColor, Color? checkColor, ThemeData? themeData}) {
       return Material(
         child: Theme(
-          data: theme,
+          data: themeData ?? theme,
           child: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
               return Checkbox(
@@ -586,7 +586,7 @@ void main() {
 
     await tester.pumpWidget(buildFrame(activeColor: activeColor));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeColor)); // paints's color is 0xFF000000 (params)
+    expect(getCheckboxRenderer(), paints..path(color: activeColor));
   });
 
   testWidgets('Material3 - Checkbox color rendering', (WidgetTester tester) async {
@@ -639,7 +639,7 @@ void main() {
 
     await tester.pumpWidget(buildFrame(activeColor: activeColor));
     await tester.pumpAndSettle();
-    expect(getCheckboxRenderer(), paints..path(color: activeColor)); // paints's color is 0xFF000000 (params)
+    expect(getCheckboxRenderer(), paints..path(color: activeColor));
   });
 
   testWidgets('Material2 - Checkbox is focusable and has correct focus color', (WidgetTester tester) async {


### PR DESCRIPTION
Updated unit tests for `Checkbox` to have M2 and M3 versions.

More info in #127064

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
