### PR TITLE
Update `DialogTheme` tests for M2/M3

### DIFF
--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -165,7 +165,31 @@ void main() {
     expect(bottomLeft.dy, 576.0);
   });
 
-  testWidgets('Dialog alignment takes priority over theme', (WidgetTester tester) async {
+  testWidgets('Material3 - Dialog alignment takes priority over theme', (WidgetTester tester) async {
+    const AlertDialog dialog = AlertDialog(
+      title: Text('Title'),
+      actions: <Widget>[ ],
+      alignment: Alignment.topRight,
+    );
+    final ThemeData theme = ThemeData(
+      useMaterial3: true,
+      dialogTheme: const DialogTheme(alignment: Alignment.bottomLeft),
+    );
+
+    await tester.pumpWidget(
+      _appWithDialog(tester, dialog, theme: theme),
+    );
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Offset bottomLeft = tester.getBottomLeft(
+      find.descendant(of: find.byType(Dialog), matching: find.byType(Material)),
+    );
+    expect(bottomLeft.dx, 480.0);
+    expect(bottomLeft.dy, 124.0);
+  });
+
+  testWidgets('Material2 - Dialog alignment takes priority over theme', (WidgetTester tester) async {
     const AlertDialog dialog = AlertDialog(
       title: Text('Title'),
       actions: <Widget>[ ],
@@ -186,7 +210,29 @@ void main() {
     expect(bottomLeft.dy, 104.0);
   });
 
-  testWidgets('Custom dialog shape matches golden', (WidgetTester tester) async {
+  testWidgets('Material3 - Custom dialog shape matches golden', (WidgetTester tester) async {
+    const RoundedRectangleBorder customBorder =
+      RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0)));
+    const AlertDialog dialog = AlertDialog(
+      title: Text('Title'),
+      actions: <Widget>[ ],
+    );
+    final ThemeData theme = ThemeData(
+      useMaterial3: true,
+      dialogTheme: const DialogTheme(shape: customBorder),
+    );
+
+    await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    await expectLater(
+      find.byKey(_painterKey),
+      matchesGoldenFile('dialog_theme.m3.dialog_with_custom_border.png'),
+    );
+  });
+
+  testWidgets('Material2 - Custom dialog shape matches golden', (WidgetTester tester) async {
     const RoundedRectangleBorder customBorder =
       RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0)));
     const AlertDialog dialog = AlertDialog(
@@ -201,7 +247,7 @@ void main() {
 
     await expectLater(
       find.byKey(_painterKey),
-      matchesGoldenFile('dialog_theme.dialog_with_custom_border.png'),
+      matchesGoldenFile('dialog_theme.m2.dialog_with_custom_border.png'),
     );
   });
 
@@ -246,7 +292,23 @@ void main() {
     expect(text.text.style!.color, dialogThemeColor);
   });
 
-  testWidgets('Custom Icon Color - Theme - lowest preference', (WidgetTester tester) async {
+  testWidgets('Material3 - Custom Icon Color - Theme - lowest preference', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    const AlertDialog dialog = AlertDialog(
+      icon: Icon(Icons.ac_unit),
+      actions: <Widget>[ ],
+    );
+
+    await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    // first is Text('X')
+    final RichText text = tester.widget(find.byType(RichText).last);
+    expect(text.text.style!.color, theme.colorScheme.secondary);
+  });
+
+  testWidgets('Material2 - Custom Icon Color - Theme - lowest preference', (WidgetTester tester) async {
     const Color iconThemeColor = Colors.yellow;
     final ThemeData theme = ThemeData(useMaterial3: false, iconTheme: const IconThemeData(color: iconThemeColor));
     const AlertDialog dialog = AlertDialog(
@@ -261,22 +323,6 @@ void main() {
     // first is Text('X')
     final RichText text = tester.widget(find.byType(RichText).last);
     expect(text.text.style!.color, iconThemeColor);
-  });
-
-  testWidgets('Custom Icon Color - Theme - lowest preference for M3', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData(useMaterial3: true);
-    const AlertDialog dialog = AlertDialog(
-      icon: Icon(Icons.ac_unit),
-      actions: <Widget>[ ],
-    );
-
-    await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
-    await tester.tap(find.text('X'));
-    await tester.pumpAndSettle();
-
-    // first is Text('X')
-    final RichText text = tester.widget(find.byType(RichText).last);
-    expect(text.text.style!.color, theme.colorScheme.secondary);
   });
 
   testWidgets('Custom Title Text Style - Constructor Param', (WidgetTester tester) async {
@@ -313,13 +359,24 @@ void main() {
     expect(title.text.style, titleTextStyle);
   });
 
-  testWidgets('Custom Title Text Style - Theme', (WidgetTester tester) async {
+  testWidgets('Material3 - Custom Title Text Style - Theme', (WidgetTester tester) async {
     const String titleText = 'Title';
     const TextStyle titleTextStyle = TextStyle(color: Colors.pink);
-    const AlertDialog dialog = AlertDialog(
-      title: Text(titleText),
-      actions: <Widget>[ ],
-    );
+    const AlertDialog dialog = AlertDialog(title: Text(titleText));
+    final ThemeData theme = ThemeData(useMaterial3: true, textTheme: const TextTheme(headlineSmall: titleTextStyle));
+
+    await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final RenderParagraph title = _getTextRenderObject(tester, titleText);
+    expect(title.text.style!.color, titleTextStyle.color);
+  });
+
+  testWidgets('Material2 - Custom Title Text Style - Theme', (WidgetTester tester) async {
+    const String titleText = 'Title';
+    const TextStyle titleTextStyle = TextStyle(color: Colors.pink);
+    const AlertDialog dialog = AlertDialog(title: Text(titleText));
     final ThemeData theme = ThemeData(useMaterial3: false, textTheme: const TextTheme(titleLarge: titleTextStyle));
 
     await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
@@ -412,13 +469,24 @@ void main() {
     expect(content.text.style, contentTextStyle);
   });
 
-  testWidgets('Custom Content Text Style - Theme', (WidgetTester tester) async {
+  testWidgets('Material3 - Custom Content Text Style - Theme', (WidgetTester tester) async {
     const String contentText = 'Content';
     const TextStyle contentTextStyle = TextStyle(color: Colors.pink);
-    const AlertDialog dialog = AlertDialog(
-      content: Text(contentText),
-      actions: <Widget>[ ],
-    );
+    const AlertDialog dialog = AlertDialog(content: Text(contentText),);
+    final ThemeData theme = ThemeData(useMaterial3: true, textTheme: const TextTheme(bodyMedium: contentTextStyle));
+
+    await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final RenderParagraph content = _getTextRenderObject(tester, contentText);
+    expect(content.text.style!.color, contentTextStyle.color);
+  });
+
+  testWidgets('Material2 - Custom Content Text Style - Theme', (WidgetTester tester) async {
+    const String contentText = 'Content';
+    const TextStyle contentTextStyle = TextStyle(color: Colors.pink);
+    const AlertDialog dialog = AlertDialog(content: Text(contentText));
     final ThemeData theme = ThemeData(useMaterial3: false, textTheme: const TextTheme(titleMedium: contentTextStyle));
 
     await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -228,7 +228,7 @@ void main() {
 
     await expectLater(
       find.byKey(_painterKey),
-      matchesGoldenFile('dialog_theme.m3.dialog_with_custom_border.png'),
+      matchesGoldenFile('m3_dialog_theme.dialog_with_custom_border.png'),
     );
   });
 
@@ -247,7 +247,7 @@ void main() {
 
     await expectLater(
       find.byKey(_painterKey),
-      matchesGoldenFile('dialog_theme.m2.dialog_with_custom_border.png'),
+      matchesGoldenFile('m2_dialog_theme.dialog_with_custom_border.png'),
     );
   });
 


### PR DESCRIPTION
Updated unit tests for `DialogTheme` to have M2 and M3 versions.

More info in https://github.com/flutter/flutter/pull/128725

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
