### PR TITLE
Update `Divider`/`VerticalDivider` and theme tests for M2/M3

### DIFF
--- a/packages/flutter/test/material/divider_test.dart
+++ b/packages/flutter/test/material/divider_test.dart
@@ -4,16 +4,29 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../rendering/mock_canvas.dart';
 
 void main() {
-  testWidgets('Divider control test', (WidgetTester tester) async {
+  testWidgets('Material3 - Divider control test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: const Center(child: Divider()),
+      ),
+    );
+    final RenderBox box = tester.firstRenderObject(find.byType(Divider));
+    expect(box.size.height, 16.0);
+    final Container container = tester.widget(find.byType(Container));
+    final BoxDecoration decoration = container.decoration! as BoxDecoration;
+    expect(decoration.border!.bottom.width, 1.0);
+  });
+
+  testWidgets('Material2 - Divider control test', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
-        home: const Center(
-          child: Divider(),
-        ),
+        home: const Center(child: Divider()),
       ),
     );
     final RenderBox box = tester.firstRenderObject(find.byType(Divider));
@@ -27,11 +40,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Center(
-          child: Divider(
-            thickness: 5.0,
-          ),
-        ),
+        child: Center(child: Divider(thickness: 5.0)),
       ),
     );
     final Container container = tester.widget(find.byType(Container));
@@ -47,11 +56,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Center(
-          child: Divider(
-            indent: customIndent,
-          ),
-        ),
+        child: Center(child: Divider(indent: customIndent)),
       ),
     );
     // The divider line is drawn with a DecoratedBox with a border
@@ -63,11 +68,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Center(
-          child: Divider(
-            endIndent: customIndent,
-          ),
-        ),
+        child: Center(child: Divider(endIndent: customIndent)),
       ),
     );
     dividerRect = tester.getRect(find.byType(Divider));
@@ -92,13 +93,26 @@ void main() {
     expect(lineRect.right, dividerRect.right - customIndent);
   });
 
-  testWidgets('Vertical Divider Test', (WidgetTester tester) async {
+  testWidgets('Material3 - Vertical Divider Test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: const Center(child: VerticalDivider()),
+      ),
+    );
+    final RenderBox box = tester.firstRenderObject(find.byType(VerticalDivider));
+    expect(box.size.width, 16.0);
+    final Container container = tester.widget(find.byType(Container));
+    final BoxDecoration decoration = container.decoration! as BoxDecoration;
+    final Border border = decoration.border! as Border;
+    expect(border.left.width, 1.0);
+  });
+
+  testWidgets('Material2 - Vertical Divider Test', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
-        home: const Center(
-          child: VerticalDivider(),
-        ),
+        home: const Center(child: VerticalDivider()),
       ),
     );
     final RenderBox box = tester.firstRenderObject(find.byType(VerticalDivider));
@@ -113,11 +127,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Center(
-          child: VerticalDivider(
-            thickness: 5.0,
-          ),
-        ),
+        child: Center(child: VerticalDivider(thickness: 5.0)),
       ),
     );
     final Container container = tester.widget(find.byType(Container));
@@ -158,11 +168,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Center(
-          child: VerticalDivider(
-            indent: customIndent,
-          ),
-        ),
+        child: Center(child: VerticalDivider(indent: customIndent)),
       ),
     );
     // The divider line is drawn with a DecoratedBox with a border
@@ -174,11 +180,7 @@ void main() {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
-        child: Center(
-          child: VerticalDivider(
-            endIndent: customIndent,
-          ),
-        ),
+        child: Center(child: VerticalDivider(endIndent: customIndent)),
       ),
     );
     dividerRect = tester.getRect(find.byType(VerticalDivider));

--- a/packages/flutter/test/material/divider_theme_test.dart
+++ b/packages/flutter/test/material/divider_theme_test.dart
@@ -26,9 +26,9 @@ void main() {
     const DividerThemeData().debugFillProperties(builder);
 
     final List<String> description = builder.properties
-        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
-        .map((DiagnosticsNode node) => node.toString())
-        .toList();
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString())
+      .toList();
 
     expect(description, <String>[]);
   });
@@ -44,9 +44,9 @@ void main() {
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
-        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
-        .map((DiagnosticsNode node) => node.toString())
-        .toList();
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString())
+      .toList();
 
     expect(description, <String>[
       'color: Color(0xffffffff)',
@@ -57,7 +57,7 @@ void main() {
     ]);
   });
 
-  group('Horizontal Divider', () {
+  group('Material3 - Horizontal Divider', () {
     testWidgets('Passing no DividerThemeData returns defaults', (WidgetTester tester) async {
       final ThemeData theme = ThemeData(useMaterial3: true);
       await tester.pumpWidget(MaterialApp(
@@ -159,7 +159,7 @@ void main() {
     });
   });
 
-  group('Vertical Divider', () {
+  group('Material3 - Vertical Divider', () {
     testWidgets('Passing no DividerThemeData returns defaults', (WidgetTester tester) async {
       final ThemeData theme = ThemeData(useMaterial3: true);
       await tester.pumpWidget(MaterialApp(
@@ -270,7 +270,7 @@ void main() {
     // support is deprecated and the APIs are removed, these tests
     // can be deleted.
 
-    group('Horizontal Divider', () {
+    group('Material2 - Horizontal Divider', () {
       testWidgets('Passing no DividerThemeData returns defaults', (WidgetTester tester) async {
         await tester.pumpWidget(MaterialApp(
           theme: ThemeData(useMaterial3: false),
@@ -313,7 +313,7 @@ void main() {
       });
     });
 
-    group('Vertical Divider', () {
+    group('Material2 - Vertical Divider', () {
       testWidgets('Passing no DividerThemeData returns defaults', (WidgetTester tester) async {
         await tester.pumpWidget(MaterialApp(
           theme: ThemeData(useMaterial3: false),


### PR DESCRIPTION
Updated unit tests for `Divider`/ `VerticalDivider`  and theme to have M2 and M3 versions.

More info in https://github.com/flutter/flutter/pull/128725

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
