### PR TITLE
Add missing links to examples that aren't linked anywhere

### DIFF
--- a/examples/api/lib/material/action_buttons/action_icon_theme.0.dart
+++ b/examples/api/lib/material/action_buttons/action_icon_theme.0.dart
@@ -73,7 +73,13 @@ class MyHomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text(title),
       ),
-      drawer: const Drawer(),
+      drawer: Drawer(
+        child: Column(
+          children: <Widget>[
+            TextButton(child: const Text('Drawer Item'), onPressed: () {}),
+          ],
+        ),
+      ),
       body: const Center(
         child: NextPageButton(),
       ),

--- a/examples/api/lib/material/search_anchor/search_anchor.3.dart
+++ b/examples/api/lib/material/search_anchor/search_anchor.3.dart
@@ -4,8 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [SearchAnchor] that shows how to fetch the suggestions
-/// from a remote API.
+/// Flutter code sample for [SearchAnchor].
 
 const Duration fakeAPIDuration = Duration(seconds: 1);
 
@@ -60,7 +59,7 @@ class _AsyncSearchAnchorState extends State<_AsyncSearchAnchor > {
           final List<String> options = (await _FakeAPI.search(_searchingWithQuery!)).toList();
 
           // If another search happened after this one, throw away these options.
-          // Use the previous options intead and wait for the newer request to
+          // Use the previous options instead and wait for the newer request to
           // finish.
           if (_searchingWithQuery != controller.text) {
             return _lastOptions;

--- a/examples/api/lib/material/search_anchor/search_anchor.4.dart
+++ b/examples/api/lib/material/search_anchor/search_anchor.4.dart
@@ -6,8 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [SearchAnchor] that demonstrates fetching the
-/// suggestions asynchronously and debouncing the network calls.
+/// Flutter code sample for [SearchAnchor].
 
 const Duration fakeAPIDuration = Duration(seconds: 1);
 const Duration debounceDuration = Duration(milliseconds: 500);

--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -4,12 +4,12 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [SnackBar] with Material 3 specifications.
+/// Flutter code sample for [SnackBar].
 
 void main() => runApp(const SnackBarExampleApp());
 
-// A Material 3 [SnackBar] demonstrating an optional icon, in either floating
-// or fixed format.
+/// A Material 3 [SnackBar] demonstrating an optional icon, in either floating
+/// or fixed format.
 class SnackBarExampleApp extends StatelessWidget {
   const SnackBarExampleApp({super.key});
 

--- a/examples/api/lib/material/switch/switch.3.dart
+++ b/examples/api/lib/material/switch/switch.3.dart
@@ -16,7 +16,7 @@ class SwitchApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData.light(useMaterial3: true).copyWith(
-        // Use the ambient [CupetinoThemeData] to style all widgets which would
+        // Use the ambient CupertinoThemeData to style all widgets which would
         // otherwise use iOS defaults.
         cupertinoOverrideTheme: const CupertinoThemeData(applyThemeToAll: true),
       ),
@@ -54,7 +54,7 @@ class _SwitchExampleState extends State<SwitchExample> {
           },
         ),
         Switch.adaptive(
-          // Don't use the ambient [CupetinoThemeData] to style this switch.
+          // Don't use the ambient CupertinoThemeData to style this switch.
           applyCupertinoTheme: false,
           value: light,
           onChanged: (bool value) {

--- a/examples/api/lib/painting/linear_border/linear_border.0.dart
+++ b/examples/api/lib/painting/linear_border/linear_border.0.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Examples of LinearBorder and LinearBorderEdge.
-
 import 'package:flutter/material.dart';
+
+/// Examples for [LinearBorder] and [LinearBorderEdge].
 
 void main() {
   runApp(const ExampleApp());
@@ -18,7 +18,8 @@ class ExampleApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData.light(useMaterial3: true),
       home: const Directionality(
-        textDirection: TextDirection.ltr, // Or try rtl.
+        // TRY THIS: Switch to TextDirection.rtl to see how the borders change.
+        textDirection: TextDirection.ltr,
         child: Home(),
       ),
     );

--- a/packages/flutter/lib/src/material/action_icons_theme.dart
+++ b/packages/flutter/lib/src/material/action_icons_theme.dart
@@ -114,6 +114,13 @@ class ActionIconThemeData with Diagnosticable {
 /// An inherited widget that overrides the default icon of [BackButtonIcon],
 /// [CloseButtonIcon], [DrawerButtonIcon], and [EndDrawerButtonIcon] in this
 /// widget's subtree.
+///
+/// {@tool dartpad}
+/// This example shows how to define custom builders for drawer and back
+/// buttons.
+///
+/// ** See code in examples/api/lib/material/action_buttons/action_icon_theme.0.dart **
+/// {@end-tool}
 class ActionIconTheme extends InheritedTheme {
   /// Creates a theme that overrides the default icon of [BackButtonIcon],
   /// [CloseButtonIcon], [DrawerButtonIcon], and [EndDrawerButtonIcon] in this

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -279,6 +279,12 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// the SnackBar to be visible.
   ///
   /// {@tool dartpad}
+  /// Here is an example showing how to display a [SnackBar] with [showSnackBar]
+  ///
+  /// ** See code in examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.0.dart **
+  /// {@end-tool}
+  ///
+  /// {@tool dartpad}
   /// Here is an example showing that a floating [SnackBar] appears above [Scaffold.floatingActionButton].
   ///
   /// ** See code in examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.1.dart **

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -87,6 +87,19 @@ typedef ViewBuilder = Widget Function(Iterable<Widget> suggestions);
 /// ** See code in examples/api/lib/material/search_anchor/search_anchor.1.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example shows how to fetch the search suggestions from a remote API.
+///
+/// ** See code in examples/api/lib/material/search_anchor/search_anchor.3.dart **
+/// {@end-tool}
+///
+/// {@tool dartpad}
+/// This example demonstrates fetching the search suggestions asynchronously and
+/// debouncing network calls.
+///
+/// ** See code in examples/api/lib/material/search_anchor/search_anchor.4.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 /// * [SearchBar], a widget that defines a search bar.

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -250,6 +250,13 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// ** See code in examples/api/lib/material/snack_bar/snack_bar.1.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example demonstrates the various [SnackBar] widget components,
+/// including an optional icon, in either floating or fixed format.
+///
+/// ** See code in examples/api/lib/material/snack_bar/snack_bar.2.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ScaffoldMessenger.of], to obtain the current [ScaffoldMessengerState],

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -69,6 +69,13 @@ enum _SwitchType { material, adaptive }
 /// ** See code in examples/api/lib/material/switch/switch.2.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example shows how to use the ambient [CupertinoThemeData] to style all
+/// widgets which would otherwise use iOS defaults.
+///
+/// ** See code in examples/api/lib/material/switch/switch.3.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [SwitchListTile], which combines this widget with a [ListTile] so that

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -178,6 +178,13 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 ///
 /// {@macro flutter.widgets.editableText.accessibility}
 ///
+/// {@tool dartpad}
+/// This sample shows how to style a text field to match a filled or outlined
+/// Material Design 3 text field.
+///
+/// ** See code in examples/api/lib/material/text_field/text_field.2.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [TextFormField], which integrates with the [Form] widget.

--- a/packages/flutter/lib/src/painting/linear_border.dart
+++ b/packages/flutter/lib/src/painting/linear_border.dart
@@ -132,6 +132,12 @@ class LinearBorderEdge {
 ///
 /// Convenience constructors are included for the common case where just one edge is specified:
 /// [LinearBorder.start], [LinearBorder.end], [LinearBorder.top], [LinearBorder.bottom].
+///
+/// {@tool dartpad}
+/// This example shows how to draw different kinds of [LinearBorder]s.
+///
+/// ** See code in examples/api/lib/painting/linear_border/linear_border.0.dart **
+/// {@end-tool}
 class LinearBorder extends OutlinedBorder {
   /// Creates a rectangular box border that's rendered as zero to four lines.
   const LinearBorder({

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3036,6 +3036,12 @@ class LimitedBox extends SingleChildRenderObjectWidget {
 /// A widget that imposes different constraints on its child than it gets
 /// from its parent, possibly allowing the child to overflow the parent.
 ///
+/// {@tool dartpad}
+/// This example shows how an [OverflowBox] is used, and what its effect is.
+///
+/// ** See code in examples/api/lib/widgets/basic/overflowbox.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [RenderConstrainedOverflowBox] for details about how [OverflowBox] is


### PR DESCRIPTION
## Description

This adds links to examples that were not linked anywhere.

## Related Issues
 - Fixes #129956

## Tests
 - Documentation only change