### PR TITLE
[flutter_tools] remove desktop device restrictions on Impeller.

### DIFF
--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -209,8 +209,6 @@ abstract class DesktopDevice extends Device {
   /// steps to be run.
   void onAttached(ApplicationPackage package, BuildInfo buildInfo, Process process) {}
 
-  bool get supportsImpeller => false;
-
   /// Computes a set of environment variables used to pass debugging information
   /// to the engine without interfering with application level command line
   /// arguments.
@@ -268,14 +266,12 @@ abstract class DesktopDevice extends Device {
     if (debuggingOptions.purgePersistentCache) {
       addFlag('purge-persistent-cache=true');
     }
-    if (supportsImpeller) {
-      switch (debuggingOptions.enableImpeller) {
-        case ImpellerStatus.enabled:
-          addFlag('enable-impeller=true');
-        case ImpellerStatus.disabled:
-        case ImpellerStatus.platformDefault:
-          addFlag('enable-impeller=false');
-      }
+    switch (debuggingOptions.enableImpeller) {
+      case ImpellerStatus.enabled:
+        addFlag('enable-impeller=true');
+      case ImpellerStatus.disabled:
+      case ImpellerStatus.platformDefault:
+        addFlag('enable-impeller=false');
     }
     // Options only supported when there is a VM Service connection between the
     // tool and the device, usually in debug or profile mode.

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -48,9 +48,6 @@ class MacOSDevice extends DesktopDevice {
   String get name => 'macOS';
 
   @override
-  bool get supportsImpeller => true;
-
-  @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin;
 
   @override

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -155,14 +155,15 @@ void main() {
           'FLUTTER_ENGINE_SWITCH_10': 'dump-skp-on-shader-compilation=true',
           'FLUTTER_ENGINE_SWITCH_11': 'cache-sksl=true',
           'FLUTTER_ENGINE_SWITCH_12': 'purge-persistent-cache=true',
-          'FLUTTER_ENGINE_SWITCH_13': 'enable-checked-mode=true',
-          'FLUTTER_ENGINE_SWITCH_14': 'verify-entry-points=true',
-          'FLUTTER_ENGINE_SWITCH_15': 'start-paused=true',
-          'FLUTTER_ENGINE_SWITCH_16': 'disable-service-auth-codes=true',
-          'FLUTTER_ENGINE_SWITCH_17': 'dart-flags=--null_assertions',
-          'FLUTTER_ENGINE_SWITCH_18': 'use-test-fonts=true',
-          'FLUTTER_ENGINE_SWITCH_19': 'verbose-logging=true',
-          'FLUTTER_ENGINE_SWITCHES': '19',
+          'FLUTTER_ENGINE_SWITCH_13': 'enable-impeller=false',
+          'FLUTTER_ENGINE_SWITCH_14': 'enable-checked-mode=true',
+          'FLUTTER_ENGINE_SWITCH_15': 'verify-entry-points=true',
+          'FLUTTER_ENGINE_SWITCH_16': 'start-paused=true',
+          'FLUTTER_ENGINE_SWITCH_17': 'disable-service-auth-codes=true',
+          'FLUTTER_ENGINE_SWITCH_18': 'dart-flags=--null_assertions',
+          'FLUTTER_ENGINE_SWITCH_19': 'use-test-fonts=true',
+          'FLUTTER_ENGINE_SWITCH_20': 'verbose-logging=true',
+          'FLUTTER_ENGINE_SWITCHES': '20',
         }
       ),
     ]);
@@ -209,7 +210,8 @@ void main() {
           'FLUTTER_ENGINE_SWITCH_2': 'trace-startup=true',
           'FLUTTER_ENGINE_SWITCH_3': 'trace-allowlist=foo,bar',
           'FLUTTER_ENGINE_SWITCH_4': 'cache-sksl=true',
-          'FLUTTER_ENGINE_SWITCHES': '4',
+          'FLUTTER_ENGINE_SWITCH_5': 'enable-impeller=false',
+          'FLUTTER_ENGINE_SWITCHES': '5',
         }
       ),
     ]);

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -301,7 +301,7 @@ void main() {
     );
   });
 
-  testWithoutContext('Desktop devices that support impeller pass through the enable-impeller flag', () async {
+  testWithoutContext('Desktop devices pass through the enable-impeller flag', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>['debug'],
@@ -317,7 +317,6 @@ void main() {
     ]);
     final FakeDesktopDevice device = setUpDesktopDevice(
       processManager: processManager,
-      supportsImpeller: true,
     );
 
     final FakeApplicationPackage package = FakeApplicationPackage();
@@ -332,16 +331,17 @@ void main() {
     );
   });
 
-  testWithoutContext('Desktop devices that do not support impeller ignore the enable-impeller flag', () async {
+  testWithoutContext('Desktop devices pass through the --no-enable-impeller flag', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>['debug'],
         exitCode: -1,
         environment: <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
-          'FLUTTER_ENGINE_SWITCH_2': 'enable-checked-mode=true',
-          'FLUTTER_ENGINE_SWITCH_3': 'verify-entry-points=true',
-          'FLUTTER_ENGINE_SWITCHES': '3'
+          'FLUTTER_ENGINE_SWITCH_2': 'enable-impeller=false',
+          'FLUTTER_ENGINE_SWITCH_3': 'enable-checked-mode=true',
+          'FLUTTER_ENGINE_SWITCH_4': 'verify-entry-points=true',
+          'FLUTTER_ENGINE_SWITCHES': '4'
         }
       ),
     ]);
@@ -355,7 +355,7 @@ void main() {
       prebuiltApplication: true,
       debuggingOptions: DebuggingOptions.enabled(
         BuildInfo.debug,
-        enableImpeller: ImpellerStatus.enabled,
+        enableImpeller: ImpellerStatus.disabled,
         dartEntrypointArgs: <String>[],
       ),
     );
@@ -368,7 +368,6 @@ FakeDesktopDevice setUpDesktopDevice({
   ProcessManager? processManager,
   OperatingSystemUtils? operatingSystemUtils,
   bool nullExecutablePathForDevice = false,
-  bool supportsImpeller = false,
 }) {
   return FakeDesktopDevice(
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
@@ -376,7 +375,6 @@ FakeDesktopDevice setUpDesktopDevice({
     processManager: processManager ?? FakeProcessManager.any(),
     operatingSystemUtils: operatingSystemUtils ?? FakeOperatingSystemUtils(),
     nullExecutablePathForDevice: nullExecutablePathForDevice,
-    supportsImpeller: supportsImpeller,
   );
 }
 
@@ -388,7 +386,6 @@ class FakeDesktopDevice extends DesktopDevice {
     required FileSystem fileSystem,
     required OperatingSystemUtils operatingSystemUtils,
     this.nullExecutablePathForDevice = false,
-    this.supportsImpeller = false,
   }) : super(
       'dummy',
       platformType: PlatformType.linux,
@@ -406,9 +403,6 @@ class FakeDesktopDevice extends DesktopDevice {
   BuildInfo? lastBuildInfo;
 
   final bool nullExecutablePathForDevice;
-
-  @override
-  final bool supportsImpeller;
 
   @override
   String get name => 'dummy';


### PR DESCRIPTION
All current desktop backends will support Impeller after https://github.com/flutter/engine/pull/43388 lands. 