### PR TITLE
Skip the iteration in Layer._fireCompositionCallbacks if the callbacks map is empty

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -172,6 +172,9 @@ abstract class Layer with DiagnosticableTreeMixin {
   }
 
   void _fireCompositionCallbacks({required bool includeChildren}) {
+    if (_callbacks.isEmpty) {
+      return;
+    }
     for (final VoidCallback callback in List<VoidCallback>.of(_callbacks.values)) {
       callback();
     }


### PR DESCRIPTION
This was showing up as a hot spot in some benchmarks and profiles. This function is called frequently during frame builds and often has an empty map.  There may be significant overhead from obtaining the values iterator and cloning it into a list.

See https://github.com/flutter/flutter/issues/130339
