### PR TITLE
PlatformRouteInformationProvider does not push new entry if query par…

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -1466,12 +1467,18 @@ class PlatformRouteInformationProvider extends RouteInformationProvider with Wid
     required RouteInformation initialRouteInformation,
   }) : _value = initialRouteInformation;
 
+  static bool _equals(Uri a, Uri b) {
+    return a.path == b.path
+        && a.fragment == b.fragment
+        && const DeepCollectionEquality.unordered().equals(a.queryParametersAll, b.queryParametersAll);
+  }
+
   @override
   void routerReportsNewRouteInformation(RouteInformation routeInformation, {RouteInformationReportingType type = RouteInformationReportingType.none}) {
     final bool replace =
       type == RouteInformationReportingType.neglect ||
       (type == RouteInformationReportingType.none &&
-       _valueInEngine.uri == routeInformation.uri);
+      _equals(_valueInEngine.uri, routeInformation.uri));
     SystemNavigator.selectMultiEntryHistory();
     SystemNavigator.routeInformationUpdated(
       uri: routeInformation.uri,

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -867,6 +867,76 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     ]);
   });
 
+  testWidgets('PlatformRouteInformationProvider does not push new entry if query parameters are semantically the same', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+        SystemChannels.navigation,
+            (MethodCall methodCall) async {
+          log.add(methodCall);
+          return null;
+        }
+    );
+    final RouteInformation initial = RouteInformation(
+      uri: Uri.parse('initial?a=ws/abcd'),
+    );
+    final RouteInformationProvider provider = PlatformRouteInformationProvider(
+      initialRouteInformation: initial
+    );
+    // Make sure engine is updated with initial route
+    provider.routerReportsNewRouteInformation(initial);
+    log.clear();
+
+    provider.routerReportsNewRouteInformation(
+      RouteInformation(
+        uri: Uri(
+          path: 'initial',
+          queryParameters: <String, String>{'a': 'ws/abcd'}, // This will be escaped.
+        ),
+      ),
+    );
+    expect(provider.value.uri.toString(), 'initial?a=ws%2Fabcd');
+    // should use `replace: true`
+    expect(log, <Object>[
+      isMethodCall('selectMultiEntryHistory', arguments: null),
+      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'uri': 'initial?a=ws%2Fabcd', 'state': null, 'replace': true }),
+    ]);
+    log.clear();
+
+    provider.routerReportsNewRouteInformation(
+      RouteInformation(uri: Uri.parse('initial?a=1&b=2')),
+    );
+    log.clear();
+
+    // Change query parameters order
+    provider.routerReportsNewRouteInformation(
+      RouteInformation(uri: Uri.parse('initial?b=2&a=1')),
+    );
+    // should use `replace: true`
+    expect(log, <Object>[
+      isMethodCall('selectMultiEntryHistory', arguments: null),
+      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'uri': 'initial?b=2&a=1', 'state': null, 'replace': true }),
+    ]);
+    log.clear();
+
+    provider.routerReportsNewRouteInformation(
+      RouteInformation(uri: Uri.parse('initial?a=1&a=2')),
+    );
+    log.clear();
+
+    // Change query parameters order for same key
+    provider.routerReportsNewRouteInformation(
+      RouteInformation(uri: Uri.parse('initial?a=2&a=1')),
+    );
+    // should use `replace: true`
+    expect(log, <Object>[
+      isMethodCall('selectMultiEntryHistory', arguments: null),
+      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'uri': 'initial?a=2&a=1', 'state': null, 'replace': true }),
+    ]);
+    log.clear();
+  });
+
   testWidgets('RootBackButtonDispatcher works', (WidgetTester tester) async {
     final BackButtonDispatcher outerDispatcher = RootBackButtonDispatcher();
     final RouteInformationProvider provider = PlatformRouteInformationProvider(


### PR DESCRIPTION
…ameter is semanticsally the same

The URI compare does not taking into account that query parameter may or may not be encoded, or the parameters' order can be different. However, they are all semantically the same. 

This pr makes PlatformRouteInformationProvider to take those into account when deciding whether it should push/replace the browser history entry.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
