### PR TITLE
Revert "Marks Linux firebase_oriol33_abstract_method_smoke_test to be unflaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -412,6 +412,7 @@ targets:
       - .ci.yaml
 
   - name: Linux firebase_oriol33_abstract_method_smoke_test
+    bringup: true
     recipe: firebaselab/firebaselab
     timeout: 60
     properties:


### PR DESCRIPTION
Reverts flutter/flutter#128398

See e.g. https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20firebase_oriol33_abstract_method_smoke_test/350/overview