### PR TITLE
mark android impeller tests as bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2306,8 +2306,10 @@ targets:
   - name: Linux_android new_gallery_impeller__transition_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
+      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux"]
       task_name: new_gallery_impeller__transition_perf
@@ -2592,8 +2594,10 @@ targets:
   - name: Linux_android animated_blur_backdrop_filter_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
+      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux"]
       task_name: animated_blur_backdrop_filter_perf__timeline_summary


### PR DESCRIPTION
These should not close the tree as this backend is a WIP.