### PR TITLE
Add applyFocusChangesIfNeeded, have menus restore focus before activating

### DIFF
--- a/dev/manual_tests/lib/menu_anchor.dart
+++ b/dev/manual_tests/lib/menu_anchor.dart
@@ -706,6 +706,12 @@ List<Widget> createTestMenus({
       TestMenu.mainMenu3,
       menuChildren: <Widget>[
         menuItemButton(TestMenu.subMenu8),
+        MenuItemButton(
+          onPressed: () {
+            debugPrint('Focused Item: $primaryFocus');
+          },
+          child: const Text('Print Focused Item'),
+        )
       ],
     ),
     submenuButton(
@@ -734,7 +740,11 @@ List<Widget> createTestMenus({
               submenuButton(
                 TestMenu.subSubMenu3,
                 menuChildren: <Widget>[
-                  menuItemButton(TestMenu.subSubSubMenu1),
+                  for (int i=0; i < 100; ++i)
+                    MenuItemButton(
+                      onPressed: () {},
+                      child: Text('Menu Item $i'),
+                    ),
                 ],
               ),
           ],

--- a/examples/api/test/material/menu_anchor/checkbox_menu_button.0_test.dart
+++ b/examples/api/test/material/menu_anchor/checkbox_menu_button.0_test.dart
@@ -13,13 +13,13 @@ void main() {
     );
 
     await tester.tap(find.byType(TextButton));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('Show Message'), findsOneWidget);
     expect(find.text(example.MenuApp.kMessage), findsNothing);
 
     await tester.tap(find.text('Show Message'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('Show Message'), findsNothing);
     expect(find.text(example.MenuApp.kMessage), findsOneWidget);

--- a/examples/api/test/material/menu_anchor/menu_anchor.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_anchor.0_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text(example.MenuApp.kMessage), findsOneWidget);
     expect(find.text('Last Selected: ${example.MenuEntry.showMessage.label}'), findsOneWidget);

--- a/examples/api/test/material/menu_anchor/menu_anchor.1_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_anchor.1_test.dart
@@ -20,7 +20,7 @@ void main() {
     await tester.pumpWidget(const example.ContextMenuApp());
 
     await tester.tapAt(const Offset(100, 200), buttons: kSecondaryButton);
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(tester.getRect(findMenu()), equals(const Rect.fromLTRB(100.0, 200.0, 433.0, 360.0)));
 
     // Make sure tapping in a different place causes the menu to move.
@@ -46,7 +46,7 @@ void main() {
     expect(find.text('Background Color'), findsOneWidget);
 
     await tester.tap(find.text('Background Color'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text(example.MenuEntry.colorRed.label), findsOneWidget);
     expect(find.text(example.MenuEntry.colorGreen.label), findsOneWidget);
@@ -54,7 +54,7 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text(example.ContextMenuApp.kMessage), findsOneWidget);
     expect(find.text('Last Selected: ${example.MenuEntry.showMessage.label}'), findsOneWidget);

--- a/examples/api/test/material/menu_anchor/menu_bar.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_bar.0_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     final Finder menuButtonFinder = find.byType(SubmenuButton).first;
     await tester.tap(menuButtonFinder);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('About'), findsOneWidget);
     expect(find.text('Show Message'), findsOneWidget);
@@ -34,7 +34,7 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('About'), findsOneWidget);
     expect(find.text('Show Message'), findsOneWidget);
@@ -46,7 +46,7 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text(example.MenuBarApp.kMessage), findsOneWidget);
     expect(find.text('Last Selected: Show Message'), findsOneWidget);

--- a/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
+++ b/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
@@ -24,7 +24,7 @@ void main() {
     expect(tester.widget<Container>(find.byType(Container)).color, equals(Colors.red));
 
     await tester.tap(find.text('Green Background'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(tester.widget<Container>(find.byType(Container)).color, equals(Colors.green));
   });

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -275,12 +275,11 @@ class _MenuAnchorState extends State<MenuAnchor> {
   final FocusScopeNode _menuScopeNode = FocusScopeNode(debugLabel: kReleaseMode ? null : 'MenuAnchor sub menu');
   MenuController? _internalMenuController;
   final List<_MenuAnchorState> _anchorChildren = <_MenuAnchorState>[];
-  ScrollPosition? _scrollPosition;
+  ScrollPosition? _position;
   Size? _viewSize;
-  final OverlayPortalController _overlayController = OverlayPortalController();
-  Offset? _menuPosition;
+  OverlayEntry? _overlayEntry;
   Axis get _orientation => Axis.vertical;
-  bool get _isOpen => _overlayController.isShowing;
+  bool get _isOpen => _overlayEntry != null;
   bool get _isRoot => _parent == null;
   bool get _isTopLevel => _parent?._isRoot ?? false;
   MenuController get _menuController => widget.controller ?? _internalMenuController!;
@@ -313,9 +312,9 @@ class _MenuAnchorState extends State<MenuAnchor> {
     _parent?._removeChild(this);
     _parent = _MenuAnchorState._maybeOf(context);
     _parent?._addChild(this);
-    _scrollPosition?.isScrollingNotifier.removeListener(_handleScroll);
-    _scrollPosition = Scrollable.maybeOf(context)?.position;
-    _scrollPosition?.isScrollingNotifier.addListener(_handleScroll);
+    _position?.isScrollingNotifier.removeListener(_handleScroll);
+    _position = Scrollable.maybeOf(context)?.position;
+    _position?.isScrollingNotifier.addListener(_handleScroll);
     final Size newSize = MediaQuery.sizeOf(context);
     if (_viewSize != null && newSize != _viewSize) {
       // Close the menus if the view changes size.
@@ -339,25 +338,18 @@ class _MenuAnchorState extends State<MenuAnchor> {
       }
     }
     assert(_menuController._anchor == this);
+    if (_overlayEntry != null) {
+      // Needs to update the overlay entry on the next frame, since it's in the
+      // overlay.
+      SchedulerBinding.instance.addPostFrameCallback((Duration _) {
+        _overlayEntry?.markNeedsBuild();
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    Widget child = OverlayPortal(
-      controller: _overlayController,
-      overlayChildBuilder: (BuildContext context) {
-       return _Submenu(
-          anchor: this,
-          menuStyle: widget.style,
-          alignmentOffset: widget.alignmentOffset ?? Offset.zero,
-          menuPosition: _menuPosition,
-          clipBehavior: widget.clipBehavior,
-          menuChildren: widget.menuChildren,
-          crossAxisUnconstrained: widget.crossAxisUnconstrained,
-        );
-      },
-      child: _buildContents(context),
-    );
+    Widget child = _buildContents(context);
 
     if (!widget.anchorTapClosesMenu) {
       child = TapRegion(
@@ -501,12 +493,50 @@ class _MenuAnchorState extends State<MenuAnchor> {
     assert(_debugMenuInfo(
         'Opening $this at ${position ?? Offset.zero} with alignment offset ${widget.alignmentOffset ?? Offset.zero}'));
     _parent?._closeChildren(); // Close all siblings.
-    assert(!_overlayController.isShowing);
+    assert(_overlayEntry == null);
 
+    final BuildContext outerContext = context;
     _parent?._childChangedOpenState();
-    _menuPosition = position;
-    _overlayController.show();
+    setState(() {
+      _overlayEntry = OverlayEntry(
+        builder: (BuildContext context) {
+          final OverlayState overlay = Overlay.of(outerContext);
+          return Positioned.directional(
+            textDirection: Directionality.of(outerContext),
+            top: 0,
+            start: 0,
+            child: Directionality(
+              textDirection: Directionality.of(outerContext),
+              child: InheritedTheme.captureAll(
+                // Copy all the themes from the supplied outer context to the
+                // overlay.
+                outerContext,
+                _MenuAnchorScope(
+                  // Re-advertize the anchor here in the overlay, since
+                  // otherwise a search for the anchor by descendants won't find
+                  // it.
+                  anchorKey: _anchorKey,
+                  anchor: this,
+                  isOpen: _isOpen,
+                  child: _Submenu(
+                    anchor: this,
+                    menuStyle: widget.style,
+                    alignmentOffset: widget.alignmentOffset ?? Offset.zero,
+                    menuPosition: position,
+                    clipBehavior: widget.clipBehavior,
+                    menuChildren: widget.menuChildren,
+                    crossAxisUnconstrained: widget.crossAxisUnconstrained,
+                  ),
+                ),
+                to: overlay.context,
+              ),
+            ),
+          );
+        },
+      );
+    });
 
+    Overlay.of(context).insert(_overlayEntry!);
     widget.onOpen?.call();
   }
 
@@ -520,7 +550,8 @@ class _MenuAnchorState extends State<MenuAnchor> {
       return;
     }
     _closeChildren(inDispose: inDispose);
-    _overlayController.hide();
+    _overlayEntry?.remove();
+    _overlayEntry = null;
     if (!inDispose) {
       // Notify that _childIsOpen changed state, but only if not
       // currently disposing.

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1625,7 +1625,7 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   void applyFocusChangesIfNeeded() {
     assert(
       SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks,
-      'applyFocusChanges() should not be called during the build phase.'
+      'applyFocusChangesIfNeeded() should not be called during the build phase.'
     );
 
     _haveScheduledUpdate = false;

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2333,9 +2333,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(4.0, 0.0, 112.0, 48.0),
           Rect.fromLTRB(112.0, 0.0, 220.0, 48.0),
-          Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
-          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0),
           Rect.fromLTRB(112.0, 104.0, 326.0, 152.0),
+          Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
+          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0)
         ]),
       );
     });
@@ -2380,9 +2380,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(688.0, 0.0, 796.0, 48.0),
           Rect.fromLTRB(580.0, 0.0, 688.0, 48.0),
-          Rect.fromLTRB(472.0, 0.0, 580.0, 48.0),
-          Rect.fromLTRB(294.0, 0.0, 472.0, 48.0),
           Rect.fromLTRB(474.0, 104.0, 688.0, 152.0),
+          Rect.fromLTRB(472.0, 0.0, 580.0, 48.0),
+          Rect.fromLTRB(294.0, 0.0, 472.0, 48.0)
         ]),
       );
     });
@@ -2425,9 +2425,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(4.0, 0.0, 112.0, 48.0),
           Rect.fromLTRB(112.0, 0.0, 220.0, 48.0),
-          Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
-          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0),
           Rect.fromLTRB(86.0, 104.0, 300.0, 152.0),
+          Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
+          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0)
         ]),
       );
     });
@@ -2470,9 +2470,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(188.0, 0.0, 296.0, 48.0),
           Rect.fromLTRB(80.0, 0.0, 188.0, 48.0),
+          Rect.fromLTRB(0.0, 104.0, 214.0, 152.0),
           Rect.fromLTRB(-28.0, 0.0, 80.0, 48.0),
-          Rect.fromLTRB(-206.0, 0.0, -28.0, 48.0),
-          Rect.fromLTRB(0.0, 104.0, 214.0, 152.0)
+          Rect.fromLTRB(-206.0, 0.0, -28.0, 48.0)
         ]),
       );
     });
@@ -3064,7 +3064,7 @@ void main() {
           child: Center(
             child: MenuItemButton(
               style: MenuItemButton.styleFrom(fixedSize: const Size(88.0, 36.0)),
-              onPressed: () { },
+              onPressed: () {},
               child: const Text('ABC'),
             ),
           ),
@@ -3072,27 +3072,30 @@ void main() {
       );
 
       // The flags should not have SemanticsFlag.isButton
-      expect(semantics, hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              actions: <SemanticsAction>[
-                SemanticsAction.tap,
-              ],
-              label: 'ABC',
-              rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
-              transform: Matrix4.translationValues(356.0, 276.0, 0.0),
-              flags: <SemanticsFlag>[
-                SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isEnabled,
-                SemanticsFlag.isFocusable,
-              ],
-              textDirection: TextDirection.ltr,
-            ),
-          ],
+      expect(
+        semantics,
+        hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics.rootChild(
+                actions: <SemanticsAction>[
+                  SemanticsAction.tap,
+                ],
+                label: 'ABC',
+                rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
+                transform: Matrix4.translationValues(356.0, 276.0, 0.0),
+                flags: <SemanticsFlag>[
+                  SemanticsFlag.hasEnabledState,
+                  SemanticsFlag.isEnabled,
+                  SemanticsFlag.isFocusable,
+                ],
+                textDirection: TextDirection.ltr,
+              ),
+            ],
+          ),
+          ignoreId: true,
         ),
-        ignoreId: true,
-      ));
+      );
 
       semantics.dispose();
     });
@@ -3114,22 +3117,23 @@ void main() {
       );
 
       // The flags should not have SemanticsFlag.isButton
-      expect(semantics, hasSemantics(
-        TestSemantics.root(
-          children: <TestSemantics>[
-            TestSemantics.rootChild(
-              label: 'ABC',
-              rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
-              transform: Matrix4.translationValues(356.0, 276.0, 0.0),
-              flags: <SemanticsFlag>[
-                SemanticsFlag.hasEnabledState,
-              ],
-              textDirection: TextDirection.ltr,
-            ),
-          ],
+      expect(
+        semantics,
+        hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics(
+                rect: const Rect.fromLTRB(0.0, 0.0, 88.0, 48.0),
+                flags: <SemanticsFlag>[SemanticsFlag.hasEnabledState],
+                label: 'ABC',
+                textDirection: TextDirection.ltr,
+              ),
+            ],
+          ),
+          ignoreTransform: true,
+          ignoreId: true,
         ),
-        ignoreId: true,
-      ));
+      );
 
       semantics.dispose();
     });

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -486,6 +486,53 @@ void main() {
     );
   }, variant: TargetPlatformVariant.desktop());
 
+  testWidgets('focus is returned to previous focus before invoking onPressed', (WidgetTester tester) async {
+    final FocusNode buttonFocus = FocusNode(debugLabel: 'Button Focus');
+    FocusNode? focusInOnPressed;
+
+    void onMenuSelected(TestMenu item) {
+      focusInOnPressed = FocusManager.instance.primaryFocus;
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Column(
+            children: <Widget>[
+              MenuBar(
+                controller: controller,
+                children: createTestMenus(
+                  onPressed: onMenuSelected,
+                ),
+              ),
+              ElevatedButton(
+                autofocus: true,
+                onPressed: () {},
+                focusNode: buttonFocus,
+                child: const Text('Press Me'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(FocusManager.instance.primaryFocus, equals(buttonFocus));
+
+    await tester.tap(find.text(TestMenu.mainMenu1.label));
+    await tester.pump();
+
+    await tester.tap(find.text(TestMenu.subMenu11.label));
+    await tester.pump();
+
+    await tester.tap(find.text(TestMenu.subSubMenu110.label));
+    await tester.pump();
+
+    expect(focusInOnPressed, equals(buttonFocus));
+    expect(FocusManager.instance.primaryFocus, equals(buttonFocus));
+  });
+
   group('Menu functions', () {
     testWidgets('basic menu structure', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -2335,7 +2382,7 @@ void main() {
           Rect.fromLTRB(112.0, 0.0, 220.0, 48.0),
           Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
           Rect.fromLTRB(328.0, 0.0, 506.0, 48.0),
-          Rect.fromLTRB(112.0, 104.0, 326.0, 152.0)
+          Rect.fromLTRB(112.0, 104.0, 326.0, 152.0),
         ]),
       );
     });
@@ -2382,7 +2429,7 @@ void main() {
           Rect.fromLTRB(580.0, 0.0, 688.0, 48.0),
           Rect.fromLTRB(472.0, 0.0, 580.0, 48.0),
           Rect.fromLTRB(294.0, 0.0, 472.0, 48.0),
-          Rect.fromLTRB(474.0, 104.0, 688.0, 152.0)
+          Rect.fromLTRB(474.0, 104.0, 688.0, 152.0),
         ]),
       );
     });
@@ -2427,7 +2474,7 @@ void main() {
           Rect.fromLTRB(112.0, 0.0, 220.0, 48.0),
           Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
           Rect.fromLTRB(328.0, 0.0, 506.0, 48.0),
-          Rect.fromLTRB(86.0, 104.0, 300.0, 152.0)
+          Rect.fromLTRB(86.0, 104.0, 300.0, 152.0),
         ]),
       );
     });

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2333,9 +2333,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(4.0, 0.0, 112.0, 48.0),
           Rect.fromLTRB(112.0, 0.0, 220.0, 48.0),
-          Rect.fromLTRB(112.0, 104.0, 326.0, 152.0),
           Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
-          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0)
+          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0),
+          Rect.fromLTRB(112.0, 104.0, 326.0, 152.0)
         ]),
       );
     });
@@ -2380,9 +2380,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(688.0, 0.0, 796.0, 48.0),
           Rect.fromLTRB(580.0, 0.0, 688.0, 48.0),
-          Rect.fromLTRB(474.0, 104.0, 688.0, 152.0),
           Rect.fromLTRB(472.0, 0.0, 580.0, 48.0),
-          Rect.fromLTRB(294.0, 0.0, 472.0, 48.0)
+          Rect.fromLTRB(294.0, 0.0, 472.0, 48.0),
+          Rect.fromLTRB(474.0, 104.0, 688.0, 152.0)
         ]),
       );
     });
@@ -2425,9 +2425,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(4.0, 0.0, 112.0, 48.0),
           Rect.fromLTRB(112.0, 0.0, 220.0, 48.0),
-          Rect.fromLTRB(86.0, 104.0, 300.0, 152.0),
           Rect.fromLTRB(220.0, 0.0, 328.0, 48.0),
-          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0)
+          Rect.fromLTRB(328.0, 0.0, 506.0, 48.0),
+          Rect.fromLTRB(86.0, 104.0, 300.0, 152.0)
         ]),
       );
     });
@@ -2470,9 +2470,9 @@ void main() {
         equals(const <Rect>[
           Rect.fromLTRB(188.0, 0.0, 296.0, 48.0),
           Rect.fromLTRB(80.0, 0.0, 188.0, 48.0),
-          Rect.fromLTRB(0.0, 104.0, 214.0, 152.0),
           Rect.fromLTRB(-28.0, 0.0, 80.0, 48.0),
-          Rect.fromLTRB(-206.0, 0.0, -28.0, 48.0)
+          Rect.fromLTRB(-206.0, 0.0, -28.0, 48.0),
+          Rect.fromLTRB(0.0, 104.0, 214.0, 152.0)
         ]),
       );
     });


### PR DESCRIPTION
## Description

This modifies the `MenuAnchor` `onPressed` activation to delay until after the current frame is built, and resolve any focus changes before it invokes the `onPressed`, so that actions that operate on the `primaryFocus` can have a chance of working on the focused item they were meant to work on.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/118731

## Tests
 - No tests yet (hence draft still)