### PR TITLE
Fix AppBar.title ignoring `SafeArea`

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -951,48 +951,43 @@ class _AppBarState extends State<AppBar> {
 
     Widget? title = widget.title;
     if (title != null) {
-      bool? namesRoute;
-      switch (theme.platform) {
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.windows:
-          namesRoute = true;
-        case TargetPlatform.iOS:
-        case TargetPlatform.macOS:
-          break;
-      }
+      final bool? namesRoute = switch (theme.platform) {
+        TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => true,
+        TargetPlatform.iOS || TargetPlatform.macOS => null,
+      };
 
-      title = _AppBarTitleBox(child: title);
+      Widget wrappedTitle = _AppBarTitleBox(child: title);
       if (!widget.excludeHeaderSemantics) {
-        title = Semantics(
+        wrappedTitle = Semantics(
           namesRoute: namesRoute,
           header: true,
           child: title,
         );
       }
 
-      title = DefaultTextStyle(
-        style: titleTextStyle!,
-        softWrap: false,
-        overflow: TextOverflow.ellipsis,
-        child: title,
-      );
-
       // Set maximum text scale factor to [_kMaxTitleTextScaleFactor] for the
       // title to keep the visual hierarchy the same even with larger font
       // sizes. To opt out, wrap the [title] widget in a [MediaQuery] widget
       // with [MediaQueryData.textScaleFactor] set to
       // `MediaQuery.textScaleFactorOf(context)`.
-      final MediaQueryData mediaQueryData = MediaQuery.of(context);
-      title = MediaQuery(
-        data: mediaQueryData.copyWith(
-          textScaleFactor: math.min(
-            mediaQueryData.textScaleFactor,
-            _kMaxTitleTextScaleFactor,
-          ),
-        ),
-        child: title,
+      title = Builder(
+        builder: (BuildContext context) {
+          final MediaQueryData mediaQueryData = MediaQuery.of(context);
+          return MediaQuery(
+            data: mediaQueryData.copyWith(
+              textScaleFactor: math.min(
+                mediaQueryData.textScaleFactor,
+                _kMaxTitleTextScaleFactor,
+              ),
+            ),
+            child: DefaultTextStyle(
+              style: titleTextStyle!,
+              softWrap: false,
+              overflow: TextOverflow.ellipsis,
+              child: wrappedTitle,
+            ),
+          );
+        }
       );
     }
 
@@ -1284,10 +1279,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
         title: effectiveTitle,
         actions: actions,
         flexibleSpace: (title == null && flexibleSpace != null && !excludeHeaderSemantics)
-          ? Semantics(
-              header: true,
-              child: flexibleSpace,
-            )
+          ? Semantics(header: true, child: flexibleSpace)
           : flexibleSpace,
         bottom: bottom,
         elevation: isScrolledUnder ? elevation : 0.0,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -951,17 +951,15 @@ class _AppBarState extends State<AppBar> {
 
     Widget? title = widget.title;
     if (title != null) {
-      final bool? namesRoute = switch (theme.platform) {
-        TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => true,
-        TargetPlatform.iOS || TargetPlatform.macOS => null,
-      };
-
       Widget wrappedTitle = _AppBarTitleBox(child: title);
       if (!widget.excludeHeaderSemantics) {
         wrappedTitle = Semantics(
-          namesRoute: namesRoute,
+          namesRoute: switch (theme.platform) {
+            TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => true,
+            TargetPlatform.iOS || TargetPlatform.macOS => null,
+          },
           header: true,
-          child: title,
+          child: wrappedTitle,
         );
       }
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1685,6 +1685,36 @@ void main() {
     expect(appBarHeight(tester), kToolbarHeight + 100.0);
   });
 
+  testWidgets('AppBar.title sees the correct padding from MediaQuery', (WidgetTester tester) async {
+    bool titleBuilt = false;
+    await tester.pumpWidget(
+      Localizations(
+        locale: const Locale('en', 'US'),
+        delegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+        ],
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(padding: EdgeInsets.fromLTRB(12, 34, 56, 78)),
+            child: Scaffold(
+              appBar: AppBar(
+                title: Builder(builder: (BuildContext context) {
+                  titleBuilt = true;
+                  final EdgeInsets padding = MediaQuery.paddingOf(context);
+                  expect(padding, EdgeInsets.zero);
+                  return const Text('heh');
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(titleBuilt, isTrue);
+  });
+
   testWidgets('AppBar updates when you add a drawer', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Extracted from https://github.com/flutter/flutter/pull/128522.

`AppBar.title` uses a `MediaQueryData` captured from the context above the `SafeArea` (introduced by `NavigationBar`), so it still sees non-zero paddings. It's causing scuba failures when #128522 used the correct `BuildContext` to get the `MediaQueryData`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
