### PR TITLE
Remove duplicated dart:ui imports

### DIFF
--- a/packages/flutter/lib/src/material/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons.dart
@@ -6,8 +6,7 @@
 library material_animated_icons;
 
 import 'dart:math' as math show pi;
-import 'dart:ui' as ui show Canvas, Paint, Path;
-import 'dart:ui' show lerpDouble;
+import 'dart:ui' as ui show Canvas, Paint, Path, lerpDouble;
 
 import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -196,7 +196,7 @@ class _PathFrames {
   final List<double> opacities;
 
   void paint(ui.Canvas canvas, Color color, _UiPathFactory uiPathFactory, double progress) {
-    final double opacity = _interpolate<double?>(opacities, progress, lerpDouble)!;
+    final double opacity = _interpolate<double?>(opacities, progress, ui.lerpDouble)!;
     final ui.Paint paint = ui.Paint()
       ..style = PaintingStyle.fill
       ..color = color.withOpacity(color.opacity * opacity);
@@ -293,7 +293,7 @@ T _interpolate<T>(List<T> values, double progress, _Interpolator<T> interpolator
   if (values.length == 1) {
     return values[0];
   }
-  final double targetIdx = lerpDouble(0, values.length -1, progress)!;
+  final double targetIdx = ui.lerpDouble(0, values.length -1, progress)!;
   final int lowIdx = targetIdx.floor();
   final int highIdx = targetIdx.ceil();
   final double t = targetIdx - lowIdx;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
-import 'dart:ui' show Locale, Size, TextDirection;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -54,7 +52,7 @@ class ImageConfiguration {
   ImageConfiguration copyWith({
     AssetBundle? bundle,
     double? devicePixelRatio,
-    Locale? locale,
+    ui.Locale? locale,
     TextDirection? textDirection,
     Size? size,
     TargetPlatform? platform,
@@ -77,7 +75,7 @@ class ImageConfiguration {
   final double? devicePixelRatio;
 
   /// The language and region for which to select the image.
-  final Locale? locale;
+  final ui.Locale? locale;
 
   /// The reading direction of the language for which to select the image.
   final TextDirection? textDirection;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3,8 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
-import 'dart:ui' as ui;
-import 'dart:ui' show Offset, Rect, SemanticsAction, SemanticsFlag, StringAttribute, TextDirection;
+import 'dart:ui' show Offset, Rect, SemanticsAction, SemanticsFlag, SemanticsUpdate, SemanticsUpdateBuilder, StringAttribute, TextDirection;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -52,7 +51,7 @@ typedef SemanticsActionHandler = void Function(Object? args);
 /// Signature for a function that receives a semantics update and returns no result.
 ///
 /// Used by [SemanticsOwner.onSemanticsUpdate].
-typedef SemanticsUpdateCallback = void Function(ui.SemanticsUpdate update);
+typedef SemanticsUpdateCallback = void Function(SemanticsUpdate update);
 
 /// Signature for the [SemanticsConfiguration.childConfigurationsDelegate].
 ///
@@ -2668,7 +2667,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   static final Int32List _kEmptyCustomSemanticsActionsList = Int32List(0);
   static final Float64List _kIdentityTransform = _initIdentityTransform();
 
-  void _addToUpdate(ui.SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {
+  void _addToUpdate(SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {
     assert(_dirty);
     final SemanticsData data = getSemanticsData();
     final Int32List childrenInTraversalOrder;
@@ -3288,7 +3287,7 @@ class SemanticsOwner extends ChangeNotifier {
       }
     }
     visitedNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
-    final ui.SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
+    final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
     for (final SemanticsNode node in visitedNodes) {
       assert(node.parent?._dirty != true); // could be null (no parent) or false (not dirty)
       // The _serialize() method marks the node as not dirty, and

--- a/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
+++ b/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
@@ -12,8 +12,7 @@
 library material_animated_icons;
 
 import 'dart:math' as math show pi;
-import 'dart:ui' show Offset, lerpDouble;
-import 'dart:ui' as ui show Canvas, Paint, Path;
+import 'dart:ui' as ui show Canvas, Paint, Path, lerpDouble;
 
 import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/widgets.dart';


### PR DESCRIPTION
Small clean up. A file probably doesn't need multiple way to refer to dart:ui concepts.