### PR TITLE
Make ProxiedDevices a subclass of PollingDeviceDiscovery.

### DIFF
--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -36,14 +36,15 @@ T _cast<T>(Object? object) {
 ///
 /// If [deltaFileTransfer] is true, the proxy will use an rsync-like algorithm that
 /// only transfers the changed part of the application package for deployment.
-class ProxiedDevices extends DeviceDiscovery {
+class ProxiedDevices extends PollingDeviceDiscovery {
   ProxiedDevices(this.connection, {
     bool deltaFileTransfer = true,
     bool enableDdsProxy = false,
     required Logger logger,
   }) : _deltaFileTransfer = deltaFileTransfer,
        _enableDdsProxy = enableDdsProxy,
-       _logger = logger;
+       _logger = logger,
+       super('Proxied devices');
 
   /// [DaemonConnection] used to communicate with the daemon.
   final DaemonConnection connection;
@@ -87,6 +88,9 @@ class ProxiedDevices extends DeviceDiscovery {
     }
     return filter.filterDevices(devices);
   }
+
+  @override
+  Future<List<Device>> pollingGetDevices({Duration? timeout}) => discoverDevices(timeout: timeout);
 
   @override
   List<String> get wellKnownIds => const <String>[];

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_tools/src/base/dds.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/daemon.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/proxied_devices/devices.dart';
@@ -363,7 +364,43 @@ void main() {
       expect(fakeFilter.devices![0].id, fakeDevice['id']);
       expect(fakeFilter.devices![1].id, fakeDevice2['id']);
     });
-  });
+
+    testWithoutContext('publishes the devices on deviceNotifier after startPolling', () async {
+      bufferLogger = BufferLogger.test();
+      final ProxiedDevices proxiedDevices = ProxiedDevices(
+        clientDaemonConnection,
+        logger: bufferLogger,
+      );
+
+      proxiedDevices.startPolling();
+
+      final ItemListNotifier<Device>? deviceNotifier = proxiedDevices.deviceNotifier;
+      expect(deviceNotifier, isNotNull);
+
+      final List<Device> devicesAdded = <Device>[];
+      deviceNotifier!.onAdded.listen((Device device) {
+        devicesAdded.add(device);
+      });
+
+      final DaemonMessage message = await serverDaemonConnection.incomingCommands.first;
+      expect(message.data['id'], isNotNull);
+      expect(message.data['method'], 'device.discoverDevices');
+
+      serverDaemonConnection.sendResponse(message.data['id']!, <Map<String, Object?>>[
+        fakeDevice,
+        fakeDevice2,
+      ]);
+
+      await pumpEventQueue();
+
+      expect(devicesAdded.length, 2);
+      expect(devicesAdded[0].id, fakeDevice['id']);
+      expect(devicesAdded[1].id, fakeDevice2['id']);
+    });
+    // Explicit timeout is needed because the default timeout is 2s, but `startPolling` waits for
+    // 4s before making its first poll.
+    // TODO(chingjun): Remove the timeout.
+  }, timeout: const Timeout(Duration(seconds: 6)));
 
   group('ProxiedDartDevelopmentService', () {
     testWithoutContext('forwards start and shutdown to remote', () async {


### PR DESCRIPTION
The daemon ignores all device discovery that is not a PollingDeviceDiscovery. Make ProxiedDevices a PollingDeviceDiscovery so that it can be used in flutter daemon.

Note that there is a TODO item added in the test, which I intend to attempt fixing in a subsequent PR.