### PR TITLE
[DropdownMenu] Close menu after editing is completed

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -612,9 +612,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
               if (!widget.enableSearch) {
                 currentHighlight = null;
               }
-              if (_textEditingController.text.isNotEmpty) {
-                controller.close();
-              }
+              controller.close();
             },
             onTap: () {
               handlePressed(controller);

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -953,6 +953,38 @@ void main() {
     expect(controller.text, 'New Item');
   });
 
+  testWidgets('The menu should be closed after text editing is complete', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData();
+    final TextEditingController controller = TextEditingController();
+    await tester.pumpWidget(MaterialApp(
+      theme: themeData,
+      home: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: DropdownMenu<TestMenu>(
+              requestFocusOnTap: true,
+              enableFilter: true,
+              dropdownMenuEntries: menuChildren,
+              controller: controller,
+            ),
+          );
+        }
+      ),
+    ));
+    // Access the MenuAnchor
+    final MenuAnchor menuAnchor = tester.widget<MenuAnchor>(find.byType(MenuAnchor));
+
+    // Open the menu
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pumpAndSettle();
+    expect(menuAnchor.controller!.isOpen, true);
+
+    // Simulate `TextInputAction.done` on textfield
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+    expect(menuAnchor.controller!.isOpen, false);
+  });
+
   testWidgets('The onSelected gets called only when a selection is made', (WidgetTester tester) async {
     int selectionCount = 0;
 


### PR DESCRIPTION
Fixes: #130674 

Before: The dropdown menu was not closed if empty text was provided

After: The dropdown menu is closed even if empty text is provided

https://github.com/flutter/flutter/assets/61322712/fccac501-9fca-4f60-8a94-abfc50552ec9

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [✔️] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✔️] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✔️] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [✔️] I signed the [CLA].
- [✔️] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [✔️] I added new tests to check the change I am making, or this PR is [test-exempt].
- [✔️] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
