### PR TITLE
Fix IconButton leaks its internal MaterialStatesController

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -880,6 +880,12 @@ class _SelectableIconButtonState extends State<_SelectableIconButton> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    statesController.dispose();
+    super.dispose();
+  }
 }
 
 class _IconButtonM3 extends ButtonStyleButton {


### PR DESCRIPTION
## Description

This PR adds a call to dispose the internal `MaterialStatesController` instantiated by `_SelectableIconButtonState`.

I found this memory leak while working on M2/M3 test update for `about_test.dart`. This memory leak only happens when using M3 because `IconButton` relies on `_SelectableIconButton` only when useMaterial3 is true:

https://github.com/flutter/flutter/blob/3a1190a5a85c3e6a0cf3a9c30f34548fdd48ac1e/packages/flutter/lib/src/material/icon_button.dart#L671-L721

## Related Issue

Fixes https://github.com/flutter/flutter/issues/130708

## Tests

Adds 1 test.


