### PR TITLE
Resolve TODOs in channels integration test

### DIFF
--- a/dev/integration_tests/channels/integration_test/main_test.dart
+++ b/dev/integration_tests/channels/integration_test/main_test.dart
@@ -14,9 +14,6 @@ String getStatus(WidgetTester tester) => tester.widget<Text>(statusField).data!;
 
 void main() {
   testWidgets('step through', (WidgetTester tester) async {
-    // TODO(goderbauer): Remove this once https://github.com/flutter/flutter/issues/116663 is diagnosed.
-    debugPrintHitTestResults = true;
-
     await tester.pumpWidget(const TestApp());
     await tester.pumpAndSettle();
 
@@ -36,9 +33,6 @@ void main() {
         await tester.pumpAndSettle();
       }
     }
-
-    // TODO(goderbauer): Remove this once https://github.com/flutter/flutter/issues/116663 is diagnosed.
-    debugPrintHitTestResults = false;
 
     final String status = getStatus(tester);
     if (status != 'complete') {

--- a/dev/integration_tests/channels/integration_test/main_test.dart
+++ b/dev/integration_tests/channels/integration_test/main_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:channels/main.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
They were helpful in diagnosing the flake in https://github.com/flutter/flutter/issues/116663, but now that that's resolved they have outlived their usefulness. Let's remove 'em!