### PR TITLE
Update app tests for M3

### DIFF
--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -979,7 +979,7 @@ void main() {
     expect(themeAfterBrightnessChange!.brightness, Brightness.dark);
   });
 
-  testWidgets('MaterialApp provides default overscroll color', (WidgetTester tester) async {
+  testWidgets('Material2 - MaterialApp provides default overscroll color', (WidgetTester tester) async {
     Future<void> slowDrag(WidgetTester tester, Offset start, Offset offset) async {
       final TestGesture gesture = await tester.startGesture(start);
       for (int index = 0; index < 10; index += 1) {
@@ -1262,7 +1262,7 @@ void main() {
     expect(scrollBehavior.getScrollPhysics(capturedContext).runtimeType, NeverScrollableScrollPhysics);
   });
 
-  testWidgets('ScrollBehavior default android overscroll indicator', (WidgetTester tester) async {
+  testWidgets('Material2 - ScrollBehavior default android overscroll indicator', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
       scrollBehavior: const MaterialScrollBehavior(),
@@ -1281,9 +1281,10 @@ void main() {
     expect(find.byType(GlowingOverscrollIndicator), findsOneWidget);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets('ScrollBehavior stretch android overscroll indicator', (WidgetTester tester) async {
+  testWidgets('Material3 - ScrollBehavior default android overscroll indicator', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
-      scrollBehavior: const MaterialScrollBehavior(androidOverscrollIndicator: AndroidOverscrollIndicator.stretch),
+      theme: ThemeData(useMaterial3: true),
+      scrollBehavior: const MaterialScrollBehavior(),
       home: ListView(
         children: const <Widget>[
           SizedBox(
@@ -1299,9 +1300,9 @@ void main() {
     expect(find.byType(GlowingOverscrollIndicator), findsNothing);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets('ScrollBehavior stretch android overscroll indicator via useMaterial3 flag', (WidgetTester tester) async {
+  testWidgets('ScrollBehavior stretch android overscroll indicator', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(useMaterial3: true),
+      scrollBehavior: const MaterialScrollBehavior(androidOverscrollIndicator: AndroidOverscrollIndicator.stretch),
       home: ListView(
         children: const <Widget>[
           SizedBox(
@@ -1356,81 +1357,80 @@ void main() {
     expect(find.byType(GlowingOverscrollIndicator), findsNothing);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets(
-    'ListView clip behavior updates overscroll indicator clip behavior', (WidgetTester tester) async {
-      Widget buildFrame(Clip clipBehavior) {
-        return MaterialApp(
-          theme: ThemeData(useMaterial3: true),
-          home: Column(
-            children: <Widget>[
-              SizedBox(
-                height: 300,
-                child: ListView.builder(
-                  itemCount: 20,
-                  clipBehavior: clipBehavior,
-                  itemBuilder: (BuildContext context, int index){
-                    return Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Text('Index $index'),
-                    );
-                  },
-                ),
+  testWidgets('Material3 - ListView clip behavior updates overscroll indicator clip behavior', (WidgetTester tester) async {
+    Widget buildFrame(Clip clipBehavior) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: Column(
+          children: <Widget>[
+            SizedBox(
+              height: 300,
+              child: ListView.builder(
+                itemCount: 20,
+                clipBehavior: clipBehavior,
+                itemBuilder: (BuildContext context, int index){
+                  return Padding(
+                    padding: const EdgeInsets.all(10.0),
+                    child: Text('Index $index'),
+                  );
+                },
               ),
-              Opacity(
-                opacity: 0.5,
-                child: Container(
-                  color: const Color(0xD0FF0000),
-                  height: 100,
-                ),
+            ),
+            Opacity(
+              opacity: 0.5,
+              child: Container(
+                color: const Color(0xD0FF0000),
+                height: 100,
               ),
-            ],
-          ),
-        );
-      }
+            ),
+          ],
+        ),
+      );
+    }
 
-      // Test default clip behavior.
-      await tester.pumpWidget(buildFrame(Clip.hardEdge));
+    // Test default clip behavior.
+    await tester.pumpWidget(buildFrame(Clip.hardEdge));
 
-      expect(find.byType(StretchingOverscrollIndicator), findsOneWidget);
-      expect(find.byType(GlowingOverscrollIndicator), findsNothing);
-      expect(find.text('Index 1'), findsOneWidget);
+    expect(find.byType(StretchingOverscrollIndicator), findsOneWidget);
+    expect(find.byType(GlowingOverscrollIndicator), findsNothing);
+    expect(find.text('Index 1'), findsOneWidget);
 
-      RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
-      // Currently not clipping
-      expect(renderClip.clipBehavior, equals(Clip.none));
+    RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Currently not clipping
+    expect(renderClip.clipBehavior, equals(Clip.none));
 
-      TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
-      // Overscroll the start.
-      await gesture.moveBy(const Offset(0.0, 200.0));
-      await tester.pumpAndSettle();
-      expect(find.text('Index 1'), findsOneWidget);
-      expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
-      renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
-      // Now clipping
-      expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+    TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll the start.
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
+    renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Now clipping
+    expect(renderClip.clipBehavior, equals(Clip.hardEdge));
 
-      await gesture.up();
-      await tester.pumpAndSettle();
+    await gesture.up();
+    await tester.pumpAndSettle();
 
-      // Test custom clip behavior.
-      await tester.pumpWidget(buildFrame(Clip.none));
+    // Test custom clip behavior.
+    await tester.pumpWidget(buildFrame(Clip.none));
 
-      renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
-      // Currently not clipping
-      expect(renderClip.clipBehavior, equals(Clip.none));
+    renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Currently not clipping
+    expect(renderClip.clipBehavior, equals(Clip.none));
 
-      gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
-      // Overscroll the start.
-      await gesture.moveBy(const Offset(0.0, 200.0));
-      await tester.pumpAndSettle();
-      expect(find.text('Index 1'), findsOneWidget);
-      expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
-      renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
-      // Now clipping
-      expect(renderClip.clipBehavior, equals(Clip.none));
+    gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll the start.
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
+    renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Now clipping
+    expect(renderClip.clipBehavior, equals(Clip.none));
 
-      await gesture.up();
-      await tester.pumpAndSettle();
+    await gesture.up();
+    await tester.pumpAndSettle();
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('When `useInheritedMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {


### PR DESCRIPTION
This PR updates unit tests from `app_test.dart` for M3 migration.

More info in https://github.com/flutter/flutter/issues/127064

The diff is somewhat misleading because third test in the original code is now the fourth in the updated one, but because they were very similar git diff does not reflect this swap.

And also, first test is M2 only and last one M3 only.