### PR TITLE
Update app_builder_test.dart for M3

### DIFF
--- a/packages/flutter/test/material/app_builder_test.dart
+++ b/packages/flutter/test/material/app_builder_test.dart
@@ -9,14 +9,9 @@ void main() {
   testWidgets("builder doesn't get called if app doesn't change", (WidgetTester tester) async {
     final List<String> log = <String>[];
     final Widget app = MaterialApp(
-      theme: ThemeData(
-        useMaterial3: false,
-        primarySwatch: Colors.green,
-      ),
       home: const Placeholder(),
       builder: (BuildContext context, Widget? child) {
         log.add('build');
-        expect(Theme.of(context).primaryColor, Colors.green);
         expect(Directionality.of(context), TextDirection.ltr);
         expect(child, isA<FocusScope>());
         return const Placeholder();
@@ -42,14 +37,9 @@ void main() {
     final List<String> log = <String>[];
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(
-          useMaterial3: false,
-          primarySwatch: Colors.yellow,
-        ),
         home: Builder(
           builder: (BuildContext context) {
             log.add('build');
-            expect(Theme.of(context).primaryColor, Colors.yellow);
             expect(Directionality.of(context), TextDirection.rtl);
             return const Placeholder();
           },


### PR DESCRIPTION
This PR updates unit tests from app_builder_test.dart for M3 migration.

More info in https://github.com/flutter/flutter/issues/127064

In this particular case, I choose to make the tests Material-agnostic by removing the color theming which was not meaningful to what is tested here.