### PR TITLE
Localize the 'No Replacements Found' spell check string

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/cupertino_ru.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_ru.arb
@@ -32,5 +32,5 @@
   "tabSemanticsLabel": "Вкладка $tabIndex из $tabCount",
   "modalBarrierDismissLabel": "Закрыть",
   "searchTextFieldPlaceholderLabel": "Поиск",
-  "noSpellCheckReplacementsLabel": "No Replacements Found"
+  "noSpellCheckReplacementsLabel": "Замен не найдено"
 }


### PR DESCRIPTION
This PR:

1. Fixes [this pr](https://github.com/flutter/flutter/issues/130874)
2. translates noSpellCheckReplacementsLabel for Russian localization