### PR TITLE
Update AutoComplete test for M3 migration

### DIFF
--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -459,9 +459,7 @@ void main() {
     const Color highlightColor = Color(0xFF112233);
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.light(useMaterial3: false).copyWith(
-          focusColor: highlightColor,
-        ),
+        theme: ThemeData.light().copyWith(focusColor: highlightColor),
         home: Scaffold(
           body: Autocomplete<String>(
             optionsBuilder: (TextEditingValue textEditingValue) {
@@ -481,26 +479,38 @@ void main() {
     final ListView list = find.byType(ListView).evaluate().first.widget as ListView;
     expect(list.semanticChildCount, 6);
 
-    // Highlighted item should be at the top
-    expect(tester.getTopLeft(find.text('chameleon')).dy, equals(64.0));
-    checkOptionHighlight(tester, 'chameleon', highlightColor);
+    final Rect optionsGroupRect = tester.getRect(find.byType(ListView));
+    const double optionsGroupPadding = 16.0;
 
-    // Move down the list of options
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
+    // Highlighted item should be at the top.
+    checkOptionHighlight(tester, 'chameleon', highlightColor);
+    expect(
+      tester.getTopLeft(find.text('chameleon')).dy,
+      equals(optionsGroupRect.top + optionsGroupPadding),
+    );
+
+    // Move down the list of options.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown); // Select 'elephant'.
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown); // Select 'goose'.
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown); // Select 'lemur'.
+    await tester.pumpAndSettle();
+
+    // Highlighted item 'lemur' should be centered in the options popup.
+    checkOptionHighlight(tester, 'lemur', highlightColor);
+    expect(
+      tester.getCenter(find.text('lemur')).dy,
+      equals(optionsGroupRect.center.dy),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown); // Select 'mouse'.
+    await tester.pumpAndSettle();
+
+    checkOptionHighlight(tester, 'mouse', highlightColor);
 
     // First item should have scrolled off the top, and not be selected.
     expect(find.text('chameleon'), findsNothing);
-
-    // Highlighted item 'lemur' should be centered in the options popup
-    expect(tester.getTopLeft(find.text('mouse')).dy, equals(187.0));
-    checkOptionHighlight(tester, 'mouse', highlightColor);
 
     // The other items on screen should not be selected.
     checkOptionHighlight(tester, 'goose', null);


### PR DESCRIPTION
This PR updates unit tests from autocomplete_test.dart for M3 migration.

More info in https://github.com/flutter/flutter/issues/127064

I replaced magic numbers (64.0 and 187.0) and found ways to compute them without relying on the Material version.