### PR TITLE
fixes l10n for CupertinoDatePicker in monthYear mode

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -492,8 +492,11 @@ class CupertinoDatePicker extends StatefulWidget {
           }
         }
       case _PickerColumnType.month:
-        for (int i = 1; i <=12; i++) {
-          final String month = localizations.datePickerMonth(i, standaloneMonth);
+        for (int i = 1; i <= 12; i++) {
+          String month = localizations.datePickerMonth(i);
+          if (standaloneMonth) {
+            month = localizations.datePickerStandaloneMonth(i);
+          }
           if (longestText.length < month.length) {
             longestText = month;
           }
@@ -1281,11 +1284,12 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
           final int month = index + 1;
           final bool isInvalidMonth = (widget.minimumDate?.year == selectedYear && widget.minimumDate!.month > month)
                                    || (widget.maximumDate?.year == selectedYear && widget.maximumDate!.month < month);
+          final String monthName = (widget.mode == CupertinoDatePickerMode.monthYear) ? localizations.datePickerStandaloneMonth(month) : localizations.datePickerMonth(month);
 
           return itemPositioningBuilder(
             context,
             Text(
-              localizations.datePickerMonth(month, widget.mode == CupertinoDatePickerMode.monthYear),
+              monthName,
               style: _themeTextStyle(context, isValid: !isInvalidMonth),
             ),
           );
@@ -1614,11 +1618,12 @@ class _CupertinoDatePickerMonthYearState extends State<CupertinoDatePicker> {
           final int month = index + 1;
           final bool isInvalidMonth = (widget.minimumDate?.year == selectedYear && widget.minimumDate!.month > month)
                                    || (widget.maximumDate?.year == selectedYear && widget.maximumDate!.month < month);
+          final String monthName = (widget.mode == CupertinoDatePickerMode.monthYear) ? localizations.datePickerStandaloneMonth(month) : localizations.datePickerMonth(month);
 
           return itemPositioningBuilder(
             context,
             Text(
-              localizations.datePickerMonth(month, widget.mode == CupertinoDatePickerMode.monthYear),
+              monthName,
               style: _themeTextStyle(context, isValid: !isInvalidMonth),
             ),
           );

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -438,9 +438,9 @@ class CupertinoDatePicker extends StatefulWidget {
     _PickerColumnType columnType,
     CupertinoLocalizations localizations,
     BuildContext context,
-    bool showDayOfWeek,
-    [bool standaloneMonth = false]
-  ) {
+    bool showDayOfWeek, {
+    bool standaloneMonth = false,
+  }) {
     String longestText = '';
 
     switch (columnType) {
@@ -1582,7 +1582,8 @@ class _CupertinoDatePickerMonthYearState extends State<CupertinoDatePicker> {
   }
 
   void _refreshEstimatedColumnWidths() {
-    estimatedColumnWidths[_PickerColumnType.month.index] = CupertinoDatePicker._getColumnWidth(_PickerColumnType.month, localizations, context, false, widget.mode == CupertinoDatePickerMode.monthYear);
+    estimatedColumnWidths[_PickerColumnType.month.index] =
+        CupertinoDatePicker._getColumnWidth(_PickerColumnType.month, localizations, context, false, standaloneMonth: widget.mode == CupertinoDatePickerMode.monthYear);
     estimatedColumnWidths[_PickerColumnType.year.index] = CupertinoDatePicker._getColumnWidth(_PickerColumnType.year, localizations, context, false);
   }
 

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -493,10 +493,9 @@ class CupertinoDatePicker extends StatefulWidget {
         }
       case _PickerColumnType.month:
         for (int i = 1; i <= 12; i++) {
-          String month = localizations.datePickerMonth(i);
-          if (standaloneMonth) {
-            month = localizations.datePickerStandaloneMonth(i);
-          }
+          final String month = standaloneMonth
+              ? localizations.datePickerStandaloneMonth(i)
+              : localizations.datePickerMonth(i);
           if (longestText.length < month.length) {
             longestText = month;
           }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -438,7 +438,8 @@ class CupertinoDatePicker extends StatefulWidget {
     _PickerColumnType columnType,
     CupertinoLocalizations localizations,
     BuildContext context,
-    bool showDayOfWeek
+    bool showDayOfWeek,
+    [bool standaloneMonth = false]
   ) {
     String longestText = '';
 
@@ -492,7 +493,7 @@ class CupertinoDatePicker extends StatefulWidget {
         }
       case _PickerColumnType.month:
         for (int i = 1; i <=12; i++) {
-          final String month = localizations.datePickerMonth(i);
+          final String month = localizations.datePickerMonth(i, standaloneMonth);
           if (longestText.length < month.length) {
             longestText = month;
           }
@@ -1284,7 +1285,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
           return itemPositioningBuilder(
             context,
             Text(
-              localizations.datePickerMonth(month),
+              localizations.datePickerMonth(month, widget.mode == CupertinoDatePickerMode.monthYear),
               style: _themeTextStyle(context, isValid: !isInvalidMonth),
             ),
           );
@@ -1577,7 +1578,7 @@ class _CupertinoDatePickerMonthYearState extends State<CupertinoDatePicker> {
   }
 
   void _refreshEstimatedColumnWidths() {
-    estimatedColumnWidths[_PickerColumnType.month.index] = CupertinoDatePicker._getColumnWidth(_PickerColumnType.month, localizations, context, false);
+    estimatedColumnWidths[_PickerColumnType.month.index] = CupertinoDatePicker._getColumnWidth(_PickerColumnType.month, localizations, context, false, widget.mode == CupertinoDatePickerMode.monthYear);
     estimatedColumnWidths[_PickerColumnType.year.index] = CupertinoDatePicker._getColumnWidth(_PickerColumnType.year, localizations, context, false);
   }
 
@@ -1617,7 +1618,7 @@ class _CupertinoDatePickerMonthYearState extends State<CupertinoDatePicker> {
           return itemPositioningBuilder(
             context,
             Text(
-              localizations.datePickerMonth(month),
+              localizations.datePickerMonth(month, widget.mode == CupertinoDatePickerMode.monthYear),
               style: _themeTextStyle(context, isValid: !isInvalidMonth),
             ),
           );

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -76,8 +76,13 @@ abstract class CupertinoLocalizations {
   ///
   ///  - US English: January
   ///  - Korean: 1월
+  ///  - Russian: Января
+  ///
+  /// Examples: datePickerMonth(1, true) in:
+  ///
+  /// - Russian: Январь
   // The global version uses date symbols data from the intl package.
-  String datePickerMonth(int monthIndex);
+  String datePickerMonth(int monthIndex, [bool standalone = false]);
 
   /// Day of month that is shown in [CupertinoDatePicker] spinner corresponding
   /// to the given day index.
@@ -365,7 +370,7 @@ class DefaultCupertinoLocalizations implements CupertinoLocalizations {
   String datePickerYear(int yearIndex) => yearIndex.toString();
 
   @override
-  String datePickerMonth(int monthIndex) => _months[monthIndex - 1];
+  String datePickerMonth(int monthIndex, [bool standalone = false]) => _months[monthIndex - 1];
 
   @override
   String datePickerDayOfMonth(int dayIndex, [int? weekDay]) {

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -76,11 +76,16 @@ abstract class CupertinoLocalizations {
   ///
   ///  - US English: January
   ///  - Korean: 1월
+  ///  - Russian: января
   // The global version uses date symbols data from the intl package.
   String datePickerMonth(int monthIndex);
 
   /// Month that is shown in [CupertinoDatePicker] spinner corresponding to
   /// the given month index in [CupertinoDatePickerMode.monthYear] mode.
+  ///
+  /// This is distinct from [datePickerMonth] because in some languages, like Russian,
+  /// the name of a month takes a different form depending
+  /// on whether it is preceded by a day or whether it stands alone.
   ///
   /// Examples: datePickerMonth(1) in:
   ///

--- a/packages/flutter/lib/src/cupertino/localizations.dart
+++ b/packages/flutter/lib/src/cupertino/localizations.dart
@@ -76,13 +76,19 @@ abstract class CupertinoLocalizations {
   ///
   ///  - US English: January
   ///  - Korean: 1월
-  ///  - Russian: Января
-  ///
-  /// Examples: datePickerMonth(1, true) in:
-  ///
-  /// - Russian: Январь
   // The global version uses date symbols data from the intl package.
-  String datePickerMonth(int monthIndex, [bool standalone = false]);
+  String datePickerMonth(int monthIndex);
+
+  /// Month that is shown in [CupertinoDatePicker] spinner corresponding to
+  /// the given month index in [CupertinoDatePickerMode.monthYear] mode.
+  ///
+  /// Examples: datePickerMonth(1) in:
+  ///
+  ///  - US English: January
+  ///  - Korean: 1월
+  ///  - Russian: Январь
+  // The global version uses date symbols data from the intl package.
+  String datePickerStandaloneMonth(int monthIndex);
 
   /// Day of month that is shown in [CupertinoDatePicker] spinner corresponding
   /// to the given day index.
@@ -370,7 +376,10 @@ class DefaultCupertinoLocalizations implements CupertinoLocalizations {
   String datePickerYear(int yearIndex) => yearIndex.toString();
 
   @override
-  String datePickerMonth(int monthIndex, [bool standalone = false]) => _months[monthIndex - 1];
+  String datePickerMonth(int monthIndex) => _months[monthIndex - 1];
+
+  @override
+  String datePickerStandaloneMonth(int monthIndex) => _months[monthIndex - 1];
 
   @override
   String datePickerDayOfMonth(int dayIndex, [int? weekDay]) {

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -93,10 +93,14 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   }
 
   @override
-  String datePickerMonth(int monthIndex) {
+  String datePickerMonth(int monthIndex, [bool standalone = false]) {
     // It doesn't actually have anything to do with _fullYearFormat. It's just
     // taking advantage of the fact that _fullYearFormat loaded the needed
     // locale's symbols.
+    if (standalone) {
+      return _fullYearFormat.dateSymbols.STANDALONEMONTHS[monthIndex - 1];
+    }
+    
     return _fullYearFormat.dateSymbols.MONTHS[monthIndex - 1];
   }
 

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -107,7 +107,7 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
     // locale's symbols.
     //
     // Because this will be used without specifying any day of month,
-    // in most cases it should be capitalized (according to rules in specific language)
+    // in most cases it should be capitalized (according to rules in specific language).
     return intl.toBeginningOfSentenceCase(_fullYearFormat.dateSymbols.STANDALONEMONTHS[monthIndex - 1]) ??
         _fullYearFormat.dateSymbols.STANDALONEMONTHS[monthIndex - 1];
   }

--- a/packages/flutter_localizations/lib/src/cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/cupertino_localizations.dart
@@ -93,15 +93,23 @@ abstract class GlobalCupertinoLocalizations implements CupertinoLocalizations {
   }
 
   @override
-  String datePickerMonth(int monthIndex, [bool standalone = false]) {
+  String datePickerMonth(int monthIndex) {
     // It doesn't actually have anything to do with _fullYearFormat. It's just
     // taking advantage of the fact that _fullYearFormat loaded the needed
     // locale's symbols.
-    if (standalone) {
-      return _fullYearFormat.dateSymbols.STANDALONEMONTHS[monthIndex - 1];
-    }
-    
     return _fullYearFormat.dateSymbols.MONTHS[monthIndex - 1];
+  }
+
+  @override
+  String datePickerStandaloneMonth(int monthIndex) {
+    // It doesn't actually have anything to do with _fullYearFormat. It's just
+    // taking advantage of the fact that _fullYearFormat loaded the needed
+    // locale's symbols.
+    //
+    // Because this will be used without specifying any day of month,
+    // in most cases it should be capitalized (according to rules in specific language)
+    return intl.toBeginningOfSentenceCase(_fullYearFormat.dateSymbols.STANDALONEMONTHS[monthIndex - 1]) ??
+        _fullYearFormat.dateSymbols.STANDALONEMONTHS[monthIndex - 1];
   }
 
   @override

--- a/packages/flutter_localizations/test/cupertino/date_picker_test.dart
+++ b/packages/flutter_localizations/test/cupertino/date_picker_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Test correct month form for CupertinoDatePicker in monthYear mode', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+              child: CupertinoDatePicker(
+            initialDateTime: DateTime(2023, 5),
+            onDateTimeChanged: (_) {},
+            mode: CupertinoDatePickerMode.monthYear,
+          )),
+        ),
+        supportedLocales: [Locale('ru', 'RU')],
+        localizationsDelegates: [GlobalCupertinoLocalizations.delegate],
+      ),
+    );
+
+    expect(find.text('май'), findsWidgets);
+  });
+
+  testWidgets('Test correct month form for CupertinoDatePicker in date mode', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+              child: CupertinoDatePicker(
+            initialDateTime: DateTime(2023, 5),
+            onDateTimeChanged: (_) {},
+            mode: CupertinoDatePickerMode.date,
+          )),
+        ),
+        supportedLocales: [Locale('ru', 'RU')],
+        localizationsDelegates: [GlobalCupertinoLocalizations.delegate],
+      ),
+    );
+
+    expect(find.text('мая'), findsWidgets);
+  });
+}

--- a/packages/flutter_localizations/test/cupertino/date_picker_test.dart
+++ b/packages/flutter_localizations/test/cupertino/date_picker_test.dart
@@ -18,8 +18,8 @@ void main() {
             mode: CupertinoDatePickerMode.monthYear,
           )),
         ),
-        supportedLocales: [Locale('ru', 'RU')],
-        localizationsDelegates: [GlobalCupertinoLocalizations.delegate],
+        supportedLocales: const <Locale>[Locale('ru', 'RU')],
+        localizationsDelegates: GlobalCupertinoLocalizations.delegates,
       ),
     );
 
@@ -37,8 +37,8 @@ void main() {
             mode: CupertinoDatePickerMode.date,
           )),
         ),
-        supportedLocales: [Locale('ru', 'RU')],
-        localizationsDelegates: [GlobalCupertinoLocalizations.delegate],
+        supportedLocales: const <Locale>[Locale('ru', 'RU')],
+        localizationsDelegates: GlobalCupertinoLocalizations.delegates,
       ),
     );
 

--- a/packages/flutter_localizations/test/cupertino/date_picker_test.dart
+++ b/packages/flutter_localizations/test/cupertino/date_picker_test.dart
@@ -23,7 +23,7 @@ void main() {
       ),
     );
 
-    expect(find.text('май'), findsWidgets);
+    expect(find.text('Май'), findsWidgets);
   });
 
   testWidgets('Test correct month form for CupertinoDatePicker in date mode', (WidgetTester tester) async {

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -34,6 +34,11 @@ void main() {
       expect(localizations.datePickerMonth(11), isNotNull);
       expect(localizations.datePickerMonth(12), isNotNull);
 
+      expect(localizations.datePickerMonth(1, true), isNotNull);
+      expect(localizations.datePickerMonth(2, true), isNotNull);
+      expect(localizations.datePickerMonth(11, true), isNotNull);
+      expect(localizations.datePickerMonth(12, true), isNotNull);
+
       expect(localizations.datePickerDayOfMonth(0), isNotNull);
       expect(localizations.datePickerDayOfMonth(1), isNotNull);
       expect(localizations.datePickerDayOfMonth(2), isNotNull);

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -34,10 +34,10 @@ void main() {
       expect(localizations.datePickerMonth(11), isNotNull);
       expect(localizations.datePickerMonth(12), isNotNull);
 
-      expect(localizations.datePickerMonth(1, true), isNotNull);
-      expect(localizations.datePickerMonth(2, true), isNotNull);
-      expect(localizations.datePickerMonth(11, true), isNotNull);
-      expect(localizations.datePickerMonth(12, true), isNotNull);
+      expect(localizations.datePickerStandaloneMonth(1), isNotNull);
+      expect(localizations.datePickerStandaloneMonth(2), isNotNull);
+      expect(localizations.datePickerStandaloneMonth(11), isNotNull);
+      expect(localizations.datePickerStandaloneMonth(12), isNotNull);
 
       expect(localizations.datePickerDayOfMonth(0), isNotNull);
       expect(localizations.datePickerDayOfMonth(1), isNotNull);


### PR DESCRIPTION
This PR fixes l10n issue when months names are being used in incorrect form in CupertinoDatePicker in CupertinoDatePickerMode.yearMonth (#130930).

The idea of this proposal is to add an optional parameter `standalone` for `CupertinoLocalizations.datePickerMonth` to be able to choose when to use months names in base form (intl DateSymbols.STANDALONEMONTHS) and when in day-dependent form (intl DateSymbols.MONTHS)

<details>
<summary>Before</summary>

<img width="366" alt="image" src="https://github.com/flutter/flutter/assets/32621121/1dd54fa7-6dd9-4053-889b-57134c145432">

<img width="387" alt="image" src="https://github.com/flutter/flutter/assets/32621121/c176070e-73e4-49d3-883b-ba31eca6d1d7">

</details>

<details>
<summary>After</summary>

<img width="369" alt="image" src="https://github.com/flutter/flutter/assets/32621121/255594f1-219d-4bd4-9b75-1012912f8ab0">

<img width="378" alt="image" src="https://github.com/flutter/flutter/assets/32621121/16bbb41f-3f62-4446-bf41-e27140b649a9">

</details>


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
