### PR TITLE
Update BottomAppBar and BottomAppBarTheme tests for M3

### DIFF
--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -15,7 +15,7 @@ import '../foundation/leak_tracking.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('shadow effect is not doubled', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Shadow effect is not doubled', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/123064
     debugDisableShadows = false;
 
@@ -41,7 +41,7 @@ void main() {
     debugDisableShadows = true;
   });
 
-  testWidgetsWithLeakTracking('only one layer with `color` is painted', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Only one layer with `color` is painted', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/122667
     const Color bottomAppBarColor = Colors.black45;
 
@@ -51,7 +51,6 @@ void main() {
         home: const Scaffold(
           bottomNavigationBar: BottomAppBar(
             color: bottomAppBarColor,
-
             // Avoid getting a surface tint color, to keep the color check below simple
             elevation: 0,
           ),
@@ -80,7 +79,7 @@ void main() {
     }
   });
 
-  testWidgetsWithLeakTracking('no overlap with floating action button', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('No overlap with floating action button', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -111,7 +110,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('custom shape', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - Custom shape', (WidgetTester tester) async {
     final Key key = UniqueKey();
     Future<void> pump(FloatingActionButtonLocation location) async {
       await tester.pumpWidget(
@@ -145,13 +144,57 @@ void main() {
     await pump(FloatingActionButtonLocation.endDocked);
     await expectLater(
       find.byKey(key),
-      matchesGoldenFile('bottom_app_bar.custom_shape.1.png'),
+      matchesGoldenFile('m2_bottom_app_bar.custom_shape.1.png'),
     );
     await pump(FloatingActionButtonLocation.centerDocked);
     await tester.pumpAndSettle();
     await expectLater(
       find.byKey(key),
-      matchesGoldenFile('bottom_app_bar.custom_shape.2.png'),
+      matchesGoldenFile('m2_bottom_app_bar.custom_shape.2.png'),
+    );
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44572
+
+  testWidgetsWithLeakTracking('Material3 - Custom shape', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    Future<void> pump(FloatingActionButtonLocation location) async {
+      await tester.pumpWidget(
+        SizedBox(
+          width: 200,
+          height: 200,
+          child: RepaintBoundary(
+            key: key,
+            child: MaterialApp(
+              theme: ThemeData(useMaterial3: true),
+              home: Scaffold(
+                floatingActionButton: FloatingActionButton(
+                  onPressed: () { },
+                ),
+                floatingActionButtonLocation: location,
+                bottomNavigationBar: const BottomAppBar(
+                  shape: AutomaticNotchedShape(
+                    BeveledRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(50.0))),
+                    ContinuousRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(30.0))),
+                  ),
+                  notchMargin: 10.0,
+                  color: Colors.green,
+                  child: SizedBox(height: 100.0),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    await pump(FloatingActionButtonLocation.endDocked);
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('m3_bottom_app_bar.custom_shape.1.png'),
+    );
+    await pump(FloatingActionButtonLocation.centerDocked);
+    await tester.pumpAndSettle();
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('m3_bottom_app_bar.custom_shape.2.png'),
     );
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/44572
 
@@ -187,39 +230,7 @@ void main() {
     expect(babRect, const Rect.fromLTRB(240, 520, 560, 600));
   });
 
-  testWidgetsWithLeakTracking('Custom Padding in Material 3', (WidgetTester tester) async {
-    const EdgeInsets customPadding = EdgeInsets.all(10);
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData.from(colorScheme: const ColorScheme.light(), useMaterial3: true),
-        home: Builder(
-          builder: (BuildContext context) {
-            return const Scaffold(
-              body: Align(
-                alignment: Alignment.bottomCenter,
-                child: BottomAppBar(
-                  padding: customPadding,
-                  child: ColoredBox(
-                    color: Colors.green,
-                    child: SizedBox(width: 300, height: 60),
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-    );
-
-    final BottomAppBar bottomAppBar = tester.widget(find.byType(BottomAppBar));
-    expect(bottomAppBar.padding, customPadding);
-    final Rect babRect = tester.getRect(find.byType(BottomAppBar));
-    final Rect childRect = tester.getRect(find.byType(ColoredBox));
-    expect(childRect, const Rect.fromLTRB(250, 530, 550, 590));
-    expect(babRect, const Rect.fromLTRB(240, 520, 560, 600));
-  });
-
-  testWidgetsWithLeakTracking('color defaults to Theme.bottomAppBarColor in M2', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - Color defaults to Theme.bottomAppBarColor', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
@@ -245,7 +256,7 @@ void main() {
     expect(physicalShape.color, const Color(0xffffff00));
   });
 
-  testWidgetsWithLeakTracking('color overrides theme color', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - Color overrides theme color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
@@ -276,11 +287,12 @@ void main() {
   });
 
 
-  testWidgetsWithLeakTracking('color overrides theme color with Material 3', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Color overrides theme color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.light(useMaterial3: true).copyWith(
-          bottomAppBarColor: const Color(0xffffff00)),
+          bottomAppBarColor: const Color(0xffffff00),
+        ),
         home: Builder(
           builder: (BuildContext context) {
             return const Scaffold(
@@ -303,7 +315,7 @@ void main() {
     expect(physicalShape.color, const Color(0xff0000ff));
   });
 
-  testWidgetsWithLeakTracking('Shadow color is transparent in Material 3', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Shadow color is transparent', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: true,
@@ -325,7 +337,7 @@ void main() {
     expect(physicalShape.shadowColor, Colors.transparent);
   });
 
-  testWidgetsWithLeakTracking('dark theme applies an elevation overlay color', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - Dark theme applies an elevation overlay color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.from(useMaterial3: false, colorScheme: const ColorScheme.dark()),
@@ -341,6 +353,26 @@ void main() {
 
     // For the default dark theme the overlay color for elevation 8 is 0xFF2D2D2D
     expect(physicalShape.color, const Color(0xFF2D2D2D));
+  });
+
+  testWidgetsWithLeakTracking('Material3 - Dark theme applies an elevation overlay color', (WidgetTester tester) async {
+    const ColorScheme colorScheme = ColorScheme.dark();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.from(useMaterial3: true, colorScheme: colorScheme),
+        home: Scaffold(
+          bottomNavigationBar: BottomAppBar(
+            color: colorScheme.surface,
+          ),
+        ),
+      ),
+    );
+
+    final PhysicalShape physicalShape = tester.widget(find.byType(PhysicalShape).at(0));
+
+    const double elevation = 3.0; // Default for M3.
+    final Color overlayColor = ElevationOverlay.applySurfaceTint(colorScheme.surface, colorScheme.surfaceTint, elevation);
+    expect(physicalShape.color, overlayColor);
   });
 
   // This is a regression test for a bug we had where toggling the notch on/off
@@ -510,7 +542,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('observes safe area', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - Observes safe area', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
@@ -532,6 +564,37 @@ void main() {
     expect(
       tester.getBottomLeft(find.widgetWithText(Center, 'safe')),
       const Offset(50.0, 550.0),
+    );
+  });
+
+  testWidgetsWithLeakTracking('Material3 - Observes safe area', (WidgetTester tester) async {
+    const double safeAreaPadding = 50.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: const MediaQuery(
+          data: MediaQueryData(
+            padding: EdgeInsets.all(safeAreaPadding),
+          ),
+          child: Scaffold(
+            bottomNavigationBar: BottomAppBar(
+              child: Center(
+                child: Text('safe'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    const double appBarVerticalPadding = 12.0;
+    const double appBarHorizontalPadding = 16.0;
+    expect(
+      tester.getBottomLeft(find.widgetWithText(Center, 'safe')),
+      const Offset(
+        safeAreaPadding + appBarHorizontalPadding,
+        600 - safeAreaPadding - appBarVerticalPadding,
+      ),
     );
   });
 
@@ -569,9 +632,9 @@ void main() {
     expect(physicalShape.clipBehavior, Clip.antiAliasWithSaveLayer);
   });
 
-  testWidgetsWithLeakTracking('BottomAppBar with shape when Scaffold.bottomNavigationBar == null', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - BottomAppBar with shape when Scaffold.bottomNavigationBar == null', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/80878
-    final ThemeData theme = ThemeData();
+    final ThemeData theme = ThemeData(useMaterial3: false);
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
@@ -602,7 +665,43 @@ void main() {
     );
 
     expect(tester.getRect(find.byType(FloatingActionButton)), const Rect.fromLTRB(372, 528, 428, 584));
-    expect(tester.getSize(find.byType(BottomAppBar)), theme.useMaterial3 ? const Size(800, 80) : const Size(800, 50));
+    expect(tester.getSize(find.byType(BottomAppBar)), const Size(800, 50));
+  });
+
+  testWidgetsWithLeakTracking('Material3 - BottomAppBar with shape when Scaffold.bottomNavigationBar == null', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/80878
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+          floatingActionButton: FloatingActionButton(
+            backgroundColor: Colors.green,
+            child: const Icon(Icons.home),
+            onPressed: () {},
+          ),
+          body: Stack(
+            children: <Widget>[
+              Container(
+                color: Colors.amber,
+              ),
+              Container(
+                alignment: Alignment.bottomCenter,
+                child: BottomAppBar(
+                  color: Colors.green,
+                  shape: const CircularNotchedRectangle(),
+                  child: Container(height: 50),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getRect(find.byType(FloatingActionButton)), const Rect.fromLTRB(372, 528, 428, 584));
+    expect(tester.getSize(find.byType(BottomAppBar)), const Size(800, 80));
   });
 
   testWidgetsWithLeakTracking('notch with margin and top padding, home safe area', (WidgetTester tester) async {
@@ -691,7 +790,7 @@ void main() {
     expect(physicalShape.clipper.toString(), 'ShapeBorderClipper');
   });
 
-  testWidgetsWithLeakTracking('BottomAppBar adds bottom padding to height', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - BottomAppBar adds bottom padding to height', (WidgetTester tester) async {
     const double bottomPadding = 35.0;
 
     await tester.pumpWidget(

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -20,17 +20,17 @@ void main() {
   });
 
   group('Material 2 tests', () {
-    testWidgetsWithLeakTracking('BAB theme overrides color', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB theme overrides color', (WidgetTester tester) async {
       const Color themedColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: themedColor);
 
-      await tester.pumpWidget(_withTheme(theme));
+      await tester.pumpWidget(_withTheme(theme, useMaterial3: false));
 
       final PhysicalShape widget = _getBabRenderObject(tester);
       expect(widget.color, themedColor);
     });
 
-    testWidgetsWithLeakTracking('BAB color - Widget', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB color - Widget', (WidgetTester tester) async {
       const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const Color babColor = Colors.pink;
@@ -49,7 +49,7 @@ void main() {
       expect(widget.color, babColor);
     });
 
-    testWidgetsWithLeakTracking('BAB color - BabTheme', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB color - BabTheme', (WidgetTester tester) async {
       const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: babThemeColor);
@@ -67,7 +67,7 @@ void main() {
       expect(widget.color, babThemeColor);
     });
 
-    testWidgetsWithLeakTracking('BAB color - Theme', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB color - Theme', (WidgetTester tester) async {
       const Color themeColor = Colors.white10;
 
       await tester.pumpWidget(MaterialApp(
@@ -79,7 +79,7 @@ void main() {
       expect(widget.color, themeColor);
     });
 
-    testWidgetsWithLeakTracking('BAB color - Default', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB color - Default', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(useMaterial3: false),
         home: const Scaffold(body: BottomAppBar()),
@@ -90,14 +90,14 @@ void main() {
       expect(widget.color, Colors.white);
     });
 
-    testWidgetsWithLeakTracking('BAB theme customizes shape', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB theme customizes shape', (WidgetTester tester) async {
       const BottomAppBarTheme theme = BottomAppBarTheme(
         color: Colors.white30,
         shape: CircularNotchedRectangle(),
         elevation: 1.0,
       );
 
-      await tester.pumpWidget(_withTheme(theme));
+      await tester.pumpWidget(_withTheme(theme, useMaterial3: false));
 
       await expectLater(
         find.byKey(_painterKey),
@@ -105,7 +105,7 @@ void main() {
       );
     });
 
-    testWidgetsWithLeakTracking('BAB theme does not affect defaults', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - BAB theme does not affect defaults', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(useMaterial3: false),
         home: const Scaffold(body: BottomAppBar()),
@@ -119,19 +119,19 @@ void main() {
   });
 
   group('Material 3 tests', () {
-    testWidgetsWithLeakTracking('BAB theme overrides color - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB theme overrides color', (WidgetTester tester) async {
       const Color themedColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(
         color: themedColor,
         elevation: 0
       );
-      await tester.pumpWidget(_withTheme(theme, true));
+      await tester.pumpWidget(_withTheme(theme, useMaterial3: true));
 
       final PhysicalShape widget = _getBabRenderObject(tester);
       expect(widget.color, themedColor);
     });
 
-    testWidgetsWithLeakTracking('BAB color - Widget - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB color - Widget', (WidgetTester tester) async {
       const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const Color babColor = Colors.pink;
@@ -150,7 +150,7 @@ void main() {
       expect(widget.color, babColor);
     });
 
-    testWidgetsWithLeakTracking('BAB color - BabTheme - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB color - BabTheme', (WidgetTester tester) async {
       const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: babThemeColor);
@@ -168,7 +168,7 @@ void main() {
       expect(widget.color, babThemeColor);
     });
 
-    testWidgetsWithLeakTracking('BAB theme does not affect defaults - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB theme does not affect defaults', (WidgetTester tester) async {
       final ThemeData theme = ThemeData(useMaterial3: true);
       await tester.pumpWidget(MaterialApp(
         theme: theme,
@@ -181,30 +181,30 @@ void main() {
       expect(widget.elevation, equals(3.0));
     });
 
-    testWidgetsWithLeakTracking('BAB theme overrides surfaceTintColor - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB theme overrides surfaceTintColor', (WidgetTester tester) async {
       const Color color = Colors.blue; // base color that the surface tint will be applied to
       const Color babThemeSurfaceTintColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(
           color: color, surfaceTintColor: babThemeSurfaceTintColor, elevation: 0,
       );
-      await tester.pumpWidget(_withTheme(theme, true));
+      await tester.pumpWidget(_withTheme(theme, useMaterial3: true));
 
       final PhysicalShape widget = _getBabRenderObject(tester);
       expect(widget.color, ElevationOverlay.applySurfaceTint(color, babThemeSurfaceTintColor, 0));
     });
 
-    testWidgetsWithLeakTracking('BAB theme overrides shadowColor - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB theme overrides shadowColor', (WidgetTester tester) async {
       const Color babThemeShadowColor = Colors.yellow;
       const BottomAppBarTheme theme = BottomAppBarTheme(
         shadowColor: babThemeShadowColor, elevation: 0
       );
-      await tester.pumpWidget(_withTheme(theme, true));
+      await tester.pumpWidget(_withTheme(theme, useMaterial3: true));
 
       final PhysicalShape widget = _getBabRenderObject(tester);
       expect(widget.shadowColor, babThemeShadowColor);
     });
 
-    testWidgetsWithLeakTracking('BAB surfaceTintColor - Widget - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB surfaceTintColor - Widget', (WidgetTester tester) async {
       const Color color = Colors.white10; // base color that the surface tint will be applied to
       const Color themeSurfaceTintColor = Colors.white10;
       const Color babThemeSurfaceTintColor = Colors.black87;
@@ -227,7 +227,7 @@ void main() {
       expect(widget.color, ElevationOverlay.applySurfaceTint(color, babSurfaceTintColor, 3.0));
     });
 
-    testWidgetsWithLeakTracking('BAB surfaceTintColor - BabTheme - M3', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material3 - BAB surfaceTintColor - BabTheme', (WidgetTester tester) async {
       const Color color = Colors.blue; // base color that the surface tint will be applied to
       const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
@@ -261,7 +261,7 @@ PhysicalShape _getBabRenderObject(WidgetTester tester) {
 
 final Key _painterKey = UniqueKey();
 
-Widget _withTheme(BottomAppBarTheme theme, [bool useMaterial3 = false]) {
+Widget _withTheme(BottomAppBarTheme theme, {required bool useMaterial3}) {
   return MaterialApp(
     theme: ThemeData(useMaterial3: useMaterial3, bottomAppBarTheme: theme),
     home: Scaffold(


### PR DESCRIPTION
This PR updates `BottomAppBar` and `BottomAppBarTheme` tests for M3 migration.

More info in https://github.com/flutter/flutter/issues/127064

- Some tests are M2 or M3 only.
- Added several M3 tests.
- One golden change.