### PR TITLE
Fix M3 TimePicker dial background uses incorrect color

### DIFF
--- a/dev/tools/gen_defaults/lib/time_picker_template.dart
+++ b/dev/tools/gen_defaults/lib/time_picker_template.dart
@@ -132,7 +132,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dialBackgroundColor {
-    return ${componentColor(dialComponent)}.withOpacity(_colors.brightness == Brightness.dark ? 0.12 : 0.08);
+    return ${componentColor(dialComponent)};
   }
 
   @override

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -3434,7 +3434,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dialBackgroundColor {
-    return _colors.surfaceVariant.withOpacity(_colors.brightness == Brightness.dark ? 0.12 : 0.08);
+    return _colors.surfaceVariant;
   }
 
   @override

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -136,8 +136,14 @@ class TimePickerThemeData with Diagnosticable {
   /// The background color of the time picker dial when the entry mode is
   /// [TimePickerEntryMode.dial] or [TimePickerEntryMode.dialOnly].
   ///
-  /// If this is null, the time picker defaults to the overall theme's
-  /// [ColorScheme.primary].
+  /// If this is null and [ThemeData.useMaterial3] is true, the time picker
+  /// dial background color defaults [ColorScheme.surfaceVariant] color.
+  ///
+  /// If this is null and [ThemeData.useMaterial3] is false, the time picker
+  /// dial background color defaults to [ColorScheme.onSurface] color with
+  /// an opacity of 0.08 when the overall theme's brightness is [Brightness.light]
+  /// and [ColorScheme.onSurface] color with an opacity of 0.12 when the overall
+  /// theme's brightness is [Brightness.dark].
   final Color? dialBackgroundColor;
 
   /// The color of the time picker dial's hand when the entry mode is

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -242,7 +242,7 @@ void main() {
     expect(
       dial,
       paints
-        ..circle(color: defaultTheme.colorScheme.surfaceVariant.withOpacity(0.08)) // Dial background color.
+        ..circle(color: defaultTheme.colorScheme.surfaceVariant) // Dial background color.
         ..circle(color: Color(defaultTheme.colorScheme.primary.value)), // Dial hand color.
     );
 


### PR DESCRIPTION
fixes [Material3: TimePicker clock dial use wrong spec color and its web spec has a mistake](https://github.com/flutter/flutter/issues/118657)

### Description 

This PR fixes the default color used for the Material 3 dial background.

### Code sample

<details> 
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    final ThemeData theme = ThemeData(useMaterial3: true);

    return MaterialApp(
      debugShowCheckedModeBanner: false,
      // theme: theme,
      theme: theme.copyWith(
        colorScheme: theme.colorScheme.copyWith(
          surfaceVariant: const Color(0xffffbf00),
        ),
      ),
      home: const Example(),
    );
  }
}

class Example extends StatelessWidget {
  const Example({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Sample'),
      ),
      body: Center(
        child: ElevatedButton(
          onPressed: () {
            showTimePicker(
              context: context,
              initialTime: TimeOfDay.now(),
            );
          },
          child: const Text('Open Time Picker'),
        ),
      ),
    );
  }
}
``` 
	
</details>

### Default dial background color 
| Before | After |
| --------------- | --------------- |
| <img src="https://github.com/flutter/flutter/assets/48603081/59514586-60c6-489f-b024-f659a26fa1e7"  /> | <img src="https://github.com/flutter/flutter/assets/48603081/75c3c360-df2b-47c8-8187-136ff6d963b6"  /> |

### Custom color scheme
| Before | After |
| --------------- | --------------- |
| <img src="https://github.com/flutter/flutter/assets/48603081/666dd2fc-7ee2-4268-9af0-923019adfccd"  /> | <img src="https://github.com/flutter/flutter/assets/48603081/f32dc39e-a43f-4a63-a6e4-9df479b723ed"  /> |


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
