### PR TITLE
Add `CheckedPopupMenuItem‎.labelTextStyle` and update default text style for Material 3

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -475,6 +475,7 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
     super.enabled,
     super.padding,
     super.height,
+    super.labelTextStyle,
     super.mouseCursor,
     super.child,
   });
@@ -529,9 +530,19 @@ class _CheckedPopupMenuItemState<T> extends PopupMenuItemState<T, CheckedPopupMe
 
   @override
   Widget buildChild() {
+    final ThemeData theme = Theme.of(context);
+    final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
+    final PopupMenuThemeData defaults = theme.useMaterial3 ? _PopupMenuDefaultsM3(context) : _PopupMenuDefaultsM2(context);
+    final Set<MaterialState> states = <MaterialState>{
+      if (widget.checked) MaterialState.selected,
+    };
+    final MaterialStateProperty<TextStyle?>? effectiveLabelTextStyle = widget.labelTextStyle
+      ?? popupMenuTheme.labelTextStyle
+      ?? defaults.labelTextStyle;
     return IgnorePointer(
       child: ListTile(
         enabled: widget.enabled,
+        titleTextStyle: effectiveLabelTextStyle?.resolve(states),
         leading: FadeTransition(
           opacity: _opacity,
           child: Icon(_controller.isDismissed ? null : Icons.done),

--- a/packages/flutter/test/material/popup_menu_theme_test.dart
+++ b/packages/flutter/test/material/popup_menu_theme_test.dart
@@ -147,6 +147,13 @@ void main() {
                       enabled: false,
                       child: const Text('Disabled PopupMenuItem'),
                     ),
+                    const CheckedPopupMenuItem<void>(
+                      child: Text('Unchecked item'),
+                    ),
+                    const CheckedPopupMenuItem<void>(
+                      checked: true,
+                      child: Text('Checked item'),
+                    ),
                   ];
                 },
               ),
@@ -179,22 +186,23 @@ void main() {
     /// [PopupMenuItem] specified above, so by finding the last descendent of
     /// popupItemKey that is of type DefaultTextStyle, this code retrieves the
     /// built [PopupMenuItem].
-    final DefaultTextStyle enabledText = tester.widget<DefaultTextStyle>(
+    DefaultTextStyle popupMenuItemLabel = tester.widget<DefaultTextStyle>(
       find.descendant(
         of: find.byKey(enabledPopupItemKey),
         matching: find.byType(DefaultTextStyle),
       ).last,
     );
-    expect(enabledText.style.fontFamily, 'Roboto');
-    expect(enabledText.style.color, theme.colorScheme.onSurface);
+    expect(popupMenuItemLabel.style.fontFamily, 'Roboto');
+    expect(popupMenuItemLabel.style.color, theme.colorScheme.onSurface);
+
     /// Test disabled text color
-    final DefaultTextStyle disabledText = tester.widget<DefaultTextStyle>(
+    popupMenuItemLabel = tester.widget<DefaultTextStyle>(
       find.descendant(
         of: find.byKey(disabledPopupItemKey),
         matching: find.byType(DefaultTextStyle),
       ).last,
     );
-    expect(disabledText.style.color, theme.colorScheme.onSurface.withOpacity(0.38));
+    expect(popupMenuItemLabel.style.color, theme.colorScheme.onSurface.withOpacity(0.38));
 
     final Offset topLeftButton = tester.getTopLeft(find.byType(PopupMenuButton<void>));
     final Offset topLeftMenu = tester.getTopLeft(find.byWidget(button));
@@ -215,6 +223,14 @@ void main() {
       RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
       SystemMouseCursors.click,
     );
+
+    // Test unchecked CheckedPopupMenuItem label.
+    ListTile listTile = tester.widget<ListTile>(find.byType(ListTile).first);
+    expect(listTile.titleTextStyle?.color, theme.colorScheme.onSurface);
+
+    // Test checked CheckedPopupMenuItem label.
+    listTile = tester.widget<ListTile>(find.byType(ListTile).last);
+    expect(listTile.titleTextStyle?.color, theme.colorScheme.onSurface);
   });
 
   testWidgets('Popup menu uses values from PopupMenuThemeData', (WidgetTester tester) async {
@@ -249,6 +265,13 @@ void main() {
                     onTap: () { },
                     child: const Text('enabled'),
                   ),
+                  const CheckedPopupMenuItem<Object>(
+                    child: Text('Unchecked item'),
+                  ),
+                  const CheckedPopupMenuItem<Object>(
+                    checked: true,
+                    child: Text('Checked item'),
+                  ),
                 ];
               },
             ),
@@ -276,25 +299,25 @@ void main() {
     expect(button.shape, const BeveledRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))));
     expect(button.elevation, 12.0);
 
-    final DefaultTextStyle enabledText = tester.widget<DefaultTextStyle>(
+    DefaultTextStyle popupMenuItemLabel = tester.widget<DefaultTextStyle>(
       find.descendant(
         of: find.byKey(enabledPopupItemKey),
         matching: find.byType(DefaultTextStyle),
       ).last,
     );
     expect(
-      enabledText.style,
+      popupMenuItemLabel.style,
       popupMenuTheme.labelTextStyle?.resolve(enabled),
     );
     /// Test disabled text color
-    final DefaultTextStyle disabledText = tester.widget<DefaultTextStyle>(
+    popupMenuItemLabel = tester.widget<DefaultTextStyle>(
       find.descendant(
         of: find.byKey(disabledPopupItemKey),
         matching: find.byType(DefaultTextStyle),
       ).last,
     );
     expect(
-      disabledText.style,
+      popupMenuItemLabel.style,
       popupMenuTheme.labelTextStyle?.resolve(disabled),
     );
 
@@ -313,6 +336,14 @@ void main() {
       RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
       popupMenuTheme.mouseCursor?.resolve(enabled),
     );
+
+    // Test unchecked CheckedPopupMenuItem label.
+    ListTile listTile = tester.widget<ListTile>(find.byType(ListTile).first);
+    expect(listTile.titleTextStyle, popupMenuTheme.labelTextStyle?.resolve(enabled));
+
+    // Test checked CheckedPopupMenuItem label.
+    listTile = tester.widget<ListTile>(find.byType(ListTile).last);
+    expect(listTile.titleTextStyle, popupMenuTheme.labelTextStyle?.resolve(enabled));
   });
 
   testWidgets('Popup menu widget properties take priority over theme', (WidgetTester tester) async {
@@ -352,6 +383,11 @@ void main() {
                     mouseCursor: cursor,
                     child: const Text('Example'),
                   ),
+                  CheckedPopupMenuItem<void>(
+                    checked: true,
+                    labelTextStyle: MaterialStateProperty.all<TextStyle>(textStyle),
+                    child: const Text('Checked item'),
+                  )
                 ];
               },
             ),
@@ -397,6 +433,10 @@ void main() {
     await gesture.moveTo(tester.getCenter(find.byKey(popupItemKey)));
     await tester.pumpAndSettle();
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), cursor);
+
+    // Test CheckedPopupMenuItem label.
+    final ListTile listTile = tester.widget<ListTile>(find.byType(ListTile).first);
+    expect(listTile.titleTextStyle, textStyle);
   });
 
   group('Material 2', () {


### PR DESCRIPTION
fixes [Update `CheckedPopupMenuItem‎` for Material 3](https://github.com/flutter/flutter/issues/128576)

### Description

- This adds the missing ``CheckedPopupMenuItem‎.labelTextStyle` parameter
- Fixes default text style for `CheckedPopupMenuItem‎`. 
It used `ListTile`'s  `bodyLarge` instead of `LabelLarge` similar to `PopupMenuItem`.

### Code sample

<details> 
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(
        useMaterial3: true,
        textTheme: const TextTheme(
          labelLarge: TextStyle(
            fontWeight: FontWeight.bold,
            fontStyle: FontStyle.italic,
            letterSpacing: 5.0,
          ),
        ),
      ),
      home: const Example(),
    );
  }
}

class Example extends StatelessWidget {
  const Example({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Sample'),
        actions: <Widget>[
          PopupMenuButton<String>(
            icon: const Icon(Icons.more_vert),
            itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
              const CheckedPopupMenuItem<String>(
                // labelTextStyle: MaterialStateProperty.resolveWith(
                //     (Set<MaterialState> states) {
                //   if (states.contains(MaterialState.selected)) {
                //     return const TextStyle(
                //       color: Colors.red,
                //       fontStyle: FontStyle.italic,
                //       fontWeight: FontWeight.bold,
                //     );
                //   }

                //   return const TextStyle(
                //     color: Colors.amber,
                //     fontStyle: FontStyle.italic,
                //     fontWeight: FontWeight.bold,
                //   );
                // }),
                child: Text('Mild'),
              ),
              const CheckedPopupMenuItem<String>(
                checked: true,
                // labelTextStyle: MaterialStateProperty.resolveWith(
                //     (Set<MaterialState> states) {
                //   if (states.contains(MaterialState.selected)) {
                //     return const TextStyle(
                //       color: Colors.red,
                //       fontStyle: FontStyle.italic,
                //       fontWeight: FontWeight.bold,
                //     );
                //   }

                //   return const TextStyle(
                //     color: Colors.amber,
                //     fontStyle: FontStyle.italic,
                //     fontWeight: FontWeight.bold,
                //   );
                // }),
                child: Text('Spicy'),
              ),
              const PopupMenuDivider(),
              const PopupMenuItem<String>(
                value: 'Close',
                child: Text('Close'),
              ),
            ],
          )
        ],
      ),
    );
  }
}

``` 
	
</details>


### Customized `textTheme.labelLarge` text theme.
| Before | After |
| --------------- | --------------- |
| <img src="https://github.com/flutter/flutter/assets/48603081/2672438d-b2da-479b-a5d3-d239ef646365" /> | <img src="https://github.com/flutter/flutter/assets/48603081/b9f83719-dede-4c2f-8247-18f74e63eb29"  /> |

### New `CheckedPopupMenuItem‎.labelTextStyle` parameter with material states support
<img src="https://github.com/flutter/flutter/assets/48603081/ef0a88aa-9811-42b1-a3aa-53b90c8d43fb" height="450" />




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
