### PR TITLE
Remove deprecated *TestValues from TestWindow

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -492,7 +492,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   }
 
   /// Re-attempts the initialization of the lifecycle state after providing
-  /// test values in [TestWindow.initialLifecycleStateTestValue].
+  /// test values in [TestPlatformDispatcher.initialLifecycleStateTestValue].
   void readTestInitialLifecycleStateFromNativeWindow() {
     readInitialLifecycleStateFromNativeWindow();
   }

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -1507,22 +1507,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   Locale get locale => platformDispatcher.locale;
-  /// Hides the real locale and reports the given [localeTestValue] instead.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.localeTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set localeTestValue(Locale localeTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.localeTestValue = localeTestValue;
-  }
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.clearLocaleTestValue() instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  /// Deletes any existing test locale and returns to using the real locale.
-  void clearLocaleTestValue() {
-    platformDispatcher.clearLocaleTestValue();
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.locales instead. '
@@ -1531,22 +1515,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   List<Locale> get locales => platformDispatcher.locales;
-  /// Hides the real locales and reports the given [localesTestValue] instead.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.localesTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set localesTestValue(List<Locale> localesTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.localesTestValue = localesTestValue;
-  }
-  /// Deletes any existing test locales and returns to using the real locales.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.clearLocalesTestValue() instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  void clearLocalesTestValue() {
-    platformDispatcher.clearLocalesTestValue();
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.onLocaleChanged instead. '
@@ -1572,14 +1540,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   String get initialLifecycleState => platformDispatcher.initialLifecycleState;
-  /// Sets a faked initialLifecycleState for testing.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.initialLifecycleStateTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set initialLifecycleStateTestValue(String state) { // ignore: avoid_setters_without_getters
-    platformDispatcher.initialLifecycleStateTestValue = state;
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.textScaleFactor instead. '
@@ -1656,24 +1616,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   bool get alwaysUse24HourFormat => platformDispatcher.alwaysUse24HourFormat;
-  /// Hides the real clock format and reports the given
-  /// [alwaysUse24HourFormatTestValue] instead.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.alwaysUse24HourFormatTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set alwaysUse24HourFormatTestValue(bool alwaysUse24HourFormatTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.alwaysUse24HourFormatTestValue = alwaysUse24HourFormatTestValue;
-  }
-  /// Deletes any existing test clock format and returns to using the real clock
-  /// format.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.clearAlwaysUse24HourTestValue() instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  void clearAlwaysUse24HourTestValue() {
-    platformDispatcher.clearAlwaysUse24HourTestValue();
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.onTextScaleFactorChanged instead. '
@@ -1715,15 +1657,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   bool get brieflyShowPassword => platformDispatcher.brieflyShowPassword;
-  /// Hides the real [brieflyShowPassword] and reports the given
-  /// `brieflyShowPasswordTestValue` instead.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.brieflyShowPasswordTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set brieflyShowPasswordTestValue(bool brieflyShowPasswordTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.brieflyShowPasswordTestValue = brieflyShowPasswordTestValue;
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.onBeginFrame instead. '
@@ -1800,24 +1733,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   String get defaultRouteName => platformDispatcher.defaultRouteName;
-  /// Hides the real default route name and reports the given
-  /// [defaultRouteNameTestValue] instead.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.defaultRouteNameTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set defaultRouteNameTestValue(String defaultRouteNameTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.defaultRouteNameTestValue = defaultRouteNameTestValue;
-  }
-  /// Deletes any existing test default route name and returns to using the real
-  /// default route name.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.clearDefaultRouteNameTestValue() instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  void clearDefaultRouteNameTestValue() {
-    platformDispatcher.clearDefaultRouteNameTestValue();
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.scheduleFrame() instead. '
@@ -1846,24 +1761,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   bool get semanticsEnabled => platformDispatcher.semanticsEnabled;
-  /// Hides the real semantics enabled and reports the given
-  /// [semanticsEnabledTestValue] instead.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.semanticsEnabledTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set semanticsEnabledTestValue(bool semanticsEnabledTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.semanticsEnabledTestValue = semanticsEnabledTestValue;
-  }
-  /// Deletes any existing test semantics enabled and returns to using the real
-  /// semantics enabled.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.clearSemanticsEnabledTestValue() instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  void clearSemanticsEnabledTestValue() {
-    platformDispatcher.clearSemanticsEnabledTestValue();
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.onSemanticsEnabledChanged instead. '
@@ -1889,27 +1786,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   AccessibilityFeatures get accessibilityFeatures => platformDispatcher.accessibilityFeatures;
-  /// Hides the real accessibility features and reports the given
-  /// [accessibilityFeaturesTestValue] instead.
-  ///
-  /// Consider using [FakeAccessibilityFeatures] to provide specific
-  /// values for the various accessibility features under test.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.accessibilityFeaturesTestValue instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  set accessibilityFeaturesTestValue(AccessibilityFeatures accessibilityFeaturesTestValue) { // ignore: avoid_setters_without_getters
-    platformDispatcher.accessibilityFeaturesTestValue = accessibilityFeaturesTestValue;
-  }
-  /// Deletes any existing test accessibility features and returns to using the
-  /// real accessibility features.
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.clearAccessibilityFeaturesTestValue() instead. '
-    'This feature was deprecated after v2.11.0-0.0.pre.'
-  )
-  void clearAccessibilityFeaturesTestValue() {
-    platformDispatcher.clearAccessibilityFeaturesTestValue();
-  }
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.onAccessibilityFeaturesChanged instead. '

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -1186,7 +1186,7 @@ class _UnsupportedDisplay implements TestDisplay {
 /// If a test needs to override a real [SingletonFlutterWindow] property and
 /// then later return to using the real [SingletonFlutterWindow] property,
 /// [TestWindow] provides methods to clear each individual test value, e.g.,
-/// [clearLocaleTestValue].
+/// [clearDevicePixelRatioTestValue].
 ///
 /// To clear all fake test values in a [TestWindow], consider using
 /// [clearAllTestValues].
@@ -1860,7 +1860,7 @@ class TestWindow implements SingletonFlutterWindow {
   /// [PlatformDispatcher] values are reported again.
   ///
   /// If desired, clearing of properties can be done on an individual basis,
-  /// e.g., [clearLocaleTestValue].
+  /// e.g., [clearDevicePixelRatioTestValue].
   @Deprecated(
     'Use WidgetTester.platformDispatcher.clearAllTestValues() and WidgetTester.view.reset() instead. '
     'Deprecated to prepare for the upcoming multi-window support. '

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -8,7 +8,7 @@
 import 'dart:ui' as ui show window;
 import 'dart:ui';
 
-import 'package:flutter/widgets.dart' show WidgetsBinding, WidgetsBindingObserver;
+import 'package:flutter/widgets.dart' show WidgetsBinding;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'utils/fake_and_mock_utils.dart';
@@ -83,34 +83,6 @@ void main() {
     );
   });
 
-  testWidgets('TestWindow can fake locale', (WidgetTester tester) async {
-    verifyPropertyFaked<Locale>(
-      tester: tester,
-      realValue: ui.window.locale,
-      fakeValue: const Locale('fake_language_code'),
-      propertyRetriever: () {
-        return WidgetsBinding.instance.window.locale;
-      },
-      propertyFaker: (TestWidgetsFlutterBinding binding, Locale fakeValue) {
-        binding.window.localeTestValue = fakeValue;
-      },
-    );
-  });
-
-  testWidgets('TestWindow can fake locales', (WidgetTester tester) async {
-    verifyPropertyFaked<List<Locale>>(
-      tester: tester,
-      realValue: ui.window.locales,
-      fakeValue: <Locale>[const Locale('fake_language_code')],
-      propertyRetriever: () {
-        return WidgetsBinding.instance.window.locales;
-      },
-      propertyFaker: (TestWidgetsFlutterBinding binding, List<Locale> fakeValue) {
-        binding.window.localesTestValue = fakeValue;
-      },
-    );
-  });
-
   testWidgets('TestWindow can fake text scale factor', (WidgetTester tester) async {
     verifyPropertyFaked<double>(
       tester: tester,
@@ -121,60 +93,6 @@ void main() {
       },
       propertyFaker: (TestWidgetsFlutterBinding binding, double fakeValue) {
         binding.window.textScaleFactorTestValue = fakeValue;
-      },
-    );
-  });
-
-  testWidgets('TestWindow can fake clock format', (WidgetTester tester) async {
-    verifyPropertyFaked<bool>(
-      tester: tester,
-      realValue: ui.window.alwaysUse24HourFormat,
-      fakeValue: !ui.window.alwaysUse24HourFormat,
-      propertyRetriever: () {
-        return WidgetsBinding.instance.window.alwaysUse24HourFormat;
-      },
-      propertyFaker: (TestWidgetsFlutterBinding binding, bool fakeValue) {
-        binding.window.alwaysUse24HourFormatTestValue = fakeValue;
-      },
-    );
-  });
-
-  testWidgets('TestWindow can fake brieflyShowPassword', (WidgetTester tester) async {
-    verifyPropertyFaked<bool>(
-      tester: tester,
-      realValue: ui.window.brieflyShowPassword,
-      fakeValue: !ui.window.brieflyShowPassword,
-      propertyRetriever: () => WidgetsBinding.instance.window.brieflyShowPassword,
-      propertyFaker: (TestWidgetsFlutterBinding binding, bool fakeValue) {
-        binding.window.brieflyShowPasswordTestValue = fakeValue;
-      },
-    );
-  });
-
-  testWidgets('TestWindow can fake default route name', (WidgetTester tester) async {
-    verifyPropertyFaked<String>(
-      tester: tester,
-      realValue: ui.window.defaultRouteName,
-      fakeValue: 'fake_route',
-      propertyRetriever: () {
-        return WidgetsBinding.instance.window.defaultRouteName;
-      },
-      propertyFaker: (TestWidgetsFlutterBinding binding, String fakeValue) {
-        binding.window.defaultRouteNameTestValue = fakeValue;
-      },
-    );
-  });
-
-  testWidgets('TestWindow can fake accessibility features', (WidgetTester tester) async {
-    verifyPropertyFaked<AccessibilityFeatures>(
-      tester: tester,
-      realValue: ui.window.accessibilityFeatures,
-      fakeValue: const FakeAccessibilityFeatures(),
-      propertyRetriever: () {
-        return WidgetsBinding.instance.window.accessibilityFeatures;
-      },
-      propertyFaker: (TestWidgetsFlutterBinding binding, AccessibilityFeatures fakeValue) {
-        binding.window.accessibilityFeaturesTestValue = fakeValue;
       },
     );
   });
@@ -210,16 +128,6 @@ void main() {
     expect(WidgetsBinding.instance.window.textScaleFactor, originalTextScaleFactor);
   });
 
-  testWidgets('TestWindow sends fake locales when WidgetsBindingObserver notifiers are called', (WidgetTester tester) async {
-    final List<Locale> defaultLocales = WidgetsBinding.instance.window.locales;
-    final TestObserver observer = TestObserver();
-    retrieveTestBinding(tester).addObserver(observer);
-    final List<Locale> expectedValue = <Locale>[const Locale('fake_language_code')];
-    retrieveTestBinding(tester).window.localesTestValue = expectedValue;
-    expect(observer.locales, equals(expectedValue));
-    retrieveTestBinding(tester).window.localesTestValue = defaultLocales;
-  });
-
   testWidgets('Updates to window also update tester.view', (WidgetTester tester) async {
     tester.binding.window.devicePixelRatioTestValue = 7;
     tester.binding.window.displayFeaturesTestValue = <DisplayFeature>[const DisplayFeature(bounds: Rect.fromLTWH(0, 0, 20, 300), type: DisplayFeatureType.unknown, state: DisplayFeatureState.unknown)];
@@ -239,13 +147,4 @@ void main() {
     expect(tester.binding.window.viewPadding, tester.view.viewPadding);
     expect(tester.binding.window.gestureSettings, tester.view.gestureSettings);
   });
-}
-
-class TestObserver with WidgetsBindingObserver {
-  List<Locale>? locales;
-
-  @override
-  void didChangeLocales(List<Locale>? locales) {
-    this.locales = locales;
-  }
 }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/133171.

Removes from `TestWindow`:
* `localeTestValue`
* `clearLocaleTestValue`
* `localesTestValue`
* `clearLocalesTestValue`
* `initialLifecycleStateTestValue`
* `alwaysUse24HourFormatTestValue`
* `clearAlwaysUse24HourTestValue`
* `brieflyShowPasswordTestValue`
* `defaultRouteNameTestValue`
* `clearDefaultRouteNameTestValue`
* `semanticsEnabledTestValue`
* `clearSemanticsEnabledTestValue`
* `accessibilityFeaturesTestValue`
* `clearAccessibilityFeaturesTestValue`

These properties have reached the end of their deprecation period.