### PR TITLE
🐛 Only format Dart files for `gen-l10n`

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -84,11 +84,14 @@ Future<LocalizationsGenerator> generateLocalizations({
   final File? untranslatedMessagesFile = generator.untranslatedMessagesFile;
 
   if (options.format) {
-    final List<String> formatFileList = outputFileList.toList();
-    if (untranslatedMessagesFile != null) {
-      // Don't format the messages file using `dart format`.
-      formatFileList.remove(untranslatedMessagesFile.absolute.path);
-    }
+    // Only format Dart files using `dart format`.
+    final List<String> formatFileList = outputFileList
+        .where(
+          (String e) =>
+              e.endsWith('.dart') ||
+              e == untranslatedMessagesFile?.absolute.path,
+        )
+        .toList(growable: false);
     if (formatFileList.isEmpty) {
       return generator;
     }

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -88,8 +88,8 @@ Future<LocalizationsGenerator> generateLocalizations({
     final List<String> formatFileList = outputFileList
         .where(
           (String e) =>
-              e.endsWith('.dart') ||
-              e == untranslatedMessagesFile?.absolute.path,
+              e.endsWith('.dart') &&
+              e != untranslatedMessagesFile?.absolute.path,
         )
         .toList(growable: false);
     if (formatFileList.isEmpty) {

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -80,17 +80,10 @@ Future<LocalizationsGenerator> generateLocalizations({
     throwToolExit(e.message);
   }
 
-  final List<String> outputFileList = generator.outputFileList;
-  final File? untranslatedMessagesFile = generator.untranslatedMessagesFile;
-
   if (options.format) {
     // Only format Dart files using `dart format`.
-    final List<String> formatFileList = outputFileList
-        .where(
-          (String e) =>
-              e.endsWith('.dart') &&
-              e != untranslatedMessagesFile?.absolute.path,
-        )
+    final List<String> formatFileList = generator.outputFileList
+        .where((String e) => e.endsWith('.dart'))
         .toList(growable: false);
     if (formatFileList.isEmpty) {
       return generator;


### PR DESCRIPTION
Improves #119596. The tests remain valid, so no tests were updated in the request.

This does not resolve issue #128932, it's handled by another part of the code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
