### PR TITLE
Relax HarwareKeyboard assert on first received event

### DIFF
--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -485,6 +485,48 @@ void main() {
     expect(messagesStr, contains('KEYBOARD: Pressed state before processing the event:'));
     expect(messagesStr, contains('KEYBOARD: Pressed state after processing the event:'));
   });
+
+  testWidgets('Do not assert on first up event', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/125975.
+    HardwareKeyboard.instance.setInitialState(<PhysicalKeyboardKey, LogicalKeyboardKey>{});
+    bool assertionErrorSent = false;
+
+    try {
+      tester.binding.keyEventManager.handleKeyData(ui.KeyData(
+        type: ui.KeyEventType.up,
+        timeStamp: Duration.zero,
+        logical: LogicalKeyboardKey.keyA.keyId,
+        physical: PhysicalKeyboardKey.keyA.usbHidUsage,
+        character: null,
+        synthesized: true,
+      ));
+    } on AssertionError {
+      assertionErrorSent = true;
+    }
+
+    expect(assertionErrorSent, false);
+  }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
+
+  testWidgets('Do not assert on first down event', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/125975.
+    HardwareKeyboard.instance.setInitialState(<PhysicalKeyboardKey, LogicalKeyboardKey>{PhysicalKeyboardKey.keyA: LogicalKeyboardKey.keyA});
+    bool assertionErrorSent = false;
+
+    try {
+      tester.binding.keyEventManager.handleKeyData(ui.KeyData(
+        type: ui.KeyEventType.down,
+        timeStamp: Duration.zero,
+        logical: LogicalKeyboardKey.keyA.keyId,
+        physical: PhysicalKeyboardKey.keyA.usbHidUsage,
+        character: null,
+        synthesized: true,
+      ));
+    } on AssertionError {
+      assertionErrorSent = true;
+    }
+
+    expect(assertionErrorSent, false);
+  }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 }
 
 Future<void> _runWhileOverridingOnError(AsyncCallback body, {required FlutterExceptionHandler onError}) async {


### PR DESCRIPTION
## Description

This PR updates the `HardwareKeyboard` to not assert for the first up or down event.

Since https://github.com/flutter/flutter/pull/122885 (and the related PRs on engine side), the `HardwareKeyboard` is initialized with the known keyboard state returned by the engine.
Because the engine sent keyboard event using channel buffers which are created with the default buffer size (which is 1), the first event received on framework side might be an obsolete buffered event.

This PR take a no-risk approach which is to relax two kinds of assert for the very first received event. This logic will only apply to debug mode and apply for only two cases:
- a buffered up event: if a key is pressed and released before the framework starts, the initial state will be empty but the framework will receive the buffered up event.
- a buffered down event: when a key is pressed while the framework starts, the initial state (queried by a call from the framework to the engine) already reflects that the key is pressed.

An alternative would be to set buffer size to 0 but it is risky because it will apply to release mode and none of the existing channels does set its buffer size to 0.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/125975

## Tests

Adds 2 tests.


