### PR TITLE
Add 'vm:keep-name' pragmas to platform channel classes

### DIFF
--- a/packages/flutter/lib/src/services/message_codec.dart
+++ b/packages/flutter/lib/src/services/message_codec.dart
@@ -30,6 +30,7 @@ abstract class MessageCodec<T> {
 }
 
 /// A command object representing the invocation of a named method.
+@pragma('vm:keep-name')
 @immutable
 class MethodCall {
   /// Creates a [MethodCall] representing the invocation of [method] with the

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -246,6 +246,7 @@ class BasicMessageChannel<T> {
 /// {@endtemplate}
 ///
 /// See: <https://flutter.dev/platform-channels/>
+@pragma('vm:keep-name')
 class MethodChannel {
   /// Creates a [MethodChannel] with the specified [name].
   ///


### PR DESCRIPTION
Pragma will allow future proofing Dart snapshot utilities to work by preserving the names of important classes used in platform channel communication

@Hixie 
