### PR TITLE
Revert "Run benchmarks with `--omit-type-checks`"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1079,6 +1079,7 @@ targets:
 
   - name: Linux web_benchmarks_html
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
       dependencies: >-
@@ -1095,6 +1096,7 @@ targets:
       - .ci.yaml
 
   - name: Linux web_benchmarks_skwasm
+    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -36,7 +36,6 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       if (benchmarkOptions.useWasm) ...<String>[
         '--wasm',
         '--wasm-opt=debug',
-        '--omit-type-checks',
       ],
       '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
       '--web-renderer=${benchmarkOptions.webRenderer}',


### PR DESCRIPTION
Reverts flutter/flutter#131102 as it closed the tree due to `Linux web_benchmarks_skwasm` failures. The test seems to be timing out without completing.

Example failure: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20web_benchmarks_skwasm/1/overview