### PR TITLE
[web] Encode AssetManifest.bin as JSON and use that on the web.

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -88,8 +88,8 @@ abstract class AssetBundle {
   Future<String> loadString(String key, { bool cache = true }) async {
     final ByteData data = await load(key);
     // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
-    // on a Pixel 4.
-    if (data.lengthInBytes < 50 * 1024) {
+    // on a Pixel 4. On the web we can't bail to isolates, though...
+    if (data.lengthInBytes < 50 * 1024 || kIsWeb) {
       return utf8.decode(Uint8List.sublistView(data));
     }
     // For strings larger than 50 KB, run the computation in an isolate to

--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -25,7 +25,14 @@ abstract class AssetManifest {
   /// Loads asset manifest data from an [AssetBundle] object and creates an
   /// [AssetManifest] object from that data.
   static Future<AssetManifest> loadFromAssetBundle(AssetBundle bundle) {
+    // The AssetManifest file contains binary data.
+    //
+    // On the web, the build process wraps this binary data in json+base64 so
+    // it can be transmitted over the network without special configuration
+    // (see #131382).
     if (kIsWeb) {
+      // On the web, the AssetManifest is downloaded as a String, then
+      // json+base64-decoded to get to the binary data.
       return bundle.loadStructuredData(_kAssetManifestWebFilename, (String jsonData) async {
         // Decode the manifest JSON file to the underlying BIN, and convert to ByteData.
         final ByteData message = ByteData.sublistView(base64.decode(json.decode(jsonData) as String));
@@ -33,6 +40,7 @@ abstract class AssetManifest {
         return _AssetManifestBin.fromStandardMessageCodecMessage(message);
       });
     }
+    // On every other platform, the binary file contents are used directly.
     return bundle.loadStructuredBinaryData(_kAssetManifestFilename, _AssetManifestBin.fromStandardMessageCodecMessage);
   }
 

--- a/packages/flutter/lib/src/services/asset_manifest.dart
+++ b/packages/flutter/lib/src/services/asset_manifest.dart
@@ -1,6 +1,7 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -11,10 +12,11 @@ import 'message_codecs.dart';
 // We use .bin as the extension since it is well-known to represent
 // data in some arbitrary binary format.
 const String _kAssetManifestFilename = 'AssetManifest.bin';
-// We use the same bin file for the web, but slightly bloated because we base64
-// and JSON-encode it so it can be downloaded by even the dumbest of browsers.
+
+// We use the same bin file for the web, but re-encoded as JSON(base64(bytes))
+// so it can be downloaded by even the dumbest of browsers.
 // See https://github.com/flutter/flutter/issues/128456
-const String _kAssetManifestWebFilename = 'AssetManifest.json';
+const String _kAssetManifestWebFilename = 'AssetManifest.bin.json';
 
 /// Contains details about available assets and their variants.
 /// See [Resolution-aware image assets](https://docs.flutter.dev/ui/assets-and-images#resolution-aware)

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -18,7 +18,7 @@ class TestAssetBundle extends CachingAssetBundle {
 
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.bin') {
+    if (key == 'AssetManifest.bin' || key == 'AssetManifest.bin.json') {
       return const StandardMessageCodec().encodeMessage(_assetBundleMap)!;
     }
 

--- a/packages/flutter/test/painting/image_resolution_test.dart
+++ b/packages/flutter/test/painting/image_resolution_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -18,8 +19,24 @@ class TestAssetBundle extends CachingAssetBundle {
 
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.bin' || key == 'AssetManifest.bin.json') {
+    if (key == 'AssetManifest.bin') {
       return const StandardMessageCodec().encodeMessage(_assetBundleMap)!;
+    }
+
+    if (key == 'AssetManifest.bin.json') {
+      // Encode the manifest data that will be used by the app
+      final ByteData data = const StandardMessageCodec().encodeMessage(_assetBundleMap)!;
+      // Simulate the behavior of NetworkAssetBundle.load here, for web tests
+      return ByteData.sublistView(
+        utf8.encode(
+          json.encode(
+            base64.encode(
+              // Encode only the actual bytes of the buffer, and no more...
+              data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes)
+            )
+          )
+        )
+      );
     }
 
     loadCallCount[key] = loadCallCount[key] ?? 0 + 1;

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -19,9 +19,25 @@ class TestAssetBundle extends CachingAssetBundle {
       return ByteData.sublistView(utf8.encode('{"one": ["one"]}'));
     }
 
-    if (key == 'AssetManifest.bin' || key == 'AssetManifest.bin.json') {
+    if (key == 'AssetManifest.bin') {
       return const StandardMessageCodec()
           .encodeMessage(<String, Object>{'one': <Object>[]})!;
+    }
+
+    if (key == 'AssetManifest.bin.json') {
+      // Encode the manifest data that will be used by the app
+      final ByteData data = const StandardMessageCodec().encodeMessage(<String, Object> {'one': <Object>[]})!;
+      // Simulate the behavior of NetworkAssetBundle.load here, for web tests
+      return ByteData.sublistView(
+        utf8.encode(
+          json.encode(
+            base64.encode(
+              // Encode only the actual bytes of the buffer, and no more...
+              data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes)
+            )
+          )
+        )
+      );
     }
 
     if (key == 'counter') {

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -19,7 +19,7 @@ class TestAssetBundle extends CachingAssetBundle {
       return ByteData.sublistView(utf8.encode('{"one": ["one"]}'));
     }
 
-    if (key == 'AssetManifest.bin') {
+    if (key == 'AssetManifest.bin' || key == 'AssetManifest.bin.json') {
       return const StandardMessageCodec()
           .encodeMessage(<String, Object>{'one': <Object>[]})!;
     }

--- a/packages/flutter/test/services/asset_manifest_test.dart
+++ b/packages/flutter/test/services/asset_manifest_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 class TestAssetBundle extends AssetBundle {
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.bin') {
+    if (key == 'AssetManifest.bin' || key == 'AssetManifest.bin.json') {
       final Map<String, List<Object>> binManifestData = <String, List<Object>>{
         'assets/foo.png': <Object>[
           <String, Object>{

--- a/packages/flutter/test/services/asset_manifest_test.dart
+++ b/packages/flutter/test/services/asset_manifest_test.dart
@@ -2,32 +2,50 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class TestAssetBundle extends AssetBundle {
+  static const Map<String, List<Object>> _binManifestData = <String, List<Object>>{
+    'assets/foo.png': <Object>[
+      <String, Object>{
+        'asset': 'assets/foo.png',
+      },
+      <String, Object>{
+        'asset': 'assets/2x/foo.png',
+        'dpr': 2.0
+      },
+    ],
+    'assets/bar.png': <Object>[
+      <String, Object>{
+        'asset': 'assets/bar.png',
+      },
+    ],
+  };
+
   @override
   Future<ByteData> load(String key) async {
-    if (key == 'AssetManifest.bin' || key == 'AssetManifest.bin.json') {
-      final Map<String, List<Object>> binManifestData = <String, List<Object>>{
-        'assets/foo.png': <Object>[
-          <String, Object>{
-            'asset': 'assets/foo.png',
-          },
-          <String, Object>{
-            'asset': 'assets/2x/foo.png',
-            'dpr': 2.0
-          },
-        ],
-        'assets/bar.png': <Object>[
-          <String, Object>{
-            'asset': 'assets/bar.png',
-          },
-        ],
-      };
-
-      final ByteData data = const StandardMessageCodec().encodeMessage(binManifestData)!;
+    if (key == 'AssetManifest.bin') {
+      final ByteData data = const StandardMessageCodec().encodeMessage(_binManifestData)!;
       return data;
+    }
+
+    if (key == 'AssetManifest.bin.json') {
+      // Encode the manifest data that will be used by the app
+      final ByteData data = const StandardMessageCodec().encodeMessage(_binManifestData)!;
+      // Simulate the behavior of NetworkAssetBundle.load here, for web tests
+      return ByteData.sublistView(
+        utf8.encode(
+          json.encode(
+            base64.encode(
+              // Encode only the actual bytes of the buffer, and no more...
+              data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes)
+            )
+          )
+        )
+      );
     }
 
     throw ArgumentError('Unexpected key');

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -437,8 +437,10 @@ class ManifestAssetBundle implements AssetBundle {
 
     final Map<String, List<String>> assetManifest =
       _createAssetManifest(assetVariants, deferredComponentsAssetVariants);
-    final DevFSStringContent assetManifestJson = DevFSStringContent(json.encode(assetManifest));
     final DevFSByteContent assetManifestBinary = _createAssetManifestBinary(assetManifest);
+    final DevFSStringContent assetManifestJson = DevFSStringContent(json.encode(
+      base64.encode(assetManifestBinary.bytes)
+    ));
     final DevFSStringContent fontManifest = DevFSStringContent(json.encode(fonts));
     final LicenseResult licenseResult = _licenseCollector.obtainLicenses(packageConfig, additionalLicenseFiles);
     if (licenseResult.errorMessages.isNotEmpty) {

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -238,14 +238,13 @@ class ManifestAssetBundle implements AssetBundle {
       entryKinds[_kAssetManifestJsonFilename] = AssetKind.regular;
       final ByteData emptyAssetManifest =
         const StandardMessageCodec().encodeMessage(<dynamic, dynamic>{})!;
-      // Create .bin.json on web builds, and .bin for everybody else.
+      entries[_kAssetManifestBinFilename] =
+        DevFSByteContent(emptyAssetManifest.buffer.asUint8List(0, emptyAssetManifest.lengthInBytes));
+      entryKinds[_kAssetManifestBinFilename] = AssetKind.regular;
+      // Create .bin.json on web builds.
       if (targetPlatform == TargetPlatform.web_javascript) {
         entries[_kAssetManifestBinJsonFilename] = DevFSStringContent('""');
         entryKinds[_kAssetManifestBinJsonFilename] = AssetKind.regular;
-      } else {
-        entries[_kAssetManifestBinFilename] =
-          DevFSByteContent(emptyAssetManifest.buffer.asUint8List(0, emptyAssetManifest.lengthInBytes));
-        entryKinds[_kAssetManifestBinFilename] = AssetKind.regular;
       }
       return 0;
     }
@@ -468,14 +467,13 @@ class ManifestAssetBundle implements AssetBundle {
     }
 
     _setIfChanged(_kAssetManifestJsonFilename, assetManifestJson, AssetKind.regular);
-    // Create .bin.json on web builds, and .bin for everybody else.
+    _setIfChanged(_kAssetManifestBinFilename, assetManifestBinary, AssetKind.regular);
+    // Create .bin.json on web builds.
     if (targetPlatform == TargetPlatform.web_javascript) {
       final DevFSStringContent assetManifestBinaryJson = DevFSStringContent(json.encode(
         base64.encode(assetManifestBinary.bytes)
       ));
       _setIfChanged(_kAssetManifestBinJsonFilename, assetManifestBinaryJson, AssetKind.regular);
-    } else {
-      _setIfChanged(_kAssetManifestBinFilename, assetManifestBinary, AssetKind.regular);
     }
     _setIfChanged(kFontManifestJson, fontManifest, AssetKind.regular);
     _setLicenseIfChanged(licenseResult.combinedLicenses, targetPlatform);

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -346,13 +346,16 @@ flutter:
       await bundle.build(packagesPath: '.packages', targetPlatform: TargetPlatform.web_javascript);
 
       expect(bundle.entries.keys,
-        unorderedEquals(<String>['AssetManifest.json', 'AssetManifest.bin.json'])
+        unorderedEquals(<String>[
+          'AssetManifest.json',
+          'AssetManifest.bin',
+          'AssetManifest.bin.json',
+        ])
       );
       expect(
         utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes()),
         '{}',
       );
-      expect(bundle.entries['AssetManifest.bin'], isNull);
       expect(
         utf8.decode(await bundle.entries['AssetManifest.bin.json']!.contentsAsBytes()),
         '""',
@@ -383,6 +386,7 @@ flutter:
       expect(bundle.entries.keys,
         unorderedEquals(<String>[
           'AssetManifest.json',
+          'AssetManifest.bin',
           'AssetManifest.bin.json',
           'FontManifest.json',
           'NOTICES', // not .Z
@@ -397,21 +401,20 @@ flutter:
       expect(manifestJson, isNotEmpty);
       expect(manifestJson['assets/bar/lizard.png'], isNotNull);
 
-      expect(bundle.entries['AssetManifest.bin'], isNull);
-
-      final Object? manifestBinJson = const StandardMessageCodec().decodeMessage(
-        ByteData.sublistView(
-          base64.decode(
-            json.decode(
-              utf8.decode(
-                await bundle.entries['AssetManifest.bin.json']!.contentsAsBytes()
-              )
-            ) as String
+      final Uint8List manifestBinJsonBytes = base64.decode(
+        json.decode(
+          utf8.decode(
+            await bundle.entries['AssetManifest.bin.json']!.contentsAsBytes()
           )
-        )
+        ) as String
       );
-      expect(manifestBinJson, isA<Map<Object?, Object?>>());
-      expect(manifestBinJson! as Map<Object?, Object?>, isNotEmpty);
+
+      final Uint8List manifestBinBytes = Uint8List.fromList(
+        await bundle.entries['AssetManifest.bin']!.contentsAsBytes()
+      );
+
+      expect(manifestBinJsonBytes, equals(manifestBinBytes),
+        reason: 'JSON-encoded binary content should be identical to BIN file.');
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -325,6 +325,99 @@ flutter:
     });
   });
 
+  group('AssetBundle.build (web builds)', () {
+    late FileSystem testFileSystem;
+
+    setUp(() async {
+      testFileSystem = MemoryFileSystem(
+        style: globals.platform.isWindows
+          ? FileSystemStyle.windows
+          : FileSystemStyle.posix,
+      );
+      testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+    });
+
+    testUsingContext('empty pubspec', () async {
+      globals.fs.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('');
+
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+      await bundle.build(packagesPath: '.packages', targetPlatform: TargetPlatform.web_javascript);
+
+      expect(bundle.entries.keys,
+        unorderedEquals(<String>['AssetManifest.json', 'AssetManifest.bin.json'])
+      );
+      expect(
+        utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes()),
+        '{}',
+      );
+      expect(bundle.entries['AssetManifest.bin'], isNull);
+      expect(
+        utf8.decode(await bundle.entries['AssetManifest.bin.json']!.contentsAsBytes()),
+        '""',
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('pubspec contains an asset', () async {
+      globals.fs.file('.packages').createSync();
+      globals.fs.file('pubspec.yaml').writeAsStringSync(r'''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  assets:
+    - assets/bar/lizard.png
+''');
+      globals.fs.file(
+        globals.fs.path.joinAll(<String>['assets', 'bar', 'lizard.png'])
+      ).createSync(recursive: true);
+
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+      await bundle.build(packagesPath: '.packages', targetPlatform: TargetPlatform.web_javascript);
+
+      expect(bundle.entries.keys,
+        unorderedEquals(<String>[
+          'AssetManifest.json',
+          'AssetManifest.bin.json',
+          'FontManifest.json',
+          'NOTICES', // not .Z
+          'assets/bar/lizard.png',
+        ])
+      );
+      final Map<Object?, Object?> manifestJson = json.decode(
+        utf8.decode(
+          await bundle.entries['AssetManifest.json']!.contentsAsBytes()
+        )
+      ) as Map<Object?, Object?>;
+      expect(manifestJson, isNotEmpty);
+      expect(manifestJson['assets/bar/lizard.png'], isNotNull);
+
+      expect(bundle.entries['AssetManifest.bin'], isNull);
+
+      final Object? manifestBinJson = const StandardMessageCodec().decodeMessage(
+        ByteData.sublistView(
+          base64.decode(
+            json.decode(
+              utf8.decode(
+                await bundle.entries['AssetManifest.bin.json']!.contentsAsBytes()
+              )
+            ) as String
+          )
+        )
+      );
+      expect(manifestBinJson, isA<Map<Object?, Object?>>());
+      expect(manifestBinJson! as Map<Object?, Object?>, isNotEmpty);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
+
   testUsingContext('Failed directory delete shows message', () async {
     final FileExceptionHandler handler = FileExceptionHandler();
     final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);


### PR DESCRIPTION
This PR modifies the web build slightly to create an `AssetManifest.json`, that is a JSON(base64)-encoded version of the `AssetManifest.bin` file.

_(This should enable all browsers to download the file without any interference, and all servers to serve it with the correct headers.)_

It also modifies Flutter's `AssetManifest` class so it loads and uses said file `if (kIsWeb)`.

### Issues

* Fixes https://github.com/flutter/flutter/issues/124883

### Tests

* Unit tests added.
* Some tests that run on the Web needed to be informed of the new filename, but their behavior didn't have to change (binary contents are the same across all platforms).
* I've deployed a test app, so users affected by the BIN issue may take a look at the PR in action:
  * https://dit-tests.web.app


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
