### PR TITLE
Move ios_app_with_extensions_test to host only

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3756,7 +3756,6 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac"]
       task_name: ios_app_with_extensions_test
-    bringup: true
 
   - name: Mac_arm64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
@@ -3766,7 +3765,6 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac", "arm64"]
       task_name: ios_app_with_extensions_test
-    bringup: true
 
   - name: Mac_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3756,6 +3756,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_app_with_extensions_test
+    bringup: true
 
   - name: Mac_arm64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
@@ -3765,6 +3766,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: ios_app_with_extensions_test
+    bringup: true
 
   - name: Mac_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3748,7 +3748,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_textfield
 
-   - name: Mac_ios ios_app_with_extensions_test
+  - name: Mac_ios ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3756,6 +3756,7 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac"]
       task_name: ios_app_with_extensions_test
+    bringup: true
 
   - name: Mac_arm64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
@@ -3765,6 +3766,7 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac", "arm64"]
       task_name: ios_app_with_extensions_test
+    bringup: true
 
   - name: Mac_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3748,13 +3748,13 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_textfield
 
-  - name: Mac ios_app_with_extensions_test
+  - name: Mac_x64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: ios_app_with_extensions_test
     bringup: true
 
@@ -3764,7 +3764,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: ios_app_with_extensions_test
     bringup: true
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3748,7 +3748,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_textfield
 
-  - name: Mac_ios ios_app_with_extensions_test
+  - name: Mac ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
@@ -3757,7 +3757,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: ios_app_with_extensions_test
 
-  - name: Mac_arm64_ios ios_app_with_extensions_test
+  - name: Mac_arm64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3748,6 +3748,24 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_textfield
 
+   - name: Mac_ios ios_app_with_extensions_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: ios_app_with_extensions_test
+
+  - name: Mac_arm64_ios ios_app_with_extensions_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac", "arm64"]
+      task_name: ios_app_with_extensions_test
+
   - name: Mac_x64 ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
`ios_app_with_extensions_test` only builds the artifact, it does not need a device to run.
This PR adds the copies of these tests to run hostonly. When the new tests pass in post submit, we should remove the old ones.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
