### PR TITLE
Deprecate `useMaterial3` parameter in `ThemeData.copyWith()`

### DIFF
--- a/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
@@ -25,6 +25,16 @@
 #     * TextTheme: fix_text_theme.yaml
 version: 1
 transforms:
+  - title: "Remove 'useMaterial3'"
+    date: 2021-11-11
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'ThemeData'
+    changes:
+      - kind: 'removeParameter'
+        name: 'useMaterial3'
+
   # Changes made in https://github.com/flutter/flutter/pull/87281
   - title: "Remove 'fixTextFieldOutlineLabel'"
     date: 2021-04-30

--- a/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
@@ -26,7 +26,7 @@
 version: 1
 transforms:
   - title: "Remove 'useMaterial3'"
-    date: 2021-11-11
+    date: 2023-07-27
     element:
       uris: [ 'material.dart' ]
       method: 'copyWith'

--- a/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
@@ -25,17 +25,6 @@
 #     * TextTheme: fix_text_theme.yaml
 version: 1
 transforms:
-  # Changes made in https://github.com/flutter/flutter/pull/131455
-  - title: "Remove 'useMaterial3'"
-    date: 2023-07-27
-    element:
-      uris: [ 'material.dart' ]
-      method: 'copyWith'
-      inClass: 'ThemeData'
-    changes:
-      - kind: 'removeParameter'
-        name: 'useMaterial3'
-
   # Changes made in https://github.com/flutter/flutter/pull/87281
   - title: "Remove 'fixTextFieldOutlineLabel'"
     date: 2021-04-30
@@ -1696,5 +1685,16 @@ transforms:
       colorScheme:
         kind: 'fragment'
         value: 'arguments[colorScheme]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/131455
+  - title: "Remove 'useMaterial3'"
+    date: 2023-07-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'ThemeData'
+    changes:
+      - kind: 'removeParameter'
+        name: 'useMaterial3'
 
 # Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_theme_data.yaml
@@ -25,6 +25,7 @@
 #     * TextTheme: fix_text_theme.yaml
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/131455
   - title: "Remove 'useMaterial3'"
     date: 2023-07-27
     element:

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1638,7 +1638,7 @@ class ThemeData with Diagnosticable {
     Color? bottomAppBarColor,
     @Deprecated(
       'Use ThemeData.useMaterial3 instead. '
-      'Setting this value causes issues on changing the default theme. '
+      'Setting this value cannot successfully change the default theme. '
       'This feature was deprecated after v3.13.0-0.2.pre.',
     )
     bool? useMaterial3,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1637,8 +1637,10 @@ class ThemeData with Diagnosticable {
     )
     Color? bottomAppBarColor,
     @Deprecated(
-      'Use ThemeData.useMaterial3 instead. '
-      'Setting this value cannot successfully change the default theme. '
+      'Use a ThemeData constructor (.from, .light, or .dark) instead. '
+      'These constructors all have a useMaterial3 argument, '
+      'and they set appropriate default values based on its value. '
+      'See the useMaterial3 API documentation for full details. '
       'This feature was deprecated after v3.13.0-0.2.pre.',
     )
     bool? useMaterial3,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1525,7 +1525,6 @@ class ThemeData with Diagnosticable {
     TargetPlatform? platform,
     ScrollbarThemeData? scrollbarTheme,
     InteractiveInkFeatureFactory? splashFactory,
-    bool? useMaterial3,
     VisualDensity? visualDensity,
     // COLOR
     // [colorScheme] is the preferred way to configure colors. The other color
@@ -1637,6 +1636,12 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.3.0-0.6.pre.',
     )
     Color? bottomAppBarColor,
+    @Deprecated(
+      'Use ThemeData.useMaterial3 instead. '
+      'Setting this value causes issues on changing the default theme. '
+      'This feature was deprecated after v3.13.0-0.2.pre.',
+    )
+    bool? useMaterial3,
   }) {
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
     return ThemeData.raw(

--- a/packages/flutter/test_fixes/material/theme_data.dart
+++ b/packages/flutter/test_fixes/material/theme_data.dart
@@ -234,4 +234,6 @@ void main() {
   themeData = ThemeData(bottomAppBarColor: Colors.green);
   themeData = ThemeData.raw(bottomAppBarColor: Colors.green);
   themeData = ThemeData.copyWith(bottomAppBarColor: Colors.green);
+
+  ThemeData themeData = ThemeData.copyWith(useMaterial3: false);
 }

--- a/packages/flutter/test_fixes/material/theme_data.dart
+++ b/packages/flutter/test_fixes/material/theme_data.dart
@@ -235,5 +235,6 @@ void main() {
   themeData = ThemeData.raw(bottomAppBarColor: Colors.green);
   themeData = ThemeData.copyWith(bottomAppBarColor: Colors.green);
 
+  // Changes made in https://github.com/flutter/flutter/pull/131455
   ThemeData themeData = ThemeData.copyWith(useMaterial3: false);
 }

--- a/packages/flutter/test_fixes/material/theme_data.dart.expect
+++ b/packages/flutter/test_fixes/material/theme_data.dart.expect
@@ -441,5 +441,6 @@ void main() {
   themeData = ThemeData.raw(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
   themeData = ThemeData.copyWith(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
 
+  // Changes made in https://github.com/flutter/flutter/pull/131455
   ThemeData themeData = ThemeData.copyWith();
 }

--- a/packages/flutter/test_fixes/material/theme_data.dart.expect
+++ b/packages/flutter/test_fixes/material/theme_data.dart.expect
@@ -440,4 +440,6 @@ void main() {
   themeData = ThemeData(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
   themeData = ThemeData.raw(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
   themeData = ThemeData.copyWith(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
+
+  ThemeData themeData = ThemeData.copyWith();
 }


### PR DESCRIPTION
This PR is to deprecate `useMaterial3` parameter in `ThemeData.copyWith()`.

Setting `useMaterial3` to false in `ThemeData.copyWith()` doesn't force Flutter to use Material 2, instead, we should set it in `ThemeData()` directly. The documentation of `useMaterial3` has covered this limitation: https://api.flutter.dev/flutter/material/ThemeData/useMaterial3.html, but it still likely to be misused in the `.copyWith()` method.

A related issue happens in b/292560771

Related to #131041

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
