### PR TITLE
Update `Card.color` documentation for Material 3

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -78,6 +78,12 @@ class Card extends StatelessWidget {
   ///
   /// Defines the card's [Material.color].
   ///
+  /// In Material 3, [surfaceTintColor] is drawn on top of this color
+  /// when the card is elevated. This might make the appearance of
+  /// the card slightly different than in Material 2. To disable this
+  /// feature, set [surfaceTintColor] to [Colors.transparent].
+  /// See [Material.surfaceTintColor] for more details.
+  ///
   /// If this property is null then the ambient [CardTheme.color] is used. If that is null,
   /// and [ThemeData.useMaterial3] is true, then [ColorScheme.surface] of
   /// [ThemeData.colorScheme] is used. Otherwise, [ThemeData.cardColor] is used.


### PR DESCRIPTION
fixes [Card color parameter not respected while using Material 3](https://github.com/flutter/flutter/issues/122177)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
