### PR TITLE
Reland --omit-type-checks for benchmarks.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1096,7 +1096,7 @@ targets:
 
   - name: Linux web_benchmarks_skwasm
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    #presubmit: false
     timeout: 60
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1096,7 +1096,7 @@ targets:
 
   - name: Linux web_benchmarks_skwasm
     recipe: devicelab/devicelab_drone
-    #presubmit: false
+    presubmit: false
     timeout: 60
     properties:
       dependencies: >-

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -36,6 +36,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
       if (benchmarkOptions.useWasm) ...<String>[
         '--wasm',
         '--wasm-opt=debug',
+        '--omit-type-checks',
       ],
       '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
       '--web-renderer=${benchmarkOptions.webRenderer}',


### PR DESCRIPTION
Because the cost of type checks dominate our dart2wasm benchmarks, we've decided to pass `--omit-type-checks` for now.

This was previously reverted because the skwasm benchmarks were broken in general for a separate reason, and my getting rid of `bringup: true` broke the tree. I ended up fixing the benchmarks and getting rid of `bringup: true` in a separate commit, so this just adds the flag only.