### PR TITLE
Adds callback onWillAcceptWithDetails in DragTarget.

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -624,7 +624,7 @@ class DragTarget<T extends Object> extends StatefulWidget {
     this.onLeave,
     this.onMove,
     this.hitTestBehavior = HitTestBehavior.translucent,
-  }) : assert(onWillAccept == null || onWillAcceptWithDetails == null, 'Don't pass both onWillAccept and onWillAcceptWithDetails.');
+  }) : assert(onWillAccept == null || onWillAcceptWithDetails == null, "Don't pass both onWillAccept and onWillAcceptWithDetails.");
 
   /// Called to build the contents of this widget.
   ///

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -641,7 +641,7 @@ class DragTarget<T extends Object> extends StatefulWidget {
   ///
   /// Equivalent to [onWillAcceptWithDetails], but only includes the data.
   ///
-  /// Should not be provided if [onWillAcceptWithDetails] is provided.
+  /// Must not be provided if [onWillAcceptWithDetails] is provided.
   final DragTargetWillAccept<T>? onWillAccept;
 
   /// Called to determine whether this widget is interested in receiving a given
@@ -654,7 +654,7 @@ class DragTarget<T extends Object> extends StatefulWidget {
   /// Equivalent to [onWillAccept], but with information, including the data,
   /// in a [DragTargetDetails].
   ///
-  /// Should not be provided if [onWillAccept] is provided.
+  /// Must not be provided if [onWillAccept] is provided.
   final DragTargetWillAcceptWithDetails<T>? onWillAcceptWithDetails;
 
   /// Called when an acceptable piece of data was dropped over this drag target.

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -20,6 +20,12 @@ import 'view.dart';
 /// Used by [DragTarget.onWillAccept].
 typedef DragTargetWillAccept<T> = bool Function(T? data);
 
+/// Signature for determining whether the given data will be accepted by a [DragTarget],
+/// based on provided information.
+///
+/// Used by [DragTarget.onWillAcceptWithDetails].
+typedef DragTargetWillAcceptWithDetails<T> = bool Function(DragTargetDetails<T> details);
+
 /// Signature for causing a [DragTarget] to accept the given data.
 ///
 /// Used by [DragTarget.onAccept].
@@ -612,12 +618,13 @@ class DragTarget<T extends Object> extends StatefulWidget {
     super.key,
     required this.builder,
     this.onWillAccept,
+    this.onWillAcceptWithDetails,
     this.onAccept,
     this.onAcceptWithDetails,
     this.onLeave,
     this.onMove,
     this.hitTestBehavior = HitTestBehavior.translucent,
-  });
+  }): assert(onWillAccept == null || onWillAcceptWithDetails == null, 'Both onWillAccept and onWillAcceptWithDetails must not be provided.');
 
   /// Called to build the contents of this widget.
   ///
@@ -631,7 +638,24 @@ class DragTarget<T extends Object> extends StatefulWidget {
   /// Called when a piece of data enters the target. This will be followed by
   /// either [onAccept] and [onAcceptWithDetails], if the data is dropped, or
   /// [onLeave], if the drag leaves the target.
+  ///
+  /// Equivalent to [onWillAcceptWithDetails], but only includes the data.
+  ///
+  /// Should not be provided if [onWillAcceptWithDetails] is provided.
   final DragTargetWillAccept<T>? onWillAccept;
+
+  /// Called to determine whether this widget is interested in receiving a given
+  /// piece of data being dragged over this drag target.
+  ///
+  /// Called when a piece of data enters the target. This will be followed by
+  /// either [onAccept] and [onAcceptWithDetails], if the data is dropped, or
+  /// [onLeave], if the drag leaves the target.
+  ///
+  /// Equivalent to [onWillAccept], but with information, including the data,
+  /// in a [DragTargetDetails].
+  ///
+  /// Should not be provided if [onWillAccept] is provided.
+  final DragTargetWillAcceptWithDetails<T>? onWillAcceptWithDetails;
 
   /// Called when an acceptable piece of data was dropped over this drag target.
   ///
@@ -684,7 +708,13 @@ class _DragTargetState<T extends Object> extends State<DragTarget<T>> {
   bool didEnter(_DragAvatar<Object> avatar) {
     assert(!_candidateAvatars.contains(avatar));
     assert(!_rejectedAvatars.contains(avatar));
-    if (widget.onWillAccept == null || widget.onWillAccept!(avatar.data as T?)) {
+    final bool resolvedWillAccept = (widget.onWillAccept == null &&
+                                    widget.onWillAcceptWithDetails == null) ||
+                                    (widget.onWillAccept != null &&
+                                    widget.onWillAccept!(avatar.data as T?)) ||
+                                    (widget.onWillAcceptWithDetails != null &&
+                                    widget.onWillAcceptWithDetails!(DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset!)));
+    if (resolvedWillAccept) {
       setState(() {
         _candidateAvatars.add(avatar);
       });

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -624,7 +624,7 @@ class DragTarget<T extends Object> extends StatefulWidget {
     this.onLeave,
     this.onMove,
     this.hitTestBehavior = HitTestBehavior.translucent,
-  }): assert(onWillAccept == null || onWillAcceptWithDetails == null, 'Both onWillAccept and onWillAcceptWithDetails must not be provided.');
+  }) : assert(onWillAccept == null || onWillAcceptWithDetails == null, 'Both onWillAccept and onWillAcceptWithDetails must not be provided.');
 
   /// Called to build the contents of this widget.
   ///

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -624,7 +624,7 @@ class DragTarget<T extends Object> extends StatefulWidget {
     this.onLeave,
     this.onMove,
     this.hitTestBehavior = HitTestBehavior.translucent,
-  }) : assert(onWillAccept == null || onWillAcceptWithDetails == null, 'Both onWillAccept and onWillAcceptWithDetails must not be provided.');
+  }) : assert(onWillAccept == null || onWillAcceptWithDetails == null, 'Don't pass both onWillAccept and onWillAcceptWithDetails.');
 
   /// Called to build the contents of this widget.
   ///


### PR DESCRIPTION
This PR adds onWillAcceptWithDetails callback to DragTarget to get information about offset.

Fixes: #131378 

This PR is subject to changes based on #131542 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
