### PR TITLE
Avoid concurrent modification of persistent frame callbacks

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -1227,7 +1227,7 @@ mixin SchedulerBinding on BindingBase {
     try {
       // PERSISTENT FRAME CALLBACKS
       _schedulerPhase = SchedulerPhase.persistentCallbacks;
-      for (final FrameCallback callback in _persistentCallbacks) {
+      for (final FrameCallback callback in List<FrameCallback>.of(_persistentCallbacks)) {
         _invokeFrameCallback(callback, _currentFrameTimeStamp!);
       }
 

--- a/packages/flutter/test/scheduler/binding_test.dart
+++ b/packages/flutter/test/scheduler/binding_test.dart
@@ -29,7 +29,7 @@ void main() {
     timeDilation = 1.0;
   });
 
-  test('Adding a persistent frame callback during a persisten frame callback', () {
+  test('Adding a persistent frame callback during a persistent frame callback', () {
     bool calledBack = false;
     SchedulerBinding.instance.addPersistentFrameCallback((Duration timeStamp) {
       if (!calledBack) {

--- a/packages/flutter/test/scheduler/binding_test.dart
+++ b/packages/flutter/test/scheduler/binding_test.dart
@@ -28,4 +28,21 @@ void main() {
     );
     timeDilation = 1.0;
   });
+
+  test('Adding a persistent frame callback during a persisten frame callback', () {
+    bool calledBack = false;
+    SchedulerBinding.instance.addPersistentFrameCallback((Duration timeStamp) {
+      if (!calledBack) {
+        SchedulerBinding.instance.addPersistentFrameCallback((Duration timeStamp) {
+          calledBack = true;
+        });
+      }
+    });
+    SchedulerBinding.instance.handleBeginFrame(null);
+    SchedulerBinding.instance.handleDrawFrame();
+    expect(calledBack, false);
+    SchedulerBinding.instance.handleBeginFrame(null);
+    SchedulerBinding.instance.handleDrawFrame();
+    expect(calledBack, true);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/131415

We should do an audit of all such cases though, filed https://github.com/flutter/flutter/issues/131678