### PR TITLE
Fix flex methods for min and max column widths

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -263,12 +263,11 @@ class MaxColumnWidth extends TableColumnWidth {
   @override
   double? flex(Iterable<RenderBox> cells) {
     final double? aFlex = a.flex(cells);
-    if (aFlex == null) {
-      return b.flex(cells);
-    }
     final double? bFlex = b.flex(cells);
-    if (bFlex == null) {
-      return null;
+    if (aFlex == null) {
+      return bFlex;
+    } else if (bFlex == null) {
+      return aFlex;
     }
     return math.max(aFlex, bFlex);
   }
@@ -316,12 +315,11 @@ class MinColumnWidth extends TableColumnWidth {
   @override
   double? flex(Iterable<RenderBox> cells) {
     final double? aFlex = a.flex(cells);
-    if (aFlex == null) {
-      return b.flex(cells);
-    }
     final double? bFlex = b.flex(cells);
-    if (bFlex == null) {
-      return null;
+    if (aFlex == null) {
+      return bFlex;
+    } else if (bFlex == null) {
+      return aFlex;
     }
     return math.min(aFlex, bFlex);
   }

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -277,4 +277,37 @@ void main() {
     );
   });
 
+  test('MaxColumnWidth.flex returns the correct result', () {
+    MaxColumnWidth columnWidth = const MaxColumnWidth(
+      FixedColumnWidth(100), // returns null from .flex
+      FlexColumnWidth(), // returns 1 from .flex
+    );
+    final double? flexValue = columnWidth.flex(<RenderBox>[]);
+    expect(flexValue, 1.0);
+
+    // Swap a and b, check for same result.
+    columnWidth = const MaxColumnWidth(
+      FlexColumnWidth(), // returns 1 from .flex
+      FixedColumnWidth(100), // returns null from .flex
+    );
+    // Same result.
+    expect(columnWidth.flex(<RenderBox>[]), flexValue);
+  });
+
+  test('MinColumnWidth.flex returns the correct result', () {
+    MinColumnWidth columnWidth = const MinColumnWidth(
+      FixedColumnWidth(100), // returns null from .flex
+      FlexColumnWidth(), // returns 1 from .flex
+    );
+    final double? flexValue = columnWidth.flex(<RenderBox>[]);
+    expect(flexValue, 1.0);
+
+    // Swap a and b, check for same result.
+    columnWidth = const MinColumnWidth(
+      FlexColumnWidth(), // returns 1 from .flex
+      FixedColumnWidth(100), // returns null from .flex
+    );
+    // Same result.
+    expect(columnWidth.flex(<RenderBox>[]), flexValue);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/131467

An error in the flex methods of min and max column width would produce different results based on the position of the widths that were provided:
`MaxColumnWidth(a, b) != MaxColumnWidth(b, a)`

This fixes that.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
