### PR TITLE
Fix: use --web-launch-url and --web-hostname arguments in flutter drive

### DIFF
--- a/dev/integration_tests/flutter_gallery/.gitignore
+++ b/dev/integration_tests/flutter_gallery/.gitignore
@@ -1,3 +1,2 @@
-lib/generated_plugin_registrant.dart
 vmservice.out
 *.sksl.json

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -74,10 +74,12 @@ class WebDriverService extends DriverService {
         DebuggingOptions.disabled(
           buildInfo,
           port: debuggingOptions.port,
+          hostname: debuggingOptions.hostname,
         )
         : DebuggingOptions.enabled(
           buildInfo,
           port: debuggingOptions.port,
+          hostname: debuggingOptions.hostname,
           disablePortPublication: debuggingOptions.disablePortPublication,
         ),
       stayResident: true,
@@ -116,11 +118,11 @@ class WebDriverService extends DriverService {
       throw ToolExit('Failed to start application');
     }
 
-    _webUri = _residentRunner.uri;
-
-    if (_webUri == null) {
+    if (_residentRunner.uri == null) {
       throw ToolExit('Unable to connect to the app. URL not available.');
     }
+
+    _webUri = Uri.tryParse(debuggingOptions.webLaunchUrl ?? '') ?? _residentRunner.uri;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -125,7 +125,7 @@ class WebDriverService extends DriverService {
       throw ToolExit('Unable to connect to the app. URL not available.');
     }
 
-    if(debuggingOptions.webLaunchUrl != null){
+    if (debuggingOptions.webLaunchUrl != null) {
       // It should thow an error if the provided url is invalid so no tryParse
       _webUri = Uri.parse(debuggingOptions.webLaunchUrl!);
     } else {

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -41,6 +41,9 @@ class WebDriverService extends DriverService {
   late ResidentRunner _residentRunner;
   Uri? _webUri;
 
+  @visibleForTesting
+  Uri? get webUri => _webUri;
+
   /// The result of [ResidentRunner.run].
   ///
   /// This is expected to stay `null` throughout the test, as the application
@@ -122,7 +125,12 @@ class WebDriverService extends DriverService {
       throw ToolExit('Unable to connect to the app. URL not available.');
     }
 
-    _webUri = Uri.tryParse(debuggingOptions.webLaunchUrl ?? '') ?? _residentRunner.uri;
+    if(debuggingOptions.webLaunchUrl != null){
+      // It should thow an error if the provided url is invalid so no tryParse
+      _webUri = Uri.parse(debuggingOptions.webLaunchUrl!);
+    } else {
+      _webUri = _residentRunner.uri;
+    }
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -258,6 +258,29 @@ void main() {
     WebRunnerFactory: () => FakeWebRunnerFactory(),
   });
 
+  testUsingContext('WebDriverService can start an app with a launch url provided', () async {
+    final WebDriverService service = setUpDriverService();
+    final FakeDevice device = FakeDevice();
+    const String testUrl = 'http://localhost:1234/test';
+    await service.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile, webLaunchUrl: testUrl), true);
+    await service.stop();
+    expect(service.webUri, Uri.parse(testUrl));
+  }, overrides: <Type, Generator>{
+    WebRunnerFactory: () => FakeWebRunnerFactory(),
+  });
+
+  testUsingContext('WebDriverService will throw when an invalid launch url is provided', () async {
+    final WebDriverService service = setUpDriverService();
+    final FakeDevice device = FakeDevice();
+    const String invalidTestUrl = '::INVALID_URL::';
+    await expectLater(
+      service.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile, webLaunchUrl: invalidTestUrl), true),
+      throwsA(isA<FormatException>()),
+    );
+  }, overrides: <Type, Generator>{
+    WebRunnerFactory: () => FakeWebRunnerFactory(),
+  });
+
   testUsingContext('WebDriverService forwards exception when run future fails before app starts', () async {
     final WebDriverService service = setUpDriverService();
     final Device device = FakeDevice();


### PR DESCRIPTION
Implement expected functionalities when supplying `--web-launch-url` and/or `--web-hostname` arguments to `flutter drive`.
- `--web-launch-url` now sets the starting url for the (headless) browser
  - Which for example means you can start at a certain part of the app at the start of your integration test
- `--web-hostname` now sets the hostname where the target of flutter drive will be hosted
  - Which allows you to set something other than localhost (allowing access via a reverse-proxy for example)

Fixes #118028

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
