### PR TITLE
Assert against infinite values of control points in CatmullRomSpline

### DIFF
--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -705,6 +705,27 @@ class CatmullRomSpline extends Curve2D {
     Offset? startHandle,
     Offset? endHandle,
   }) {
+    assert(
+      startHandle == null || startHandle.isFinite,
+      'The provided startHandle of CatmullRomSpline must be finite. The '
+      'startHandle given was $startHandle.'
+    );
+    assert(
+      endHandle == null || endHandle.isFinite,
+      'The provided endHandle of CatmullRomSpline must be finite. The endHandle '
+      'given was $endHandle.'
+    );
+    assert(() {
+      for (int index = 0; index < controlPoints.length; index++) {
+        if (!controlPoints[index].isFinite) {
+          throw FlutterError(
+            'The provided CatmullRomSpline control point at index $index is not '
+            'finite. The control point given was ${controlPoints[index]}.'
+          );
+        }
+      }
+      return true;
+    }());
     // If not specified, select the first and last control points (which are
     // handles: they are not intersected by the resulting curve) so that they
     // extend the first and last segments, respectively.

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -305,6 +305,28 @@ void main() {
     expect(() {
       CatmullRomSpline(const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero], tension: 2.0);
     }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline(
+        const <Offset>[Offset(double.infinity, 0.0), Offset.zero, Offset.zero, Offset.zero],
+      ).generateSamples();
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline(
+        const <Offset>[Offset(0.0, double.infinity), Offset.zero, Offset.zero, Offset.zero],
+      ).generateSamples();
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline(
+        startHandle: const Offset(0.0, double.infinity),
+        const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero],
+      ).generateSamples();
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline(
+        endHandle: const Offset(0.0, double.infinity),
+        const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero],
+      ).generateSamples();
+    }, throwsAssertionError);
   });
 
   test('CatmullRomSpline interpolates values properly when precomputed', () {
@@ -352,6 +374,24 @@ void main() {
     }, throwsAssertionError);
     expect(() {
       CatmullRomSpline.precompute(const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero], tension: 2.0);
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline.precompute(const <Offset>[Offset(double.infinity, 0.0), Offset.zero, Offset.zero, Offset.zero]);
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline.precompute(const <Offset>[Offset(0.0, double.infinity), Offset.zero, Offset.zero, Offset.zero]);
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline.precompute(
+        startHandle: const Offset(0.0, double.infinity),
+        const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero],
+      );
+    }, throwsAssertionError);
+    expect(() {
+      CatmullRomSpline.precompute(
+        endHandle: const Offset(0.0, double.infinity),
+        const <Offset>[Offset.zero, Offset.zero, Offset.zero, Offset.zero],
+      );
     }, throwsAssertionError);
   });
 


### PR DESCRIPTION
When providing infinite values for the control points of CatmullRomSpline, a StackOverflowError occurs. This asserts against that and provides a helpful error message. 

Fixes https://github.com/flutter/flutter/issues/131246

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
