### PR TITLE
Introduce architecture subdirectory for Windows build (#129805, #116196)

### DIFF
--- a/dev/a11y_assessments/windows/flutter/CMakeLists.txt
+++ b/dev/a11y_assessments/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dev/benchmarks/complex_layout/windows/flutter/CMakeLists.txt
+++ b/dev/benchmarks/complex_layout/windows/flutter/CMakeLists.txt
@@ -14,6 +14,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -96,7 +101,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -894,6 +894,7 @@ class StartupTest {
             testDirectory,
             'build',
             'windows',
+            'x64',
             'runner',
             'Profile',
             '$basename.exe'
@@ -1645,6 +1646,7 @@ class CompileTest {
           cwd,
           'build',
           'windows',
+          'x64',
           'runner',
           'release',
           '$basename.exe');

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -294,7 +294,7 @@ public class $pluginClass: NSObject, FlutterPlugin {
         }
       case 'windows':
         if (await exec(
-          path.join(rootPath, 'build', 'windows', 'plugins', 'plugintest', 'Release', 'plugintest_test.exe'),
+          path.join(rootPath, 'build', 'windows', 'x64', 'plugins', 'plugintest', 'Release', 'plugintest_test.exe'),
           <String>[],
           canFail: true,
         ) != 0) {

--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -178,7 +178,7 @@ class WindowsRunOutputTest extends DesktopRunOutputTest {
     multiLine: true,
   );
   static final RegExp _builtOutput = RegExp(
-    r'Built build\\windows\\runner\\(Debug|Release)\\\w+\.exe( \(\d+(\.\d+)?MB\))?\.',
+    r'Built build\\windows\\x64\\runner\\(Debug|Release)\\\w+\.exe( \(\d+(\.\d+)?MB\))?\.',
   );
 
   @override
@@ -205,7 +205,7 @@ class WindowsRunOutputTest extends DesktopRunOutputTest {
 
         return true;
       },
-      'Built build\\windows\\runner\\$buildMode\\app.exe',
+      'Built build\\windows\\x64\\runner\\$buildMode\\app.exe',
     );
   }
 }

--- a/dev/integration_tests/flutter_gallery/windows/flutter/CMakeLists.txt
+++ b/dev/integration_tests/flutter_gallery/windows/flutter/CMakeLists.txt
@@ -1,3 +1,4 @@
+# This file controls Flutter-level build steps. It should not be edited.
 cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
@@ -8,6 +9,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # TODO: Move the rest of this into files in ephemeral. See
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
+
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
 
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
@@ -91,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dev/integration_tests/ui/windows/flutter/CMakeLists.txt
+++ b/dev/integration_tests/ui/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dev/integration_tests/windows_startup_test/windows/flutter/CMakeLists.txt
+++ b/dev/integration_tests/windows_startup_test/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dev/manual_tests/windows/flutter/CMakeLists.txt
+++ b/dev/manual_tests/windows/flutter/CMakeLists.txt
@@ -1,3 +1,4 @@
+# This file controls Flutter-level build steps. It should not be edited.
 cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
@@ -8,6 +9,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # TODO: Move the rest of this into files in ephemeral. See
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
+
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
 
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
@@ -91,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/examples/api/windows/flutter/CMakeLists.txt
+++ b/examples/api/windows/flutter/CMakeLists.txt
@@ -1,3 +1,4 @@
+# This file controls Flutter-level build steps. It should not be edited.
 cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
@@ -8,6 +9,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # TODO: Move the rest of this into files in ephemeral. See
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
+
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
 
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
@@ -91,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/examples/flutter_view/windows/flutter/CMakeLists.txt
+++ b/examples/flutter_view/windows/flutter/CMakeLists.txt
@@ -14,6 +14,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -96,7 +101,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/examples/hello_world/windows/flutter/CMakeLists.txt
+++ b/examples/hello_world/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/examples/layers/windows/flutter/CMakeLists.txt
+++ b/examples/layers/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/examples/platform_channel/windows/flutter/CMakeLists.txt
+++ b/examples/platform_channel/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/examples/platform_view/windows/flutter/CMakeLists.txt
+++ b/examples/platform_view/windows/flutter/CMakeLists.txt
@@ -14,6 +14,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -96,7 +101,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -872,8 +872,9 @@ String getLinuxBuildDirectory([TargetPlatform? targetPlatform]) {
 }
 
 /// Returns the Windows build output directory.
-String getWindowsBuildDirectory() {
-  return globals.fs.path.join(getBuildDirectory(), 'windows');
+String getWindowsBuildDirectory(TargetPlatform targetPlatform) {
+  final String arch = targetPlatform.simpleName;
+  return globals.fs.path.join(getBuildDirectory(), 'windows', arch);
 }
 
 /// Returns the Fuchsia build output directory.

--- a/packages/flutter_tools/lib/src/windows/application_package.dart
+++ b/packages/flutter_tools/lib/src/windows/application_package.dart
@@ -111,7 +111,7 @@ class BuildableWindowsApp extends WindowsApp {
   String executable(BuildMode buildMode) {
     final String? binaryName = getCmakeExecutableName(project);
     return globals.fs.path.join(
-        getWindowsBuildDirectory(),
+        getWindowsBuildDirectory(TargetPlatform.windows_x64),
         'runner',
         sentenceCase(buildMode.cliName),
         '$binaryName.exe',

--- a/packages/flutter_tools/lib/src/windows/migrations/build_architecture_migration.dart
+++ b/packages/flutter_tools/lib/src/windows/migrations/build_architecture_migration.dart
@@ -1,0 +1,126 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../base/file_system.dart';
+import '../../base/project_migrator.dart';
+import '../../cmake_project.dart';
+import 'utils.dart';
+
+const String _cmakeFileToolBackendBefore = r'''
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CPP_WRAPPER_SOURCES_CORE} ${CPP_WRAPPER_SOURCES_PLUGIN}
+    ${CPP_WRAPPER_SOURCES_APP}
+    ${PHONY_OUTPUT}
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
+      windows-x64 $<CONFIG>
+  VERBATIM
+)
+''';
+
+const String _cmakeFileToolBackendAfter = r'''
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CPP_WRAPPER_SOURCES_CORE} ${CPP_WRAPPER_SOURCES_PLUGIN}
+    ${CPP_WRAPPER_SOURCES_APP}
+    ${PHONY_OUTPUT}
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
+  VERBATIM
+)
+''';
+
+const String _cmakeFileTargetPlatformBefore = r'''
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
+
+# === Flutter Library ===
+''';
+
+const String _cmakeFileTargetPlatformAfter = r'''
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
+
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
+# === Flutter Library ===
+''';
+
+/// Migrates Windows build to target specific architecture.
+/// In more, it deletes old runner folder
+class BuildArchitectureMigration extends ProjectMigrator {
+  BuildArchitectureMigration(
+    WindowsProject project,
+    Directory buildDirectory,
+    super.logger
+  )
+    : _cmakeFile = project.managedCmakeFile,
+      _buildDirectory = buildDirectory;
+
+  final File _cmakeFile;
+  final Directory _buildDirectory;
+
+  @override
+  void migrate() {
+    final Directory oldRunnerDirectory = _buildDirectory
+      .parent
+      .childDirectory('runner');
+    if (oldRunnerDirectory.existsSync()) {
+      logger.printTrace('''
+Deleting previous build folder ${oldRunnerDirectory.path}.
+New binaries can be found in ${_buildDirectory.childDirectory('runner').path}.
+''');
+      try {
+        oldRunnerDirectory.deleteSync(recursive: true);
+      } on FileSystemException catch (error) {
+        logger.printError(
+          'Failed to remove ${oldRunnerDirectory.path}: $error. '
+          'A program may still be using a file in the directory or the directory itself. '
+          'To find and stop such a program, see: '
+          'https://superuser.com/questions/1333118/cant-delete-empty-folder-because-it-is-used'
+        );
+      }
+    }
+
+    // Skip this migration if the affected file does not exist. This indicates
+    // the app has done non-trivial changes to its runner and this migration
+    // might not work as expected if applied.
+    if (!_cmakeFile.existsSync()) {
+      logger.printTrace('''
+windows/flutter/CMakeLists.txt file not found, skipping build architecture migration.
+
+This indicates non-trivial changes have been made to the "windows" folder.
+If needed, you can reset it by deleting the "windows" folder and then using the
+"flutter create --platforms=windows ." command.
+''');
+      return;
+    }
+
+    // Migrate the windows/flutter/CMakeLists.txt file.
+    final String originalCmakeContents = _cmakeFile.readAsStringSync();
+    final String cmakeContentsWithTargetPlatform = replaceFirst(
+      originalCmakeContents,
+      _cmakeFileTargetPlatformBefore,
+      _cmakeFileTargetPlatformAfter,
+    );
+    final String newCmakeContents = replaceFirst(
+      cmakeContentsWithTargetPlatform,
+      _cmakeFileToolBackendBefore,
+      _cmakeFileToolBackendAfter,
+    );
+    if (originalCmakeContents != newCmakeContents) {
+      logger.printStatus('windows/flutter/CMakeLists.txt does not use FLUTTER_TARGET_PLATFORM, updating.');
+      _cmakeFile.writeAsStringSync(newCmakeContents);
+    }
+  }
+}

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -82,9 +82,12 @@ void main() {
         '-S',
         fileSystem.path.absolute(fileSystem.path.dirname(buildFilePath)),
         '-B',
-        r'build\windows',
+        r'build\windows\x64',
         '-G',
         generator,
+        '-A',
+        'x64',
+        '-DFLUTTER_TARGET_PLATFORM=windows-x64',
       ],
       onRun: onRun,
     );
@@ -100,7 +103,7 @@ void main() {
       command: <String>[
         _cmakePath,
         '--build',
-        r'build\windows',
+        r'build\windows\x64',
         '--config',
         buildMode,
         ...<String>['--target', 'INSTALL'],
@@ -222,21 +225,21 @@ Microsoft (R) Build Engine version 16.6.0+5ff7b0c9e for .NET Framework
 Copyright (C) Microsoft Corporation. All rights reserved.
 
   Checking Build System
-  Generating C:/foo/windows/flutter/ephemeral/flutter_windows.dll, [etc], _phony_
-  Building Custom Rule C:/foo/windows/flutter/CMakeLists.txt
+  Generating C:/foo/windows/x64/flutter/ephemeral/flutter_windows.dll, [etc], _phony_
+  Building Custom Rule C:/foo/windows/x64/flutter/CMakeLists.txt
   standard_codec.cc
   Generating Code...
-  flutter_wrapper_plugin.vcxproj -> C:\foo\build\windows\flutter\Debug\flutter_wrapper_plugin.lib
-C:\foo\windows\runner\main.cpp(18): error C2220: the following warning is treated as an error [C:\foo\build\windows\runner\test.vcxproj]
-C:\foo\windows\runner\main.cpp(18): warning C4706: assignment within conditional expression [C:\foo\build\windows\runner\test.vcxproj]
-main.obj : error LNK2019: unresolved external symbol "void __cdecl Bar(void)" (?Bar@@YAXXZ) referenced in function wWinMain [C:\foo\build\windows\runner\test.vcxproj]
-C:\foo\build\windows\runner\Debug\test.exe : fatal error LNK1120: 1 unresolved externals [C:\foo\build\windows\runner\test.vcxproj]
-  Building Custom Rule C:/foo/windows/runner/CMakeLists.txt
+  flutter_wrapper_plugin.vcxproj -> C:\foo\build\windows\x64\flutter\Debug\flutter_wrapper_plugin.lib
+C:\foo\windows\x64\runner\main.cpp(18): error C2220: the following warning is treated as an error [C:\foo\build\windows\x64\runner\test.vcxproj]
+C:\foo\windows\x64\runner\main.cpp(18): warning C4706: assignment within conditional expression [C:\foo\build\windows\x64\runner\test.vcxproj]
+main.obj : error LNK2019: unresolved external symbol "void __cdecl Bar(void)" (?Bar@@YAXXZ) referenced in function wWinMain [C:\foo\build\windows\x64\runner\test.vcxproj]
+C:\foo\build\windows\x64\runner\Debug\test.exe : fatal error LNK1120: 1 unresolved externals [C:\foo\build\windows\x64\runner\test.vcxproj]
+  Building Custom Rule C:/foo/windows/x64/runner/CMakeLists.txt
   flutter_window.cpp
   main.cpp
-C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier [C:\foo\build\windows\runner\test.vcxproj]
+C:\foo\windows\x64\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier [C:\foo\build\windows\x64\runner\test.vcxproj]
   -- Install configuration: "Debug"
-  -- Installing: C:/foo/build/windows/runner/Debug/data/icudtl.dat
+  -- Installing: C:/foo/build/windows/x64/runner/Debug/data/icudtl.dat
 ''';
 
     processManager = FakeProcessManager.list(<FakeCommand>[
@@ -251,11 +254,11 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
     );
     // Just the warnings and errors should be surfaced.
     expect(testLogger.errorText, r'''
-C:\foo\windows\runner\main.cpp(18): error C2220: the following warning is treated as an error [C:\foo\build\windows\runner\test.vcxproj]
-C:\foo\windows\runner\main.cpp(18): warning C4706: assignment within conditional expression [C:\foo\build\windows\runner\test.vcxproj]
-main.obj : error LNK2019: unresolved external symbol "void __cdecl Bar(void)" (?Bar@@YAXXZ) referenced in function wWinMain [C:\foo\build\windows\runner\test.vcxproj]
-C:\foo\build\windows\runner\Debug\test.exe : fatal error LNK1120: 1 unresolved externals [C:\foo\build\windows\runner\test.vcxproj]
-C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier [C:\foo\build\windows\runner\test.vcxproj]
+C:\foo\windows\x64\runner\main.cpp(18): error C2220: the following warning is treated as an error [C:\foo\build\windows\x64\runner\test.vcxproj]
+C:\foo\windows\x64\runner\main.cpp(18): warning C4706: assignment within conditional expression [C:\foo\build\windows\x64\runner\test.vcxproj]
+main.obj : error LNK2019: unresolved external symbol "void __cdecl Bar(void)" (?Bar@@YAXXZ) referenced in function wWinMain [C:\foo\build\windows\x64\runner\test.vcxproj]
+C:\foo\build\windows\x64\runner\Debug\test.exe : fatal error LNK1120: 1 unresolved externals [C:\foo\build\windows\x64\runner\test.vcxproj]
+C:\foo\windows\x64\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier [C:\foo\build\windows\x64\runner\test.vcxproj]
 ''');
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -311,7 +314,7 @@ C:\foo\windows\runner\main.cpp(17,1): error C2065: 'Baz': undeclared identifier 
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <CustomBuild Include="somepath\build\windows\CMakeFiles\8b570225f626c250e12bc1ede88babae\flutter_windows.dll.rule">
+    <CustomBuild Include="somepath\build\windows\x64\CMakeFiles\8b570225f626c250e12bc1ede88babae\flutter_windows.dll.rule">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating some files</Message>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">setlocal
 "C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E env FOO=bar C:/src/flutter/packages/flutter_tools/bin/tool_backend.bat windows-x64 Debug
@@ -391,6 +394,7 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
     final File assembleProject = fileSystem.currentDirectory
       .childDirectory('build')
       .childDirectory('windows')
+      .childDirectory('x64')
       .childDirectory('flutter')
       .childFile('flutter_assemble.vcxproj');
     assembleProject.createSync(recursive: true);
@@ -892,7 +896,7 @@ if %errorlevel% neq 0 goto :VCEnd</Command>
       ..visualStudioOverride = fakeVisualStudio;
     setUpMockProjectFilesForBuild();
 
-    fileSystem.file(r'build\windows\runner\Release\app.so')
+    fileSystem.file(r'build\windows\x64\runner\Release\app.so')
       ..createSync(recursive: true)
       ..writeAsBytesSync(List<int>.generate(10000, (int index) => 0));
 

--- a/packages/flutter_tools/test/general.shard/windows/migrations/build_architecture_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/migrations/build_architecture_migration_test.dart
@@ -1,0 +1,299 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/cmake_project.dart';
+import 'package:flutter_tools/src/windows/migrations/build_architecture_migration.dart';
+import 'package:test/fake.dart';
+
+import '../../../src/common.dart';
+
+void main () {
+  group('Windows Flutter build architecture migration', () {
+    late MemoryFileSystem memoryFileSystem;
+    late BufferLogger testLogger;
+    late FakeWindowsProject mockProject;
+    late File cmakeFile;
+    late Directory buildDirectory;
+
+    setUp(() {
+      memoryFileSystem = MemoryFileSystem.test();
+      cmakeFile = memoryFileSystem.file('CMakeLists.txt');
+      buildDirectory = memoryFileSystem.directory('x64');
+
+      testLogger = BufferLogger(
+        terminal: Terminal.test(),
+        outputPreferences: OutputPreferences.test(),
+      );
+
+      mockProject = FakeWindowsProject(cmakeFile);
+    });
+
+    testWithoutContext('delete old runner directory', () {
+      buildDirectory.createSync();
+      final Directory oldRunnerDirectory =
+        buildDirectory
+        .parent
+        .childDirectory('runner');
+      oldRunnerDirectory.createSync();
+      final File executable = oldRunnerDirectory.childFile('program.exe');
+      executable.createSync();
+      expect(oldRunnerDirectory.existsSync(), isTrue);
+
+      final BuildArchitectureMigration migration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      migration.migrate();
+
+      expect(oldRunnerDirectory.existsSync(), isFalse);
+      expect(testLogger.traceText,
+        contains(
+          'Deleting previous build folder ./runner.\n'
+          'New binaries can be found in x64/runner.\n'
+        )
+      );
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('skipped if CMake file is missing', () {
+      final BuildArchitectureMigration migration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      migration.migrate();
+      expect(cmakeFile.existsSync(), isFalse);
+
+      expect(testLogger.traceText,
+        contains('windows/flutter/CMakeLists.txt file not found, skipping build architecture migration'));
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('skipped if nothing to migrate', () {
+      const String cmakeFileContents = 'Nothing to migrate';
+
+      cmakeFile.writeAsStringSync(cmakeFileContents);
+
+      final DateTime cmakeUpdatedAt = cmakeFile.lastModifiedSync();
+
+      final BuildArchitectureMigration buildArchitectureMigration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      buildArchitectureMigration.migrate();
+
+      expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
+      expect(cmakeFile.readAsStringSync(), cmakeFileContents);
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('skipped if already migrated', () {
+      const String cmakeFileContents =
+        '# TODO: Move the rest of this into files in ephemeral. See\n'
+        '# https://github.com/flutter/flutter/issues/57146.\n'
+        'set(WRAPPER_ROOT "\${EPHEMERAL_DIR}/cpp_client_wrapper")\n'
+        '\n'
+        '# Set fallback configurations for older versions of the flutter tool.\n'
+        'if (NOT DEFINED FLUTTER_TARGET_PLATFORM)\n'
+        '  set(FLUTTER_TARGET_PLATFORM "windows-x64")\n'
+        'endif()\n'
+        '\n'
+        '# === Flutter Library ===\n'
+        '...\n'
+        'add_custom_command(\n'
+        '  OUTPUT \${FLUTTER_LIBRARY} \${FLUTTER_LIBRARY_HEADERS}\n'
+        '    \${CPP_WRAPPER_SOURCES_CORE} \${CPP_WRAPPER_SOURCES_PLUGIN}\n'
+        '    \${CPP_WRAPPER_SOURCES_APP}\n'
+        '    \${PHONY_OUTPUT}\n'
+        '  COMMAND \${CMAKE_COMMAND} -E env\n'
+        '    \${FLUTTER_TOOL_ENVIRONMENT}\n'
+        '    "\${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"\n'
+        '      \${FLUTTER_TARGET_PLATFORM} \$<CONFIG>\n'
+        '  VERBATIM\n'
+        ')\n';
+
+      cmakeFile.writeAsStringSync(cmakeFileContents);
+
+      final DateTime cmakeUpdatedAt = cmakeFile.lastModifiedSync();
+
+      final BuildArchitectureMigration buildArchitectureMigration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      buildArchitectureMigration.migrate();
+
+      expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
+      expect(cmakeFile.readAsStringSync(), cmakeFileContents);
+
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('skipped if already migrated (CRLF)', () {
+      const String cmakeFileContents =
+        '# TODO: Move the rest of this into files in ephemeral. See\r\n'
+        '# https://github.com/flutter/flutter/issues/57146.\r\n'
+        'set(WRAPPER_ROOT "\${EPHEMERAL_DIR}/cpp_client_wrapper")\r\n'
+        '\r\n'
+        '# Set fallback configurations for older versions of the flutter tool.\r\n'
+        'if (NOT DEFINED FLUTTER_TARGET_PLATFORM)\r\n'
+        '  set(FLUTTER_TARGET_PLATFORM "windows-x64")\r\n'
+        'endif()\r\n'
+        '\r\n'
+        '# === Flutter Library ===\r\n'
+        '...\r\n'
+        'add_custom_command(\r\n'
+        '  OUTPUT \${FLUTTER_LIBRARY} \${FLUTTER_LIBRARY_HEADERS}\r\n'
+        '    \${CPP_WRAPPER_SOURCES_CORE} \${CPP_WRAPPER_SOURCES_PLUGIN}\r\n'
+        '    \${CPP_WRAPPER_SOURCES_APP}\r\n'
+        '    \${PHONY_OUTPUT}\r\n'
+        '  COMMAND \${CMAKE_COMMAND} -E env\r\n'
+        '    \${FLUTTER_TOOL_ENVIRONMENT}\r\n'
+        '    "\${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"\r\n'
+        '      \${FLUTTER_TARGET_PLATFORM} \$<CONFIG>\r\n'
+        '  VERBATIM\r\n'
+        ')\r\n';
+
+      cmakeFile.writeAsStringSync(cmakeFileContents);
+
+      final DateTime cmakeUpdatedAt = cmakeFile.lastModifiedSync();
+
+      final BuildArchitectureMigration buildArchitectureMigration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      buildArchitectureMigration.migrate();
+
+      expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
+      expect(cmakeFile.readAsStringSync(), cmakeFileContents);
+
+      expect(testLogger.statusText, isEmpty);
+    });
+
+    testWithoutContext('migrates project to set the target platform', () {
+      cmakeFile.writeAsStringSync(
+        '# TODO: Move the rest of this into files in ephemeral. See\n'
+        '# https://github.com/flutter/flutter/issues/57146.\n'
+        'set(WRAPPER_ROOT "\${EPHEMERAL_DIR}/cpp_client_wrapper")\n'
+        '\n'
+        '# === Flutter Library ===\n'
+        '...\n'
+        'add_custom_command(\n'
+        '  OUTPUT \${FLUTTER_LIBRARY} \${FLUTTER_LIBRARY_HEADERS}\n'
+        '    \${CPP_WRAPPER_SOURCES_CORE} \${CPP_WRAPPER_SOURCES_PLUGIN}\n'
+        '    \${CPP_WRAPPER_SOURCES_APP}\n'
+        '    \${PHONY_OUTPUT}\n'
+        '  COMMAND \${CMAKE_COMMAND} -E env\n'
+        '    \${FLUTTER_TOOL_ENVIRONMENT}\n'
+        '    "\${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"\n'
+        '      windows-x64 \$<CONFIG>\n'
+        '  VERBATIM\n'
+        ')\n'
+      );
+      final BuildArchitectureMigration buildArchitectureMigration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      buildArchitectureMigration.migrate();
+
+      expect(cmakeFile.readAsStringSync(),
+        '# TODO: Move the rest of this into files in ephemeral. See\n'
+        '# https://github.com/flutter/flutter/issues/57146.\n'
+        'set(WRAPPER_ROOT "\${EPHEMERAL_DIR}/cpp_client_wrapper")\n'
+        '\n'
+        '# Set fallback configurations for older versions of the flutter tool.\n'
+        'if (NOT DEFINED FLUTTER_TARGET_PLATFORM)\n'
+        '  set(FLUTTER_TARGET_PLATFORM "windows-x64")\n'
+        'endif()\n'
+        '\n'
+        '# === Flutter Library ===\n'
+        '...\n'
+        'add_custom_command(\n'
+        '  OUTPUT \${FLUTTER_LIBRARY} \${FLUTTER_LIBRARY_HEADERS}\n'
+        '    \${CPP_WRAPPER_SOURCES_CORE} \${CPP_WRAPPER_SOURCES_PLUGIN}\n'
+        '    \${CPP_WRAPPER_SOURCES_APP}\n'
+        '    \${PHONY_OUTPUT}\n'
+        '  COMMAND \${CMAKE_COMMAND} -E env\n'
+        '    \${FLUTTER_TOOL_ENVIRONMENT}\n'
+        '    "\${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"\n'
+        '      \${FLUTTER_TARGET_PLATFORM} \$<CONFIG>\n'
+        '  VERBATIM\n'
+        ')\n'
+      );
+
+      expect(testLogger.statusText, contains('windows/flutter/CMakeLists.txt does not use FLUTTER_TARGET_PLATFORM, updating.'));
+    });
+
+    testWithoutContext('migrates project to set the target platform (CRLF)', () {
+      cmakeFile.writeAsStringSync(
+        '# TODO: Move the rest of this into files in ephemeral. See\r\n'
+        '# https://github.com/flutter/flutter/issues/57146.\r\n'
+        'set(WRAPPER_ROOT "\${EPHEMERAL_DIR}/cpp_client_wrapper")\r\n'
+        '\r\n'
+        '# === Flutter Library ===\r\n'
+        '...\r\n'
+        'add_custom_command(\r\n'
+        '  OUTPUT \${FLUTTER_LIBRARY} \${FLUTTER_LIBRARY_HEADERS}\r\n'
+        '    \${CPP_WRAPPER_SOURCES_CORE} \${CPP_WRAPPER_SOURCES_PLUGIN}\r\n'
+        '    \${CPP_WRAPPER_SOURCES_APP}\r\n'
+        '    \${PHONY_OUTPUT}\r\n'
+        '  COMMAND \${CMAKE_COMMAND} -E env\r\n'
+        '    \${FLUTTER_TOOL_ENVIRONMENT}\r\n'
+        '    "\${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"\r\n'
+        '      windows-x64 \$<CONFIG>\r\n'
+        '  VERBATIM\r\n'
+        ')\r\n'
+      );
+
+      final BuildArchitectureMigration buildArchitectureMigration = BuildArchitectureMigration(
+        mockProject,
+        buildDirectory,
+        testLogger,
+      );
+      buildArchitectureMigration.migrate();
+
+      expect(cmakeFile.readAsStringSync(),
+        '# TODO: Move the rest of this into files in ephemeral. See\r\n'
+        '# https://github.com/flutter/flutter/issues/57146.\r\n'
+        'set(WRAPPER_ROOT "\${EPHEMERAL_DIR}/cpp_client_wrapper")\r\n'
+        '\r\n'
+        '# Set fallback configurations for older versions of the flutter tool.\r\n'
+        'if (NOT DEFINED FLUTTER_TARGET_PLATFORM)\r\n'
+        '  set(FLUTTER_TARGET_PLATFORM "windows-x64")\r\n'
+        'endif()\r\n'
+        '\r\n'
+        '# === Flutter Library ===\r\n'
+        '...\r\n'
+        'add_custom_command(\r\n'
+        '  OUTPUT \${FLUTTER_LIBRARY} \${FLUTTER_LIBRARY_HEADERS}\r\n'
+        '    \${CPP_WRAPPER_SOURCES_CORE} \${CPP_WRAPPER_SOURCES_PLUGIN}\r\n'
+        '    \${CPP_WRAPPER_SOURCES_APP}\r\n'
+        '    \${PHONY_OUTPUT}\r\n'
+        '  COMMAND \${CMAKE_COMMAND} -E env\r\n'
+        '    \${FLUTTER_TOOL_ENVIRONMENT}\r\n'
+        '    "\${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"\r\n'
+        '      \${FLUTTER_TARGET_PLATFORM} \$<CONFIG>\r\n'
+        '  VERBATIM\r\n'
+        ')\r\n'
+      );
+
+      expect(testLogger.statusText, contains('windows/flutter/CMakeLists.txt does not use FLUTTER_TARGET_PLATFORM, updating.'));
+    });
+  });
+}
+
+class FakeWindowsProject extends Fake implements WindowsProject {
+  FakeWindowsProject(this.managedCmakeFile);
+
+  @override
+  final File managedCmakeFile;
+}

--- a/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
@@ -45,6 +45,7 @@ void main() {
         projectRoot.path,
         'build',
         'windows',
+        'x64',
         'runner',
         'Release',
       ));


### PR DESCRIPTION
To implement windows-arm64 support, it is needed to add architecture as a subdirectory (https://github.com/flutter/flutter/issues/129805).

In short, when performing a flutter windows build, we have:
- Before: build/windows/runner/Release/gallery.exe
- After: build/windows/x64/runner/Release/gallery.exe

This convention follows what flutter linux build does.

The old "runner" folder is automatically cleaned to prevent confusion for users not aware of this change, and who could continue to use outdated binaries accidentally.

We didn't introduce any change in ephemeral build folder. This might be required when introducing another architecture, but it won't be a breaking change, as those files are not used by end user.

Since we use a fresh cmake folder, we introduce FLUTTER_TARGET_PLATFORM in flutter cmake file (https://github.com/flutter/flutter/issues/116196). This will be needed when targeting another architecture than x64, and will avoid to have to clean existing cmake files. An automatic migration was implemented to automate this change in existing applications.

Finally, we set a specific architecture when calling cmake. This fixes existing build and tests on Windows on Arm, where cmake tries to compile native windows-arm64 binaries by default (which fails to link x64 libraries). In more, it will avoid need to clean existing cmake files when introducing another architecture.

Design doc: [flutter.dev/go/windows-arm64](https://flutter.dev/go/windows-arm64)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
