### PR TITLE
Build-time asset transformation support

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1076,7 +1076,7 @@ class _Asset {
 
   final AssetKind assetKind;
 
-  // todo document
+  // TODO document
   final AssetTransformer? transformer;
 
   File lookupAssetFile(FileSystem fileSystem) {

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -54,7 +54,7 @@ class BuildSystemConfig {
 /// be either an md5 hash of the file contents or a timestamp.
 ///
 /// A Target has both implicit and explicit inputs and outputs. Only the
-/// later are safe to evaluate before invoking the [buildAction]. For example,
+/// latter are safe to evaluate before invoking the [buildAction]. For example,
 /// a wildcard output pattern requires the outputs to exist before it can
 /// glob files correctly.
 ///

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -194,6 +194,8 @@ Future<void> writeBundle(
                 input: input,
                 outputPath: file.path,
               );
+            case AssetKind.transformed:
+              // TODO: Handle this case.
           }
           if (doCopy) {
             input.copySync(file.path);
@@ -206,3 +208,4 @@ Future<void> writeBundle(
       }
     }));
 }
+

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -179,6 +179,7 @@ Future<void> writeBundle(
           bool doCopy = true;
           switch (assetKind) {
             case AssetKind.regular:
+              // todo may need to handle asset transformation here
               break;
             case AssetKind.font:
               break;
@@ -194,8 +195,6 @@ Future<void> writeBundle(
                 input: input,
                 outputPath: file.path,
               );
-            case AssetKind.transformed:
-              // TODO: Handle this case.
           }
           if (doCopy) {
             input.copySync(file.path);

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -8,6 +8,7 @@ import 'package:package_config/package_config.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import 'asset.dart';
+import 'base/common.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/io.dart';
@@ -696,6 +697,8 @@ class DevFS {
             if (!bundleFirstUpload) {
               assetPathsToEvict.add(archivePath);
             }
+            case AssetKind.transformed:
+              throwToolExit('hi'); //todo
         }
       });
 

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -690,6 +690,7 @@ class DevFS {
               }
             });
           case AssetKind.regular:
+            // todo do we need to handle transforms here
           case AssetKind.font:
           case null:
             dirtyEntries[deviceUri] = content;
@@ -697,8 +698,6 @@ class DevFS {
             if (!bundleFirstUpload) {
               assetPathsToEvict.add(archivePath);
             }
-            case AssetKind.transformed:
-              throwToolExit('hi'); //todo
         }
       });
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -339,12 +339,12 @@ class FlutterManifest {
 
   Map<Uri, AssetTransformer> _computeTransformedAssets() {
     String extractPackageNameFromKey(String packageKey) {
-      final Match? match = packageKey.matchAsPrefix(r'package:(.*):');
+      final Match? match = RegExp('package:(.*)').matchAsPrefix(packageKey);
       if (match == null) {
         // TODO make message more useful.
         throwToolExit('Invalid package key $packageKey');
       }
-      return match[0]!;
+      return match[1]!;
     }
 
     final Map<Uri, AssetTransformer>  result = <Uri, AssetTransformer>{};
@@ -581,6 +581,10 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
     final Object? yamlValue = kvp.value;
     if (yamlKey is! String) {
       errors.add('Expected YAML key to be a string, but got $yamlKey (${yamlValue.runtimeType}).');
+      continue;
+    }
+    // TODO actually implement validation
+    if (yamlKey.startsWith('package')) {
       continue;
     }
     switch (yamlKey) {

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -520,16 +520,15 @@ class FontAsset {
 }
 
 class AssetTransformer {
-  // TODO does constructor go first?
-  final String package;
-  final String executable;
-  final String args;
-
   AssetTransformer({
     required this.package,
     required this.executable,
     required this.args,
   });
+
+  final String package;
+  final String executable;
+  final String args;
 }
 
 bool _validate(Object? manifest, Logger logger) {

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/build_system/targets/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
@@ -734,6 +735,9 @@ class FakeBundle extends AssetBundle {
 
   @override
   final Map<String, AssetKind> entryKinds = <String, AssetKind>{};
+
+  @override
+  final Map<String, AssetTransformer> transformers = <String, AssetTransformer>{};
 
   @override
   List<File> get inputFiles => <File>[];

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/build_system/targets/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
@@ -736,7 +737,7 @@ class FakeBundle extends AssetBundle {
   final Map<String, AssetKind> entryKinds = <String, AssetKind>{};
 
   @override
-  final Map<String, List<AssetTransformer>> transformers = <String, List<AssetTransformer>>{};
+  final Map<String, List<AssetTransformerEntry>> transformers = <String, List<AssetTransformerEntry>>{};
 
   @override
   List<File> get inputFiles => <File>[];

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -21,7 +21,6 @@ import 'package:flutter_tools/src/build_system/targets/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
@@ -737,7 +736,7 @@ class FakeBundle extends AssetBundle {
   final Map<String, AssetKind> entryKinds = <String, AssetKind>{};
 
   @override
-  final Map<String, AssetTransformer> transformers = <String, AssetTransformer>{};
+  final Map<String, List<AssetTransformer>> transformers = <String, List<AssetTransformer>>{};
 
   @override
   List<File> get inputFiles => <File>[];


### PR DESCRIPTION
This PR introduces a new feature that allows flutter users to author and consume dart packages that flutter can use to transform asset files as they are copied to build output. See the design doc, [Asset transformation in the Flutter tool](https://flutter.dev/go/asset-transformation), for the core idea. This PR uses a modified version of one of the alternative designs in the doc.

You can use this [test flutter project](https://github.com/andrewkolos/asset_transformers_test) to test this PR. It comes with asset transformers.

## Usage example

Suppose `grayscale_transformer` and `blur_transformer` are CLI packages that both take an `--input` and `--output` parameter (both representing file paths).

```yaml
# pubspec.yaml

assets:
  - assets/transform-me.jpeg
asset-transformers: # New yaml section added by this PR.
  - package: grayscale_transformer
    assets:
      - 'assets/*.jpeg' # All assets referred to here must also be defined in the `assets` section.
                        # This section will not add any assets to the bundle, only transform them.
                        # Note that we support globs here despite us not supporting them
                        # for asset declaration.
  - package: blur_transformer
    assets:
      - 'assets/*.jpeg' 
    args: --radius=20 # One raw string. Maybe we should use a key-value map instead?
```

When building the asset bundle during `flutter build/run`, `grayscale_transformer` and `blur_transformer` will get invoked (in sequence) with each asset matching the glob `assets/*.jpeg` (which is only `assets/transform-me.jpeg` in this example.

This pubspec syntax one of the more complicated ones in the design doc. However, it is optimized for what we assume to be the most common use case--applying a transformer against large groups of assets (e.g. all files with a particular extension). We _could_ group transformer declarations with asset declarations (see the design involving the new `group` yaml section in the doc), but this might not scale well with other incoming features, like [Flavor-specific Assets](https://flutter.dev/go/flavor-specific-assets)).

## TODO

* Implement asset bundle cache invalidation when there is a transformer change.
* Clean up hacks/todos in code
* Get a semblance of overhead of asset transformation
* Tests
* Refactor

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
