### PR TITLE
Sped up the time to find macrobenchmarks.

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -23,7 +23,11 @@ Future<void> runDriverTestForRoute(String routeName, DriverTestCallBack body) as
   expect(scrollable, isNotNull);
   final SerializableFinder button = find.byValueKey(routeName);
   expect(button, isNotNull);
-  await driver.scrollUntilVisible(scrollable, button, dyScroll: -100.0);
+  // -320 comes from the logical pixels for a full screen scroll for the
+  // smallest reference device, iPhone 4, whose physical screen dimensions are
+  // 960px × 640px.
+  final double dyScroll = -320.0;
+  await driver.scrollUntilVisible(scrollable, button, dyScroll: dyScroll);
   await driver.tap(button);
 
   await body(driver);

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -26,7 +26,7 @@ Future<void> runDriverTestForRoute(String routeName, DriverTestCallBack body) as
   // -320 comes from the logical pixels for a full screen scroll for the
   // smallest reference device, iPhone 4, whose physical screen dimensions are
   // 960px × 640px.
-  final double dyScroll = -320.0;
+  const double dyScroll = -320.0;
   await driver.scrollUntilVisible(scrollable, button, dyScroll: dyScroll);
   await driver.tap(button);
 


### PR DESCRIPTION
This reduce the execution time of macrobenchmarks driver tests.

I tried to find the exact size to scroll the screen but I couldn't find a way to do that with driver tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
