### PR TITLE
Fix: SelectableText userUpdateTextEditingValue calls _scheduleShowCar…

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4045,9 +4045,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause? cause) {
     // Compare the current TextEditingValue with the pre-format new
     // TextEditingValue value, in case the formatter would reject the change.
-    final bool shouldShowCaret = widget.readOnly
-      ? _value.selection != value.selection
-      : _value != value;
+    final bool shouldShowCaret = (widget.readOnly
+        ? _value.selection != value.selection
+        : _value != value) && !value.selection.isCollapsed;
     if (shouldShowCaret) {
       _scheduleShowCaretOnScreen(withAnimation: true);
     }


### PR DESCRIPTION
SelectableText: userUpdateTextEditingValue calls _scheduleShowCaretOnScreen when it should not:

https://github.com/flutter/flutter/issues/131547

@justinmc Made PR as requested, please review.