### PR TITLE
Making TextPainter rounding hack disabled by default

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -101,7 +101,7 @@ final String flutterTester = path.join(flutterRoot, 'bin', 'cache', 'artifacts',
 
 /// The arguments to pass to `flutter test` (typically the local engine
 /// configuration) -- prefilled with the arguments passed to test.dart.
-final List<String> flutterTestArgs = <String>['--dart-define="SKPARAGRAPH_REMOVE_ROUNDING_HACK=true"'];
+final List<String> flutterTestArgs = <String>['--dart-define=SKPARAGRAPH_REMOVE_ROUNDING_HACK=true'];
 
 /// Environment variables to override the local engine when running `pub test`,
 /// if such flags are provided to `test.dart`.
@@ -1307,8 +1307,8 @@ Future<void> _runFlutterDriverWebTest({
   await runCommand(
     flutter,
     <String>[
-      ...flutterTestArgs,
       'drive',
+      ...flutterTestArgs,
       if (driver != null) '--driver=$driver',
       '--target=$target',
       '--browser-name=chrome',
@@ -1582,8 +1582,8 @@ Future<void> _runGalleryE2eWebTest(String buildMode, { bool canvasKit = false })
   await runCommand(
     flutter,
     <String>[
-      ...flutterTestArgs,
       'drive',
+      ...flutterTestArgs,
       if (canvasKit)
         '--dart-define=FLUTTER_WEB_USE_SKIA=true',
       if (!canvasKit)
@@ -1663,10 +1663,10 @@ Future<void> _runWebReleaseTest(String target, {
   await runCommand(
     flutter,
     <String>[
-      ...flutterTestArgs,
       'build',
       'web',
       '--release',
+      ...flutterTestArgs,
       ...additionalArguments,
       '-t',
       target,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -101,7 +101,7 @@ final String flutterTester = path.join(flutterRoot, 'bin', 'cache', 'artifacts',
 
 /// The arguments to pass to `flutter test` (typically the local engine
 /// configuration) -- prefilled with the arguments passed to test.dart.
-final List<String> flutterTestArgs = <String>[];
+final List<String> flutterTestArgs = <String>['--dart-define="SKPARAGRAPH_REMOVE_ROUNDING_HACK=true"'];
 
 /// Environment variables to override the local engine when running `pub test`,
 /// if such flags are provided to `test.dart`.

--- a/dev/integration_tests/flutter_gallery/test/drawer_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/drawer_test.dart
@@ -105,7 +105,7 @@ void main() {
     await tester.tap(find.text('Small'));
     await tester.pumpAndSettle();
     Size textSize = tester.getSize(find.text('Text size'));
-    expect(textSize, equals(const Size(116.0, 13.0)));
+    expect(textSize, equals(within(distance: 0.05, from: const Size(115.2, 13.0))));
 
     // Set font scale back to the default.
     await tester.tap(find.byIcon(Icons.arrow_drop_down).at(1));

--- a/examples/api/test/material/floating_action_button/floating_action_button.1_test.dart
+++ b/examples/api/test/material/floating_action_button/floating_action_button.1_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     final Finder extendedFABMaterialButton = find.byType(RawMaterialButton).at(3);
     final RenderBox extendedFABRenderBox = tester.renderObject(extendedFABMaterialButton);
-    expect(extendedFABRenderBox.size, const Size(111.0, 56.0));
+    expect(extendedFABRenderBox.size, within(distance: 0.01, from: const Size(110.3, 56.0)));
     expect(getRawMaterialButtonWidget(extendedFABMaterialButton).fillColor, theme.colorScheme.primaryContainer);
     expect(getRawMaterialButtonWidget(extendedFABMaterialButton).shape, RoundedRectangleBorder(borderRadius:  BorderRadius.circular(16.0)));
   });

--- a/examples/api/test/material/menu_anchor/menu_accelerator_label.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_accelerator_label.0_test.dart
@@ -29,7 +29,7 @@ void main() {
     expect(find.text('About', findRichText: true), findsOneWidget);
     expect(
       tester.getRect(findMenu('About')),
-      equals(const Rect.fromLTRB(4.0, 48.0, 111.0, 208.0)),
+      equals(const Rect.fromLTRB(4.0, 48.0, 110.5, 208.0)),
     );
     expect(find.text('Save', findRichText: true), findsOneWidget);
     expect(find.text('Quit', findRichText: true), findsOneWidget);

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -513,7 +513,11 @@ class TextPainter {
        _locale = locale,
        _strutStyle = strutStyle,
        _textWidthBasis = textWidthBasis,
-       _textHeightBehavior = textHeightBehavior;
+       _textHeightBehavior = textHeightBehavior,
+       assert(() {
+         ui.ParagraphBuilder.setDisableRoundingHack(true);
+         return true;
+       }());
 
   /// Computes the width of a configured [TextPainter].
   ///

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -515,7 +515,9 @@ class TextPainter {
        _textWidthBasis = textWidthBasis,
        _textHeightBehavior = textHeightBehavior,
        assert(() {
-         ui.ParagraphBuilder.setDisableRoundingHack(true);
+         if (const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK')) {
+           ui.ParagraphBuilder.setDisableRoundingHack(true);
+         }
          return true;
        }());
 

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -344,11 +344,9 @@ void main() {
     // regular font. However, when using the test font, "Cancel" becomes 2 lines which
     // is why the height we're verifying for "Cancel" is larger than "OK".
 
-    // TODO(yjbanov): https://github.com/flutter/flutter/issues/99933
-    //                A bug in the HTML renderer and/or Chrome 96+ causes a
-    //                discrepancy in the paragraph height.
-    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-    expect(tester.getSize(find.text('The Title')), equals(const Size(270.0, hasIssue99933 ? 133 : 132.0)));
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(tester.getSize(find.text('The Title')), equals(const Size(270.0, 132.0)));
+    }
     expect(tester.getTopLeft(find.text('The Title')), equals(const Offset(265.0, 80.0 + 24.0)));
     expect(tester.getSize(find.widgetWithText(CupertinoDialogAction, 'Cancel')), equals(const Size(310.0, 148.0)));
     expect(tester.getSize(find.widgetWithText(CupertinoDialogAction, 'OK')), equals(const Size(310.0, 98.0)));

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -145,15 +145,15 @@ void main() {
     // place.
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).first),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 342.547737105096302912 : 342.33420100808144,
+      const Offset(
+        342.547737105096302912,
         13.5,
       ),
     );
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).last),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 342.547737105096302912 : 342.33420100808144,
+      const Offset(
+        342.547737105096302912,
         13.5,
       ),
     );
@@ -172,15 +172,15 @@ void main() {
     // Same as LTR but more to the right now.
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).first),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 357.912261979376353338 : 357.66579899191856,
+      const Offset(
+        357.912261979376353338,
         13.5,
       ),
     );
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).last),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 357.912261979376353338 : 357.66579899191856,
+      const Offset(
+        357.912261979376353338,
         13.5,
       ),
     );
@@ -371,8 +371,8 @@ void main() {
 
       expect(
         tester.getTopLeft(flying(tester, find.text('Page 1')).first),
-        Offset(
-          ParagraphBuilder.shouldDisableRoundingHack ? 342.547737105096302912 : 342.33420100808144,
+        const Offset(
+          342.547737105096302912,
           13.5,
         ),
       );
@@ -384,8 +384,8 @@ void main() {
       expect(topBackLabel.text.style!.color, const Color(0xff000306));
       expect(
         tester.getTopLeft(flying(tester, find.text('Page 1')).last),
-        Offset(
-          ParagraphBuilder.shouldDisableRoundingHack ? 342.547737105096302912 : 342.33420100808144,
+        const Offset(
+          342.547737105096302912,
           13.5,
         ),
       );
@@ -422,8 +422,8 @@ void main() {
       expect(bottomMiddle.text.style!.color, const Color(0xff000306));
       expect(
         tester.getTopLeft(flying(tester, find.text('Page 1')).first),
-        Offset(
-          ParagraphBuilder.shouldDisableRoundingHack ? 357.912261979376353338 : 357.66579899191856,
+        const Offset(
+          357.912261979376353338,
           13.5,
         ),
       );
@@ -435,8 +435,8 @@ void main() {
       expect(topBackLabel.text.style!.color, const Color(0xff000306));
       expect(
         tester.getTopLeft(flying(tester, find.text('Page 1')).last),
-        Offset(
-          ParagraphBuilder.shouldDisableRoundingHack ? 357.912261979376353338 : 357.66579899191856,
+        const Offset(
+          357.912261979376353338,
           13.5,
         ),
       );
@@ -736,15 +736,15 @@ void main() {
     );
     // Come in from the right and fade in.
     checkOpacity(tester, backChevron, 0.0);
-    expect(tester.getTopLeft(backChevron), Offset(
-      ParagraphBuilder.shouldDisableRoundingHack ? 87.2460581221158690823 : 88.04496401548386,
+    expect(tester.getTopLeft(backChevron), const Offset(
+      87.2460581221158690823,
       7.0,
     ));
 
     await tester.pump(const Duration(milliseconds: 200));
     checkOpacity(tester, backChevron, 0.09497911669313908);
-    expect(tester.getTopLeft(backChevron), Offset(
-      ParagraphBuilder.shouldDisableRoundingHack ? 30.8718595298545324113 : 31.055883467197418,
+    expect(tester.getTopLeft(backChevron), const Offset(
+      30.8718595298545324113,
       7.0,
     ));
   });
@@ -784,8 +784,8 @@ void main() {
     checkOpacity(tester, backChevron, 0.0);
     expect(
       tester.getTopRight(backChevron),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 687.163941725296126606 : 685.9550359845161,
+      const Offset(
+        687.163941725296126606,
         7.0,
       ),
     );
@@ -794,8 +794,8 @@ void main() {
     checkOpacity(tester, backChevron, 0.09497911669313908);
     expect(
       tester.getTopRight(backChevron),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 743.538140317557690651 : 742.9441165328026,
+      const Offset(
+        743.538140317557690651,
         7.0,
       ),
     );
@@ -899,8 +899,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('custom')), 0.9280824661254883);
     expect(
       tester.getTopLeft(flying(tester, find.text('custom'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 684.459999084472656250 : 684.0,
+      const Offset(
+        684.459999084472656250,
         13.5,
       ),
     );
@@ -909,8 +909,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('custom')), 0.0);
     expect(
       tester.getTopLeft(flying(tester, find.text('custom'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 684.459999084472656250 : 684.0,
+      const Offset(
+        684.459999084472656250,
         13.5,
       ),
     );
@@ -941,8 +941,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 1')), 0.7952219992876053);
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 41.3003370761871337891 : 41.71033692359924,
+      const Offset(
+        41.3003370761871337891,
         13.5,
       ),
     );
@@ -951,8 +951,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 1')), 0.0);
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? -258.642192125320434570 : -258.2321922779083,
+      const Offset(
+        -258.642192125320434570,
         13.5,
       ),
     );
@@ -984,8 +984,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 1')), 0.7952219992876053);
     expect(
       tester.getTopRight(flying(tester, find.text('Page 1'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 758.699662923812866211 : 758.2896630764008,
+      const Offset(
+        758.699662923812866211,
         13.5,
       ),
     );
@@ -995,8 +995,8 @@ void main() {
     expect(
       tester.getTopRight(flying(tester, find.text('Page 1'))),
       // >1000. It's now off the screen.
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 1058.64219212532043457 : 1058.2321922779083,
+      const Offset(
+        1058.64219212532043457,
         13.5,
       ),
     );
@@ -1021,15 +1021,15 @@ void main() {
 
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).first),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 16.9155227761479522997 : 16.926069676876068,
+      const Offset(
+        16.9155227761479522997,
         52.73951627314091,
       ),
     );
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).last),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 16.9155227761479522997 : 16.926069676876068,
+      const Offset(
+        16.9155227761479522997,
         52.73951627314091,
       ),
     );
@@ -1040,15 +1040,15 @@ void main() {
 
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).first),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 43.6029094262710827934 : 43.92089730501175,
+      const Offset(
+        43.6029094262710827934,
         22.49655644595623,
       ),
     );
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 1')).last),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 43.6029094262710827934 : 43.92089730501175,
+      const Offset(
+        43.6029094262710827934,
         22.49655644595623,
       ),
     );
@@ -1072,15 +1072,15 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Back')), 0.0);
     expect(
       tester.getTopLeft(flying(tester, find.text('A title too long to fit'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 16.9155227761479522997 : 16.926069676876068,
+      const Offset(
+        16.9155227761479522997,
         52.73951627314091,
       ),
     );
     expect(
       tester.getTopLeft(flying(tester, find.text('Back'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 16.9155227761479522997 : 16.926069676876068,
+      const Offset(
+        16.9155227761479522997,
         52.73951627314091,
       ),
     );
@@ -1090,15 +1090,15 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Back')), 0.4604858811944723);
     expect(
       tester.getTopLeft(flying(tester, find.text('A title too long to fit'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 43.6029094262710827934 : 43.92089730501175,
+      const Offset(
+        43.6029094262710827934,
         22.49655644595623,
       ),
     );
     expect(
       tester.getTopLeft(flying(tester, find.text('Back'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 43.6029094262710827934 : 43.92089730501175,
+      const Offset(
+        43.6029094262710827934,
         22.49655644595623,
       ),
     );
@@ -1156,8 +1156,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 2')), 0.0);
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 739.940336465835571289 : 739.7103369235992,
+      const Offset(
+        739.940336465835571289,
         13.5,
       ),
     );
@@ -1167,8 +1167,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 2')), 0.29867843724787235);
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 504.880443334579467773 : 504.65044379234314,
+      const Offset(
+        504.880443334579467773,
         13.5,
       ),
     );
@@ -1212,8 +1212,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 2')), 0.0);
     expect(
       tester.getTopRight(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 60.0596635341644287109 : 60.28966307640076,
+      const Offset(
+        60.0596635341644287109,
         13.5,
       ),
     );
@@ -1223,8 +1223,8 @@ void main() {
     checkOpacity(tester, flying(tester, find.text('Page 2')), 0.29867843724787235);
     expect(
       tester.getTopRight(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 295.119556665420532227 : 295.34955620765686,
+      const Offset(
+        295.119556665420532227,
         13.5,
       ),
     );
@@ -1350,8 +1350,8 @@ void main() {
     // Page 2, which is the middle of the top route, start to fly back to the right.
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 353.810205429792404175 : 353.5802058875561,
+      const Offset(
+        353.810205429792404175,
         13.5,
       ),
     );
@@ -1368,16 +1368,16 @@ void main() {
     // Transition continues.
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 655.435583114624023438 : 655.2055835723877,
+      const Offset(
+        655.435583114624023438,
         13.5,
       ),
     );
     await tester.pump(const Duration(milliseconds: 50));
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 749.863556146621704102 : 749.6335566043854,
+      const Offset(
+        749.863556146621704102,
         13.5,
       ),
     );
@@ -1421,8 +1421,8 @@ void main() {
     // Page 2, which is the middle of the top route, start to fly back to the right.
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 353.810205429792404175 : 353.5802058875561,
+      const Offset(
+        353.810205429792404175,
         13.5,
       ),
     );
@@ -1433,16 +1433,16 @@ void main() {
     // Transition continues from the point we let off.
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 353.810205429792404175 : 353.5802058875561,
+      const Offset(
+        353.810205429792404175,
         13.5,
       ),
     );
     await tester.pump(const Duration(milliseconds: 50));
     expect(
       tester.getTopLeft(flying(tester, find.text('Page 2'))),
-      Offset(
-        ParagraphBuilder.shouldDisableRoundingHack ? 350.231143206357955933 : 350.0011436641216,
+      const Offset(
+        350.231143206357955933,
         13.5,
       ),
     );

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -583,7 +583,7 @@ void main() {
       tester.getTopLeft(find.text('Licenses')),
       const Offset(16.0 + safeareaPadding, 14.0 + safeareaPadding),
     );
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgetsWithLeakTracking('LicensePage returns early if unmounted', (WidgetTester tester) async {
     final Completer<LicenseEntry> licenseCompleter = Completer<LicenseEntry>();
@@ -1578,7 +1578,9 @@ void main() {
     // If the layout width is less than 840.0 pixels, nested layout is
     // used which positions license page title at the top center.
     Offset titleOffset = tester.getCenter(find.text(title));
-    expect(titleOffset, Offset(defaultSize.width / 2, 96.0));
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(titleOffset, Offset(defaultSize.width / 2, 96.0));
+    }
     expect(tester.getCenter(find.byType(ListView)), Offset(defaultSize.width / 2, 328.0));
 
     // Configure a wide window to show the lateral UI.
@@ -1708,7 +1710,9 @@ void main() {
     // If the layout width is less than 840.0 pixels, nested layout is
     // used which positions license page title at the top center.
     Offset titleOffset = tester.getCenter(find.text(title));
-    expect(titleOffset, Offset(defaultSize.width / 2, 96.0));
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(titleOffset, Offset(defaultSize.width / 2, 96.0));
+    }
     expect(tester.getCenter(find.byType(ListView)), Offset(defaultSize.width / 2, 328.0));
 
     // Configure a wide window to show the lateral UI.

--- a/packages/flutter/test/material/action_chip_test.dart
+++ b/packages/flutter/test/material/action_chip_test.dart
@@ -84,7 +84,10 @@ void main() {
     );
 
     // Test default chip size.
-    expect(tester.getSize(find.byType(ActionChip)), const Size(190.0, 48.0));
+    expect(
+      tester.getSize(find.byType(ActionChip)),
+      within<Size>(distance: 0.01, from: const Size(189.1, 48.0)),
+    );
     // Test default label style.
     expect(
       getLabelStyle(tester, label).style.color!.value,
@@ -155,7 +158,10 @@ void main() {
     );
 
     // Test default chip size.
-    expect(tester.getSize(find.byType(ActionChip)), const Size(190.0, 48.0));
+    expect(
+      tester.getSize(find.byType(ActionChip)),
+      within<Size>(distance: 0.01, from: const Size(189.1, 48.0)),
+    );
     // Test default label style.
     expect(
       getLabelStyle(tester, label).style.color!.value,

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1280,7 +1280,9 @@ void main() {
     // Test the expanded title is positioned correctly.
     final Offset titleOffset = tester.getBottomLeft(expandedTitle);
     expect(titleOffset.dx, 16.0);
-    expect(titleOffset.dy, 96.0);
+    if (!kIsWeb || isCanvasKit) {
+      expect(titleOffset.dy, 96.0);
+    }
 
     _verifyTextNotClipped(expandedTitle, tester);
 
@@ -5191,7 +5193,7 @@ void main() {
     await tester.pumpWidget(buildAppBar(textScaleFactor: 3.0));
     expect(tester.getRect(expandedTitle).height, 43.0);
     _verifyTextNotClipped(expandedTitle, tester);
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgets('SliverAppBar.large expanded title has upper limit on text scaling', (WidgetTester tester) async {
     const String title = 'Large AppBar';
@@ -5221,22 +5223,15 @@ void main() {
 
     await tester.pumpWidget(buildAppBar());
 
-    // TODO(tahatesser): https://github.com/flutter/flutter/issues/99933
-    // A bug in the HTML renderer and/or Chrome 96+ causes a
-    // discrepancy in the paragraph height.
-    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
     final Finder expandedTitle = find.text(title).first;
-    expect(
-      tester.getRect(expandedTitle).height,
-      closeTo( hasIssue99933 ? 37.0 : 36.0, 0.1),
-    );
+    expect(tester.getRect(expandedTitle).height, 36.0);
 
     await tester.pumpWidget(buildAppBar(textScaleFactor: 2.0));
     expect(tester.getRect(expandedTitle).height, closeTo(48.0, 0.1));
 
     await tester.pumpWidget(buildAppBar(textScaleFactor: 3.0));
     expect(tester.getRect(expandedTitle).height, closeTo(48.0, 0.1));
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgets('SliverAppBar.medium expanded title position is adjusted with textScaleFactor', (WidgetTester tester) async {
     const String title = 'Medium AppBar';
@@ -5277,7 +5272,7 @@ void main() {
     await tester.pumpWidget(buildAppBar(textScaleFactor: 3.0));
     expect(tester.getBottomLeft(expandedTitle).dy, 107.0);
     _verifyTextNotClipped(expandedTitle, tester);
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgets('SliverAppBar.large expanded title position is adjusted with textScaleFactor', (WidgetTester tester) async {
     const String title = 'Large AppBar';

--- a/packages/flutter/test/material/badge_test.dart
+++ b/packages/flutter/test/material/badge_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -49,12 +48,12 @@ void main() {
     expect(tester.getSize(find.byType(Badge)), const Size(24, 24)); // default Icon size
     expect(tester.getTopLeft(find.byType(Badge)), Offset.zero);
 
-    expect(tester.getTopLeft(find.text('0')), const Offset(16, -4));
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(tester.getTopLeft(find.text('0')), const Offset(16, -4));
+    }
 
     final RenderBox box = tester.renderObject(find.byType(Badge));
-    final RRect rrect = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? RRect.fromLTRBR(12, -4, 31.5, 12, const Radius.circular(8))
-      : RRect.fromLTRBR(12, -4, 32, 12, const Radius.circular(8));
+    final RRect rrect = RRect.fromLTRBR(12, -4, 31.5, 12, const Radius.circular(8));
     expect(box, paints..rrect(rrect: rrect, color: theme.colorScheme.error));
   });
 
@@ -91,12 +90,12 @@ void main() {
     expect(tester.getSize(find.byType(Badge)), const Size(24, 24)); // default Icon size
     expect(tester.getTopLeft(find.byType(Badge)), Offset.zero);
 
-    expect(tester.getTopLeft(find.text('0')), const Offset(0, -4));
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(tester.getTopLeft(find.text('0')), const Offset(0, -4));
+    }
 
     final RenderBox box = tester.renderObject(find.byType(Badge));
-    final RRect rrect = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? RRect.fromLTRBR(-4, -4, 15.5, 12, const Radius.circular(8))
-      : RRect.fromLTRBR(-4, -4, 16, 12, const Radius.circular(8));
+    final RRect rrect = RRect.fromLTRBR(-4, -4, 15.5, 12, const Radius.circular(8));
     expect(box, paints..rrect(rrect: rrect, color: theme.colorScheme.error));
   });
 
@@ -143,7 +142,9 @@ void main() {
 
     // x = alignment.start + padding.left
     // y = alignment.top
-    expect(tester.getTopLeft(find.text('0')), const Offset(16, -4));
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(tester.getTopLeft(find.text('0')), const Offset(16, -4));
+    }
 
     final RenderBox box = tester.renderObject(find.byType(Badge));
     // '0'.width = 12
@@ -151,9 +152,7 @@ void main() {
     // T = alignment.top
     // R = L + '0'.width + padding.width
     // B = T + largeSize, R = largeSize/2
-    final RRect rrect = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? RRect.fromLTRBR(12, -4, 31.5, 12, const Radius.circular(8))
-      : RRect.fromLTRBR(12, -4, 32, 12, const Radius.circular(8));
+    final RRect rrect = RRect.fromLTRBR(12, -4, 31.5, 12, const Radius.circular(8));
     expect(box, paints..rrect(rrect: rrect, color: theme.colorScheme.error));
 
     await tester.pumpWidget(buildFrame(1000));

--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -600,7 +600,7 @@ void main() {
 
     final Offset actionsTopLeft = tester.getTopLeft(find.byType(OverflowBar));
     final Offset bannerTopLeft = tester.getTopLeft(find.byType(MaterialBanner));
-    expect(actionsTopLeft.dx - 8, bannerTopLeft.dx); // actions OverflowBar is padded by 8
+    expect(actionsTopLeft.dx - 8, moreOrLessEquals(bannerTopLeft.dx)); // actions OverflowBar is padded by 8
   });
 
   testWidgetsWithLeakTracking('Single action laid out beside content but aligned to the trailing edge when presented by ScaffoldMessenger - RTL', (WidgetTester tester) async {
@@ -640,7 +640,7 @@ void main() {
 
     final Offset actionsTopLeft = tester.getTopLeft(find.byType(OverflowBar));
     final Offset bannerTopLeft = tester.getTopLeft(find.byType(MaterialBanner));
-    expect(actionsTopLeft.dx - 8, bannerTopLeft.dx); // actions OverflowBar is padded by 8
+    expect(actionsTopLeft.dx - 8, moreOrLessEquals(bannerTopLeft.dx)); // actions OverflowBar is padded by 8
   });
 
   testWidgetsWithLeakTracking('Actions laid out below content if forced override', (WidgetTester tester) async {

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -3499,7 +3499,7 @@ void main() {
     expect(calledDelete, isFalse);
 
     // Tap after end of the label.
-    await tester.tapAt(Offset(labelCenter.dx + (labelSize.width / 2), labelCenter.dy));
+    await tester.tapAt(Offset(labelCenter.dx + (labelSize.width / 2) + 0.01, labelCenter.dy));
     await tester.pump();
     expect(calledDelete, isTrue);
   });

--- a/packages/flutter/test/material/choice_chip_test.dart
+++ b/packages/flutter/test/material/choice_chip_test.dart
@@ -85,7 +85,10 @@ void main() {
     );
 
     // Test default chip size.
-    expect(tester.getSize(find.byType(ChoiceChip)), const Size(190.0, 48.0));
+    expect(
+      tester.getSize(find.byType(ChoiceChip)),
+      within(distance: 0.01, from: const Size(189.1, 48.0)),
+    );
     // Test default label style.
     expect(
       getLabelStyle(tester, label).style.color!.value,
@@ -217,7 +220,10 @@ void main() {
     );
 
     // Test default chip size.
-    expect(tester.getSize(find.byType(ChoiceChip)), const Size(190.0, 48.0));
+    expect(
+      tester.getSize(find.byType(ChoiceChip)),
+      within(distance: 0.01, from: const Size(189.1, 48.0)),
+    );
     // Test default label style.
     expect(
       getLabelStyle(tester, label).style.color!.value,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -330,7 +330,7 @@ void main() {
       // We expect the left edge of the 'OK' button in the RTL
       // layout to match the gap between right edge of the 'OK'
       // button and the right edge of the 800 wide view.
-      expect(tester.getBottomLeft(find.text('OK')).dx, 800 - ltrOkRight);
+      expect(tester.getBottomLeft(find.text('OK')).dx, moreOrLessEquals(800 - ltrOkRight));
     });
 
     group('Barrier dismissible', () {
@@ -876,11 +876,9 @@ void main() {
       final Offset subHeaderTextTopLeft = tester.getTopLeft(subHeaderText);
       final Offset dividerTopRight = tester.getTopRight(divider);
       expect(subHeaderTextTopLeft.dx, dividerTopRight.dx + 24.0);
-      // TODO(tahatesser): https://github.com/flutter/flutter/issues/99933
-      // A bug in the HTML renderer and/or Chrome 96+ causes a
-      // discrepancy in the paragraph height.
-      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-      expect(subHeaderTextTopLeft.dy,  dialogTopLeft.dy + 16.0 - (hasIssue99933 ? 0.5 : 0.0));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(subHeaderTextTopLeft.dy,  dialogTopLeft.dy + 16.0);
+      }
 
       // Test sub header icon position.
       final Finder subHeaderIcon = find.byIcon(Icons.arrow_drop_down);
@@ -894,7 +892,9 @@ void main() {
       final Offset calendarPageViewTopLeft = tester.getTopLeft(calendarPageView);
       final Offset subHeaderTextBottomLeft = tester.getBottomLeft(subHeaderText);
       expect(calendarPageViewTopLeft.dx, dividerTopRight.dx);
-      expect(calendarPageViewTopLeft.dy, subHeaderTextBottomLeft.dy + 16.0 - (hasIssue99933 ? 0.5 : 0.0));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(calendarPageViewTopLeft.dy, subHeaderTextBottomLeft.dy + 16.0);
+      }
 
       // Test month navigation icons position.
       final Finder previousMonthButton = find.widgetWithIcon(IconButton, Icons.chevron_left);
@@ -954,11 +954,9 @@ void main() {
       final Offset headerTextTextTopLeft = tester.getTopLeft(headerText);
       final Offset helpTextBottomLeft = tester.getBottomLeft(helpText);
       expect(headerTextTextTopLeft.dx, dialogTopLeft.dx + 24.0);
-      // TODO(tahatesser): https://github.com/flutter/flutter/issues/99933
-      // A bug in the HTML renderer and/or Chrome 96+ causes a
-      // discrepancy in the paragraph height.
-      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-      expect(headerTextTextTopLeft.dy, helpTextBottomLeft.dy + 28.0 - (hasIssue99933 ? 1.0 : 0.0));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(headerTextTextTopLeft.dy, helpTextBottomLeft.dy + 28.0);
+      }
 
       // Test switch button position.
       final Finder switchButtonM3 = find.widgetWithIcon(IconButton, Icons.edit_outlined);
@@ -978,7 +976,9 @@ void main() {
       final Offset subHeaderTextTopLeft = tester.getTopLeft(subHeaderText);
       final Offset dividerBottomLeft = tester.getBottomLeft(divider);
       expect(subHeaderTextTopLeft.dx, dialogTopLeft.dx + 24.0);
-      expect(subHeaderTextTopLeft.dy, dividerBottomLeft.dy + 16.0 - (hasIssue99933 ? 0.5 : 0.0));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(subHeaderTextTopLeft.dy, dividerBottomLeft.dy + 16.0);
+      }
 
       // Test sub header icon position.
       final Finder subHeaderIcon = find.byIcon(Icons.arrow_drop_down);
@@ -1001,7 +1001,9 @@ void main() {
       final Offset calendarPageViewTopLeft = tester.getTopLeft(calendarPageView);
       final Offset subHeaderTextBottomLeft = tester.getBottomLeft(subHeaderText);
       expect(calendarPageViewTopLeft.dx, dialogTopLeft.dx);
-      expect(calendarPageViewTopLeft.dy, subHeaderTextBottomLeft.dy + 16.0 - (hasIssue99933 ? 0.5 : 0.0));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(calendarPageViewTopLeft.dy, subHeaderTextBottomLeft.dy + 16.0);
+      }
 
       // Test action buttons position.
       final Offset dialogBottomRight = tester.getBottomRight(find.byType(AnimatedContainer));

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -133,22 +133,21 @@ void main() {
       final Offset entryButtonBottomLeft = tester.getBottomLeft(
         find.widgetWithIcon(IconButton, Icons.edit_outlined),
       );
-      expect(
-        saveButtonBottomLeft.dx,
-        ParagraphBuilder.shouldDisableRoundingHack ? moreOrLessEquals(711.6, epsilon: 1e-5) : (800 - 89.0),
-      );
-      expect(saveButtonBottomLeft.dy, helpTextTopLeft.dy);
+      expect(saveButtonBottomLeft.dx, moreOrLessEquals(711.6, epsilon: 1e-5));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(saveButtonBottomLeft.dy, helpTextTopLeft.dy);
+      }
       expect(entryButtonBottomLeft.dx, saveButtonBottomLeft.dx - 48.0);
-      expect(entryButtonBottomLeft.dy, helpTextTopLeft.dy);
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(entryButtonBottomLeft.dy, helpTextTopLeft.dy);
+      }
 
       // Test help text position.
       final Offset helpTextBottomLeft = tester.getBottomLeft(helpText);
       expect(helpTextBottomLeft.dx, 72.0);
-      // TODO(tahatesser): https://github.com/flutter/flutter/issues/99933
-      // A bug in the HTML renderer and/or Chrome 96+ causes a
-      // discrepancy in the paragraph height.
-      const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-      expect(helpTextBottomLeft.dy, closeButtonBottomRight.dy + 20.0 + (hasIssue99933 ? 1.0 : 0.0));
+      if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+        expect(helpTextBottomLeft.dy, closeButtonBottomRight.dy + 20.0);
+      }
 
       // Test the header position.
       final Offset firstDateHeaderTopLeft = tester.getTopLeft(firstDateHeaderText);

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -7,6 +7,7 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -186,7 +187,9 @@ void main() {
       find.descendant(of: find.byType(Dialog), matching: find.byType(Material)),
     );
     expect(bottomLeft.dx, 480.0);
-    expect(bottomLeft.dy, 124.0);
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(bottomLeft.dy, 124.0);
+    }
   });
 
   testWidgets('Material2 - Dialog alignment takes priority over theme', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -5,7 +5,6 @@
 
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -146,8 +145,8 @@ void main() {
     await tester.pumpWidget(buildTest(themeData, menuChildren, width: 200.0));
 
     final Finder anchor = find.byType(TextField);
-    final Size size = tester.getSize(anchor);
-    expect(size, const Size(200.0, 56.0));
+    final double width = tester.getSize(anchor).width;
+    expect(width, 200.0);
 
     await tester.tap(anchor);
     await tester.pumpAndSettle();
@@ -156,8 +155,8 @@ void main() {
       of: find.byType(SingleChildScrollView),
       matching: find.byType(Material),
     );
-    final Size updatedMenuSize = tester.getSize(updatedMenu);
-    expect(updatedMenuSize, const Size(200.0, 304.0));
+    final double updatedMenuWidth = tester.getSize(updatedMenu).width;
+    expect(updatedMenuWidth, 200.0);
   });
 
   testWidgets('Material3 - The width of the text field should always be the same as the menu view',
@@ -177,12 +176,8 @@ void main() {
     );
 
     final Finder textField = find.byType(TextField);
-    final Size anchorSize = tester.getSize(textField);
-    if (kIsWeb && !isCanvasKit) {
-      expect(anchorSize, const Size(195.0, 61.0));
-    } else {
-      expect(anchorSize, const Size(195.0, 60.0));
-    }
+    final double anchorWidth = tester.getSize(textField).width;
+    expect(anchorWidth, 195.0);
 
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
@@ -191,20 +186,16 @@ void main() {
       of: find.byType(SingleChildScrollView),
       matching: find.byType(Material),
     );
-    final Size menuSize = tester.getSize(menuMaterial);
-    expect(menuSize, const Size(195.0, 304.0));
+    final double menuWidth = tester.getSize(menuMaterial).width;
+    expect(menuWidth, 195.0);
 
     // The text field should have same width as the menu
     // when the width property is not null.
     await tester.pumpWidget(buildTest(themeData, menuChildren, width: 200.0));
 
     final Finder anchor = find.byType(TextField);
-    final Size size = tester.getSize(anchor);
-    if (kIsWeb && !isCanvasKit) {
-      expect(size, const Size(200.0, 61.0));
-    } else {
-      expect(size, const Size(200.0, 60.0));
-    }
+    final double width = tester.getSize(anchor).width;
+    expect(width, 200.0);
 
     await tester.tap(anchor);
     await tester.pumpAndSettle();
@@ -213,8 +204,8 @@ void main() {
       of: find.byType(SingleChildScrollView),
       matching: find.byType(Material),
     );
-    final Size updatedMenuSize = tester.getSize(updatedMenu);
-    expect(updatedMenuSize, const Size(200.0, 304.0));
+    final double updatedMenuWidth = tester.getSize(updatedMenu).width;
+    expect(updatedMenuWidth, 200.0);
   });
 
   testWidgets('The width property can customize the width of the dropdown menu', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -3346,7 +3346,7 @@ void main() {
     // Should be center-center aligned, the icon size is 24.0 pixels.
     expect(
       buttonBox.localToGlobal(Offset((buttonBox.size.width -24.0) / 2.0, buttonBox.size.height / 2.0)),
-      selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)),
+      offsetMoreOrLessEquals(selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0))),
     );
 
     // Open dropdown.
@@ -3362,10 +3362,10 @@ void main() {
       Offset(selectedItemBoxInMenu.size.width / 2.0, selectedItemBoxInMenu.size.height / 2.0)
     );
 
-    expect(center.dx, menuRect.topCenter.dx,);
+    expect(center.dx, moreOrLessEquals(menuRect.topCenter.dx));
     expect(
       center.dy,
-      selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)).dy,
+      moreOrLessEquals(selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)).dy),
     );
   });
 

--- a/packages/flutter/test/material/filter_chip_test.dart
+++ b/packages/flutter/test/material/filter_chip_test.dart
@@ -135,7 +135,10 @@ void main() {
     );
 
     // Test default chip size.
-    expect(tester.getSize(find.byType(FilterChip)), const Size(190.0, 48.0));
+    expect(
+      tester.getSize(find.byType(FilterChip)),
+      within(distance: 0.001, from: const Size(189.1, 48.0)),
+    );
     // Test default label style.
     expect(
       getLabelStyle(tester, label).style.color!.value,
@@ -267,7 +270,10 @@ void main() {
     );
 
     // Test default chip size.
-    expect(tester.getSize(find.byType(FilterChip)), const Size(190.0, 48.0));
+    expect(
+      tester.getSize(find.byType(FilterChip)),
+      within(distance: 0.001, from: const Size(189.1, 48.0)),
+    );
     // Test default label style.
     expect(
       getLabelStyle(tester, 'filter chip').style.color!.value,

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -7,8 +7,6 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -473,9 +471,7 @@ void main() {
       ),
     );
 
-    final double textWidth = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? width
-      : (width / 1.5).floorToDouble() * 1.5;
+    final double textWidth = width;
     // The title is scaled and transformed to be 1.5 times bigger, when the
     // FlexibleSpaceBar is fully expanded, thus we expect the width to be
     // 1.5 times smaller than the full width. The height of the text is the same
@@ -544,9 +540,7 @@ void main() {
     // bottom edge.
     const double bottomMargin = titleFontSize * (expandedTitleScale - 1);
 
-    final double textWidth = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? collapsedWidth
-      : (collapsedWidth / 3).floorToDouble() * 3;
+    final double textWidth = collapsedWidth;
     // The title is scaled and transformed to be 3 times bigger, when the
     // FlexibleSpaceBar is fully expanded, thus we expect the width to be
     // 3 times smaller than the full width. The height of the text is the same

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5930,10 +5930,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
         }
         final Rect clipRect = arguments[0] as Rect;
         // _kFinalLabelScale = 0.75
-        final double width = ParagraphBuilder.shouldDisableRoundingHack
-          ? 100 / 0.75
-          : 133.0;
-        expect(clipRect, rectMoreOrLessEquals(Rect.fromLTWH(0, 0, width, 16.0), epsilon: 1e-5));
+        expect(clipRect, rectMoreOrLessEquals(const Rect.fromLTWH(0, 0, 100 / 0.75, 16.0), epsilon: 1e-5));
         return true;
       }),
     );

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -156,22 +156,24 @@ void main() {
     await tester.pumpWidget(buildFrame(isTwoLine: true, textScaleFactor: 4.0));
     testChildren();
     testHorizontalGeometry();
-    // TODO(tahatesser): https://github.com/flutter/flutter/issues/99933
-    //                A bug in the HTML renderer and/or Chrome 96+ causes a
-    //                discrepancy in the paragraph height.
-    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-    testVerticalGeometry(hasIssue99933 ? 193 : 192.0);
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      testVerticalGeometry(192.0);
+    }
 
     // Make sure that the height of a large subtitle is taken into account.
     await tester.pumpWidget(buildFrame(isTwoLine: true, textScaleFactor: 0.5, subtitleScaleFactor: 4.0));
     testChildren();
     testHorizontalGeometry();
-    testVerticalGeometry(hasIssue99933 ? 109 : 108.0);
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      testVerticalGeometry(108.0);
+    }
 
     await tester.pumpWidget(buildFrame(isThreeLine: true, textScaleFactor: 4.0));
     testChildren();
     testHorizontalGeometry();
-    testVerticalGeometry(hasIssue99933 ? 193 : 192.0);
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      testVerticalGeometry(192.0);
+    }
   });
 
   testWidgetsWithLeakTracking('ListTile geometry (RTL)', (WidgetTester tester) async {
@@ -504,13 +506,13 @@ void main() {
         ),
       ),
     );
-    // TODO(tahatesser): https://github.com/flutter/flutter/issues/99933
-    //                A bug in the HTML renderer and/or Chrome 96+ causes a
-    //                discrepancy in the paragraph height.
-    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-    const double height = hasIssue99933 ? 301.0 : 300;
-    const double avatarTop = hasIssue99933 ? 130.5 : 130.0;
-    const double placeholderTop = hasIssue99933 ? 138.5 : 138.0;
+
+    if (kIsWeb && !isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      return;
+    }
+    const double height = 300;
+    const double avatarTop = 130.0;
+    const double placeholderTop = 138.0;
     //                                                                          LEFT                 TOP          WIDTH  HEIGHT
     expect(tester.getRect(find.byType(ListTile).at(0)),     const Rect.fromLTWH(                0.0,            0.0, 800.0, height));
     expect(tester.getRect(find.byType(CircleAvatar).at(0)), const Rect.fromLTWH(               16.0,      avatarTop,  40.0,  40.0));

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -411,10 +411,8 @@ void main() {
     await tester.longPress(find.text(label));
     expect(find.text(label), findsNWidgets(2));
 
-    if (kIsWeb && !isCanvasKit) {
-      expect(tester.getSize(find.text(label).last), const Size(15.0, 21.0));
-    } else {
-      expect(tester.getSize(find.text(label).last), const Size(15.0, 20.0));
+    if (!kIsWeb || isCanvasKit) {
+      expect(tester.getSize(find.text(label).last), const Size(14.25, 20.0));
     }
     // The duration is needed to ensure the tooltip disappears.
     await tester.pumpAndSettle(const Duration(seconds: 2));
@@ -423,10 +421,8 @@ void main() {
     expect(find.text(label), findsOneWidget);
     await tester.longPress(find.text(label));
 
-    if (kIsWeb && !isCanvasKit) {
-      expect(tester.getSize(find.text(label).last), const Size(57.0, 81.0));
-    } else {
-      expect(tester.getSize(find.text(label).last), const Size(57.0, 80.0));
+    if (!kIsWeb || isCanvasKit) {
+      expect(tester.getSize(find.text(label).last), const Size(56.25, 80.0));
     }
   });
 
@@ -831,7 +827,7 @@ void main() {
           color: const Color(0x0a000000),
         )
     );
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgetsWithLeakTracking('Material3 - Navigation indicator ripple golden test', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/117420.

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -544,48 +542,54 @@ void main() {
     // The second destination is below the first with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox secondIconRenderBox = _iconRenderBox(tester, Icons.bookmark_border);
-    expect(
-      secondIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - secondIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        secondIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - secondIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The third destination is below the second with some spacing.
     nextDestinationY += destinationHeight + destinationSpacing;
     final RenderBox thirdIconRenderBox = _iconRenderBox(tester, Icons.star_border);
-    expect(
-      thirdIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        thirdIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The fourth destination is below the third with some spacing.
     nextDestinationY += destinationHeight + destinationSpacing;
     final RenderBox fourthIconRenderBox = _iconRenderBox(tester, Icons.hotel);
-    expect(
-      fourthIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        fourthIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=selected, [textScaleFactor]=3.0', (WidgetTester tester) async {
     // Padding at the top of the rail.
     const double topPadding = 8.0;
     // Width of a destination.
-    final double destinationWidth = ui.ParagraphBuilder.shouldDisableRoundingHack ? 125.5 : 126.0;
+    const double destinationWidth = 125.5;
     // Height of a destination indicator with icon.
     const double destinationHeight = 32.0;
     // Space between the indicator and label.
@@ -636,41 +640,47 @@ void main() {
     // The second destination is below the first with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox secondIconRenderBox = _iconRenderBox(tester, Icons.bookmark_border);
-    expect(
-      secondIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - secondIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        secondIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - secondIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The third destination is below the second with some spacing.
     nextDestinationY += destinationHeight + destinationSpacing;
     final RenderBox thirdIconRenderBox = _iconRenderBox(tester, Icons.star_border);
-    expect(
-      thirdIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        thirdIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The fourth destination is below the third with some spacing.
     nextDestinationY += destinationHeight + destinationSpacing;
     final RenderBox fourthIconRenderBox = _iconRenderBox(tester, Icons.hotel);
-    expect(
-      fourthIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        fourthIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=selected, [textScaleFactor]=0.75', (WidgetTester tester) async {
@@ -728,41 +738,47 @@ void main() {
     // The second destination is below the first with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox secondIconRenderBox = _iconRenderBox(tester, Icons.bookmark_border);
-    expect(
-      secondIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - secondIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        secondIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - secondIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The third destination is below the second with some spacing.
     nextDestinationY += destinationHeight + destinationSpacing;
     final RenderBox thirdIconRenderBox = _iconRenderBox(tester, Icons.star_border);
-    expect(
-      thirdIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        thirdIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The fourth destination is below the third with some spacing.
     nextDestinationY += destinationHeight + destinationSpacing;
     final RenderBox fourthIconRenderBox = _iconRenderBox(tester, Icons.hotel);
-    expect(
-      fourthIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        fourthIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=all, [textScaleFactor]=1.0 (default)', (WidgetTester tester) async {
@@ -819,48 +835,54 @@ void main() {
     // The second destination is below the first with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox secondIconRenderBox = _iconRenderBox(tester, Icons.bookmark_border);
-    expect(
-      secondIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - secondIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        secondIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - secondIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The third destination is below the second with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox thirdIconRenderBox = _iconRenderBox(tester, Icons.star_border);
-    expect(
-      thirdIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        thirdIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The fourth destination is below the third with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox fourthIconRenderBox = _iconRenderBox(tester, Icons.hotel);
-    expect(
-      fourthIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        fourthIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=all, [textScaleFactor]=3.0', (WidgetTester tester) async {
     // Padding at the top of the rail.
     const double topPadding = 8.0;
     // Width of a destination.
-    final double destinationWidth = ui.ParagraphBuilder.shouldDisableRoundingHack ? 125.5 : 126.0;
+    const double destinationWidth = 125.5;
     // Height of a destination indicator with icon.
     const double destinationHeight = 32.0;
     // Space between the indicator and label.
@@ -911,41 +933,47 @@ void main() {
     // The second destination is below the first with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox secondIconRenderBox = _iconRenderBox(tester, Icons.bookmark_border);
-    expect(
-      secondIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - secondIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        secondIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - secondIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The third destination is below the second with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox thirdIconRenderBox = _iconRenderBox(tester, Icons.star_border);
-    expect(
-      thirdIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        thirdIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The fourth destination is below the third with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox fourthIconRenderBox = _iconRenderBox(tester, Icons.hotel);
-    expect(
-      fourthIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        fourthIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=all, [textScaleFactor]=0.75', (WidgetTester tester) async {
@@ -1003,41 +1031,47 @@ void main() {
     // The second destination is below the first with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox secondIconRenderBox = _iconRenderBox(tester, Icons.bookmark_border);
-    expect(
-      secondIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - secondIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        secondIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - secondIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - secondIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The third destination is below the second with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox thirdIconRenderBox = _iconRenderBox(tester, Icons.star_border);
-    expect(
-      thirdIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        thirdIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - thirdIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - thirdIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     // The fourth destination is below the third with some spacing.
     nextDestinationY += destinationHeightWithLabel + destinationSpacing;
     final RenderBox fourthIconRenderBox = _iconRenderBox(tester, Icons.hotel);
-    expect(
-      fourthIconRenderBox.localToGlobal(Offset.zero),
-      equals(
-        Offset(
-          (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
-          nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(
+        fourthIconRenderBox.localToGlobal(Offset.zero),
+        equals(
+          Offset(
+            (destinationWidth - fourthIconRenderBox.size.width) / 2.0,
+            nextDestinationY + (destinationHeight - fourthIconRenderBox.size.height) / 2.0,
+          ),
         ),
-      ),
-    );
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('Destination spacing is correct for a compact rail - [preferredWidth]=56, [textScaleFactor]=1.0 (default)', (WidgetTester tester) async {
@@ -2790,7 +2824,7 @@ void main() {
           color: const Color(0xffe8def8),
         ),
     );
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgetsWithLeakTracking('NavigationRail indicator renders ripple - extended', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/117126
@@ -3123,7 +3157,7 @@ void main() {
           color: const Color(0xffe8def8),
         ),
     );
-  });
+  }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
   testWidgetsWithLeakTracking('NavigationRail indicator scale transform', (WidgetTester tester) async {
     int selectedIndex = 0;
@@ -3371,7 +3405,7 @@ void main() {
           ),
         ),
       );
-    });
+    }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
     testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=none (default), [textScaleFactor]=3.0', (WidgetTester tester) async {
       // Since the rail is icon only, its destinations should not be affected by
@@ -3441,7 +3475,7 @@ void main() {
           ),
         ),
       );
-    });
+    }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
     testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=none (default), [textScaleFactor]=0.75', (WidgetTester tester) async {
       // Since the rail is icon only, its destinations should not be affected by
@@ -3511,7 +3545,7 @@ void main() {
           ),
         ),
       );
-    });
+    }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/99933
 
     testWidgetsWithLeakTracking('Destination spacing is correct - [labelType]=selected, [textScaleFactor]=1.0 (default)', (WidgetTester tester) async {
       await _pumpNavigationRail(

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -1068,10 +1066,7 @@ void main() {
     );
 
     expect(tester.getSize(find.byType(OutlinedButton)), equals(const Size(88.0, 48.0)));
-    expect(tester.getSize(find.byType(Text)), Size(
-      ui.ParagraphBuilder.shouldDisableRoundingHack ? 52.5 : 53.0,
-      18.0,
-    ));
+    expect(tester.getSize(find.byType(Text)), const Size(52.5, 18.0));
 
     // Set text scale large enough to expand text and button.
     await tester.pumpWidget(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2788,11 +2788,9 @@ void main() {
     await expectLater(find.byType(MaterialApp), matchesGoldenFile('m3_snack_bar.scaffold.nested.png'));
     final Offset snackBarTopRight = tester.getTopRight(find.byType(SnackBar));
 
-    // TODO(bleroux): https://github.com/flutter/flutter/issues/99933
-    // A bug in the HTML renderer and/or Chrome 96+ causes a
-    // discrepancy in the paragraph height.
-    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
-    expect(snackBarTopRight.dy, hasIssue99933 ? 464.0 : 465.0);
+    if (!kIsWeb || isCanvasKit) { // https://github.com/flutter/flutter/issues/99933
+      expect(snackBarTopRight.dy, 465.0);
+    }
   });
 
 

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -968,17 +968,23 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
 
     const String continueStr = 'Continue';
     const String cancelStr = 'Cancel';
-    const Rect continueButtonRect = Rect.fromLTRB(24.0, 212.0, 169.0, 260.0);
-    const Rect cancelButtonRect = Rect.fromLTRB(177.0, 212.0, 294.0, 260.0);
+    const Rect continueButtonRect = Rect.fromLTRB(24.0, 212.0, 168.8, 260.0);
+    const Rect cancelButtonRect = Rect.fromLTRB(176.8, 212.0, 293.4, 260.0);
     expect(buttonMaterial(continueStr).color!.value, themeLight.colorScheme.primary.value);
     expect(buttonMaterial(continueStr).textStyle!.color!.value, 0xffffffff);
     expect(buttonMaterial(continueStr).shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, continueStr)), continueButtonRect);
+    expect(
+      tester.getRect(find.widgetWithText(TextButton, continueStr)),
+      rectMoreOrLessEquals(continueButtonRect, epsilon: 0.001),
+    );
 
     expect(buttonMaterial(cancelStr).color!.value, 0);
     expect(buttonMaterial(cancelStr).textStyle!.color!.value, 0x8a000000);
     expect(buttonMaterial(cancelStr).shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, cancelStr)), cancelButtonRect);
+    expect(
+      tester.getRect(find.widgetWithText(TextButton, cancelStr)),
+      rectMoreOrLessEquals(cancelButtonRect, epsilon: 0.001),
+    );
 
     final ThemeData themeDark = ThemeData.dark(useMaterial3: true);
     await tester.pumpWidget(buildFrame(themeDark));
@@ -987,12 +993,18 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     expect(buttonMaterial(continueStr).color!.value, 0);
     expect(buttonMaterial(continueStr).textStyle!.color!.value, themeDark.colorScheme.onSurface.value);
     expect(buttonMaterial(continueStr).shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, continueStr)), continueButtonRect);
+    expect(
+      tester.getRect(find.widgetWithText(TextButton, continueStr)),
+      rectMoreOrLessEquals(continueButtonRect, epsilon: 0.001),
+    );
 
     expect(buttonMaterial(cancelStr).color!.value, 0);
     expect(buttonMaterial(cancelStr).textStyle!.color!.value, 0xb3ffffff);
     expect(buttonMaterial(cancelStr).shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, cancelStr)), cancelButtonRect);
+    expect(
+      tester.getRect(find.widgetWithText(TextButton, cancelStr)),
+      rectMoreOrLessEquals(cancelButtonRect, epsilon: 0.001),
+    );
   });
 
   testWidgets('Material2 - Stepper disabled button styles', (WidgetTester tester) async {

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -7,8 +7,6 @@
 @Tags(<String>['reduced-test-set'])
 library;
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -675,8 +673,8 @@ void main() {
         ..line(
           color: theme.colorScheme.primary,
           strokeWidth: indicatorWeight,
-          p1: Offset(ui.ParagraphBuilder.shouldDisableRoundingHack ? 65.75 : 65.5, indicatorY),
-          p2: Offset(ui.ParagraphBuilder.shouldDisableRoundingHack ? 134.25 : 134.5, indicatorY),
+          p1: const Offset(65.75, indicatorY),
+          p2: const Offset(134.25, indicatorY),
         ),
     );
   });

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -328,7 +326,10 @@ void main() {
       MaterialApp(theme: theme, home: const Center(child: Material(child: Tab(text: 'x')))),
     );
     expect(tester.renderObject<RenderParagraph>(find.byType(RichText)).text.style!.fontFamily, 'FlutterTest');
-    expect(tester.getSize(find.byType(Tab)), material3 ? const Size(15.0, 46.0) : const Size(14.0, 46.0));
+    expect(
+      tester.getSize(find.byType(Tab)),
+      material3 ? const Size(14.25, 46.0) : const Size(14.0, 46.0),
+    );
   });
 
   testWidgets('Tab sizing - icon and text', (WidgetTester tester) async {
@@ -338,7 +339,9 @@ void main() {
       MaterialApp(theme: theme, home: const Center(child: Material(child: Tab(icon: SizedBox(width: 10.0, height: 10.0), text: 'x')))),
     );
     expect(tester.renderObject<RenderParagraph>(find.byType(RichText)).text.style!.fontFamily, 'FlutterTest');
-    expect(tester.getSize(find.byType(Tab)), material3 ? const Size(15.0, 72.0) : const Size(14.0, 72.0));
+    expect(
+      tester.getSize(find.byType(Tab)),
+      material3 ? const Size(14.25, 72.0) : const Size(14.0, 72.0));
   });
 
   testWidgets('Tab sizing - icon, iconMargin and text', (WidgetTester tester) async {
@@ -372,7 +375,9 @@ void main() {
       MaterialApp(theme: theme, home: const Center(child: Material(child: Tab(icon: SizedBox(width: 10.0, height: 10.0), child: Text('x'))))),
     );
     expect(tester.renderObject<RenderParagraph>(find.byType(RichText)).text.style!.fontFamily, 'FlutterTest');
-    expect(tester.getSize(find.byType(Tab)), material3 ? const Size(15.0, 72.0) : const Size(14.0, 72.0));
+    expect(
+      tester.getSize(find.byType(Tab)),
+      material3 ? const Size(14.25, 72.0) : const Size(14.0, 72.0));
   });
 
   testWidgets('Tab color - normal', (WidgetTester tester) async {
@@ -488,23 +493,14 @@ void main() {
 
     const double indicatorWeight = 3.0;
 
-    final RRect rrect = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? RRect.fromLTRBAndCorners(
-          64.75,
-          tabBarBox.size.height - indicatorWeight,
-          135.25,
-          tabBarBox.size.height,
-          topLeft: const Radius.circular(3.0),
-          topRight: const Radius.circular(3.0),
-        )
-      : RRect.fromLTRBAndCorners(
-          64.5,
-          tabBarBox.size.height - indicatorWeight,
-          135.5,
-          tabBarBox.size.height,
-          topLeft: const Radius.circular(3.0),
-          topRight: const Radius.circular(3.0),
-        );
+    final RRect rrect = RRect.fromLTRBAndCorners(
+      64.75,
+      tabBarBox.size.height - indicatorWeight,
+      135.25,
+      tabBarBox.size.height,
+      topLeft: const Radius.circular(3.0),
+      topRight: const Radius.circular(3.0),
+    );
 
     expect(
       tabBarBox,
@@ -2416,7 +2412,7 @@ void main() {
     // that. Tabs are padded horizontally with kTabLabelPadding.
     final double tabRight = 800.0 - kTabLabelPadding.right;
 
-    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB #19')).dx, tabRight);
+    expect(tester.getTopRight(find.widgetWithText(Tab, 'TAB #19')).dx, moreOrLessEquals(tabRight));
   });
 
   testWidgets('TabBar with indicatorWeight, indicatorPadding (LTR)', (WidgetTester tester) async {
@@ -6089,9 +6085,9 @@ void main() {
 
     // Tabs should fill the width of the TabBar.
     double tabOneLeft = ((tabBar.width / 2) - tabOneRect.width) / 2;
-    expect(tabOneRect.left, equals(tabOneLeft));
+    expect(tabOneRect.left, moreOrLessEquals(tabOneLeft));
     double tabTwoRight = tabBar.width - ((tabBar.width / 2) - tabTwoRect.width) / 2;
-    expect(tabTwoRect.right, equals(tabTwoRight));
+    expect(tabTwoRect.right, moreOrLessEquals(tabTwoRight));
 
     // Test default TabAlignment when isScrollable is true.
     await tester.pumpWidget(buildFrame(
@@ -6106,9 +6102,9 @@ void main() {
 
     // Tabs should be aligned to the start of the TabBar.
     tabOneLeft = kTabLabelPadding.left + tabStartOffset;
-    expect(tabOneRect.left, equals(tabOneLeft));
+    expect(tabOneRect.left, moreOrLessEquals(tabOneLeft));
     tabTwoRight = kTabLabelPadding.horizontal + tabStartOffset + tabOneRect.width + kTabLabelPadding.left + tabTwoRect.width;
-    expect(tabTwoRect.right, equals(tabTwoRight));
+    expect(tabTwoRect.right, moreOrLessEquals(tabTwoRight));
   });
 
   testWidgets('TabAlignment.fill only supports non-scrollable tab bar', (WidgetTester tester) async {
@@ -6181,9 +6177,9 @@ void main() {
 
     // By defaults tabs should fill the width of the TabBar.
     double tabOneLeft = ((availableWidth / 2) - tabOneRect.width) / 2;
-    expect(tabOneRect.left, equals(tabOneLeft));
+    expect(tabOneRect.left, moreOrLessEquals(tabOneLeft));
     double tabTwoRight = availableWidth - ((availableWidth / 2) - tabTwoRect.width) / 2;
-    expect(tabTwoRect.right, equals(tabTwoRight));
+    expect(tabTwoRect.right, moreOrLessEquals(tabTwoRight));
 
     // Test TabAlignment.center when isScrollable is false.
     await tester.pumpWidget(buildFrame(
@@ -6199,9 +6195,9 @@ void main() {
 
     // Tabs should not fill the width of the TabBar.
     tabOneLeft = kTabLabelPadding.left;
-    expect(tabOneRect.left, equals(tabOneLeft));
+    expect(tabOneRect.left, moreOrLessEquals(tabOneLeft));
     tabTwoRight = kTabLabelPadding.horizontal + tabOneRect.width + kTabLabelPadding.left + tabTwoRect.width;
-    expect(tabTwoRect.right, equals(tabTwoRight));
+    expect(tabTwoRect.right, moreOrLessEquals(tabTwoRight));
   });
 
   testWidgets('Material3 - TabAlignment updates tabs alignment (scrollable TabBar)', (WidgetTester tester) async {
@@ -6690,9 +6686,9 @@ void main() {
 
       // By default tabs should fill the width of the TabBar.
       double tabOneLeft = ((tabBar.width / 2) - tabOneRect.width) / 2;
-      expect(tabOneRect.left, equals(tabOneLeft));
+      expect(tabOneRect.left, moreOrLessEquals(tabOneLeft));
       double tabTwoRight = tabBar.width - ((tabBar.width / 2) - tabTwoRect.width) / 2;
-      expect(tabTwoRect.right, equals(tabTwoRight));
+      expect(tabTwoRect.right, moreOrLessEquals(tabTwoRight));
 
       // Test TabAlignment.center when isScrollable is false.
       await tester.pumpWidget(MaterialApp(
@@ -6706,9 +6702,9 @@ void main() {
 
       // Tabs should not fill the width of the TabBar.
       tabOneLeft = kTabLabelPadding.left;
-      expect(tabOneRect.left, equals(tabOneLeft));
+      expect(tabOneRect.left, moreOrLessEquals(tabOneLeft));
       tabTwoRight = kTabLabelPadding.horizontal + tabOneRect.width + kTabLabelPadding.left + tabTwoRect.width;
-      expect(tabTwoRect.right, equals(tabTwoRight));
+      expect(tabTwoRect.right, moreOrLessEquals(tabTwoRight));
     });
   });
 }

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show ParagraphBuilder;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -620,12 +618,8 @@ void main() {
       ),
     );
 
-    final Size textButtonSize = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? const Size(68.5, 48.0)
-      : const Size(69.0, 48.0);
-    final Size textSize = ui.ParagraphBuilder.shouldDisableRoundingHack
-      ? const Size(52.5, 18.0)
-      : const Size(53.0, 18.0);
+    const Size textButtonSize = Size(68.5, 48.0);
+    const Size textSize = Size(52.5, 18.0);
     expect(tester.getSize(find.byType(TextButton)), textButtonSize);
     expect(tester.getSize(find.byType(Text)), textSize);
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -969,7 +969,7 @@ void main() {
 
         expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(154, 155)));
         expect(tester.getBottomRight(find.text(selectTimeString)), equals(
-          ParagraphBuilder.shouldDisableRoundingHack ? const Offset(280.5, 165) : const Offset(281, 165),
+          const Offset(280.5, 165),
         ));
         expect(tester.getBottomRight(find.text(okString)).dx, 644);
         expect(tester.getBottomLeft(find.text(okString)).dx, 616);
@@ -983,7 +983,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(tester.getTopLeft(find.text(selectTimeString)), equals(
-          ParagraphBuilder.shouldDisableRoundingHack ? const Offset(519.5, 155) : const Offset(519, 155),
+          const Offset(519.5, 155),
         ));
         expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(646, 165)));
         expect(tester.getBottomLeft(find.text(okString)).dx, 156);
@@ -1031,8 +1031,14 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(138, 129)));
-        expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(295.0, 149.0)));
-        expect(tester.getBottomLeft(find.text(okString)).dx, 615.5);
+        expect(
+          tester.getBottomRight(find.text(selectTimeString)),
+          const Offset(294.75, 149.0),
+        );
+        expect(
+          tester.getBottomLeft(find.text(okString)).dx,
+          moreOrLessEquals(615.9, epsilon: 0.001),
+        );
         expect(tester.getBottomRight(find.text(cancelString)).dx, 578);
 
         await tester.tap(find.text(okString));
@@ -1042,10 +1048,19 @@ void main() {
         await tester.tap(find.text('X'));
         await tester.pumpAndSettle();
 
-        expect(tester.getTopLeft(find.text(selectTimeString)), equals(const Offset(505.0, 129.0)));
+        expect(
+          tester.getTopLeft(find.text(selectTimeString)),
+          equals(const Offset(505.25, 129.0)),
+        );
         expect(tester.getBottomRight(find.text(selectTimeString)), equals(const Offset(662, 149)));
-        expect(tester.getBottomLeft(find.text(okString)).dx, 155.5);
-        expect(tester.getBottomRight(find.text(okString)).dx, 184.5);
+        expect(
+          tester.getBottomLeft(find.text(okString)).dx,
+          moreOrLessEquals(155.9, epsilon: 0.001),
+        );
+        expect(
+          tester.getBottomRight(find.text(okString)).dx,
+          moreOrLessEquals(184.1, epsilon: 0.001),
+        );
         expect(tester.getBottomLeft(find.text(cancelString)).dx, 222);
 
         await tester.tap(find.text(okString));

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1509,9 +1509,6 @@ void main() {
   });
 
   test('TextPainter line breaking does not round to integers', () {
-    if (!ui.ParagraphBuilder.shouldDisableRoundingHack) {
-      return;
-    }
     const double fontSize = 1.25;
     const String text = '12345';
     assert((fontSize * text.length).truncate() != fontSize * text.length);

--- a/packages/flutter_localizations/test/text_test.dart
+++ b/packages/flutter_localizations/test/text_test.dart
@@ -71,25 +71,11 @@ void main() {
     expect(find.text('hello, world'), findsOneWidget);
     expect(find.text('你好，世界'), findsOneWidget);
 
-    Offset topLeft = tester.getTopLeft(find.text('hello, world'));
-    Offset topRight = tester.getTopRight(find.text('hello, world'));
-    Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
-    Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
+    expect(tester.getTopLeft(find.text('hello, world')).dy, 298.0);
+    expect(tester.getBottomLeft(find.text('hello, world')).dy, 318.0);
 
-    expect(topLeft, const Offset(392.0, 298.0));
-    expect(topRight, const Offset(562.0, 298.0));
-    expect(bottomLeft, const Offset(392.0, 318.0));
-    expect(bottomRight, const Offset(562.0, 318.0));
-
-    topLeft = tester.getTopLeft(find.text('你好，世界'));
-    topRight = tester.getTopRight(find.text('你好，世界'));
-    bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
-    bottomRight = tester.getBottomRight(find.text('你好，世界'));
-
-    expect(topLeft, const Offset(392.0, 346.0));
-    expect(topRight, const Offset(463.0, 346.0));
-    expect(bottomLeft, const Offset(392.0, 366.0));
-    expect(bottomRight, const Offset(463.0, 366.0));
+    expect(tester.getTopLeft(find.text('你好，世界')).dy, 346.0);
+    expect(tester.getBottomLeft(find.text('你好，世界')).dy, 366.0);
   });
 
   testWidgets('Text baseline with EN locale', (WidgetTester tester) async {
@@ -156,24 +142,10 @@ void main() {
     expect(find.text('hello, world'), findsOneWidget);
     expect(find.text('你好，世界'), findsOneWidget);
 
-    Offset topLeft = tester.getTopLeft(find.text('hello, world'));
-    Offset topRight = tester.getTopRight(find.text('hello, world'));
-    Offset bottomLeft = tester.getBottomLeft(find.text('hello, world'));
-    Offset bottomRight = tester.getBottomRight(find.text('hello, world'));
+    expect(tester.getTopLeft(find.text('hello, world')).dy, 298.0);
+    expect(tester.getBottomLeft(find.text('hello, world')).dy, 318.0);
 
-    expect(topLeft, const Offset(392.0, 298.0));
-    expect(topRight, const Offset(562.0, 298.0));
-    expect(bottomLeft, const Offset(392.0, 318.0));
-    expect(bottomRight, const Offset(562.0, 318.0));
-
-    topLeft = tester.getTopLeft(find.text('你好，世界'));
-    topRight = tester.getTopRight(find.text('你好，世界'));
-    bottomLeft = tester.getBottomLeft(find.text('你好，世界'));
-    bottomRight = tester.getBottomRight(find.text('你好，世界'));
-
-    expect(topLeft, const Offset(392.0, 346.0));
-    expect(topRight, const Offset(463.0, 346.0));
-    expect(bottomLeft, const Offset(392.0, 366.0));
-    expect(bottomRight, const Offset(463.0, 366.0));
+    expect(tester.getTopLeft(find.text('你好，世界')).dy, 346.0);
+    expect(tester.getBottomLeft(find.text('你好，世界')).dy, 366.0);
   });
 }


### PR DESCRIPTION
Migrate tests in flutter/flutter. Once the tests here and in `*_customer_testing` are migrated, the default value of the migration flag will be changed from false to true, making the rounding hack disabled by default.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
