### PR TITLE
Never send warmup frames to engine

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -487,7 +487,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   ///
   ///  * [deferFirstFrame], which defers when the first frame is sent to the
   ///    engine.
-  bool get sendFramesToEngine => (_firstFrameSent || _firstFrameDeferredCount == 0) && !duringWarmUpFrame;
+  bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
 
   /// Tell the framework to not send the first frames to the engine until there
   /// is a corresponding call to [allowFirstFrame].
@@ -592,6 +592,9 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     rootPipelineOwner.flushCompositingBits();
     rootPipelineOwner.flushPaint();
     if (sendFramesToEngine) {
+      if (!duringBeginOrDrawFrame) {
+        return;
+      }
       for (final RenderView renderView in renderViews) {
         renderView.compositeFrame(); // this sends the bits to the GPU
       }

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -487,7 +487,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   ///
   ///  * [deferFirstFrame], which defers when the first frame is sent to the
   ///    engine.
-  bool get sendFramesToEngine => _firstFrameSent || _firstFrameDeferredCount == 0;
+  bool get sendFramesToEngine => (_firstFrameSent || _firstFrameDeferredCount == 0) && !duringWarmUpFrame;
 
   /// Tell the framework to not send the first frames to the engine until there
   /// is a corresponding call to [allowFirstFrame].

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -807,7 +807,7 @@ mixin SchedulerBinding on BindingBase {
 
   /// Ensures callbacks for [PlatformDispatcher.onBeginFrame] and
   /// [PlatformDispatcher.onDrawFrame] are registered.
-  @protected
+  // @protected
   void ensureFrameCallbacksRegistered() {
     platformDispatcher.onBeginFrame ??= _handleBeginFrame;
     platformDispatcher.onDrawFrame ??= _handleDrawFrame;
@@ -1058,6 +1058,10 @@ mixin SchedulerBinding on BindingBase {
   // engine frame.
   bool _rescheduleAfterWarmUpFrame = false;
 
+  @protected
+  bool get duringBeginOrDrawFrame => _duringBeginOrDrawFrame;
+  bool _duringBeginOrDrawFrame = false;
+
   void _handleBeginFrame(Duration rawTimeStamp) {
     if (_warmUpFrame) {
       // "begin frame" and "draw frame" must strictly alternate. Therefore
@@ -1067,7 +1071,9 @@ mixin SchedulerBinding on BindingBase {
       _rescheduleAfterWarmUpFrame = true;
       return;
     }
+    _duringBeginOrDrawFrame = true;
     handleBeginFrame(rawTimeStamp);
+    _duringBeginOrDrawFrame = false;
   }
 
   void _handleDrawFrame() {
@@ -1088,7 +1094,9 @@ mixin SchedulerBinding on BindingBase {
       });
       return;
     }
+    _duringBeginOrDrawFrame = true;
     handleDrawFrame();
+    _duringBeginOrDrawFrame = false;
   }
 
   final TimelineTask? _frameTimelineTask = kReleaseMode ? null : TimelineTask();

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -916,6 +916,8 @@ mixin SchedulerBinding on BindingBase {
     _hasScheduledFrame = true;
   }
 
+  @protected
+  bool get duringWarmUpFrame => _warmUpFrame;
   bool _warmUpFrame = false;
 
   /// Schedule a frame to run as soon as possible, rather than waiting for

--- a/packages/flutter/test/rendering/multi_view_binding_test.dart
+++ b/packages/flutter/test/rendering/multi_view_binding_test.dart
@@ -116,24 +116,25 @@ void main() {
     expect(flutterView1.renderedScenes, isEmpty);
     expect(flutterView2.renderedScenes, isEmpty);
 
-    binding.handleBeginFrame(Duration.zero);
-    binding.handleDrawFrame();
+    binding.ensureFrameCallbacksRegistered();
+    PlatformDispatcher.instance.onBeginFrame!.call(Duration.zero);
+    PlatformDispatcher.instance.onDrawFrame!.call();
 
     expect(flutterView1.renderedScenes, hasLength(1));
     expect(flutterView2.renderedScenes, hasLength(1));
 
     binding.removeRenderView(renderView1);
 
-    binding.handleBeginFrame(Duration.zero);
-    binding.handleDrawFrame();
+    PlatformDispatcher.instance.onBeginFrame!.call(Duration.zero);
+    PlatformDispatcher.instance.onDrawFrame!.call();
 
     expect(flutterView1.renderedScenes, hasLength(1));
     expect(flutterView2.renderedScenes, hasLength(2));
 
     binding.removeRenderView(renderView2);
 
-    binding.handleBeginFrame(Duration.zero);
-    binding.handleDrawFrame();
+    PlatformDispatcher.instance.onBeginFrame!.call(Duration.zero);
+    PlatformDispatcher.instance.onDrawFrame!.call();
 
     expect(flutterView1.renderedScenes, hasLength(1));
     expect(flutterView2.renderedScenes, hasLength(2));


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
