### PR TITLE
fixed documentation error input decorator

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -260,7 +260,7 @@ class _BorderContainerState extends State<_BorderContainer> with TickerProviderS
   }
 }
 
-// Used to "shake" the floating label to the left to the left and right
+// Used to "shake" the floating label to the left and right
 // when the errorText first appears.
 class _Shaker extends AnimatedWidget {
   const _Shaker({


### PR DESCRIPTION
In the documentation of _Shaker in InputDecoration "Used to "shake" the floating label to the left and right"
to the left was twice I have removed it.



