### PR TITLE
Remove bringup from Windows build_tests shards

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4187,7 +4187,6 @@ targets:
       - .ci.yaml
 
   - name: Windows build_tests_1_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4206,7 +4205,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_2_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4225,7 +4223,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_3_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4244,7 +4241,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_4_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4263,7 +4259,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_5_5
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Context: https://github.com/flutter/flutter/commit/aff8ef13d428395725ce8f836ca771b8bf2d87db