### PR TITLE
Fixed [NavigationRailDestination]'s label opacity while disabled not being coherent with the icon

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -594,7 +594,9 @@ class _RailDestination extends StatelessWidget {
       child: icon,
     );
     final Widget styledLabel = DefaultTextStyle(
-      style: labelTextStyle,
+      style: disabled
+        ? labelTextStyle.copyWith(color: theme.colorScheme.onSurface.withOpacity(0.38))
+        : labelTextStyle,
       child: label,
     );
 

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3313,28 +3313,23 @@ void main() {
       ),
     );
 
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    final double? abcLabelOpacity = tester.widget<DefaultTextStyle>(
-      find.ancestor(
-        of: find.text('Abc'),
-        matching: find.byType(DefaultTextStyle),
-      ).first,
-    ).style.color?.opacity;
-    final double? bcdLabelOpacity = tester.widget<DefaultTextStyle>(
-      find.ancestor(
-        of: find.text('Bcd'),
-        matching: find.byType(DefaultTextStyle),
-      ).first,
-    ).style.color?.opacity;
-
-    expect(abcLabelOpacity, 1.0);
-
-    if (bcdLabelOpacity == 1.0) {
-      fail('Bcd''s opacity should be lower than 1.0 since it is disabled');
+    double? defaultTextStyleOpacity(String text) {
+      final String? opacity = tester.widget<DefaultTextStyle>(
+        find.ancestor(
+          of: find.text(text),
+          matching: find.byType(DefaultTextStyle),
+        ).first,
+      ).style.color?.opacity.toStringAsFixed(2);
+      return double.tryParse(opacity ?? '');
     }
 
-    tester.pumpAndSettle();
+    final double? abcLabelOpacity = defaultTextStyleOpacity('Abc');
+    final double? bcdLabelOpacity = defaultTextStyleOpacity('Bcd');
+
+    expect(abcLabelOpacity, 1.0);
+    expect(bcdLabelOpacity, 0.38);
   });
 
   group('Material 2', () {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3314,7 +3314,7 @@ void main() {
     );
 
     await tester.pump();
-    
+
     final double? abcLabelOpacity = tester.widget<DefaultTextStyle>(
       find.ancestor(
         of: find.text('Abc'),
@@ -3329,6 +3329,7 @@ void main() {
     ).style.color?.opacity;
 
     expect(abcLabelOpacity, 1.0);
+
     if(bcdLabelOpacity == 1.0) {
       fail('Bcd''s opacity should be lower than 1.0 since it is disabled');
     }

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3290,6 +3290,52 @@ void main() {
     tester.pumpAndSettle();
   });
 
+  testWidgetsWithLeakTracking("Destination's label with the right opacity while disabled", (WidgetTester tester) async {
+    await _pumpNavigationRail(
+      tester,
+      navigationRail: NavigationRail(
+        selectedIndex: 0,
+        destinations: const <NavigationRailDestination>[
+          NavigationRailDestination(
+            icon: Icon(Icons.favorite_border),
+            selectedIcon: Icon(Icons.favorite),
+            label: Text('Abc'),
+          ),
+          NavigationRailDestination(
+            icon: Icon(Icons.bookmark_border),
+            selectedIcon: Icon(Icons.bookmark),
+            label: Text('Bcd'),
+            disabled: true,
+          ),
+        ],
+        onDestinationSelected: (int index) {},
+        labelType: NavigationRailLabelType.all,
+      ),
+    );
+
+    await tester.pump();
+    
+    final double? abcLabelOpacity = tester.widget<DefaultTextStyle>(
+      find.ancestor(
+        of: find.text('Abc'),
+        matching: find.byType(DefaultTextStyle),
+      ).first,
+    ).style.color?.opacity;
+    final double? bcdLabelOpacity = tester.widget<DefaultTextStyle>(
+      find.ancestor(
+        of: find.text('Bcd'),
+        matching: find.byType(DefaultTextStyle),
+      ).first,
+    ).style.color?.opacity;
+
+    expect(abcLabelOpacity, 1.0);
+    if(bcdLabelOpacity == 1.0) {
+      fail('Bcd''s opacity should be lower than 1.0 since it is disabled');
+    }
+
+    tester.pumpAndSettle();
+  });
+
   group('Material 2', () {
     // These tests are only relevant for Material 2. Once Material 2
     // support is deprecated and the APIs are removed, these tests

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3316,20 +3316,19 @@ void main() {
     await tester.pumpAndSettle();
 
     double? defaultTextStyleOpacity(String text) {
-      final String? opacity = tester.widget<DefaultTextStyle>(
+      return tester.widget<DefaultTextStyle>(
         find.ancestor(
           of: find.text(text),
           matching: find.byType(DefaultTextStyle),
         ).first,
-      ).style.color?.opacity.toStringAsFixed(2);
-      return double.tryParse(opacity ?? '');
+      ).style.color?.opacity;
     }
 
     final double? abcLabelOpacity = defaultTextStyleOpacity('Abc');
     final double? bcdLabelOpacity = defaultTextStyleOpacity('Bcd');
 
     expect(abcLabelOpacity, 1.0);
-    expect(bcdLabelOpacity, 0.38);
+    expect(bcdLabelOpacity, closeTo(0.38, 0.01));
   });
 
   group('Material 2', () {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3330,7 +3330,7 @@ void main() {
 
     expect(abcLabelOpacity, 1.0);
 
-    if(bcdLabelOpacity == 1.0) {
+    if (bcdLabelOpacity == 1.0) {
       fail('Bcd''s opacity should be lower than 1.0 since it is disabled');
     }
 


### PR DESCRIPTION
Fixing the opacity of the NavigationRailDestination widget label while it is disabled, right now it doesn't get affected by the disabled attribute, which doesn't match the icon that gets affected

* https://github.com/flutter/flutter/issues/132344

I believe this PR should be marked as [test-exempt]

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.