### PR TITLE
Added option to disable [NavigationDrawerDestination]s

### DIFF
--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -193,7 +193,7 @@ class NavigationDrawerDestination extends StatelessWidget {
     required this.icon,
     this.selectedIcon,
     required this.label,
-    this.disabled = false,
+    this.enabled = true,
   });
 
   /// Sets the color of the [Material] that holds all of the [Drawer]'s
@@ -230,8 +230,8 @@ class NavigationDrawerDestination extends StatelessWidget {
   /// text style would use [TextTheme.labelLarge] with [ColorScheme.onSurfaceVariant].
   final Widget label;
 
-  /// Indicates that this destination is inaccessible.
-  final bool disabled;
+  /// Indicates that this destination is accessible.
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -279,7 +279,7 @@ class NavigationDrawerDestination extends StatelessWidget {
           child: label,
         );
       },
-      disabled: disabled,
+      enabled: enabled,
     );
   }
 }
@@ -301,7 +301,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
   const _NavigationDestinationBuilder({
     required this.buildIcon,
     required this.buildLabel,
-    this.disabled = false,
+    this.enabled = true,
   });
 
   /// Builds the icon for a destination in a [NavigationDrawer].
@@ -328,7 +328,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
   /// animation is decreasing or dismissed.
   final WidgetBuilder buildLabel;
 
-  final bool disabled;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -352,7 +352,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
           height: navigationDrawerTheme.tileHeight ?? defaults.tileHeight,
           child: InkWell(
             highlightColor: Colors.transparent,
-            onTap: disabled ? null : info.onTap,
+            onTap: enabled ? info.onTap : null,
             customBorder: info.indicatorShape ?? navigationDrawerTheme.indicatorShape ?? defaults.indicatorShape!,
             child: Stack(
               alignment: Alignment.center,
@@ -365,13 +365,13 @@ class _NavigationDestinationBuilder extends StatelessWidget {
                   height: (navigationDrawerTheme.indicatorSize ?? defaults.indicatorSize!).height,
                 ),
 
-                if (disabled)
+                if (enabled)
+                  destinationBody
+                else
                   Opacity(
                     opacity: 0.38,
                     child: destinationBody,
-                  )
-                else
-                  destinationBody,
+                  ),
               ],
             ),
           ),

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -239,6 +239,9 @@ class NavigationDrawerDestination extends StatelessWidget {
       MaterialState.selected
     };
     const Set<MaterialState> unselectedState = <MaterialState>{};
+    const Set<MaterialState> disabledState = <MaterialState>{
+      MaterialState.disabled
+    };
 
     final NavigationDrawerThemeData navigationDrawerTheme =
         NavigationDrawerTheme.of(context);
@@ -251,13 +254,13 @@ class NavigationDrawerDestination extends StatelessWidget {
     return _NavigationDestinationBuilder(
       buildIcon: (BuildContext context) {
         final Widget selectedIconWidget = IconTheme.merge(
-          data: navigationDrawerTheme.iconTheme?.resolve(selectedState) ??
-              defaults.iconTheme!.resolve(selectedState)!,
+          data: navigationDrawerTheme.iconTheme?.resolve(enabled ? selectedState : disabledState) ??
+              defaults.iconTheme!.resolve(enabled ? selectedState : disabledState)!,
           child: selectedIcon ?? icon,
         );
         final Widget unselectedIconWidget = IconTheme.merge(
-          data: navigationDrawerTheme.iconTheme?.resolve(unselectedState) ??
-              defaults.iconTheme!.resolve(unselectedState)!,
+          data: navigationDrawerTheme.iconTheme?.resolve(enabled ? unselectedState : disabledState) ??
+              defaults.iconTheme!.resolve(enabled ? unselectedState : disabledState)!,
           child: icon,
         );
 
@@ -267,11 +270,12 @@ class NavigationDrawerDestination extends StatelessWidget {
       },
       buildLabel: (BuildContext context) {
         final TextStyle? effectiveSelectedLabelTextStyle =
-            navigationDrawerTheme.labelTextStyle?.resolve(selectedState) ??
-            defaults.labelTextStyle!.resolve(selectedState);
+            navigationDrawerTheme.labelTextStyle?.resolve(enabled ? selectedState : disabledState) ??
+            defaults.labelTextStyle!.resolve(enabled ? selectedState : disabledState);
         final TextStyle? effectiveUnselectedLabelTextStyle =
-            navigationDrawerTheme.labelTextStyle?.resolve(unselectedState) ??
-            defaults.labelTextStyle!.resolve(unselectedState);
+            navigationDrawerTheme.labelTextStyle?.resolve(enabled ? unselectedState : disabledState) ??
+            defaults.labelTextStyle!.resolve(enabled ? unselectedState : disabledState);
+
         return DefaultTextStyle(
           style: _isForwardOrCompleted(animation)
             ? effectiveSelectedLabelTextStyle!
@@ -364,14 +368,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
                   width: (navigationDrawerTheme.indicatorSize ?? defaults.indicatorSize!).width,
                   height: (navigationDrawerTheme.indicatorSize ?? defaults.indicatorSize!).height,
                 ),
-
-                if (enabled)
-                  destinationBody
-                else
-                  Opacity(
-                    opacity: 0.38,
-                    child: destinationBody,
-                  ),
+                destinationBody
               ],
             ),
           ),
@@ -719,7 +716,9 @@ class _NavigationDrawerDefaultsM3 extends NavigationDrawerThemeData {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       return IconThemeData(
         size: 24.0,
-        color: states.contains(MaterialState.selected)
+        color: states.contains(MaterialState.disabled)
+          ? _colors.onSurfaceVariant.withOpacity(0.38)
+          : states.contains(MaterialState.selected)
             ? _colors.onSecondaryContainer
             : _colors.onSurfaceVariant,
       );
@@ -731,7 +730,9 @@ class _NavigationDrawerDefaultsM3 extends NavigationDrawerThemeData {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       final TextStyle style = _textTheme.labelLarge!;
       return style.apply(
-        color: states.contains(MaterialState.selected)
+        color: states.contains(MaterialState.disabled)
+          ? _colors.onSurfaceVariant.withOpacity(0.38)
+          : states.contains(MaterialState.selected)
             ? _colors.onSecondaryContainer
             : _colors.onSurfaceVariant,
       );

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -231,6 +231,8 @@ class NavigationDrawerDestination extends StatelessWidget {
   final Widget label;
 
   /// Indicates that this destination is selectable.
+  ///
+  /// Defaults to true.
   final bool enabled;
 
   @override
@@ -332,6 +334,9 @@ class _NavigationDestinationBuilder extends StatelessWidget {
   /// animation is decreasing or dismissed.
   final WidgetBuilder buildLabel;
 
+  /// Indicates that this destination is selectable.
+  ///
+  /// Defaults to true.
   final bool enabled;
 
   @override

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -193,6 +193,7 @@ class NavigationDrawerDestination extends StatelessWidget {
     required this.icon,
     this.selectedIcon,
     required this.label,
+    this.disabled = false,
   });
 
   /// Sets the color of the [Material] that holds all of the [Drawer]'s
@@ -228,6 +229,9 @@ class NavigationDrawerDestination extends StatelessWidget {
   /// [NavigationDrawerThemeData.labelTextStyle]. If this are null, the default
   /// text style would use [TextTheme.labelLarge] with [ColorScheme.onSurfaceVariant].
   final Widget label;
+
+  /// Indicates that this destination is inaccessible.
+  final bool disabled;
 
   @override
   Widget build(BuildContext context) {
@@ -275,6 +279,7 @@ class NavigationDrawerDestination extends StatelessWidget {
           child: label,
         );
       },
+      disabled: disabled,
     );
   }
 }
@@ -296,6 +301,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
   const _NavigationDestinationBuilder({
     required this.buildIcon,
     required this.buildLabel,
+    this.disabled = false,
   });
 
   /// Builds the icon for a destination in a [NavigationDrawer].
@@ -322,11 +328,22 @@ class _NavigationDestinationBuilder extends StatelessWidget {
   /// animation is decreasing or dismissed.
   final WidgetBuilder buildLabel;
 
+  final bool disabled;
+
   @override
   Widget build(BuildContext context) {
     final _NavigationDrawerDestinationInfo info = _NavigationDrawerDestinationInfo.of(context);
     final NavigationDrawerThemeData navigationDrawerTheme = NavigationDrawerTheme.of(context);
     final NavigationDrawerThemeData defaults = _NavigationDrawerDefaultsM3(context);
+
+    final Row destinationBody = Row(
+      children: <Widget>[
+        const SizedBox(width: 16),
+        buildIcon(context),
+        const SizedBox(width: 12),
+        buildLabel(context),
+      ],
+    );
 
     return Padding(
       padding: info.tilePadding,
@@ -335,7 +352,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
           height: navigationDrawerTheme.tileHeight ?? defaults.tileHeight,
           child: InkWell(
             highlightColor: Colors.transparent,
-            onTap: info.onTap,
+            onTap: disabled ? null : info.onTap,
             customBorder: info.indicatorShape ?? navigationDrawerTheme.indicatorShape ?? defaults.indicatorShape!,
             child: Stack(
               alignment: Alignment.center,
@@ -347,14 +364,14 @@ class _NavigationDestinationBuilder extends StatelessWidget {
                   width: (navigationDrawerTheme.indicatorSize ?? defaults.indicatorSize!).width,
                   height: (navigationDrawerTheme.indicatorSize ?? defaults.indicatorSize!).height,
                 ),
-                Row(
-                  children: <Widget>[
-                    const SizedBox(width: 16),
-                    buildIcon(context),
-                    const SizedBox(width: 12),
-                    buildLabel(context),
-                  ],
-                ),
+
+                if(disabled)
+                  Opacity(
+                    opacity: 0.38,
+                    child: destinationBody,
+                  )
+                else
+                  destinationBody,
               ],
             ),
           ),

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -230,7 +230,7 @@ class NavigationDrawerDestination extends StatelessWidget {
   /// text style would use [TextTheme.labelLarge] with [ColorScheme.onSurfaceVariant].
   final Widget label;
 
-  /// Indicates that this destination is accessible.
+  /// Indicates that this destination is selectable.
   final bool enabled;
 
   @override

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -365,7 +365,7 @@ class _NavigationDestinationBuilder extends StatelessWidget {
                   height: (navigationDrawerTheme.indicatorSize ?? defaults.indicatorSize!).height,
                 ),
 
-                if(disabled)
+                if (disabled)
                   Opacity(
                     opacity: 0.38,
                     child: destinationBody,

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -424,7 +424,6 @@ void main() {
           selectedIndex = i;
         },
       ),
-      useMaterial3: true,
     );
 
     await tester.pumpWidget(widget);

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -417,7 +417,7 @@ void main() {
           NavigationDrawerDestination(
             icon: Icon(Icons.accessible),
             label: Text('Accessible'),
-            disabled: true,
+            enabled: false,
           ),
         ],
         onDestinationSelected: (int i) {

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -395,6 +395,58 @@ void main() {
     final NavigationDrawer drawer = tester.widget(find.byType(NavigationDrawer));
     expect(drawer.tilePadding, const EdgeInsets.symmetric(horizontal: 12.0));
   });
+  
+  testWidgetsWithLeakTracking('Destinations respect their disabled state', (WidgetTester tester) async {
+    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    int selectedIndex = 0;
+
+    widgetSetup(tester, 800);
+    
+    final Widget widget = _buildWidget(
+      scaffoldKey,
+      NavigationDrawer(
+        children: const <Widget>[
+          NavigationDrawerDestination(
+            icon: Icon(Icons.ac_unit),
+            label: Text('AC'),
+          ),
+          NavigationDrawerDestination(
+            icon: Icon(Icons.access_alarm),
+            label: Text('Alarm'),
+          ),
+          NavigationDrawerDestination(
+            icon: Icon(Icons.accessible),
+            label: Text('Accessible'),
+            disabled: true,
+          ),
+        ],
+        onDestinationSelected: (int i) {
+          selectedIndex = i;
+        },
+      ),
+      useMaterial3: true,
+    );
+
+    await tester.pumpWidget(widget);
+    scaffoldKey.currentState!.openDrawer();
+    await tester.pump();
+
+    expect(find.text('AC'), findsOneWidget);
+    expect(find.text('Alarm'), findsOneWidget);
+    expect(find.text('Accessible'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(selectedIndex, 0);
+
+    await tester.tap(find.text('Alarm'));
+    expect(selectedIndex, 1);
+
+    await tester.tap(find.text('Accessible'));
+    expect(selectedIndex, 1);
+
+    tester.pumpAndSettle();
+  });
 }
 
 Widget _buildWidget(GlobalKey<ScaffoldState> scaffoldKey, Widget child, { bool? useMaterial3 }) {

--- a/packages/flutter/test/material/navigation_drawer_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_test.dart
@@ -395,13 +395,13 @@ void main() {
     final NavigationDrawer drawer = tester.widget(find.byType(NavigationDrawer));
     expect(drawer.tilePadding, const EdgeInsets.symmetric(horizontal: 12.0));
   });
-  
+
   testWidgetsWithLeakTracking('Destinations respect their disabled state', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     int selectedIndex = 0;
 
     widgetSetup(tester, 800);
-    
+
     final Widget widget = _buildWidget(
       scaffoldKey,
       NavigationDrawer(


### PR DESCRIPTION
This PR adds a new option in the NavigationDrawerDestination api allowing it to be disabled, this is very useful for role based access control, especially in the navigation drawer which is used to lay out all the app destinations

* https://github.com/flutter/flutter/issues/132348

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
