### PR TITLE
Update menu examples for `SafeArea`

### DIFF
--- a/examples/api/lib/material/menu_anchor/checkbox_menu_button.0.dart
+++ b/examples/api/lib/material/menu_anchor/checkbox_menu_button.0.dart
@@ -101,8 +101,9 @@ class MenuApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(body: MyCheckboxMenu(message: kMessage)),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const Scaffold(body: SafeArea(child: MyCheckboxMenu(message: kMessage))),
     );
   }
 }

--- a/examples/api/lib/material/menu_anchor/menu_accelerator_label.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_accelerator_label.0.dart
@@ -110,7 +110,7 @@ class MenuAcceleratorApp extends StatelessWidget {
             debugDumpApp();
           }),
         },
-        child: const Scaffold(body: MyMenuBar()),
+        child: const Scaffold(body: SafeArea(child: MyMenuBar())),
       ),
     );
   }

--- a/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
@@ -204,7 +204,7 @@ class MenuApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(useMaterial3: true),
-      home: const Scaffold(body: MyCascadingMenu(message: kMessage)),
+      home: const Scaffold(body: SafeArea(child: MyCascadingMenu(message: kMessage))),
     );
   }
 }

--- a/examples/api/lib/material/menu_anchor/menu_bar.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_bar.0.dart
@@ -230,7 +230,7 @@ class MenuBarApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(body: MyMenuBar(message: kMessage)),
+      home: Scaffold(body: SafeArea(child: MyMenuBar(message: kMessage))),
     );
   }
 }

--- a/examples/api/lib/material/menu_anchor/radio_menu_button.0.dart
+++ b/examples/api/lib/material/menu_anchor/radio_menu_button.0.dart
@@ -107,8 +107,9 @@ class MenuApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(body: MyRadioMenu()),
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const Scaffold(body: SafeArea(child: MyRadioMenu())),
     );
   }
 }

--- a/examples/api/test/material/menu_anchor/checkbox_menu_button.0_test.dart
+++ b/examples/api/test/material/menu_anchor/checkbox_menu_button.0_test.dart
@@ -24,4 +24,18 @@ void main() {
     expect(find.text('Show Message'), findsNothing);
     expect(find.text(example.MenuApp.kMessage), findsOneWidget);
   });
+
+  testWidgets('MenuAnchor is wrapped in a SafeArea', (WidgetTester tester) async {
+    const double safeAreaPadding = 100.0;
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          padding: EdgeInsets.symmetric(vertical: safeAreaPadding),
+        ),
+        child: example.MenuApp(),
+      ),
+    );
+
+    expect(tester.getTopLeft(find.byType(MenuAnchor)), const Offset(0.0, safeAreaPadding));
+  });
 }

--- a/examples/api/test/material/menu_anchor/menu_accelerator_label.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_accelerator_label.0_test.dart
@@ -51,4 +51,18 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Close'), findsNothing);
   });
+
+  testWidgets('MenuBar is wrapped in a SafeArea', (WidgetTester tester) async {
+    const double safeAreaPadding = 100.0;
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          padding: EdgeInsets.symmetric(vertical: safeAreaPadding),
+        ),
+        child: example.MenuAcceleratorApp(),
+      ),
+    );
+
+    expect(tester.getTopLeft(find.byType(MenuBar)), const Offset(0.0, safeAreaPadding));
+  });
 }

--- a/examples/api/test/material/menu_anchor/menu_anchor.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_anchor.0_test.dart
@@ -104,4 +104,18 @@ void main() {
 
     expect(find.text('Last Selected: ${example.MenuEntry.colorBlue.label}'), findsOneWidget);
   });
+
+  testWidgets('MenuAnchor is wrapped in a SafeArea', (WidgetTester tester) async {
+    const double safeAreaPadding = 100.0;
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          padding: EdgeInsets.symmetric(vertical: safeAreaPadding),
+        ),
+        child: example.MenuApp(),
+      ),
+    );
+
+    expect(tester.getTopLeft(find.byType(MenuAnchor)), const Offset(0.0, safeAreaPadding));
+  });
 }

--- a/examples/api/test/material/menu_anchor/menu_bar.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_bar.0_test.dart
@@ -91,4 +91,18 @@ void main() {
 
     expect(find.text('Last Selected: Blue Background'), findsOneWidget);
   });
+
+  testWidgets('MenuBar is wrapped in a SafeArea', (WidgetTester tester) async {
+    const double safeAreaPadding = 100.0;
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          padding: EdgeInsets.symmetric(vertical: safeAreaPadding),
+        ),
+        child: example.MenuBarApp(),
+      ),
+    );
+
+    expect(tester.getTopLeft(find.byType(MenuBar)), const Offset(0.0, safeAreaPadding));
+  });
 }

--- a/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
+++ b/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
@@ -74,4 +74,18 @@ void main() {
     expect(tester.widget<Radio<Color>>(find.descendant(of: find.byType(RadioMenuButton<Color>).at(2), matching: find.byType(Radio<Color>))).groupValue, equals(Colors.blue));
     expect(tester.widget<Container>(find.byType(Container)).color, equals(Colors.blue));
   });
+
+  testWidgets('MenuAnchor is wrapped in a SafeArea', (WidgetTester tester) async {
+    const double safeAreaPadding = 100.0;
+    await tester.pumpWidget(
+      const MediaQuery(
+        data: MediaQueryData(
+          padding: EdgeInsets.symmetric(vertical: safeAreaPadding),
+        ),
+        child: example.MenuApp(),
+      ),
+    );
+
+    expect(tester.getTopLeft(find.byType(MenuAnchor)), const Offset(0.0, safeAreaPadding));
+  });
 }


### PR DESCRIPTION
fixes [Some of the menu examples don't contain `SafeArea`](https://github.com/flutter/flutter/issues/132388)

### Description

This fixes the menu examples for running on mobile with a safe area.


![Group 2](https://github.com/flutter/flutter/assets/48603081/0d460c00-60f5-45e0-87ee-c010ede9ee42)



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
