### PR TITLE
Fix typo in error message of local-engine-host

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -310,7 +310,7 @@ class UserMessages {
       'You must specify --local-engine or --local-web-sdk if you are using a locally built engine or web sdk.';
   // TODO(matanlurey): Make this an error, https://github.com/flutter/flutter/issues/132245.
   String get runnerLocalEngineRequiresHostEngine =>
-      'Warning! You are using a locally built engine (--local-engine) but have not specified --local-host-engine.\n'
+      'Warning! You are using a locally built engine (--local-engine) but have not specified --local-engine-host.\n'
       'You may be building with a different engine than the one you are running with. '
       'See https://github.com/flutter/flutter/issues/132245 for details (in the future this will become '
       'an error).';

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -119,7 +119,7 @@ void main() {
     expect(logger.traceText, contains('Local engine source at /arbitrary/engine/src'));
   });
 
-  testWithoutContext('works but produces a warning if --local-engine is specified but not --local-host-engine', () async {
+  testWithoutContext('works but produces a warning if --local-engine is specified but not --local-engine-host', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Directory localEngine = fileSystem
         .directory('$kArbitraryEngineRoot/src/out/android_debug_unopt_arm64/')
@@ -142,7 +142,7 @@ void main() {
         targetEngine: '/arbitrary/engine/src/out/android_debug_unopt_arm64',
       ),
     );
-    expect(logger.statusText, contains('Warning! You are using a locally built engine (--local-engine) but have not specified --local-host-engine'));
+    expect(logger.statusText, contains('Warning! You are using a locally built engine (--local-engine) but have not specified --local-engine-host'));
   });
 
   testWithoutContext('works if --local-engine is specified and --local-engine-src-path '


### PR DESCRIPTION
It's not `local-host-engine`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
