### PR TITLE
Make completeError be a proper JS function

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -165,7 +165,8 @@ class NetworkImage
         }
       }.toJS);
 
-      request.addEventListener('error', completer.completeError.toJS);
+      request.addEventListener('error',
+          ((JSObject e) => completer.completeError(e)).toJS);
 
       request.send();
 


### PR DESCRIPTION
Function.toJS will start requiring that the function accept and return JS types only.

Allows https://dart-review.googlesource.com/c/sdk/+/316867 to land.
