### PR TITLE
Selection area should move selection word by word on a long press drag

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -529,7 +529,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleTouchLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
-    _selectEndTo(offset: details.globalPosition);
+    _selectEndTo(offset: details.globalPosition, textGranularity: TextGranularity.word);
   }
 
   void _handleTouchLongPressEnd(LongPressEndDetails details) {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -338,6 +338,7 @@ void main() {
       expect(renderSelectionSpy.events[0].type, SelectionEventType.endEdgeUpdate);
       final SelectionEdgeUpdateEvent edgeEvent = renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent;
       expect(edgeEvent.globalPosition, const Offset(200.0, 50.0));
+      expect(edgeEvent.granularity, TextGranularity.word);
     });
 
   testWidgets(
@@ -1656,7 +1657,7 @@ void main() {
       await gesture.up();
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61020
 
-    testWidgets('long press and drag touch selection', (WidgetTester tester) async {
+    testWidgets('long press and drag touch moves selection word by word', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(
@@ -1681,9 +1682,9 @@ void main() {
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
 
       final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
-      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 7));
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 12));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 9));
       await gesture.up();
     });
 


### PR DESCRIPTION
On native iOS and Android when long pressing and then dragging the selection expands word by word. Before this change `SelectionArea` expanded the selection character by character on a long press drag.

Fixes #104603

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.