### PR TITLE
[devicelab] fix NAN/Inf in drawPoints benchmark.

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/draw_points.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/draw_points.dart
@@ -72,10 +72,10 @@ class PointsPainter extends CustomPainter {
     }
     canvas.drawPaint(Paint()..color = Colors.white);
     for (int i = 0; i < 8; i++) {
-      final double x = ((size.width / i) + tick) % size.width;
+      final double x = ((size.width / (i + 1)) + tick) % size.width;
       for (int j = 0; j < data.length; j += 2) {
         data[j] = x;
-        data[j + 1] = (size.height / j) + 200;
+        data[j + 1] = (size.height / (j + 1)) + 200;
       }
       final Paint paint = Paint()
         ..color = kColors[i]


### PR DESCRIPTION
This is causing the benchmark to not render with Skia. We probably need to CHECK this somewhere in the backend..