### PR TITLE
Adds API for performing semantics actions in tests

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -639,6 +639,26 @@ class CommonSemanticsFinders {
     );
   }
 
+  /// Finds any [SemanticsNode]s that can scroll in at least one direction.
+  ///
+  /// If `axis` is provided, then the search will be limited to scrollable nodes
+  /// that can scroll in the given axis. If `axis` is not provided, then both
+  /// horizontal and vertical scrollable nodes will be found.
+  ///
+  /// {@macro flutter_test.finders.CommonSemanticsFinders.viewParameter}
+  SemanticsFinder scrollable({Axis? axis, FlutterView? view}) {
+    return byAnyAction(<SemanticsAction>[
+      if (axis == null || axis == Axis.vertical) ...<SemanticsAction>[
+        SemanticsAction.scrollUp,
+        SemanticsAction.scrollDown,
+      ],
+      if (axis == null || axis == Axis.horizontal) ...<SemanticsAction>[
+        SemanticsAction.scrollLeft,
+        SemanticsAction.scrollRight,
+      ],
+    ]);
+  }
+
   bool _matchesPattern(String target, Pattern pattern) {
     if (pattern is RegExp) {
       return pattern.hasMatch(target);

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -600,7 +600,11 @@ AsyncMatcher matchesReferenceImage(ui.Image image) {
 /// provided, then they are not part of the comparison. All of the boolean
 /// flag and action fields must match, and default to false.
 ///
-/// To retrieve the semantics data of a widget, use [WidgetTester.getSemantics]
+/// To find a [SemanticsNode] directly, use [CommonFinders.semantics].
+/// These methods will search the semantics tree directly and avoid the edge
+/// cases that [SemanticsController.find] sometimes runs into.
+///
+/// To retrieve the semantics data of a widget, use [SemanticsController.find]
 /// with a [Finder] that returns a single widget. Semantics must be enabled
 /// in order to use this method.
 ///
@@ -780,7 +784,11 @@ Matcher matchesSemantics({
 /// There are no default expected values, so no unspecified values will be
 /// validated.
 ///
-/// To retrieve the semantics data of a widget, use [WidgetTester.getSemantics]
+/// To find a [SemanticsNode] directly, use [CommonFinders.semantics].
+/// These methods will search the semantics tree directly and avoid the edge
+/// cases that [SemanticsController.find] sometimes runs into.
+///
+/// To retrieve the semantics data of a widget, use [SemanticsController.find]
 /// with a [Finder] that returns a single widget. Semantics must be enabled
 /// in order to use this method.
 ///
@@ -2502,7 +2510,13 @@ class _MatchesSemanticsData extends Matcher {
       return failWithDescription(matchState, 'No SemanticsData provided. '
         'Maybe you forgot to enable semantics?');
     }
-    final SemanticsData data = node is SemanticsNode ? node.getSemanticsData() : (node as SemanticsData);
+
+    final SemanticsData data = switch (node) {
+      SemanticsNode() => node.getSemanticsData(),
+      FinderBase<SemanticsNode>() => node.evaluate().single.getSemanticsData(),
+      _ => node as SemanticsData,
+    };
+
     if (label != null && label != data.label) {
       return failWithDescription(matchState, 'label was: ${data.label}');
     }

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -5,7 +5,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stack_trace/stack_trace.dart';
 
@@ -1015,6 +1015,472 @@ void main() {
         );
       });
     });
+
+    group('actions', () {
+      testWidgets('performAction with unsupported action throws StateError', (WidgetTester tester) async {
+        await tester.pumpWidget(Semantics(onTap: () {}));
+
+        expect(
+          () => tester.semantics.performAction(
+            find.semantics.byLabel('Test'),
+            SemanticsAction.dismiss,
+          ),
+          throwsStateError,
+        );
+      });
+
+      testWidgets('tap causes semantic tap', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: TextButton(
+              onPressed: () => invoked = true,
+              child: const Text('Test Button'),
+            ),
+          ),
+        );
+
+        tester.semantics.tap(find.semantics.byAction(SemanticsAction.tap));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('longPress causes semantic long press', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: TextButton(
+              onPressed: () {},
+              onLongPress: () => invoked = true,
+              child: const Text('Test Button'),
+            ),
+          ),
+        );
+
+        tester.semantics.longPress(find.semantics.byAction(SemanticsAction.longPress));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('scrollLeft and scrollRight scroll left and right respectively', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: ListView(
+            scrollDirection: Axis.horizontal,
+            children: <Widget>[
+              SizedBox(
+                height: 40,
+                width: tester.binding.window.physicalSize.width * 1.5,
+              )
+            ],
+          ),
+        ));
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollLeftAction: true, hasScrollRightAction: false),
+          reason: 'When not yet scrolled, a scrollview should only be able to support left scrolls.',
+        );
+
+        tester.semantics.scrollLeft();
+        await tester.pump();
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollLeftAction: true, hasScrollRightAction: true),
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
+
+        // This will scroll the listview until it's completely scrolled to the right.
+        final SemanticsFinder leftScrollable = find.semantics.byAction(SemanticsAction.scrollLeft);
+        while (leftScrollable.tryEvaluate()) {
+          tester.semantics.scrollLeft(scrollable: leftScrollable);
+          await tester.pump();
+        }
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollLeftAction: false, hasScrollRightAction: true),
+          reason: 'When fully scrolled, a scrollview should only support right scrolls.',
+        );
+
+        tester.semantics.scrollRight();
+        await tester.pump();
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollLeftAction: true, hasScrollRightAction: true),
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
+      });
+
+      testWidgets('scrollUp and scrollDown scrolls up and down respectively', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: ListView(
+            children: <Widget>[
+              SizedBox(
+                height: tester.binding.window.physicalSize.height * 1.5,
+                width: 40,
+              )
+            ],
+          ),
+        ));
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollUpAction: true, hasScrollDownAction: false),
+          reason: 'When not yet scrolled, a scrollview should only be able to support left scrolls.',
+        );
+
+        tester.semantics.scrollUp();
+        await tester.pump();
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollUpAction: true, hasScrollDownAction: true),
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
+
+        // This will scroll the listview until it's completely scrolled to the right.
+        final SemanticsFinder upScrollable = find.semantics.byAction(SemanticsAction.scrollUp);
+        while (upScrollable.tryEvaluate()) {
+          tester.semantics.scrollUp(scrollable: upScrollable);
+          await tester.pump();
+        }
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollUpAction: false, hasScrollDownAction: true),
+          reason: 'When fully scrolled, a scrollview should only support right scrolls.',
+        );
+
+        tester.semantics.scrollDown();
+        await tester.pump();
+
+        expect(
+          find.semantics.scrollable(),
+          containsSemantics(hasScrollUpAction: true, hasScrollDownAction: true),
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
+      });
+
+      testWidgets('increase causes semantic increase', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Material(
+            child: _StatefulSlider(
+              initialValue: 0,
+              onChanged: (double _) {invoked = true;},
+            ),
+          )
+        ));
+
+        final SemanticsFinder sliderFinder = find.semantics.byFlag(SemanticsFlag.isSlider);
+        final String expected = sliderFinder.evaluate().single.increasedValue;
+        tester.semantics.increase(sliderFinder);
+        await tester.pumpAndSettle();
+
+        expect(invoked, isTrue);
+        expect(
+          find.semantics.byFlag(SemanticsFlag.isSlider).evaluate().single.value,
+          equals(expected),
+        );
+      });
+
+      testWidgets('decrease causes semantic decrease', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Material(
+            child: _StatefulSlider(
+              initialValue: 1,
+              onChanged: (double _) {invoked = true;},
+            ),
+          )
+        ));
+
+        final SemanticsFinder sliderFinder = find.semantics.byFlag(SemanticsFlag.isSlider);
+        final String expected = sliderFinder.evaluate().single.decreasedValue;
+        tester.semantics.decrease(sliderFinder);
+        await tester.pumpAndSettle();
+
+        expect(invoked, isTrue);
+        expect(
+          tester.semantics.find(find.byType(Slider)).value,
+          equals(expected),
+        );
+      });
+
+      testWidgets('showOnScreen sends showOnScreen action', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: ListView(
+            controller: ScrollController(initialScrollOffset: 50),
+            children: <Widget>[
+              const MergeSemantics(
+                child: SizedBox(
+                  height: 40,
+                  child: Text('Test'),
+                ),
+              ),
+              SizedBox(
+                width: 40,
+                height: tester.binding.window.physicalSize.height * 1.5,
+              ),
+            ],
+          ),
+        ));
+
+        expect(
+          find.semantics.byLabel('Test'),
+          containsSemantics(isHidden:true),
+        );
+
+        tester.semantics.showOnScreen(find.semantics.byLabel('Test'));
+        await tester.pump();
+
+        expect(
+          tester.semantics.find(find.text('Test')),
+          containsSemantics(isHidden: false),
+        );
+      });
+
+      testWidgets('actions for moving the cursor without modifying selection can move the cursor forward and back by character and word', (WidgetTester tester) async {
+        const String text = 'This is some text.';
+        int currentIndex = text.length;
+        final TextEditingController controller = TextEditingController(text: text);
+        await tester.pumpWidget(MaterialApp(
+          home: Material(child: TextField(controller: controller)),
+        ));
+
+        void expectUnselectedIndex(int expectedIndex) {
+          expect(controller.selection.start, equals(expectedIndex));
+          expect(controller.selection.end, equals(expectedIndex));
+        }
+
+        final SemanticsFinder finder = find.semantics.byValue(text);
+
+        // Get focus onto the text field
+        tester.semantics.tap(finder);
+        await tester.pump();
+
+        tester.semantics.moveCursorBackwardByCharacter(finder);
+        await tester.pump();
+        expectUnselectedIndex(currentIndex - 1);
+        currentIndex -= 1;
+
+        tester.semantics.moveCursorBackwardByWord(finder);
+        await tester.pump();
+        expectUnselectedIndex(currentIndex - 4);
+        currentIndex -= 4;
+
+        tester.semantics.moveCursorBackwardByWord(finder);
+        await tester.pump();
+        expectUnselectedIndex(currentIndex - 5);
+        currentIndex -= 5;
+
+        tester.semantics.moveCursorForwardByCharacter(finder);
+        await tester.pump();
+        expectUnselectedIndex(currentIndex + 1);
+        currentIndex += 1;
+
+        tester.semantics.moveCursorForwardByWord(finder);
+        await tester.pump();
+        expectUnselectedIndex(currentIndex + 4);
+        currentIndex += 4;
+      });
+
+      testWidgets('actions for moving the cursor with modifying selection can update the selection forward and back by character and word', (WidgetTester tester) async {
+        const String text = 'This is some text.';
+        int currentIndex = text.length;
+        final TextEditingController controller = TextEditingController(text: text);
+        await tester.pumpWidget(MaterialApp(
+          home: Material(child: TextField(controller: controller)),
+        ));
+
+        void expectSelectedIndex(int start) {
+          expect(controller.selection.start, equals(start));
+          expect(controller.selection.end, equals(text.length));
+        }
+
+        final SemanticsFinder finder = find.semantics.byValue(text);
+
+        // Get focus onto the text field
+        tester.semantics.tap(finder);
+        await tester.pump();
+
+        tester.semantics.moveCursorBackwardByCharacter(finder, shouldModifySelection: true);
+        await tester.pump();
+        expectSelectedIndex(currentIndex - 1);
+        currentIndex -= 1;
+
+        tester.semantics.moveCursorBackwardByWord(finder, shouldModifySelection: true);
+        await tester.pump();
+        expectSelectedIndex(currentIndex - 4);
+        currentIndex -= 4;
+
+        tester.semantics.moveCursorBackwardByWord(finder, shouldModifySelection: true);
+        await tester.pump();
+        expectSelectedIndex(currentIndex - 5);
+        currentIndex -= 5;
+
+        tester.semantics.moveCursorForwardByCharacter(finder, shouldModifySelection: true);
+        await tester.pump();
+        expectSelectedIndex(currentIndex + 1);
+        currentIndex += 1;
+
+        tester.semantics.moveCursorForwardByWord(finder, shouldModifySelection: true);
+        await tester.pump();
+        expectSelectedIndex(currentIndex + 4);
+        currentIndex += 4;
+      });
+
+      testWidgets('setText causes semantics to set the text', (WidgetTester tester) async {
+        const String expectedText = 'This is some text.';
+        final TextEditingController controller = TextEditingController();
+        await tester.pumpWidget(MaterialApp(
+          home: Material(child: TextField(controller: controller)),
+        ));
+
+        final SemanticsFinder finder = find.semantics.byFlag(SemanticsFlag.isTextField);
+
+        tester.semantics.tap(finder);
+        await tester.pump();
+
+        tester.semantics.setText(finder, expectedText);
+        await tester.pump();
+
+        expect(controller.text, equals(expectedText));
+      });
+
+      testWidgets('setSelection causes semantics to select text', (WidgetTester tester) async {
+        const String text = 'This is some text.';
+        const int expectedStart = text.length - 8;
+        const int expectedEnd = text.length - 4;
+        final TextEditingController controller = TextEditingController(text: text);
+        await tester.pumpWidget(MaterialApp(
+          home: Material(child: TextField(controller: controller)),
+        ));
+
+        final SemanticsFinder finder = find.semantics.byFlag(SemanticsFlag.isTextField);
+
+        tester.semantics.tap(finder);
+        await tester.pump();
+
+        tester.semantics.setSelection(
+          finder,
+          base: expectedStart,
+          extent: expectedEnd,
+        );
+        await tester.pump();
+
+        expect(controller.selection.start, equals(expectedStart));
+        expect(controller.selection.end, equals(expectedEnd));
+      });
+
+      testWidgets('copy sends semantic copy', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Semantics(
+            label: 'test',
+            onCopy: () => invoked = true,
+          ),
+        ));
+
+        tester.semantics.copy(find.semantics.byLabel('test'));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('cut sends semantic cut', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Semantics(
+            label: 'test',
+            onCut: () => invoked = true,
+          ),
+        ));
+
+        tester.semantics.cut(find.semantics.byLabel('test'));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('paste sends semantic paste', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Semantics(
+            label: 'test',
+            onPaste: () => invoked = true,
+          ),
+        ));
+
+        tester.semantics.paste(find.semantics.byLabel('test'));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('didGainAccessibilityFocus causes semantic focus on node', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Semantics(
+            label: 'test',
+            onDidGainAccessibilityFocus: () => invoked = true,
+          ),
+        ));
+
+        tester.semantics.didGainAccessibilityFocus(find.semantics.byLabel('test'));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('didLoseAccessibility causes semantic focus to be lost', (WidgetTester tester) async {
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Semantics(
+            label: 'test',
+            onDidLoseAccessibilityFocus: () => invoked = true,
+          ),
+        ));
+
+        tester.semantics.didLoseAccessibilityFocus(find.semantics.byLabel('test'));
+        expect(invoked, isTrue);
+      });
+
+      testWidgets('dismiss sends semantic dismiss', (WidgetTester tester) async {
+        final GlobalKey key = GlobalKey();
+        const Duration duration = Duration(seconds: 3);
+        final Duration halfDuration = Duration(milliseconds: (duration.inMilliseconds / 2).floor());
+        late SnackBarClosedReason reason;
+
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            key: key,
+          )
+        ));
+
+        final ScaffoldMessengerState messenger = ScaffoldMessenger.of(key.currentContext!);
+        messenger.showSnackBar(const SnackBar(
+          content: SizedBox(height: 40, width: 300,),
+          duration: duration
+        )).closed.then((SnackBarClosedReason result) => reason = result);
+        await tester.pumpFrames(tester.widget(find.byType(MaterialApp)), halfDuration);
+
+        tester.semantics.dismiss(find.semantics.byAction(SemanticsAction.dismiss));
+        await tester.pumpAndSettle();
+
+        expect(reason, equals(SnackBarClosedReason.dismiss));
+      });
+
+      testWidgets('customAction invokes appropriate custom action', (WidgetTester tester) async {
+        const CustomSemanticsAction customAction = CustomSemanticsAction(label: 'test');
+        bool invoked = false;
+        await tester.pumpWidget(MaterialApp(
+          home: Semantics(
+            label: 'test',
+            customSemanticsActions: <CustomSemanticsAction, void Function()>{
+              customAction:() => invoked = true,
+            },
+          ),
+        ));
+
+        tester.semantics.customAction(find.semantics.byLabel('test'), customAction);
+        await tester.pump();
+
+        expect(invoked, isTrue);
+      });
+    });
   });
 }
 
@@ -1093,5 +1559,38 @@ class _SemanticsTestCard extends StatelessWidget {
         trailing: SizedBox(width: 200, child: widget),
       ),
     );
+  }
+}
+
+class _StatefulSlider extends StatefulWidget {
+  const _StatefulSlider({required this.initialValue, required this.onChanged});
+
+  final double initialValue;
+  final ValueChanged<double> onChanged;
+
+  @override
+  _StatefulSliderState createState() => _StatefulSliderState();
+}
+
+class _StatefulSliderState extends State<_StatefulSlider> {
+  double _value = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.initialValue;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Slider(
+      value: _value,
+      onChanged: (double value) {
+        setState(() {
+            _value = value;
+          },
+        );
+        widget.onChanged(value);
+    });
   }
 }

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -988,6 +988,110 @@ void main() {
         expect(failure.message, contains('Actual: _PredicateSemanticsFinder:<Found 2 SemanticsNodes with any of the following flags: [SemanticsFlag.isHeader, SemanticsFlag.isTextField]:'));
       });
     });
+
+    group('scrollable', () {
+      testWidgets('can find node that can scroll up', (WidgetTester tester) async {
+        final ScrollController controller = ScrollController();
+        await tester.pumpWidget(MaterialApp(
+          home: SingleChildScrollView(
+            controller: controller,
+            child: const SizedBox(width: 100, height: 1000),
+          ),
+        ));
+
+        expect(find.semantics.scrollable(), containsSemantics(
+          hasScrollUpAction: true,
+          hasScrollDownAction: false,
+        ));
+      });
+
+      testWidgets('can find node that can scroll down', (WidgetTester tester) async {
+        final ScrollController controller = ScrollController(initialScrollOffset: 400);
+        await tester.pumpWidget(MaterialApp(
+          home: SingleChildScrollView(
+            controller: controller,
+            child: const SizedBox(width: 100, height: 1000),
+          ),
+        ));
+
+        expect(find.semantics.scrollable(), containsSemantics(
+          hasScrollUpAction: false,
+          hasScrollDownAction: true,
+        ));
+      });
+
+      testWidgets('can find node that can scroll left', (WidgetTester tester) async {
+        final ScrollController controller = ScrollController();
+        await tester.pumpWidget(MaterialApp(
+          home: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            controller: controller,
+            child: const SizedBox(width: 1000, height: 100),
+          ),
+        ));
+
+        expect(find.semantics.scrollable(), containsSemantics(
+          hasScrollLeftAction: true,
+          hasScrollRightAction: false,
+        ));
+      });
+
+      testWidgets('can find node that can scroll right', (WidgetTester tester) async {
+        final ScrollController controller = ScrollController(initialScrollOffset: 200);
+        await tester.pumpWidget(MaterialApp(
+          home: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            controller: controller,
+            child: const SizedBox(width: 1000, height: 100),
+          ),
+        ));
+
+        expect(find.semantics.scrollable(), containsSemantics(
+          hasScrollLeftAction: false,
+          hasScrollRightAction: true,
+        ));
+      });
+
+      testWidgets('can exclusively find node that scrolls horizontally', (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(
+          home: Column(
+            children: <Widget>[
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SizedBox(width: 1000, height: 100),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: SizedBox(width: 100, height: 1000),
+                ),
+              ),
+            ],
+          )
+        ));
+
+        expect(find.semantics.scrollable(axis: Axis.horizontal), findsOne);
+      });
+
+      testWidgets('can exclusively find node that scrolls vertically', (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(
+          home: Column(
+            children: <Widget>[
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SizedBox(width: 1000, height: 100),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: SizedBox(width: 100, height: 1000),
+                ),
+              ),
+            ],
+          )
+        ));
+
+        expect(find.semantics.scrollable(axis: Axis.vertical), findsOne);
+      });
+    });
   });
 
   group('FinderBase', () {


### PR DESCRIPTION
* Added `performAction` to `SemanticsController` as well as specific methods for specific actions
* Added a `scrollable` finder to `find.semantics` as a convenience method for `findAny(<all scrollable actions>)`
* Updated `containsSemantics` and `matchSemantics` matchers to also work on `FinderBase<Semantics>`

Closes #112413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.