### PR TITLE
Fix flutter_tools use of --local-engine-host

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -331,7 +331,7 @@ class FlutterPlugin implements Plugin<Project> {
             if (!engineHostOut.isDirectory()) {
                 throw new GradleException('local-engine-host-out must point to a local engine host build')
             }
-            localEngineHostOut = engineHostOut.name
+            localEngineHost = engineHostOut.name
         }
         project.android.buildTypes.all this.&addFlutterDependencies
     }


### PR DESCRIPTION
PR #132346 added the use of --local-engine-host to flutter_tools internals, and had an error on one line. Fix that error, to use the correct field name.

The error occurs when building plugins with the changed tools.
