### PR TITLE
Implement SelectionArea single click/tap gestures

### DIFF
--- a/examples/api/test/material/context_menu/selectable_region_toolbar_builder.0_test.dart
+++ b/examples/api/test/material/context_menu/selectable_region_toolbar_builder.0_test.dart
@@ -24,6 +24,9 @@ void main() {
 
     // Right clicking the Text in the SelectionArea shows the custom context
     // menu.
+    final TestGesture primaryMouseButtonGesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
     final TestGesture gesture = await tester.startGesture(
       tester.getCenter(find.text(example.text)),
       kind: PointerDeviceKind.mouse,
@@ -37,7 +40,9 @@ void main() {
     expect(find.text('Print'), findsOneWidget);
 
     // Tap to dismiss.
-    await tester.tapAt(tester.getCenter(find.byType(Scaffold)));
+    await primaryMouseButtonGesture.down(tester.getCenter(find.byType(Scaffold)));
+    await tester.pump();
+    await primaryMouseButtonGesture.up();
     await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1308,9 +1308,9 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
 
 /// A continuous, selectable piece of paragraph.
 ///
-/// Since the selections in [PlaceHolderSpan] are handled independently in its
+/// Since the selections in [PlaceholderSpan] are handled independently in its
 /// subtree, a selection in [RenderParagraph] can't continue across a
-/// [PlaceHolderSpan]. The [RenderParagraph] splits itself on [PlaceHolderSpan]
+/// [PlaceholderSpan]. The [RenderParagraph] splits itself on [PlaceholderSpan]
 /// to create multiple `_SelectableFragment`s so that they can be selected
 /// separately.
 class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutMetrics {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -132,7 +132,7 @@ mixin RenderInlineChildrenContainerDefaults on RenderBox, ContainerRenderObjectM
             ui.PlaceholderAlignment.belowBaseline ||
             ui.PlaceholderAlignment.bottom ||
             ui.PlaceholderAlignment.middle ||
-            ui.PlaceholderAlignment.top      => null,
+            ui.PlaceholderAlignment.top => null,
             ui.PlaceholderAlignment.baseline => child.getDistanceToBaseline(span.baseline!),
           },
         );

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1720,7 +1720,7 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     _selectableContainsOriginWord = true;
 
     final TextPosition position = paragraph.getPositionForOffset(paragraph.globalToLocal(globalPosition));
-    if (_positionIsWithinCurrentSelection(position)) {
+    if (_positionIsWithinCurrentSelection(position) && _textSelectionStart != _textSelectionEnd) {
       return SelectionResult.end;
     }
     final _WordBoundaryRecord wordBoundary = _getWordBoundaryAtPosition(position);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1417,9 +1417,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
         result = _handleClearSelection();
       case SelectionEventType.selectAll:
         result = _handleSelectAll();
-      case SelectionEventType.collapseSelection:
-        final CollapseSelectionSelectionEvent colllapseSelection = event as CollapseSelectionSelectionEvent;
-        result = _handleCollapseSelection(colllapseSelection.globalPosition);
       case SelectionEventType.selectWord:
         final SelectWordSelectionEvent selectWord = event as SelectWordSelectionEvent;
         result = _handleSelectWord(selectWord.globalPosition);
@@ -1716,25 +1713,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
     _textSelectionStart = TextPosition(offset: range.start);
     _textSelectionEnd = TextPosition(offset: range.end, affinity: TextAffinity.upstream);
     return SelectionResult.none;
-  }
-
-  SelectionResult _handleCollapseSelection(Offset globalPosition) {
-    _selectableContainsOriginWord = true;
-
-    final TextPosition position = paragraph.getPositionForOffset(paragraph.globalToLocal(globalPosition));
-    if (_positionIsWithinCurrentSelection(position) && _textSelectionStart != _textSelectionEnd) {
-      return SelectionResult.end;
-    }
-    if (position.offset < range.start) {
-      return SelectionResult.previous;
-    } else if (position.offset > range.end) {
-      return SelectionResult.next;
-    }
-    // Fragments are separated by placeholder span, the target position shouldn't
-    // expand across fragments.
-    assert(position.offset >= range.start && position.offset <= range.end);
-    _textSelectionStart = _textSelectionEnd = position;
-    return SelectionResult.end;
   }
 
   SelectionResult _handleSelectWord(Offset globalPosition) {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -351,8 +351,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     final List<TextSelection> results = <TextSelection>[];
     for (final _SelectableFragment fragment in _lastSelectableFragments!) {
       if (fragment._textSelectionStart != null &&
-          fragment._textSelectionEnd != null &&
-          fragment._textSelectionStart!.offset != fragment._textSelectionEnd!.offset) {
+          fragment._textSelectionEnd != null) {
         results.add(
           TextSelection(
             baseOffset: fragment._textSelectionStart!.offset,

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -289,6 +289,12 @@ enum SelectionEventType {
   /// Used by [SelectAllSelectionEvent].
   selectAll,
 
+  /// An event to collapse the selection at the location
+  /// [CollapseSelectionSelectionEvent.globalPosition].
+  ///
+  /// Used by [CollapseSelectionSelectionEvent].
+  collapseSelection,
+
   /// An event to select a word at the location
   /// [SelectWordSelectionEvent.globalPosition].
   ///
@@ -353,6 +359,17 @@ class SelectAllSelectionEvent extends SelectionEvent {
 class ClearSelectionEvent extends SelectionEvent {
   /// Create a clear selection event.
   const ClearSelectionEvent(): super._(SelectionEventType.clear);
+}
+
+/// Collapses the selection at the location.
+///
+/// This event can be sent as the result of a single click/tap to move the selection.
+class CollapseSelectionSelectionEvent extends SelectionEvent {
+  /// Creates a collapse selection event at the [globalPosition].
+  const CollapseSelectionSelectionEvent({required this.globalPosition}): super._(SelectionEventType.collapseSelection);
+
+  /// The position in global coordinates to collapse the selection at.
+  final Offset globalPosition;
 }
 
 /// Selects the whole word at the location.

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -289,12 +289,6 @@ enum SelectionEventType {
   /// Used by [SelectAllSelectionEvent].
   selectAll,
 
-  /// An event to collapse the selection at the location
-  /// [CollapseSelectionSelectionEvent.globalPosition].
-  ///
-  /// Used by [CollapseSelectionSelectionEvent].
-  collapseSelection,
-
   /// An event to select a word at the location
   /// [SelectWordSelectionEvent.globalPosition].
   ///
@@ -359,17 +353,6 @@ class SelectAllSelectionEvent extends SelectionEvent {
 class ClearSelectionEvent extends SelectionEvent {
   /// Create a clear selection event.
   const ClearSelectionEvent(): super._(SelectionEventType.clear);
-}
-
-/// Collapses the selection at the location.
-///
-/// This event can be sent as the result of a single click/tap to move the selection.
-class CollapseSelectionSelectionEvent extends SelectionEvent {
-  /// Creates a collapse selection event at the [globalPosition].
-  const CollapseSelectionSelectionEvent({required this.globalPosition}): super._(SelectionEventType.collapseSelection);
-
-  /// The position in global coordinates to collapse the selection at.
-  final Offset globalPosition;
 }
 
 /// Selects the whole word at the location.

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1417,6 +1417,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
         _selectableEndEdgeUpdateRecords.remove(selectable);
         _selectableStartEdgeUpdateRecords.remove(selectable);
       case SelectionEventType.selectAll:
+      case SelectionEventType.collapseSelection:
       case SelectionEventType.selectWord:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -657,7 +657,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       if (oldWidget.controller == null) {
         // The old controller was null, meaning the fallback cannot be null.
         // Dispose of the fallback.
-        assert(_fallbackScrollController !=  null);
+        assert(_fallbackScrollController != null);
         assert(widget.controller != null);
         _fallbackScrollController!.detach(position);
         _fallbackScrollController!.dispose();
@@ -1919,7 +1919,7 @@ class TwoDimensionalScrollableState extends State<TwoDimensionalScrollable> {
       if (oldWidget.horizontalDetails.controller == null) {
         // The old controller was null, meaning the fallback cannot be null.
         // Dispose of the fallback.
-        assert(_horizontalFallbackController !=  null);
+        assert(_horizontalFallbackController != null);
         assert(widget.horizontalDetails.controller != null);
         _horizontalFallbackController!.dispose();
         _horizontalFallbackController = null;

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1417,7 +1417,6 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
         _selectableEndEdgeUpdateRecords.remove(selectable);
         _selectableStartEdgeUpdateRecords.remove(selectable);
       case SelectionEventType.selectAll:
-      case SelectionEventType.collapseSelection:
       case SelectionEventType.selectWord:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -353,7 +353,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             }
           } else {
             hideToolbar();
-            _collapseSelectionAtPosition(offset: details.globalPosition);
+            _collapseSelectionAt(offset: details.globalPosition);
           }
         };
         instance.onSecondaryTapDown = _handleRightClickDown;
@@ -509,7 +509,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
           case TargetPlatform.windows:
-            _collapseSelectionAtPosition(offset: details.globalPosition);
+            _collapseSelectionAt(offset: details.globalPosition);
         }
       case 2:
         _selectWordAt(offset: details.globalPosition);
@@ -547,7 +547,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:
-            _collapseSelectionAtPosition(offset: details.globalPosition);
+            _collapseSelectionAt(offset: details.globalPosition);
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
           case TargetPlatform.windows:
@@ -616,7 +616,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         // keep the current selection, if not then collapse it.
         final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
         if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-          _collapseSelectionAtPosition(offset: lastSecondaryTapDownPosition!);
+          _collapseSelectionAt(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
         _showToolbar(location: lastSecondaryTapDownPosition);
@@ -641,7 +641,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         // keep the current selection, if not then collapse it.
         final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
         if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-          _collapseSelectionAtPosition(offset: lastSecondaryTapDownPosition!);
+          _collapseSelectionAt(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
         _showToolbar(location: lastSecondaryTapDownPosition);
@@ -953,8 +953,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// See also:
   ///  * [_selectStartTo], which sets or updates selection start edge.
   ///  * [_finalizeSelection], which stops the `continuous` updates.
-  ///  * [_clearSelection], which clear the ongoing selection.
+  ///  * [_clearSelection], which clears the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
+  ///  * [_collapseSelectionAt], which collapses the selection at the location.
   ///  * [selectAll], which selects the entire content.
   void _selectEndTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
@@ -992,8 +993,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// See also:
   ///  * [_selectEndTo], which sets or updates selection end edge.
   ///  * [_finalizeSelection], which stops the `continuous` updates.
-  ///  * [_clearSelection], which clear the ongoing selection.
+  ///  * [_clearSelection], which clears the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
+  ///  * [_collapseSelectionAt], which collapses the selection at the location.
   ///  * [selectAll], which selects the entire content.
   void _selectStartTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
@@ -1012,10 +1014,10 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_selectStartTo], which sets or updates selection start edge.
   ///  * [_selectEndTo], which sets or updates selection end edge.
   ///  * [_finalizeSelection], which stops the `continuous` updates.
-  ///  * [_clearSelection], which clear the ongoing selection.
+  ///  * [_clearSelection], which clears the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
-  void _collapseSelectionAtPosition({required Offset offset}) {
+  void _collapseSelectionAt({required Offset offset}) {
     _selectStartTo(offset: offset);
     _selectEndTo(offset: offset);
     _selectionDelegate._flushInactiveSelections();
@@ -1034,7 +1036,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_selectStartTo], which sets or updates selection start edge.
   ///  * [_selectEndTo], which sets or updates selection end edge.
   ///  * [_finalizeSelection], which stops the `continuous` updates.
-  ///  * [_clearSelection], which clear the ongoing selection.
+  ///  * [_clearSelection], which clears the ongoing selection.
+  ///  * [_collapseSelectionAt], which collapses the selection at the location.
   ///  * [selectAll], which selects the entire content.
   void _selectWordAt({required Offset offset}) {
     // There may be other selection ongoing.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -352,7 +352,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
               _showToolbar(location: details.globalPosition);
             }
           } else {
-            _clearSelection();
+            _selectPositionAt(offset: details.globalPosition);
           }
         };
         instance.onSecondaryTapDown = _handleRightClickDown;
@@ -472,6 +472,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           (TapAndPanGestureRecognizer instance) {
         instance
           ..onTapDown = _startNewMouseSelectionGesture
+          ..onTapUp = _handleMouseTapUp
           ..onDragStart = _handleMouseDragStart
           ..onDragUpdate = _handleMouseDragUpdate
           ..onDragEnd = _handleMouseDragEnd
@@ -498,7 +499,17 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case 1:
         widget.focusNode.requestFocus();
         hideToolbar();
-        _clearSelection();
+        switch (defaultTargetPlatform) {
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+          case TargetPlatform.iOS:
+            // On mobile platforms the selection is set on tap up.
+            break;
+          case TargetPlatform.macOS:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+            _selectPositionAt(offset: details.globalPosition);
+        }
       case 2:
         _selectWordAt(offset: details.globalPosition);
     }
@@ -526,6 +537,23 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleMouseDragEnd(TapDragEndDetails details) {
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
+  }
+
+  void _handleMouseTapUp(TapDragUpDetails details) {
+    switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
+      case 1:
+        switch (defaultTargetPlatform) {
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+          case TargetPlatform.iOS:
+            _selectPositionAt(offset: details.globalPosition);
+          case TargetPlatform.macOS:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+            // On desktop platforms the selection is set on tap down.
+            break;
+        }
+    }
   }
 
   void _updateSelectedContentIfNeeded() {
@@ -586,8 +614,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         // keep the current selection, if not then collapse it.
         final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
         if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-          _selectStartTo(offset: lastSecondaryTapDownPosition!);
-          _selectEndTo(offset: lastSecondaryTapDownPosition!);
+          _selectPositionAt(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
         _showToolbar(location: lastSecondaryTapDownPosition);
@@ -612,8 +639,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         // keep the current selection, if not then collapse it.
         final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
         if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-          _selectStartTo(offset: lastSecondaryTapDownPosition!);
-          _selectEndTo(offset: lastSecondaryTapDownPosition!);
+          _selectPositionAt(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
         _showToolbar(location: lastSecondaryTapDownPosition);
@@ -976,6 +1002,22 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       _selectionStartPosition = offset;
       _triggerSelectionStartEdgeUpdate(textGranularity: textGranularity);
     }
+  }
+
+  /// Selects a position at the `offset` location.
+  ///
+  /// The selection will be collapsed at the `offset` location.
+  ///
+  /// See also:
+  ///  * [_selectStartTo], which sets or updates selection start edge.
+  ///  * [_selectEndTo], which sets or updates selection end edge.
+  ///  * [_finalizeSelection], which stops the `continuous` updates.
+  ///  * [_clearSelection], which clear the ongoing selection.
+  ///  * [_selectWordAt], which selects a whole word at the location.
+  ///  * [selectAll], which selects the entire content.
+  void _selectPositionAt({required Offset offset}) {
+    _selectStartTo(offset: offset);
+    _selectEndTo(offset: offset);
   }
 
   /// Selects a whole word at the `offset` location.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1928,7 +1928,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
 
     SelectionPoint? startPoint;
     if (startGeometry.startSelectionPoint != null) {
-      final Matrix4 startTransform =  getTransformFrom(selectables[startIndexWalker]);
+      final Matrix4 startTransform = getTransformFrom(selectables[startIndexWalker]);
       final Offset start = MatrixUtils.transformPoint(startTransform, startGeometry.startSelectionPoint!.localPosition);
       // It can be NaN if it is detached or off-screen.
       if (start.isFinite) {
@@ -1949,7 +1949,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     }
     SelectionPoint? endPoint;
     if (endGeometry.endSelectionPoint != null) {
-      final Matrix4 endTransform =  getTransformFrom(selectables[endIndexWalker]);
+      final Matrix4 endTransform = getTransformFrom(selectables[endIndexWalker]);
       final Offset end = MatrixUtils.transformPoint(endTransform, endGeometry.endSelectionPoint!.localPosition);
       // It can be NaN if it is detached or off-screen.
       if (end.isFinite) {
@@ -2033,8 +2033,8 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       final Rect? drawableArea = hasSize ? Rect
         .fromLTWH(0, 0, containerSize.width, containerSize.height)
         .inflate(_kSelectionHandleDrawableAreaPadding) : null;
-      final bool hideStartHandle = value.startSelectionPoint == null || drawableArea ==  null || !drawableArea.contains(value.startSelectionPoint!.localPosition);
-      final bool hideEndHandle = value.endSelectionPoint == null || drawableArea ==  null|| !drawableArea.contains(value.endSelectionPoint!.localPosition);
+      final bool hideStartHandle = value.startSelectionPoint == null || drawableArea == null || !drawableArea.contains(value.startSelectionPoint!.localPosition);
+      final bool hideEndHandle = value.endSelectionPoint == null || drawableArea == null|| !drawableArea.contains(value.endSelectionPoint!.localPosition);
       effectiveStartHandle = hideStartHandle ? null : _startHandleLayer;
       effectiveEndHandle = hideEndHandle ? null : _endHandleLayer;
     }
@@ -2145,14 +2145,14 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
+        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
+          return SelectionResult.next;
+        }
         if (lastSelectionResult == SelectionResult.next) {
           continue;
         }
         if (index == 0 && lastSelectionResult == SelectionResult.previous) {
           return SelectionResult.previous;
-        }
-        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
-          return SelectionResult.next;
         }
         if (selectables[index].value != existingGeometry) {
           // Geometry has changed as a result of select word, need to clear the
@@ -2365,7 +2365,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     bool hasFoundEdgeIndex = false;
     SelectionResult? result;
     for (int index = 0; index < selectables.length && !hasFoundEdgeIndex; index += 1) {
-      final Selectable child =  selectables[index];
+      final Selectable child = selectables[index];
       final SelectionResult childResult = dispatchSelectionEventToChild(child, event);
       switch (childResult) {
         case SelectionResult.next:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1006,9 +1006,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     }
   }
 
-  /// Selects a position at the `offset` location.
-  ///
-  /// The selection will be collapsed at the `offset` location.
+  /// Collapses the selection at the given `offset` location.
   ///
   /// See also:
   ///  * [_selectStartTo], which sets or updates selection start edge.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -520,6 +520,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleMouseDragStart(TapDragStartDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
+        _clearSelection();
         _selectStartTo(offset: details.globalPosition);
     }
     _updateSelectedContentIfNeeded();
@@ -1018,6 +1019,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
   void _collapseSelectionAt({required Offset offset}) {
+    _clearSelection();
     _selectStartTo(offset: offset);
     _selectEndTo(offset: offset);
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2421,10 +2421,10 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     SelectionResult? finalResult;
     final bool isCurrentEdgeWithinViewport = isEnd ? _selectionGeometry.endSelectionPoint != null : _selectionGeometry.startSelectionPoint != null;
     final bool isOppositeEdgeWithinViewport = isEnd ? _selectionGeometry.startSelectionPoint != null : _selectionGeometry.endSelectionPoint != null;
-    // Determines if the edge being adjusted is within the current viewport boundaries.
+    // Determines if the edge being adjusted is within the current viewport.
     // If it is not, we attempt to locate the selection edge starting from the opposite end.
     // In cases where neither edge is within the viewport, the search for the new edge position
-    // commences from 0.
+    // begins at 0.
     int newIndex = switch ((isEnd, isCurrentEdgeWithinViewport, isOppositeEdgeWithinViewport)) {
       (true, true, true) => currentSelectionEndIndex,
       (true, true, false) => currentSelectionEndIndex,

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -353,7 +353,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             }
           } else {
             hideToolbar();
-            _selectPositionAt(offset: details.globalPosition);
+            _collapseSelectionAtPosition(offset: details.globalPosition);
           }
         };
         instance.onSecondaryTapDown = _handleRightClickDown;
@@ -509,7 +509,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
           case TargetPlatform.windows:
-            _selectPositionAt(offset: details.globalPosition);
+            _collapseSelectionAtPosition(offset: details.globalPosition);
         }
       case 2:
         _selectWordAt(offset: details.globalPosition);
@@ -547,7 +547,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:
-            _selectPositionAt(offset: details.globalPosition);
+            _collapseSelectionAtPosition(offset: details.globalPosition);
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
           case TargetPlatform.windows:
@@ -616,7 +616,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         // keep the current selection, if not then collapse it.
         final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
         if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-          _selectPositionAt(offset: lastSecondaryTapDownPosition!);
+          _collapseSelectionAtPosition(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
         _showToolbar(location: lastSecondaryTapDownPosition);
@@ -641,7 +641,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         // keep the current selection, if not then collapse it.
         final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
         if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
-          _selectPositionAt(offset: lastSecondaryTapDownPosition!);
+          _collapseSelectionAtPosition(offset: lastSecondaryTapDownPosition!);
         }
         _showHandles();
         _showToolbar(location: lastSecondaryTapDownPosition);
@@ -1017,7 +1017,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_clearSelection], which clear the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
-  void _selectPositionAt({required Offset offset}) {
+  void _collapseSelectionAtPosition({required Offset offset}) {
     _selectStartTo(offset: offset);
     _selectEndTo(offset: offset);
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -546,6 +546,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:
+            debugPrint('here');
             _selectPositionAt(offset: details.globalPosition);
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
@@ -554,6 +555,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             break;
         }
     }
+    _updateSelectedContentIfNeeded();
   }
 
   void _updateSelectedContentIfNeeded() {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1020,7 +1020,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _collapseSelectionAt({required Offset offset}) {
     _selectStartTo(offset: offset);
     _selectEndTo(offset: offset);
-    _selectionDelegate._flushInactiveSelections();
   }
 
   /// Selects a whole word at the `offset` location.
@@ -2397,6 +2396,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     } else {
       currentSelectionStartIndex = newIndex;
     }
+    _flushInactiveSelections();
     // The result can only be null if the loop went through the entire list
     // without any of the selection returned end or previous. In this case, the
     // caller of this method needs to find the next selectable in their list.
@@ -2465,6 +2465,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     } else {
       currentSelectionStartIndex = newIndex;
     }
+    _flushInactiveSelections();
     return finalResult!;
   }
 }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1016,23 +1016,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [selectAll], which selects the entire content.
   void _collapseSelectionAtPosition({required Offset offset}) {
-    // Placing this before updating the start/end edge does not
-    // work to clear all unrelated selections because dispatching a selection edge
-    // update event will send the edge update to every selectable until arriving
-    // at the correct selectable, so the selection is set again after it is cleared.
-    // _clearSelection();
-
-    // _selectStartTo(offset: offset);
-    // _selectEndTo(offset: offset);
-
-    // This works to clear all unrelated selections but relies on a new selection event.
-    _selectable?.dispatchSelectionEvent(CollapseSelectionSelectionEvent(globalPosition: offset));
-
-    // This works to clear all unrelated selections but does not abide by the delegate
-    // contract i.e. dispatching SelectionEvents and reacting to them. Making a new
-    // selection event, ClearAllOtherSelectionEvent is also an an option, but i'm not
-    // sure it makes much sense to add a selection event for this.
-    // _selectionDelegate.handleClearAllOtherSelections();
+    _selectStartTo(offset: offset);
+    _selectEndTo(offset: offset);
   }
 
   /// Selects a whole word at the `offset` location.
@@ -1577,7 +1562,6 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
         _hasReceivedStartEvent.remove(selectable);
         _hasReceivedEndEvent.remove(selectable);
       case SelectionEventType.selectAll:
-      case SelectionEventType.collapseSelection:
       case SelectionEventType.selectWord:
         break;
       case SelectionEventType.granularlyExtendSelection:
@@ -2116,34 +2100,29 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     return SelectionResult.none;
   }
 
-  SelectionResult _handleSelectBoundary(SelectionEvent event) {
-    final Offset effectiveGlobalPosition;
-    if (event.type == SelectionEventType.selectWord) {
-      effectiveGlobalPosition = (event as SelectWordSelectionEvent).globalPosition;
-    } else if (event.type == SelectionEventType.collapseSelection) {
-      effectiveGlobalPosition = (event as CollapseSelectionSelectionEvent).globalPosition;
-    } else {
-      throw UnimplementedError();
-    }
+  /// Selects a word in a selectable at the location
+  /// [SelectWordSelectionEvent.globalPosition].
+  @protected
+  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
     SelectionResult? lastSelectionResult;
     for (int index = 0; index < selectables.length; index += 1) {
       final Rect localRect = Rect.fromLTWH(0, 0, selectables[index].size.width, selectables[index].size.height);
       final Matrix4 transform = selectables[index].getTransformTo(null);
       final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
-      if (globalRect.contains(effectiveGlobalPosition)) {
+      if (globalRect.contains(event.globalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
-        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
-          return SelectionResult.next;
-        }
         if (lastSelectionResult == SelectionResult.next) {
           continue;
         }
         if (index == 0 && lastSelectionResult == SelectionResult.previous) {
           return SelectionResult.previous;
         }
+        if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
+          return SelectionResult.next;
+        }
         if (selectables[index].value != existingGeometry) {
-          // Geometry has changed as a result of select boundary, need to clear the
+          // Geometry has changed as a result of select word, need to clear the
           // selection of other selectables to keep selection in sync.
           selectables
             .where((Selectable target) => target != selectables[index])
@@ -2160,31 +2139,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     }
     assert(lastSelectionResult == null);
     return SelectionResult.end;
-  }
-
-  /// Collapses the selection in a selectable at the location
-  /// [CollapseSelectionSelectionEvent.globalPosition].
-  @protected
-  SelectionResult handleCollapseSelection(CollapseSelectionSelectionEvent event) {
-    return _handleSelectBoundary(event);
-  }
-
-  /// Selects a word in a selectable at the location
-  /// [SelectWordSelectionEvent.globalPosition].
-  @protected
-  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
-    return _handleSelectBoundary(event);
-  }
-
-  void handleClearAllOtherSelections() {
-    final int skipStart = min(currentSelectionStartIndex, currentSelectionEndIndex);
-    final int skipEnd = max(currentSelectionStartIndex, currentSelectionEndIndex);
-    for (int index = 0; index < selectables.length; index += 1) {
-      if (index >= skipStart && index <= skipEnd) {
-        continue;
-      }
-      dispatchSelectionEventToChild(selectables[index], const ClearSelectionEvent());
-    }
   }
 
   /// Removes the selection of all selectables this delegate manages.
@@ -2317,9 +2271,6 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       case SelectionEventType.selectAll:
         _extendSelectionInProgress = false;
         result = handleSelectAll(event as SelectAllSelectionEvent);
-      case SelectionEventType.collapseSelection:
-        _extendSelectionInProgress = false;
-        result = handleCollapseSelection(event as CollapseSelectionSelectionEvent);
       case SelectionEventType.selectWord:
         _extendSelectionInProgress = false;
         result = handleSelectWord(event as SelectWordSelectionEvent);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -546,7 +546,6 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:
-            debugPrint('here');
             _selectPositionAt(offset: details.globalPosition);
           case TargetPlatform.macOS:
           case TargetPlatform.linux:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -352,6 +352,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
               _showToolbar(location: details.globalPosition);
             }
           } else {
+            hideToolbar();
             _selectPositionAt(offset: details.globalPosition);
           }
         };

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -224,8 +224,14 @@ void main() {
 
     // Backwards selection.
     await gesture.down(textOffsetToPosition(paragraph, 3));
-    await tester.pumpAndSettle();
-    expect(content, isNull);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(content, isNotNull);
+    expect(content!.plainText, '');
+
+    await gesture.down(textOffsetToPosition(paragraph, 3));
+    await tester.pump();
     await gesture.moveTo(textOffsetToPosition(paragraph, 0));
     await gesture.up();
     await tester.pump();

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -978,7 +978,7 @@ void main() {
           granularity: TextGranularity.word,
         ),
       );
-      expect(paragraph.selections.length, 0); // how []are you
+      expect(paragraph.selections.length, 1); // how []are you
 
       // Equivalent to sending shift + alt + arrow-left.
       registrar.selectables[0].dispatchSelectionEvent(

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -979,6 +979,7 @@ void main() {
         ),
       );
       expect(paragraph.selections.length, 1); // how []are you
+      expect(paragraph.selections[0], const TextSelection.collapsed(offset: 4));
 
       // Equivalent to sending shift + alt + arrow-left.
       registrar.selectables[0].dispatchSelectionEvent(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -61,6 +61,7 @@ void main() {
       renderSelectionSpy.events.clear();
 
       await gesture.moveTo(const Offset(200.0, 100.0));
+      expect(renderSelectionSpy.events.removeAt(0), isA<ClearSelectionEvent>());
       expect(renderSelectionSpy.events.length, 2);
       expect(renderSelectionSpy.events[0].type, SelectionEventType.startEdgeUpdate);
       final SelectionEdgeUpdateEvent startEdge = renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent;
@@ -303,11 +304,12 @@ void main() {
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
-      expect(renderSelectionSpy.events.length, 2);
-      expect(renderSelectionSpy.events[0], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
+      expect(renderSelectionSpy.events.length, 3);
+      expect(renderSelectionSpy.events[0], isA<ClearSelectionEvent>());
       expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
+      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
+      expect(renderSelectionSpy.events[2], isA<SelectionEdgeUpdateEvent>());
+      expect((renderSelectionSpy.events[2] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
 
     testWidgetsWithLeakTracking('touch long press sends select-word event', (WidgetTester tester) async {
@@ -478,10 +480,12 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
-      expect(
-        renderSelectionSpy.events.every((SelectionEvent element) => element is SelectionEdgeUpdateEvent),
-        isTrue,
-      );
+      expect(renderSelectionSpy.events.length, 3);
+      expect(renderSelectionSpy.events[0], isA<ClearSelectionEvent>());
+      expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
+      expect(renderSelectionSpy.events[1].type, SelectionEventType.startEdgeUpdate);
+      expect(renderSelectionSpy.events[2], isA<SelectionEdgeUpdateEvent>());
+      expect(renderSelectionSpy.events[2].type, SelectionEventType.endEdgeUpdate);
     });
   });
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -821,13 +821,13 @@ void main() {
       // Should clear the selection on paragraph 3.
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
       expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
-      expect(paragraph3.selections[0], const TextSelection.collapsed(offset: 0));
+      expect(paragraph3.selections.isEmpty, isTrue);
 
       await gesture.moveTo(textOffsetToPosition(paragraph1, 4));
       // Should clear the selection on paragraph 2.
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
-      expect(paragraph2.selections[0], const TextSelection.collapsed(offset: 0));
-      expect(paragraph3.selections[0], const TextSelection.collapsed(offset: 0));
+      expect(paragraph2.selections.isEmpty, isTrue);
+      expect(paragraph3.selections.isEmpty, isTrue);
 
       await gesture.up();
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3172,8 +3172,14 @@ void main() {
 
     // Backwards selection.
     await mouseGesture.down(textOffsetToPosition(paragraph, 3));
-    await tester.pumpAndSettle();
-    expect(content, isNull);
+    await tester.pump();
+    await mouseGesture.up();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(content, isNotNull);
+    expect(content!.plainText, '');
+
+    await mouseGesture.down(textOffsetToPosition(paragraph, 3));
+    await tester.pump();
 
     await mouseGesture.moveTo(textOffsetToPosition(paragraph, 0));
     await tester.pumpAndSettle();
@@ -3200,9 +3206,10 @@ void main() {
     // Called on tap.
     await mouseGesture.down(textOffsetToPosition(paragraph, 0));
     await tester.pumpAndSettle();
-    expect(content, isNull);
     await mouseGesture.up();
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(kDoubleTapTimeout);
+    expect(content, isNotNull);
+    expect(content!.plainText, '');
 
     // With touch gestures.
 
@@ -3379,7 +3386,7 @@ void main() {
     expect(paragraph2.selections.length, 1);
     expect(paragraph2.selections[0].start, 0);
     expect(paragraph2.selections[0].end, 8);
-    expect(paragraph3.selections.length, 0);
+    expect(paragraph3.selections.length, 1);
     expect(content, isNotNull);
     expect(content!.plainText, 'w are you?Good, an');
 
@@ -3388,8 +3395,8 @@ void main() {
     expect(paragraph1.selections.length, 1);
     expect(paragraph1.selections[0].start, 2);
     expect(paragraph1.selections[0].end, 7);
-    expect(paragraph2.selections.length, 0);
-    expect(paragraph3.selections.length, 0);
+    expect(paragraph2.selections.length, 1);
+    expect(paragraph3.selections.length, 1);
     expect(content, isNotNull);
     expect(content!.plainText, 'w are');
 
@@ -3398,8 +3405,8 @@ void main() {
     expect(paragraph1.selections.length, 1);
     expect(paragraph1.selections[0].start, 0);
     expect(paragraph1.selections[0].end, 2);
-    expect(paragraph2.selections.length, 0);
-    expect(paragraph3.selections.length, 0);
+    expect(paragraph2.selections.length, 1);
+    expect(paragraph3.selections.length, 1);
     expect(content, isNotNull);
     expect(content!.plainText, 'Ho');
   });

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -599,11 +599,14 @@ void main() {
       await gesture.up();
     }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets('mouse can select single text on mobile platforms', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('mouse can select single text on mobile platforms', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(
-            focusNode: FocusNode(),
+            focusNode: focusNode,
             selectionControls: materialTextSelectionControls,
             child: const Center(
               child: Text('How are you'),
@@ -923,11 +926,14 @@ void main() {
       await gesture.up();
     });
 
-    testWidgets('collapsing selection should clear selection of all other selectables', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('collapsing selection should clear selection of all other selectables', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
       await tester.pumpWidget(
         MaterialApp(
           home: SelectableRegion(
-            focusNode: FocusNode(),
+            focusNode: focusNode,
             selectionControls: materialTextSelectionControls,
             child: const Column(
               children: <Widget>[

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -61,7 +61,6 @@ void main() {
       renderSelectionSpy.events.clear();
 
       await gesture.moveTo(const Offset(200.0, 100.0));
-      expect(renderSelectionSpy.events.removeAt(0), isA<ClearSelectionEvent>());
       expect(renderSelectionSpy.events.length, 2);
       expect(renderSelectionSpy.events[0].type, SelectionEventType.startEdgeUpdate);
       final SelectionEdgeUpdateEvent startEdge = renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent;
@@ -304,12 +303,11 @@ void main() {
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
-      expect(renderSelectionSpy.events.length, 3);
-      expect(renderSelectionSpy.events[0], isA<ClearSelectionEvent>());
+      expect(renderSelectionSpy.events.length, 2);
+      expect(renderSelectionSpy.events[0], isA<SelectionEdgeUpdateEvent>());
+      expect((renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
       expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
-      expect(renderSelectionSpy.events[2], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[2] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
+      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
 
     testWidgetsWithLeakTracking('touch long press sends select-word event', (WidgetTester tester) async {
@@ -480,12 +478,10 @@ void main() {
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
-      expect(renderSelectionSpy.events.length, 3);
-      expect(renderSelectionSpy.events[0], isA<ClearSelectionEvent>());
-      expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
-      expect(renderSelectionSpy.events[1].type, SelectionEventType.startEdgeUpdate);
-      expect(renderSelectionSpy.events[2], isA<SelectionEdgeUpdateEvent>());
-      expect(renderSelectionSpy.events[2].type, SelectionEventType.endEdgeUpdate);
+      expect(
+        renderSelectionSpy.events.every((SelectionEvent element) => element is SelectionEdgeUpdateEvent),
+        isTrue,
+      );
     });
   });
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -303,11 +303,9 @@ void main() {
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
-      expect(renderSelectionSpy.events.length, 2);
-      expect(renderSelectionSpy.events[0], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
-      expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
-      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
+      expect(renderSelectionSpy.events.length, 1);
+      expect(renderSelectionSpy.events[0], isA<CollapseSelectionSelectionEvent>());
+      expect((renderSelectionSpy.events[0] as CollapseSelectionSelectionEvent).type, SelectionEventType.collapseSelection);
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
 
     testWidgetsWithLeakTracking('touch long press sends select-word event', (WidgetTester tester) async {
@@ -479,7 +477,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
       expect(
-        renderSelectionSpy.events.every((SelectionEvent element) => element is SelectionEdgeUpdateEvent),
+        renderSelectionSpy.events.every((SelectionEvent element) => element is CollapseSelectionSelectionEvent || element is ClearSelectionEvent),
         isTrue,
       );
     });
@@ -923,6 +921,49 @@ void main() {
       await gesture.up();
     });
 
+    testWidgets('collapsing selection should clear selection of all other selectables', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?'),
+                Text('Good, and you?'),
+                Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(paragraph1.selections[0], const TextSelection.collapsed(offset: 2));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.down(textOffsetToPosition(paragraph2, 5));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(paragraph1.selections.isEmpty, isTrue);
+      expect(paragraph2.selections[0], const TextSelection.collapsed(offset: 5));
+
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
+      await gesture.down(textOffsetToPosition(paragraph3, 13));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(paragraph1.selections.isEmpty, isTrue);
+      expect(paragraph2.selections.isEmpty, isTrue);
+      expect(paragraph3.selections[0], const TextSelection.collapsed(offset: 13));
+    });
+
     testWidgetsWithLeakTracking('mouse can work with disabled container', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
@@ -1168,10 +1209,11 @@ void main() {
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
+        // Collapse selection.
         await tester.tapAt(textOffsetToPosition(paragraph, 9));
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, isFalse);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 9));
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -281,7 +281,7 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgetsWithLeakTracking('mouse selection always cancels previous selection', (WidgetTester tester) async {
+    testWidgets('mouse single-click selection collapses the selection', (WidgetTester tester) async {
       final UniqueKey spy = UniqueKey();
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
@@ -300,9 +300,14 @@ void main() {
       final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
       final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0), kind: PointerDeviceKind.mouse);
       addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
       await tester.pumpAndSettle();
-      expect(renderSelectionSpy.events.length, 1);
-      expect(renderSelectionSpy.events[0], isA<ClearSelectionEvent>());
+      expect(renderSelectionSpy.events.length, 2);
+      expect(renderSelectionSpy.events[0], isA<SelectionEdgeUpdateEvent>());
+      expect((renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent).type, SelectionEventType.startEdgeUpdate);
+      expect(renderSelectionSpy.events[1], isA<SelectionEdgeUpdateEvent>());
+      expect((renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent).type, SelectionEventType.endEdgeUpdate);
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
 
     testWidgetsWithLeakTracking('touch long press sends select-word event', (WidgetTester tester) async {
@@ -474,7 +479,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
       expect(
-        renderSelectionSpy.events.every((SelectionEvent element) => element is ClearSelectionEvent),
+        renderSelectionSpy.events.every((SelectionEvent element) => element is SelectionEdgeUpdateEvent),
         isTrue,
       );
     });
@@ -580,7 +585,7 @@ void main() {
       await gesture.up();
       await gesture.down(textOffsetToPosition(paragraph, 5));
       await tester.pumpAndSettle();
-      expect(paragraph.selections.isEmpty, isTrue);
+      // expect(paragraph.selections.isEmpty, isTrue);
 
       // Selecting across line should select to the end.
       await gesture.moveTo(textOffsetToPosition(paragraph, 5) + const Offset(0.0, 200.0));
@@ -1151,7 +1156,9 @@ void main() {
         expect(find.byKey(toolbarKey), findsNothing);
 
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+        final TestGesture primaryMouseButtonGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
         final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        addTearDown(primaryMouseButtonGesture.removePointer);
         addTearDown(gesture.removePointer);
         await tester.pump();
         expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
@@ -1185,9 +1192,12 @@ void main() {
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
-        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        // Collapse selection.
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 1));
         await tester.pump();
+        await primaryMouseButtonGesture.up();
+        await tester.pumpAndSettle();
+        // Selection is collapsed.
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
       },
@@ -1229,6 +1239,8 @@ void main() {
 
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
         final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        final TestGesture primaryMouseButtonGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        addTearDown(primaryMouseButtonGesture.removePointer);
         addTearDown(gesture.removePointer);
         await tester.pump();
         expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
@@ -1286,9 +1298,12 @@ void main() {
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
-        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        // Collapse selection.
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 1));
         await tester.pump();
+        await primaryMouseButtonGesture.up();
+        await tester.pumpAndSettle();
+        // Selection is collapsed.
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
       },
@@ -1330,6 +1345,8 @@ void main() {
 
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
         final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        final TestGesture primaryMouseButtonGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        addTearDown(primaryMouseButtonGesture.removePointer);
         addTearDown(gesture.removePointer);
         await tester.pump();
         // Selection is collapsed so none is reported.
@@ -1364,20 +1381,22 @@ void main() {
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
-        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        // Collapse selection.
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 1));
         await tester.pump();
+        await primaryMouseButtonGesture.up();
+        await tester.pumpAndSettle(kDoubleTapTimeout);
+        // Selection is collapsed.
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
 
         // Create an uncollapsed selection by dragging.
-        final TestGesture dragGesture = await tester.startGesture(textOffsetToPosition(paragraph, 0), kind: PointerDeviceKind.mouse);
-        addTearDown(dragGesture.removePointer);
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 0));
         await tester.pump();
-        await dragGesture.moveTo(textOffsetToPosition(paragraph, 5));
+        await primaryMouseButtonGesture.moveTo(textOffsetToPosition(paragraph, 5));
         await tester.pump();
         expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
-        await dragGesture.up();
+        await primaryMouseButtonGesture.up();
         await tester.pump();
 
         // Right click on previous selection should not collapse the selection.
@@ -1397,9 +1416,12 @@ void main() {
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
-        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        // Collapse selection.
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 1));
         await tester.pump();
+        await primaryMouseButtonGesture.up();
+        await tester.pumpAndSettle();
+        // Selection is collapsed.
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
       },
@@ -1441,6 +1463,8 @@ void main() {
 
         final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
         final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+        final TestGesture primaryMouseButtonGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        addTearDown(primaryMouseButtonGesture.removePointer);
         addTearDown(gesture.removePointer);
         await tester.pump();
         // Selection is collapsed so none is reported.
@@ -1476,19 +1500,21 @@ void main() {
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
-        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        // Collapse selection.
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 1));
         await tester.pump();
+        await primaryMouseButtonGesture.up();
+        await tester.pumpAndSettle(kDoubleTapTimeout);
+        // Selection is collapsed.
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
 
-        final TestGesture dragGesture = await tester.startGesture(textOffsetToPosition(paragraph, 0), kind: PointerDeviceKind.mouse);
-        addTearDown(dragGesture.removePointer);
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 0));
         await tester.pump();
-        await dragGesture.moveTo(textOffsetToPosition(paragraph, 5));
+        await primaryMouseButtonGesture.moveTo(textOffsetToPosition(paragraph, 5));
         await tester.pump();
         expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
-        await dragGesture.up();
+        await primaryMouseButtonGesture.up();
         await tester.pump();
 
         // Right click on previous selection should not collapse the selection.
@@ -1517,9 +1543,12 @@ void main() {
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsOneWidget);
 
-        // Clear selection.
-        await tester.tapAt(textOffsetToPosition(paragraph, 1));
+        // Collapse selection.
+        await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 1));
         await tester.pump();
+        await primaryMouseButtonGesture.up();
+        await tester.pumpAndSettle();
+        // Selection is collapsed.
         expect(paragraph.selections.isEmpty, true);
         expect(find.byKey(toolbarKey), findsNothing);
       },

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -579,13 +579,13 @@ void main() {
       // Check backward selection.
       await gesture.moveTo(textOffsetToPosition(paragraph, 1));
       await tester.pump();
+      expect(paragraph.selections.isEmpty, isFalse);
       expect(paragraph.selections[0], const TextSelection(baseOffset: 2, extentOffset: 1));
 
       // Start a new drag.
       await gesture.up();
       await gesture.down(textOffsetToPosition(paragraph, 5));
       await tester.pumpAndSettle();
-      // expect(paragraph.selections.isEmpty, isTrue);
 
       // Selecting across line should select to the end.
       await gesture.moveTo(textOffsetToPosition(paragraph, 5) + const Offset(0.0, 200.0));
@@ -648,7 +648,8 @@ void main() {
       await gesture.down(textOffsetToPosition(paragraph, 5));
       await tester.pump();
       await gesture.up();
-      expect(paragraph.selections.isEmpty, isTrue);
+      expect(paragraph.selections.isEmpty, isFalse);
+      expect(paragraph.selections[0], const TextSelection.collapsed(offset: 5));
       await tester.pump(kDoubleTapTimeout);
 
       // Double-click.
@@ -766,13 +767,13 @@ void main() {
       // Should clear the selection on paragraph 3.
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
       expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
-      expect(paragraph3.selections.isEmpty, true);
+      expect(paragraph3.selections[0], const TextSelection.collapsed(offset: 0));
 
       await gesture.moveTo(textOffsetToPosition(paragraph1, 4));
       // Should clear the selection on paragraph 2.
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
-      expect(paragraph2.selections.isEmpty, true);
-      expect(paragraph3.selections.isEmpty, true);
+      expect(paragraph2.selections[0], const TextSelection.collapsed(offset: 0));
+      expect(paragraph3.selections[0], const TextSelection.collapsed(offset: 0));
 
       await gesture.up();
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
@@ -1198,7 +1199,8 @@ void main() {
         await primaryMouseButtonGesture.up();
         await tester.pumpAndSettle();
         // Selection is collapsed.
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 1));
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
@@ -1304,7 +1306,8 @@ void main() {
         await primaryMouseButtonGesture.up();
         await tester.pumpAndSettle();
         // Selection is collapsed.
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 1));
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.macOS),
@@ -1349,19 +1352,20 @@ void main() {
         addTearDown(primaryMouseButtonGesture.removePointer);
         addTearDown(gesture.removePointer);
         await tester.pump();
-        // Selection is collapsed so none is reported.
-        expect(paragraph.selections.isEmpty, true);
-
         await gesture.up();
         await tester.pump();
 
+        // Selection is collapsed.
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 2));
         expect(buttonTypes.length, 1);
         expect(buttonTypes, contains(ContextMenuButtonType.selectAll));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
         await gesture.down(textOffsetToPosition(paragraph, 6));
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 6));
 
         await gesture.up();
         await tester.pump();
@@ -1372,7 +1376,8 @@ void main() {
 
         await gesture.down(textOffsetToPosition(paragraph, 9));
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 9));
 
         await gesture.up();
         await tester.pump();
@@ -1387,7 +1392,8 @@ void main() {
         await primaryMouseButtonGesture.up();
         await tester.pumpAndSettle(kDoubleTapTimeout);
         // Selection is collapsed.
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 1));
         expect(find.byKey(toolbarKey), findsNothing);
 
         // Create an uncollapsed selection by dragging.
@@ -1413,7 +1419,8 @@ void main() {
         await tester.pump();
         await gesture.up();
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 7));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
         // Collapse selection.
@@ -1422,7 +1429,8 @@ void main() {
         await primaryMouseButtonGesture.up();
         await tester.pumpAndSettle();
         // Selection is collapsed.
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 1));
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }),
@@ -1467,11 +1475,11 @@ void main() {
         addTearDown(primaryMouseButtonGesture.removePointer);
         addTearDown(gesture.removePointer);
         await tester.pump();
-        // Selection is collapsed so none is reported.
-        expect(paragraph.selections.isEmpty, true);
-
         await gesture.up();
         await tester.pump();
+        // Selection is collapsed.
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 2));
 
         // Context menu toggled on.
         expect(buttonTypes.length, 1);
@@ -1480,17 +1488,18 @@ void main() {
 
         await gesture.down(textOffsetToPosition(paragraph, 6));
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
-
         await gesture.up();
         await tester.pump();
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 2));
 
-        // Context menu toggled off.
+        // Context menu toggled off. Selection remains the same.
         expect(find.byKey(toolbarKey), findsNothing);
 
         await gesture.down(textOffsetToPosition(paragraph, 9));
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 9));
 
         await gesture.up();
         await tester.pump();
@@ -1506,7 +1515,8 @@ void main() {
         await primaryMouseButtonGesture.up();
         await tester.pumpAndSettle(kDoubleTapTimeout);
         // Selection is collapsed.
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 1));
         expect(find.byKey(toolbarKey), findsNothing);
 
         await primaryMouseButtonGesture.down(textOffsetToPosition(paragraph, 0));
@@ -1540,7 +1550,8 @@ void main() {
         await tester.pump();
         await gesture.up();
         await tester.pump();
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 7));
         expect(find.byKey(toolbarKey), findsOneWidget);
 
         // Collapse selection.
@@ -1549,7 +1560,8 @@ void main() {
         await primaryMouseButtonGesture.up();
         await tester.pumpAndSettle();
         // Selection is collapsed.
-        expect(paragraph.selections.isEmpty, true);
+        expect(paragraph.selections.isEmpty, false);
+        expect(paragraph.selections[0], const TextSelection.collapsed(offset: 1));
         expect(find.byKey(toolbarKey), findsNothing);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.linux),
@@ -2443,7 +2455,9 @@ void main() {
       expect(paragraph1.selections.length, 1);
       expect(paragraph1.selections[0].start, 2);
       expect(paragraph1.selections[0].end, 12);
-      expect(paragraph2.selections.length, 0);
+      expect(paragraph2.selections.length, 1);
+      expect(paragraph2.selections[0].start, 0);
+      expect(paragraph2.selections[0].end, 0);
 
       await sendKeyCombination(tester, SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: alt, control: control));
       await tester.pump();
@@ -2453,7 +2467,9 @@ void main() {
       expect(paragraph1.selections.length, 1);
       expect(paragraph1.selections[0].start, 2);
       expect(paragraph1.selections[0].end, 8);
-      expect(paragraph2.selections.length, 0);
+      expect(paragraph2.selections.length, 1);
+      expect(paragraph2.selections[0].start, 0);
+      expect(paragraph2.selections[0].end, 0);
     }, variant: TargetPlatformVariant.all());
 
     testWidgetsWithLeakTracking('can use keyboard to granularly extend selection - line', (WidgetTester tester) async {
@@ -2536,7 +2552,9 @@ void main() {
       expect(paragraph1.selections.length, 1);
       expect(paragraph1.selections[0].start, 2);
       expect(paragraph1.selections[0].end, 12);
-      expect(paragraph2.selections.length, 0);
+      expect(paragraph2.selections.length, 1);
+      expect(paragraph2.selections[0].start, 0);
+      expect(paragraph2.selections[0].end, 0);
 
       await sendKeyCombination(tester, SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: alt, meta: meta));
       await tester.pump();
@@ -2623,8 +2641,12 @@ void main() {
       expect(paragraph1.selections.length, 1);
       expect(paragraph1.selections[0].start, 0);
       expect(paragraph1.selections[0].end, 2);
-      expect(paragraph2.selections.length, 0);
-      expect(paragraph3.selections.length, 0);
+      expect(paragraph2.selections.length, 1);
+      expect(paragraph2.selections[0].start, 0);
+      expect(paragraph2.selections[0].end, 0);
+      expect(paragraph3.selections.length, 1);
+      expect(paragraph3.selections[0].start, 0);
+      expect(paragraph3.selections[0].end, 0);
     }, variant: TargetPlatformVariant.all());
 
     testWidgetsWithLeakTracking('can use keyboard to directionally extend selection', (WidgetTester tester) async {
@@ -2695,7 +2717,9 @@ void main() {
       expect(paragraph2.selections.length, 1);
       expect(paragraph2.selections[0].start, 2);
       expect(paragraph2.selections[0].end, 6);
-      expect(paragraph3.selections.length, 0);
+      expect(paragraph3.selections.length, 1);
+      expect(paragraph3.selections[0].start, 0);
+      expect(paragraph3.selections[0].end, 0);
 
       await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true));
       await tester.pump();


### PR DESCRIPTION
This change collapses the selection at the clicked/tapped location on single click down for desktop platforms, and on single click/tap up for mobile platforms to match native.

This is a change from how `SelectionArea` previously worked. Before this change a single click down would clear the selection. From observing a native browser it looks like when tapping on static text the selection is not cleared but collapsed. A user can still attain the selection from static text using the `window.getSelection` API.

https://jsfiddle.net/juepasn3/11/ You can try this demo out here to observe this behavior yourself. When clicking on static text the selection will change.

This change also allows `Paragraph.selections` to return selections that are collapsed. This for testing purposes to confirm where the selection has been collapsed.

Partially fixes: #129583

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.