### PR TITLE
Fix lower bound of children from TwoDimensionalChildBuilderDelegate

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_delegate.dart
+++ b/packages/flutter/lib/src/widgets/scroll_delegate.dart
@@ -933,8 +933,8 @@ class TwoDimensionalChildBuilderDelegate extends TwoDimensionalChildDelegate {
     int? maxYIndex,
     this.addRepaintBoundaries = true,
     this.addAutomaticKeepAlives = true,
-  }) : assert(maxYIndex == null || maxYIndex >= 0),
-       assert(maxXIndex == null || maxXIndex >= 0),
+  }) : assert(maxYIndex == null || maxYIndex >= -1),
+       assert(maxXIndex == null || maxXIndex >= -1),
        _maxYIndex = maxYIndex,
        _maxXIndex = maxXIndex;
 
@@ -976,7 +976,9 @@ class TwoDimensionalChildBuilderDelegate extends TwoDimensionalChildDelegate {
   /// [TwoDimensionalViewport] subclass to learn how this value is applied in
   /// the specific use case.
   ///
-  /// If not null, the value must be non-negative.
+  /// If not null, the value must be greater than or equal to -1, where -1
+  /// indicates there will be no children at all provided to the
+  /// [TwoDimensionalViewport].
   ///
   /// If the value changes, the delegate will call [notifyListeners]. This
   /// informs the [RenderTwoDimensionalViewport] that any cached information
@@ -997,7 +999,7 @@ class TwoDimensionalChildBuilderDelegate extends TwoDimensionalChildDelegate {
     if (value == maxXIndex) {
       return;
     }
-    assert(value == null || value >= 0);
+    assert(value == null || value >= -1);
     _maxXIndex = value;
     notifyListeners();
   }
@@ -1020,7 +1022,7 @@ class TwoDimensionalChildBuilderDelegate extends TwoDimensionalChildDelegate {
     if (maxYIndex == value) {
       return;
     }
-    assert(value == null || value >= 0);
+    assert(value == null || value >= -1);
     _maxYIndex = value;
     notifyListeners();
   }

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -120,27 +120,29 @@ void main() {
           }
         );
         // Update
+        delegate.maxXIndex = -1; // No exception.
         expect(
           () {
-            delegate.maxXIndex = -1;
+            delegate.maxXIndex = -2;
           },
           throwsA(
             isA<AssertionError>().having(
               (AssertionError error) => error.toString(),
               'description',
-              contains('value == null || value >= 0'),
+              contains('value == null || value >= -1'),
             ),
           ),
         );
+        delegate.maxYIndex = -1; // No exception
         expect(
           () {
-            delegate.maxYIndex = -1;
+            delegate.maxYIndex = -2;
           },
           throwsA(
             isA<AssertionError>().having(
               (AssertionError error) => error.toString(),
               'description',
-              contains('value == null || value >= 0'),
+              contains('value == null || value >= -1'),
             ),
           ),
         );
@@ -148,7 +150,7 @@ void main() {
         expect(
           () {
             TwoDimensionalChildBuilderDelegate(
-              maxXIndex: -1,
+              maxXIndex: -2,
               maxYIndex: 0,
               builder: (BuildContext context, ChildVicinity vicinity) {
                 return const SizedBox.shrink();
@@ -167,7 +169,7 @@ void main() {
           () {
             TwoDimensionalChildBuilderDelegate(
               maxXIndex: 0,
-              maxYIndex: -1,
+              maxYIndex: -2,
               builder: (BuildContext context, ChildVicinity vicinity) {
                 return const SizedBox.shrink();
               }

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -161,7 +161,7 @@ void main() {
             isA<AssertionError>().having(
               (AssertionError error) => error.toString(),
               'description',
-              contains('maxXIndex == null || maxXIndex >= 0'),
+              contains('maxXIndex == null || maxXIndex >= -1'),
             ),
           ),
         );
@@ -179,7 +179,7 @@ void main() {
             isA<AssertionError>().having(
               (AssertionError error) => error.toString(),
               'description',
-              contains('maxYIndex == null || maxYIndex >= 0'),
+              contains('maxYIndex == null || maxYIndex >= -1'),
             ),
           ),
         );


### PR DESCRIPTION
Found in https://github.com/flutter/packages/pull/4536

The max x and max y index  should allow for a case where there are no children in the viewport.
This should be CP'd into stable once it lands.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
