### PR TITLE
Fix TabBarView desynchronized after animation interruption

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -63,6 +63,8 @@ abstract class ScrollActivity {
   ScrollActivityDelegate get delegate => _delegate;
   ScrollActivityDelegate _delegate;
 
+  bool _isDisposed = false;
+
   /// Updates the activity's link to the [ScrollActivityDelegate].
   ///
   /// This should only be called when an activity is being moved from a defunct
@@ -134,7 +136,9 @@ abstract class ScrollActivity {
 
   /// Called when the scroll view stops performing this activity.
   @mustCallSuper
-  void dispose() { }
+  void dispose() {
+    _isDisposed = true;
+  }
 
   @override
   String toString() => describeIdentity(this);
@@ -535,7 +539,7 @@ class BallisticScrollActivity extends ScrollActivity {
     )
       ..addListener(_tick)
       ..animateWith(simulation)
-       .whenComplete(_end); // won't trigger if we dispose _controller first
+       .whenComplete(_end); // won't trigger if we dispose _controller before it completes.
   }
 
   late AnimationController _controller;
@@ -569,7 +573,11 @@ class BallisticScrollActivity extends ScrollActivity {
   }
 
   void _end() {
-    delegate.goBallistic(0.0);
+    // Check if the activity was disposed before going ballistic because _end might be called
+    // if _controller is disposed just after completion.
+    if (!_isDisposed) {
+      delegate.goBallistic(0.0);
+    }
   }
 
   @override
@@ -628,7 +636,7 @@ class DrivenScrollActivity extends ScrollActivity {
     )
       ..addListener(_tick)
       ..animateTo(to, duration: duration, curve: curve)
-       .whenComplete(_end); // won't trigger if we dispose _controller first
+       .whenComplete(_end); // won't trigger if we dispose _controller before it completes.
   }
 
   late final Completer<void> _completer;
@@ -648,7 +656,11 @@ class DrivenScrollActivity extends ScrollActivity {
   }
 
   void _end() {
-    delegate.goBallistic(velocity);
+    // Check if the activity was disposed before going ballistic because _end might be called
+    // if _controller is disposed just after completion.
+    if (!_isDisposed) {
+      delegate.goBallistic(velocity);
+    }
   }
 
   @override


### PR DESCRIPTION
## Description

This PR fixes a `DrivenScrollActivity` issue which surfaced in TabBar/TabBarView desynchronization (see https://github.com/flutter/flutter/issues/132293).

A comment in `DrivenScrollActivity` constructor states that `_end` will not be called if the animation controller is disposed.
While investigating this tab bar view issue, I noticed that the `_end` method of a first `DrivenScrollActivity` was called after this activity was disposed (and in the tab bar view case, this leads to `goBallistic` and `goIdle` being called and inteferring with a new `DrivenScrollActivity` that just started).

Filing this PR as a WIP to gather feedback because It seems strange that this issue never surfaced before so maybe there is something wrong on how `TabBarView` calls `PageController.animateTo()`, but after hours of investigation It seems that `DrivenScrollActivity._end` being called when it is not expected is a good candidate (and the small change in this PR fixes the TabBarView issue). It is also possible that this issue requires very specific conditions to surface.

In the TabBarView case this issue surfaced after https://github.com/flutter/flutter/pull/122021 that made it possible to interrupt a pending tab bar view animation and start a new one (before that PR, a tab bar view animation had to end before a new one is started).

## Related Issue

Fixes https://github.com/flutter/flutter/issues/132293.

## Tests

Adds 1 tests.
I will add a second one in scroll_activity_test.dart if this fix is valid.