### PR TITLE
[CP] [Windows] Allow overwriting the cache's Dart SDK archive license file

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -18,6 +18,7 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 
 $cachePath = "$flutterRoot\bin\cache"
 $dartSdkPath = "$cachePath\dart-sdk"
+$dartSdkLicense = "$cachePath\LICENSE.dart_sdk_archive.md"
 $engineStamp = "$cachePath\engine-dart-sdk.stamp"
 $engineVersion = (Get-Content "$flutterRoot\bin\internal\engine.version")
 
@@ -45,11 +46,18 @@ if (-not $dartSdkBaseUrl) {
 $dartZipName = "dart-sdk-windows-x64.zip"
 $dartSdkUrl = "$dartSdkBaseUrl/flutter_infra_release/flutter/$engineVersion/$dartZipName"
 
-if (Test-Path $dartSdkPath) {
+if ((Test-Path $dartSdkPath) -or (Test-Path $dartSdkLicense)) {
     # Move old SDK to a new location instead of deleting it in case it is still in use (e.g. by IntelliJ).
     $oldDartSdkSuffix = 1
     while (Test-Path "$cachePath\$oldDartSdkPrefix$oldDartSdkSuffix") { $oldDartSdkSuffix++ }
-    Rename-Item $dartSdkPath "$oldDartSdkPrefix$oldDartSdkSuffix"
+
+    if (Test-Path $dartSdkPath) {
+        Rename-Item $dartSdkPath "$oldDartSdkPrefix$oldDartSdkSuffix"
+    }
+
+    if (Test-Path $dartSdkLicense) {
+        Rename-Item $dartSdkLicense "$oldDartSdkPrefix$oldDartSdkSuffix.LICENSE.md"
+    }
 }
 New-Item $dartSdkPath -force -type directory | Out-Null
 $dartSdkZip = "$cachePath\$dartZipName"
@@ -94,5 +102,5 @@ If (Get-Command 7z -errorAction SilentlyContinue) {
 Remove-Item $dartSdkZip
 $engineVersion | Out-File $engineStamp -Encoding ASCII
 
-# Try to delete all old SDKs.
+# Try to delete all old SDKs and license files.
 Get-ChildItem -Path $cachePath | Where {$_.BaseName.StartsWith($oldDartSdkPrefix)} | Remove-Item -Recurse -ErrorAction SilentlyContinue

--- a/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
@@ -1,0 +1,108 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+final String flutterRootPath = getFlutterRoot();
+final Directory flutterRoot = fileSystem.directory(flutterRootPath);
+
+Future<void> main() async {
+  // Regression test for https://github.com/flutter/flutter/issues/132592
+  test('flutter/bin/dart updates the Dart SDK without hanging', () async {
+    // Run the Dart entrypoint once to ensure the Dart SDK is downloaded.
+    await runDartBatch();
+
+    expect(dartSdkStamp.existsSync(), true);
+
+    // Remove the Dart SDK stamp and run the Dart entrypoint again to trigger
+    // the Dart SDK update.
+    dartSdkStamp.deleteSync();
+    final Future<String> runFuture = runDartBatch();
+    final Timer timer = Timer(const Duration(minutes: 5), () {
+      // This print is useful for people debugging this test. Normally we would
+      // avoid printing in a test but this is an exception because it's useful
+      // ambient information.
+      // ignore: avoid_print
+      print(
+        'The Dart batch entrypoint did not complete after 5 minutes. '
+        'Historically this is a sign that 7-Zip zip extraction is waiting for '
+        'the user to confirm they would like to overwrite files. '
+        "This likely means the test isn't a flake and will fail. "
+        'See: https://github.com/flutter/flutter/issues/132592'
+      );
+    });
+
+    final String output = await runFuture;
+    timer.cancel();
+
+    // Check the Dart SDK was re-downloaded and extracted.
+    // If 7-Zip is installed, unexpected overwrites causes this to hang.
+    // If 7-Zip is not installed, unexpected overwrites results in error messages.
+    // See: https://github.com/flutter/flutter/issues/132592
+    expect(dartSdkStamp.existsSync(), true);
+    expect(output, contains('Downloading Dart SDK from Flutter engine ...'));
+    expect(output, contains('Expanding downloaded archive...'));
+    expect(output, isNot(contains('Use the -Force parameter' /* Luke */)));
+  },
+  skip: !platform.isWindows); // [intended] Only Windows uses the batch entrypoint
+}
+
+Future<String> runDartBatch() async {
+  String output = '';
+  final Process process = await processManager.start(
+    <String>[
+      dartBatch.path
+    ],
+  );
+  final Future<Object?> stdoutFuture = process.stdout
+    .transform<String>(utf8.decoder)
+    .forEach((String str) {
+      output += str;
+    });
+  final Future<Object?> stderrFuture = process.stderr
+    .transform<String>(utf8.decoder)
+    .forEach((String str) {
+      output += str;
+    });
+
+  // Wait for the output to complete
+  await Future.wait(<Future<Object?>>[stdoutFuture, stderrFuture]);
+  // Ensure child exited successfully
+  expect(
+    await process.exitCode,
+    0,
+    reason: 'child process exited with code ${await process.exitCode}, and '
+    'output:\n$output',
+  );
+
+  // Check the Dart tool prints the expected output.
+  expect(output, contains('A command-line utility for Dart development.'));
+  expect(output, contains('Usage: dart <command|dart-file> [arguments]'));
+
+  return output;
+}
+
+// The executable batch entrypoint for the Dart binary.
+File get dartBatch {
+  return flutterRoot
+    .childDirectory('bin')
+    .childFile('dart.bat')
+    .absolute;
+}
+
+// The Dart SDK's stamp file.
+File get dartSdkStamp {
+  return flutterRoot
+    .childDirectory('bin')
+    .childDirectory('cache')
+    .childFile('engine-dart-sdk.stamp')
+    .absolute;
+}


### PR DESCRIPTION
Original pull request: https://github.com/flutter/flutter/pull/132669
Cherrypick issue: https://github.com/flutter/flutter/issues/132718

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
