### PR TITLE
Implement SelectionArea triple click gestures

### DIFF
--- a/examples/api/lib/material/selectable_region/selectable_region.0.dart
+++ b/examples/api/lib/material/selectable_region/selectable_region.0.dart
@@ -182,6 +182,7 @@ class _RenderSelectableAdapter extends RenderProxyBox with Selectable, Selection
         _start = _end = null;
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
+      case SelectionEventType.selectParagraph:
         _start = Offset.zero;
         _end = Offset.infinite;
       case SelectionEventType.granularlyExtendSelection:

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1147,7 +1147,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   }
 
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
-    debugPrint('$selection');
     final bool willShowSelectionHandles = _shouldShowSelectionHandles(cause);
     if (willShowSelectionHandles != _showSelectionHandles) {
       setState(() {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1147,6 +1147,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   }
 
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
+    debugPrint('$selection');
     final bool willShowSelectionHandles = _shouldShowSelectionHandles(cause);
     if (willShowSelectionHandles != _showSelectionHandles) {
       setState(() {

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1790,8 +1790,11 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   _TextBoundaryRecord _getParagraphBoundaryAtPosition(TextPosition position) {
-    final ParagraphBoundary paragraphBoundary = ParagraphBoundary(range.textInside(fullText));
-    final TextRange paragraphRange = paragraphBoundary.getTextBoundaryAt(position.offset);
+    final String text = range.textInside(fullText);
+    final ParagraphBoundary paragraphBoundary = ParagraphBoundary(text);
+    final int start = paragraphBoundary.getLeadingTextBoundaryAt(position.offset - 1) ?? 0;
+    final int end = paragraphBoundary.getTrailingTextBoundaryAt(position.offset) ?? text.length;
+    final TextRange paragraphRange = TextRange(start: start, end: end);
     assert(paragraphRange.isNormalized);
     return (boundaryStart: TextPosition(offset: paragraphRange.start), boundaryEnd: TextPosition(offset: paragraphRange.end));
   }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1792,7 +1792,9 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   _TextBoundaryRecord _getParagraphBoundaryAtPosition(TextPosition position) {
     final String text = range.textInside(fullText);
     final ParagraphBoundary paragraphBoundary = ParagraphBoundary(text);
-    final int start = paragraphBoundary.getLeadingTextBoundaryAt(position.offset - 1) ?? 0;
+    // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
+    // the previous text boundary's location.
+    final int start = paragraphBoundary.getLeadingTextBoundaryAt(position.offset == range.end ? position.offset - 1 : position.offset) ?? 0;
     final int end = paragraphBoundary.getTrailingTextBoundaryAt(position.offset) ?? text.length;
     final TextRange paragraphRange = TextRange(start: start, end: end);
     assert(paragraphRange.isNormalized);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1810,10 +1810,6 @@ class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutM
   }
 
   _TextBoundaryRecord _getParagraphBoundaryAtPosition(TextPosition position) {
-    // final String text = fullText;
-    // final String text = range.textInside(fullText);
-    // String text = fullText;
-    // text = range.textBefore(fullText) + '\n' + range.textAfter(fullText);
     final ParagraphBoundary paragraphBoundary = ParagraphBoundary(fullText);
     // Use position.offset - 1 when `position` is at the end of the selectable to retrieve
     // the previous text boundary's location.

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -53,6 +53,8 @@ enum SelectionResult {
   /// [SelectAllSelectionEvent], [ClearSelectionEvent], and
   /// [SelectWordSelectionEvent].
   none,
+  /// TODO(Renzo-Olivares): Document.
+  forward,
 }
 
 /// The abstract interface to handle [SelectionEvent]s.

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -295,6 +295,12 @@ enum SelectionEventType {
   /// Used by [SelectWordSelectionEvent].
   selectWord,
 
+  /// An event to select a word at the location
+  /// [SelectParagraphSelectionEvent.globalPosition].
+  ///
+  /// Used by [SelectParagraphSelectionEvent].
+  selectParagraph,
+
   /// An event that extends the selection by a specific [TextGranularity].
   granularlyExtendSelection,
 
@@ -318,6 +324,9 @@ enum TextGranularity {
 
   /// Treats the entire document as an atomic unit when moving the selection handles.
   document,
+
+  /// Treats a paragraph as an atomic unit when moving the selection handles.
+  paragraph,
 }
 
 /// An abstract base class for selection events.
@@ -363,6 +372,17 @@ class SelectWordSelectionEvent extends SelectionEvent {
   const SelectWordSelectionEvent({required this.globalPosition}): super._(SelectionEventType.selectWord);
 
   /// The position in global coordinates to select word at.
+  final Offset globalPosition;
+}
+
+/// Selects the entire paragraph at the location.
+///
+/// This event can be sent as the result of a triple click to select.
+class SelectParagraphSelectionEvent extends SelectionEvent {
+  /// Creates a select word event at the [globalPosition].
+  const SelectParagraphSelectionEvent({required this.globalPosition}): super._(SelectionEventType.selectParagraph);
+
+  /// The position in global coordinates to select paragraph at.
   final Offset globalPosition;
 }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1453,6 +1453,7 @@ class _ScrollableSelectionContainerDelegate extends MultiSelectableSelectionCont
         _selectableStartEdgeUpdateRecords.remove(selectable);
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
+      case SelectionEventType.selectParagraph:
         _selectableEndEdgeUpdateRecords[selectable] = state.position.pixels;
         _selectableStartEdgeUpdateRecords[selectable] = state.position.pixels;
     }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -444,7 +444,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   // This method should be used in all instances when details.consecutiveTapCount
   // would be used.
   static int _getEffectiveConsecutiveTapCount(int rawCount) {
-    const int maxConsecutiveTap = 2;
+    const int maxConsecutiveTap = 3;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -513,6 +513,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         }
       case 2:
         _selectWordAt(offset: details.globalPosition);
+      case 3:
+        _selectParagraphAt(offset: details.globalPosition);
     }
     _updateSelectedContentIfNeeded();
   }
@@ -531,6 +533,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
         _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
+      case 3:
+        _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.paragraph);
     }
     _updateSelectedContentIfNeeded();
   }
@@ -956,6 +960,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_clearSelection], which clears the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [_collapseSelectionAt], which collapses the selection at the location.
+  ///  * [_selectParagraphAt], which selects an entire paragraph at the location.
   ///  * [selectAll], which selects the entire content.
   void _selectEndTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
@@ -996,6 +1001,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_clearSelection], which clears the ongoing selection.
   ///  * [_selectWordAt], which selects a whole word at the location.
   ///  * [_collapseSelectionAt], which collapses the selection at the location.
+  ///  * [_selectParagraphAt], which selects an entire paragraph at the location.
   ///  * [selectAll], which selects the entire content.
   void _selectStartTo({required Offset offset, bool continuous = false, TextGranularity? textGranularity}) {
     if (!continuous) {
@@ -1037,11 +1043,34 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   ///  * [_finalizeSelection], which stops the `continuous` updates.
   ///  * [_clearSelection], which clears the ongoing selection.
   ///  * [_collapseSelectionAt], which collapses the selection at the location.
+  ///  * [_selectParagraphAt], which selects an entire paragraph at the location.
   ///  * [selectAll], which selects the entire content.
   void _selectWordAt({required Offset offset}) {
     // There may be other selection ongoing.
     _finalizeSelection();
     _selectable?.dispatchSelectionEvent(SelectWordSelectionEvent(globalPosition: offset));
+  }
+
+  /// Selects the entire paragraph at the `offset` location.
+  ///
+  /// If the paragraph is already in the current selection, selection won't
+  /// change. One call [_clearSelection] first if the selection needs to be
+  /// updated even if the paragraph is already covered by the current selection.
+  ///
+  /// One can also use [_selectEndTo] or [_selectStartTo] to adjust the selection
+  /// edges after calling this method.
+  ///
+  /// See also:
+  ///  * [_selectStartTo], which sets or updates selection start edge.
+  ///  * [_selectEndTo], which sets or updates selection end edge.
+  ///  * [_finalizeSelection], which stops the `continuous` updates.
+  ///  * [_clearSelection], which clear the ongoing selection.
+  ///  * [_selectWordAt], which selects a whole word at the location.
+  ///  * [selectAll], which selects the entire content.
+  void _selectParagraphAt({required Offset offset}) {
+    // There may be other selection ongoing.
+    _finalizeSelection();
+    _selectable?.dispatchSelectionEvent(SelectParagraphSelectionEvent(globalPosition: offset));
   }
 
   /// Stops any ongoing selection updates.
@@ -1566,6 +1595,7 @@ class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContain
         _hasReceivedEndEvent.remove(selectable);
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
+      case SelectionEventType.selectParagraph:
         break;
       case SelectionEventType.granularlyExtendSelection:
       case SelectionEventType.directionallyExtendSelection:
@@ -2131,16 +2161,19 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     return SelectionResult.none;
   }
 
-  /// Selects a word in a selectable at the location
-  /// [SelectWordSelectionEvent.globalPosition].
-  @protected
-  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
+  SelectionResult _handleSelectTextBoundary(SelectionEvent event) {
+    late final Offset effectiveGlobalPosition;
+    if (event.type == SelectionEventType.selectWord) {
+      effectiveGlobalPosition = (event as SelectWordSelectionEvent).globalPosition;
+    } else if (event.type == SelectionEventType.selectParagraph) {
+      effectiveGlobalPosition = (event as SelectParagraphSelectionEvent).globalPosition;
+    }
     SelectionResult? lastSelectionResult;
     for (int index = 0; index < selectables.length; index += 1) {
       final Rect localRect = Rect.fromLTWH(0, 0, selectables[index].size.width, selectables[index].size.height);
       final Matrix4 transform = selectables[index].getTransformTo(null);
       final Rect globalRect = MatrixUtils.transformRect(transform, localRect);
-      if (globalRect.contains(event.globalPosition)) {
+      if (globalRect.contains(effectiveGlobalPosition)) {
         final SelectionGeometry existingGeometry = selectables[index].value;
         lastSelectionResult = dispatchSelectionEventToChild(selectables[index], event);
         if (index == selectables.length - 1 && lastSelectionResult == SelectionResult.next) {
@@ -2153,7 +2186,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
           return SelectionResult.previous;
         }
         if (selectables[index].value != existingGeometry) {
-          // Geometry has changed as a result of select word, need to clear the
+          // Geometry has changed as a result of select text boundary, need to clear the
           // selection of other selectables to keep selection in sync.
           selectables
             .where((Selectable target) => target != selectables[index])
@@ -2170,6 +2203,20 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     }
     assert(lastSelectionResult == null);
     return SelectionResult.end;
+  }
+
+  /// Selects a word in a selectable at the location
+  /// [SelectWordSelectionEvent.globalPosition].
+  @protected
+  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
+    return _handleSelectTextBoundary(event);
+  }
+
+  /// Selects a paragraph in a selectable at the location
+  /// [SelectParagraphSelectionEvent.globalPosition].
+  @protected
+  SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
+    return _handleSelectTextBoundary(event);
   }
 
   /// Removes the selection of all selectables this delegate manages.
@@ -2305,6 +2352,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
       case SelectionEventType.selectWord:
         _extendSelectionInProgress = false;
         result = handleSelectWord(event as SelectWordSelectionEvent);
+      case SelectionEventType.selectParagraph:
+        _extendSelectionInProgress = false;
+        result = handleSelectParagraph(event as SelectParagraphSelectionEvent);
       case SelectionEventType.granularlyExtendSelection:
         _extendSelectionInProgress = true;
         result = handleGranularlyExtendSelection(event as GranularlyExtendSelectionEvent);

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -191,6 +191,102 @@ void main() {
     await gesture.up();
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
 
+  testWidgets('mouse can select multiple widgets on triple-click drag', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: SelectionArea(
+        selectionControls: materialTextSelectionControls,
+        child: ListView.builder(
+          itemCount: 100,
+          itemBuilder: (BuildContext context, int index) {
+            return Text('Item $index');
+          },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await gesture.down(textOffsetToPosition(paragraph1, 2));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await gesture.down(textOffsetToPosition(paragraph1, 2));
+    await tester.pumpAndSettle();
+    expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 1'), matching: find.byType(RichText)));
+    await gesture.moveTo(textOffsetToPosition(paragraph2, 4));
+    // Should select paragraph 2.
+    expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+    final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 3'), matching: find.byType(RichText)));
+    await gesture.moveTo(textOffsetToPosition(paragraph3, 3));
+    // Should select paragraph 3.
+    expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+    final RenderParagraph paragraph4 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 4'), matching: find.byType(RichText)));
+    await gesture.moveTo(textOffsetToPosition(paragraph4, 3));
+    // Should select paragraph 4.
+    expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph4.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+    await gesture.up();
+  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+
+  testWidgets('mouse can select multiple widgets on triple-click drag - horizontal', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: SelectionArea(
+        selectionControls: materialTextSelectionControls,
+        child: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          itemCount: 100,
+          itemBuilder: (BuildContext context, int index) {
+            return Text('Item $index');
+          },
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await gesture.down(textOffsetToPosition(paragraph1, 2));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await gesture.down(textOffsetToPosition(paragraph1, 2));
+    await tester.pumpAndSettle();
+    expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 1'), matching: find.byType(RichText)));
+    final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 2'), matching: find.byType(RichText)));
+    await gesture.moveTo(textOffsetToPosition(paragraph2, 5) + const Offset(0, 50));
+    // Should select paragraph 2 and 3.
+    expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+    expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+    await gesture.up();
+  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+
   testWidgetsWithLeakTracking('select to scroll forward', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -110,6 +110,39 @@ void main() {
       expect(selectionEvent.globalPosition, const Offset(200.0, 200.0));
     });
 
+    testWidgets('mouse triple click sends select-paragraph event', (WidgetTester tester) async {
+      final UniqueKey spy = UniqueKey();
+      await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              focusNode: FocusNode(),
+              selectionControls: materialTextSelectionControls,
+              child: SelectionSpy(key: spy),
+            ),
+          )
+      );
+
+      final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
+      final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      renderSelectionSpy.events.clear();
+      await gesture.down(const Offset(200.0, 200.0));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      renderSelectionSpy.events.clear();
+      await gesture.down(const Offset(200.0, 200.0));
+      await tester.pump();
+      await gesture.up();
+      expect(renderSelectionSpy.events.length, 1);
+      expect(renderSelectionSpy.events[0], isA<SelectParagraphSelectionEvent>());
+      final SelectParagraphSelectionEvent selectionEvent = renderSelectionSpy.events[0] as SelectParagraphSelectionEvent;
+      expect(selectionEvent.globalPosition, const Offset(200.0, 200.0));
+    });
+
     testWidgetsWithLeakTracking('Does not crash when using Navigator pages', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/119776
       final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -916,6 +916,268 @@ void main() {
       await gesture.up();
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
 
+    testWidgets('mouse can select paragraph-by-paragraph on triple click drag', (WidgetTester tester) async {
+      const String longText = 'Hello world this is some long piece of text '
+          'that will represent a long paragraph, when triple clicking this block '
+          'of text all of it will be selected.\n'
+          'This will be the start of a new line. When triple clicking this block '
+          'of text all of it should be selected.';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Center(
+              child: Text(longText),
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text(longText), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph, 2));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph, 2));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 150));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph, 155));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 257));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph, 170));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 257));
+
+      // Check backward selection.
+      await gesture.moveTo(textOffsetToPosition(paragraph, 1));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 150));
+
+      // Start a new triple-click drag.
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textOffsetToPosition(paragraph, 151));
+      await tester.pump();
+      await gesture.up();
+      expect(paragraph.selections.isEmpty, isTrue);
+      await tester.pump(kDoubleTapTimeout);
+
+      // triple-click.
+      await gesture.down(textOffsetToPosition(paragraph, 151));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textOffsetToPosition(paragraph, 151));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textOffsetToPosition(paragraph, 151));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 150, extentOffset: 257));
+
+      // Selecting across line should select to the end.
+      await gesture.moveTo(textOffsetToPosition(paragraph, 5) + const Offset(0.0, -200.0));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 257, extentOffset: 0));
+      await gesture.up();
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+
+    testWidgets('mouse can select multiple widgets on triple click drag', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?\nThis is the first text widget.'),
+                Text('Good, and you?\nThis is the second text widget.'),
+                Text('Fine, thank you.\nThis is the third text widget.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('first text widget'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph1, 2));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph1, 2));
+      await tester.pumpAndSettle();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 13));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 14));
+      await tester.pump();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 43));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('second text widget'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      // Should select line 1 of text widget 2.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 43));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 15));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 16));
+      // Should select the rest of text widget 2.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 43));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 46));
+
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('third text widget'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 6));
+      // Should select line 1 of text widget 3.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 43));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 46));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 17));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 18));
+      // Should select the rest of text widget 3.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 43));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 46));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 47));
+
+      await gesture.up();
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+
+    testWidgets('mouse can select multiple widgets on triple click drag and return to origin paragraph', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?\nThis is the first text widget.'),
+                Text('Good, and you?\nThis is the second text widget.'),
+                Text('Fine, thank you.\nThis is the third text widget.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('second text widget'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 2), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph2, 2));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph2, 2));
+      await tester.pumpAndSettle();
+      // Should select line 1 of text widget 2.
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 15));
+
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('first text widget'), matching: find.byType(RichText)));
+
+      // Should select line 2 of text widget 1.
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 14));
+      await tester.pump();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 43, extentOffset: 13));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 15, extentOffset: 0));
+
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('third text widget'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 5));
+      // Should select rest of text widget 1.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 43, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 15, extentOffset: 0));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 2));
+      // Should clear the selection on paragraph 1 and return to the origin paragraph.
+      expect(paragraph1.selections.isEmpty, true);
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 15, extentOffset: 0));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 6));
+      // Should select line 1 of text widget 3.
+      expect(paragraph1.selections.isEmpty, true);
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 46));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 17));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 18));
+      // Should select line 2 of text widget 3.
+      expect(paragraph1.selections.isEmpty, true);
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 46));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 47));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      // Should clear the selection on paragraph 3 and return to the origin paragraph.
+      expect(paragraph1.selections.isEmpty, true);
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 15));
+      expect(paragraph3.selections.isEmpty, true);
+
+      await gesture.up();
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+
+    testWidgets('mouse can reverse selection across multiple widgets on triple click drag', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: FocusNode(),
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?\nThis is the first text widget.'),
+                Text('Good, and you?\nThis is the second text widget.'),
+                Text('Fine, thank you.\nThis is the third text widget.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('Fine, thank you.'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 18), kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph3, 18));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph3, 18));
+      await tester.pumpAndSettle();
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 17, extentOffset: 47));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 4));
+      await tester.pump();
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 47, extentOffset: 0));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 47, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 46, extentOffset: 0));
+
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.textContaining('How are you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 6));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 47, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 46, extentOffset: 0));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 43, extentOffset: 0));
+
+      await gesture.up();
+    }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/125582.
+
     testWidgetsWithLeakTracking('mouse can select multiple widgets', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);


### PR DESCRIPTION
This change adds support for triple click to select a paragraph at the clicked position and triple click + drag to extend the selection paragraph-by-paragraph when using the `SelectionArea` widget.

Partially fixes: https://github.com/flutter/flutter/issues/104552

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.