### PR TITLE
 Update `ExpansionPanel` example for the updated `expansionCallback` callback

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -306,7 +306,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/icon_button/icon_button.3_test.dart',
   'examples/api/test/material/icon_button/icon_button.0_test.dart',
   'examples/api/test/material/icon_button/icon_button.1_test.dart',
-  'examples/api/test/material/expansion_panel/expansion_panel_list.0_test.dart',
   'examples/api/test/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0_test.dart',
   'examples/api/test/material/input_decorator/input_decoration.1_test.dart',
   'examples/api/test/material/input_decorator/input_decoration.prefix_icon_constraints.0_test.dart',

--- a/examples/api/lib/material/expansion_panel/expansion_panel_list.0.dart
+++ b/examples/api/lib/material/expansion_panel/expansion_panel_list.0.dart
@@ -67,7 +67,7 @@ class _ExpansionPanelListExampleState extends State<ExpansionPanelListExample> {
     return ExpansionPanelList(
       expansionCallback: (int index, bool isExpanded) {
         setState(() {
-          _data[index].isExpanded = !isExpanded;
+          _data[index].isExpanded = isExpanded;
         });
       },
       children: _data.map<ExpansionPanel>((Item item) {

--- a/examples/api/test/material/expansion_panel/expansion_panel_list.0_test.dart
+++ b/examples/api/test/material/expansion_panel/expansion_panel_list.0_test.dart
@@ -1,0 +1,75 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/expansion_panel/expansion_panel_list.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('ExpansionPanel can be expanded', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ExpansionPanelListExampleApp(),
+    );
+
+    // Verify the first tile is collapsed.
+    expect(tester.widget<ExpandIcon>(find.byType(ExpandIcon).first).isExpanded, false);
+
+    // Tap to expand the first tile.
+    await tester.tap(find.byType(ExpandIcon).first);
+    await tester.pumpAndSettle();
+
+    // Verify that the first tile is expanded.
+    expect(tester.widget<ExpandIcon>(find.byType(ExpandIcon).first).isExpanded, true);
+  });
+
+  testWidgets('Tap to delete a ExpansionPanel', (WidgetTester tester) async {
+    const int index = 3;
+
+    await tester.pumpWidget(
+      const example.ExpansionPanelListExampleApp(),
+    );
+
+    expect(find.widgetWithText(ListTile, 'Panel $index'), findsOneWidget);
+    expect(tester.widget<ExpandIcon>(find.byType(ExpandIcon).at(index)).isExpanded, false);
+
+    // Tap to expand the tile at index 3.
+    await tester.tap(find.byType(ExpandIcon).at(index));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<ExpandIcon>(find.byType(ExpandIcon).at(index)).isExpanded, true);
+
+    // Tap to delete the tile at index 3.
+    await tester.tap(find.byIcon(Icons.delete).at(index));
+    await tester.pumpAndSettle();
+
+    // Verify that the tile at index 3 is deleted.
+    expect(find.widgetWithText(ListTile, 'Panel $index'), findsNothing);
+  });
+
+  testWidgets('ExpansionPanelList is scrollable', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ExpansionPanelListExampleApp(),
+    );
+
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+
+    // Expand all the tiles.
+    for (int i = 0; i < 8; i++) {
+      await tester.tap(find.byType(ExpandIcon).at(i));
+    }
+    await tester.pumpAndSettle();
+
+    // Check panel 3 tile position.
+    Offset tilePosition = tester.getBottomLeft(find.widgetWithText(ListTile, 'Panel 3'));
+    expect(tilePosition.dy, 656.0);
+
+    // Scroll up.
+    await tester.drag(find.byType(SingleChildScrollView), const Offset(0, -300));
+    await tester.pumpAndSettle();
+
+    // Verify panel 3 tile position is updated after scrolling.
+    tilePosition = tester.getBottomLeft(find.widgetWithText(ListTile, 'Panel 3'));
+    expect(tilePosition.dy, 376.0);
+  });
+}


### PR DESCRIPTION
fixes [ExpansionPanelList can't expand/collapse on the latest stable/master
](https://github.com/flutter/flutter/issues/132759)

https://github.com/flutter/flutter/pull/128082 updated the `expansionCallback` and also the `ExpansionPanel` sample in the Flutter gallery but not the API example. 

This PR fixes the API example and adds tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
