### PR TITLE
Forward port API docs creation realm handling from prior script

### DIFF
--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -775,16 +775,19 @@ class PlatformDocGenerator {
   final FileSystem filesystem;
   final Directory outputDir;
   final String engineRevision = FlutterInformation.instance.getEngineRevision();
+  final String engineRealm = FlutterInformation.instance.getEngineRealm();
 
   /// This downloads an archive of platform docs for the engine from the artifact
   /// store and extracts them to the location used for Dartdoc.
   void generatePlatformDocs() {
+    final String realm = engineRealm.isNotEmpty ? '$engineRealm/' : '';
+
     final String javadocUrl =
-        'https://storage.googleapis.com/flutter_infra_release/flutter/$engineRevision/android-javadoc.zip';
+        'https://storage.googleapis.com/${realm}flutter_infra_release/flutter/$engineRevision/android-javadoc.zip';
     _extractDocs(javadocUrl, 'javadoc', 'io/flutter/view/FlutterView.html', outputDir);
 
     final String objcdocUrl =
-        'https://storage.googleapis.com/flutter_infra_release/flutter/$engineRevision/ios-objcdoc.zip';
+        'https://storage.googleapis.com/${realm}flutter_infra_release/flutter/$engineRevision/ios-objcdoc.zip';
     _extractDocs(objcdocUrl, 'objcdoc', 'Classes/FlutterViewController.html', outputDir);
   }
 
@@ -1034,6 +1037,10 @@ class FlutterInformation {
   /// Gets the git hash of the engine used by the Flutter framework in the repo.
   String getEngineRevision() => getFlutterInformation()['engineRevision']! as String;
 
+  /// Gets the value stored in bin/internal/engine.realm used by the Flutter
+  /// framework repo.
+  String getEngineRealm() => getFlutterInformation()['engineRealm']! as String;
+
   /// Gets the git hash of the Flutter framework in the repo.
   String getFlutterRevision() => getFlutterInformation()['flutterGitRevision']! as String;
 
@@ -1090,6 +1097,9 @@ class FlutterInformation {
     info['flutterRoot'] = flutterRoot;
     info['frameworkVersion'] = Version.parse(flutterVersion['frameworkVersion'] as String);
     info['engineRevision'] = flutterVersion['engineRevision'] as String;
+    info['engineRealm'] = filesystem.file(
+      path.join(flutterRoot.path, 'bin', 'internal', 'engine.realm',
+    )).readAsStringSync().trim();
 
     final RegExpMatch? dartVersionRegex = RegExp(r'(?<base>[\d.]+)(?:\s+\(build (?<detail>[-.\w]+)\))?')
         .firstMatch(flutterVersion['dartSdkVersion'] as String);

--- a/dev/tools/test/create_api_docs_test.dart
+++ b/dev/tools/test/create_api_docs_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:path/path.dart' as path;
 import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
@@ -178,6 +179,17 @@ void main() {
       expect(info['frameworkVersion'], equals(Version.parse('2.5.0')));
       expect(info['dartSdkVersion'], isNotNull);
       expect(info['dartSdkVersion'], equals(Version.parse('2.14.0-360.0.dev')));
+    });
+    test('the engine realm is read from the engine.realm file', () async {
+      const String flutterRoot = '/home/user/flutter';
+      final File realmFile = memoryFileSystem.file(
+        path.join(flutterRoot, 'bin', 'internal', 'engine.realm',
+      ));
+      realmFile.writeAsStringSync('realm');
+      setUpWithEnvironment(<String, String>{'FLUTTER_ROOT': flutterRoot});
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      final Map<String, dynamic> info = flutterInformation.getFlutterInformation();
+      expect(info['engineRealm'], equals('realm'));
     });
   });
 }


### PR DESCRIPTION
It looks like the logic added here:

https://github.com/flutter/flutter/pull/131951/files#diff-297ee4cfe6d9bffc2fa1376918a50b8e4165ada4569575880c40811b6f749265R18

got dropped in the refactor here:

https://github.com/flutter/flutter/pull/132710