### PR TITLE
Docs on iOS's directional quote characters

### DIFF
--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -253,6 +253,7 @@ class _TextEditingValueAccumulator {
 /// patterns are usually meant for matching the whole string.
 ///
 /// ### Quote characters on iOS
+///
 /// When filtering single (`'`) or double (`"`) quote characters, be aware that
 /// the default iOS keyboard actually inserts special directional versions of
 /// these characters (`‘` and `’` for single quote, and `“` and `”` for double

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -251,6 +251,13 @@ class _TextEditingValueAccumulator {
 /// As an example, [FilteringTextInputFormatter] typically shouldn't be used
 /// with [RegExp]s that contain positional matchers (`^` or `$`) since these
 /// patterns are usually meant for matching the whole string.
+///
+/// ### Quote characters on iOS
+/// When filtering single (`'`) or double (`"`) quote characters, be aware that
+/// the default iOS keyboard actually inserts special directional versions of
+/// these characters (`‘` and `’` for single quote, and `“` and `”` for double
+/// quote). Consider including all three variants in your regular expressions to
+/// support iOS.
 class FilteringTextInputFormatter extends TextInputFormatter {
   /// Creates a formatter that replaces banned patterns with the given
   /// [replacementString].


### PR DESCRIPTION
When you type a single or double quote character on the default iOS keyboard, it doesn't actually insert the usual `'` or `"`.  Instead, it inserts a directional version that tries to match with others.  This is very tricky when allow/deny-listing characters, so I've added a section about this to the docs.

Fixes https://github.com/flutter/flutter/issues/132232