### PR TITLE
Cleanup no longer used scale and turns getters.

### DIFF
--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -347,9 +347,6 @@ class ScaleTransition extends MatrixTransition {
     super.child,
   }) : super(animation: scale, onTransform: _handleScaleMatrix);
 
-  /// The animation that controls the scale of the child.
-  Animation<double> get scale => animation;
-
   /// The callback that controls the scale of the child.
   ///
   /// If the current value of the animation is v, the child will be
@@ -385,9 +382,6 @@ class RotationTransition extends MatrixTransition {
     super.filterQuality,
     super.child,
   }) : super(animation: turns, onTransform: _handleTurnsMatrix);
-
-  /// The animation that controls the rotation of the child.
-  Animation<double> get turns => animation;
 
   /// The callback that controls the rotation of the child.
   ///

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -132,7 +132,7 @@ void main() {
       ),
     ));
     final RotationTransition rotation = tester.firstWidget(find.byType(RotationTransition));
-    expect(rotation.turns.value, 0.5);
+    expect(rotation.animation.value, 0.5);
   });
 
   testWidgetsWithLeakTracking('ExpandIcon default size is 24', (WidgetTester tester) async {

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -131,7 +131,7 @@ void main() {
           final Iterable<RotationTransition> rotationTransitions = tester.widgetList(
             find.byType(RotationTransition),
           );
-          final Iterable<double> currentRotations = rotationTransitions.map((RotationTransition t) => t.turns.value);
+          final Iterable<double> currentRotations = rotationTransitions.map((RotationTransition t) => t.animation.value);
 
           if (previousRotations != null && previousRotations!.isNotEmpty && currentRotations.isNotEmpty
               && previousRect != null && currentRect != null) {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1551,7 +1551,7 @@ void main() {
 
       final double transitioningRotation = tester.widget<RotationTransition>(
         find.byType(RotationTransition),
-      ).turns.value;
+      ).animation.value;
 
       await tester.pump(const Duration(seconds: 3));
       geometry = listenerState.cache.value;
@@ -1560,7 +1560,7 @@ void main() {
 
       final double completedRotation = tester.widget<RotationTransition>(
         find.byType(RotationTransition),
-      ).turns.value;
+      ).animation.value;
 
       expect(transitioningRotation, lessThan(1.0));
 

--- a/packages/flutter/test/widgets/animated_grid_test.dart
+++ b/packages/flutter/test/widgets/animated_grid_test.dart
@@ -201,7 +201,7 @@ void main() {
       );
 
       double itemScale(int index) =>
-          tester.widget<ScaleTransition>(find.byKey(ValueKey<int>(index), skipOffstage: false)).scale.value;
+          tester.widget<ScaleTransition>(find.byKey(ValueKey<int>(index), skipOffstage: false)).animation.value;
       double itemLeft(int index) => tester.getTopLeft(find.byKey(ValueKey<int>(index), skipOffstage: false)).dx;
       double itemRight(int index) => tester.getTopRight(find.byKey(ValueKey<int>(index), skipOffstage: false)).dx;
 
@@ -281,7 +281,7 @@ void main() {
       );
 
       double itemScale(int index) =>
-          tester.widget<ScaleTransition>(find.byKey(ValueKey<int>(index), skipOffstage: false)).scale.value;
+          tester.widget<ScaleTransition>(find.byKey(ValueKey<int>(index), skipOffstage: false)).animation.value;
       double itemLeft(int index) => tester.getTopLeft(find.byKey(ValueKey<int>(index), skipOffstage: false)).dx;
       double itemRight(int index) => tester.getTopRight(find.byKey(ValueKey<int>(index), skipOffstage: false)).dx;
 
@@ -345,7 +345,7 @@ void main() {
       );
 
       double itemScale(int index) =>
-          tester.widget<ScaleTransition>(find.byKey(ValueKey<int>(index), skipOffstage: false)).scale.value;
+          tester.widget<ScaleTransition>(find.byKey(ValueKey<int>(index), skipOffstage: false)).animation.value;
       double itemLeft(int index) => tester.getTopLeft(find.byKey(ValueKey<int>(index), skipOffstage: false)).dx;
       double itemRight(int index) => tester.getTopRight(find.byKey(ValueKey<int>(index), skipOffstage: false)).dx;
 
@@ -496,7 +496,7 @@ void main() {
 
       await tester.pump(const Duration(milliseconds: 500));
       expect(
-        tester.widget<ScaleTransition>(find.byKey(const ObjectKey('removing'), skipOffstage: false)).scale.value,
+        tester.widget<ScaleTransition>(find.byKey(const ObjectKey('removing'), skipOffstage: false)).animation.value,
         0.5,
       );
       expect(tester.getTopLeft(find.text('item 0')).dx, 100);

--- a/packages/flutter/test/widgets/dual_transition_builder_test.dart
+++ b/packages/flutter/test/widgets/dual_transition_builder_test.dart
@@ -277,7 +277,7 @@ void main() {
 
 double _getScale(WidgetTester tester) {
   final ScaleTransition scale = tester.widget(find.byType(ScaleTransition));
-  return scale.scale.value;
+  return scale.animation.value;
 }
 
 double _getOpacity(WidgetTester tester) {

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -288,17 +288,17 @@ void main() {
     await tester.tap(switchFinder);
     expect(state.builds, equals(1));
     await tester.pump();
-    expect(scaleWidget.scale.value, equals(1.0));
+    expect(scaleWidget.animation.value, equals(1.0));
     expect(state.builds, equals(2));
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(scaleWidget.scale.value, equals(1.5));
+    expect(scaleWidget.animation.value, equals(1.5));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(scaleWidget.scale.value, equals(1.75));
+    expect(scaleWidget.animation.value, equals(1.75));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(scaleWidget.scale.value, equals(2.0));
+    expect(scaleWidget.animation.value, equals(2.0));
     expect(state.builds, equals(2));
   });
 
@@ -348,17 +348,17 @@ void main() {
     await tester.tap(switchFinder);
     expect(state.builds, equals(1));
     await tester.pump();
-    expect(rotationWidget.turns.value, equals(0.0));
+    expect(rotationWidget.animation.value, equals(0.0));
     expect(state.builds, equals(2));
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(rotationWidget.turns.value, equals(0.75));
+    expect(rotationWidget.animation.value, equals(0.75));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(rotationWidget.turns.value, equals(1.125));
+    expect(rotationWidget.animation.value, equals(1.125));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(rotationWidget.turns.value, equals(1.5));
+    expect(rotationWidget.animation.value, equals(1.5));
     expect(state.builds, equals(2));
   });
 


### PR DESCRIPTION
Remove RotationTransition.turns and ScaleTransition.scale getters.

fixes #130946
