### PR TITLE
Add ability to customize arrow icon in SubmenuButton

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1567,6 +1567,7 @@ class SubmenuButton extends StatefulWidget {
     this.statesController,
     this.leadingIcon,
     this.trailingIcon,
+    this.submenuIcon,
     required this.menuChildren,
     required this.child,
   });
@@ -1633,6 +1634,9 @@ class SubmenuButton extends StatefulWidget {
 
   /// An optional icon to display after the [child].
   final Widget? trailingIcon;
+
+  /// An optional icon to display instead of the default arrow icon.
+  final Widget? submenuIcon;
 
   /// The list of widgets that appear in the menu when it is opened.
   ///
@@ -1764,6 +1768,7 @@ class SubmenuButton extends StatefulWidget {
     properties.add(DiagnosticsProperty<Widget>('leadingIcon', leadingIcon, defaultValue: null));
     properties.add(DiagnosticsProperty<String>('child', child.toString()));
     properties.add(DiagnosticsProperty<Widget>('trailingIcon', trailingIcon, defaultValue: null));
+    properties.add(DiagnosticsProperty<Widget>('submenuIcon', submenuIcon, defaultValue: null));
     properties.add(DiagnosticsProperty<FocusNode?>('focusNode', focusNode));
     properties.add(DiagnosticsProperty<MenuStyle>('menuStyle', menuStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<Offset>('alignmentOffset', alignmentOffset));
@@ -1918,6 +1923,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
               child: _MenuItemLabel(
                 leadingIcon: widget.leadingIcon,
                 trailingIcon: widget.trailingIcon,
+                submenuIcon: widget.submenuIcon,
                 hasSubmenu: true,
                 showDecoration: (controller._anchor!._parent?._orientation ?? Axis.horizontal) == Axis.vertical,
                 child: child ?? const SizedBox(),
@@ -2985,6 +2991,7 @@ class _MenuItemLabel extends StatelessWidget {
     this.showDecoration = true,
     this.leadingIcon,
     this.trailingIcon,
+    this.submenuIcon,
     this.shortcut,
     required this.child,
   });
@@ -3004,6 +3011,9 @@ class _MenuItemLabel extends StatelessWidget {
 
   /// The optional icon that comes after the [child].
   final Widget? trailingIcon;
+
+  /// The optional icon that will be displayed instead of the default arrow icon.
+  final Widget? submenuIcon;
 
   /// The shortcut for this label, so that it can generate a string describing
   /// the shortcut.
@@ -3050,7 +3060,7 @@ class _MenuItemLabel extends StatelessWidget {
         if (showDecoration && hasSubmenu)
           Padding(
             padding: EdgeInsetsDirectional.only(start: horizontalPadding),
-            child: const Icon(
+            child: submenuIcon ?? const Icon(
               Icons.arrow_right, // Automatically switches with text direction.
               size: _kDefaultSubmenuIconSize,
             ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2184,6 +2184,73 @@ void main() {
       expect(find.text(TestMenu.subMenu00.label), findsNothing);
     });
 
+    testWidgets('SubmenuButton shows default arrow icon when submenuIcon is null', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              children: <Widget>[
+                SubmenuButton(
+                  menuChildren: <Widget>[
+                    SubmenuButton(
+                      menuChildren: <Widget>[
+                        MenuItemButton(
+                          child: Text(TestMenu.subSubMenu110.label),
+                        ),
+                      ],
+                      child: Text(TestMenu.subMenu00.label),
+                    ),
+                  ],
+                  child: Text(TestMenu.mainMenu0.label),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(TestMenu.mainMenu0.label));
+      await tester.pump();
+
+      // Direction of the arrow is automatically switched
+      expect(find.byIcon(Icons.arrow_right), findsOneWidget);
+    });
+
+    testWidgets('SubmenuButton can show custom submenu widget instead of the default arrow icon', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              children: <Widget>[
+                SubmenuButton(
+                  menuChildren: <Widget>[
+                    SubmenuButton(
+                      submenuIcon: const Text('customSubmenuIcon'),
+                      menuChildren: <Widget>[
+                        MenuItemButton(
+                          child: Text(TestMenu.subSubMenu110.label),
+                        ),
+                      ],
+                      child: Text(TestMenu.subMenu00.label),
+                    ),
+                  ],
+                  child: Text(TestMenu.mainMenu0.label),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(TestMenu.mainMenu0.label));
+      await tester.pump();
+
+      expect(find.text('customSubmenuIcon'), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_right), findsNothing);
+    });
+
     testWidgets('diagnostics', (WidgetTester tester) async {
       final ButtonStyle style = ButtonStyle(
         shape: MaterialStateProperty.all<OutlinedBorder?>(const StadiumBorder()),


### PR DESCRIPTION
This PR adds `arrowIcon` to `SubmenuButton`. That way we can easily override the default arrow icon, which was always visible.

Before, that icon was always visible in menu:
<img width="207" alt="image" src="https://github.com/flutter/flutter/assets/22731536/420f1d4b-074c-44b1-8cbb-9892f5033d26">

Now we can customize it:
<img width="200" alt="image" src="https://github.com/flutter/flutter/assets/22731536/6aea0d2e-e5fa-4bd0-b5dc-a84446669737">

```dart
SubmenuButton(
  arrowIcon: Icon(Icons.arrow_forward_ios),
)
```

Implements #132898

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
