### PR TITLE
Add deleteBackwardByDecomposingPreviousCharacter mapping for tests

### DIFF
--- a/packages/flutter_test/lib/src/test_text_input_key_handler.dart
+++ b/packages/flutter_test/lib/src/test_text_input_key_handler.dart
@@ -50,6 +50,8 @@ class MacOSTestTextInputKeyHandler extends TestTextInputKeyHandler {
           alt: true, shift: pressShift): <String>['deleteWordBackward:'],
       SingleActivator(LogicalKeyboardKey.backspace,
           meta: true, shift: pressShift): <String>['deleteToBeginningOfLine:'],
+      SingleActivator(LogicalKeyboardKey.backspace,
+          control: true, shift: pressShift): <String>['deleteBackwardByDecomposingPreviousCharacter:'],
       SingleActivator(LogicalKeyboardKey.delete, shift: pressShift): <String>[
         'deleteForward:'
       ],

--- a/packages/flutter_test/lib/src/test_text_input_key_handler.dart
+++ b/packages/flutter_test/lib/src/test_text_input_key_handler.dart
@@ -50,8 +50,8 @@ class MacOSTestTextInputKeyHandler extends TestTextInputKeyHandler {
           alt: true, shift: pressShift): <String>['deleteWordBackward:'],
       SingleActivator(LogicalKeyboardKey.backspace,
           meta: true, shift: pressShift): <String>['deleteToBeginningOfLine:'],
-      SingleActivator(LogicalKeyboardKey.backspace,
-          control: true, shift: pressShift): <String>['deleteBackwardByDecomposingPreviousCharacter:'],
+      SingleActivator(LogicalKeyboardKey.backspace, control: true, shift: pressShift):
+          <String>['deleteBackwardByDecomposingPreviousCharacter:'],
       SingleActivator(LogicalKeyboardKey.delete, shift: pressShift): <String>[
         'deleteForward:'
       ],

--- a/packages/flutter_test/test/test_text_input_test.dart
+++ b/packages/flutter_test/test/test_text_input_test.dart
@@ -76,4 +76,26 @@ void main() {
       expect(selectorNames, isNull);
     }
   }, variant: TargetPlatformVariant.all());
+
+  testWidgets('selector is called for ctrl + backspace on macOS', (WidgetTester tester) async {
+    List<dynamic>? selectorNames;
+    await SystemChannels.textInput.invokeMethod('TextInput.setClient', <dynamic>[1, <String, dynamic>{}]);
+    await SystemChannels.textInput.invokeMethod('TextInput.show');
+    SystemChannels.textInput.setMethodCallHandler((MethodCall call) async {
+      if (call.method == 'TextInputClient.performSelectors') {
+        selectorNames = (call.arguments as List<dynamic>)[1] as List<dynamic>;
+      }
+    });
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.backspace);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.backspace);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+    await SystemChannels.textInput.invokeMethod('TextInput.clearClient');
+
+    if (defaultTargetPlatform == TargetPlatform.macOS) {
+      expect(selectorNames, <dynamic>['deleteBackwardByDecomposingPreviousCharacter:']);
+    } else {
+      expect(selectorNames, isNull);
+    }
+  }, variant: TargetPlatformVariant.all());
 }


### PR DESCRIPTION
In  `MacOSTestTextInputKeyHandler`, there are some mappings from shortcuts to generate macOS selectors. However, `ctrl + backspace` isn't mapped to `deleteBackwardByDecomposingPreviousCharacter:`.

This PR adds the mapping for `deleteBackwardByDecomposingPreviousCharacter:`.

Fixes: https://github.com/flutter/flutter/issues/132917

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
