### PR TITLE
Change gradle lockfile generation script to use --config-only flag

### DIFF
--- a/dev/tools/bin/generate_gradle_lockfiles.dart
+++ b/dev/tools/bin/generate_gradle_lockfiles.dart
@@ -86,13 +86,11 @@ void main(List<String> arguments) {
 
     // Verify that the Gradlew wrapper exists.
     final File gradleWrapper = androidDirectory.childFile('gradlew');
-    // Generate Gradle wrapper if it doesn't exists.
-    // This logic is embedded within the Flutter tool.
-    // To generate the wrapper, build a flavor that doesn't exist.
+    // Generate Gradle wrapper if it doesn't exist.
     if (!gradleWrapper.existsSync()) {
       Process.runSync(
         'flutter',
-        <String>['build', 'apk', '--debug', '--flavor=does-not-exist'],
+        <String>['build', 'apk', '--config-only'],
         workingDirectory: appDirectory,
       );
     }


### PR DESCRIPTION
The `generate_gradle_lockfiles.dart` script was generating the gradle wrapper by building a flavor that didn't exist. In the time since the script was written, the `--config-only` flag was created and should be used instead.

Context https://github.com/flutter/flutter/pull/132406#discussion_r1300352602

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
