### PR TITLE
Bump memory usage for flutter gallery

### DIFF
--- a/dev/integration_tests/flutter_gallery/android/gradle.properties
+++ b/dev/integration_tests/flutter_gallery/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/131006
Flakes related to out of memory in gradle when running tests. 

Opted not to add enforcement for gradle.properties in https://github.com/flutter/flutter/blob/master/dev/bots/analyze.dart because the memory usage has been stable for 6 years and not every example needs more memory. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
