### PR TITLE
Fix visual overflow for SliverMainAxisGroup

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -288,6 +288,7 @@ class RenderSliverMainAxisGroup extends RenderSliver with ContainerRenderObjectM
       scrollExtent: totalScrollExtent,
       paintExtent: calculatePaintOffset(constraints, from: 0, to: totalScrollExtent),
       maxPaintExtent: maxPaintExtent,
+      hasVisualOverflow: totalScrollExtent > constraints.remainingPaintExtent || constraints.scrollOffset > 0.0,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6278,7 +6278,6 @@ abstract class RenderObjectElement extends Element {
       if (result == null || ancestor == null) {
         return true;
       }
-      return true;
       // Check that no other ParentDataWidgets want to provide parent data.
       final List<ParentDataElement<ParentData>> badAncestors = <ParentDataElement<ParentData>>[];
       ancestor = ancestor!._parent;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6278,6 +6278,7 @@ abstract class RenderObjectElement extends Element {
       if (result == null || ancestor == null) {
         return true;
       }
+      return true;
       // Check that no other ParentDataWidgets want to provide parent data.
       final List<ParentDataElement<ParentData>> badAncestors = <ParentDataElement<ParentData>>[];
       ancestor = ancestor!._parent;

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -61,6 +61,7 @@ void main() {
     final RenderSliverMainAxisGroup renderGroup =
         tester.renderObject<RenderSliverMainAxisGroup>(find.byType(SliverMainAxisGroup));
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
+    expect(renderGroup.geometry!.hasVisualOverflow, isTrue);
   });
 
   testWidgets('SliverMainAxisGroup is laid out properly when reversed', (WidgetTester tester) async {
@@ -112,6 +113,7 @@ void main() {
     final RenderSliverMainAxisGroup renderGroup =
         tester.renderObject<RenderSliverMainAxisGroup>(find.byType(SliverMainAxisGroup));
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
+    expect(renderGroup.geometry!.hasVisualOverflow, isTrue);
   });
 
   testWidgets('SliverMainAxisGroup is laid out properly when horizontal', (WidgetTester tester) async {
@@ -168,6 +170,7 @@ void main() {
     final RenderSliverMainAxisGroup renderGroup =
         tester.renderObject<RenderSliverMainAxisGroup>(find.byType(SliverMainAxisGroup));
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
+    expect(renderGroup.geometry!.hasVisualOverflow, isTrue);
   });
 
   testWidgets('SliverMainAxisGroup is laid out properly when horizontal, reversed', (WidgetTester tester) async {
@@ -225,6 +228,7 @@ void main() {
     final RenderSliverMainAxisGroup renderGroup =
         tester.renderObject<RenderSliverMainAxisGroup>(find.byType(SliverMainAxisGroup));
     expect(renderGroup.geometry!.scrollExtent, equals(300 * 20 + 200 * 20));
+    expect(renderGroup.geometry!.hasVisualOverflow, isTrue);
   });
 
   testWidgets('Hit test works properly on various parts of SliverMainAxisGroup', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/132788

The SliverGeometry was not set properly for SliverMainAxisGroup. Omitting hasVisualOverflow affected the Viewport's choice to apply a clip, leading to the sliver being rendered outside of the bounds of the viewport.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
