### PR TITLE
Add `--experimental-wasm-type-reflection` and support newer emscripten builds.

### DIFF
--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -87,6 +87,10 @@ class Chrome {
       print('Launching Chrome...');
     }
 
+    final String jsFlags = options.enableWasmGC ? <String>[
+      '--experimental-wasm-gc',
+      '--experimental-wasm-type-reflection',
+    ].join(' ') : '';
     final bool withDebugging = options.debugPort != null;
     final List<String> args = <String>[
       if (options.userDataDirectory != null)
@@ -108,8 +112,7 @@ class Chrome {
       '--no-default-browser-check',
       '--disable-default-apps',
       '--disable-translate',
-      if (options.enableWasmGC)
-        '--js-flags=--experimental-wasm-gc',
+      if (jsFlags.isNotEmpty) '--js-flags=$jsFlags',
     ];
 
     final io.Process chromeProcess = await _spawnChromiumProcess(

--- a/packages/flutter_tools/lib/src/web/file_generators/wasm_bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/wasm_bootstrap.dart
@@ -46,7 +46,7 @@ String generateImports(bool isSkwasm) {
         const skwasmInstance = await skwasm();
         window._flutter_skwasmInstance = skwasmInstance;
         resolve({
-          'skwasm': skwasmInstance.asm,
+          'skwasm': skwasmInstance.asm ?? skwasmInstance.wasmExports,
           'ffi': {
             'memory': skwasmInstance.wasmMemory,
           }


### PR DESCRIPTION
This makes two changes to prepare for incoming changes to skwasm in the web engine:
* We will (at least for now) be depending on the `WebAssembly.Function` constructor in `skwasm`, which is hidden behind the `--experimental-wasm-type-reflection` flag. We need to pass that when running skwasm benchmarks.
* We are going to be upgrading the skwasm build to a newer version of emscripten, which exposes the wasm exports via the `wasmExports` property instead of the `asm` property. Make sure to support either, if passed.