### PR TITLE
Revert "[gallery] roll gallery to  ecfb9e5352bd12032301b12b30d5853d83d89bda"

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = 'ecfb9e5352bd12032301b12b30d5853d83d89bda';
+const String galleryVersion = '6a8d738c94d0710e229d726729c09fdb5ccaf7ed';


### PR DESCRIPTION
Reverts flutter/flutter#133083

failing on cocoapods:

```
[2023-08-22 16:28:37.783355] [STDOUT] stdout: [        ] Error output from CocoaPods:
[2023-08-22 16:28:37.783379] [STDOUT] stdout:            ↳
[2023-08-22 16:28:37.783402] [STDOUT] stdout: [        ]     [!] The version of CocoaPods used to generate the lockfile (1.12.1) is higher than the version of the current executable (1.11.3). Incompatibility issues may arise.
[2023-08-22 16:28:37.783423] [STDOUT] stdout: 
[2023-08-22 16:28:37.783445] [STDOUT] stdout:                [!] Automatically assigning platform `iOS` with version `11.0` on target `Runner` because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.
[2023-08-22 16:28:37.783469] [STDOUT] stdout: 
[2023-08-22 16:28:37.784059] [STDOUT] stderr: [        ] Error: CocoaPods's specs repository is too out-of-date to satisfy dependencies.
[2023-08-22 16:28:37.784102] [STDOUT] stderr:            To update the CocoaPods specs, run:
[2023-08-22 16:28:37.784126] [STDOUT] stderr:              pod repo update
[2023-08-22 16:28:37.784147] [STDOUT] stderr: 
```

https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20new_gallery_ios__transition_perf/10590/overview