### PR TITLE
Fix context menu button color on Android when textButtonTheme is set

### DIFF
--- a/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
@@ -134,6 +134,8 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
   // Android API level 34.
   static const Color _defaultForegroundColorLight = Color(0xff000000);
   static const Color _defaultForegroundColorDark = Color(0xffffffff);
+  static const Color _defaultBackgroundColorLight = Color(0xffffffff);
+  static const Color _defaultBackgroundColorDark = Color(0xff424242);
 
   static Color _getForegroundColor(ColorScheme colorScheme) {
     final bool isDefaultOnSurface = switch (colorScheme.brightness) {
@@ -149,11 +151,26 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
     };
   }
 
+  static Color _getBackgroundColor(ColorScheme colorScheme) {
+    final bool isDefaultSurface = switch (colorScheme.brightness) {
+      Brightness.light => identical(ThemeData().colorScheme.surface, colorScheme.surface),
+      Brightness.dark => identical(ThemeData.dark().colorScheme.surface, colorScheme.surface),
+    };
+    if (!isDefaultSurface) {
+      return colorScheme.surface;
+    }
+    return switch (colorScheme.brightness) {
+      Brightness.light => _defaultBackgroundColorLight,
+      Brightness.dark => _defaultBackgroundColorDark,
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return TextButton(
       style: TextButton.styleFrom(
+        backgroundColor: _getBackgroundColor(colorScheme),
         foregroundColor: _getForegroundColor(colorScheme),
         shape: const RoundedRectangleBorder(),
         minimumSize: const Size(kMinInteractiveDimension, kMinInteractiveDimension),

--- a/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
@@ -134,6 +134,11 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
   // Android API level 34.
   static const Color _defaultForegroundColorLight = Color(0xff000000);
   static const Color _defaultForegroundColorDark = Color(0xffffffff);
+
+  // The background color is hardcoded to transparent by default so the buttons
+  // are the color of the container behind them. For example TextSelectionToolbar
+  // hardcodes the color value, and TextSelectionToolbarTextButtons that are its
+  // children become that color.
   static const Color _defaultBackgroundColorTransparent = Color(0x00000000);
 
   static Color _getForegroundColor(ColorScheme colorScheme) {

--- a/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar_text_button.dart
@@ -134,8 +134,7 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
   // Android API level 34.
   static const Color _defaultForegroundColorLight = Color(0xff000000);
   static const Color _defaultForegroundColorDark = Color(0xffffffff);
-  static const Color _defaultBackgroundColorLight = Color(0xffffffff);
-  static const Color _defaultBackgroundColorDark = Color(0xff424242);
+  static const Color _defaultBackgroundColorTransparent = Color(0x00000000);
 
   static Color _getForegroundColor(ColorScheme colorScheme) {
     final bool isDefaultOnSurface = switch (colorScheme.brightness) {
@@ -151,26 +150,12 @@ class TextSelectionToolbarTextButton extends StatelessWidget {
     };
   }
 
-  static Color _getBackgroundColor(ColorScheme colorScheme) {
-    final bool isDefaultSurface = switch (colorScheme.brightness) {
-      Brightness.light => identical(ThemeData().colorScheme.surface, colorScheme.surface),
-      Brightness.dark => identical(ThemeData.dark().colorScheme.surface, colorScheme.surface),
-    };
-    if (!isDefaultSurface) {
-      return colorScheme.surface;
-    }
-    return switch (colorScheme.brightness) {
-      Brightness.light => _defaultBackgroundColorLight,
-      Brightness.dark => _defaultBackgroundColorDark,
-    };
-  }
-
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return TextButton(
       style: TextButton.styleFrom(
-        backgroundColor: _getBackgroundColor(colorScheme),
+        backgroundColor: _defaultBackgroundColorTransparent,
         foregroundColor: _getForegroundColor(colorScheme),
         shape: const RoundedRectangleBorder(),
         minimumSize: const Size(kMinInteractiveDimension, kMinInteractiveDimension),

--- a/packages/flutter/test/material/text_selection_toolbar_text_button_test.dart
+++ b/packages/flutter/test/material/text_selection_toolbar_text_button_test.dart
@@ -145,14 +145,13 @@ void main() {
       expect(find.byType(TextButton), findsOneWidget);
 
       final TextButton textButton = tester.widget(find.byType(TextButton));
-      // The background color is hardcoded to grey or white by default, not the
-      // default value from ColorScheme.surface.
+      // The background color is hardcoded to transparent by default so the buttons
+      // are the color of the container behind them. For example TextSelectionToolbar
+      // hardcodes the color value, and TextSelectionToolbarTextButton that are its
+      // children should be that color.
       expect(
         textButton.style!.backgroundColor!.resolve(<MaterialState>{}),
-        switch (colorScheme.brightness) {
-          Brightness.light => const Color(0xffffffff),
-          Brightness.dark => const Color(0xff424242),
-        },
+        Colors.transparent,
       );
     });
 
@@ -182,45 +181,13 @@ void main() {
       expect(find.byType(TextButton), findsOneWidget);
 
       final TextButton textButton = tester.widget(find.byType(TextButton));
-      // The background color is hardcoded to grey or white by default, not the
-      // default value from ColorScheme.surface.
+      // The background color is hardcoded to transparent by default so the buttons
+      // are the color of the container behind them. For example TextSelectionToolbar
+      // hardcodes the color value, and TextSelectionToolbarTextButton that are its
+      // children should be that color.
       expect(
         textButton.style!.backgroundColor!.resolve(<MaterialState>{}),
-        switch (colorScheme.brightness) {
-          Brightness.light => const Color(0xffffffff),
-          Brightness.dark => const Color(0xff424242),
-        },
-      );
-    });
-
-    testWidgetsWithLeakTracking('custom background color', (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/133027
-      const Color customBackgroundColor = Colors.red;
-
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(
-            colorScheme: colorScheme.copyWith(
-              surface: customBackgroundColor,
-            ),
-          ),
-          home: Scaffold(
-            body: Center(
-              child: TextSelectionToolbarTextButton(
-                padding: TextSelectionToolbarTextButton.getPadding(0, 1),
-                child: const Text('button'),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.byType(TextButton), findsOneWidget);
-
-      final TextButton textButton = tester.widget(find.byType(TextButton));
-      expect(
-        textButton.style!.backgroundColor!.resolve(<MaterialState>{}),
-        customBackgroundColor,
+        Colors.transparent,
       );
     });
   }

--- a/packages/flutter/test/material/text_selection_toolbar_text_button_test.dart
+++ b/packages/flutter/test/material/text_selection_toolbar_text_button_test.dart
@@ -123,5 +123,105 @@ void main() {
         customForegroundColor,
       );
     });
+
+    testWidgetsWithLeakTracking('background color by default', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/133027
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: colorScheme,
+          ),
+          home: Scaffold(
+            body: Center(
+              child: TextSelectionToolbarTextButton(
+                padding: TextSelectionToolbarTextButton.getPadding(0, 1),
+                child: const Text('button'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(TextButton), findsOneWidget);
+
+      final TextButton textButton = tester.widget(find.byType(TextButton));
+      // The background color is hardcoded to grey or white by default, not the
+      // default value from ColorScheme.surface.
+      expect(
+        textButton.style!.backgroundColor!.resolve(<MaterialState>{}),
+        switch (colorScheme.brightness) {
+          Brightness.light => const Color(0xffffffff),
+          Brightness.dark => const Color(0xff424242),
+        },
+      );
+    });
+
+    testWidgetsWithLeakTracking('textButtonTheme should not override default background color', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/133027
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: colorScheme,
+            textButtonTheme: const TextButtonThemeData(
+              style: ButtonStyle(
+                backgroundColor: MaterialStatePropertyAll<Color>(Colors.blue),
+              ),
+            ),
+          ),
+          home: Scaffold(
+            body: Center(
+              child: TextSelectionToolbarTextButton(
+                padding: TextSelectionToolbarTextButton.getPadding(0, 1),
+                child: const Text('button'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(TextButton), findsOneWidget);
+
+      final TextButton textButton = tester.widget(find.byType(TextButton));
+      // The background color is hardcoded to grey or white by default, not the
+      // default value from ColorScheme.surface.
+      expect(
+        textButton.style!.backgroundColor!.resolve(<MaterialState>{}),
+        switch (colorScheme.brightness) {
+          Brightness.light => const Color(0xffffffff),
+          Brightness.dark => const Color(0xff424242),
+        },
+      );
+    });
+
+    testWidgetsWithLeakTracking('custom background color', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/133027
+      const Color customBackgroundColor = Colors.red;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: colorScheme.copyWith(
+              surface: customBackgroundColor,
+            ),
+          ),
+          home: Scaffold(
+            body: Center(
+              child: TextSelectionToolbarTextButton(
+                padding: TextSelectionToolbarTextButton.getPadding(0, 1),
+                child: const Text('button'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(TextButton), findsOneWidget);
+
+      final TextButton textButton = tester.widget(find.byType(TextButton));
+      expect(
+        textButton.style!.backgroundColor!.resolve(<MaterialState>{}),
+        customBackgroundColor,
+      );
+    });
   }
 }


### PR DESCRIPTION
Fixes #133027

When setting a `textButtonTheme` it should not override the native context menu colors.

```dart
  theme: ThemeData(
    textButtonTheme: const TextButtonThemeData(
      style: ButtonStyle(
        backgroundColor: MaterialStatePropertyAll<Color>(
            Color(0xff05164d)), // blue color
      ),
    ),
  ),
```

Before|After
--|--
<img width="341" alt="Screenshot 2023-08-24 at 1 17 25 PM" src="https://github.com/flutter/flutter/assets/948037/30ea0ef8-b41a-4e1f-93a3-50fcd87ab2bf">|<img width="341" alt="Screenshot 2023-08-24 at 1 15 35 PM" src="https://github.com/flutter/flutter/assets/948037/5f59481c-aa5d-4850-aa4b-daa678e54044">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.