### PR TITLE
[flutter_tools] print out the unzipping method used by update_dart_sdk.ps1

### DIFF
--- a/bin/internal/update_dart_sdk.ps1
+++ b/bin/internal/update_dart_sdk.ps1
@@ -83,18 +83,21 @@ Catch {
     $ProgressPreference = $OriginalProgressPreference
 }
 
-Write-Host "Expanding downloaded archive..."
 If (Get-Command 7z -errorAction SilentlyContinue) {
+    Write-Host "Expanding downloaded archive with 7z..."
     # The built-in unzippers are painfully slow. Use 7-Zip, if available.
     & 7z x $dartSdkZip "-o$cachePath" -bd | Out-Null
 } ElseIf (Get-Command 7za -errorAction SilentlyContinue) {
+    Write-Host "Expanding downloaded archive with 7za..."
     # Use 7-Zip's standalone version 7za.exe, if available.
     & 7za x $dartSdkZip "-o$cachePath" -bd | Out-Null
 } ElseIf (Get-Command Microsoft.PowerShell.Archive\Expand-Archive -errorAction SilentlyContinue) {
+    Write-Host "Expanding downloaded archive with PowerShell..."
     # Use PowerShell's built-in unzipper, if available (requires PowerShell 5+).
     $global:ProgressPreference='SilentlyContinue'
     Microsoft.PowerShell.Archive\Expand-Archive $dartSdkZip -DestinationPath $cachePath
 } Else {
+    Write-Host "Expanding downloaded archive with Windows..."
     # As last resort: fall back to the Windows GUI.
     $shell = New-Object -com shell.application
     $zip = $shell.NameSpace($dartSdkZip)

--- a/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/batch_entrypoint_test.dart
@@ -49,7 +49,8 @@ Future<void> main() async {
     // See: https://github.com/flutter/flutter/issues/132592
     expect(dartSdkStamp.existsSync(), true);
     expect(output, contains('Downloading Dart SDK from Flutter engine ...'));
-    expect(output, contains('Expanding downloaded archive...'));
+    // Do not assert on the exact unzipping method, as this could change on CI
+    expect(output, contains(RegExp(r'Expanding downloaded archive with (.*)...')));
     expect(output, isNot(contains('Use the -Force parameter' /* Luke */)));
   },
   skip: !platform.isWindows); // [intended] Only Windows uses the batch entrypoint


### PR DESCRIPTION
in case there are future issues with unzipping the dart sdk, such as https://github.com/flutter/flutter/issues/132592, we should log out what tool we are using to try to extract the archive.