### PR TITLE
Fix stuck predictive back platform channel calls

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1338,7 +1338,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     ? WidgetsBinding.instance.platformDispatcher.defaultRouteName
     : widget.initialRoute ?? WidgetsBinding.instance.platformDispatcher.defaultRouteName;
 
-  late AppLifecycleState _appLifecycleState;
+  AppLifecycleState? _appLifecycleState;
 
   /// The default value for [onNavigationNotification].
   ///
@@ -1347,6 +1347,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   /// bubbling.
   bool _defaultOnNavigationNotification(NavigationNotification notification) {
     switch (_appLifecycleState) {
+      case null:
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
         // Avoid updating the engine when the app isn't ready.
@@ -1371,9 +1372,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     _updateRouting();
     _locale = _resolveLocales(WidgetsBinding.instance.platformDispatcher.locales, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
-    if (WidgetsBinding.instance.lifecycleState != null) {
-      _appLifecycleState = WidgetsBinding.instance.lifecycleState!;
-    }
+    _appLifecycleState = WidgetsBinding.instance.lifecycleState;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1338,7 +1338,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     ? WidgetsBinding.instance.platformDispatcher.defaultRouteName
     : widget.initialRoute ?? WidgetsBinding.instance.platformDispatcher.defaultRouteName;
 
-  AppLifecycleState? _appLifecycleState;
+  late AppLifecycleState _appLifecycleState;
 
   /// The default value for [onNavigationNotification].
   ///
@@ -1347,7 +1347,6 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   /// bubbling.
   bool _defaultOnNavigationNotification(NavigationNotification notification) {
     switch(_appLifecycleState) {
-      case null:
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
         // Avoid updating the engine when the app isn't ready.
@@ -1373,7 +1372,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     _locale = _resolveLocales(WidgetsBinding.instance.platformDispatcher.locales, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
     if (WidgetsBinding.instance.lifecycleState != null) {
-      _appLifecycleState = WidgetsBinding.instance.lifecycleState;
+      _appLifecycleState = WidgetsBinding.instance.lifecycleState!;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1366,6 +1366,9 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     _updateRouting();
     _locale = _resolveLocales(WidgetsBinding.instance.platformDispatcher.locales, widget.supportedLocales);
     WidgetsBinding.instance.addObserver(this);
+    if (WidgetsBinding.instance.lifecycleState != null) {
+      _appLifecycleState = WidgetsBinding.instance.lifecycleState;
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1346,12 +1346,18 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   /// the platform with [NavigationNotification.canHandlePop] and stops
   /// bubbling.
   bool _defaultOnNavigationNotification(NavigationNotification notification) {
-    // Don't do anything with navigation notifications if there is no engine
-    // attached.
-    if (_appLifecycleState != AppLifecycleState.detached) {
-      SystemNavigator.setFrameworkHandlesBack(notification.canHandlePop);
+    switch(_appLifecycleState) {
+      case null:
+      case AppLifecycleState.detached:
+      case AppLifecycleState.inactive:
+        // Avoid updating the engine when the app isn't ready.
+        return true;
+      case AppLifecycleState.resumed:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        SystemNavigator.setFrameworkHandlesBack(notification.canHandlePop);
+        return true;
     }
-    return true;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1346,7 +1346,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   /// the platform with [NavigationNotification.canHandlePop] and stops
   /// bubbling.
   bool _defaultOnNavigationNotification(NavigationNotification notification) {
-    switch(_appLifecycleState) {
+    switch (_appLifecycleState) {
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
         // Avoid updating the engine when the app isn't ready.

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -1220,10 +1220,6 @@ void main() {
   group('Android Predictive Back', () {
     bool? lastFrameworkHandlesBack;
     setUp(() {
-      // Initialize to false. Because this uses a static boolean internally, it
-      // is not reset between tests or calls to pumpWidget. Explicitly setting
-      // it to false before each test makes them behave deterministically.
-      SystemNavigator.setFrameworkHandlesBack(false);
       lastFrameworkHandlesBack = null;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -1238,7 +1234,6 @@ void main() {
     tearDown(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
-      SystemNavigator.setFrameworkHandlesBack(true);
     });
 
     testWidgets('System back navigation inside of tabs', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -1219,7 +1219,7 @@ void main() {
 
   group('Android Predictive Back', () {
     bool? lastFrameworkHandlesBack;
-    setUp(() {
+    setUp(() async {
       lastFrameworkHandlesBack = null;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -1229,6 +1229,12 @@ void main() {
           }
           return;
         });
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'flutter/lifecycle',
+            const StringCodec().encodeMessage(AppLifecycleState.resumed.toString()),
+            (ByteData? data) {},
+          );
     });
 
     tearDown(() {

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -683,6 +683,91 @@ void main() {
     expect(copySpy.invoked, isTrue);
     expect(pasteSpy.invoked, isTrue);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+
+  group('Android Predictive Back', () {
+    final List<bool> frameworkHandlesBacks = <bool>[];
+    setUp(() {
+      // Initialize to false. Because this uses a static boolean internally, it
+      // is not reset between tests or calls to pumpWidget. Explicitly setting
+      // it to false before each test makes them behave deterministically.
+      SystemNavigator.setFrameworkHandlesBack(false);
+      frameworkHandlesBacks.clear();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
+          if (methodCall.method == 'SystemNavigator.setFrameworkHandlesBack') {
+            expect(methodCall.arguments, isA<bool>());
+            frameworkHandlesBacks.add(methodCall.arguments as bool);
+          }
+          return;
+        });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+      SystemNavigator.setFrameworkHandlesBack(true);
+    });
+
+    Future<void> setAppLifeCycleState(AppLifecycleState state) async {
+      final ByteData? message = const StringCodec().encodeMessage(state.toString());
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage('flutter/lifecycle', message, (_) {});
+    }
+
+    testWidgets('WidgetsApp calls setFrameworkHandlesBack only when app is ready', (WidgetTester tester) async {
+      // Start in the `resumed` state, where setFrameworkHandlesBack should be
+      // called like normal.
+      await setAppLifeCycleState(AppLifecycleState.resumed);
+
+      late BuildContext currentContext;
+      await tester.pumpWidget(
+        WidgetsApp(
+          color: const Color(0xFF123456),
+          builder: (BuildContext context, Widget? child) {
+            currentContext = context;
+            return const Placeholder();
+          },
+        ),
+      );
+
+      expect(frameworkHandlesBacks, isEmpty);
+
+      const NavigationNotification(canHandlePop: true).dispatch(currentContext);
+      await tester.pumpAndSettle();
+      expect(frameworkHandlesBacks, isNotEmpty);
+      expect(frameworkHandlesBacks.last, isTrue);
+
+      const NavigationNotification(canHandlePop: false).dispatch(currentContext);
+      await tester.pumpAndSettle();
+      expect(frameworkHandlesBacks.last, isFalse);
+
+      // Set the app state to inactive, where setFrameworkHandlesBack shouldn't
+      // be called.
+      await setAppLifeCycleState(AppLifecycleState.inactive);
+
+      final int finalCallsLength = frameworkHandlesBacks.length;
+      const NavigationNotification(canHandlePop: true).dispatch(currentContext);
+      await tester.pumpAndSettle();
+      expect(frameworkHandlesBacks, hasLength(finalCallsLength));
+
+      const NavigationNotification(canHandlePop: false).dispatch(currentContext);
+      await tester.pumpAndSettle();
+      expect(frameworkHandlesBacks, hasLength(finalCallsLength));
+
+      // Set the app state to detached, which also shouldn't call
+      // setFrameworkHandlesBack. Must go to paused, then detached.
+      await setAppLifeCycleState(AppLifecycleState.paused);
+      await setAppLifeCycleState(AppLifecycleState.detached);
+
+      const NavigationNotification(canHandlePop: true).dispatch(currentContext);
+      await tester.pumpAndSettle();
+      expect(frameworkHandlesBacks, hasLength(finalCallsLength));
+
+      const NavigationNotification(canHandlePop: false).dispatch(currentContext);
+      await tester.pumpAndSettle();
+      expect(frameworkHandlesBacks, hasLength(finalCallsLength));
+    });
+  });
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -687,10 +687,6 @@ void main() {
   group('Android Predictive Back', () {
     final List<bool> frameworkHandlesBacks = <bool>[];
     setUp(() {
-      // Initialize to false. Because this uses a static boolean internally, it
-      // is not reset between tests or calls to pumpWidget. Explicitly setting
-      // it to false before each test makes them behave deterministically.
-      SystemNavigator.setFrameworkHandlesBack(false);
       frameworkHandlesBacks.clear();
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -705,7 +701,6 @@ void main() {
     tearDown(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
-      SystemNavigator.setFrameworkHandlesBack(true);
     });
 
     Future<void> setAppLifeCycleState(AppLifecycleState state) async {

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -762,7 +762,10 @@ void main() {
       const NavigationNotification(canHandlePop: false).dispatch(currentContext);
       await tester.pumpAndSettle();
       expect(frameworkHandlesBacks, hasLength(finalCallsLength));
-    });
+    },
+      skip: kIsWeb, // [intended] predictive back is only native Android.
+      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android })
+    );
   });
 }
 

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -685,8 +685,14 @@ void main() {
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   group('Android Predictive Back', () {
+    Future<void> setAppLifeCycleState(AppLifecycleState state) async {
+      final ByteData? message = const StringCodec().encodeMessage(state.toString());
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage('flutter/lifecycle', message, (ByteData? data) {});
+    }
+
     final List<bool> frameworkHandlesBacks = <bool>[];
-    setUp(() {
+    setUp(() async {
       frameworkHandlesBacks.clear();
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -698,16 +704,11 @@ void main() {
         });
     });
 
-    tearDown(() {
+    tearDown(() async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
+      await setAppLifeCycleState(AppLifecycleState.resumed);
     });
-
-    Future<void> setAppLifeCycleState(AppLifecycleState state) async {
-      final ByteData? message = const StringCodec().encodeMessage(state.toString());
-      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .handlePlatformMessage('flutter/lifecycle', message, (_) {});
-    }
 
     testWidgets('WidgetsApp calls setFrameworkHandlesBack only when app is ready', (WidgetTester tester) async {
       // Start in the `resumed` state, where setFrameworkHandlesBack should be

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -4160,10 +4160,6 @@ void main() {
   group('Android Predictive Back', () {
     bool? lastFrameworkHandlesBack;
     setUp(() {
-      // Initialize to false. Because this uses a static boolean internally, it
-      // is not reset between tests or calls to pumpWidget. Explicitly setting
-      // it to false before each test makes them behave deterministically.
-      SystemNavigator.setFrameworkHandlesBack(false);
       lastFrameworkHandlesBack = null;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -4178,7 +4174,6 @@ void main() {
     tearDown(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
-      SystemNavigator.setFrameworkHandlesBack(true);
     });
 
     testWidgets('a single route is already defaulted to false', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -4159,7 +4159,7 @@ void main() {
 
   group('Android Predictive Back', () {
     bool? lastFrameworkHandlesBack;
-    setUp(() {
+    setUp(() async {
       lastFrameworkHandlesBack = null;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -4169,6 +4169,12 @@ void main() {
           }
           return;
         });
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'flutter/lifecycle',
+            const StringCodec().encodeMessage(AppLifecycleState.resumed.toString()),
+            (ByteData? data) {},
+          );
     });
 
     tearDown(() {

--- a/packages/flutter/test/widgets/pop_scope_test.dart
+++ b/packages/flutter/test/widgets/pop_scope_test.dart
@@ -15,7 +15,6 @@ void main() {
     // Initialize to false. Because this uses a static boolean internally, it
     // is not reset between tests or calls to pumpWidget. Explicitly setting
     // it to false before each test makes them behave deterministically.
-    SystemNavigator.setFrameworkHandlesBack(false);
     lastFrameworkHandlesBack = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -30,7 +29,6 @@ void main() {
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, null);
-    SystemNavigator.setFrameworkHandlesBack(true);
   });
 
   testWidgets('toggling canPop on root route allows/prevents backs', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/pop_scope_test.dart
+++ b/packages/flutter/test/widgets/pop_scope_test.dart
@@ -11,10 +11,7 @@ import 'navigator_utils.dart';
 
 void main() {
   bool? lastFrameworkHandlesBack;
-  setUp(() {
-    // Initialize to false. Because this uses a static boolean internally, it
-    // is not reset between tests or calls to pumpWidget. Explicitly setting
-    // it to false before each test makes them behave deterministically.
+  setUp(() async {
     lastFrameworkHandlesBack = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -24,6 +21,12 @@ void main() {
         }
         return;
       });
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          'flutter/lifecycle',
+          const StringCodec().encodeMessage(AppLifecycleState.resumed.toString()),
+          (ByteData? data) {},
+        );
   });
 
   tearDown(() {


### PR DESCRIPTION
Sometimes, platform channel calls to setFrameworkHandlesBack, were getting stuck when made when the app was shutting down.  This was uncovered by Google tests that were flaking.  This PR avoids making those calls and fixes the tests.

b/296900781