### PR TITLE
Fix `subtitleTextStyle.color` isn't applied to the `ListTile.subtitle` in Material 2

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -801,8 +801,7 @@ class ListTile extends StatelessWidget {
       subtitleStyle = subtitleTextStyle
         ?? tileTheme.subtitleTextStyle
         ?? defaults.subtitleTextStyle!;
-      final Color? subtitleColor = effectiveColor
-        ?? (theme.useMaterial3 ? null : theme.textTheme.bodySmall!.color);
+      final Color? subtitleColor = effectiveColor;
       subtitleStyle = subtitleStyle.copyWith(
         color: subtitleColor,
         fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -797,24 +797,15 @@ class ListTile extends StatelessWidget {
 
     Widget? subtitleText;
     TextStyle? subtitleStyle;
-
     if (subtitle != null) {
-      subtitleStyle = subtitleTextStyle ?? tileTheme.subtitleTextStyle;
-      if (theme.useMaterial3) {
-        subtitleStyle = (subtitleStyle ?? defaults.subtitleTextStyle)!.copyWith(
-          color: effectiveColor,
-          fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
-        );
-      } else {
-        subtitleStyle = subtitleTextStyle?.copyWith(
-          color: effectiveColor,
-          fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
-        );
-        subtitleStyle ??= defaults.subtitleTextStyle!.copyWith(
-          color: effectiveColor ??  theme.textTheme.bodySmall!.color,
-          fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
-        );
-      }
+      subtitleStyle = subtitleTextStyle
+        ?? tileTheme.subtitleTextStyle
+        ?? defaults.subtitleTextStyle!;
+      final Color? subtitleColor = effectiveColor;
+      subtitleStyle = subtitleStyle.copyWith(
+        color: subtitleColor,
+        fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
+      );
       subtitleText = AnimatedDefaultTextStyle(
         style: subtitleStyle,
         duration: kThemeChangeDuration,
@@ -1541,7 +1532,8 @@ class _LisTileDefaultsM2 extends ListTileThemeData {
   }
 
   @override
-  TextStyle? get subtitleTextStyle => _textTheme.bodyMedium;
+  TextStyle? get subtitleTextStyle => _textTheme.bodyMedium!
+    .copyWith(color: _textTheme.bodySmall!.color);
 
   @override
   TextStyle? get leadingAndTrailingTextStyle => _textTheme.bodyMedium;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -797,15 +797,24 @@ class ListTile extends StatelessWidget {
 
     Widget? subtitleText;
     TextStyle? subtitleStyle;
+
     if (subtitle != null) {
-      subtitleStyle = subtitleTextStyle
-        ?? tileTheme.subtitleTextStyle
-        ?? defaults.subtitleTextStyle!;
-      final Color? subtitleColor = effectiveColor;
-      subtitleStyle = subtitleStyle.copyWith(
-        color: subtitleColor,
-        fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
-      );
+      subtitleStyle = subtitleTextStyle ?? tileTheme.subtitleTextStyle;
+      if (theme.useMaterial3) {
+        subtitleStyle = (subtitleStyle ?? defaults.subtitleTextStyle)!.copyWith(
+          color: effectiveColor,
+          fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
+        );
+      } else {
+        subtitleStyle = subtitleTextStyle?.copyWith(
+          color: effectiveColor,
+          fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
+        );
+        subtitleStyle ??= defaults.subtitleTextStyle!.copyWith(
+          color: effectiveColor ??  theme.textTheme.bodySmall!.color,
+          fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
+        );
+      }
       subtitleText = AnimatedDefaultTextStyle(
         style: subtitleStyle,
         duration: kThemeChangeDuration,

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -3616,7 +3616,7 @@ void main() {
       RenderParagraph title = _getTextRenderObject(tester, 'title');
       expect(title.text.style!.color, theme.textTheme.titleMedium!.color);
       RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
-      expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
+      expect(subtitle.text.style!.color, theme.textTheme.bodyMedium!.color);
       RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
       expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -3616,7 +3616,7 @@ void main() {
       RenderParagraph title = _getTextRenderObject(tester, 'title');
       expect(title.text.style!.color, theme.textTheme.titleMedium!.color);
       RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
-      expect(subtitle.text.style!.color, theme.textTheme.bodyMedium!.color);
+      expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
       RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
       expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
 
@@ -3628,7 +3628,7 @@ void main() {
       title = _getTextRenderObject(tester, 'title');
       expect(title.text.style!.color, theme.textTheme.titleMedium!.color);
       subtitle = _getTextRenderObject(tester, 'subtitle');
-      expect(subtitle.text.style!.color, theme.textTheme.bodyMedium!.color);
+      expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
       trailing = _getTextRenderObject(tester, 'trailing');
       expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
     });

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -3628,7 +3628,7 @@ void main() {
       title = _getTextRenderObject(tester, 'title');
       expect(title.text.style!.color, theme.textTheme.titleMedium!.color);
       subtitle = _getTextRenderObject(tester, 'subtitle');
-      expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
+      expect(subtitle.text.style!.color, theme.textTheme.bodyMedium!.color);
       trailing = _getTextRenderObject(tester, 'trailing');
       expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
     });

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -393,14 +393,30 @@ void main() {
   });
 
   testWidgetsWithLeakTracking(
-    "ListTile respects ListTileTheme's titleTextStyle, subtitleTextStyle & leadingAndTrailingTextStyle",
+    "Material3 - ListTile respects ListTileTheme's titleTextStyle, subtitleTextStyle & leadingAndTrailingTextStyle",
     (WidgetTester tester) async {
+      const TextStyle titleTextStyle = TextStyle(
+        fontSize: 23.0,
+        color: Color(0xffff0000),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle subtitleTextStyle = TextStyle(
+        fontSize: 20.0,
+        color: Color(0xff00ff00),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle leadingAndTrailingTextStyle = TextStyle(
+        fontSize: 18.0,
+        color: Color(0xff0000ff),
+        fontStyle: FontStyle.italic,
+      );
+
     final ThemeData theme = ThemeData(
         useMaterial3: true,
         listTileTheme: const ListTileThemeData(
-        titleTextStyle: TextStyle(fontSize: 20.0),
-        subtitleTextStyle: TextStyle(fontSize: 17.5),
-        leadingAndTrailingTextStyle: TextStyle(fontSize: 15.0),
+        titleTextStyle: titleTextStyle,
+        subtitleTextStyle: subtitleTextStyle,
+        leadingAndTrailingTextStyle: leadingAndTrailingTextStyle,
       ),
     );
 
@@ -426,30 +442,50 @@ void main() {
 
     await tester.pumpWidget(buildFrame());
     final RenderParagraph leading = _getTextRenderObject(tester, 'leading');
-    expect(leading.text.style!.fontSize, 15.0);
+    expect(leading.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+    expect(leading.text.style!.color, leadingAndTrailingTextStyle.color);
+    expect(leading.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
     final RenderParagraph title = _getTextRenderObject(tester, 'title');
-    expect(title.text.style!.fontSize, 20.0);
+    expect(title.text.style!.fontSize, titleTextStyle.fontSize);
+    expect(title.text.style!.color, titleTextStyle.color);
+    expect(title.text.style!.fontStyle, titleTextStyle.fontStyle);
     final RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
-    expect(subtitle.text.style!.fontSize, 17.5);
+    expect(subtitle.text.style!.fontSize, subtitleTextStyle.fontSize);
+    expect(subtitle.text.style!.color, subtitleTextStyle.color);
+    expect(subtitle.text.style!.fontStyle, subtitleTextStyle.fontStyle);
     final RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
-    expect(trailing.text.style!.fontSize, 15.0);
+    expect(trailing.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+    expect(trailing.text.style!.color, leadingAndTrailingTextStyle.color);
+    expect(trailing.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
   });
 
   testWidgetsWithLeakTracking(
-    "ListTile's titleTextStyle, subtitleTextStyle & leadingAndTrailingTextStyle are overridden by ListTile properties",
+    "Material2 - ListTile respects ListTileTheme's titleTextStyle, subtitleTextStyle & leadingAndTrailingTextStyle",
     (WidgetTester tester) async {
+      const TextStyle titleTextStyle = TextStyle(
+        fontSize: 23.0,
+        color: Color(0xffff0000),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle subtitleTextStyle = TextStyle(
+        fontSize: 20.0,
+        color: Color(0xff00ff00),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle leadingAndTrailingTextStyle = TextStyle(
+        fontSize: 18.0,
+        color: Color(0xff0000ff),
+        fontStyle: FontStyle.italic,
+      );
+
     final ThemeData theme = ThemeData(
-      useMaterial3: true,
-      listTileTheme: const ListTileThemeData(
-        titleTextStyle: TextStyle(fontSize: 20.0),
-        subtitleTextStyle: TextStyle(fontSize: 17.5),
-        leadingAndTrailingTextStyle: TextStyle(fontSize: 15.0),
+        useMaterial3: false,
+        listTileTheme: const ListTileThemeData(
+        titleTextStyle: titleTextStyle,
+        subtitleTextStyle: subtitleTextStyle,
+        leadingAndTrailingTextStyle: leadingAndTrailingTextStyle,
       ),
     );
-
-    const TextStyle titleTextStyle = TextStyle(fontSize: 23.0);
-    const TextStyle subtitleTextStyle = TextStyle(fontSize: 20.0);
-    const TextStyle leadingAndTrailingTextStyle = TextStyle(fontSize: 18.0);
 
     Widget buildFrame() {
       return MaterialApp(
@@ -459,9 +495,6 @@ void main() {
             child: Builder(
               builder: (BuildContext context) {
                 return const ListTile(
-                  titleTextStyle: titleTextStyle,
-                  subtitleTextStyle: subtitleTextStyle,
-                  leadingAndTrailingTextStyle: leadingAndTrailingTextStyle,
                   leading: TestText('leading'),
                   title: TestText('title'),
                   subtitle: TestText('subtitle'),
@@ -476,13 +509,159 @@ void main() {
 
     await tester.pumpWidget(buildFrame());
     final RenderParagraph leading = _getTextRenderObject(tester, 'leading');
-    expect(leading.text.style!.fontSize, 18.0);
+    expect(leading.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+    expect(leading.text.style!.color, leadingAndTrailingTextStyle.color);
+    expect(leading.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
     final RenderParagraph title = _getTextRenderObject(tester, 'title');
-    expect(title.text.style!.fontSize, 23.0);
+    expect(title.text.style!.fontSize, titleTextStyle.fontSize);
+    expect(title.text.style!.color, titleTextStyle.color);
+    expect(title.text.style!.fontStyle, titleTextStyle.fontStyle);
     final RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
-    expect(subtitle.text.style!.fontSize, 20.0);
+    expect(subtitle.text.style!.fontSize, subtitleTextStyle.fontSize);
+    expect(subtitle.text.style!.color, subtitleTextStyle.color);
+    expect(subtitle.text.style!.fontStyle, subtitleTextStyle.fontStyle);
     final RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
-    expect(trailing.text.style!.fontSize, 18.0);
+    expect(trailing.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+    expect(trailing.text.style!.color, leadingAndTrailingTextStyle.color);
+    expect(trailing.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
+  });
+
+  testWidgetsWithLeakTracking(
+    "Material3 - ListTile's titleTextStyle, subtitleTextStyle & leadingAndTrailingTextStyle are overridden by ListTile properties",
+    (WidgetTester tester) async {
+      final ThemeData theme = ThemeData(
+        useMaterial3: true,
+        listTileTheme: const ListTileThemeData(
+          titleTextStyle: TextStyle(fontSize: 20.0),
+          subtitleTextStyle: TextStyle(fontSize: 17.5),
+          leadingAndTrailingTextStyle: TextStyle(fontSize: 15.0),
+        ),
+      );
+      const TextStyle titleTextStyle = TextStyle(
+        fontSize: 23.0,
+        color: Color(0xffff0000),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle subtitleTextStyle = TextStyle(
+        fontSize: 20.0,
+        color: Color(0xff00ff00),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle leadingAndTrailingTextStyle = TextStyle(
+        fontSize: 18.0,
+        color: Color(0xff0000ff),
+        fontStyle: FontStyle.italic,
+      );
+
+      Widget buildFrame() {
+        return MaterialApp(
+          theme: theme,
+          home: Material(
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return const ListTile(
+                    titleTextStyle: titleTextStyle,
+                    subtitleTextStyle: subtitleTextStyle,
+                    leadingAndTrailingTextStyle: leadingAndTrailingTextStyle,
+                    leading: TestText('leading'),
+                    title: TestText('title'),
+                    subtitle: TestText('subtitle'),
+                    trailing: TestText('trailing'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildFrame());
+      final RenderParagraph leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+      expect(leading.text.style!.color, leadingAndTrailingTextStyle.color);
+      expect(leading.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
+      final RenderParagraph title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.fontSize, titleTextStyle.fontSize);
+      expect(title.text.style!.color, titleTextStyle.color);
+      expect(title.text.style!.fontStyle, titleTextStyle.fontStyle);
+      final RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.fontSize, subtitleTextStyle.fontSize);
+      expect(subtitle.text.style!.color, subtitleTextStyle.color);
+      expect(subtitle.text.style!.fontStyle, subtitleTextStyle.fontStyle);
+      final RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+      expect(trailing.text.style!.color, leadingAndTrailingTextStyle.color);
+      expect(trailing.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
+  });
+
+  testWidgetsWithLeakTracking(
+    "Material2 - ListTile's titleTextStyle, subtitleTextStyle & leadingAndTrailingTextStyle are overridden by ListTile properties",
+    (WidgetTester tester) async {
+      final ThemeData theme = ThemeData(
+        useMaterial3: false,
+        listTileTheme: const ListTileThemeData(
+          titleTextStyle: TextStyle(fontSize: 20.0),
+          subtitleTextStyle: TextStyle(fontSize: 17.5),
+          leadingAndTrailingTextStyle: TextStyle(fontSize: 15.0),
+        ),
+      );
+      const TextStyle titleTextStyle = TextStyle(
+        fontSize: 23.0,
+        color: Color(0xffff0000),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle subtitleTextStyle = TextStyle(
+        fontSize: 20.0,
+        color: Color(0xff00ff00),
+        fontStyle: FontStyle.italic,
+      );
+      const TextStyle leadingAndTrailingTextStyle = TextStyle(
+        fontSize: 18.0,
+        color: Color(0xff0000ff),
+        fontStyle: FontStyle.italic,
+      );
+
+      Widget buildFrame() {
+        return MaterialApp(
+          theme: theme,
+          home: Material(
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return const ListTile(
+                    titleTextStyle: titleTextStyle,
+                    subtitleTextStyle: subtitleTextStyle,
+                    leadingAndTrailingTextStyle: leadingAndTrailingTextStyle,
+                    leading: TestText('leading'),
+                    title: TestText('title'),
+                    subtitle: TestText('subtitle'),
+                    trailing: TestText('trailing'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildFrame());
+      final RenderParagraph leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+      expect(leading.text.style!.color, leadingAndTrailingTextStyle.color);
+      expect(leading.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
+      final RenderParagraph title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.fontSize, titleTextStyle.fontSize);
+      expect(title.text.style!.color, titleTextStyle.color);
+      expect(title.text.style!.fontStyle, titleTextStyle.fontStyle);
+      final RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.fontSize, subtitleTextStyle.fontSize);
+      expect(subtitle.text.style!.color, subtitleTextStyle.color);
+      expect(subtitle.text.style!.fontStyle, subtitleTextStyle.fontStyle);
+      final RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.fontSize, leadingAndTrailingTextStyle.fontSize);
+      expect(trailing.text.style!.color, leadingAndTrailingTextStyle.color);
+      expect(trailing.text.style!.fontStyle, leadingAndTrailingTextStyle.fontStyle);
   });
 
   testWidgetsWithLeakTracking("ListTile respects ListTileTheme's tileColor & selectedTileColor", (WidgetTester tester) async {


### PR DESCRIPTION
The difference between header text style and subtitle text style and the reason why it doesn't work is the code difference below. If we make the subtitle text style the same as the title text style it will work

<details>
  <summary>Title Text Style</summary>
  
  ###  All Code
  
  ```dart
  TextStyle titleStyle = titleTextStyle
      ?? tileTheme.titleTextStyle
      ?? defaults.titleTextStyle!;
    final Color? titleColor = effectiveColor;
    titleStyle = titleStyle.copyWith(
      color: titleColor,
      fontSize: _isDenseLayout(theme, tileTheme) ? 13.0 : null,
    );
    final Widget titleText = AnimatedDefaultTextStyle(
      style: titleStyle,
      duration: kThemeChangeDuration,
      child: title ?? const SizedBox(),
    );
  ```
  
  ## Different Code Section
  
  ```dart
  final Color? titleColor = effectiveColor;
  ```
</details>

<details>
  <summary>Subtitle Text Style</summary>
  
  ## All Code
  
  ```dart
  subtitleStyle = subtitleTextStyle
        ?? tileTheme.subtitleTextStyle
        ?? defaults.subtitleTextStyle!;
      final Color? subtitleColor = effectiveColor
        ?? (theme.useMaterial3 ? null : theme.textTheme.bodySmall!.color);
      subtitleStyle = subtitleStyle.copyWith(
        color: subtitleColor,
        fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
      );
      subtitleText = AnimatedDefaultTextStyle(
        style: subtitleStyle,
        duration: kThemeChangeDuration,
        child: subtitle!,
      );
  ```
  
  ## Different Code Section
  
  ```dart
  final Color? subtitleColor = effectiveColor
        ?? (theme.useMaterial3 ? null : theme.textTheme.bodySmall!.color);
  ```

### Description for code 
- The value `theme.textTheme.bodySmall!.color` is given because the `effectiveColor` value is `null` and the `theme.useMaterial3` value is `false`
</details>

<details>
  <summary>Problem solved code</summary>
  
  ## All Code
  
  ```dart
  subtitleStyle = subtitleTextStyle
        ?? tileTheme.subtitleTextStyle
        ?? defaults.subtitleTextStyle!;
      final Color? subtitleColor = effectiveColor;
      subtitleStyle = subtitleStyle.copyWith(
        color: subtitleColor,
        fontSize: _isDenseLayout(theme, tileTheme) ? 12.0 : null,
      );
      subtitleText = AnimatedDefaultTextStyle(
        style: subtitleStyle,
        duration: kThemeChangeDuration,
        child: subtitle!,
      );
  ```
</details>

<details>
<summary>Screenshot of the result after making the necessary change</summary>
<img src="https://github.com/flutter/flutter/assets/70351342/b552fd4c-fdcd-4bf5-b4ba-d6b2cfe527cc" width=250>
</details>

#133412

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
