### PR TITLE
Add findChildIndexCallback examples

### DIFF
--- a/examples/api/lib/widgets/page_view/page_view.1.dart
+++ b/examples/api/lib/widgets/page_view/page_view.1.dart
@@ -13,12 +13,7 @@ class PageViewExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('PageView Sample')),
-        body: const PageViewExample(),
-      ),
-    );
+    return MaterialApp(home: const PageViewExample());
   }
 }
 
@@ -41,6 +36,7 @@ class _PageViewExampleState extends State<PageViewExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(title: const Text('PageView Sample')),
       body: SafeArea(
         child: PageView.custom(
           childrenDelegate: SliverChildBuilderDelegate(

--- a/examples/api/lib/widgets/page_view/page_view.1.dart
+++ b/examples/api/lib/widgets/page_view/page_view.1.dart
@@ -1,0 +1,100 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for a [PageView] using the `findChildIndexCallback` argument
+
+void main() => runApp(const PageViewExampleApp());
+
+class PageViewExampleApp extends StatelessWidget {
+  const PageViewExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('PageView Sample')),
+        body: const PageViewExample(),
+      ),
+    );
+  }
+}
+
+class PageViewExample extends StatefulWidget {
+  const PageViewExample({super.key});
+
+  @override
+  State<PageViewExample> createState() => _PageViewExampleState();
+}
+
+class _PageViewExampleState extends State<PageViewExample> {
+  List<String> items = <String>['1', '2', '3', '4', '5'];
+
+  void _reverse() {
+    setState(() {
+      items = items.reversed.toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: PageView.custom(
+          childrenDelegate: SliverChildBuilderDelegate(
+            (BuildContext context, int index) {
+              return KeepAlive(
+                data: items[index],
+                key: ValueKey<String>(items[index]),
+              );
+            },
+            childCount: items.length,
+            findChildIndexCallback: (Key key) {
+              final ValueKey<String> valueKey = key as ValueKey<String>;
+              final String data = valueKey.value;
+              final int index = items.indexOf(data);
+              if (index >= 0) {
+                return index;
+              }
+              return null;
+            },
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            TextButton(
+              onPressed: () => _reverse(),
+              child: const Text('Reverse items'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class KeepAlive extends StatefulWidget {
+  const KeepAlive({super.key, required this.data});
+
+  final String data;
+
+  @override
+  State<KeepAlive> createState() => _KeepAliveState();
+}
+
+class _KeepAliveState extends State<KeepAlive>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return Text(widget.data);
+  }
+}

--- a/examples/api/lib/widgets/page_view/page_view.1.dart
+++ b/examples/api/lib/widgets/page_view/page_view.1.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 
 /// Flutter code sample for a [PageView] using the `findChildIndexCallback` argument
-
 void main() => runApp(const PageViewExampleApp());
 
 class PageViewExampleApp extends StatelessWidget {
@@ -13,7 +12,7 @@ class PageViewExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(home: const PageViewExample());
+    return const MaterialApp(home: PageViewExample());
   }
 }
 
@@ -41,7 +40,7 @@ class _PageViewExampleState extends State<PageViewExample> {
         child: PageView.custom(
           childrenDelegate: SliverChildBuilderDelegate(
             (BuildContext context, int index) {
-              return KeepAlive(
+              return KeepAliveItem(
                 data: items[index],
                 key: ValueKey<String>(items[index]),
               );
@@ -74,16 +73,16 @@ class _PageViewExampleState extends State<PageViewExample> {
   }
 }
 
-class KeepAlive extends StatefulWidget {
-  const KeepAlive({super.key, required this.data});
+class KeepAliveItem extends StatefulWidget {
+  const KeepAliveItem({super.key, required this.data});
 
   final String data;
 
   @override
-  State<KeepAlive> createState() => _KeepAliveState();
+  State<KeepAliveItem> createState() => _KeepAliveItemState();
 }
 
-class _KeepAliveState extends State<KeepAlive>
+class _KeepAliveItemState extends State<KeepAliveItem>
     with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;

--- a/examples/api/lib/widgets/page_view/page_view.1.dart
+++ b/examples/api/lib/widgets/page_view/page_view.1.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for a [PageView] using the `findChildIndexCallback` argument
+/// Flutter code sample for a [PageView] using the `findChildIndexCallback` argument.
 void main() => runApp(const PageViewExampleApp());
 
 class PageViewExampleApp extends StatelessWidget {

--- a/examples/api/lib/widgets/scroll_view/list_view.1.dart
+++ b/examples/api/lib/widgets/scroll_view/list_view.1.dart
@@ -4,8 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for a [ListView.custom] using the `findChildIndexCallback` argument
-
+/// Flutter code sample for a [ListView.custom] using the `findChildIndexCallback` argument.
 void main() => runApp(const ListViewExampleApp());
 
 class ListViewExampleApp extends StatelessWidget {

--- a/examples/api/lib/widgets/scroll_view/list_view.1.dart
+++ b/examples/api/lib/widgets/scroll_view/list_view.1.dart
@@ -1,0 +1,98 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for a [ListView.custom] using the `findChildIndexCallback` argument
+
+void main() => runApp(const ListViewExampleApp());
+
+class ListViewExampleApp extends StatelessWidget {
+  const ListViewExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home: const ListViewExample());
+  }
+}
+
+class ListViewExample extends StatefulWidget {
+  const ListViewExample({super.key});
+
+  @override
+  State<ListViewExample> createState() => _ListViewExampleState();
+}
+
+class _ListViewExampleState extends State<ListViewExample> {
+  List<String> items = <String>['1', '2', '3', '4', '5'];
+
+  void _reverse() {
+    setState(() {
+      items = items.reversed.toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: ListView.custom(
+          childrenDelegate: SliverChildBuilderDelegate(
+            (BuildContext context, int index) {
+              return KeepAlive(
+                data: items[index],
+                key: ValueKey<String>(items[index]),
+              );
+            },
+            childCount: items.length,
+            findChildIndexCallback: (Key key) {
+              final ValueKey<String> valueKey = key as ValueKey<String>;
+              final String data = valueKey.value;
+              final int index = items.indexOf(data);
+              if (index >= 0) {
+                return index;
+              }
+              return null;
+            },
+          ),
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            TextButton(
+              onPressed: () => _reverse(),
+              child: const Text('Reverse items'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class KeepAlive extends StatefulWidget {
+  const KeepAlive({
+    required Key key,
+    required this.data,
+  }) : super(key: key);
+
+  final String data;
+
+  @override
+  State<KeepAlive> createState() => _KeepAliveState();
+}
+
+class _KeepAliveState extends State<KeepAlive>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return Text(widget.data);
+  }
+}

--- a/examples/api/lib/widgets/scroll_view/list_view.1.dart
+++ b/examples/api/lib/widgets/scroll_view/list_view.1.dart
@@ -13,7 +13,7 @@ class ListViewExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(home: const ListViewExample());
+    return const MaterialApp(home: ListViewExample());
   }
 }
 
@@ -40,7 +40,7 @@ class _ListViewExampleState extends State<ListViewExample> {
         child: ListView.custom(
           childrenDelegate: SliverChildBuilderDelegate(
             (BuildContext context, int index) {
-              return KeepAlive(
+              return KeepAliveItem(
                 data: items[index],
                 key: ValueKey<String>(items[index]),
               );
@@ -73,8 +73,8 @@ class _ListViewExampleState extends State<ListViewExample> {
   }
 }
 
-class KeepAlive extends StatefulWidget {
-  const KeepAlive({
+class KeepAliveItem extends StatefulWidget {
+  const KeepAliveItem({
     required Key key,
     required this.data,
   }) : super(key: key);
@@ -82,10 +82,10 @@ class KeepAlive extends StatefulWidget {
   final String data;
 
   @override
-  State<KeepAlive> createState() => _KeepAliveState();
+  State<KeepAliveItem> createState() => _KeepAliveItemState();
 }
 
-class _KeepAliveState extends State<KeepAlive>
+class _KeepAliveItemState extends State<KeepAliveItem>
     with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;

--- a/examples/api/test/widgets/page_view/page_view.1_test.dart
+++ b/examples/api/test/widgets/page_view/page_view.1_test.dart
@@ -24,8 +24,6 @@ void main() {
     expect(lastItemFinder, findsNothing);
     await tester.tap(reverseFinder);
     await tester.pump();
-    expect(pageView, findsOneWidget);
-    expect(reverseFinder, findsOneWidget);
     expect(firstItemFinder, findsNothing);
     expect(lastItemFinder, findsOneWidget);
   });

--- a/examples/api/test/widgets/page_view/page_view.1_test.dart
+++ b/examples/api/test/widgets/page_view/page_view.1_test.dart
@@ -14,8 +14,8 @@ void main() {
       await tester.pumpWidget(const example.PageViewExampleApp());
       final Finder pageView = find.byType(PageView);
       final Finder reverseFinder = find.text('Reverse items');
-      final Finder firstItemFinder = find.byKey(ValueKey<String>('1'));
-      final Finder lastItemFinder = find.byKey(ValueKey<String>('5'));
+      final Finder firstItemFinder = find.byKey(const ValueKey<String>('1'));
+      final Finder lastItemFinder = find.byKey(const ValueKey<String>('5'));
       expect(pageView, findsOneWidget);
       expect(reverseFinder, findsOneWidget);
       expect(firstItemFinder, findsOneWidget);

--- a/examples/api/test/widgets/page_view/page_view.1_test.dart
+++ b/examples/api/test/widgets/page_view/page_view.1_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/page_view/page_view.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('tapping Reverse button should reverse PageView',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.PageViewExampleApp(),
+    );
+
+    final Finder pageView = find.byType(PageView);
+    final Finder reverseFinder = find.text('Reverse items');
+    final Finder firstItemFinder = find.byKey(ValueKey<String>('1'));
+    final Finder lastItemFinder = find.byKey(ValueKey<String>('5'));
+    expect(pageView, findsOneWidget);
+    expect(reverseFinder, findsOneWidget);
+    expect(firstItemFinder, findsOneWidget);
+    expect(lastItemFinder, findsNothing);
+    await tester.tap(reverseFinder);
+    await tester.pump();
+    expect(pageView, findsOneWidget);
+    expect(reverseFinder, findsOneWidget);
+    expect(firstItemFinder, findsNothing);
+    expect(lastItemFinder, findsOneWidget);
+  });
+}

--- a/examples/api/test/widgets/page_view/page_view.1_test.dart
+++ b/examples/api/test/widgets/page_view/page_view.1_test.dart
@@ -8,23 +8,22 @@ import 'package:flutter_api_samples/widgets/page_view/page_view.1.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('tapping Reverse button should reverse PageView',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const example.PageViewExampleApp(),
-    );
-
-    final Finder pageView = find.byType(PageView);
-    final Finder reverseFinder = find.text('Reverse items');
-    final Finder firstItemFinder = find.byKey(ValueKey<String>('1'));
-    final Finder lastItemFinder = find.byKey(ValueKey<String>('5'));
-    expect(pageView, findsOneWidget);
-    expect(reverseFinder, findsOneWidget);
-    expect(firstItemFinder, findsOneWidget);
-    expect(lastItemFinder, findsNothing);
-    await tester.tap(reverseFinder);
-    await tester.pump();
-    expect(firstItemFinder, findsNothing);
-    expect(lastItemFinder, findsOneWidget);
-  });
+  testWidgets(
+    'tapping Reverse button should reverse PageView',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.PageViewExampleApp());
+      final Finder pageView = find.byType(PageView);
+      final Finder reverseFinder = find.text('Reverse items');
+      final Finder firstItemFinder = find.byKey(ValueKey<String>('1'));
+      final Finder lastItemFinder = find.byKey(ValueKey<String>('5'));
+      expect(pageView, findsOneWidget);
+      expect(reverseFinder, findsOneWidget);
+      expect(firstItemFinder, findsOneWidget);
+      expect(lastItemFinder, findsNothing);
+      await tester.tap(reverseFinder);
+      await tester.pump();
+      expect(firstItemFinder, findsNothing);
+      expect(lastItemFinder, findsOneWidget);
+    },
+  );
 }

--- a/examples/api/test/widgets/scroll_view/list_view.1_test.dart
+++ b/examples/api/test/widgets/scroll_view/list_view.1_test.dart
@@ -16,12 +16,12 @@ void main() {
       final Finder reverseFinder = find.text('Reverse items');
       expect(listView, findsOneWidget);
       expect(reverseFinder, findsOneWidget);
-      final Finder keepAliveFinder = find.byType(KeepAlive);
-      KeepAlive firstWidget = tester.firstWidget(keepAliveFinder);
+      final Finder keepAliveItemFinder = find.byType(KeepAliveItem);
+      KeepAliveItem firstWidget = tester.firstWidget(keepAliveItemFinder);
       expect(firstWidget.data, '1');
       await tester.tap(reverseFinder);
       await tester.pump();
-      firstWidget = tester.firstWidget(keepAliveFinder);
+      firstWidget = tester.firstWidget(keepAliveItemFinder);
       expect(firstWidget.data, '5');
     },
   );

--- a/examples/api/test/widgets/scroll_view/list_view.1_test.dart
+++ b/examples/api/test/widgets/scroll_view/list_view.1_test.dart
@@ -16,8 +16,8 @@ void main() {
       final Finder reverseFinder = find.text('Reverse items');
       expect(listView, findsOneWidget);
       expect(reverseFinder, findsOneWidget);
-      final Finder keepAliveItemFinder = find.byType(KeepAliveItem);
-      KeepAliveItem firstWidget = tester.firstWidget(keepAliveItemFinder);
+      final Finder keepAliveItemFinder = find.byType(example.KeepAliveItem);
+      example.KeepAliveItem firstWidget = tester.firstWidget(keepAliveItemFinder);
       expect(firstWidget.data, '1');
       await tester.tap(reverseFinder);
       await tester.pump();

--- a/examples/api/test/widgets/scroll_view/list_view.1_test.dart
+++ b/examples/api/test/widgets/scroll_view/list_view.1_test.dart
@@ -1,0 +1,31 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/scroll_view/list_view.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'tapping Reverse button should reverse ListView',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.ListViewExampleApp(),
+      );
+
+      final Finder listView = find.byType(ListView);
+      final Finder reverseFinder = find.text('Reverse items');
+      expect(listView, findsOneWidget);
+      expect(reverseFinder, findsOneWidget);
+      final Finder keepAliveFinder = find.byType(KeepAlive);
+      KeepAlive firstWidget = tester.firstWidget(keepAliveFinder);
+      expect(firstWidget.data, '1');
+      await tester.tap(reverseFinder);
+      await tester.pump();
+      firstWidget = tester.firstWidget(keepAliveFinder);
+      expect(firstWidget.data, '5');
+    },
+  );
+}

--- a/examples/api/test/widgets/scroll_view/list_view.1_test.dart
+++ b/examples/api/test/widgets/scroll_view/list_view.1_test.dart
@@ -11,10 +11,7 @@ void main() {
   testWidgets(
     'tapping Reverse button should reverse ListView',
     (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const example.ListViewExampleApp(),
-      );
-
+      await tester.pumpWidget(const example.ListViewExampleApp());
       final Finder listView = find.byType(ListView);
       final Finder reverseFinder = find.text('Reverse items');
       expect(listView, findsOneWidget);

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -750,7 +750,9 @@ class PageView extends StatefulWidget {
   ///               final ValueKey<String> valueKey = key as ValueKey<String>;
   ///               final String data = valueKey.value;
   ///               final int index = items.indexOf(data);
-  ///               if (index >= 0) return index;
+  ///               if (index >= 0) {
+  ///                 return index;
+  ///               }
   ///               return null;
   ///             }
   ///           ),

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -711,88 +711,11 @@ class PageView extends StatefulWidget {
   /// Creates a scrollable list that works page by page with a custom child
   /// model.
   ///
-  /// {@tool snippet}
-  ///
-  /// This [PageView] uses a custom [SliverChildBuilderDelegate] to support child
+  /// {@tool dartpad}
+  /// This example shows a [PageView] that uses a custom [SliverChildBuilderDelegate] to support child
   /// reordering.
   ///
-  /// ```dart
-  /// class MyPageView extends StatefulWidget {
-  ///   const MyPageView({super.key});
-  ///
-  ///   @override
-  ///   State<MyPageView> createState() => _MyPageViewState();
-  /// }
-  ///
-  /// class _MyPageViewState extends State<MyPageView> {
-  ///   List<String> items = <String>['1', '2', '3', '4', '5'];
-  ///
-  ///   void _reverse() {
-  ///     setState(() {
-  ///       items = items.reversed.toList();
-  ///     });
-  ///   }
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     return Scaffold(
-  ///       body: SafeArea(
-  ///         child: PageView.custom(
-  ///           childrenDelegate: SliverChildBuilderDelegate(
-  ///             (BuildContext context, int index) {
-  ///               return KeepAlive(
-  ///                 data: items[index],
-  ///                 key: ValueKey<String>(items[index]),
-  ///               );
-  ///             },
-  ///             childCount: items.length,
-  ///             findChildIndexCallback: (Key key) {
-  ///               final ValueKey<String> valueKey = key as ValueKey<String>;
-  ///               final String data = valueKey.value;
-  ///               final int index = items.indexOf(data);
-  ///               if (index >= 0) {
-  ///                 return index;
-  ///               }
-  ///               return null;
-  ///             }
-  ///           ),
-  ///         ),
-  ///       ),
-  ///       bottomNavigationBar: BottomAppBar(
-  ///         child: Row(
-  ///           mainAxisAlignment: MainAxisAlignment.center,
-  ///           children: <Widget>[
-  ///             TextButton(
-  ///               onPressed: () => _reverse(),
-  ///               child: const Text('Reverse items'),
-  ///             ),
-  ///           ],
-  ///         ),
-  ///       ),
-  ///     );
-  ///   }
-  /// }
-  ///
-  /// class KeepAlive extends StatefulWidget {
-  ///   const KeepAlive({super.key, required this.data});
-  ///
-  ///   final String data;
-  ///
-  ///   @override
-  ///   State<KeepAlive> createState() => _KeepAliveState();
-  /// }
-  ///
-  /// class _KeepAliveState extends State<KeepAlive> with AutomaticKeepAliveClientMixin{
-  ///   @override
-  ///   bool get wantKeepAlive => true;
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     super.build(context);
-  ///     return Text(widget.data);
-  ///   }
-  /// }
-  /// ```
+  /// ** See code in examples/api/lib/widgets/page_view/page_view.1.dart **
   /// {@end-tool}
   ///
   /// {@macro flutter.widgets.PageView.allowImplicitScrolling}

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -749,7 +749,9 @@ class PageView extends StatefulWidget {
   ///             findChildIndexCallback: (Key key) {
   ///               final ValueKey<String> valueKey = key as ValueKey<String>;
   ///               final String data = valueKey.value;
-  ///               return items.indexOf(data);
+  ///               final int index = items.indexOf(data);
+  ///               if (index >= 0) return index;
+  ///               return null;
   ///             }
   ///           ),
   ///         ),

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1480,7 +1480,9 @@ class ListView extends BoxScrollView {
   ///               final ValueKey<String> valueKey = key as ValueKey<String>;
   ///               final String data = valueKey.value;
   ///               final int index = items.indexOf(data);
-  ///               if (index >= 0) return index;
+  ///               if (index >= 0) { 
+  ///                 return index;
+  ///               }
   ///               return null;
   ///             }
   ///           ),

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1479,7 +1479,9 @@ class ListView extends BoxScrollView {
   ///             findChildIndexCallback: (Key key) {
   ///               final ValueKey<String> valueKey = key as ValueKey<String>;
   ///               final String data = valueKey.value;
-  ///               return items.indexOf(data);
+  ///               final int index = items.indexOf(data);
+  ///               if (index >= 0) return index;
+  ///               return null;
   ///             }
   ///           ),
   ///         ),

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1441,91 +1441,11 @@ class ListView extends BoxScrollView {
   /// For example, a custom child model can control the algorithm used to
   /// estimate the size of children that are not actually visible.
   ///
-  /// {@tool snippet}
-  ///
-  /// This [ListView] uses a custom [SliverChildBuilderDelegate] to support child
+  /// {@tool dartpad}
+  /// This example shows a [ListView] that uses a custom [SliverChildBuilderDelegate] to support child
   /// reordering.
   ///
-  /// ```dart
-  /// class MyListView extends StatefulWidget {
-  ///   const MyListView({super.key});
-  ///
-  ///   @override
-  ///   State<MyListView> createState() => _MyListViewState();
-  /// }
-  ///
-  /// class _MyListViewState extends State<MyListView> {
-  ///   List<String> items = <String>['1', '2', '3', '4', '5'];
-  ///
-  ///   void _reverse() {
-  ///     setState(() {
-  ///       items = items.reversed.toList();
-  ///     });
-  ///   }
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     return Scaffold(
-  ///       body: SafeArea(
-  ///         child: ListView.custom(
-  ///           childrenDelegate: SliverChildBuilderDelegate(
-  ///             (BuildContext context, int index) {
-  ///               return KeepAlive(
-  ///                 data: items[index],
-  ///                 key: ValueKey<String>(items[index]),
-  ///               );
-  ///             },
-  ///             childCount: items.length,
-  ///             findChildIndexCallback: (Key key) {
-  ///               final ValueKey<String> valueKey = key as ValueKey<String>;
-  ///               final String data = valueKey.value;
-  ///               final int index = items.indexOf(data);
-  ///               if (index >= 0) {
-  ///                 return index;
-  ///               }
-  ///               return null;
-  ///             }
-  ///           ),
-  ///         ),
-  ///       ),
-  ///       bottomNavigationBar: BottomAppBar(
-  ///         child: Row(
-  ///           mainAxisAlignment: MainAxisAlignment.center,
-  ///           children: <Widget>[
-  ///             TextButton(
-  ///               onPressed: () => _reverse(),
-  ///               child: const Text('Reverse items'),
-  ///             ),
-  ///           ],
-  ///         ),
-  ///       ),
-  ///     );
-  ///   }
-  /// }
-  ///
-  /// class KeepAlive extends StatefulWidget {
-  ///   const KeepAlive({
-  ///     required Key key,
-  ///     required this.data,
-  ///   }) : super(key: key);
-  ///
-  ///   final String data;
-  ///
-  ///   @override
-  ///   State<KeepAlive> createState() => _KeepAliveState();
-  /// }
-  ///
-  /// class _KeepAliveState extends State<KeepAlive> with AutomaticKeepAliveClientMixin{
-  ///   @override
-  ///   bool get wantKeepAlive => true;
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     super.build(context);
-  ///     return Text(widget.data);
-  ///   }
-  /// }
-  /// ```
+  /// ** See code in examples/api/lib/widgets/scroll_view/list_view.1.dart **
   /// {@end-tool}
   const ListView.custom({
     super.key,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1480,7 +1480,7 @@ class ListView extends BoxScrollView {
   ///               final ValueKey<String> valueKey = key as ValueKey<String>;
   ///               final String data = valueKey.value;
   ///               final int index = items.indexOf(data);
-  ///               if (index >= 0) { 
+  ///               if (index >= 0) {
   ///                 return index;
   ///               }
   ///               return null;


### PR DESCRIPTION
The documentation for using `findChildIndexCallback` recommends using `indexOf`, but that causes [this line](https://github.com/flutter/flutter/blob/05259ca938c9ea27aa551048b690d5a06371a6c0/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart#L259) to throw in debug mode, and when using `SliverList`, it breaks the render.

This PR changes the usage to check if the index is not negative before using it, and changes to return `null` instead if the child wasn't able to be found.

There's the related issue #107123, but this doesn't actually fix it.

-----

This PR has been updated to add the snippets that were used in the `findChildIndexCallback` comment as examples with proper tests, as well as updating the comment to reference the new examples.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
