### PR TITLE
Revert "ShortcutManager should dispatch creation in constructor."

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -747,11 +747,7 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   ShortcutManager({
     Map<ShortcutActivator, Intent> shortcuts = const <ShortcutActivator, Intent>{},
     this.modal = false,
-  })  : _shortcuts = shortcuts {
-    if (kFlutterMemoryAllocationsEnabled) {
-      maybeDispatchObjectCreation();
-    }
-  }
+  })  : _shortcuts = shortcuts;
 
   /// True if the [ShortcutManager] should not pass on keys that it doesn't
   /// handle to any key-handling widgets that are ancestors to this one.
@@ -1444,7 +1440,6 @@ class _ShortcutRegistrarState extends State<ShortcutRegistrar> {
   void dispose() {
     registry.removeListener(_shortcutsChanged);
     registry.dispose();
-    manager.dispose();
     super.dispose();
   }
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -666,19 +666,6 @@ void main() {
       expect(pressedKeys, isEmpty);
     });
 
-    test('$ShortcutManager dispatches object creation in constructor', () {
-      int eventCount = 0;
-      void listener(ObjectEvent event) => eventCount++;
-      MemoryAllocations.instance.addListener(listener);
-
-      final ShortcutManager registry = ShortcutManager();
-
-      expect(eventCount, 1);
-
-      registry.dispose();
-      MemoryAllocations.instance.removeListener(listener);
-    });
-
     testWidgets("Shortcuts passes to the next Shortcuts widget if it doesn't map the key", (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
@@ -1866,17 +1853,20 @@ void main() {
       token.dispose();
     });
 
-    test('dispatches object creation in constructor', () {
+    testWidgets('dispatches object creation in constructor', (WidgetTester tester) async {
+      final MemoryAllocations ma = MemoryAllocations.instance;
+      assert(!ma.hasListeners);
       int eventCount = 0;
       void listener(ObjectEvent event) => eventCount++;
-      MemoryAllocations.instance.addListener(listener);
+      ma.addListener(listener);
 
       final ShortcutRegistry registry = ShortcutRegistry();
 
       expect(eventCount, 1);
 
       registry.dispose();
-      MemoryAllocations.instance.removeListener(listener);
+      ma.removeListener(listener);
+      assert(!ma.hasListeners);
     });
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#133356

Tree is failing on Mac and Linux customer_testing on this PR.
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20customer_testing/14646/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20customer_testing/14974/overview