### PR TITLE
Revert "FocusNode and FocusManager should dispatch creation in constructor."

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -471,7 +471,6 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   void dispose() {
     _historyEntry?.remove();
     _controller.dispose();
-    _focusScopeNode.dispose();
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -437,10 +437,6 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
         _descendantsAreTraversable = descendantsAreTraversable {
     // Set it via the setter so that it does nothing on release builds.
     this.debugLabel = debugLabel;
-
-    if (kFlutterMemoryAllocationsEnabled) {
-      maybeDispatchObjectCreation();
-    }
   }
 
   /// If true, tells the focus traversal policy to skip over this node for
@@ -1467,9 +1463,6 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   /// handlers, callers must call [registerGlobalHandlers]. See the
   /// documentation in that method for caveats to watch out for.
   FocusManager() {
-    if (kFlutterMemoryAllocationsEnabled) {
-      maybeDispatchObjectCreation();
-    }
     rootScope._manager = this;
   }
 

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1609,41 +1609,6 @@ void main() {
     tester.binding.focusManager.removeListener(handleFocusChange);
   });
 
-  test('$FocusManager dispatches object creation in constructor', () {
-    final List<ObjectEvent> events = <ObjectEvent>[];
-    void listener(ObjectEvent event) {
-      if (event.object.runtimeType == FocusManager) {
-        events.add(event);
-      }
-    }
-    MemoryAllocations.instance.addListener(listener);
-
-    final FocusManager focusManager = FocusManager();
-
-    expect(events, hasLength(1));
-
-    focusManager.dispose();
-
-    MemoryAllocations.instance.removeListener(listener);
-  });
-
-  test('$FocusNode dispatches object creation in constructor', () {
-    final List<ObjectEvent> events = <ObjectEvent>[];
-    void listener(ObjectEvent event) {
-      if (event.object.runtimeType == FocusNode) {
-        events.add(event);
-      }
-    }
-    MemoryAllocations.instance.addListener(listener);
-
-    final FocusNode focusManager = FocusNode();
-
-    expect(events, hasLength(1));
-
-    focusManager.dispose();
-    MemoryAllocations.instance.removeListener(listener);
-  });
-
   testWidgets('FocusManager notifies listeners when a widget loses focus because it was removed.', (WidgetTester tester) async {
     final FocusNode nodeA = FocusNode(debugLabel: 'a');
     final FocusNode nodeB = FocusNode(debugLabel: 'b');


### PR DESCRIPTION
Reverts flutter/flutter#133352

Tree is failing on Mac and Linux customer_testing on this PR.
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20customer_testing/14646/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20customer_testing/14974/overview