### PR TITLE
Revert "PlatformRouteInformationProvider  should dispatch creation in constructor."

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1465,11 +1465,7 @@ class PlatformRouteInformationProvider extends RouteInformationProvider with Wid
   /// provider.
   PlatformRouteInformationProvider({
     required RouteInformation initialRouteInformation,
-  }) : _value = initialRouteInformation {
-    if (kFlutterMemoryAllocationsEnabled) {
-      maybeDispatchObjectCreation();
-    }
-  }
+  }) : _value = initialRouteInformation;
 
   static bool _equals(Uri a, Uri b) {
     return a.path == b.path

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1161,7 +1161,6 @@ void main() {
       routerDelegate: delegate,
     ));
     expect(tester.takeException(), isAssertionError);
-    provider.dispose();
   });
 
   testWidgetsWithLeakTracking('MaterialApp.router throw if route configuration is provided along with other delegate', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -1582,21 +1582,6 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
       expect(info2.location, '/abc?def=ghi&def=jkl#mno');
     });
   });
-
-  test('$PlatformRouteInformationProvider dispatches object creation in constructor', () {
-    int eventCount = 0;
-    void listener(ObjectEvent event) => eventCount++;
-    MemoryAllocations.instance.addListener(listener);
-
-    final PlatformRouteInformationProvider registry = PlatformRouteInformationProvider(
-      initialRouteInformation: RouteInformation(uri: Uri.parse('http://google.com')),
-    );
-
-    expect(eventCount, 1);
-
-    registry.dispose();
-    MemoryAllocations.instance.removeListener(listener);
-  });
 }
 
 Widget buildBoilerPlate(Widget child) {


### PR DESCRIPTION
Reverts flutter/flutter#133353

Tree is failing on Mac and Linux customer_testing on this PR.
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20customer_testing/14646/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20customer_testing/14974/overview

