### PR TITLE
Use flutter pub get instead of dart pub get in create_api_docs.dart

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,5 @@
     "githubPullRequests.ignoredPullRequestBranches": [
         "master"
     ],
-    "files.trimTrailingWhitespace": true,
-    "cSpell.words": [
-        "apidocs"
-    ]
+    "files.trimTrailingWhitespace": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
     "githubPullRequests.ignoredPullRequestBranches": [
         "master"
     ],
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "cSpell.words": [
+        "apidocs"
+    ]
 }

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -77,7 +77,7 @@ Future<void> main(List<String> arguments) async {
   configurator.generateConfiguration();
 
   final PlatformDocGenerator platformGenerator = PlatformDocGenerator(outputDir: publishRoot, filesystem: filesystem);
-  platformGenerator.generatePlatformDocs();
+  await platformGenerator.generatePlatformDocs();
 
   final DartdocGenerator dartdocGenerator = DartdocGenerator(
     publishRoot: publishRoot,
@@ -779,16 +779,16 @@ class PlatformDocGenerator {
 
   /// This downloads an archive of platform docs for the engine from the artifact
   /// store and extracts them to the location used for Dartdoc.
-  void generatePlatformDocs() {
+  Future<void> generatePlatformDocs() async {
     final String realm = engineRealm.isNotEmpty ? '$engineRealm/' : '';
 
     final String javadocUrl =
         'https://storage.googleapis.com/${realm}flutter_infra_release/flutter/$engineRevision/android-javadoc.zip';
-    _extractDocs(javadocUrl, 'javadoc', 'io/flutter/view/FlutterView.html', outputDir);
+    await _extractDocs(javadocUrl, 'javadoc', 'io/flutter/view/FlutterView.html', outputDir);
 
     final String objcdocUrl =
         'https://storage.googleapis.com/${realm}flutter_infra_release/flutter/$engineRevision/ios-objcdoc.zip';
-    _extractDocs(objcdocUrl, 'objcdoc', 'Classes/FlutterViewController.html', outputDir);
+    await _extractDocs(objcdocUrl, 'objcdoc', 'Classes/FlutterViewController.html', outputDir);
   }
 
   /// Fetches the zip archive at the specified url.
@@ -968,21 +968,13 @@ List<Directory> findPackages(FileSystem filesystem) {
 }
 
 /// An exception class used to indicate problems when collecting information.
-class DartdocException implements Exception {
-  DartdocException(this.message, {this.file, this.line});
+class FlutterInformationException implements Exception {
+  FlutterInformationException(this.message);
   final String message;
-  final String? file;
-  final int? line;
 
   @override
   String toString() {
-    if (file != null || line != null) {
-      final String fileStr = file == null ? '' : '$file:';
-      final String lineStr = line == null ? '' : '$line:';
-      return '$runtimeType: $fileStr$lineStr: $message';
-    } else {
-      return '$runtimeType: $message';
-    }
+    return '$runtimeType: $message';
   }
 }
 
@@ -1081,11 +1073,12 @@ class FlutterInformation {
       try {
         result = processManager.runSync(<String>[flutterCommand, '--version', '--machine'], stdoutEncoding: utf8);
       } on ProcessException catch (e) {
-        throw DartdocException(
+        throw FlutterInformationException(
             'Unable to determine Flutter information. Either set FLUTTER_ROOT, or place flutter command in your path.\n$e');
       }
       if (result.exitCode != 0) {
-        throw DartdocException('Unable to determine Flutter information, because of abnormal exit to flutter command.');
+        throw FlutterInformationException(
+            'Unable to determine Flutter information, because of abnormal exit to flutter command.');
       }
       flutterVersionJson = (result.stdout as String)
           .replaceAll('Waiting for another flutter command to release the startup lock...', '');
@@ -1095,7 +1088,7 @@ class FlutterInformation {
     if (flutterVersion['flutterRoot'] == null ||
         flutterVersion['frameworkVersion'] == null ||
         flutterVersion['dartSdkVersion'] == null) {
-      throw DartdocException(
+      throw FlutterInformationException(
           'Flutter command output has unexpected format, unable to determine flutter root location.');
     }
 
@@ -1111,7 +1104,7 @@ class FlutterInformation {
     final RegExpMatch? dartVersionRegex = RegExp(r'(?<base>[\d.]+)(?:\s+\(build (?<detail>[-.\w]+)\))?')
         .firstMatch(flutterVersion['dartSdkVersion'] as String);
     if (dartVersionRegex == null) {
-      throw DartdocException(
+      throw FlutterInformationException(
           'Flutter command output has unexpected format, unable to parse dart SDK version ${flutterVersion['dartSdkVersion']}.');
     }
     info['dartSdkVersion'] =

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -1097,9 +1097,8 @@ class FlutterInformation {
     info['flutterRoot'] = flutterRoot;
     info['frameworkVersion'] = Version.parse(flutterVersion['frameworkVersion'] as String);
     info['engineRevision'] = flutterVersion['engineRevision'] as String;
-    info['engineRealm'] = filesystem.file(
-      path.join(flutterRoot.path, 'bin', 'internal', 'engine.realm',
-    )).readAsStringSync().trim();
+    final File engineRealm = flutterRoot.childDirectory('bin').childDirectory('internal').childFile('engine.realm');
+    info['engineRealm'] = engineRealm.existsSync() ? engineRealm.readAsStringSync().trim() : '';
 
     final RegExpMatch? dartVersionRegex = RegExp(r'(?<base>[\d.]+)(?:\s+\(build (?<detail>[-.\w]+)\))?')
         .firstMatch(flutterVersion['dartSdkVersion'] as String);

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -465,7 +465,7 @@ class DartdocGenerator {
 
     // Verify which version of snippets and dartdoc we're using.
     final ProcessResult snippetsResult = Process.runSync(
-      FlutterInformation.instance.getDartBinaryPath().path,
+      FlutterInformation.instance.getFlutterBinaryPath().path,
       <String>[
         'pub',
         'global',
@@ -935,7 +935,7 @@ Future<Process> runPubProcess({
   @visibleForTesting FileSystem filesystem = const LocalFileSystem(),
 }) {
   return processManager.start(
-    <Object>[FlutterInformation.instance.getDartBinaryPath().path, 'pub', ...arguments],
+    <Object>[FlutterInformation.instance.getFlutterBinaryPath().path, 'pub', ...arguments],
     workingDirectory: (workingDirectory ?? filesystem.currentDirectory).path,
     environment: environment,
   );
@@ -1015,6 +1015,13 @@ class FlutterInformation {
   /// This is probably a shell script.
   File getDartBinaryPath() {
     return getFlutterRoot().childDirectory('bin').childFile('dart');
+  }
+
+  /// The path to the Dart binary in the Flutter repo.
+  ///
+  /// This is probably a shell script.
+  File getFlutterBinaryPath() {
+    return getFlutterRoot().childDirectory('bin').childFile('flutter');
   }
 
   /// The path to the Flutter repo root directory.

--- a/dev/tools/examples_smoke_test.dart
+++ b/dev/tools/examples_smoke_test.dart
@@ -17,21 +17,21 @@ import 'package:path/path.dart' as path;
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
-FileSystem filesystem = const LocalFileSystem();
-ProcessManager processManager = const LocalProcessManager();
-Platform platform = const LocalPlatform();
+const FileSystem _kFilesystem = LocalFileSystem();
+const ProcessManager _kProcessManager = LocalProcessManager();
+const Platform _kPlatform = LocalPlatform();
 
 FutureOr<dynamic> main() async {
-  if (!platform.isLinux && !platform.isWindows && !platform.isMacOS) {
+  if (!_kPlatform.isLinux && !_kPlatform.isWindows && !_kPlatform.isMacOS) {
     stderr.writeln('Example smoke tests are only designed to run on desktop platforms');
     exitCode = 4;
     return;
   }
-  final Directory flutterDir = filesystem.directory(
+  final Directory flutterDir = _kFilesystem.directory(
     path.absolute(
       path.dirname(
         path.dirname(
-          path.dirname(platform.script.toFilePath()),
+          path.dirname(_kPlatform.script.toFilePath()),
         ),
       ),
     ),
@@ -63,16 +63,16 @@ Future<void> runSmokeTests({
   required Directory apiDir,
 }) async {
   final File flutterExe =
-      flutterDir.childDirectory('bin').childFile(platform.isWindows ? 'flutter.bat' : 'flutter');
+      flutterDir.childDirectory('bin').childFile(_kPlatform.isWindows ? 'flutter.bat' : 'flutter');
   final List<String> cmd = <String>[
     // If we're in a container with no X display, then use the virtual framebuffer.
-    if (platform.isLinux &&
-        (platform.environment['DISPLAY'] == null ||
-         platform.environment['DISPLAY']!.isEmpty)) '/usr/bin/xvfb-run',
+    if (_kPlatform.isLinux &&
+        (_kPlatform.environment['DISPLAY'] == null ||
+         _kPlatform.environment['DISPLAY']!.isEmpty)) '/usr/bin/xvfb-run',
     flutterExe.absolute.path,
     'test',
     '--reporter=expanded',
-    '--device-id=${platform.operatingSystem}',
+    '--device-id=${_kPlatform.operatingSystem}',
     integrationTest.absolute.path,
   ];
   await runCommand(cmd, workingDirectory: apiDir);
@@ -112,7 +112,7 @@ Future<File> generateTest(Directory apiDir) async {
     .trim()
     .split('\n');
   final Iterable<File> examples = gitFiles.map<File>((String examplePath) {
-    return filesystem.file(path.join(examplesLibDir.absolute.path, examplePath));
+    return _kFilesystem.file(path.join(examplesLibDir.absolute.path, examplePath));
   });
 
   // Collect the examples, and import them all as separate symbols.
@@ -202,7 +202,7 @@ Future<String> runCommand(
   }
 
   try {
-    process = await processManager.start(
+    process = await _kProcessManager.start(
       cmd,
       workingDirectory: workingDirectory.absolute.path,
       environment: environment,

--- a/dev/tools/test/create_api_docs_test.dart
+++ b/dev/tools/test/create_api_docs_test.dart
@@ -4,116 +4,14 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
-import 'package:path/path.dart' as path;
 import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../../../packages/flutter_tools/test/src/fake_process_manager.dart';
 import '../create_api_docs.dart' as apidocs;
-import '../examples_smoke_test.dart';
 
 void main() {
-  test('getBranchName does not call git if env LUCI_BRANCH provided', () {
-    final Platform platform = FakePlatform(
-      environment: <String, String>{
-        'LUCI_BRANCH': branchName,
-      },
-    );
-
-    final ProcessManager processManager = FakeProcessManager.list(
-      <FakeCommand>[
-        const FakeCommand(
-          command: <String>['flutter', '--version', '--machine'],
-          stdout: testVersionInfo,
-        ),
-      ],
-    );
-
-    expect(
-      apidocs.FlutterInformation(platform: platform, processManager: processManager).getBranchName(),
-      branchName,
-    );
-    expect(processManager, hasNoRemainingExpectations);
-  });
-
-  test('getBranchName calls git if env LUCI_BRANCH not provided', () {
-    final Platform platform = FakePlatform(
-      environment: <String, String>{},
-    );
-
-    final ProcessManager processManager = FakeProcessManager.list(
-      <FakeCommand>[
-        const FakeCommand(
-          command: <String>['flutter', '--version', '--machine'],
-          stdout: testVersionInfo,
-        ),
-        const FakeCommand(
-          command: <String>['git', 'status', '-b', '--porcelain'],
-          stdout: '## $branchName',
-        ),
-      ],
-    );
-
-    expect(
-      apidocs.FlutterInformation(platform: platform, processManager: processManager).getBranchName(),
-      branchName,
-    );
-    expect(processManager, hasNoRemainingExpectations);
-  });
-
-  test('getBranchName calls git if env LUCI_BRANCH is empty', () {
-    final Platform platform = FakePlatform(
-      environment: <String, String>{
-        'LUCI_BRANCH': '',
-      },
-    );
-
-    final ProcessManager processManager = FakeProcessManager.list(
-      <FakeCommand>[
-        const FakeCommand(
-          command: <String>['flutter', '--version', '--machine'],
-          stdout: testVersionInfo,
-        ),
-        const FakeCommand(
-          command: <String>['git', 'status', '-b', '--porcelain'],
-          stdout: '## $branchName',
-        ),
-      ],
-    );
-
-    expect(
-      apidocs.FlutterInformation(platform: platform, processManager: processManager).getBranchName(),
-      branchName,
-    );
-    expect(processManager, hasNoRemainingExpectations);
-  });
-
-  test("runPubProcess doesn't use the pub binary", () {
-    final Platform platform = FakePlatform(
-      environment: <String, String>{
-        'FLUTTER_ROOT': '/flutter',
-      },
-    );
-    final ProcessManager processManager = FakeProcessManager.list(
-      <FakeCommand>[
-        const FakeCommand(
-          command: <String>['/flutter/bin/dart', 'pub', '--one', '--two'],
-        ),
-      ],
-    );
-    apidocs.FlutterInformation.instance =
-        apidocs.FlutterInformation(platform: platform, processManager: processManager);
-
-    apidocs.runPubProcess(
-      arguments: <String>['--one', '--two'],
-      processManager: processManager,
-      filesystem: filesystem,
-    );
-
-    expect(processManager, hasNoRemainingExpectations);
-  });
-
   group('FlutterInformation', () {
     late FakeProcessManager fakeProcessManager;
     late FakePlatform fakePlatform;
@@ -133,14 +31,108 @@ void main() {
     setUp(() {
       fakeProcessManager = FakeProcessManager.empty();
       memoryFileSystem = MemoryFileSystem();
+      final Directory flutterHome = memoryFileSystem
+          .directory('/home')
+          .childDirectory('user')
+          .childDirectory('flutter')
+          .childDirectory('bin')
+          .childDirectory('internal');
+      flutterHome.childFile('engine.realm')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('realm');
       setUpWithEnvironment(<String, String>{});
     });
 
+    test('getBranchName does not call git if env LUCI_BRANCH provided', () {
+      setUpWithEnvironment(
+        <String, String>{
+          'LUCI_BRANCH': branchName,
+        },
+      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['flutter', '--version', '--machine'],
+        stdout: testVersionInfo,
+      ));
+      expect(
+        apidocs.FlutterInformation.instance.getBranchName(),
+        branchName,
+      );
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+    });
+
+    test('getBranchName calls git if env LUCI_BRANCH not provided', () {
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['flutter', '--version', '--machine'],
+        stdout: testVersionInfo,
+      ));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
+
+      expect(
+        apidocs.FlutterInformation.instance.getBranchName(),
+        branchName,
+      );
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+    });
+
+    test('getBranchName calls git if env LUCI_BRANCH is empty', () {
+      setUpWithEnvironment(
+        <String, String>{
+          'LUCI_BRANCH': '',
+        },
+      );
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['flutter', '--version', '--machine'],
+        stdout: testVersionInfo,
+      ));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
+
+      expect(
+        apidocs.FlutterInformation.instance.getBranchName(),
+        branchName,
+      );
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+    });
+
+    test("runPubProcess doesn't use the pub binary", () {
+      final Platform platform = FakePlatform(
+        environment: <String, String>{
+          'FLUTTER_ROOT': '/flutter',
+        },
+      );
+      final ProcessManager processManager = FakeProcessManager.list(
+        <FakeCommand>[
+          const FakeCommand(
+            command: <String>['/flutter/bin/flutter', 'pub', '--one', '--two'],
+          ),
+        ],
+      );
+      apidocs.FlutterInformation.instance =
+          apidocs.FlutterInformation(platform: platform, processManager: processManager, filesystem: memoryFileSystem);
+
+      apidocs.runPubProcess(
+        arguments: <String>['--one', '--two'],
+        processManager: processManager,
+        filesystem: memoryFileSystem,
+      );
+
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
     test('calls out to flutter if FLUTTER_VERSION is not set', () async {
-      fakeProcessManager.addCommand(
-          const FakeCommand(command: <Pattern>['flutter', '--version', '--machine'], stdout: testVersionInfo));
-      fakeProcessManager.addCommand(
-          const FakeCommand(command: <Pattern>['git', 'status', '-b', '--porcelain'], stdout: testVersionInfo));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['flutter', '--version', '--machine'],
+        stdout: testVersionInfo,
+      ));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
       final Map<String, dynamic> info = flutterInformation.getFlutterInformation();
       expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(info['frameworkVersion'], equals(Version.parse('2.5.0')));
@@ -149,17 +141,23 @@ void main() {
       setUpWithEnvironment(<String, String>{
         'FLUTTER_VERSION': testVersionInfo,
       });
-      fakeProcessManager.addCommand(
-          const FakeCommand(command: <Pattern>['git', 'status', '-b', '--porcelain'], stdout: testVersionInfo));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
       final Map<String, dynamic> info = flutterInformation.getFlutterInformation();
       expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(info['frameworkVersion'], equals(Version.parse('2.5.0')));
     });
     test('getFlutterRoot calls out to flutter if FLUTTER_ROOT is not set', () async {
-      fakeProcessManager.addCommand(
-          const FakeCommand(command: <Pattern>['flutter', '--version', '--machine'], stdout: testVersionInfo));
-      fakeProcessManager.addCommand(
-          const FakeCommand(command: <Pattern>['git', 'status', '-b', '--porcelain'], stdout: testVersionInfo));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['flutter', '--version', '--machine'],
+        stdout: testVersionInfo,
+      ));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
       final Directory root = flutterInformation.getFlutterRoot();
       expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(root.path, equals('/home/user/flutter'));
@@ -172,8 +170,10 @@ void main() {
     });
     test('parses version properly', () async {
       fakePlatform.environment['FLUTTER_VERSION'] = testVersionInfo;
-      fakeProcessManager.addCommand(
-          const FakeCommand(command: <Pattern>['git', 'status', '-b', '--porcelain'], stdout: testVersionInfo));
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
       final Map<String, dynamic> info = flutterInformation.getFlutterInformation();
       expect(info['frameworkVersion'], isNotNull);
       expect(info['frameworkVersion'], equals(Version.parse('2.5.0')));
@@ -181,14 +181,17 @@ void main() {
       expect(info['dartSdkVersion'], equals(Version.parse('2.14.0-360.0.dev')));
     });
     test('the engine realm is read from the engine.realm file', () async {
-      const String flutterRoot = '/home/user/flutter';
-      final File realmFile = memoryFileSystem.file(
-        path.join(flutterRoot, 'bin', 'internal', 'engine.realm',
+      setUpWithEnvironment(<String, String>{'FLUTTER_ROOT': '/home/user/flutter'});
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['/home/user/flutter/bin/flutter', '--version', '--machine'],
+        stdout: testVersionInfo,
       ));
-      realmFile.writeAsStringSync('realm');
-      setUpWithEnvironment(<String, String>{'FLUTTER_ROOT': flutterRoot});
-      expect(fakeProcessManager, hasNoRemainingExpectations);
+      fakeProcessManager.addCommand(const FakeCommand(
+        command: <Pattern>['git', 'status', '-b', '--porcelain'],
+        stdout: '## $branchName',
+      ));
       final Map<String, dynamic> info = flutterInformation.getFlutterInformation();
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(info['engineRealm'], equals('realm'));
     });
   });

--- a/dev/tools/test/create_api_docs_test.dart
+++ b/dev/tools/test/create_api_docs_test.dart
@@ -31,15 +31,6 @@ void main() {
     setUp(() {
       fakeProcessManager = FakeProcessManager.empty();
       memoryFileSystem = MemoryFileSystem();
-      final Directory flutterHome = memoryFileSystem
-          .directory('/home')
-          .childDirectory('user')
-          .childDirectory('flutter')
-          .childDirectory('bin')
-          .childDirectory('internal');
-      flutterHome.childFile('engine.realm')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('realm');
       setUpWithEnvironment(<String, String>{});
     });
 
@@ -181,6 +172,15 @@ void main() {
       expect(info['dartSdkVersion'], equals(Version.parse('2.14.0-360.0.dev')));
     });
     test('the engine realm is read from the engine.realm file', () async {
+      final Directory flutterHome = memoryFileSystem
+          .directory('/home')
+          .childDirectory('user')
+          .childDirectory('flutter')
+          .childDirectory('bin')
+          .childDirectory('internal');
+      flutterHome.childFile('engine.realm')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('realm');
       setUpWithEnvironment(<String, String>{'FLUTTER_ROOT': '/home/user/flutter'});
       fakeProcessManager.addCommand(const FakeCommand(
         command: <Pattern>['/home/user/flutter/bin/flutter', '--version', '--machine'],


### PR DESCRIPTION
## Description

Switches some instances of calling `dart pub` for `flutter pub` to make sure Flutter SDK is available when run.

## Tests

- Fixes the test for create_api_docs.dart so that it succeeds locally.
- Fixes the example smoke test so it doesn't export global variables for filesystem, process and platform.
