### PR TITLE
Ignore macOS Cocoapods linting failure on DT_TOOLCHAIN_DIR error

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -543,11 +543,13 @@ Future<void> _tryMacOSLint(String executable, List<String> arguments) async {
       stdout: lintStdout,
     );
   } on BuildFailedError {
-    // Temporarily ignore errors due to DT_TOOLCHAIN_DIR. This error was
-    // introduced with Xcode 15. Fix was made in Cocoapods, but is not in an
-    // official release yet.
+    // Temporarily ignore errors due to DT_TOOLCHAIN_DIR if it's the only error.
+    // This error was introduced with Xcode 15. Fix was made in Cocoapods, but
+    // is not in an official release yet.
     // TODO(vashworth): Stop ignoring when https://github.com/flutter/flutter/issues/133584 is complete.
-    if (!lintStdout.toString().contains('error: DT_TOOLCHAIN_DIR cannot be used to evaluate')) {
+    final String lintResult = lintStdout.toString();
+    if (!(lintResult.contains('error: DT_TOOLCHAIN_DIR cannot be used to evaluate') &&
+        lintResult.contains('did not pass validation, due to 1 error'))) {
       rethrow;
     }
   }

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -44,6 +44,7 @@ Future<void> main() async {
             '--allow-warnings',
           ],
         );
+
         final String macosintegrationTestPodspec = path.join(integrationTestPackage, 'integration_test_macos', 'macos', 'integration_test_macos.podspec');
         await _tryMacOSLint(
           'pod',

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -47,11 +47,8 @@ Future<void> main() async {
 
         final String macosintegrationTestPodspec = path.join(integrationTestPackage, 'integration_test_macos', 'macos', 'integration_test_macos.podspec');
         await _tryMacOSLint(
-          'pod',
+          macosintegrationTestPodspec,
           <String>[
-            'lib',
-            'lint',
-            macosintegrationTestPodspec,
             '--verbose',
             // TODO(cyanglaz): remove allow-warnings when https://github.com/flutter/flutter/issues/125812 is fixed.
             // https://github.com/flutter/flutter/issues/125812
@@ -165,11 +162,8 @@ Future<void> main() async {
       final String macOSPodspecPath = path.join(swiftPluginPath, 'macos', '$swiftPluginName.podspec');
       await inDirectory(tempDir, () async {
         await _tryMacOSLint(
-          'pod',
+          macOSPodspecPath,
           <String>[
-            'lib',
-            'lint',
-            macOSPodspecPath,
             '--allow-warnings',
             '--verbose',
           ],
@@ -180,11 +174,8 @@ Future<void> main() async {
 
       await inDirectory(tempDir, () async {
         await _tryMacOSLint(
-          'pod',
+          macOSPodspecPath,
           <String>[
-            'lib',
-            'lint',
-            macOSPodspecPath,
             '--allow-warnings',
             '--use-libraries',
             '--verbose',
@@ -534,12 +525,20 @@ void _validateMacOSPodfile(String appPath) {
   ));
 }
 
-Future<void> _tryMacOSLint(String executable, List<String> arguments) async {
+Future<void> _tryMacOSLint(
+  String podspecPath,
+  List<String> extraArguments,
+) async {
   final StringBuffer lintStdout = StringBuffer();
   try {
     await eval(
-      executable,
-      arguments,
+      'pod',
+      <String>[
+        'lib',
+        'lint',
+        podspecPath,
+        ...extraArguments,
+      ],
       stdout: lintStdout,
     );
   } on BuildFailedError {

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -44,20 +44,6 @@ Future<void> main() async {
             '--allow-warnings',
           ],
         );
-
-        final String macosintegrationTestPodspec = path.join(integrationTestPackage, 'integration_test_macos', 'macos', 'integration_test_macos.podspec');
-        await exec(
-          'pod',
-          <String>[
-            'lib',
-            'lint',
-            macosintegrationTestPodspec,
-            '--verbose',
-            // TODO(cyanglaz): remove allow-warnings when https://github.com/flutter/flutter/issues/125812 is fixed.
-            // https://github.com/flutter/flutter/issues/125812
-            '--allow-warnings',
-          ],
-        );
       });
 
       section('Create Objective-C plugin');
@@ -153,38 +139,6 @@ Future<void> main() async {
             'lib',
             'lint',
             swiftPodspecPath,
-            '--allow-warnings',
-            '--use-libraries',
-            '--verbose',
-          ],
-        );
-      });
-
-      section('Lint Swift macOS podspec plugin as framework');
-
-      final String macOSPodspecPath = path.join(swiftPluginPath, 'macos', '$swiftPluginName.podspec');
-      await inDirectory(tempDir, () async {
-        await exec(
-          'pod',
-          <String>[
-            'lib',
-            'lint',
-            macOSPodspecPath,
-            '--allow-warnings',
-            '--verbose',
-          ],
-        );
-      });
-
-      section('Lint Swift macOS podspec plugin as library');
-
-      await inDirectory(tempDir, () async {
-        await exec(
-          'pod',
-          <String>[
-            'lib',
-            'lint',
-            macOSPodspecPath,
             '--allow-warnings',
             '--use-libraries',
             '--verbose',

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -430,11 +430,12 @@ Future<String> eval(
   Map<String, String>? environment,
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   String? workingDirectory,
+  StringBuffer? stdout,
   StringBuffer? stderr, // if not null, the stderr will be written here
   bool printStdout = true,
   bool printStderr = true,
 }) async {
-  final StringBuffer output = StringBuffer();
+  final StringBuffer output = stdout ?? StringBuffer();
   await _execute(
     executable,
     arguments,

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -430,7 +430,7 @@ Future<String> eval(
   Map<String, String>? environment,
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   String? workingDirectory,
-  StringBuffer? stdout,
+  StringBuffer? stdout, // if not null, the stdout will be written here
   StringBuffer? stderr, // if not null, the stderr will be written here
   bool printStdout = true,
   bool printStderr = true,


### PR DESCRIPTION
Xcode 15 introduced an [error](https://github.com/flutter/flutter/issues/132755) into Cocoapods when building macOS apps. 

When `pod lib lint` runs, it under the covers is building the app with `xcodebuild`, which is why this error occurs when linting.

A fix has been made in Cocoapods, but is not in an official release so we can't upgrade Cocoapods yet. This is to temporarily ignore lint failure due to that error.

Fixes https://github.com/flutter/flutter/issues/132980.

Tracking issue to upgrade Cocoapods when fix is in a release: https://github.com/flutter/flutter/issues/133584

Since Xcode 15 isn't in CI, I tested it in a one-off led test:
* [Pre-fix failure](https://chromium-swarm.appspot.com/task?id=6431f228ecf98e10)
* [Post-fix success](https://chromium-swarm.appspot.com/task?id=645ba7ebdab97210)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
