### PR TITLE
Fixed `PaginatedDataTable` not using `dataRowMinHeight` and `dataRowMaxHeight` from Theme

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -122,8 +122,8 @@ class PaginatedDataTable extends StatefulWidget {
        assert(dataRowMinHeight == null || dataRowMaxHeight == null || dataRowMaxHeight >= dataRowMinHeight),
        assert(dataRowHeight == null || (dataRowMinHeight == null && dataRowMaxHeight == null),
          'dataRowHeight ($dataRowHeight) must not be set if dataRowMinHeight ($dataRowMinHeight) or dataRowMaxHeight ($dataRowMaxHeight) are set.'),
-       dataRowMinHeight = dataRowHeight ?? dataRowMinHeight ?? kMinInteractiveDimension,
-       dataRowMaxHeight = dataRowHeight ?? dataRowMaxHeight ?? kMinInteractiveDimension,
+       dataRowMinHeight = dataRowHeight ?? dataRowMinHeight,
+       dataRowMaxHeight = dataRowHeight ?? dataRowMaxHeight,
        assert(rowsPerPage > 0),
        assert(() {
          if (onRowsPerPageChanged != null) {
@@ -192,13 +192,13 @@ class PaginatedDataTable extends StatefulWidget {
   ///
   /// This value is optional and defaults to [kMinInteractiveDimension] if not
   /// specified.
-  final double dataRowMinHeight;
+  final double? dataRowMinHeight;
 
   /// The maximum height of each row (excluding the row that contains column headings).
   ///
-  /// This value is optional and defaults to kMinInteractiveDimension if not
+  /// This value is optional and defaults to [kMinInteractiveDimension] if not
   /// specified.
-  final double dataRowMaxHeight;
+  final double? dataRowMaxHeight;
 
   /// The height of the heading row.
   ///

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1023,7 +1023,6 @@ void main() {
   });
 
   testWidgets('dataRowMinHeight & dataRowMaxHeight if not set will use DataTableTheme', (WidgetTester tester) async {
-    final Size originalSize = binding.renderView.size;
     addTearDown(() => binding.setSurfaceSize(null));    
     await binding.setSurfaceSize(const Size(800, 800));
 

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1024,35 +1024,35 @@ void main() {
 
   testWidgets('dataRowMinHeight & dataRowMaxHeight if not set will use DataTableTheme', (WidgetTester tester) async {
     final Size originalSize = binding.renderView.size;
+    addTearDown(() => binding.setSurfaceSize(null));    
     await binding.setSurfaceSize(const Size(800, 800));
 
     const double minMaxDataRowHeight = 30.0;
 
-    Widget buildTable() {
-      return MaterialApp(
-        theme: ThemeData.light().copyWith(
-          dataTableTheme: const DataTableThemeData(
-            dataRowMinHeight: minMaxDataRowHeight,
-            dataRowMaxHeight: minMaxDataRowHeight,
-          ),
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        dataTableTheme: const DataTableThemeData(
+          dataRowMinHeight: minMaxDataRowHeight,
+          dataRowMaxHeight: minMaxDataRowHeight,
         ),
-        home: PaginatedDataTable(
-          header: const Text('Test table'),
-          source: TestDataSource(allowSelection: true),
-          columns: const <DataColumn>[
-            DataColumn(label: Text('Name')),
-            DataColumn(label: Text('Calories'), numeric: true),
-            DataColumn(label: Text('Generation')),
-          ],
-        ),
-      );
-    }
+      ),
+      home: PaginatedDataTable(
+        header: const Text('Test table'),
+        source: TestDataSource(allowSelection: true),
+        columns: const <DataColumn>[
+          DataColumn(label: Text('Name')),
+          DataColumn(label: Text('Calories'), numeric: true),
+          DataColumn(label: Text('Generation')),
+        ],
+      ),
+    ));
 
-    await tester.pumpWidget(buildTable());
-    expect(tester.getSize(find.widgetWithText(Container, 'Frozen yogurt (0)').first).height, minMaxDataRowHeight);
-
-    // Reset the surface size.
-    await binding.setSurfaceSize(originalSize);
+    final Container rowContainer = tester.widget<Container>(find.descendant(
+      of: find.byType(Table),
+      matching: find.byType(Container),
+    ).last);
+    expect(rowContainer.constraints?.minHeight, minMaxDataRowHeight);
+    expect(rowContainer.constraints?.maxHeight, minMaxDataRowHeight);
   });
 
   testWidgets('PaginatedDataTable custom checkboxHorizontalMargin properly applied', (WidgetTester tester) async {

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1023,7 +1023,7 @@ void main() {
   });
 
   testWidgets('dataRowMinHeight & dataRowMaxHeight if not set will use DataTableTheme', (WidgetTester tester) async {
-    addTearDown(() => binding.setSurfaceSize(null));    
+    addTearDown(() => binding.setSurfaceSize(null));
     await binding.setSurfaceSize(const Size(800, 800));
 
     const double minMaxDataRowHeight = 30.0;

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1022,6 +1022,39 @@ void main() {
     await binding.setSurfaceSize(originalSize);
   });
 
+  testWidgets('dataRowMinHeight & dataRowMaxHeight if not set will use DataTableTheme', (WidgetTester tester) async {
+    final Size originalSize = binding.renderView.size;
+    await binding.setSurfaceSize(const Size(800, 800));
+
+    const double minMaxDataRowHeight = 30.0;
+
+    Widget buildTable() {
+      return MaterialApp(
+        theme: ThemeData.light().copyWith(
+          dataTableTheme: const DataTableThemeData(
+            dataRowMinHeight: minMaxDataRowHeight,
+            dataRowMaxHeight: minMaxDataRowHeight,
+          ),
+        ),
+        home: PaginatedDataTable(
+          header: const Text('Test table'),
+          source: TestDataSource(allowSelection: true),
+          columns: const <DataColumn>[
+            DataColumn(label: Text('Name')),
+            DataColumn(label: Text('Calories'), numeric: true),
+            DataColumn(label: Text('Generation')),
+          ],
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildTable());
+    expect(tester.getSize(find.widgetWithText(Container, 'Frozen yogurt (0)').first).height, minMaxDataRowHeight);
+
+    // Reset the surface size.
+    await binding.setSurfaceSize(originalSize);
+  });
+
   testWidgets('PaginatedDataTable custom checkboxHorizontalMargin properly applied', (WidgetTester tester) async {
     const double customCheckboxHorizontalMargin = 15.0;
     const double customHorizontalMargin = 10.0;


### PR DESCRIPTION
`PaginatedDataTable` will now make use of `dataRowMinHeight` and `dataRowMaxHeight` from the Theme

*List which issues are fixed by this PR. You must list at least one issue.*

Resolves #133633

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
