### PR TITLE
Fix memory leak in RenderAnimatedSize

### DIFF
--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -351,6 +351,8 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
   @override
   void dispose() {
     _clipRectLayer.layer = null;
+    _controller.dispose();
+    _animation.dispose();
     super.dispose();
   }
 }

--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -99,8 +99,18 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
     );
   }
 
+  /// The animation controller that is used to drive the resizing.
+  ///
+  /// The animation itself is exposed by the [animation] property.
+  @visibleForTesting
+  AnimationController get controller => _controller;
   late final AnimationController _controller;
+
+  /// The animation that drives the resizing.
+  @visibleForTesting
+  CurvedAnimation get animation => _animation;
   late final CurvedAnimation _animation;
+
   final SizeTween _sizeTween = SizeTween();
   late bool _hasVisualOverflow;
   double? _lastValue;

--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -99,16 +99,40 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
     );
   }
 
-  /// The animation controller that is used to drive the resizing.
+  /// When asserts are enabled, returns the animation controller that is used
+  /// to drive the resizing.
   ///
-  /// The animation itself is exposed by the [animation] property.
+  /// Otherwise, returns null.
+  ///
+  /// This getter is intended for use in framework unit tests. Applications must
+  /// not depend on its value.
   @visibleForTesting
-  AnimationController get controller => _controller;
-  late final AnimationController _controller;
+  AnimationController? get debugController {
+    AnimationController? controller;
+    assert(() {
+      controller = _controller;
+      return true;
+    }());
+    return controller;
+  }
 
-  /// The animation that drives the resizing.
+  /// When asserts are enabled, returns the animation that drives the resizing.
+  ///
+  /// Otherwise, returns null.
+  ///
+  /// This getter is intended for use in framework unit tests. Applications must
+  /// not depend on its value.
   @visibleForTesting
-  CurvedAnimation get animation => _animation;
+  CurvedAnimation? get debugAnimation {
+    CurvedAnimation? animation;
+    assert(() {
+      animation = _animation;
+      return true;
+    }());
+    return animation;
+  }
+
+  late final AnimationController _controller;
   late final CurvedAnimation _animation;
 
   final SizeTween _sizeTween = SizeTween();

--- a/packages/flutter/test/widgets/animated_size_test.dart
+++ b/packages/flutter/test/widgets/animated_size_test.dart
@@ -434,5 +434,40 @@ void main() {
         const Size.square(150),
       );
     });
+
+    testWidgets('disposes animation and controller', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Center(
+          child: AnimatedSize(
+            duration: Duration(milliseconds: 200),
+            child: SizedBox(
+              width: 100.0,
+              height: 100.0,
+            ),
+          ),
+        ),
+      );
+
+      final RenderAnimatedSize box = tester.renderObject(find.byType(AnimatedSize));
+
+      await tester.pumpWidget(
+        const Center(),
+      );
+
+      expect(box.animation.isDisposed, isTrue);
+      await expectLater(
+        () => box.controller.dispose(),
+        throwsA(isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          equalsIgnoringHashCodes(
+            'AnimationController.dispose() called more than once.\n'
+            'A given AnimationController cannot be disposed more than once.\n'
+            'The following AnimationController object was disposed multiple times:\n'
+            '  AnimationController#00000(⏮ 0.000; paused; DISPOSED)',
+          ),
+        )),
+      );
+    });
   });
 }

--- a/packages/flutter/test/widgets/animated_size_test.dart
+++ b/packages/flutter/test/widgets/animated_size_test.dart
@@ -454,9 +454,11 @@ void main() {
         const Center(),
       );
 
-      expect(box.animation.isDisposed, isTrue);
-      await expectLater(
-        () => box.controller.dispose(),
+      expect(box.debugAnimation, isNotNull);
+      expect(box.debugAnimation!.isDisposed, isTrue);
+      expect(box.debugController, isNotNull);
+      expect(
+        () => box.debugController!.dispose(),
         throwsA(isA<AssertionError>().having(
           (AssertionError error) => error.message,
           'message',


### PR DESCRIPTION
`AnimationController` and `CurvedAnimation` objects were not disposed in `RenderAnimatedSize`.

### Description
- Fixes https://github.com/flutter/flutter/issues/133903;
- Adds the missing `dispose()` calls for `AnimationController` and `CurvedAnimation` in `RenderAnimatedSize`.

### Tests
- Updates `animated_size_test.dart` to test that `AnimationController` and `CurvedAnimation` are disposed after `RenderSize` disposal.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
