### PR TITLE
Add more documentation for SystemChannels.keyboard getKeyboardState

### DIFF
--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -532,6 +532,10 @@ class HardwareKeyboard {
   }
 
   /// Query the engine and update _pressedKeys accordingly to the engine answer.
+  //
+  /// Both the framework and the engine maintain a state of the current pressed
+  /// keys. There are edge cases, related to startup and restart, where the framework
+  /// needs to resynchronize its keyboard state.
   Future<void> syncKeyboardState() async {
     final Map<int, int>? keyboardState = await SystemChannels.keyboard.invokeMapMethod<int, int>(
       'getKeyboardState',

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -503,6 +503,10 @@ abstract final class SystemChannels {
   ///    represents a pressed keyboard key. The entry key is the physical
   ///    key ID and the entry value is the logical key ID.
   ///
+  ///    Both the framework and the engine maintain a state of the current
+  ///    pressed keys. There are edge cases, related to startup and restart,
+  ///    where the framework needs to resynchronize its keyboard state.
+  ///
   /// See also:
   ///
   ///  * [HardwareKeyboard.syncKeyboardState], which uses this channel to synchronize


### PR DESCRIPTION
## Description

This PR adds some documentation to SystemChannels.keyboard getKeyboardState.
This method was added in https://github.com/flutter/flutter/pull/122885.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/132938.

## Tests

Documentation only.

