### PR TITLE
Removed test that asserts exceptions in platform channel handlers breaks in the debugger

### DIFF
--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -120,19 +120,6 @@ void main() {
     await expectException(project, "throw 'while handling a gesture';");
   });
 
-  testWithoutContext('breaks when platform message callback throws', () async {
-    final TestProject project = TestProject(
-      r'''
-      BasicMessageChannel<String>('foo', const StringCodec()).setMessageHandler((_) {
-        throw 'platform message callback';
-      });
-      tester.binding.defaultBinaryMessenger.handlePlatformMessage('foo', const StringCodec().encodeMessage('Hello'), (_) {});
-      '''
-    );
-
-    await expectException(project, "throw 'platform message callback';");
-  });
-
   testWithoutContext('breaks when SliverChildBuilderDelegate.builder throws', () async {
     final TestProject project = TestProject(
       r'''


### PR DESCRIPTION
fixes: https://github.com/flutter/flutter/issues/133677

This test asserts that the debugger breaks when exceptions are thrown in platform channel handlers.  That assertion was based on erroneous debugger logic that reported exceptions called in `Future.then(closure, onError:)` to be reported as uncaught.

Removing the `onError` usage would result in a degradation of the experience when using Flutter without the debugger.  The workaround is that users can manually break there after being informed by the error message or catch on `throw` globally.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
