### PR TITLE
Deprecates onWillAccept and onAccept callbacks in DragTarget.

### DIFF
--- a/dev/manual_tests/lib/drag_and_drop.dart
+++ b/dev/manual_tests/lib/drag_and_drop.dart
@@ -16,16 +16,16 @@ class ExampleDragTarget extends StatefulWidget {
 class ExampleDragTargetState extends State<ExampleDragTarget> {
   Color _color = Colors.grey;
 
-  void _handleAccept(Color data) {
+  void _handleAccept(DragTargetDetails<Color> details) {
     setState(() {
-      _color = data;
+      _color = details.data;
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return DragTarget<Color>(
-      onAccept: _handleAccept,
+      onAcceptWithDetails: _handleAccept,
       builder: (BuildContext context, List<Color?> data, List<dynamic> rejectedData) {
         return Container(
           height: 100.0,
@@ -217,7 +217,7 @@ class MovableBall extends StatelessWidget {
       );
     } else {
       return DragTarget<bool>(
-        onAccept: (bool data) { callback(position); },
+        onAcceptWithDetails: (DragTargetDetails<bool> data) { callback(position); },
         builder: (BuildContext context, List<bool?> accepted, List<dynamic> rejected) {
           return dashedBall;
         },

--- a/examples/api/lib/widgets/drag_target/draggable.0.dart
+++ b/examples/api/lib/widgets/drag_target/draggable.0.dart
@@ -78,9 +78,9 @@ class _DraggableExampleState extends State<DraggableExample> {
               ),
             );
           },
-          onAccept: (int data) {
+          onAcceptWithDetails: (DragTargetDetails<int> details) {
             setState(() {
-              acceptedData += data;
+              acceptedData += details.data;
             });
           },
         ),

--- a/packages/flutter/lib/fix_data/fix_widgets/fix_drag_target.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_drag_target.yaml
@@ -1,0 +1,46 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the flutter/packages/flutter/test_fixes/README.md
+# file for instructions on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for DragTarget from the Widgets library. *
+version: 1
+transforms:
+
+  # Changes made in https://github.com/flutter/flutter/pull/133691
+  - title: "Migrate 'onWillAccept' to 'onWillAcceptWithDetails'"
+    date: 2023-08-30
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: ''
+      inClass: 'DragTarget'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'onWillAccept'
+        newName: 'onWillAcceptWithDetails'
+
+  # Changes made in https://github.com/flutter/flutter/pull/133691
+  - title: "Migrate 'onAccept' to 'onAcceptWithDetails'"
+    date: 2023-08-30
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: ''
+      inClass: 'DragTarget'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'onAccept'
+        newName: 'onAcceptWithDetails'
+
+# Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -611,8 +611,18 @@ class DragTarget<T extends Object> extends StatefulWidget {
   const DragTarget({
     super.key,
     required this.builder,
+    @Deprecated(
+      'Use onWillAcceptWithDetails instead. '
+      'This callback is similar to onWillAcceptWithDetails but does not provide drag details. '
+      'This feature was deprecated after v3.14.0-0.2.pre.'
+    )
     this.onWillAccept,
     this.onWillAcceptWithDetails,
+    @Deprecated(
+      'Use onAcceptWithDetails instead. '
+      'This callback is similar to onAcceptWithDetails but does not provide drag details. '
+      'This feature was deprecated after v3.14.0-0.2.pre.'
+    )
     this.onAccept,
     this.onAcceptWithDetails,
     this.onLeave,
@@ -636,6 +646,11 @@ class DragTarget<T extends Object> extends StatefulWidget {
   /// Equivalent to [onWillAcceptWithDetails], but only includes the data.
   ///
   /// Must not be provided if [onWillAcceptWithDetails] is provided.
+  @Deprecated(
+    'Use onWillAcceptWithDetails instead. '
+    'This callback is similar to onWillAcceptWithDetails but does not provide drag details. '
+    'This feature was deprecated after v3.14.0-0.2.pre.'
+  )
   final DragTargetWillAccept<T>? onWillAccept;
 
   /// Called to determine whether this widget is interested in receiving a given
@@ -655,6 +670,11 @@ class DragTarget<T extends Object> extends StatefulWidget {
   /// It will not be called if `data` is `null`.
   ///
   /// Equivalent to [onAcceptWithDetails], but only includes the data.
+  @Deprecated(
+    'Use onAcceptWithDetails instead. '
+    'This callback is similar to onAcceptWithDetails but does not provide drag details. '
+    'This feature was deprecated after v3.14.0-0.2.pre.'
+  )
   final DragTargetAccept<T>? onAccept;
 
   /// Called when an acceptable piece of data was dropped over this drag target.

--- a/packages/flutter/test_fixes/cupertino/drag_target.dart
+++ b/packages/flutter/test_fixes/cupertino/drag_target.dart
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onWillAccept: (data) => ());
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onAccept: (data) => ());
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+}

--- a/packages/flutter/test_fixes/cupertino/drag_target.dart.expect
+++ b/packages/flutter/test_fixes/cupertino/drag_target.dart.expect
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+}

--- a/packages/flutter/test_fixes/material/drag_target.dart
+++ b/packages/flutter/test_fixes/material/drag_target.dart
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onWillAccept: (data) => ());
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onAccept: (data) => ());
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+}

--- a/packages/flutter/test_fixes/material/drag_target.dart.expect
+++ b/packages/flutter/test_fixes/material/drag_target.dart.expect
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+}

--- a/packages/flutter/test_fixes/widgets/drag_target.dart
+++ b/packages/flutter/test_fixes/widgets/drag_target.dart
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onWillAccept: (data) => ());
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onAccept: (data) => ());
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+}

--- a/packages/flutter/test_fixes/widgets/drag_target.dart.expect
+++ b/packages/flutter/test_fixes/widgets/drag_target.dart.expect
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+  dragTarget = DragTarget(onWillAcceptWithDetails: (data) => ());
+
+  // Changes made in https://github.com/flutter/flutter/pull/133691
+  const dragTarget = DragTarget();
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+  dragTarget = DragTarget(onAcceptWithDetails: (data) => ());
+}


### PR DESCRIPTION
This PR deprecates `onWillAccept` and `onAccept` over `onWillAcceptWithDetails` and `onAcceptWithDetails`.

Fixes: #133347

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
