### PR TITLE
_FocusTraversalGroupNode should communicate creation in constructor.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1784,7 +1784,11 @@ class _FocusTraversalGroupNode extends FocusNode {
   _FocusTraversalGroupNode({
     super.debugLabel,
     required this.policy,
-  });
+  }) {
+    if (kFlutterMemoryAllocationsEnabled) {
+      maybeDispatchObjectCreation();
+    }
+  }
 
   FocusTraversalPolicy policy;
 }


### PR DESCRIPTION
No testing because the classes are private and the change impacts just debugging UX. 
[see Discord message](https://discord.com/channels/608014603317936148/608018585025118217/1146806178953842688)