### PR TITLE
Cover some test/widgets tests with leak tracking

### DIFF
--- a/packages/flutter/test/widgets/absorb_pointer_test.dart
+++ b/packages/flutter/test/widgets/absorb_pointer_test.dart
@@ -4,11 +4,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'semantics_tester.dart';
 
 void main() {
-  testWidgets('AbsorbPointers do not block siblings', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AbsorbPointers do not block siblings', (WidgetTester tester) async {
     bool tapped = false;
     await tester.pumpWidget(
       Column(
@@ -29,7 +30,7 @@ void main() {
   });
 
   group('AbsorbPointer semantics', () {
-    testWidgets('does not change semantics when not absorbing', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('does not change semantics when not absorbing', (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(
@@ -56,7 +57,7 @@ void main() {
       );
     });
 
-    testWidgets('drops semantics when its ignoreSemantics is true', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('drops semantics when its ignoreSemantics is true', (WidgetTester tester) async {
       final SemanticsTester semantics = SemanticsTester(tester);
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(
@@ -75,7 +76,7 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgets('ignores user interactions', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('ignores user interactions', (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -8,10 +8,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   group(ActionDispatcher, () {
-    testWidgets('ActionDispatcher invokes actions when asked.', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('ActionDispatcher invokes actions when asked.', (WidgetTester tester) async {
       await tester.pumpWidget(Container());
       bool invoked = false;
       const ActionDispatcher dispatcher = ActionDispatcher();
@@ -48,7 +49,7 @@ void main() {
 
     setUp(clear);
 
-    testWidgets('Actions widget can invoke actions with default dispatcher', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions widget can invoke actions with default dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -75,7 +76,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    testWidgets('Actions widget can invoke actions with default dispatcher and maybeInvoke', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions widget can invoke actions with default dispatcher and maybeInvoke', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -102,7 +103,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    testWidgets('maybeInvoke returns null when no action is found', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('maybeInvoke returns null when no action is found', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -129,7 +130,7 @@ void main() {
       expect(invoked, isFalse);
     });
 
-    testWidgets('invoke throws when no action is found', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('invoke throws when no action is found', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -156,7 +157,7 @@ void main() {
       expect(invoked, isFalse);
     });
 
-    testWidgets('Actions widget can invoke actions with custom dispatcher', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions widget can invoke actions with custom dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -187,7 +188,7 @@ void main() {
       expect(invokedIntent, equals(intent));
     });
 
-    testWidgets('Actions can invoke actions in ancestor dispatcher', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions can invoke actions in ancestor dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -224,7 +225,7 @@ void main() {
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
     });
 
-    testWidgets("Actions can invoke actions in ancestor dispatcher if a lower one isn't specified", (WidgetTester tester) async {
+    testWidgetsWithLeakTracking("Actions can invoke actions in ancestor dispatcher if a lower one isn't specified", (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -260,7 +261,7 @@ void main() {
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
     });
 
-    testWidgets('Actions widget can be found with of', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions widget can be found with of', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final ActionDispatcher testDispatcher = TestDispatcher1(postInvoke: collect);
 
@@ -277,7 +278,7 @@ void main() {
       expect(dispatcher, equals(testDispatcher));
     });
 
-    testWidgets('Action can be found with find', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Action can be found with find', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final ActionDispatcher testDispatcher = TestDispatcher1(postInvoke: collect);
       bool invoked = false;
@@ -324,7 +325,7 @@ void main() {
       expect(Actions.maybeFind<DoNothingIntent>(containerKey.currentContext!), isNull);
     });
 
-    testWidgets('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -392,9 +393,11 @@ void main() {
       await buildTest(true);
       expect(hovering, isFalse);
       expect(focusing, isFalse);
+
+      focusNode.dispose();
     });
 
-    testWidgets('FocusableActionDetector changes mouse cursor when hovered', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusableActionDetector changes mouse cursor when hovered', (WidgetTester tester) async {
       await tester.pumpWidget(
         MouseRegion(
           cursor: SystemMouseCursors.forbidden,
@@ -427,7 +430,7 @@ void main() {
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
     });
 
-    testWidgets('Actions.invoke returns the value of Action.invoke', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions.invoke returns the value of Action.invoke', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final Object sentinel = Object();
       bool invoked = false;
@@ -458,7 +461,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    testWidgets('ContextAction can return null', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('ContextAction can return null', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       const TestIntent intent = TestIntent();
       final TestContextAction testAction = TestContextAction();
@@ -485,7 +488,7 @@ void main() {
       expect(testAction.capturedContexts.single, containerKey.currentContext);
     });
 
-    testWidgets('Disabled actions stop propagation to an ancestor', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Disabled actions stop propagation to an ancestor', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -534,7 +537,7 @@ void main() {
   });
 
   group('Listening', () {
-    testWidgets('can listen to enabled state of Actions', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('can listen to enabled state of Actions', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked1 = false;
       bool invoked2 = false;
@@ -756,7 +759,11 @@ void main() {
       );
     });
 
-    testWidgets('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
+    tearDown(() async {
+      focusNode.dispose();
+    });
+
+    testWidgetsWithLeakTracking('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
 
@@ -790,7 +797,7 @@ void main() {
       expect(focusing, isFalse);
     });
 
-    testWidgets('FocusableActionDetector shows focus highlight appropriately when focused and disabled', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusableActionDetector shows focus highlight appropriately when focused and disabled', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
 
@@ -821,7 +828,7 @@ void main() {
       expect(focusing, isTrue);
     });
 
-    testWidgets('FocusableActionDetector can be used without callbacks', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusableActionDetector can be used without callbacks', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
 
@@ -855,7 +862,7 @@ void main() {
       expect(focusing, isFalse);
     });
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'FocusableActionDetector can prevent its descendants from being focusable',
       (WidgetTester tester) async {
         final FocusNode buttonNode = FocusNode(debugLabel: 'Test');
@@ -896,19 +903,22 @@ void main() {
         buttonNode.requestFocus();
         await tester.pump();
         expect(buttonNode.hasFocus, isFalse);
+
+        buttonNode.dispose();
       },
     );
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'FocusableActionDetector can prevent its descendants from being traversable',
           (WidgetTester tester) async {
         final FocusNode buttonNode1 = FocusNode(debugLabel: 'Button Node 1');
         final FocusNode buttonNode2 = FocusNode(debugLabel: 'Button Node 2');
+        final FocusNode skipTraversalNode = FocusNode(skipTraversal: true);
 
         await tester.pumpWidget(
           MaterialApp(
             home: FocusableActionDetector(
-              focusNode: FocusNode(skipTraversal: true),
+              focusNode: skipTraversalNode,
               child: Column(
                 children: <Widget>[
                   ElevatedButton(
@@ -939,7 +949,7 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: FocusableActionDetector(
-              focusNode: FocusNode(skipTraversal: true),
+              focusNode: skipTraversalNode,
               descendantsAreTraversable: false,
               child: Column(
                 children: <Widget>[
@@ -967,10 +977,14 @@ void main() {
         await tester.pump();
         expect(buttonNode1.hasFocus, isTrue);
         expect(buttonNode2.hasFocus, isFalse);
+
+        buttonNode1.dispose();
+        buttonNode2.dispose();
+        skipTraversalNode.dispose();
       },
     );
 
-    testWidgets('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: FocusableActionDetector(
@@ -1076,7 +1090,7 @@ void main() {
   });
 
   group('Action subclasses', () {
-    testWidgets('CallbackAction passes correct intent when invoked.', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('CallbackAction passes correct intent when invoked.', (WidgetTester tester) async {
       late Intent passedIntent;
       final TestAction action = TestAction(onInvoke: (Intent intent) {
         passedIntent = intent;
@@ -1087,7 +1101,7 @@ void main() {
       expect(passedIntent, equals(intent));
     });
 
-    testWidgets('VoidCallbackAction', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('VoidCallbackAction', (WidgetTester tester) async {
       bool called = false;
       void testCallback() {
         called = true;
@@ -1097,7 +1111,7 @@ void main() {
       action.invoke(intent);
       expect(called, isTrue);
     });
-    testWidgets('Base Action class default toKeyEventResult delegates to consumesKey', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Base Action class default toKeyEventResult delegates to consumesKey', (WidgetTester tester) async {
       expect(
         DefaultToKeyEventResultAction(consumesKey: false).toKeyEventResult(const DefaultToKeyEventResultIntent(), null),
         KeyEventResult.skipRemainingHandlers,
@@ -1110,7 +1124,7 @@ void main() {
   });
 
   group('Diagnostics', () {
-    testWidgets('default Intent debugFillProperties', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('default Intent debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       // ignore: invalid_use_of_protected_member
@@ -1126,7 +1140,7 @@ void main() {
       expect(description, isEmpty);
     });
 
-    testWidgets('default Actions debugFillProperties', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('default Actions debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       Actions(
@@ -1152,7 +1166,7 @@ void main() {
       );
     });
 
-    testWidgets('Actions implements debugFillProperties', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Actions implements debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       Actions(
@@ -1191,7 +1205,7 @@ void main() {
       invokingContext = null;
     });
 
-    testWidgets('Basic usage', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Basic usage', (WidgetTester tester) async {
       late BuildContext invokingContext2;
       late BuildContext invokingContext3;
       await tester.pumpWidget(
@@ -1256,7 +1270,7 @@ void main() {
       expect(invocations, <String>['action1.invoke']);
     });
 
-    testWidgets('Does not break after use', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Does not break after use', (WidgetTester tester) async {
       late BuildContext invokingContext2;
       late BuildContext invokingContext3;
       await tester.pumpWidget(
@@ -1323,7 +1337,7 @@ void main() {
       ]);
     });
 
-    testWidgets('Does not override if not overridable', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Does not override if not overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1366,7 +1380,7 @@ void main() {
       ]);
     });
 
-    testWidgets('The final override controls isEnabled', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('The final override controls isEnabled', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1453,7 +1467,7 @@ void main() {
       expect(invocations, <String>[]);
     });
 
-    testWidgets('The override can choose to defer isActionEnabled to the overridable', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('The override can choose to defer isActionEnabled to the overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1543,7 +1557,7 @@ void main() {
       ]);
     });
 
-    testWidgets('Throws on infinite recursions', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Throws on infinite recursions', (WidgetTester tester) async {
       late StateSetter setState;
       BuildContext? action2LookupContext;
       await tester.pumpWidget(
@@ -1602,7 +1616,7 @@ void main() {
       expect(exception?.toString(), contains('debugAssertIsEnabledMutuallyRecursive'));
     });
 
-    testWidgets('Throws on invoking invalid override', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Throws on invoking invalid override', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context) {
@@ -1640,7 +1654,7 @@ void main() {
       );
     });
 
-    testWidgets('Make an overridable action overridable', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Make an overridable action overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1696,7 +1710,7 @@ void main() {
       ]);
     });
 
-    testWidgets('Overriding Actions can change the intent', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Overriding Actions can change the intent', (WidgetTester tester) async {
       final List<String> newLogChannel = <String>[];
       await tester.pumpWidget(
         Builder(
@@ -1746,7 +1760,7 @@ void main() {
       ]);
     });
 
-    testWidgets('Override non-context overridable Actions with a ContextAction', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Override non-context overridable Actions with a ContextAction', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1799,7 +1813,7 @@ void main() {
       expect(LogInvocationContextAction.invokeContext, invokingContext);
     });
 
-    testWidgets('Override a ContextAction with a regular Action', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Override a ContextAction with a regular Action', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {

--- a/packages/flutter/test/widgets/align_test.dart
+++ b/packages/flutter/test/widgets/align_test.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('Align smoke test', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Align smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       Align(
         alignment: const Alignment(0.50, 0.50),
@@ -38,7 +39,7 @@ void main() {
     );
   });
 
-  testWidgets('Align control test (LTR)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Align control test (LTR)', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,
       child: Align(
@@ -62,7 +63,7 @@ void main() {
     expect(tester.getBottomRight(find.byType(SizedBox)).dx, 100.0);
   });
 
-  testWidgets('Align control test (RTL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Align control test (RTL)', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.rtl,
       child: Align(
@@ -86,7 +87,7 @@ void main() {
     expect(tester.getBottomRight(find.byType(SizedBox)).dx, 100.0);
   });
 
-  testWidgets('Shrink wraps in finite space', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Shrink wraps in finite space', (WidgetTester tester) async {
     final GlobalKey alignKey = GlobalKey();
     await tester.pumpWidget(
       SingleChildScrollView(
@@ -105,7 +106,7 @@ void main() {
     expect(size.height, equals(10.0));
   });
 
-  testWidgets('Align widthFactor', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Align widthFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -128,7 +129,7 @@ void main() {
     expect(box.size.width, equals(50.0));
   });
 
-  testWidgets('Align heightFactor', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Align heightFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/animated_align_test.dart
+++ b/packages/flutter/test/widgets/animated_align_test.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('AnimatedAlign.debugFillProperties', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedAlign.debugFillProperties', (WidgetTester tester) async {
     const AnimatedAlign box = AnimatedAlign(
       alignment: Alignment.topCenter,
       curve: Curves.ease,
@@ -15,7 +16,7 @@ void main() {
     expect(box, hasOneLineDescription);
   });
 
-  testWidgets('AnimatedAlign alignment visual-to-directional animation', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedAlign alignment visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -57,7 +58,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 400.0));
   });
 
-  testWidgets('AnimatedAlign widthFactor', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedAlign widthFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -82,7 +83,7 @@ void main() {
     expect(box.size.width, equals(50.0));
   });
 
-  testWidgets('AnimatedAlign heightFactor', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedAlign heightFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -106,7 +107,7 @@ void main() {
     expect(box.size.height, equals( 50.0));
   });
 
-  testWidgets('AnimatedAlign null height factor', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedAlign null height factor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -130,7 +131,7 @@ void main() {
     expect(box.size, equals(const Size(100.0, 100)));
   });
 
-  testWidgets('AnimatedAlign null widthFactor', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedAlign null widthFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/animated_container_test.dart
+++ b/packages/flutter/test/widgets/animated_container_test.dart
@@ -5,9 +5,10 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('AnimatedContainer.debugFillProperties', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer.debugFillProperties', (WidgetTester tester) async {
     final AnimatedContainer container = AnimatedContainer(
       constraints: const BoxConstraints.tightFor(width: 17.0, height: 23.0),
       decoration: const BoxDecoration(color: Color(0xFF00FF00)),
@@ -24,7 +25,7 @@ void main() {
     expect(container, hasOneLineDescription);
   });
 
-  testWidgets('AnimatedContainer control test', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer control test', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     const BoxDecoration decorationA = BoxDecoration(
@@ -102,7 +103,7 @@ void main() {
     );
   });
 
-  testWidgets('AnimatedContainer overanimate test', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer overanimate test', (WidgetTester tester) async {
     await tester.pumpWidget(
       AnimatedContainer(
         duration: const Duration(milliseconds: 200),
@@ -139,7 +140,7 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
   });
 
-  testWidgets('AnimatedContainer padding visual-to-directional animation', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer padding visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -181,7 +182,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(700.0, 0.0));
   });
 
-  testWidgets('AnimatedContainer alignment visual-to-directional animation', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer alignment visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -223,7 +224,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 400.0));
   });
 
-  testWidgets('Animation rerun', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Animation rerun', (WidgetTester tester) async {
     await tester.pumpWidget(
       Center(
         child: AnimatedContainer(
@@ -291,7 +292,7 @@ void main() {
     expect(text.size.height, equals(100.0));
   });
 
-  testWidgets('AnimatedContainer sets transformAlignment', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer sets transformAlignment', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -339,7 +340,7 @@ void main() {
     expect(tester.getTopLeft(find.byKey(target)), const Offset(400.0, 300.0));
   });
 
-  testWidgets('AnimatedContainer sets clipBehavior', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedContainer sets clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(
       AnimatedContainer(
         decoration: const BoxDecoration(

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -5,9 +5,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('AnimatedCrossFade test', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -61,7 +62,7 @@ void main() {
     expect(box.size.height, equals(150.0));
   });
 
-  testWidgets('AnimatedCrossFade test showSecond', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade test showSecond', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -88,7 +89,7 @@ void main() {
     expect(box.size.height, equals(200.0));
   });
 
-  testWidgets('AnimatedCrossFade alignment (VISUAL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade alignment (VISUAL)', (WidgetTester tester) async {
     final Key firstKey = UniqueKey();
     final Key secondKey = UniqueKey();
 
@@ -146,7 +147,7 @@ void main() {
     expect(box2.localToGlobal(Offset.zero), const Offset(275.0, 175.0));
   });
 
-  testWidgets('AnimatedCrossFade alignment (LTR)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade alignment (LTR)', (WidgetTester tester) async {
     final Key firstKey = UniqueKey();
     final Key secondKey = UniqueKey();
 
@@ -204,7 +205,7 @@ void main() {
     expect(box2.localToGlobal(Offset.zero), const Offset(275.0, 175.0));
   });
 
-  testWidgets('AnimatedCrossFade alignment (RTL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade alignment (RTL)', (WidgetTester tester) async {
     final Key firstKey = UniqueKey();
     final Key secondKey = UniqueKey();
 
@@ -274,7 +275,7 @@ void main() {
     );
   }
 
-  testWidgets('AnimatedCrossFade preserves widget state', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade preserves widget state', (WidgetTester tester) async {
     await tester.pumpWidget(crossFadeWithWatcher());
 
     _TickerWatchingWidgetState findState() => tester.state(find.byType(_TickerWatchingWidget));
@@ -287,7 +288,7 @@ void main() {
     }
   });
 
-  testWidgets('AnimatedCrossFade switches off TickerMode and semantics on faded out widget', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade switches off TickerMode and semantics on faded out widget', (WidgetTester tester) async {
     ExcludeSemantics findSemantics() {
       return tester.widget(find.descendant(
         of: find.byKey(const ValueKey<CrossFadeState>(CrossFadeState.showFirst)),
@@ -317,7 +318,7 @@ void main() {
     expect(findSemantics().excluding, true);
   });
 
-  testWidgets('AnimatedCrossFade.layoutBuilder', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade.layoutBuilder', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -361,7 +362,7 @@ void main() {
     expect(find.text('AAA'), findsNothing);
   });
 
-  testWidgets('AnimatedCrossFade test focus', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade test focus', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -385,7 +386,7 @@ void main() {
     expect(hiddenNode.hasPrimaryFocus, isFalse);
   });
 
-  testWidgets('AnimatedCrossFade bottom child can have focus', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedCrossFade bottom child can have focus', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -410,7 +411,7 @@ void main() {
     expect(hiddenNode.hasPrimaryFocus, isTrue);
   });
 
-  testWidgets('AnimatedCrossFade second child do not receive touch events',
+  testWidgetsWithLeakTracking('AnimatedCrossFade second child do not receive touch events',
       (WidgetTester tester) async {
     int numberOfTouchEventNoticed = 0;
 

--- a/packages/flutter/test/widgets/animated_grid_test.dart
+++ b/packages/flutter/test/widgets/animated_grid_test.dart
@@ -5,10 +5,11 @@
 import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/100451
-  testWidgets('SliverAnimatedGrid.builder respects findChildIndexCallback', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('SliverAnimatedGrid.builder respects findChildIndexCallback', (WidgetTester tester) async {
     bool finderCalled = false;
     int itemCount = 7;
     late StateSetter stateSetter;
@@ -50,7 +51,7 @@ void main() {
     expect(finderCalled, true);
   });
 
-  testWidgets('AnimatedGrid', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedGrid', (WidgetTester tester) async {
     Widget builder(BuildContext context, int index, Animation<double> animation) {
       return SizedBox(
         height: 100.0,
@@ -132,7 +133,7 @@ void main() {
   });
 
   group('SliverAnimatedGrid', () {
-    testWidgets('initialItemCount', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('initialItemCount', (WidgetTester tester) async {
       final Map<int, Animation<double>> animations = <int, Animation<double>>{};
 
       await tester.pumpWidget(
@@ -170,7 +171,7 @@ void main() {
       expect(animations[1]!.value, 1.0);
     });
 
-    testWidgets('insert', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('insert', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
 
       await tester.pumpWidget(
@@ -250,7 +251,7 @@ void main() {
       expect(itemRight(2), 300.0);
     });
 
-    testWidgets('insertAll', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('insertAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
 
       await tester.pumpWidget(
@@ -306,7 +307,7 @@ void main() {
       expect(itemRight(1), 200.0);
     });
 
-    testWidgets('remove', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('remove', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -384,7 +385,7 @@ void main() {
       expect(itemRight(2), 200.0);
     });
 
-    testWidgets('removeAll', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('removeAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -436,7 +437,7 @@ void main() {
       expect(find.text('item 2'), findsNothing);
     });
 
-    testWidgets('works in combination with other slivers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('works in combination with other slivers', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
 
       await tester.pumpWidget(
@@ -505,7 +506,7 @@ void main() {
       expect(tester.getTopLeft(find.text('item 0')).dx, 0);
     });
 
-    testWidgets('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate',
+    testWidgetsWithLeakTracking('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate',
         (WidgetTester tester) async {
       final List<int> items = <int>[0, 1, 2, 3];
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
@@ -573,7 +574,7 @@ void main() {
     });
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'AnimatedGrid.of() and maybeOf called with a context that does not contain AnimatedGrid',
     (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
@@ -618,7 +619,7 @@ void main() {
     },
   );
 
-  testWidgets('AnimatedGrid.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedGrid.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
     const Clip clipBehavior = Clip.none;
 
     await tester.pumpWidget(
@@ -647,7 +648,7 @@ void main() {
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).clipBehavior, clipBehavior);
   });
 
-  testWidgets('AnimatedGrid applies MediaQuery padding', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedGrid applies MediaQuery padding', (WidgetTester tester) async {
     const EdgeInsets padding = EdgeInsets.all(30.0);
     EdgeInsets? innerMediaQueryPadding;
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/animated_image_filtered_repaint_test.dart
+++ b/packages/flutter/test/widgets/animated_image_filtered_repaint_test.dart
@@ -7,9 +7,10 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('ImageFiltered avoids repainting child as it animates', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('ImageFiltered avoids repainting child as it animates', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     await tester.pumpWidget(
       ColoredBox(

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -5,10 +5,11 @@
 import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/100451
-  testWidgets('SliverAnimatedList.builder respects findChildIndexCallback', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('SliverAnimatedList.builder respects findChildIndexCallback', (WidgetTester tester) async {
     bool finderCalled = false;
     int itemCount = 7;
     late StateSetter stateSetter;
@@ -47,7 +48,7 @@ void main() {
     expect(finderCalled, true);
   });
 
-  testWidgets('AnimatedList', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedList', (WidgetTester tester) async {
     Widget builder(BuildContext context, int index, Animation<double> animation) {
       return SizedBox(
         height: 100.0,
@@ -126,7 +127,7 @@ void main() {
   });
 
   group('SliverAnimatedList', () {
-    testWidgets('initialItemCount', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('initialItemCount', (WidgetTester tester) async {
       final Map<int, Animation<double>> animations = <int, Animation<double>>{};
 
       await tester.pumpWidget(
@@ -159,7 +160,7 @@ void main() {
       expect(animations[1]!.value, 1.0);
     });
 
-    testWidgets('insert', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('insert', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -245,7 +246,7 @@ void main() {
     });
 
     // Test for insertAllItems with SliverAnimatedList
-    testWidgets('insertAll', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('insertAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -302,7 +303,7 @@ void main() {
     });
 
     // Test for removeAllItems with SliverAnimatedList
-    testWidgets('remove', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('remove', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -379,7 +380,7 @@ void main() {
     });
 
     // Test for removeAllItems with SliverAnimatedList
-    testWidgets('removeAll', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('removeAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -429,7 +430,7 @@ void main() {
       expect(find.text('item 2'), findsNothing);
     });
 
-    testWidgets('works in combination with other slivers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('works in combination with other slivers', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -494,7 +495,7 @@ void main() {
       expect(tester.getTopLeft(find.text('item 0')).dy, 200);
     });
 
-    testWidgets('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate', (WidgetTester tester) async {
       final List<int> items = <int>[0, 1, 2, 3];
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
@@ -556,7 +557,7 @@ void main() {
     });
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'AnimatedList.of() and maybeOf called with a context that does not contain AnimatedList',
     (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
@@ -601,7 +602,7 @@ void main() {
     },
   );
 
-  testWidgets('AnimatedList.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedList.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
     const Clip clipBehavior = Clip.none;
 
     await tester.pumpWidget(
@@ -625,7 +626,7 @@ void main() {
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).clipBehavior, clipBehavior);
   });
 
-  testWidgets('AnimatedList.shrinkwrap is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedList.shrinkwrap is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/115040
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
@@ -650,7 +651,7 @@ void main() {
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).shrinkWrap, true);
   });
 
-  testWidgets('AnimatedList applies MediaQuery padding', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedList applies MediaQuery padding', (WidgetTester tester) async {
     const EdgeInsets padding = EdgeInsets.all(30.0);
     EdgeInsets? innerMediaQueryPadding;
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/animated_opacity_repaint_test.dart
+++ b/packages/flutter/test/widgets/animated_opacity_repaint_test.dart
@@ -5,9 +5,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('RenderAnimatedOpacityMixin does not drop layer when animating to 1', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('RenderAnimatedOpacityMixin does not drop layer when animating to 1', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     final AnimationController controller = AnimationController(vsync: const TestVSync(), duration: const Duration(seconds: 1));
     final Tween<double> opacityTween = Tween<double>(begin: 0, end: 1);
@@ -40,7 +41,7 @@ void main() {
     expect(RenderTestObject.paintCount, 1);
   });
 
-  testWidgets('RenderAnimatedOpacityMixin avoids repainting child as it animates', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('RenderAnimatedOpacityMixin avoids repainting child as it animates', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     final AnimationController controller = AnimationController(vsync: const TestVSync(), duration: const Duration(seconds: 1));
     final Tween<double> opacityTween = Tween<double>(begin: 0, end: 0.99); // Layer is dropped at 1
@@ -73,7 +74,7 @@ void main() {
     expect(RenderTestObject.paintCount, 1);
   });
 
-  testWidgets('RenderAnimatedOpacityMixin allows opacity layer to be disposed when animating to 0 opacity', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('RenderAnimatedOpacityMixin allows opacity layer to be disposed when animating to 0 opacity', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     final AnimationController controller = AnimationController(vsync: const TestVSync(), duration: const Duration(seconds: 1));
     final Tween<double> opacityTween = Tween<double>(begin: 0.99, end: 0);

--- a/packages/flutter/test/widgets/animated_padding_test.dart
+++ b/packages/flutter/test/widgets/animated_padding_test.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('AnimatedPadding.debugFillProperties', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPadding.debugFillProperties', (WidgetTester tester) async {
     final AnimatedPadding padding = AnimatedPadding(
       padding: const EdgeInsets.all(7.0),
       curve: Curves.ease,
@@ -16,7 +17,7 @@ void main() {
     expect(padding, hasOneLineDescription);
   });
 
-  testWidgets('AnimatedPadding padding visual-to-directional animation', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPadding padding visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -58,7 +59,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(700.0, 0.0));
   });
 
-  testWidgets('AnimatedPadding animated padding clamped to positive values', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPadding animated padding clamped to positive values', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/animated_positioned_test.dart
+++ b/packages/flutter/test/widgets/animated_positioned_test.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('AnimatedPositioned.fromRect control test', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositioned.fromRect control test', (WidgetTester tester) async {
     final AnimatedPositioned positioned = AnimatedPositioned.fromRect(
       rect: const Rect.fromLTWH(7.0, 5.0, 12.0, 16.0),
       duration: const Duration(milliseconds: 200),
@@ -20,7 +21,7 @@ void main() {
     expect(positioned, hasOneLineDescription);
   });
 
-  testWidgets('AnimatedPositioned - basics (VISUAL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositioned - basics (VISUAL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -102,7 +103,7 @@ void main() {
     );
   });
 
-  testWidgets('AnimatedPositionedDirectional - basics (LTR)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - basics (LTR)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -188,7 +189,7 @@ void main() {
     );
   });
 
-  testWidgets('AnimatedPositionedDirectional - basics (RTL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - basics (RTL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -274,7 +275,7 @@ void main() {
     );
   });
 
-  testWidgets('AnimatedPositioned - interrupted animation (VISUAL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositioned - interrupted animation (VISUAL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -357,7 +358,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(200.0, 200.0)));
   });
 
-  testWidgets('AnimatedPositioned - switching variables (VISUAL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositioned - switching variables (VISUAL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -416,7 +417,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(350.0, 150.0)));
   });
 
-  testWidgets('AnimatedPositionedDirectional - interrupted animation (LTR)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - interrupted animation (LTR)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -505,7 +506,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(200.0, 200.0)));
   });
 
-  testWidgets('AnimatedPositionedDirectional - switching variables (LTR)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - switching variables (LTR)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -568,7 +569,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(350.0, 150.0)));
   });
 
-  testWidgets('AnimatedPositionedDirectional - interrupted animation (RTL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - interrupted animation (RTL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -657,7 +658,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(600.0, 200.0)));
   });
 
-  testWidgets('AnimatedPositionedDirectional - switching variables (RTL)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - switching variables (RTL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;


### PR DESCRIPTION
### Description
This PR changes `testWidgets` by `testWidgetsWithLeakTracking` in number of `flutter/test/widgets` tests according to the https://github.com/dart-lang/leak_tracker/issues/134.

### Tests
- Updates `absorb_pointer_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `actions_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `align_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_align_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_container_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_cross_fade_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_grid_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_image_filtered_repaint_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_list_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_opacity_repaint_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_padding_test.dart` to use `testWidgetsWithLeakTracking`;
- Updates `animated_positioned_test.dart` to use `testWidgetsWithLeakTracking`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
