### PR TITLE
Revert "Cover some test/widgets tests with leak tracking"

### DIFF
--- a/packages/flutter/test/widgets/absorb_pointer_test.dart
+++ b/packages/flutter/test/widgets/absorb_pointer_test.dart
@@ -4,12 +4,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'semantics_tester.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('AbsorbPointers do not block siblings', (WidgetTester tester) async {
+  testWidgets('AbsorbPointers do not block siblings', (WidgetTester tester) async {
     bool tapped = false;
     await tester.pumpWidget(
       Column(
@@ -30,7 +29,7 @@ void main() {
   });
 
   group('AbsorbPointer semantics', () {
-    testWidgetsWithLeakTracking('does not change semantics when not absorbing', (WidgetTester tester) async {
+    testWidgets('does not change semantics when not absorbing', (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(
@@ -57,7 +56,7 @@ void main() {
       );
     });
 
-    testWidgetsWithLeakTracking('drops semantics when its ignoreSemantics is true', (WidgetTester tester) async {
+    testWidgets('drops semantics when its ignoreSemantics is true', (WidgetTester tester) async {
       final SemanticsTester semantics = SemanticsTester(tester);
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(
@@ -76,7 +75,7 @@ void main() {
       semantics.dispose();
     });
 
-    testWidgetsWithLeakTracking('ignores user interactions', (WidgetTester tester) async {
+    testWidgets('ignores user interactions', (WidgetTester tester) async {
       final UniqueKey key = UniqueKey();
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -8,11 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   group(ActionDispatcher, () {
-    testWidgetsWithLeakTracking('ActionDispatcher invokes actions when asked.', (WidgetTester tester) async {
+    testWidgets('ActionDispatcher invokes actions when asked.', (WidgetTester tester) async {
       await tester.pumpWidget(Container());
       bool invoked = false;
       const ActionDispatcher dispatcher = ActionDispatcher();
@@ -49,7 +48,7 @@ void main() {
 
     setUp(clear);
 
-    testWidgetsWithLeakTracking('Actions widget can invoke actions with default dispatcher', (WidgetTester tester) async {
+    testWidgets('Actions widget can invoke actions with default dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -76,7 +75,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    testWidgetsWithLeakTracking('Actions widget can invoke actions with default dispatcher and maybeInvoke', (WidgetTester tester) async {
+    testWidgets('Actions widget can invoke actions with default dispatcher and maybeInvoke', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -103,7 +102,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    testWidgetsWithLeakTracking('maybeInvoke returns null when no action is found', (WidgetTester tester) async {
+    testWidgets('maybeInvoke returns null when no action is found', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -130,7 +129,7 @@ void main() {
       expect(invoked, isFalse);
     });
 
-    testWidgetsWithLeakTracking('invoke throws when no action is found', (WidgetTester tester) async {
+    testWidgets('invoke throws when no action is found', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
 
@@ -157,7 +156,7 @@ void main() {
       expect(invoked, isFalse);
     });
 
-    testWidgetsWithLeakTracking('Actions widget can invoke actions with custom dispatcher', (WidgetTester tester) async {
+    testWidgets('Actions widget can invoke actions with custom dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -188,7 +187,7 @@ void main() {
       expect(invokedIntent, equals(intent));
     });
 
-    testWidgetsWithLeakTracking('Actions can invoke actions in ancestor dispatcher', (WidgetTester tester) async {
+    testWidgets('Actions can invoke actions in ancestor dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -225,7 +224,7 @@ void main() {
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
     });
 
-    testWidgetsWithLeakTracking("Actions can invoke actions in ancestor dispatcher if a lower one isn't specified", (WidgetTester tester) async {
+    testWidgets("Actions can invoke actions in ancestor dispatcher if a lower one isn't specified", (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -261,7 +260,7 @@ void main() {
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
     });
 
-    testWidgetsWithLeakTracking('Actions widget can be found with of', (WidgetTester tester) async {
+    testWidgets('Actions widget can be found with of', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final ActionDispatcher testDispatcher = TestDispatcher1(postInvoke: collect);
 
@@ -278,7 +277,7 @@ void main() {
       expect(dispatcher, equals(testDispatcher));
     });
 
-    testWidgetsWithLeakTracking('Action can be found with find', (WidgetTester tester) async {
+    testWidgets('Action can be found with find', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final ActionDispatcher testDispatcher = TestDispatcher1(postInvoke: collect);
       bool invoked = false;
@@ -325,7 +324,7 @@ void main() {
       expect(Actions.maybeFind<DoNothingIntent>(containerKey.currentContext!), isNull);
     });
 
-    testWidgetsWithLeakTracking('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
+    testWidgets('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -393,11 +392,9 @@ void main() {
       await buildTest(true);
       expect(hovering, isFalse);
       expect(focusing, isFalse);
-
-      focusNode.dispose();
     });
 
-    testWidgetsWithLeakTracking('FocusableActionDetector changes mouse cursor when hovered', (WidgetTester tester) async {
+    testWidgets('FocusableActionDetector changes mouse cursor when hovered', (WidgetTester tester) async {
       await tester.pumpWidget(
         MouseRegion(
           cursor: SystemMouseCursors.forbidden,
@@ -430,7 +427,7 @@ void main() {
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
     });
 
-    testWidgetsWithLeakTracking('Actions.invoke returns the value of Action.invoke', (WidgetTester tester) async {
+    testWidgets('Actions.invoke returns the value of Action.invoke', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final Object sentinel = Object();
       bool invoked = false;
@@ -461,7 +458,7 @@ void main() {
       expect(invoked, isTrue);
     });
 
-    testWidgetsWithLeakTracking('ContextAction can return null', (WidgetTester tester) async {
+    testWidgets('ContextAction can return null', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       const TestIntent intent = TestIntent();
       final TestContextAction testAction = TestContextAction();
@@ -488,7 +485,7 @@ void main() {
       expect(testAction.capturedContexts.single, containerKey.currentContext);
     });
 
-    testWidgetsWithLeakTracking('Disabled actions stop propagation to an ancestor', (WidgetTester tester) async {
+    testWidgets('Disabled actions stop propagation to an ancestor', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
       const TestIntent intent = TestIntent();
@@ -537,7 +534,7 @@ void main() {
   });
 
   group('Listening', () {
-    testWidgetsWithLeakTracking('can listen to enabled state of Actions', (WidgetTester tester) async {
+    testWidgets('can listen to enabled state of Actions', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked1 = false;
       bool invoked2 = false;
@@ -759,11 +756,7 @@ void main() {
       );
     });
 
-    tearDown(() async {
-      focusNode.dispose();
-    });
-
-    testWidgetsWithLeakTracking('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
+    testWidgets('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
 
@@ -797,7 +790,7 @@ void main() {
       expect(focusing, isFalse);
     });
 
-    testWidgetsWithLeakTracking('FocusableActionDetector shows focus highlight appropriately when focused and disabled', (WidgetTester tester) async {
+    testWidgets('FocusableActionDetector shows focus highlight appropriately when focused and disabled', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
 
@@ -828,7 +821,7 @@ void main() {
       expect(focusing, isTrue);
     });
 
-    testWidgetsWithLeakTracking('FocusableActionDetector can be used without callbacks', (WidgetTester tester) async {
+    testWidgets('FocusableActionDetector can be used without callbacks', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
 
@@ -862,7 +855,7 @@ void main() {
       expect(focusing, isFalse);
     });
 
-    testWidgetsWithLeakTracking(
+    testWidgets(
       'FocusableActionDetector can prevent its descendants from being focusable',
       (WidgetTester tester) async {
         final FocusNode buttonNode = FocusNode(debugLabel: 'Test');
@@ -903,22 +896,19 @@ void main() {
         buttonNode.requestFocus();
         await tester.pump();
         expect(buttonNode.hasFocus, isFalse);
-
-        buttonNode.dispose();
       },
     );
 
-    testWidgetsWithLeakTracking(
+    testWidgets(
       'FocusableActionDetector can prevent its descendants from being traversable',
           (WidgetTester tester) async {
         final FocusNode buttonNode1 = FocusNode(debugLabel: 'Button Node 1');
         final FocusNode buttonNode2 = FocusNode(debugLabel: 'Button Node 2');
-        final FocusNode skipTraversalNode = FocusNode(skipTraversal: true);
 
         await tester.pumpWidget(
           MaterialApp(
             home: FocusableActionDetector(
-              focusNode: skipTraversalNode,
+              focusNode: FocusNode(skipTraversal: true),
               child: Column(
                 children: <Widget>[
                   ElevatedButton(
@@ -949,7 +939,7 @@ void main() {
         await tester.pumpWidget(
           MaterialApp(
             home: FocusableActionDetector(
-              focusNode: skipTraversalNode,
+              focusNode: FocusNode(skipTraversal: true),
               descendantsAreTraversable: false,
               child: Column(
                 children: <Widget>[
@@ -977,14 +967,10 @@ void main() {
         await tester.pump();
         expect(buttonNode1.hasFocus, isTrue);
         expect(buttonNode2.hasFocus, isFalse);
-
-        buttonNode1.dispose();
-        buttonNode2.dispose();
-        skipTraversalNode.dispose();
       },
     );
 
-    testWidgetsWithLeakTracking('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
+    testWidgets('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: FocusableActionDetector(
@@ -1090,7 +1076,7 @@ void main() {
   });
 
   group('Action subclasses', () {
-    testWidgetsWithLeakTracking('CallbackAction passes correct intent when invoked.', (WidgetTester tester) async {
+    testWidgets('CallbackAction passes correct intent when invoked.', (WidgetTester tester) async {
       late Intent passedIntent;
       final TestAction action = TestAction(onInvoke: (Intent intent) {
         passedIntent = intent;
@@ -1101,7 +1087,7 @@ void main() {
       expect(passedIntent, equals(intent));
     });
 
-    testWidgetsWithLeakTracking('VoidCallbackAction', (WidgetTester tester) async {
+    testWidgets('VoidCallbackAction', (WidgetTester tester) async {
       bool called = false;
       void testCallback() {
         called = true;
@@ -1111,7 +1097,7 @@ void main() {
       action.invoke(intent);
       expect(called, isTrue);
     });
-    testWidgetsWithLeakTracking('Base Action class default toKeyEventResult delegates to consumesKey', (WidgetTester tester) async {
+    testWidgets('Base Action class default toKeyEventResult delegates to consumesKey', (WidgetTester tester) async {
       expect(
         DefaultToKeyEventResultAction(consumesKey: false).toKeyEventResult(const DefaultToKeyEventResultIntent(), null),
         KeyEventResult.skipRemainingHandlers,
@@ -1124,7 +1110,7 @@ void main() {
   });
 
   group('Diagnostics', () {
-    testWidgetsWithLeakTracking('default Intent debugFillProperties', (WidgetTester tester) async {
+    testWidgets('default Intent debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       // ignore: invalid_use_of_protected_member
@@ -1140,7 +1126,7 @@ void main() {
       expect(description, isEmpty);
     });
 
-    testWidgetsWithLeakTracking('default Actions debugFillProperties', (WidgetTester tester) async {
+    testWidgets('default Actions debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       Actions(
@@ -1166,7 +1152,7 @@ void main() {
       );
     });
 
-    testWidgetsWithLeakTracking('Actions implements debugFillProperties', (WidgetTester tester) async {
+    testWidgets('Actions implements debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       Actions(
@@ -1205,7 +1191,7 @@ void main() {
       invokingContext = null;
     });
 
-    testWidgetsWithLeakTracking('Basic usage', (WidgetTester tester) async {
+    testWidgets('Basic usage', (WidgetTester tester) async {
       late BuildContext invokingContext2;
       late BuildContext invokingContext3;
       await tester.pumpWidget(
@@ -1270,7 +1256,7 @@ void main() {
       expect(invocations, <String>['action1.invoke']);
     });
 
-    testWidgetsWithLeakTracking('Does not break after use', (WidgetTester tester) async {
+    testWidgets('Does not break after use', (WidgetTester tester) async {
       late BuildContext invokingContext2;
       late BuildContext invokingContext3;
       await tester.pumpWidget(
@@ -1337,7 +1323,7 @@ void main() {
       ]);
     });
 
-    testWidgetsWithLeakTracking('Does not override if not overridable', (WidgetTester tester) async {
+    testWidgets('Does not override if not overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1380,7 +1366,7 @@ void main() {
       ]);
     });
 
-    testWidgetsWithLeakTracking('The final override controls isEnabled', (WidgetTester tester) async {
+    testWidgets('The final override controls isEnabled', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1467,7 +1453,7 @@ void main() {
       expect(invocations, <String>[]);
     });
 
-    testWidgetsWithLeakTracking('The override can choose to defer isActionEnabled to the overridable', (WidgetTester tester) async {
+    testWidgets('The override can choose to defer isActionEnabled to the overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1557,7 +1543,7 @@ void main() {
       ]);
     });
 
-    testWidgetsWithLeakTracking('Throws on infinite recursions', (WidgetTester tester) async {
+    testWidgets('Throws on infinite recursions', (WidgetTester tester) async {
       late StateSetter setState;
       BuildContext? action2LookupContext;
       await tester.pumpWidget(
@@ -1616,7 +1602,7 @@ void main() {
       expect(exception?.toString(), contains('debugAssertIsEnabledMutuallyRecursive'));
     });
 
-    testWidgetsWithLeakTracking('Throws on invoking invalid override', (WidgetTester tester) async {
+    testWidgets('Throws on invoking invalid override', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context) {
@@ -1654,7 +1640,7 @@ void main() {
       );
     });
 
-    testWidgetsWithLeakTracking('Make an overridable action overridable', (WidgetTester tester) async {
+    testWidgets('Make an overridable action overridable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1710,7 +1696,7 @@ void main() {
       ]);
     });
 
-    testWidgetsWithLeakTracking('Overriding Actions can change the intent', (WidgetTester tester) async {
+    testWidgets('Overriding Actions can change the intent', (WidgetTester tester) async {
       final List<String> newLogChannel = <String>[];
       await tester.pumpWidget(
         Builder(
@@ -1760,7 +1746,7 @@ void main() {
       ]);
     });
 
-    testWidgetsWithLeakTracking('Override non-context overridable Actions with a ContextAction', (WidgetTester tester) async {
+    testWidgets('Override non-context overridable Actions with a ContextAction', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {
@@ -1813,7 +1799,7 @@ void main() {
       expect(LogInvocationContextAction.invokeContext, invokingContext);
     });
 
-    testWidgetsWithLeakTracking('Override a ContextAction with a regular Action', (WidgetTester tester) async {
+    testWidgets('Override a ContextAction with a regular Action', (WidgetTester tester) async {
       await tester.pumpWidget(
         Builder(
           builder: (BuildContext context1) {

--- a/packages/flutter/test/widgets/align_test.dart
+++ b/packages/flutter/test/widgets/align_test.dart
@@ -4,10 +4,9 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('Align smoke test', (WidgetTester tester) async {
+  testWidgets('Align smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       Align(
         alignment: const Alignment(0.50, 0.50),
@@ -39,7 +38,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('Align control test (LTR)', (WidgetTester tester) async {
+  testWidgets('Align control test (LTR)', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,
       child: Align(
@@ -63,7 +62,7 @@ void main() {
     expect(tester.getBottomRight(find.byType(SizedBox)).dx, 100.0);
   });
 
-  testWidgetsWithLeakTracking('Align control test (RTL)', (WidgetTester tester) async {
+  testWidgets('Align control test (RTL)', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.rtl,
       child: Align(
@@ -87,7 +86,7 @@ void main() {
     expect(tester.getBottomRight(find.byType(SizedBox)).dx, 100.0);
   });
 
-  testWidgetsWithLeakTracking('Shrink wraps in finite space', (WidgetTester tester) async {
+  testWidgets('Shrink wraps in finite space', (WidgetTester tester) async {
     final GlobalKey alignKey = GlobalKey();
     await tester.pumpWidget(
       SingleChildScrollView(
@@ -106,7 +105,7 @@ void main() {
     expect(size.height, equals(10.0));
   });
 
-  testWidgetsWithLeakTracking('Align widthFactor', (WidgetTester tester) async {
+  testWidgets('Align widthFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -129,7 +128,7 @@ void main() {
     expect(box.size.width, equals(50.0));
   });
 
-  testWidgetsWithLeakTracking('Align heightFactor', (WidgetTester tester) async {
+  testWidgets('Align heightFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/animated_align_test.dart
+++ b/packages/flutter/test/widgets/animated_align_test.dart
@@ -4,10 +4,9 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('AnimatedAlign.debugFillProperties', (WidgetTester tester) async {
+  testWidgets('AnimatedAlign.debugFillProperties', (WidgetTester tester) async {
     const AnimatedAlign box = AnimatedAlign(
       alignment: Alignment.topCenter,
       curve: Curves.ease,
@@ -16,7 +15,7 @@ void main() {
     expect(box, hasOneLineDescription);
   });
 
-  testWidgetsWithLeakTracking('AnimatedAlign alignment visual-to-directional animation', (WidgetTester tester) async {
+  testWidgets('AnimatedAlign alignment visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -58,7 +57,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 400.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedAlign widthFactor', (WidgetTester tester) async {
+  testWidgets('AnimatedAlign widthFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -83,7 +82,7 @@ void main() {
     expect(box.size.width, equals(50.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedAlign heightFactor', (WidgetTester tester) async {
+  testWidgets('AnimatedAlign heightFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -107,7 +106,7 @@ void main() {
     expect(box.size.height, equals( 50.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedAlign null height factor', (WidgetTester tester) async {
+  testWidgets('AnimatedAlign null height factor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -131,7 +130,7 @@ void main() {
     expect(box.size, equals(const Size(100.0, 100)));
   });
 
-  testWidgetsWithLeakTracking('AnimatedAlign null widthFactor', (WidgetTester tester) async {
+  testWidgets('AnimatedAlign null widthFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/animated_container_test.dart
+++ b/packages/flutter/test/widgets/animated_container_test.dart
@@ -5,10 +5,9 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('AnimatedContainer.debugFillProperties', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer.debugFillProperties', (WidgetTester tester) async {
     final AnimatedContainer container = AnimatedContainer(
       constraints: const BoxConstraints.tightFor(width: 17.0, height: 23.0),
       decoration: const BoxDecoration(color: Color(0xFF00FF00)),
@@ -25,7 +24,7 @@ void main() {
     expect(container, hasOneLineDescription);
   });
 
-  testWidgetsWithLeakTracking('AnimatedContainer control test', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer control test', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     const BoxDecoration decorationA = BoxDecoration(
@@ -103,7 +102,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('AnimatedContainer overanimate test', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer overanimate test', (WidgetTester tester) async {
     await tester.pumpWidget(
       AnimatedContainer(
         duration: const Duration(milliseconds: 200),
@@ -140,7 +139,7 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
   });
 
-  testWidgetsWithLeakTracking('AnimatedContainer padding visual-to-directional animation', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer padding visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -182,7 +181,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(700.0, 0.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedContainer alignment visual-to-directional animation', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer alignment visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -224,7 +223,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(800.0, 400.0));
   });
 
-  testWidgetsWithLeakTracking('Animation rerun', (WidgetTester tester) async {
+  testWidgets('Animation rerun', (WidgetTester tester) async {
     await tester.pumpWidget(
       Center(
         child: AnimatedContainer(
@@ -292,7 +291,7 @@ void main() {
     expect(text.size.height, equals(100.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedContainer sets transformAlignment', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer sets transformAlignment', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -340,7 +339,7 @@ void main() {
     expect(tester.getTopLeft(find.byKey(target)), const Offset(400.0, 300.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedContainer sets clipBehavior', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer sets clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(
       AnimatedContainer(
         decoration: const BoxDecoration(

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -5,10 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('AnimatedCrossFade test', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -62,7 +61,7 @@ void main() {
     expect(box.size.height, equals(150.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade test showSecond', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade test showSecond', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -89,7 +88,7 @@ void main() {
     expect(box.size.height, equals(200.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade alignment (VISUAL)', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade alignment (VISUAL)', (WidgetTester tester) async {
     final Key firstKey = UniqueKey();
     final Key secondKey = UniqueKey();
 
@@ -147,7 +146,7 @@ void main() {
     expect(box2.localToGlobal(Offset.zero), const Offset(275.0, 175.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade alignment (LTR)', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade alignment (LTR)', (WidgetTester tester) async {
     final Key firstKey = UniqueKey();
     final Key secondKey = UniqueKey();
 
@@ -205,7 +204,7 @@ void main() {
     expect(box2.localToGlobal(Offset.zero), const Offset(275.0, 175.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade alignment (RTL)', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade alignment (RTL)', (WidgetTester tester) async {
     final Key firstKey = UniqueKey();
     final Key secondKey = UniqueKey();
 
@@ -275,7 +274,7 @@ void main() {
     );
   }
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade preserves widget state', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade preserves widget state', (WidgetTester tester) async {
     await tester.pumpWidget(crossFadeWithWatcher());
 
     _TickerWatchingWidgetState findState() => tester.state(find.byType(_TickerWatchingWidget));
@@ -288,7 +287,7 @@ void main() {
     }
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade switches off TickerMode and semantics on faded out widget', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade switches off TickerMode and semantics on faded out widget', (WidgetTester tester) async {
     ExcludeSemantics findSemantics() {
       return tester.widget(find.descendant(
         of: find.byKey(const ValueKey<CrossFadeState>(CrossFadeState.showFirst)),
@@ -318,7 +317,7 @@ void main() {
     expect(findSemantics().excluding, true);
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade.layoutBuilder', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade.layoutBuilder', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -362,7 +361,7 @@ void main() {
     expect(find.text('AAA'), findsNothing);
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade test focus', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade test focus', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -386,7 +385,7 @@ void main() {
     expect(hiddenNode.hasPrimaryFocus, isFalse);
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade bottom child can have focus', (WidgetTester tester) async {
+  testWidgets('AnimatedCrossFade bottom child can have focus', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -411,7 +410,7 @@ void main() {
     expect(hiddenNode.hasPrimaryFocus, isTrue);
   });
 
-  testWidgetsWithLeakTracking('AnimatedCrossFade second child do not receive touch events',
+  testWidgets('AnimatedCrossFade second child do not receive touch events',
       (WidgetTester tester) async {
     int numberOfTouchEventNoticed = 0;
 

--- a/packages/flutter/test/widgets/animated_grid_test.dart
+++ b/packages/flutter/test/widgets/animated_grid_test.dart
@@ -5,11 +5,10 @@
 import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/100451
-  testWidgetsWithLeakTracking('SliverAnimatedGrid.builder respects findChildIndexCallback', (WidgetTester tester) async {
+  testWidgets('SliverAnimatedGrid.builder respects findChildIndexCallback', (WidgetTester tester) async {
     bool finderCalled = false;
     int itemCount = 7;
     late StateSetter stateSetter;
@@ -51,7 +50,7 @@ void main() {
     expect(finderCalled, true);
   });
 
-  testWidgetsWithLeakTracking('AnimatedGrid', (WidgetTester tester) async {
+  testWidgets('AnimatedGrid', (WidgetTester tester) async {
     Widget builder(BuildContext context, int index, Animation<double> animation) {
       return SizedBox(
         height: 100.0,
@@ -133,7 +132,7 @@ void main() {
   });
 
   group('SliverAnimatedGrid', () {
-    testWidgetsWithLeakTracking('initialItemCount', (WidgetTester tester) async {
+    testWidgets('initialItemCount', (WidgetTester tester) async {
       final Map<int, Animation<double>> animations = <int, Animation<double>>{};
 
       await tester.pumpWidget(
@@ -171,7 +170,7 @@ void main() {
       expect(animations[1]!.value, 1.0);
     });
 
-    testWidgetsWithLeakTracking('insert', (WidgetTester tester) async {
+    testWidgets('insert', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
 
       await tester.pumpWidget(
@@ -251,7 +250,7 @@ void main() {
       expect(itemRight(2), 300.0);
     });
 
-    testWidgetsWithLeakTracking('insertAll', (WidgetTester tester) async {
+    testWidgets('insertAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
 
       await tester.pumpWidget(
@@ -307,7 +306,7 @@ void main() {
       expect(itemRight(1), 200.0);
     });
 
-    testWidgetsWithLeakTracking('remove', (WidgetTester tester) async {
+    testWidgets('remove', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -385,7 +384,7 @@ void main() {
       expect(itemRight(2), 200.0);
     });
 
-    testWidgetsWithLeakTracking('removeAll', (WidgetTester tester) async {
+    testWidgets('removeAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -437,7 +436,7 @@ void main() {
       expect(find.text('item 2'), findsNothing);
     });
 
-    testWidgetsWithLeakTracking('works in combination with other slivers', (WidgetTester tester) async {
+    testWidgets('works in combination with other slivers', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
 
       await tester.pumpWidget(
@@ -506,7 +505,7 @@ void main() {
       expect(tester.getTopLeft(find.text('item 0')).dx, 0);
     });
 
-    testWidgetsWithLeakTracking('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate',
+    testWidgets('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate',
         (WidgetTester tester) async {
       final List<int> items = <int>[0, 1, 2, 3];
       final GlobalKey<SliverAnimatedGridState> listKey = GlobalKey<SliverAnimatedGridState>();
@@ -574,7 +573,7 @@ void main() {
     });
   });
 
-  testWidgetsWithLeakTracking(
+  testWidgets(
     'AnimatedGrid.of() and maybeOf called with a context that does not contain AnimatedGrid',
     (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
@@ -619,7 +618,7 @@ void main() {
     },
   );
 
-  testWidgetsWithLeakTracking('AnimatedGrid.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+  testWidgets('AnimatedGrid.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
     const Clip clipBehavior = Clip.none;
 
     await tester.pumpWidget(
@@ -648,7 +647,7 @@ void main() {
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).clipBehavior, clipBehavior);
   });
 
-  testWidgetsWithLeakTracking('AnimatedGrid applies MediaQuery padding', (WidgetTester tester) async {
+  testWidgets('AnimatedGrid applies MediaQuery padding', (WidgetTester tester) async {
     const EdgeInsets padding = EdgeInsets.all(30.0);
     EdgeInsets? innerMediaQueryPadding;
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/animated_image_filtered_repaint_test.dart
+++ b/packages/flutter/test/widgets/animated_image_filtered_repaint_test.dart
@@ -7,10 +7,9 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('ImageFiltered avoids repainting child as it animates', (WidgetTester tester) async {
+  testWidgets('ImageFiltered avoids repainting child as it animates', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     await tester.pumpWidget(
       ColoredBox(

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -5,11 +5,10 @@
 import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/100451
-  testWidgetsWithLeakTracking('SliverAnimatedList.builder respects findChildIndexCallback', (WidgetTester tester) async {
+  testWidgets('SliverAnimatedList.builder respects findChildIndexCallback', (WidgetTester tester) async {
     bool finderCalled = false;
     int itemCount = 7;
     late StateSetter stateSetter;
@@ -48,7 +47,7 @@ void main() {
     expect(finderCalled, true);
   });
 
-  testWidgetsWithLeakTracking('AnimatedList', (WidgetTester tester) async {
+  testWidgets('AnimatedList', (WidgetTester tester) async {
     Widget builder(BuildContext context, int index, Animation<double> animation) {
       return SizedBox(
         height: 100.0,
@@ -127,7 +126,7 @@ void main() {
   });
 
   group('SliverAnimatedList', () {
-    testWidgetsWithLeakTracking('initialItemCount', (WidgetTester tester) async {
+    testWidgets('initialItemCount', (WidgetTester tester) async {
       final Map<int, Animation<double>> animations = <int, Animation<double>>{};
 
       await tester.pumpWidget(
@@ -160,7 +159,7 @@ void main() {
       expect(animations[1]!.value, 1.0);
     });
 
-    testWidgetsWithLeakTracking('insert', (WidgetTester tester) async {
+    testWidgets('insert', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -246,7 +245,7 @@ void main() {
     });
 
     // Test for insertAllItems with SliverAnimatedList
-    testWidgetsWithLeakTracking('insertAll', (WidgetTester tester) async {
+    testWidgets('insertAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -303,7 +302,7 @@ void main() {
     });
 
     // Test for removeAllItems with SliverAnimatedList
-    testWidgetsWithLeakTracking('remove', (WidgetTester tester) async {
+    testWidgets('remove', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -380,7 +379,7 @@ void main() {
     });
 
     // Test for removeAllItems with SliverAnimatedList
-    testWidgetsWithLeakTracking('removeAll', (WidgetTester tester) async {
+    testWidgets('removeAll', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
       final List<int> items = <int>[0, 1, 2];
 
@@ -430,7 +429,7 @@ void main() {
       expect(find.text('item 2'), findsNothing);
     });
 
-    testWidgetsWithLeakTracking('works in combination with other slivers', (WidgetTester tester) async {
+    testWidgets('works in combination with other slivers', (WidgetTester tester) async {
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -495,7 +494,7 @@ void main() {
       expect(tester.getTopLeft(find.text('item 0')).dy, 200);
     });
 
-    testWidgetsWithLeakTracking('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate', (WidgetTester tester) async {
+    testWidgets('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate', (WidgetTester tester) async {
       final List<int> items = <int>[0, 1, 2, 3];
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
@@ -557,7 +556,7 @@ void main() {
     });
   });
 
-  testWidgetsWithLeakTracking(
+  testWidgets(
     'AnimatedList.of() and maybeOf called with a context that does not contain AnimatedList',
     (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
@@ -602,7 +601,7 @@ void main() {
     },
   );
 
-  testWidgetsWithLeakTracking('AnimatedList.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+  testWidgets('AnimatedList.clipBehavior is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
     const Clip clipBehavior = Clip.none;
 
     await tester.pumpWidget(
@@ -626,7 +625,7 @@ void main() {
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).clipBehavior, clipBehavior);
   });
 
-  testWidgetsWithLeakTracking('AnimatedList.shrinkwrap is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+  testWidgets('AnimatedList.shrinkwrap is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/115040
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
@@ -651,7 +650,7 @@ void main() {
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).shrinkWrap, true);
   });
 
-  testWidgetsWithLeakTracking('AnimatedList applies MediaQuery padding', (WidgetTester tester) async {
+  testWidgets('AnimatedList applies MediaQuery padding', (WidgetTester tester) async {
     const EdgeInsets padding = EdgeInsets.all(30.0);
     EdgeInsets? innerMediaQueryPadding;
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/animated_opacity_repaint_test.dart
+++ b/packages/flutter/test/widgets/animated_opacity_repaint_test.dart
@@ -5,10 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('RenderAnimatedOpacityMixin does not drop layer when animating to 1', (WidgetTester tester) async {
+  testWidgets('RenderAnimatedOpacityMixin does not drop layer when animating to 1', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     final AnimationController controller = AnimationController(vsync: const TestVSync(), duration: const Duration(seconds: 1));
     final Tween<double> opacityTween = Tween<double>(begin: 0, end: 1);
@@ -41,7 +40,7 @@ void main() {
     expect(RenderTestObject.paintCount, 1);
   });
 
-  testWidgetsWithLeakTracking('RenderAnimatedOpacityMixin avoids repainting child as it animates', (WidgetTester tester) async {
+  testWidgets('RenderAnimatedOpacityMixin avoids repainting child as it animates', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     final AnimationController controller = AnimationController(vsync: const TestVSync(), duration: const Duration(seconds: 1));
     final Tween<double> opacityTween = Tween<double>(begin: 0, end: 0.99); // Layer is dropped at 1
@@ -74,7 +73,7 @@ void main() {
     expect(RenderTestObject.paintCount, 1);
   });
 
-  testWidgetsWithLeakTracking('RenderAnimatedOpacityMixin allows opacity layer to be disposed when animating to 0 opacity', (WidgetTester tester) async {
+  testWidgets('RenderAnimatedOpacityMixin allows opacity layer to be disposed when animating to 0 opacity', (WidgetTester tester) async {
     RenderTestObject.paintCount = 0;
     final AnimationController controller = AnimationController(vsync: const TestVSync(), duration: const Duration(seconds: 1));
     final Tween<double> opacityTween = Tween<double>(begin: 0.99, end: 0);

--- a/packages/flutter/test/widgets/animated_padding_test.dart
+++ b/packages/flutter/test/widgets/animated_padding_test.dart
@@ -4,10 +4,9 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('AnimatedPadding.debugFillProperties', (WidgetTester tester) async {
+  testWidgets('AnimatedPadding.debugFillProperties', (WidgetTester tester) async {
     final AnimatedPadding padding = AnimatedPadding(
       padding: const EdgeInsets.all(7.0),
       curve: Curves.ease,
@@ -17,7 +16,7 @@ void main() {
     expect(padding, hasOneLineDescription);
   });
 
-  testWidgetsWithLeakTracking('AnimatedPadding padding visual-to-directional animation', (WidgetTester tester) async {
+  testWidgets('AnimatedPadding padding visual-to-directional animation', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(
@@ -59,7 +58,7 @@ void main() {
     expect(tester.getTopRight(find.byKey(target)), const Offset(700.0, 0.0));
   });
 
-  testWidgetsWithLeakTracking('AnimatedPadding animated padding clamped to positive values', (WidgetTester tester) async {
+  testWidgets('AnimatedPadding animated padding clamped to positive values', (WidgetTester tester) async {
     final Key target = UniqueKey();
 
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/animated_positioned_test.dart
+++ b/packages/flutter/test/widgets/animated_positioned_test.dart
@@ -4,10 +4,9 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('AnimatedPositioned.fromRect control test', (WidgetTester tester) async {
+  testWidgets('AnimatedPositioned.fromRect control test', (WidgetTester tester) async {
     final AnimatedPositioned positioned = AnimatedPositioned.fromRect(
       rect: const Rect.fromLTWH(7.0, 5.0, 12.0, 16.0),
       duration: const Duration(milliseconds: 200),
@@ -21,7 +20,7 @@ void main() {
     expect(positioned, hasOneLineDescription);
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositioned - basics (VISUAL)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositioned - basics (VISUAL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -103,7 +102,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - basics (LTR)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional - basics (LTR)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -189,7 +188,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - basics (RTL)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional - basics (RTL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -275,7 +274,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositioned - interrupted animation (VISUAL)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositioned - interrupted animation (VISUAL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -358,7 +357,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(200.0, 200.0)));
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositioned - switching variables (VISUAL)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositioned - switching variables (VISUAL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -417,7 +416,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(350.0, 150.0)));
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - interrupted animation (LTR)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional - interrupted animation (LTR)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -506,7 +505,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(200.0, 200.0)));
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - switching variables (LTR)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional - switching variables (LTR)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -569,7 +568,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(350.0, 150.0)));
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - interrupted animation (RTL)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional - interrupted animation (RTL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;
@@ -658,7 +657,7 @@ void main() {
     expect(box.localToGlobal(box.size.center(Offset.zero)), equals(const Offset(600.0, 200.0)));
   });
 
-  testWidgetsWithLeakTracking('AnimatedPositionedDirectional - switching variables (RTL)', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional - switching variables (RTL)', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
 
     RenderBox box;


### PR DESCRIPTION
Reverts flutter/flutter#133767

Causing failures to Mac framework_tests_widgets and Linux framework_tests_widgets