### PR TITLE
give --task-args option in `test_runner` a help description

### DIFF
--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -13,7 +13,7 @@ class TestCommand extends Command<void> {
         help: 'The name of a task listed under bin/tasks.\n'
             '   Example: complex_layout__start_up.\n');
     argParser.addMultiOption('task-args',
-        help: 'The name of a task listed under bin/tasks.\n'
+        help: 'List of arguments to pass the to the task.\n'
             'For example, "--task-args build" is passed as "bin/task/task.dart --build"');
     argParser.addOption(
       'device-id',

--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -13,7 +13,7 @@ class TestCommand extends Command<void> {
         help: 'The name of a task listed under bin/tasks.\n'
             '   Example: complex_layout__start_up.\n');
     argParser.addMultiOption('task-args',
-        help: 'List of arguments to pass the to the task.\n'
+        help: 'List of arguments to pass to the task.\n'
             'For example, "--task-args build" is passed as "bin/task/task.dart --build"');
     argParser.addOption(
       'device-id',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133790

Provides help text for the `--task-args` option of the `test_runner` devicelab command. The current help text is just copypasta from another option's help text

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
