### PR TITLE
Revert "Run Mac_arm64_ios run_debug_test_macos in presubmit"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4317,6 +4317,7 @@ targets:
 
   - name: Mac_arm64_ios run_debug_test_macos
     recipe: devicelab/devicelab_drone
+    presubmit: false # https://github.com/flutter/flutter/issues/118827
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Reverts flutter/flutter#133788

Something is wrong with bot https://chromium-swarm.appspot.com/bot?id=flutter-devicelab-mac-38, it's unable to open the project in Xcode. Failing consistently. 

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8771213845302282993/+/u/ios_debug_symbol_doctor/recover_with_120_second_timeout/stdout

So reverting until we can get the bot fixed.