### PR TITLE
[CP] Fix flutter upgrade failing with "Unknown Flutter tag" to 3.14

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -77,7 +77,11 @@ class UpgradeCommand extends FlutterCommand {
       force: boolArg('force'),
       continueFlow: boolArg('continue'),
       testFlow: stringArg('working-directory') != null,
-      gitTagVersion: GitTagVersion.determine(globals.processUtils, globals.platform),
+      gitTagVersion: GitTagVersion.determine(
+        globals.processUtils,
+        globals.platform,
+        workingDirectory: _commandRunner.workingDirectory,
+      ),
       flutterVersion: stringArg('working-directory') == null
         ? globals.flutterVersion
         : FlutterVersion(flutterRoot: _commandRunner.workingDirectory!, fs: globals.fs),

--- a/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
@@ -23,9 +23,11 @@ void main() {
   late FakeProcessManager processManager;
   UpgradeCommand command;
   late CommandRunner<void> runner;
+  const String flutterRoot = '/path/to/flutter';
 
   setUpAll(() {
     Cache.disableLocking();
+    Cache.flutterRoot = flutterRoot;
   });
 
   setUp(() {
@@ -214,28 +216,35 @@ void main() {
       const FakeCommand(
         command: <String>['git', 'tag', '--points-at', 'HEAD'],
         stdout: startingTag,
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['git', 'fetch', '--tags'],
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['git', 'rev-parse', '--verify', '@{upstream}'],
         stdout: upstreamHeadRevision,
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['git', 'tag', '--points-at', upstreamHeadRevision],
         stdout: latestUpstreamTag,
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['git', 'status', '-s'],
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['git', 'reset', '--hard', upstreamHeadRevision],
+        workingDirectory: flutterRoot,
       ),
       FakeCommand(
         command: const <String>['bin/flutter', 'upgrade', '--continue', '--no-version-check'],
         onRun: reEnterTool,
         completer: reEntryCompleter,
+        workingDirectory: flutterRoot,
       ),
 
       // commands following this are from the re-entrant `flutter upgrade --continue` call
@@ -243,12 +252,15 @@ void main() {
       const FakeCommand(
         command: <String>['git', 'tag', '--points-at', 'HEAD'],
         stdout: latestUpstreamTag,
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['bin/flutter', '--no-color', '--no-version-check', 'precache'],
+        workingDirectory: flutterRoot,
       ),
       const FakeCommand(
         command: <String>['bin/flutter', '--no-version-check', 'doctor'],
+        workingDirectory: flutterRoot,
       ),
     ]);
     await runner.run(<String>['upgrade']);


### PR DESCRIPTION
Fixes flutter upgrade which would fail with "Unknown flutter tag" because it would call git commands in the user's current working directory instead of the Flutter SDK.

Fixes https://github.com/flutter/flutter/issues/133822