### PR TITLE
Update TextField docs regarding usage in different contexts (WidgetsApp/CupertinoApp/MaterialApp)

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -12,6 +12,7 @@ import 'package:flutter/widgets.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
 import 'colors.dart';
+import 'debug.dart';
 import 'desktop_text_selection.dart';
 import 'icons.dart';
 import 'magnifier.dart';
@@ -135,6 +136,9 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder extends TextSelectionGe
 /// This widget corresponds to both a `UITextField` and an editable `UITextView`
 /// on iOS.
 ///
+/// If the text field does not have an ancestor [CupertinoApp] widget, then the
+/// [DefaultCupertinoLocalizations.delegate] should be be provided by an ancestor.
+///
 /// The text field calls the [onChanged] callback whenever the user changes the
 /// text in the field. If the user indicates that they are done typing in the
 /// field (e.g., by pressing a button on the soft keyboard), the text field
@@ -174,6 +178,9 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder extends TextSelectionGe
 ///  * <https://developer.apple.com/design/human-interface-guidelines/ios/controls/text-fields/>
 class CupertinoTextField extends StatefulWidget {
   /// Creates an iOS-style text field.
+  ///
+  /// If the text field does not have an ancestor [CupertinoApp] widget, then the
+  /// [DefaultCupertinoLocalizations.delegate] should be be provided by an ancestor.
   ///
   /// To provide a prefilled text entry, pass in a [TextEditingController] with
   /// an initial value to the [controller] parameter.
@@ -1228,6 +1235,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
   @override
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
+    assert(debugCheckHasCupertinoLocalizations(context));
     assert(debugCheckHasDirectionality(context));
     final TextEditingController controller = _effectiveController;
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -112,7 +112,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// property to null, the decoration will be removed entirely, including the
 /// extra padding introduced by the decoration to save space for the labels.
 ///
-/// If the text field does not have an ancestor [Material] widget, then the
+/// If the text field does not have an ancestor [MaterialApp] widget, then the
 /// [DefaultMaterialLocalizations.delegate] should be be provided by an ancestor.
 ///
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
@@ -202,7 +202,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 class TextField extends StatefulWidget {
   /// Creates a Material Design text field.
   ///
-  /// If the text field does not have an ancestor [Material] widget, then the
+  /// If the text field does not have an ancestor [MaterialApp] widget, then the
   /// [DefaultMaterialLocalizations.delegate] should be be provided by an ancestor.
   ///
   /// To remove the decoration entirely (including the extra padding introduced

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -112,8 +112,8 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// property to null, the decoration will be removed entirely, including the
 /// extra padding introduced by the decoration to save space for the labels.
 ///
-/// If [decoration] is non-null (which is the default), the text field requires
-/// one of its ancestors to be a [Material] widget.
+/// If the text field does not have an ancestor [Material] widget, then the
+/// [DefaultMaterialLocalizations.delegate] should be be provided by an ancestor.
 ///
 /// To integrate the [TextField] into a [Form] with other [FormField] widgets,
 /// consider using [TextFormField].
@@ -202,8 +202,8 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 class TextField extends StatefulWidget {
   /// Creates a Material Design text field.
   ///
-  /// If [decoration] is non-null (which is the default), the text field requires
-  /// one of its ancestors to be a [Material] widget.
+  /// If the text field does not have an ancestor [Material] widget, then the
+  /// [DefaultMaterialLocalizations.delegate] should be be provided by an ancestor.
   ///
   /// To remove the decoration entirely (including the extra padding introduced
   /// by the decoration to save space for the labels), set the [decoration] to
@@ -1237,7 +1237,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
   @override
   Widget build(BuildContext context) {
-    assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasDirectionality(context));
     assert(

--- a/packages/flutter/test/cupertino/form_section_test.dart
+++ b/packages/flutter/test/cupertino/form_section_test.dart
@@ -125,7 +125,7 @@ void main() {
           data: const MediaQueryData(),
           child: Localizations(
             locale: const Locale('en', 'US'),
-            delegates: <LocalizationsDelegate<dynamic>>[
+            delegates: const <LocalizationsDelegate<dynamic>>[
               DefaultCupertinoLocalizations.delegate,
               DefaultWidgetsLocalizations.delegate,
             ],

--- a/packages/flutter/test/cupertino/form_section_test.dart
+++ b/packages/flutter/test/cupertino/form_section_test.dart
@@ -123,9 +123,16 @@ void main() {
         textDirection: TextDirection.ltr,
         child: MediaQuery(
           data: const MediaQueryData(),
-          child: CupertinoFormSection(
-            backgroundColor: backgroundColor,
-            children: <Widget>[CupertinoTextFormFieldRow()],
+          child: Localizations(
+            locale: const Locale('en', 'US'),
+            delegates: <LocalizationsDelegate<dynamic>>[
+              DefaultCupertinoLocalizations.delegate,
+              DefaultWidgetsLocalizations.delegate,
+            ],
+            child: CupertinoFormSection(
+              backgroundColor: backgroundColor,
+              children: <Widget>[CupertinoTextFormFieldRow()],
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -9867,4 +9867,33 @@ void main() {
     skip: isContextMenuProvidedByPlatform, // [intended] only applies to platforms where we supply the context menu.
     variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{ TargetPlatform.iOS }),
   );
+
+  testWidgets('CupertinoTextField does not throw when not descended from a CupertinoApp widget', (WidgetTester tester) async {
+    final Widget textField = Localizations(
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        // CupertinoTextField requires CupertinoLocalizations to generate messages, labels,
+        // and abbreviations.
+        DefaultCupertinoLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      locale: const Locale('en', 'US'),
+      child: CupertinoTextField(),
+    );
+    await tester.pumpWidget(textField);
+    final dynamic exception = tester.takeException();
+    expect(exception, null);
+  });
+
+  testWidgets('CupertinoTextField throws when not descended from a CupertinoLocalizations', (WidgetTester tester) async {
+    final Widget textField = Localizations(
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      locale: const Locale('en', 'US'),
+      child: CupertinoTextField(),
+    );
+    await tester.pumpWidget(textField);
+    final dynamic exception = tester.takeException();
+    expect(exception.toString(), startsWith('No CupertinoLocalizations found.'));
+  });
 }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -9877,7 +9877,7 @@ void main() {
         DefaultWidgetsLocalizations.delegate,
       ],
       locale: const Locale('en', 'US'),
-      child: CupertinoTextField(),
+      child: const CupertinoTextField(),
     );
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();
@@ -9890,7 +9890,7 @@ void main() {
         DefaultWidgetsLocalizations.delegate,
       ],
       locale: const Locale('en', 'US'),
-      child: CupertinoTextField(),
+      child: const CupertinoTextField(),
     );
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -8407,7 +8407,7 @@ void main() {
         DefaultWidgetsLocalizations.delegate,
       ],
       locale: const Locale('en', 'US'),
-      child: TextField(),
+      child: const TextField(),
     );
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();
@@ -8420,7 +8420,7 @@ void main() {
         DefaultWidgetsLocalizations.delegate,
       ],
       locale: const Locale('en', 'US'),
-      child: TextField(),
+      child: const TextField(),
     );
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -8398,12 +8398,33 @@ void main() {
     // https://github.com/flutter/flutter/pull/57139#issuecomment-629048058
   }, skip: isBrowser); // [intended] see above.
 
-  testWidgets('TextField throws when not descended from a Material widget', (WidgetTester tester) async {
-    const Widget textField = TextField();
+  testWidgets('TextField does not throw when not descended from a Material widget', (WidgetTester tester) async {
+    final Widget textField = Localizations(
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        // TextField requires MaterialLocalizations to generate messages, labels,
+        // and abbreviations.
+        DefaultMaterialLocalizations.delegate,
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      locale: const Locale('en', 'US'),
+      child: TextField(),
+    );
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();
-    expect(exception, isFlutterError);
-    expect(exception.toString(), startsWith('No Material widget found.'));
+    expect(exception, null);
+  });
+
+  testWidgets('TextField throws when not descended from a MaterialLocalizations', (WidgetTester tester) async {
+    final Widget textField = Localizations(
+      delegates: const <LocalizationsDelegate<dynamic>>[
+        DefaultWidgetsLocalizations.delegate,
+      ],
+      locale: const Locale('en', 'US'),
+      child: TextField(),
+    );
+    await tester.pumpWidget(textField);
+    final dynamic exception = tester.takeException();
+    expect(exception.toString(), startsWith('No MaterialLocalizations found.'));
   });
 
   testWidgets('TextField loses focus when disabled', (WidgetTester tester) async {


### PR DESCRIPTION
This change adds an assertion in `CupertinoTextField` to check if the default cupertino localizations have been provided. This is necessary or else users may experience crashes when opening something like the context menu in a context outside of `CupertinoApp` which provides the default localizations.

This change also removes an assertion for `TextField` that required it to have a `Material` ancestor. It looks like this was added back in https://github.com/flutter/flutter/pull/16147 in response to https://github.com/flutter/flutter/issues/14764. The latter seems to be an issue due to `TextField` having an ink splash, but I think it has been a while since `TextField` had an ink splash. This allows `TextField` to be used in `CupertinoApp` and `WidgetsApp`. 

Fixes #133662

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.