### PR TITLE
Fix links in top level README

### DIFF
--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -13,15 +13,16 @@ SDK.
 This site hosts Flutter's API documentation. Other documentation can be found at
 the following locations:
 
-* [flutter.dev](https://flutter.dev) (main site)
-* [api.flutter.dev](https://api.flutter.dev) (API docs reference site)
+* [flutter.dev](https://flutter.dev) (main Flutter site)
+* [Stable channel API Docs](https://api.flutter.dev)
+* [Main channel API Docs](https://master-api.flutter.dev)
 * Engine Embedder API documentation:
-  * [Android Embedder](https://api.flutter.dev/javadoc/index.html)
-  * [iOS Embedder](https://api.flutter.dev/ios-embedder/index.html)
-  * [macOS Embedder](https://api.flutter.dev/macos-embedder/index.html)
-  * [Linux Embedder](https://api.flutter.dev/linux-embedder/index.html)
-  * [Windows Embedder](https://api.flutter.dev/windows-embedder/index.html)
-  * [Web Embedder](https://api.flutter.dev/flutter/dart-ui_web/dart-ui_web-library.html)
+  * [Android Embedder](../javadoc/index.html)
+  * [iOS Embedder](../ios-embedder/index.html)
+  * [macOS Embedder](../macos-embedder/index.html)
+  * [Linux Embedder](../linux-embedder/index.html)
+  * [Windows Embedder](../windows-embedder/index.html)
+  * [Web Embedder](dart-ui_web/dart-ui_web-library.html)
 * [Installation](https://flutter.dev/docs/get-started/install)
 * [Codelabs](https://flutter.dev/docs/codelabs)
 * [Contributing to Flutter](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
## Description

This fixes the top level links to the platform embedders in the README that is used to create the landing page on https://master-api.flutter.dev
