### PR TITLE
Move dispose to addTearDown

### DIFF
--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -115,6 +115,7 @@ void main() {
     final GlobalKey key = GlobalKey();
     final TextEditingController controller = TextEditingController();
     final FocusNode focusNode = FocusNode();
+    addTearDown(() { controller.dispose(); focusNode.dispose(); });
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -172,8 +173,6 @@ void main() {
       case TargetPlatform.macOS:
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
     }
-    controller.dispose();
-    focusNode.dispose();
   },
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
     variant: TargetPlatformVariant.all(),
@@ -245,6 +244,7 @@ void main() {
       Set<ContextMenuButtonType> buttonTypes = <ContextMenuButtonType>{};
       final TextEditingController controller = TextEditingController();
       final FocusNode focusNode = FocusNode();
+      addTearDown(() { focusNode.dispose(); controller.dispose(); });
 
       await tester.pumpWidget(
         MaterialApp(
@@ -328,9 +328,6 @@ void main() {
         case TargetPlatform.macOS:
           expect(buttonTypes, isNot(contains(ContextMenuButtonType.selectAll)));
       }
-
-      focusNode.dispose();
-      controller.dispose();
     },
       variant: TargetPlatformVariant.all(),
       skip: kIsWeb, // [intended]

--- a/packages/flutter/test/material/animated_icons_test.dart
+++ b/packages/flutter/test/material/animated_icons_test.dart
@@ -211,6 +211,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Semantic label', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    addTearDown(() => semantics.dispose());
 
     await tester.pumpWidget(
       const Directionality(
@@ -225,8 +226,6 @@ void main() {
     );
 
     expect(semantics, includesNodeWith(label: 'a label'));
-
-    semantics.dispose();
   });
 
   testWidgetsWithLeakTracking('Inherited text direction rtl', (WidgetTester tester) async {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1659,6 +1659,7 @@ void main() {
         forceMaterialTransparency:true,
         onPressed:() { buttonWasPressed = true; },
       );
+      addTearDown(() => controller.dispose());
       await tester.pumpWidget(widget);
 
       final Material material = getSliverAppBarMaterial(tester);
@@ -1668,8 +1669,6 @@ void main() {
       await tester.tap(buttonFinder);
       await tester.pump();
       expect(buttonWasPressed, isTrue);
-
-      controller.dispose();
     });
 
     testWidgetsWithLeakTracking(
@@ -1683,6 +1682,7 @@ void main() {
         forceMaterialTransparency:false,
         onPressed:() { buttonWasPressed = true; },
       );
+      addTearDown(() => controller.dispose());
       await tester.pumpWidget(widget);
 
       final Material material = getSliverAppBarMaterial(tester);
@@ -1692,8 +1692,6 @@ void main() {
       await tester.tap(buttonFinder, warnIfMissed:false);
       await tester.pump();
       expect(buttonWasPressed, isFalse);
-
-      controller.dispose();
     });
   });
 
@@ -2341,6 +2339,7 @@ void main() {
 
   testWidgetsWithLeakTracking('SliverAppBar provides correct semantics in LTR', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    addTearDown(() => semantics.dispose());
 
     await tester.pumpWidget(
       MaterialApp(
@@ -2416,12 +2415,11 @@ void main() {
       ignoreTransform: true,
       ignoreId: true,
     ));
-
-    semantics.dispose();
   });
 
   testWidgetsWithLeakTracking('SliverAppBar provides correct semantics in RTL', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    addTearDown(() => semantics.dispose());
 
     await tester.pumpWidget(
       MaterialApp(
@@ -2508,12 +2506,11 @@ void main() {
       ignoreTransform: true,
       ignoreId: true,
     ));
-
-    semantics.dispose();
   });
 
   testWidgetsWithLeakTracking('AppBar excludes header semantics correctly', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    addTearDown(() => semantics.dispose());
 
     await tester.pumpWidget(
       MaterialApp(
@@ -2564,12 +2561,11 @@ void main() {
       ignoreTransform: true,
       ignoreId: true,
     ));
-
-    semantics.dispose();
   });
 
   testWidgetsWithLeakTracking('SliverAppBar excludes header semantics correctly', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    addTearDown(() => semantics.dispose());
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -2633,13 +2629,12 @@ void main() {
       ignoreTransform: true,
       ignoreId: true,
     ));
-
-    semantics.dispose();
   });
 
   testWidgetsWithLeakTracking('SliverAppBar with flexible space has correct semantics order', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/64922.
     final SemanticsTester semantics = SemanticsTester(tester);
+    addTearDown(() => semantics.dispose());
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -2710,8 +2705,6 @@ void main() {
       ignoreTransform: true,
       ignoreId: true,
     ));
-
-    semantics.dispose();
   });
 
   testWidgetsWithLeakTracking('Material2 - AppBar draws a light system bar for a dark background', (WidgetTester tester) async {
@@ -4283,6 +4276,8 @@ void main() {
       testWidgetsWithLeakTracking('_handleScrollNotification safely calls setState()', (WidgetTester tester) async {
         // Regression test for failures found in Google internal issue b/185192049.
         final ScrollController controller = ScrollController(initialScrollOffset: 400);
+        addTearDown(() => controller.dispose());
+
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -4304,8 +4299,6 @@ void main() {
         );
 
         expect(tester.takeException(), isNull);
-
-        controller.dispose();
       });
 
       testWidgetsWithLeakTracking('does not trigger on horizontal scroll', (WidgetTester tester) async {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -59,6 +59,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Can place app inside FocusScope', (WidgetTester tester) async {
     final FocusScopeNode focusScopeNode = FocusScopeNode();
+    addTearDown(() => focusScopeNode.dispose());
 
     await tester.pumpWidget(FocusScope(
       autofocus: true,
@@ -69,7 +70,6 @@ void main() {
     ));
 
     expect(find.text('Home'), findsOneWidget);
-    focusScopeNode.dispose();
   });
 
   testWidgetsWithLeakTracking('Can show grid without losing sync', (WidgetTester tester) async {
@@ -1165,12 +1165,12 @@ void main() {
         uri: Uri.parse('initial'),
       ),
     );
+    addTearDown(() => provider.dispose());
     await tester.pumpWidget(MaterialApp.router(
       routeInformationProvider: provider,
       routerDelegate: delegate,
     ));
     expect(tester.takeException(), isAssertionError);
-    provider.dispose();
   });
 
   testWidgetsWithLeakTracking('MaterialApp.router throw if route configuration is provided along with other delegate', (WidgetTester tester) async {


### PR DESCRIPTION
Possible prompt for AI:
    // Do refactoring. Find and remove `x.dispose()` at the end of a test,
    // where x is some variable,
    // and add `addTearDown(() => x.dispose())` after declaration of `x`.

Regex to find all instances: \.dispose\(\);\n
