### PR TITLE
Scaffold can accept a materialBuilder 

### DIFF
--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -298,6 +298,11 @@ class Material extends StatefulWidget {
   final Color? surfaceTintColor;
 
   /// The typographical style to use for text within this material.
+  ///
+  /// The text style defined by this widget will override any parent [DefaultTextStyle].
+  ///
+  /// This value will default to [TextTheme.bodyMedium] from the nearest [Theme]
+  /// ancestor in the widget tree.
   final TextStyle? textStyle;
 
   /// Defines the material's shape as well its shadow.

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -35,6 +35,14 @@ import 'theme.dart';
 // late int tabCount;
 // late TickerProvider tickerProvider;
 
+/// Signature for a widget builder that builds the [Material] widget used by a [Scaffold].
+///
+/// Use the given `scaffoldContent` when building the child of the [Material] widget.
+typedef MaterialBuilderCallback = Widget Function(
+  BuildContext context,
+  Widget scaffoldContent,
+);
+
 const FloatingActionButtonLocation _kDefaultFloatingActionButtonLocation = FloatingActionButtonLocation.endFloat;
 const FloatingActionButtonAnimator _kDefaultFloatingActionButtonAnimator = FloatingActionButtonAnimator.scaling;
 
@@ -1613,6 +1621,7 @@ class Scaffold extends StatefulWidget {
     this.drawerEnableOpenDragGesture = true,
     this.endDrawerEnableOpenDragGesture = true,
     this.restorationId,
+    this.materialBuilder,
   });
 
   /// If true, and [bottomNavigationBar] or [persistentFooterButtons]
@@ -1868,6 +1877,11 @@ class Scaffold extends StatefulWidget {
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
   final String? restorationId;
+
+  /// Builds the [Material] widget used by this widget.
+  ///
+  /// If null, then this widget builds its own material widget.
+  final MaterialBuilderCallback? materialBuilder;
 
   /// Finds the [ScaffoldState] from the closest instance of this class that
   /// encloses the given context.
@@ -2991,38 +3005,45 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     // extendBody locked when keyboard is open
     final bool extendBody = minInsets.bottom <= 0 && widget.extendBody;
 
+    final Widget child = AnimatedBuilder(
+      animation: _floatingActionButtonMoveController,
+      builder: (BuildContext context, Widget? child) {
+        return Actions(
+          actions: <Type, Action<Intent>>{
+            DismissIntent: _DismissDrawerAction(context),
+          },
+          child: CustomMultiChildLayout(
+            delegate: _ScaffoldLayout(
+              extendBody: extendBody,
+              extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
+              minInsets: minInsets,
+              minViewPadding: minViewPadding,
+              currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
+              floatingActionButtonMoveAnimationProgress: _floatingActionButtonMoveController.value,
+              floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
+              geometryNotifier: _geometryNotifier,
+              previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,
+              textDirection: textDirection,
+              isSnackBarFloating: isSnackBarFloating,
+              extendBodyBehindMaterialBanner: extendBodyBehindMaterialBanner,
+              snackBarWidth: snackBarWidth,
+            ),
+            children: children,
+          ),
+        );
+      },
+    );
+
     return _ScaffoldScope(
       hasDrawer: hasDrawer,
       geometryNotifier: _geometryNotifier,
       child: ScrollNotificationObserver(
-        child: Material(
-          color: widget.backgroundColor ?? themeData.scaffoldBackgroundColor,
-          child: AnimatedBuilder(animation: _floatingActionButtonMoveController, builder: (BuildContext context, Widget? child) {
-            return Actions(
-              actions: <Type, Action<Intent>>{
-                DismissIntent: _DismissDrawerAction(context),
-              },
-              child: CustomMultiChildLayout(
-                delegate: _ScaffoldLayout(
-                  extendBody: extendBody,
-                  extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
-                  minInsets: minInsets,
-                  minViewPadding: minViewPadding,
-                  currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
-                  floatingActionButtonMoveAnimationProgress: _floatingActionButtonMoveController.value,
-                  floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
-                  geometryNotifier: _geometryNotifier,
-                  previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,
-                  textDirection: textDirection,
-                  isSnackBarFloating: isSnackBarFloating,
-                  extendBodyBehindMaterialBanner: extendBodyBehindMaterialBanner,
-                  snackBarWidth: snackBarWidth,
-                ),
-                children: children,
-              ),
-            );
-          }),
-        ),
+        child: widget.materialBuilder != null
+          ? widget.materialBuilder!(context, child)
+          : Material(
+              color: widget.backgroundColor ?? themeData.scaffoldBackgroundColor,
+              child: child,
+            ),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1460,6 +1460,11 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 ///
 /// This class provides APIs for showing drawers and bottom sheets.
 ///
+/// This widget's internal [Material] widget will override any parent
+/// [DefaultTextStyle]. The [Material] widget's text style defaults to
+/// [TextTheme.bodyMedium]. To override this behavior, use [materialBuilder]
+/// and build a [Material] widget with a custom [TextStyle].
+///
 /// To display a persistent bottom sheet, obtain the
 /// [ScaffoldState] for the current [BuildContext] via [Scaffold.of] and use the
 /// [ScaffoldState.showBottomSheet] function.

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -50,6 +50,42 @@ void main() {
     expect(controller.position.pixels, 100.0);
   });
 
+  testWidgets('Scaffold materialBuilder overrides default material', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        materialBuilder: (BuildContext context, Widget child) {
+          return Material(
+            textStyle: const TextStyle(
+              color: Colors.red,
+            ),
+            child: child,
+          );
+        },
+        appBar: const PreferredSize(
+          preferredSize: Size(50, 50),
+          child: Text ('Foo1'),
+        ),
+        body: const Center(
+          child: Text('Foo2'),
+        ),
+        floatingActionButton: const Text('Foo3'),
+      ),
+    ));
+
+    final RichText foo1 = tester.firstWidget(find.descendant(of: find.text('Foo1'), matching: find.byType(RichText)));
+    final RichText foo2 = tester.firstWidget(find.descendant(of: find.text('Foo2'), matching: find.byType(RichText)));
+    final RichText foo3 = tester.firstWidget(find.descendant(of: find.text('Foo3'), matching: find.byType(RichText)));
+
+    expect(foo1, isNotNull);
+    expect(foo1.text.style!.color,Colors.red);
+
+    expect(foo2, isNotNull);
+    expect(foo2.text.style!.color,Colors.red);
+
+    expect(foo3, isNotNull);
+    expect(foo3.text.style!.color,Colors.red);
+  });
+
   testWidgets('Scaffold drawer callback test', (WidgetTester tester) async {
     bool isDrawerOpen = false;
     bool isEndDrawerOpen = false;


### PR DESCRIPTION
This PR adds a `materialBuilder` to the `Scaffold` so that the user can provide a `Material` widget with a different `TextStyle` than the default. This is necessary in some cases because when there is an ancestor `DefaultTextStyle`, the internal `Material` widget used by `Scaffold` will always override it.

Using a builder saves us from having to pipe through additional parameters over time. Though this may be overkill for this situation, I am open to other ideas like a `defaultTextStyle` parameter. 

Fixes #120334.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.