### PR TITLE
SelectionArea long press selection overlay behavior should match native

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -541,8 +541,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     _selectWordAt(offset: details.globalPosition);
     // Platforms besides Android will show the text selection handles when
     // the long press is initiated. Android shows the text selection handles when
-    // the long press has ended, usually after the user has lifted their finger
-    // off the screen.
+    // the long press has ended, usually after a pointer up event is received.
     if (defaultTargetPlatform != TargetPlatform.android) {
       _showHandles();
     }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -539,6 +539,10 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     HapticFeedback.selectionClick();
     widget.focusNode.requestFocus();
     _selectWordAt(offset: details.globalPosition);
+    // Platforms besides Android will show the text selection handles when
+    // the long press is initiated. Android shows the text selection handles when
+    // the long press has ended, usually after the user has lifted their finger
+    // off the screen.
     if (defaultTargetPlatform != TargetPlatform.android) {
       _showHandles();
     }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -539,8 +539,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     HapticFeedback.selectionClick();
     widget.focusNode.requestFocus();
     _selectWordAt(offset: details.globalPosition);
-    _showToolbar();
-    _showHandles();
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      _showHandles();
+    }
     _updateSelectedContentIfNeeded();
   }
 
@@ -552,6 +553,10 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleTouchLongPressEnd(LongPressEndDetails details) {
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
+    _showToolbar();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      _showHandles();
+    }
   }
 
   bool _positionIsOnActiveSelection({required Offset globalPosition}) {

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -151,6 +151,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
     // `are` is selected.
     expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
@@ -189,6 +191,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
     // `are` is selected.
     expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
@@ -262,6 +266,7 @@ void main() {
     await gesture.up();
     final List<TextBox> boxes = paragraph2.getBoxesForSelection(paragraph2.selections[0]);
     expect(boxes.length, 1);
+    await tester.pumpAndSettle();
     // There is a selection now.
     // We check the presence of the copy button to make sure the selection toolbar
     // is showing.

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -561,6 +561,7 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump(const Duration(milliseconds: 500));
     await gesture.up();
+    await tester.pumpAndSettle();
     expect(paragraph0.selections[0], const TextSelection(baseOffset: 0, extentOffset: 4));
 
     final List<TextBox> boxes = paragraph0.getBoxesForSelection(paragraph0.selections[0]);
@@ -619,6 +620,7 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump(const Duration(milliseconds: 500));
     await gesture.up();
+    await tester.pumpAndSettle();
     expect(paragraph0.selections[0], const TextSelection(baseOffset: 0, extentOffset: 4));
 
     final List<TextBox> boxes = paragraph0.getBoxesForSelection(paragraph0.selections[0]);
@@ -674,6 +676,7 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump(const Duration(milliseconds: 500));
     await gesture.up();
+    await tester.pumpAndSettle();
     expect(paragraph0.selections[0], const TextSelection(baseOffset: 0, extentOffset: 4));
 
     final List<TextBox> boxes = paragraph0.getBoxesForSelection(paragraph0.selections[0]);

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -2851,6 +2851,9 @@ void main() {
     // `are` is selected.
     expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
     await tester.pumpAndSettle();
+
+    await gesture.up();
+    await tester.pumpAndSettle();
     // Text selection toolbar has appeared.
     expect(find.text('Copy'), findsOneWidget);
 
@@ -3018,6 +3021,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
     // `are` is selected.
     expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(buttonTypes, contains(ContextMenuButtonType.copy));

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1039,7 +1039,7 @@ void main() {
         expect(right.opacity.value, equals(1.0));
         expect(find.byKey(toolbarKey), findsOneWidget);
       },
-      variant: TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
+      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
       skip: kIsWeb, // [intended] Web uses its native context menu.
     );
 


### PR DESCRIPTION
During a long press, on native iOS the context menu does not show until the long press has ended. The handles are shown immediately when the long press begins. This is true for static and editable text.

For static text on Android, the context menu appears when the long press is initiated, but the handles do not appear until the long press has ended. For editable text on Android, the context menu does not appear until the long press ended, and the handles also do not appear until the end.

For both platforms in editable/static contexts the context menu does not show while doing a long press drag.

I think the behavior where the context menu is not shown until the long press ends makes the most sense even though Android varies in this depending on the context. The user is not able to react to the context menu until the long press has ended.

Other details:
On a windows touch screen device the context menu does not show up until the long press ends in editable/static text contexts. On a long press hold it selects the word on drag start as well as popping up the selection handles (static text).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.