### PR TITLE
TextField and TextFormField can use a MaterialStatesController

### DIFF
--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -741,7 +741,6 @@ class MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
 /// are notified whenever the [value] changes. The [value] should only be
 /// changed with [update]; it should not be modified directly.
 ///
-/// {@template flutter.material.MaterialStatesController.details}
 /// The controller's [value] represents the set of states that a
 /// widget's visual properties, typically [MaterialStateProperty]
 /// values, are resolved against. It is _not_ the intrinsic state of
@@ -751,7 +750,6 @@ class MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
 /// [MaterialState.focused] to its controller. When the widget gains the
 /// or loses the focus it will [update] its controller's [value] and
 /// notify listeners of the change.
-/// {@endtemplate}
 class MaterialStatesController extends ValueNotifier<Set<MaterialState>> {
   /// Creates a MaterialStatesController.
   MaterialStatesController([Set<MaterialState>? value]) : super(<MaterialState>{...?value});

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -741,6 +741,7 @@ class MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
 /// are notified whenever the [value] changes. The [value] should only be
 /// changed with [update]; it should not be modified directly.
 ///
+/// {@template flutter.material.MaterialStatesController.details}
 /// The controller's [value] represents the set of states that a
 /// widget's visual properties, typically [MaterialStateProperty]
 /// values, are resolved against. It is _not_ the intrinsic state of
@@ -750,6 +751,7 @@ class MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
 /// [MaterialState.focused] to its controller. When the widget gains the
 /// or loses the focus it will [update] its controller's [value] and
 /// notify listeners of the change.
+/// {@endtemplate}
 class MaterialStatesController extends ValueNotifier<Set<MaterialState>> {
   /// Creates a MaterialStatesController.
   MaterialStatesController([Set<MaterialState>? value]) : super(<MaterialState>{...?value});

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1308,19 +1308,10 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   }
   // AutofillClient implementation end.
 
-  Set<MaterialState> get _materialState {
-    return <MaterialState>{
-      if (!_isEnabled) MaterialState.disabled,
-      if (_isHovering) MaterialState.hovered,
-      if (_effectiveFocusNode.hasFocus) MaterialState.focused,
-      if (_hasError) MaterialState.error,
-    };
-  }
-
   TextStyle _getInputStyleForState(TextStyle style) {
     final ThemeData theme = Theme.of(context);
-    final TextStyle stateStyle = MaterialStateProperty.resolveAs(theme.useMaterial3 ? _m3StateInputStyle(context)! : _m2StateInputStyle(context)!, _materialState);
-    final TextStyle providedStyle = MaterialStateProperty.resolveAs(style, _materialState);
+    final TextStyle stateStyle = MaterialStateProperty.resolveAs(theme.useMaterial3 ? _m3StateInputStyle(context)! : _m2StateInputStyle(context)!, _statesController.value);
+    final TextStyle providedStyle = MaterialStateProperty.resolveAs(style, _statesController.value);
     return providedStyle.merge(stateStyle);
   }
 
@@ -1337,7 +1328,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
     final ThemeData theme = Theme.of(context);
     final DefaultSelectionStyle selectionStyle = DefaultSelectionStyle.of(context);
-    final TextStyle? providedStyle = MaterialStateProperty.resolveAs(widget.style, _materialState);
+    final TextStyle? providedStyle = MaterialStateProperty.resolveAs(widget.style, _statesController.value);
     final TextStyle style = _getInputStyleForState(theme.useMaterial3 ? _m3InputStyle(context) : theme.textTheme.titleMedium!).merge(providedStyle);
     final Brightness keyboardAppearance = widget.keyboardAppearance ?? theme.brightness;
     final TextEditingController controller = _effectiveController;
@@ -1552,7 +1543,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     }
     final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor>(
       widget.mouseCursor ?? MaterialStateMouseCursor.textable,
-      _materialState,
+      _statesController.value,
     );
 
     final int? semanticsMaxValueLength;

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1067,7 +1067,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     }
     _effectiveFocusNode.canRequestFocus = widget.canRequestFocus && _isEnabled;
     _effectiveFocusNode.addListener(_handleFocusChanged);
-    initStatesController();
+    _initStatesController();
   }
 
   bool get _canRequestFocus {
@@ -1113,16 +1113,16 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     if (widget.statesController != oldWidget.statesController) {
       oldWidget.statesController?.removeListener(_handleStatesControllerChange);
       if (widget.statesController != null) {
-        internalStatesController?.dispose();
-        internalStatesController = null;
+        _internalStatesController?.dispose();
+        _internalStatesController = null;
       }
-      initStatesController();
+      _initStatesController();
     }
     if (_isWidgetEnabled(widget) != _isWidgetEnabled(oldWidget)) {
-      statesController.update(MaterialState.disabled, !_isEnabled);
+      _statesController.update(MaterialState.disabled, !_isEnabled);
     }
     if (_widgetHasError(widget) != _widgetHasError(oldWidget)) {
-      statesController.update(MaterialState.error, _hasError);
+      _statesController.update(MaterialState.error, _hasError);
     }
   }
 
@@ -1156,8 +1156,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     _effectiveFocusNode.removeListener(_handleFocusChanged);
     _focusNode?.dispose();
     _controller?.dispose();
-    statesController.removeListener(_handleStatesControllerChange);
-    internalStatesController?.dispose();
+    _statesController.removeListener(_handleStatesControllerChange);
+    _internalStatesController?.dispose();
     super.dispose();
   }
 
@@ -1202,7 +1202,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       // Rebuild the widget on focus change to show/hide the text selection
       // highlight.
     });
-    statesController.update(MaterialState.focused, _effectiveFocusNode.hasFocus);
+    _statesController.update(MaterialState.focused, _effectiveFocusNode.hasFocus);
   }
 
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
@@ -1251,26 +1251,26 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       setState(() {
         _isHovering = hovering;
       });
-      statesController.update(MaterialState.hovered, _isHovering);
+      _statesController.update(MaterialState.hovered, _isHovering);
     }
   }
 
   // Material states controller.
-  MaterialStatesController? internalStatesController;
+  MaterialStatesController? _internalStatesController;
 
   void _handleStatesControllerChange() {
     // Force a rebuild to resolve MaterialStateProperty properties
     setState(() { });
   }
 
-  MaterialStatesController get statesController => widget.statesController ?? internalStatesController!;
+  MaterialStatesController get _statesController => widget.statesController ?? _internalStatesController!;
 
-  void initStatesController() {
+  void _initStatesController() {
     if (widget.statesController == null) {
-      internalStatesController = MaterialStatesController();
+      _internalStatesController = MaterialStatesController();
     }
-    statesController.update(MaterialState.disabled, !_isEnabled);
-    statesController.addListener(_handleStatesControllerChange);
+    _statesController.update(MaterialState.disabled, !_isEnabled);
+    _statesController.addListener(_handleStatesControllerChange);
   }
 
   // AutofillClient implementation start.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1291,6 +1291,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       _internalStatesController = MaterialStatesController();
     }
     _statesController.update(MaterialState.disabled, !_isEnabled);
+    _statesController.update(MaterialState.error, _hasError);
+    _hadError = _hasError;
     _statesController.addListener(_handleStatesControllerChange);
   }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -458,7 +458,15 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
 
-  /// {@macro flutter.material.inkwell.statesController}
+  /// Represents the interactive "state" of this widget in terms of
+  /// a set of [MaterialState]s, like [MaterialState.disabled] and
+  /// [MaterialState.focused].
+  ///
+  /// Classes based on this one can provide their own
+  /// [MaterialStatesController] to which they've added listeners.
+  /// They can also update the controller's [MaterialStatesController.value]
+  /// however, this may only be done when it's safe to call
+  /// [State.setState], like in an event handler.
   final MaterialStatesController? statesController;
 
   /// {@macro flutter.widgets.editableText.obscuringCharacter}
@@ -1259,7 +1267,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   MaterialStatesController? _internalStatesController;
 
   void _handleStatesControllerChange() {
-    // Force a rebuild to resolve MaterialStateProperty properties
+    // Force a rebuild to resolve MaterialStateProperty properties.
     setState(() { });
   }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1075,11 +1075,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     _effectiveFocusNode.canRequestFocus = widget.canRequestFocus && _isEnabled;
     _effectiveFocusNode.addListener(_handleFocusChanged);
     _initStatesController();
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        _hadError = _hasError;
-      }
-    });
   }
 
   bool get _canRequestFocus {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -996,10 +996,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
   bool get _hasError => widget.decoration?.errorText != null || widget.decoration?.error != null || _hasIntrinsicError;
 
-  bool _widgetHasError(TextField widget) {
-    return widget.decoration?.errorText != null || _hasIntrinsicError;
-  }
-
   Color get _errorColor => widget.cursorErrorColor ?? widget.decoration?.errorStyle?.color ?? Theme.of(context).colorScheme.error;
 
   bool? _hadError;

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -458,8 +458,8 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
 
-  /// Represents the interactive "state" of this widget in terms of
-  /// a set of [MaterialState]s, including [MaterialState.disabled], [MaterialState.hovered],
+  /// Represents the interactive "state" of this widget in terms of a set of
+  /// [MaterialState]s, including [MaterialState.disabled], [MaterialState.hovered],
   /// [MaterialState.error], and [MaterialState.focused].
   ///
   /// Classes based on this one can provide their own
@@ -467,6 +467,8 @@ class TextField extends StatefulWidget {
   /// They can also update the controller's [MaterialStatesController.value]
   /// however, this may only be done when it's safe to call
   /// [State.setState], like in an event handler.
+  ///
+  /// {@macro flutter.material.MaterialStatesController.details}
   final MaterialStatesController? statesController;
 
   /// {@macro flutter.widgets.editableText.obscuringCharacter}

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1092,10 +1092,18 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     }
   }
 
+  void _updateMaterialErrorState() {
+    if (_hasError != _hadError) {
+      _statesController.update(MaterialState.error, _hasError);
+      _hadError = _hasError;
+    }
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _effectiveFocusNode.canRequestFocus = _canRequestFocus;
+    _updateMaterialErrorState();
   }
 
   @override
@@ -1122,24 +1130,22 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       }
     }
 
-    if (widget.statesController != oldWidget.statesController) {
+    if (widget.statesController == oldWidget.statesController) {
+      final bool isOldWidgetEnabled = oldWidget.enabled ?? oldWidget.decoration?.enabled ?? true;
+
+      if (_isEnabled != isOldWidgetEnabled) {
+        _statesController.update(MaterialState.disabled, !_isEnabled);
+      }
+
+      _updateMaterialErrorState();
+    } else {
       oldWidget.statesController?.removeListener(_handleStatesControllerChange);
       if (widget.statesController != null) {
         _internalStatesController?.dispose();
         _internalStatesController = null;
       }
       _initStatesController();
-    }
-
-    final bool isOldWidgetEnabled = oldWidget.enabled ?? oldWidget.decoration?.enabled ?? true;
-
-    if (_isEnabled != isOldWidgetEnabled) {
-      _statesController.update(MaterialState.disabled, !_isEnabled);
-    }
-
-    if (_hasError != _hadError) {
-      _statesController.update(MaterialState.error, _hasError);
-      _hadError = _hasError;
+      _updateMaterialErrorState();
     }
   }
 
@@ -1287,8 +1293,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       _internalStatesController = MaterialStatesController();
     }
     _statesController.update(MaterialState.disabled, !_isEnabled);
-    _statesController.update(MaterialState.error, _hasError);
-    _hadError = _hasError;
+    _statesController.update(MaterialState.hovered, _isHovering);
+    _statesController.update(MaterialState.focused, _effectiveFocusNode.hasFocus);
     _statesController.addListener(_handleStatesControllerChange);
   }
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -992,8 +992,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
   int get _currentLength => _effectiveController.value.text.characters.length;
 
-  bool get _hasIntrinsicError => widget.maxLength != null && 
-                                 widget.maxLength! > 0 && 
+  bool get _hasIntrinsicError => widget.maxLength != null &&
+                                 widget.maxLength! > 0 &&
                                  (widget.controller == null ?
                                  !restorePending && _effectiveController.value.text.characters.length > widget.maxLength! :
                                  _effectiveController.value.text.characters.length > widget.maxLength!);

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
 import 'color_scheme.dart';
@@ -1074,7 +1075,11 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     _effectiveFocusNode.canRequestFocus = widget.canRequestFocus && _isEnabled;
     _effectiveFocusNode.addListener(_handleFocusChanged);
     _initStatesController();
-    _hadError = _hasError;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _hadError = _hasError;
+      }
+    });
   }
 
   bool get _canRequestFocus {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -459,8 +459,8 @@ class TextField extends StatefulWidget {
   final bool autofocus;
 
   /// Represents the interactive "state" of this widget in terms of
-  /// a set of [MaterialState]s, like [MaterialState.disabled] and
-  /// [MaterialState.focused].
+  /// a set of [MaterialState]s, including [MaterialState.disabled], [MaterialState.hovered],
+  /// [MaterialState.error], and [MaterialState.focused].
   ///
   /// Classes based on this one can provide their own
   /// [MaterialStatesController] to which they've added listeners.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -995,7 +995,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   bool get _hasIntrinsicError => widget.maxLength != null && 
                                  widget.maxLength! > 0 && 
                                  (widget.controller == null ?
-                                 (_controller?.isRegistered ?? false) && _effectiveController.value.text.characters.length > widget.maxLength! :
+                                 !restorePending && _effectiveController.value.text.characters.length > widget.maxLength! :
                                  _effectiveController.value.text.characters.length > widget.maxLength!);
 
   bool get _hasError => widget.decoration?.errorText != null || widget.decoration?.error != null || _hasIntrinsicError;

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -468,7 +468,15 @@ class TextField extends StatefulWidget {
   /// however, this may only be done when it's safe to call
   /// [State.setState], like in an event handler.
   ///
-  /// {@macro flutter.material.MaterialStatesController.details}
+  /// The controller's [MaterialStatesController.value] represents the set of
+  /// states that a widget's visual properties, typically [MaterialStateProperty]
+  /// values, are resolved against. It is _not_ the intrinsic state of the widget.
+  /// The widget is responsible for ensuring that the controller's
+  /// [MaterialStatesController.value] tracks its intrinsic state. For example
+  /// one cannot request the keyboard focus for a widget by adding [MaterialState.focused]
+  /// to its controller. When the widget gains the or loses the focus it will
+  /// [MaterialStatesController.update] its controller's [MaterialStatesController.value]
+  /// and notify listeners of the change.
   final MaterialStatesController? statesController;
 
   /// {@macro flutter.widgets.editableText.obscuringCharacter}

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -9,7 +9,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/scheduler.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
 import 'color_scheme.dart';

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -980,10 +980,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
   bool get _isEnabled =>  widget.enabled ?? widget.decoration?.enabled ?? true;
 
-  bool _isWidgetEnabled(TextField widget) {
-    return widget.enabled ?? widget.decoration?.enabled ?? true;
-  }
-
   int get _currentLength => _effectiveController.value.text.characters.length;
 
   bool get _hasIntrinsicError => widget.maxLength != null && widget.maxLength! > 0 && _effectiveController.value.text.characters.length > widget.maxLength!;
@@ -995,6 +991,8 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   }
 
   Color get _errorColor => widget.cursorErrorColor ?? widget.decoration?.errorStyle?.color ?? Theme.of(context).colorScheme.error;
+
+  bool? _hadError;
 
   InputDecoration _getEffectiveDecoration() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
@@ -1076,6 +1074,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     _effectiveFocusNode.canRequestFocus = widget.canRequestFocus && _isEnabled;
     _effectiveFocusNode.addListener(_handleFocusChanged);
     _initStatesController();
+    _hadError = _hasError;
   }
 
   bool get _canRequestFocus {
@@ -1126,11 +1125,16 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       }
       _initStatesController();
     }
-    if (_isWidgetEnabled(widget) != _isWidgetEnabled(oldWidget)) {
+
+    final bool isOldWidgetEnabled = oldWidget.enabled ?? oldWidget.decoration?.enabled ?? true;
+
+    if (_isEnabled != isOldWidgetEnabled) {
       _statesController.update(MaterialState.disabled, !_isEnabled);
     }
-    if (_widgetHasError(widget) != _widgetHasError(oldWidget)) {
+
+    if (_hasError != _hadError) {
       _statesController.update(MaterialState.error, _hasError);
+      _hadError = _hasError;
     }
   }
 

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart';
 
 import 'adaptive_text_selection_toolbar.dart';
 import 'input_decorator.dart';
+import 'material_state.dart';
 import 'text_field.dart';
 import 'theme.dart';
 
@@ -167,6 +168,7 @@ class TextFormField extends FormField<String> {
     ui.BoxWidthStyle selectionWidthStyle = ui.BoxWidthStyle.tight,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
     ContentInsertionConfiguration? contentInsertionConfiguration,
+    MaterialStatesController? statesController,
     Clip clipBehavior = Clip.hardEdge,
     bool scribbleEnabled = true,
     bool canRequestFocus = true,
@@ -196,6 +198,9 @@ class TextFormField extends FormField<String> {
              field.didChange(value);
              onChanged?.call(value);
            }
+           if (statesController !=  null) {
+            statesController.update(MaterialState.error, field.errorText != null);
+           }
            return UnmanagedRestorationScope(
              bucket: field.bucket,
              child: TextField(
@@ -212,6 +217,7 @@ class TextFormField extends FormField<String> {
                textDirection: textDirection,
                textCapitalization: textCapitalization,
                autofocus: autofocus,
+               statesController: statesController,
                toolbarOptions: toolbarOptions,
                readOnly: readOnly,
                showCursor: showCursor,

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -198,9 +198,6 @@ class TextFormField extends FormField<String> {
              field.didChange(value);
              onChanged?.call(value);
            }
-           if (statesController !=  null) {
-            statesController.update(MaterialState.error, field.errorText != null);
-           }
            return UnmanagedRestorationScope(
              bucket: field.bucket,
              child: TextField(


### PR DESCRIPTION
This change adds support for a `MaterialStatesController` in `TextField` and `TextFormField`. With this change a user can listen to `MaterialState` changes in an input field by passing a `MaterialStatesController` to `TextField` or `TextFormField`.

Fixes #133273

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.