### PR TITLE
Add `CheckedPopupMenuItem.onTap` callback

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -487,7 +487,6 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
     super.mouseCursor,
     super.child,
     super.onTap,
-    super.textStyle,
   });
 
   /// Whether to display a checkmark next to the menu item.

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -486,6 +486,8 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
     super.labelTextStyle,
     super.mouseCursor,
     super.child,
+    super.onTap,
+    super.textStyle,
   });
 
   /// Whether to display a checkmark next to the menu item.

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3740,7 +3740,10 @@ void main() {
 
   testWidgets('CheckedPopupMenuItem.onTap callback is called when defined', (WidgetTester tester) async {
     final List<int> menuItemTapCounters = <int>[0, 0];
-
+    final UniqueKey key1 = UniqueKey();
+    final UniqueKey key2 = UniqueKey();
+    final UniqueKey key3 = UniqueKey();
+    
     await tester.pumpWidget(
       TestApp(
         textDirection: TextDirection.ltr,
@@ -3750,19 +3753,22 @@ void main() {
               child: const Text('Actions'),
               itemBuilder: (BuildContext context) => <PopupMenuItem<void>>[
                 CheckedPopupMenuItem<void>(
+                  key: key1,
                   child: const Text('First option'),
                   onTap: () {
                     menuItemTapCounters[0] += 1;
                   },
                 ),
                 CheckedPopupMenuItem<void>(
+                  key: key2,
                   child: const Text('Second option'),
                   onTap: () {
                     menuItemTapCounters[1] += 1;
                   },
                 ),
-                const CheckedPopupMenuItem<void>(
-                  child: Text('Option without onTap'),
+                CheckedPopupMenuItem<void>(
+                  key: key3,
+                  child: const Text('Option without onTap'),
                 ),
               ],
             ),
@@ -3774,28 +3780,28 @@ void main() {
     // Tap the first time
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('First option'));
+    await tester.tap(find.byKey(key1));
     await tester.pumpAndSettle();
     expect(menuItemTapCounters, <int>[1, 0]);
 
     // Tap the item again
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('First option'));
+    await tester.tap(find.byKey(key1));
     await tester.pumpAndSettle();
     expect(menuItemTapCounters, <int>[2, 0]);
 
     // Tap a different item
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Second option'));
+    await tester.tap(find.byKey(key2));
     await tester.pumpAndSettle();
     expect(menuItemTapCounters, <int>[2, 1]);
 
     // Tap an item without onTap
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Option without onTap'));
+    await tester.tap(find.byKey(key3));
     await tester.pumpAndSettle();
     expect(menuItemTapCounters, <int>[2, 1]);
   });

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3805,51 +3805,6 @@ void main() {
     await tester.pumpAndSettle();
     expect(menuItemTapCounters, <int>[2, 1]);
   });
-
-  testWidgets('Material2 - CheckedPopupMenuItem honors textStyle', (WidgetTester tester) async {
-    final Key popupMenuButtonKey = UniqueKey();
-    final ThemeData theme = ThemeData(useMaterial3: false);
-
-    Widget buildMenu() {
-      return MaterialApp(
-        theme: theme,
-        home: Scaffold(
-          body: Center(
-            child: PopupMenuButton<String>(
-              key: popupMenuButtonKey,
-              child: const Text('button'),
-              onSelected: (String result) { },
-              itemBuilder: (BuildContext context) {
-                return <PopupMenuItem<String>>[
-                   // Popup menu item with a Text widget.
-                   const CheckedPopupMenuItem<String>(
-                    value: '0',
-                    textStyle: TextStyle(color: Colors.red),
-                    child: Text('Item 0'),
-                  ),
-                  // Popup menu item with a ListTile widget.
-                  const CheckedPopupMenuItem<String>(
-                    value: '1',
-                    textStyle: TextStyle(color: Colors.green),
-                    child: ListTile(title: Text('Item 1')),
-                  ),
-                ];
-              },
-            ),
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(buildMenu());
-
-    // Show the menu.
-    await tester.tap(find.byKey(popupMenuButtonKey));
-    await tester.pumpAndSettle();
-
-    expect(_labelStyle(tester, 'Item 0')!.color, Colors.red);
-    expect(_labelStyle(tester, 'Item 1')!.color, Colors.green);
-  });
 }
 
 class TestApp extends StatelessWidget {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3737,6 +3737,113 @@ void main() {
     expect(_labelStyle(tester, 'Item 1')!.fontWeight, customTextStyle.fontWeight);
     expect(_labelStyle(tester, 'Item 1')!.fontStyle, customTextStyle.fontStyle);
   });
+
+  testWidgets('CheckedPopupMenuItem.onTap callback is called when defined', (WidgetTester tester) async {
+    final List<int> menuItemTapCounters = <int>[0, 0];
+
+    await tester.pumpWidget(
+      TestApp(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: RepaintBoundary(
+            child: PopupMenuButton<void>(
+              child: const Text('Actions'),
+              itemBuilder: (BuildContext context) => <PopupMenuItem<void>>[
+                CheckedPopupMenuItem<void>(
+                  child: const Text('First option'),
+                  onTap: () {
+                    menuItemTapCounters[0] += 1;
+                  },
+                ),
+                CheckedPopupMenuItem<void>(
+                  child: const Text('Second option'),
+                  onTap: () {
+                    menuItemTapCounters[1] += 1;
+                  },
+                ),
+                const CheckedPopupMenuItem<void>(
+                  child: Text('Option without onTap'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Tap the first time
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('First option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[1, 0]);
+
+    // Tap the item again
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('First option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 0]);
+
+    // Tap a different item
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Second option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 1]);
+
+    // Tap an item without onTap
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Option without onTap'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 1]);
+  });
+
+  testWidgets('Material2 - CheckedPopupMenuItem honors textStyle', (WidgetTester tester) async {
+    final Key popupMenuButtonKey = UniqueKey();
+    final ThemeData theme = ThemeData(useMaterial3: false);
+
+    Widget buildMenu() {
+      return MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              key: popupMenuButtonKey,
+              child: const Text('button'),
+              onSelected: (String result) { },
+              itemBuilder: (BuildContext context) {
+                return <PopupMenuItem<String>>[
+                   // Popup menu item with a Text widget.
+                   const CheckedPopupMenuItem<String>(
+                    value: '0',
+                    textStyle: TextStyle(color: Colors.red),
+                    child: Text('Item 0'),
+                  ),
+                  // Popup menu item with a ListTile widget.
+                  const CheckedPopupMenuItem<String>(
+                    value: '1',
+                    textStyle: TextStyle(color: Colors.green),
+                    child: ListTile(title: Text('Item 1')),
+                  ),
+                ];
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildMenu());
+
+    // Show the menu.
+    await tester.tap(find.byKey(popupMenuButtonKey));
+    await tester.pumpAndSettle();
+
+    expect(_labelStyle(tester, 'Item 0')!.color, Colors.red);
+    expect(_labelStyle(tester, 'Item 1')!.color, Colors.green);
+  });
 }
 
 class TestApp extends StatelessWidget {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3739,7 +3739,7 @@ void main() {
   });
 
   testWidgets('CheckedPopupMenuItem.onTap callback is called when defined', (WidgetTester tester) async {
-    final List<int> menuItemTapCounters = <int>[0, 0];
+    int count = 0;
     final UniqueKey key1 = UniqueKey();
     final UniqueKey key2 = UniqueKey();
 
@@ -3755,7 +3755,7 @@ void main() {
                   key: key1,
                   child: const Text('First option'),
                   onTap: () {
-                    menuItemTapCounters[0] += 1;
+                    count += 1;
                   },
                 ),
                 CheckedPopupMenuItem<void>(
@@ -3774,14 +3774,14 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(key1));
     await tester.pumpAndSettle();
-    expect(menuItemTapCounters, <int>[1, 0]);
+    expect(count, 1);
 
     // Tap an item without onTap
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(key2));
     await tester.pumpAndSettle();
-    expect(menuItemTapCounters, <int>[1, 0]);
+    expect(count, 1);
   });
 }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3740,8 +3740,7 @@ void main() {
 
   testWidgets('CheckedPopupMenuItem.onTap callback is called when defined', (WidgetTester tester) async {
     int count = 0;
-    final UniqueKey key1 = UniqueKey();
-    final UniqueKey key2 = UniqueKey();
+    final Type menuItemType = const CheckedPopupMenuItem<void>(child: Text('item')).runtimeType;
 
     await tester.pumpWidget(
       TestApp(
@@ -3752,15 +3751,13 @@ void main() {
               child: const Text('Actions'),
               itemBuilder: (BuildContext context) => <PopupMenuItem<void>>[
                 CheckedPopupMenuItem<void>(
-                  key: key1,
                   child: const Text('First option'),
                   onTap: () {
                     count += 1;
                   },
                 ),
-                CheckedPopupMenuItem<void>(
-                  key: key2,
-                  child: const Text('Option without onTap'),
+                const CheckedPopupMenuItem<void>(
+                  child: Text('Option without onTap'),
                 ),
               ],
             ),
@@ -3772,14 +3769,14 @@ void main() {
     // Tap the first time
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(key1));
+    await tester.tap(find.widgetWithText(menuItemType, 'First option'));
     await tester.pumpAndSettle();
     expect(count, 1);
 
     // Tap an item without onTap
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(key2));
+    await tester.tap(find.widgetWithText(menuItemType, 'Option without onTap'));
     await tester.pumpAndSettle();
     expect(count, 1);
   });

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3740,43 +3740,45 @@ void main() {
 
   testWidgets('CheckedPopupMenuItem.onTap callback is called when defined', (WidgetTester tester) async {
     int count = 0;
-    final Type menuItemType = const CheckedPopupMenuItem<void>(child: Text('item')).runtimeType;
-
     await tester.pumpWidget(
       TestApp(
         textDirection: TextDirection.ltr,
         child: Material(
           child: RepaintBoundary(
-            child: PopupMenuButton<void>(
-              child: const Text('Actions'),
-              itemBuilder: (BuildContext context) => <PopupMenuItem<void>>[
-                CheckedPopupMenuItem<void>(
-                  child: const Text('First option'),
-                  onTap: () {
-                    count += 1;
-                  },
-                ),
-                const CheckedPopupMenuItem<void>(
-                  child: Text('Option without onTap'),
-                ),
-              ],
+            child: PopupMenuButton<String>(
+              child: const Text('button'),
+              itemBuilder: (BuildContext context) {
+                  return  <PopupMenuItem<String>>[
+                  CheckedPopupMenuItem<String>(
+                    onTap: () {
+                      count += 1;
+                    },
+                    value: 'item1',
+                    child: const Text('Item with onTap'),
+                  ),
+                  const CheckedPopupMenuItem<String>(
+                    value: 'item2',
+                    child: Text('Item without onTap'),
+                  ),
+                ];
+              },
             ),
           ),
         ),
       ),
     );
 
-    // Tap the first time
-    await tester.tap(find.text('Actions'));
+    // Tap a checked menu item with onTap.
+    await tester.tap(find.text('button'));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(menuItemType, 'First option'));
+    await tester.tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Item with onTap'));
     await tester.pumpAndSettle();
     expect(count, 1);
 
-    // Tap an item without onTap
-    await tester.tap(find.text('Actions'));
+    // Tap a checked menu item without onTap.
+    await tester.tap(find.text('button'));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(menuItemType, 'Option without onTap'));
+    await tester.tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Item without onTap'));
     await tester.pumpAndSettle();
     expect(count, 1);
   });

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3742,7 +3742,6 @@ void main() {
     final List<int> menuItemTapCounters = <int>[0, 0];
     final UniqueKey key1 = UniqueKey();
     final UniqueKey key2 = UniqueKey();
-    final UniqueKey key3 = UniqueKey();
 
     await tester.pumpWidget(
       TestApp(
@@ -3761,13 +3760,6 @@ void main() {
                 ),
                 CheckedPopupMenuItem<void>(
                   key: key2,
-                  child: const Text('Second option'),
-                  onTap: () {
-                    menuItemTapCounters[1] += 1;
-                  },
-                ),
-                CheckedPopupMenuItem<void>(
-                  key: key3,
                   child: const Text('Option without onTap'),
                 ),
               ],
@@ -3784,26 +3776,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(menuItemTapCounters, <int>[1, 0]);
 
-    // Tap the item again
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(key1));
-    await tester.pumpAndSettle();
-    expect(menuItemTapCounters, <int>[2, 0]);
-
-    // Tap a different item
+    // Tap an item without onTap
     await tester.tap(find.text('Actions'));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(key2));
     await tester.pumpAndSettle();
-    expect(menuItemTapCounters, <int>[2, 1]);
-
-    // Tap an item without onTap
-    await tester.tap(find.text('Actions'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(key3));
-    await tester.pumpAndSettle();
-    expect(menuItemTapCounters, <int>[2, 1]);
+    expect(menuItemTapCounters, <int>[1, 0]);
   });
 }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3743,7 +3743,7 @@ void main() {
     final UniqueKey key1 = UniqueKey();
     final UniqueKey key2 = UniqueKey();
     final UniqueKey key3 = UniqueKey();
-    
+
     await tester.pumpWidget(
       TestApp(
         textDirection: TextDirection.ltr,


### PR DESCRIPTION
Adds parent prop `onTap` to CheckedPopupMenuItem.

Fixes #127800

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
