### PR TITLE
[Reland] Fix flavors test install checks

### DIFF
--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -13,8 +13,9 @@ Future<void> main() async {
   await task(() async {
     await createFlavorsTest().call();
     await createIntegrationTestFlavorsTest().call();
-    // test install and uninstall of flavors app
-    await inDirectory('${flutterDirectory.path}/dev/integration_tests/flavors', () async {
+
+    final TaskResult installTestsResult = await inDirectory(
+        '${flutterDirectory.path}/dev/integration_tests/flavors', () async {
       await flutter(
         'install',
         options: <String>['--debug', '--flavor', 'paid'],
@@ -23,6 +24,7 @@ Future<void> main() async {
         'install',
         options: <String>['--debug', '--flavor', 'paid', '--uninstall-only'],
       );
+
       final StringBuffer stderr = StringBuffer();
       await evalFlutter(
         'install',
@@ -36,8 +38,10 @@ Future<void> main() async {
         print(stderrString);
         return TaskResult.failure('Should not succeed with bogus flavor');
       }
+
+      return TaskResult.success(null);
     });
 
-    return TaskResult.success(null);
+    return installTestsResult;
   });
 }

--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -36,8 +36,8 @@ Future<void> main() async {
         );
 
         final String stderrString = stderr.toString();
-        final String expectedPath = path.join('build', 'app', 'outputs', 'flutter-apk', 'app-bogus-release.apk');
-        if (!stderrString.contains('"$expectedPath" does not exist.')) {
+        final String expectedApkPath = path.join('build', 'app', 'outputs', 'flutter-apk', 'app-bogus-release.apk');
+        if (!stderrString.contains('"$expectedApkPath" does not exist.')) {
           print(stderrString);
           return TaskResult.failure('Should not succeed with bogus flavor');
         }

--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -15,32 +15,34 @@ Future<void> main() async {
     await createIntegrationTestFlavorsTest().call();
 
     final TaskResult installTestsResult = await inDirectory(
-        '${flutterDirectory.path}/dev/integration_tests/flavors', () async {
-      await flutter(
-        'install',
-        options: <String>['--debug', '--flavor', 'paid'],
-      );
-      await flutter(
-        'install',
-        options: <String>['--debug', '--flavor', 'paid', '--uninstall-only'],
-      );
+      '${flutterDirectory.path}/dev/integration_tests/flavors',
+      () async {
+        await flutter(
+          'install',
+          options: <String>['--debug', '--flavor', 'paid'],
+        );
+        await flutter(
+          'install',
+          options: <String>['--debug', '--flavor', 'paid', '--uninstall-only'],
+        );
 
-      final StringBuffer stderr = StringBuffer();
-      await evalFlutter(
-        'install',
-        canFail: true,
-        stderr: stderr,
-        options: <String>['--flavor', 'bogus'],
-      );
+        final StringBuffer stderr = StringBuffer();
+        await evalFlutter(
+          'install',
+          canFail: true,
+          stderr: stderr,
+          options: <String>['--flavor', 'bogus'],
+        );
 
-      final String stderrString = stderr.toString();
-      if (!stderrString.contains('"build/app/outputs/flutter-apk/app-bogus-release.apk" does not exist.')) {
-        print(stderrString);
-        return TaskResult.failure('Should not succeed with bogus flavor');
-      }
+        final String stderrString = stderr.toString();
+        if (!stderrString.contains('"build/app/outputs/flutter-apk/app-bogus-release.apk" does not exist.')) {
+          print(stderrString);
+          return TaskResult.failure('Should not succeed with bogus flavor');
+        }
 
-      return TaskResult.success(null);
-    });
+        return TaskResult.success(null);
+      },
+    );
 
     return installTestsResult;
   });

--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';
+import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
@@ -35,7 +36,8 @@ Future<void> main() async {
         );
 
         final String stderrString = stderr.toString();
-        if (!stderrString.contains('"build/app/outputs/flutter-apk/app-bogus-release.apk" does not exist.')) {
+        final String expectedPath = path.join('build', 'app', 'outputs', 'flutter-apk', 'app-bogus-release.apk');
+        if (!stderrString.contains('"$expectedPath" does not exist.')) {
           print(stderrString);
           return TaskResult.failure('Should not succeed with bogus flavor');
         }

--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -34,7 +34,7 @@ Future<void> main() async {
       );
 
       final String stderrString = stderr.toString();
-      if (!stderrString.contains('The Xcode project defines schemes: free, paid')) {
+      if (!stderrString.contains('"build/app/outputs/flutter-apk/app-bogus-release.apk" does not exist.')) {
         print(stderrString);
         return TaskResult.failure('Should not succeed with bogus flavor');
       }

--- a/dev/devicelab/bin/tasks/flavors_test_ios.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_ios.dart
@@ -15,31 +15,33 @@ Future<void> main() async {
     await createIntegrationTestFlavorsTest().call();
     // test install and uninstall of flavors app
     final TaskResult installTestsResult = await inDirectory(
-        '${flutterDirectory.path}/dev/integration_tests/flavors', () async {
-      await flutter(
-        'install',
-        options: <String>['--flavor', 'paid'],
-      );
-      await flutter(
-        'install',
-        options: <String>['--flavor', 'paid', '--uninstall-only'],
-      );
-      final StringBuffer stderr = StringBuffer();
-      await evalFlutter(
-        'install',
-        canFail: true,
-        stderr: stderr,
-        options: <String>['--flavor', 'bogus'],
-      );
+      '${flutterDirectory.path}/dev/integration_tests/flavors',
+      () async {
+        await flutter(
+          'install',
+          options: <String>['--flavor', 'paid'],
+        );
+        await flutter(
+          'install',
+          options: <String>['--flavor', 'paid', '--uninstall-only'],
+        );
+        final StringBuffer stderr = StringBuffer();
+        await evalFlutter(
+          'install',
+          canFail: true,
+          stderr: stderr,
+          options: <String>['--flavor', 'bogus'],
+        );
 
-      final String stderrString = stderr.toString();
-      if (!stderrString.contains('The Xcode project defines schemes: free, paid')) {
-        print(stderrString);
-        return TaskResult.failure('Should not succeed with bogus flavor');
-      }
+        final String stderrString = stderr.toString();
+        if (!stderrString.contains('The Xcode project defines schemes: free, paid')) {
+          print(stderrString);
+          return TaskResult.failure('Should not succeed with bogus flavor');
+        }
 
-      return TaskResult.success(null);
-    });
+        return TaskResult.success(null);
+      },
+    );
 
     return installTestsResult;
   });

--- a/dev/devicelab/bin/tasks/flavors_test_ios.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_ios.dart
@@ -33,7 +33,7 @@ Future<void> main() async {
       );
 
       final String stderrString = stderr.toString();
-      if (!stderrString.contains('install failed, bogus flavor not found')) {
+      if (!stderrString.contains('The Xcode project defines schemes: free, paid')) {
         print(stderrString);
         return TaskResult.failure('Should not succeed with bogus flavor');
       }

--- a/dev/devicelab/bin/tasks/flavors_test_ios.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_ios.dart
@@ -14,7 +14,8 @@ Future<void> main() async {
     await createFlavorsTest().call();
     await createIntegrationTestFlavorsTest().call();
     // test install and uninstall of flavors app
-    await inDirectory('${flutterDirectory.path}/dev/integration_tests/flavors', () async {
+    final TaskResult installTestsResult = await inDirectory(
+        '${flutterDirectory.path}/dev/integration_tests/flavors', () async {
       await flutter(
         'install',
         options: <String>['--flavor', 'paid'],
@@ -36,8 +37,10 @@ Future<void> main() async {
         print(stderrString);
         return TaskResult.failure('Should not succeed with bogus flavor');
       }
+
+      return TaskResult.success(null);
     });
 
-    return TaskResult.success(null);
+    return installTestsResult;
   });
 }

--- a/dev/devicelab/bin/tasks/flavors_test_macos.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_macos.dart
@@ -15,27 +15,29 @@ Future<void> main() async {
     await createIntegrationTestFlavorsTest().call();
 
     final TaskResult installTestsResult = await inDirectory(
-        '${flutterDirectory.path}/dev/integration_tests/flavors', () async {
-      final StringBuffer stderr = StringBuffer();
+      '${flutterDirectory.path}/dev/integration_tests/flavors',
+      () async {
+        final StringBuffer stderr = StringBuffer();
 
-      await evalFlutter(
-        'install',
-        canFail: true,
-        stderr: stderr,
-        options: <String>[
-          '--d', 'macos',
-          '--flavor', 'free'
-        ],
-      );
+        await evalFlutter(
+          'install',
+          canFail: true,
+          stderr: stderr,
+          options: <String>[
+            '--d', 'macos',
+            '--flavor', 'free'
+          ],
+        );
 
-      final String stderrString = stderr.toString();
-      if (!stderrString.contains('Host and target are the same. Nothing to install.')) {
-        print(stderrString);
-        return TaskResult.failure('Installing a macOS app on macOS should no-op');
-      }
+        final String stderrString = stderr.toString();
+        if (!stderrString.contains('Host and target are the same. Nothing to install.')) {
+          print(stderrString);
+          return TaskResult.failure('Installing a macOS app on macOS should no-op');
+        }
 
-      return TaskResult.success(null);
-    });
+        return TaskResult.success(null);
+      },
+    );
 
     return installTestsResult;
   });

--- a/dev/devicelab/bin/tasks/flavors_test_macos.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_macos.dart
@@ -14,7 +14,8 @@ Future<void> main() async {
     await createFlavorsTest().call();
     await createIntegrationTestFlavorsTest().call();
 
-    await inDirectory('${flutterDirectory.path}/dev/integration_tests/flavors', () async {
+    final TaskResult installTestsResult = await inDirectory(
+        '${flutterDirectory.path}/dev/integration_tests/flavors', () async {
       final StringBuffer stderr = StringBuffer();
 
       await evalFlutter(
@@ -32,8 +33,10 @@ Future<void> main() async {
         print(stderrString);
         return TaskResult.failure('Installing a macOS app on macOS should no-op');
       }
+
+      return TaskResult.success(null);
     });
 
-    return TaskResult.success(null);
+    return installTestsResult;
   });
 }


### PR DESCRIPTION
Reland of https://github.com/flutter/flutter/pull/133719. Updates [the string comparison in flavor_test.dart](https://github.com/flutter/flutter/pull/134060/files#diff-53383b32b975bfed6875306dfb98911cad077a5251ca0591c5b0e125fb4a0f05R39) to use `path.join` to build the path string so that the generated path is correct for both Linux and Windows hosts.

Fixes https://github.com/flutter/flutter/issues/133713

I've tested this on a Windows host targeting a physical Android device.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
