### PR TITLE
Update DeltaTextInputClient docs

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1262,7 +1262,6 @@ class SelectionRect {
 /// An interface to receive granular information from [TextInput].
 /// 
 /// This class is susceptible to non-essential breaking changes when not mixed
-/// with a class that does not already mixin [TextInputClient]. In that case this
 /// class throws a missing concrete implementation error. [TextInputClient]
 /// provides empty implementations for members that are non-essential for core
 /// text input. Mixin [TextInputClient] along with this class to inherit these

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1261,6 +1261,9 @@ class SelectionRect {
 
 /// An interface to receive granular information from [TextInput].
 ///
+/// Mixin with [TextInputClient] to receive any default implementations from
+/// [TextInputClient].
+///
 /// See also:
 ///
 ///  * [TextInput.attach]

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1260,9 +1260,13 @@ class SelectionRect {
 }
 
 /// An interface to receive granular information from [TextInput].
-///
-/// Mixin with [TextInputClient] to receive any default implementations from
-/// [TextInputClient].
+/// 
+/// This class is susceptible to non-essential breaking changes when not mixed
+/// with a class that does not already mixin [TextInputClient]. In that case this
+/// class throws a missing concrete implementation error. [TextInputClient]
+/// provides empty implementations for members that are non-essential for core
+/// text input. Mixin [TextInputClient] along with this class to inherit these
+/// default members and prevent being broken by non-essential changes.
 ///
 /// See also:
 ///


### PR DESCRIPTION
`DeltaTextInputClient` was made a `mixin` along with `TextInputClient` to prevent breaking customers when we add APIs to `TextInputClient` that are not essential for text input, for example `showToolbar`.

When a user only mixes `DeltaTextInputClient`, they will still receive not implemented errors for non essential APIs because `DeltaTextInputClient` does not inherit default implementations from `TextInputClient` by default. This change lets the user know how they can get the default implementations from `TextInputClient`.

Fixes #114380 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.