### PR TITLE
Revert "_SearchBarState should dispose FocusNode, if it created it."

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1179,9 +1179,6 @@ class _SearchBarState extends State<SearchBar> {
   @override
   void dispose() {
     _internalStatesController.dispose();
-    if (widget.focusNode == null) {
-      _focusNode.dispose();
-    }
     super.dispose();
   }
 

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -6,10 +6,9 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('SearchBar defaults', (WidgetTester tester) async {
+  testWidgets('SearchBar defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     final ColorScheme colorScheme = theme.colorScheme;
 


### PR DESCRIPTION
Reverts flutter/flutter#133947 as it causes build failures.

https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20tool_integration_tests_5_6/9511/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20flutter_gallery_ios__start_up/12805/overview
