### PR TITLE
[Windows Arm64] Also use Windows 11 for Devicelab tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -203,7 +203,7 @@ platform_properties:
         [
           {"dependency": "certs", "version": "version:9563bb"}
         ]
-      os: Windows-11
+      os: Windows
       device_type: none
       cpu: arm64
   windows_android:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4996,7 +4996,7 @@ targets:
 
   - name: Windows_arm64 hello_world_win_desktop__compile
     recipe: devicelab/devicelab_drone
-    bringup: true
+    bringup: true # https://github.com/flutter/flutter/issues/134083
     presubmit: false
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -203,7 +203,7 @@ platform_properties:
         [
           {"dependency": "certs", "version": "version:9563bb"}
         ]
-      os: Windows-10
+      os: Windows-11
       device_type: none
       cpu: arm64
   windows_android:


### PR DESCRIPTION
Currently, the Windows Arm64 tests try to run on Windows 10 devices. However, [all Windows Arm64 devices use Windows 11](https://chromium-swarm.appspot.com/botlist?c=id&c=task&c=os&c=status&d=asc&f=cpu%3Aarm64&f=os%3AWindows-11&f=pool%3Aluci.flutter.staging&s=id) which result in the Windows Arm64 tests not running. This updates the configuration to accept both Windows 10 and 11 (ideally the tests would run on both OSes).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
