### PR TITLE
fix `--exit` flag in dev/devicelab/bin/run.dart

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -293,7 +293,6 @@ ArgParser createArgParser(List<String> taskNames) {
     )
     ..addFlag(
       'exit',
-      defaultsTo: true,
       help: 'Exit on the first test failure. Currently flakes are intentionally (though '
             'incorrectly) not considered to be failures.',
     )

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -47,8 +47,8 @@ Future<void> runTasks(
 }) async {
   for (final String taskName in taskNames) {
     TaskResult result = TaskResult.success(null);
-    int retry = 0;
-    while (retry <= Cocoon.retryNumber) {
+    int failureCount = 0;
+    while (failureCount <= Cocoon.retryNumber) {
       result = await rerunTask(
         taskName,
         deviceId: deviceId,
@@ -66,11 +66,14 @@ Future<void> runTasks(
       );
 
       if (!result.succeeded) {
-        retry += 1;
+        failureCount += 1;
+        if (exitOnFirstTestFailure) {
+          break;
+        }
       } else {
         section('Flaky status for "$taskName"');
-        if (retry > 0) {
-          print('Total ${retry+1} executions: $retry failures and 1 false positive.');
+        if (failureCount > 0) {
+          print('Total ${failureCount+1} executions: $failureCount failures and 1 false positive.');
           print('flaky: true');
           // TODO(ianh): stop ignoring this failure. We should set exitCode=1, and quit
           // if exitOnFirstTestFailure is true.
@@ -84,7 +87,7 @@ Future<void> runTasks(
 
     if (!result.succeeded) {
       section('Flaky status for "$taskName"');
-      print('Consistently failed across all $retry executions.');
+      print('Consistently failed across all $failureCount executions.');
       print('flaky: false');
       exitCode = 1;
       if (exitOnFirstTestFailure) {


### PR DESCRIPTION
Fixes #134154 

This PR also changes the default value of the `--exit` flag from `true` to `false`. Effectively, this is not a change in behavior since `--exit` didn't previously work.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
