### PR TITLE
add --exit flag to dev/devicelab/bin/test_runner.dart

### DIFF
--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -83,7 +83,6 @@ class TestCommand extends Command<void> {
     // Prepend '--' to convert args to options when passed to task
     final List<String> taskArgs = taskArgsRaw.map((String taskArg) => '--$taskArg').toList();
     print(taskArgs);
-    print('@andrewkolos ${argResults!['exit']}');
     await runTasks(
       <String>[argResults!['task'] as String],
       deviceId: argResults!['device-id'] as String?,

--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -24,6 +24,11 @@ class TestCommand extends Command<void> {
           'settings in the test case, and will results in error if no device\n'
           'with given ID/ID prefix is found.',
     );
+    argParser.addFlag(
+      'exit',
+      help: 'Exit on the first test failure. Currently flakes are intentionally (though '
+            'incorrectly) not considered to be failures.',
+    );
     argParser.addOption(
       'git-branch',
       help: '[Flutter infrastructure] Git branch of the current commit. LUCI\n'
@@ -78,6 +83,7 @@ class TestCommand extends Command<void> {
     // Prepend '--' to convert args to options when passed to task
     final List<String> taskArgs = taskArgsRaw.map((String taskArg) => '--$taskArg').toList();
     print(taskArgs);
+    print('@andrewkolos ${argResults!['exit']}');
     await runTasks(
       <String>[argResults!['task'] as String],
       deviceId: argResults!['device-id'] as String?,
@@ -90,6 +96,7 @@ class TestCommand extends Command<void> {
       silent: (argResults!['silent'] as bool?) ?? false,
       useEmulator: (argResults!['use-emulator'] as bool?) ?? false,
       taskArgs: taskArgs,
+      exitOnFirstTestFailure: argResults!['exit'] as bool,
     );
   }
 }


### PR DESCRIPTION
Resolves #134070 

Adds a flag to the `test_runner.dart test` script that will cause the test runner to exit upon first failure (or, said another way, exit without retrying).

This is in parity with the `--exit` flag of `dev/devicelab/bin/run.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
