### PR TITLE
[flutter_tools] disallow -O0 for flutter build web

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -72,8 +72,9 @@ class BuildWebCommand extends BuildSubCommand {
     );
     argParser.addOption('dart2js-optimization',
       help: 'Sets the optimization level used for Dart compilation to JavaScript. '
-          'Valid values range from O0 to O4.',
-          defaultsTo: JsCompilerConfig.kDart2jsDefaultOptimizationLevel
+          'Valid values range from O1 to O4.',
+      defaultsTo: JsCompilerConfig.kDart2jsDefaultOptimizationLevel,
+      allowed: const <String>['01', '02', '03', '04'],
     );
     argParser.addFlag('dump-info', negatable: false,
       help: 'Passes "--dump-info" to the Javascript compiler which generates '

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -74,7 +74,7 @@ class BuildWebCommand extends BuildSubCommand {
       help: 'Sets the optimization level used for Dart compilation to JavaScript. '
           'Valid values range from O1 to O4.',
       defaultsTo: JsCompilerConfig.kDart2jsDefaultOptimizationLevel,
-      allowed: const <String>['01', '02', '03', '04'],
+      allowed: const <String>['O1', 'O2', 'O3', 'O4'],
     );
     argParser.addFlag('dump-info', negatable: false,
       help: 'Passes "--dump-info" to the Javascript compiler which generates '

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -153,7 +153,10 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
     setupFileSystemForEndToEndTest(fileSystem);
     await expectLater(
-      () => runner.run(<String>['build', 'web', '--no-pub', '--no-web-resources-cdn', '--dart-define=foo=a', '--dart2js-optimization=O0']),
+      () => runner.run(<String>[
+        'build',
+        'web',
+        '--no-pub', '--no-web-resources-cdn', '--dart-define=foo=a', '--dart2js-optimization=O0']),
       throwsUsageException(message: '"O0" is not an allowed value for option "dart2js-optimization"'),
     );
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -142,6 +142,49 @@ void main() {
     }),
   });
 
+  testUsingContext('Does not allow -O0 optimization level', () async {
+    final BuildCommand buildCommand = BuildCommand(
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      osUtils: FakeOperatingSystemUtils(),
+    );
+    final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
+    setupFileSystemForEndToEndTest(fileSystem);
+    await expectLater(
+      () => runner.run(<String>['build', 'web', '--no-pub', '--no-web-resources-cdn', '--dart-define=foo=a', '--dart2js-optimization=O0']),
+      throwsUsageException(message: 'foo'),
+    );
+
+    final Directory buildDir = fileSystem.directory(fileSystem.path.join('build', 'web'));
+
+    expect(buildDir.existsSync(), isFalse);
+  }, overrides: <Type, Generator>{
+    Platform: () => fakePlatform,
+    FileSystem: () => fileSystem,
+    FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
+    ProcessManager: () => FakeProcessManager.any(),
+    BuildSystem: () => TestBuildSystem.all(BuildResult(success: true), (Target target, Environment environment) {
+      expect(environment.defines, <String, String>{
+        'TargetFile': 'lib/main.dart',
+        'HasWebPlugins': 'true',
+        'cspMode': 'false',
+        'SourceMaps': 'false',
+        'NativeNullAssertions': 'true',
+        'ServiceWorkerStrategy': 'offline-first',
+        'Dart2jsDumpInfo': 'false',
+        'Dart2jsNoFrequencyBasedMinification': 'false',
+        'Dart2jsOptimization': 'O3',
+        'BuildMode': 'release',
+        'DartDefines': 'Zm9vPWE=,RkxVVFRFUl9XRUJfQVVUT19ERVRFQ1Q9dHJ1ZQ==',
+        'DartObfuscation': 'false',
+        'TrackWidgetCreation': 'false',
+        'TreeShakeIcons': 'true',
+      });
+    }),
+  });
+
   testUsingContext('Setup for a web build with a user specified output directory',
       () async {
     final BuildCommand buildCommand = BuildCommand(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -154,7 +154,7 @@ void main() {
     setupFileSystemForEndToEndTest(fileSystem);
     await expectLater(
       () => runner.run(<String>['build', 'web', '--no-pub', '--no-web-resources-cdn', '--dart-define=foo=a', '--dart2js-optimization=O0']),
-      throwsUsageException(message: 'foo'),
+      throwsUsageException(message: '"O0" is not an allowed value for option "dart2js-optimization"'),
     );
 
     final Directory buildDir = fileSystem.directory(fileSystem.path.join('build', 'web'));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133404.

Per the dart2js team on the linked issue, `-O0` is not intended for end users, but more for actual debugging/development of the compiler.