### PR TITLE
Fix `Drawer` examples are missing `dartpad` tag

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -79,11 +79,11 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 /// are a little bit different, see the Material 3 spec at
 /// <https://m3.material.io/components/navigation-drawer/overview> for
 /// more details. While the [Drawer] widget can have only one child, the
-/// [NavigationDrawer] widget can have list of widgets, which typically contains
+/// [NavigationDrawer] widget can have a list of widgets, which typically contains
 /// [NavigationDrawerDestination] widgets and/or customized widgets like headlines
 /// and dividers.
 ///
-/// {@tool snippet}
+/// {@tool dartpad}
 /// This example shows how to create a [Scaffold] that contains an [AppBar] and
 /// a [Drawer]. A user taps the "menu" icon in the [AppBar] to open the
 /// [Drawer]. The [Drawer] displays four items: A header and three menu items.
@@ -93,7 +93,7 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 /// ** See code in examples/api/lib/material/drawer/drawer.0.dart **
 /// {@end-tool}
 ///
-/// {@tool snippet}
+/// {@tool dartpad}
 /// This example shows how to migrate the above [Drawer] to a [NavigationDrawer].
 ///
 /// ** See code in examples/api/lib/material/navigation_drawer/navigation_drawer.1.dart **

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -96,7 +96,7 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 /// {@tool dartpad}
 /// This example shows how to migrate the above [Drawer] to a [NavigationDrawer].
 ///
-/// ** See code in examples/api/lib/material/navigation_drawer/navigation_drawer.1.dart **
+/// ** See code in examples/api/lib/material/navigation_drawer/navigation_drawer.0.dart **
 /// {@end-tool}
 ///
 /// An open drawer may be closed with a swipe to close gesture, pressing the


### PR DESCRIPTION
fixes [`Drawer` examples are misssing `dartpad` tag]( https://github.com/flutter/flutter/issues/134217)

these examples were updated in https://github.com/flutter/flutter/pull/130523 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
