### PR TITLE
Remove TextPainter migration flag from the framework

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -279,12 +279,6 @@ class _TextLayout {
   // object when it's no logner needed.
   ui.Paragraph _paragraph;
 
-  // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/31707
-  // remove this hack as well as the flooring in `layout`.
-  @pragma('vm:prefer-inline')
-  // ignore: deprecated_member_use
-  static double _applyFloatingPointHack(double layoutValue) => ui.ParagraphBuilder.shouldDisableRoundingHack ? layoutValue : layoutValue.ceilToDouble();
-
   /// Whether this layout has been invalidated and disposed.
   ///
   /// Only for use when asserts are enabled.
@@ -294,23 +288,23 @@ class _TextLayout {
   ///
   /// If a line ends with trailing spaces, the trailing spaces may extend
   /// outside of the horizontal paint bounds defined by [width].
-  double get width => _applyFloatingPointHack(_paragraph.width);
+  double get width => _paragraph.width;
 
   /// The vertical space required to paint this text.
-  double get height => _applyFloatingPointHack(_paragraph.height);
+  double get height => _paragraph.height;
 
   /// The width at which decreasing the width of the text would prevent it from
   /// painting itself completely within its bounds.
-  double get minIntrinsicLineExtent => _applyFloatingPointHack(_paragraph.minIntrinsicWidth);
+  double get minIntrinsicLineExtent => _paragraph.minIntrinsicWidth;
 
   /// The width at which increasing the width of the text no longer decreases the height.
   ///
   /// Includes trailing spaces if any.
-  double get maxIntrinsicLineExtent => _applyFloatingPointHack(_paragraph.maxIntrinsicWidth);
+  double get maxIntrinsicLineExtent => _paragraph.maxIntrinsicWidth;
 
   /// The distance from the left edge of the leftmost glyph to the right edge of
   /// the rightmost glyph in the paragraph.
-  double get longestLine => _applyFloatingPointHack(_paragraph.longestLine);
+  double get longestLine => _paragraph.longestLine;
 
   /// Returns the distance from the top of the text to the first baseline of the
   /// given type.
@@ -359,13 +353,6 @@ class _TextPainterLayoutCacheWithOffset {
   ui.Paragraph get paragraph => layout._paragraph;
 
   static double _contentWidthFor(double minWidth, double maxWidth, TextWidthBasis widthBasis, _TextLayout layout) {
-    // TODO(LongCatIsLooong): remove the rounding when _applyFloatingPointHack
-    // is removed.
-    // ignore: deprecated_member_use
-    if (!ui.ParagraphBuilder.shouldDisableRoundingHack) {
-      minWidth = minWidth.floorToDouble();
-      maxWidth = maxWidth.floorToDouble();
-    }
     return switch (widthBasis) {
       TextWidthBasis.longestLine => clampDouble(layout.longestLine, minWidth, maxWidth),
       TextWidthBasis.parent => clampDouble(layout.maxIntrinsicLineExtent, minWidth, maxWidth),

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show ParagraphBuilder, SemanticsUpdate;
+import 'dart:ui' as ui show SemanticsUpdate;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -49,11 +49,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
       addPostFrameCallback(_handleWebFirstFrame);
     }
     rootPipelineOwner.attach(_manifold);
-    // TODO(LongCatIsLooong): clean up after
-    // https://github.com/flutter/flutter/issues/31707 is fully migrated.
-    if (!const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)) {
-      ui.ParagraphBuilder.setDisableRoundingHack(false);
-    }
   }
 
   /// The current [RendererBinding], if one has been created.


### PR DESCRIPTION
The migration flag in `ParagraphBuilder` will be removed next.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
