### PR TITLE
Form fields onChange callback should be called on reset

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -133,7 +133,7 @@ class CupertinoTextFormFieldRow extends FormField<String> {
     int? minLines,
     bool expands = false,
     int? maxLength,
-    ValueChanged<String>? onChanged,
+    this.onChanged,
     GestureTapCallback? onTap,
     VoidCallback? onEditingComplete,
     ValueChanged<String>? onFieldSubmitted,
@@ -179,9 +179,7 @@ class CupertinoTextFormFieldRow extends FormField<String> {
 
             void onChangedHandler(String value) {
               field.didChange(value);
-              if (onChanged != null) {
-                onChanged(value);
-              }
+              onChanged?.call(value);
             }
 
             return CupertinoFormRow(
@@ -260,6 +258,10 @@ class CupertinoTextFormFieldRow extends FormField<String> {
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
 
+  /// Called when the user initiates a change to the TextField's
+  /// value: when they have inserted or deleted text or reset the form.
+  final ValueChanged<String>? onChanged;
+
   static Widget _defaultContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {
     return CupertinoAdaptiveTextSelectionToolbar.editableText(
       editableTextState: editableTextState,
@@ -327,13 +329,11 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
 
   @override
   void reset() {
+    // Set the controller value before calling super.reset() to let
+    // _handleControllerChanged suppress the change.
+    _effectiveController!.text = widget.initialValue!;
     super.reset();
-
-    if (widget.initialValue != null) {
-      setState(() {
-        _effectiveController!.text = widget.initialValue!;
-      });
-    }
+    _cupertinoTextFormFieldRow.onChanged?.call(_effectiveController!.text);
   }
 
   void _handleControllerChanged() {

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -258,8 +258,7 @@ class CupertinoTextFormFieldRow extends FormField<String> {
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
 
-  /// Called when the user initiates a change to the TextField's
-  /// value: when they have inserted or deleted text or reset the form.
+  /// {@macro flutter.material.TextFormField.onChanged}
   final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1736,13 +1736,12 @@ class DropdownButtonFormField<T> extends FormField<T> {
 }
 
 class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
+  DropdownButtonFormField<T> get _dropdownButtonFormField => widget as DropdownButtonFormField<T>;
 
   @override
   void didChange(T? value) {
     super.didChange(value);
-    final DropdownButtonFormField<T> dropdownButtonFormField = widget as DropdownButtonFormField<T>;
-    assert(dropdownButtonFormField.onChanged != null);
-    dropdownButtonFormField.onChanged!(value);
+    _dropdownButtonFormField.onChanged!(value);
   }
 
   @override
@@ -1751,5 +1750,11 @@ class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
     if (oldWidget.initialValue != widget.initialValue) {
       setValue(widget.initialValue);
     }
+  }
+
+ @override
+  void reset() {
+    super.reset();
+    _dropdownButtonFormField.onChanged!(value);
   }
 }

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -270,8 +270,10 @@ class TextFormField extends FormField<String> {
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
 
+  /// {@template flutter.material.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's
   /// value: when they have inserted or deleted text or reset the form.
+  /// {@endtemplate}
   final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -131,7 +131,7 @@ class TextFormField extends FormField<String> {
     int? minLines,
     bool expands = false,
     int? maxLength,
-    ValueChanged<String>? onChanged,
+    this.onChanged,
     GestureTapCallback? onTap,
     TapRegionCallback? onTapOutside,
     VoidCallback? onEditingComplete,
@@ -193,9 +193,7 @@ class TextFormField extends FormField<String> {
                .applyDefaults(Theme.of(field.context).inputDecorationTheme);
            void onChangedHandler(String value) {
              field.didChange(value);
-             if (onChanged != null) {
-               onChanged(value);
-             }
+             onChanged?.call(value);
            }
            return UnmanagedRestorationScope(
              bucket: field.bucket,
@@ -271,6 +269,10 @@ class TextFormField extends FormField<String> {
   /// If null, this widget will create its own [TextEditingController] and
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
+
+  /// Called when the user initiates a change to the TextField's
+  /// value: when they have inserted or deleted text or reset the form.
+  final ValueChanged<String>? onChanged;
 
   static Widget _defaultContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {
     return AdaptiveTextSelectionToolbar.editableText(
@@ -365,10 +367,11 @@ class _TextFormFieldState extends FormFieldState<String> {
 
   @override
   void reset() {
-    // setState will be called in the superclass, so even though state is being
-    // manipulated, no setState call is needed here.
+    // Set the controller value before calling super.reset() to let
+    // _handleControllerChanged suppress the change.
     _effectiveController.text = widget.initialValue ?? '';
     super.reset();
+    _textFormField.onChanged?.call(_effectiveController.text);
   }
 
   void _handleControllerChanged() {

--- a/packages/flutter/test/cupertino/text_form_field_row_test.dart
+++ b/packages/flutter/test/cupertino/text_form_field_row_test.dart
@@ -490,4 +490,43 @@ void main() {
     final CupertinoTextField rtlTextFieldWidget = tester.widget(rtlTextFieldFinder);
     expect(rtlTextFieldWidget.textDirection, TextDirection.rtl);
   });
+
+ testWidgets('CupertinoTextFormFieldRow onChanged is called when the form is reset', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/123009.
+    final GlobalKey<FormFieldState<String>> stateKey = GlobalKey<FormFieldState<String>>();
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    String value = 'initialValue';
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: Form(
+            key: formKey,
+            child: CupertinoTextFormFieldRow(
+              key: stateKey,
+              initialValue: value,
+              onChanged: (String newValue){
+                value=newValue;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Initial value is 'initialValue'.
+    expect(stateKey.currentState!.value, 'initialValue');
+    expect(value, 'initialValue');
+
+    // Change value to 'changedValue'.
+    await tester.enterText(find.byType(CupertinoTextField), 'changedValue');
+    expect(stateKey.currentState!.value,'changedValue');
+    expect(value, 'changedValue');
+
+    // Should be back to 'initialValue' when the form is reset.
+    formKey.currentState!.reset();
+    await tester.pump();
+    expect(stateKey.currentState!.value,'initialValue');
+    expect(value, 'initialValue');
+  });
 }

--- a/packages/flutter/test/cupertino/text_form_field_row_test.dart
+++ b/packages/flutter/test/cupertino/text_form_field_row_test.dart
@@ -505,8 +505,8 @@ void main() {
             child: CupertinoTextFormFieldRow(
               key: stateKey,
               initialValue: value,
-              onChanged: (String newValue){
-                value=newValue;
+              onChanged: (String newValue) {
+                value = newValue;
               },
             ),
           ),

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -816,6 +816,31 @@ void main() {
     expect(find.text('initialValue'), findsOneWidget);
   });
 
+  testWidgetsWithLeakTracking('reset resets the text fields value to the controller initial value', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(text: 'initialValue');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: TextFormField(
+              controller: controller,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField), 'changedValue');
+
+    final FormFieldState<String> state = tester.state<FormFieldState<String>>(find.byType(TextFormField));
+    state.reset();
+
+    expect(find.text('changedValue'), findsNothing);
+    expect(find.text('initialValue'), findsOneWidget);
+
+    controller.dispose();
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/34847.
   testWidgetsWithLeakTracking("didChange resets the text field's value to empty when passed null", (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -1477,5 +1502,42 @@ void main() {
     final EditableText textField = tester.widget(find.byType(EditableText).first);
     await tester.pump();
     expect(textField.cursorColor, errorColor);
+  });
+
+  testWidgetsWithLeakTracking('TextFormField onChanged is called when the form is reset', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/123009.
+    final GlobalKey<FormFieldState<String>> stateKey = GlobalKey<FormFieldState<String>>();
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    String value='initialValue';
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Form(
+          key: formKey,
+          child: TextFormField(
+            key: stateKey,
+            initialValue: value,
+            onChanged: (String newValue) {
+              value = newValue;
+            },
+          ),
+        ),
+      ),
+    ));
+
+    // Initial value is 'initialValue'.
+    expect(stateKey.currentState!.value, 'initialValue');
+    expect(value, 'initialValue');
+
+    // Change value to 'changedValue'.
+    await tester.enterText(find.byType(TextField), 'changedValue');
+    expect(stateKey.currentState!.value,'changedValue');
+    expect(value, 'changedValue');
+
+    // Should be back to 'initialValue' when the form is reset.
+    formKey.currentState!.reset();
+    await tester.pump();
+    expect(stateKey.currentState!.value,'initialValue');
+    expect(value, 'initialValue');
   });
 }

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -818,6 +818,8 @@ void main() {
 
   testWidgetsWithLeakTracking('reset resets the text fields value to the controller initial value', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(text: 'initialValue');
+    addTearDown(controller.dispose);
+
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -837,8 +839,6 @@ void main() {
 
     expect(find.text('changedValue'), findsNothing);
     expect(find.text('initialValue'), findsOneWidget);
-
-    controller.dispose();
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/34847.
@@ -1508,7 +1508,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/123009.
     final GlobalKey<FormFieldState<String>> stateKey = GlobalKey<FormFieldState<String>>();
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
-    String value='initialValue';
+    String value = 'initialValue';
 
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(


### PR DESCRIPTION
## Description

This PR fixes form fields in order to call the `onChange` callback when the form is reset.

This change is based on the work done in https://github.com/flutter/flutter/pull/123108.

I considered adding the `onChange` callback to the `FormField` superclass but it would break existing code because two of the three subclasses defines the `onChange` callback with `ValueChanged<String>?` type and the third one defines it with `ValueChanged<String?>?`. 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/123009.

## Tests

Adds 3 tests.