### PR TITLE
mark docs_publish bringup true

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -362,6 +362,7 @@ targets:
   - name: Linux docs_publish
     recipe: flutter/flutter
     presubmit: false
+    bringup: true # https://github.com/flutter/flutter/issues/134319
     timeout: 90 # https://github.com/flutter/flutter/issues/120901
     dimensions:
       os: "Linux"


### PR DESCRIPTION
Publishing docs on master is breaking because CI is downloading an ARM64 firebase binary on x64: https://github.com/flutter/flutter/issues/134319

Mark this bringup to unblock the tree over the weekend.