### PR TITLE
Cover some Services tests with leak tracing

### DIFF
--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 class TestAssetBundle extends CachingAssetBundle {
   Map<String, int> loadCallCount = <String, int>{};
@@ -135,7 +136,7 @@ void main() {
       expect(await data, 1);
     });
 
-    testWidgets('loadStructuredData handles exceptions correctly', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('loadStructuredData handles exceptions correctly', (WidgetTester tester) async {
       final TestAssetBundle bundle = TestAssetBundle();
       try {
         await bundle.loadStructuredData('AssetManifest.json', (String value) => Future<String>.error('what do they say?'));
@@ -145,7 +146,7 @@ void main() {
       }
     });
 
-    testWidgets('loadStructuredBinaryData handles exceptions correctly', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('loadStructuredBinaryData handles exceptions correctly', (WidgetTester tester) async {
       final TestAssetBundle bundle = TestAssetBundle();
       try {
         await bundle.loadStructuredBinaryData('AssetManifest.bin', (ByteData value) => Future<String>.error('buy more crystals'));

--- a/packages/flutter/test/services/lifecycle_test.dart
+++ b/packages/flutter/test/services/lifecycle_test.dart
@@ -6,9 +6,10 @@ import 'dart:ui';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('initialLifecycleState is used to init state paused', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('initialLifecycleState is used to init state paused', (WidgetTester tester) async {
     expect(ServicesBinding.instance.lifecycleState, isNull);
     final TestWidgetsFlutterBinding binding = tester.binding;
     binding.resetLifecycleState();
@@ -20,7 +21,7 @@ void main() {
     // even though no lifecycle event was fired from the platform.
     expect(binding.lifecycleState.toString(), equals('AppLifecycleState.paused'));
   });
-  testWidgets('Handles all of the allowed states of AppLifecycleState', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Handles all of the allowed states of AppLifecycleState', (WidgetTester tester) async {
     final TestWidgetsFlutterBinding binding = tester.binding;
     for (final AppLifecycleState state in AppLifecycleState.values) {
       binding.resetLifecycleState();


### PR DESCRIPTION
This PR replaces some `testWidgets` with `testWidgestsWithLeakTracking`.
Part of: [#134](https://github.com/dart-lang/leak_tracker/issues/134#issue-1870426468) (please tell me if this isn't needed)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
