### PR TITLE
Handle debug state to avoid freezes on assertion (#134408)

### DIFF
--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -207,11 +207,16 @@ class MouseTracker extends ChangeNotifier {
       _debugDuringDeviceUpdate = true;
       return true;
     }());
-    task();
-    assert(() {
-      _debugDuringDeviceUpdate = false;
-      return true;
-    }());
+    try {
+      task();
+    } catch (e) {
+      rethrow;
+    } finally {
+      assert(() {
+        _debugDuringDeviceUpdate = false;
+        return true;
+      }());
+    }
   }
 
   // Whether an observed event might update a device.


### PR DESCRIPTION
In case of failed task, an application became fully nonfunctional (samples  #108363, #126513, #134408) by not responding to any interaction. Relevant to debug/development mode.

- https://github.com/flutter/flutter/issues/134408

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
