### PR TITLE
Enable private field promotion for framework

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -1126,7 +1126,7 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     if (_debugLabel != null) {
-      properties.add(MessageProperty('debugLabel', _debugLabel!));
+      properties.add(MessageProperty('debugLabel', _debugLabel));
     }
     properties.add(createCupertinoColorProperty('color', color));
     if (_isPlatformBrightnessDependent) {

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -845,16 +845,16 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
       return b!._colors == null ? b : _CupertinoEdgeShadowDecoration._(b._colors!.map<Color>((Color color) => Color.lerp(null, color, t)!).toList());
     }
     if (b == null) {
-      return a._colors == null ? a : _CupertinoEdgeShadowDecoration._(a._colors!.map<Color>((Color color) => Color.lerp(null, color, 1.0 - t)!).toList());
+      return a._colors == null ? a : _CupertinoEdgeShadowDecoration._(a._colors.map<Color>((Color color) => Color.lerp(null, color, 1.0 - t)!).toList());
     }
     assert(b._colors != null || a._colors != null);
     // If it ever becomes necessary, we could allow decorations with different
     // length' here, similarly to how it is handled in [LinearGradient.lerp].
-    assert(b._colors == null || a._colors == null || a._colors!.length == b._colors!.length);
+    assert(b._colors == null || a._colors == null || a._colors.length == b._colors.length);
     return _CupertinoEdgeShadowDecoration._(
       <Color>[
         for (int i = 0; i < b._colors!.length; i += 1)
-          Color.lerp(a._colors?[i], b._colors?[i], t)!,
+          Color.lerp(a._colors?[i], b._colors[i], t)!,
       ],
     );
   }
@@ -904,7 +904,7 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
   _CupertinoEdgeShadowPainter(
     this._decoration,
     super.onChanged,
-  ) : assert(_decoration._colors == null || _decoration._colors!.length > 1);
+  ) : assert(_decoration._colors == null || _decoration._colors.length > 1);
 
   final _CupertinoEdgeShadowDecoration _decoration;
 

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2673,7 +2673,7 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
   @override
   String toDescription({ TextTreeConfiguration? parentConfiguration }) {
     if (_description != null) {
-      return _addTooltip(_description!);
+      return _addTooltip(_description);
     }
 
     if (exception != null) {

--- a/packages/flutter/lib/src/foundation/persistent_hash_map.dart
+++ b/packages/flutter/lib/src/foundation/persistent_hash_map.dart
@@ -53,7 +53,7 @@ class PersistentHashMap<K extends Object, V> {
 
     // Unfortunately can not use unsafeCast<V?>(...) here because it leads
     // to worse code generation on VM.
-    return _root!.get(0, key, key.hashCode) as V?;
+    return _root.get(0, key, key.hashCode) as V?;
   }
 }
 

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -249,7 +249,7 @@ class ButtonThemeData with Diagnosticable {
   ///    child (typically the button's label).
   EdgeInsetsGeometry get padding {
     if (_padding != null) {
-      return _padding!;
+      return _padding;
     }
     switch (textTheme) {
       case ButtonTextTheme.normal:
@@ -277,7 +277,7 @@ class ButtonThemeData with Diagnosticable {
   ///    [Material].
   ShapeBorder get shape {
     if (_shape != null) {
-      return _shape!;
+      return _shape;
     }
     switch (textTheme) {
       case ButtonTextTheme.normal:
@@ -537,7 +537,7 @@ class ButtonThemeData with Diagnosticable {
       switch (getTextTheme(button)) {
         case ButtonTextTheme.normal:
         case ButtonTextTheme.accent:
-          return _splashColor!;
+          return _splashColor;
         case ButtonTextTheme.primary:
           break;
       }
@@ -642,7 +642,7 @@ class ButtonThemeData with Diagnosticable {
     }
 
     if (_padding != null) {
-      return _padding!;
+      return _padding;
     }
 
     switch (getTextTheme(button)) {

--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -130,7 +130,7 @@ class InkHighlight extends InteractiveInkFeature {
   void paintFeature(Canvas canvas, Matrix4 transform) {
     final Paint paint = Paint()..color = color.withAlpha(_alpha.value);
     final Offset? originOffset = MatrixUtils.getAsTranslation(transform);
-    final Rect rect = _rectCallback != null ? _rectCallback!() : Offset.zero & referenceBox.size;
+    final Rect rect = _rectCallback != null ? _rectCallback() : Offset.zero & referenceBox.size;
     if (originOffset == null) {
       canvas.save();
       canvas.transform(transform.storage);

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -228,7 +228,7 @@ class InkRipple extends InteractiveInkFeature {
     final Paint paint = Paint()..color = color.withAlpha(alpha);
     Rect? rect;
     if (_clipCallback != null) {
-       rect = _clipCallback!();
+       rect = _clipCallback();
     }
     // Splash moves to the center of the reference box.
     final Offset center = Offset.lerp(

--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -285,7 +285,7 @@ class InkSparkle extends InteractiveInkFeature {
     if (_clipCallback != null) {
       _clipCanvas(
         canvas: canvas,
-        clipCallback: _clipCallback!,
+        clipCallback: _clipCallback,
         textDirection: _textDirection,
         customBorder: customBorder,
         borderRadius: _borderRadius,
@@ -296,7 +296,7 @@ class InkSparkle extends InteractiveInkFeature {
 
     final Paint paint = Paint()..shader = _fragmentShader;
     if (_clipCallback != null) {
-      canvas.drawRect(_clipCallback!(), paint);
+      canvas.drawRect(_clipCallback(), paint);
     } else {
       canvas.drawPaint(paint);
     }

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -378,79 +378,79 @@ class ListTileTheme extends InheritedTheme {
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.dense] property instead.
-  bool? get dense => _data != null ? _data!.dense : _dense;
+  bool? get dense => _data != null ? _data.dense : _dense;
 
   /// Overrides the default value of [ListTile.shape].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.shape] property instead.
-  ShapeBorder? get shape => _data != null ? _data!.shape : _shape;
+  ShapeBorder? get shape => _data != null ? _data.shape : _shape;
 
   /// Overrides the default value of [ListTile.style].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.style] property instead.
-  ListTileStyle? get style => _data != null ? _data!.style : _style;
+  ListTileStyle? get style => _data != null ? _data.style : _style;
 
   /// Overrides the default value of [ListTile.selectedColor].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.selectedColor] property instead.
-  Color? get selectedColor => _data != null ? _data!.selectedColor : _selectedColor;
+  Color? get selectedColor => _data != null ? _data.selectedColor : _selectedColor;
 
   /// Overrides the default value of [ListTile.iconColor].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.iconColor] property instead.
-  Color? get iconColor => _data != null ? _data!.iconColor : _iconColor;
+  Color? get iconColor => _data != null ? _data.iconColor : _iconColor;
 
   /// Overrides the default value of [ListTile.textColor].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.textColor] property instead.
-  Color? get textColor => _data != null ? _data!.textColor : _textColor;
+  Color? get textColor => _data != null ? _data.textColor : _textColor;
 
   /// Overrides the default value of [ListTile.contentPadding].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.contentPadding] property instead.
-  EdgeInsetsGeometry? get contentPadding => _data != null ? _data!.contentPadding : _contentPadding;
+  EdgeInsetsGeometry? get contentPadding => _data != null ? _data.contentPadding : _contentPadding;
 
   /// Overrides the default value of [ListTile.tileColor].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.tileColor] property instead.
-  Color? get tileColor => _data != null ? _data!.tileColor : _tileColor;
+  Color? get tileColor => _data != null ? _data.tileColor : _tileColor;
 
   /// Overrides the default value of [ListTile.selectedTileColor].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.selectedTileColor] property instead.
-  Color? get selectedTileColor => _data != null ? _data!.selectedTileColor : _selectedTileColor;
+  Color? get selectedTileColor => _data != null ? _data.selectedTileColor : _selectedTileColor;
 
   /// Overrides the default value of [ListTile.horizontalTitleGap].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.horizontalTitleGap] property instead.
-  double? get horizontalTitleGap => _data != null ? _data!.horizontalTitleGap : _horizontalTitleGap;
+  double? get horizontalTitleGap => _data != null ? _data.horizontalTitleGap : _horizontalTitleGap;
 
   /// Overrides the default value of [ListTile.minVerticalPadding].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.minVerticalPadding] property instead.
-  double? get minVerticalPadding => _data != null ? _data!.minVerticalPadding : _minVerticalPadding;
+  double? get minVerticalPadding => _data != null ? _data.minVerticalPadding : _minVerticalPadding;
 
   /// Overrides the default value of [ListTile.minLeadingWidth].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.minLeadingWidth] property instead.
-  double? get minLeadingWidth => _data != null ? _data!.minLeadingWidth : _minLeadingWidth;
+  double? get minLeadingWidth => _data != null ? _data.minLeadingWidth : _minLeadingWidth;
 
   /// Overrides the default value of [ListTile.enableFeedback].
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.enableFeedback] property instead.
-  bool? get enableFeedback => _data != null ? _data!.enableFeedback : _enableFeedback;
+  bool? get enableFeedback => _data != null ? _data.enableFeedback : _enableFeedback;
 
   /// The [data] property of the closest instance of this class that
   /// encloses the given context.

--- a/packages/flutter/lib/src/painting/strut_style.dart
+++ b/packages/flutter/lib/src/painting/strut_style.dart
@@ -405,7 +405,7 @@ class StrutStyle with Diagnosticable {
   /// constructor.
   List<String>? get fontFamilyFallback {
     if (_package != null && _fontFamilyFallback != null) {
-      return _fontFamilyFallback!.map((String family) => 'packages/$_package/$family').toList();
+      return _fontFamilyFallback.map((String family) => 'packages/$_package/$family').toList();
     }
     return _fontFamilyFallback;
   }

--- a/packages/flutter/lib/src/rendering/error.dart
+++ b/packages/flutter/lib/src/rendering/error.dart
@@ -157,11 +157,11 @@ class RenderErrorBox extends RenderBox {
           width -= padding.left + padding.right;
           left += padding.left;
         }
-        _paragraph!.layout(ui.ParagraphConstraints(width: width));
-        if (size.height > padding.top + _paragraph!.height + padding.bottom) {
+        _paragraph.layout(ui.ParagraphConstraints(width: width));
+        if (size.height > padding.top + _paragraph.height + padding.bottom) {
           top += padding.top;
         }
-        context.canvas.drawParagraph(_paragraph!, offset + Offset(left, top));
+        context.canvas.drawParagraph(_paragraph, offset + Offset(left, top));
       }
     } catch (error) {
       // If an error happens here we're in a terrible state, so we really should

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1002,7 +1002,7 @@ class EditableText extends StatefulWidget {
     if (_strutStyle == null) {
       return StrutStyle.fromTextStyle(style, forceStrutHeight: true);
     }
-    return _strutStyle!.inheritFromTextStyle(style);
+    return _strutStyle.inheritFromTextStyle(style);
   }
   final StrutStyle? _strutStyle;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5359,7 +5359,7 @@ class ErrorWidget extends LeafRenderObjectWidget {
     if (_flutterError == null) {
       properties.add(StringProperty('message', message, quoted: false));
     } else {
-      properties.add(_flutterError!.toDiagnosticsNode(style: DiagnosticsTreeStyle.whitespace));
+      properties.add(_flutterError.toDiagnosticsNode(style: DiagnosticsTreeStyle.whitespace));
     }
   }
 }

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -157,7 +157,7 @@ class IconThemeData with Diagnosticable {
   /// An opacity to apply to both explicit and default icon colors.
   ///
   /// Falls back to 1.0.
-  double? get opacity => _opacity == null ? null : clampDouble(_opacity!, 0.0, 1.0);
+  double? get opacity => _opacity == null ? null : clampDouble(_opacity, 0.0, 1.0);
   final double? _opacity;
 
   /// The default for [Icon.shadows].

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -65,7 +65,7 @@ class RouteInformation {
   )
   String get location {
     if (_location != null) {
-      return _location!;
+      return _location;
     }
     return Uri.decodeComponent(
       Uri(
@@ -86,7 +86,7 @@ class RouteInformation {
   /// In web platform, the host and scheme are always empty.
   Uri get uri {
     if (_uri != null){
-      return _uri!;
+      return _uri;
     }
     return Uri.parse(_location!);
   }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2155,7 +2155,7 @@ class RawDialogRoute<T> extends PopupRoute<T> {
         child: child,
       );
     }
-    return _transitionBuilder!(context, animation, secondaryAnimation, child);
+    return _transitionBuilder(context, animation, secondaryAnimation, child);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_delegate.dart
+++ b/packages/flutter/lib/src/widgets/scroll_delegate.dart
@@ -670,22 +670,22 @@ class SliverChildListDelegate extends SliverChildDelegate {
     }
     // Lazily fill the [_keyToIndex].
     if (!_keyToIndex!.containsKey(key)) {
-      int index = _keyToIndex![null]!;
+      int index = _keyToIndex[null]!;
       while (index < children.length) {
         final Widget child = children[index];
         if (child.key != null) {
-          _keyToIndex![child.key] = index;
+          _keyToIndex[child.key] = index;
         }
         if (child.key == key) {
           // Record current index for next function call.
-          _keyToIndex![null] = index + 1;
+          _keyToIndex[null] = index + 1;
           return index;
         }
         index += 1;
       }
-      _keyToIndex![null] = index;
+      _keyToIndex[null] = index;
     } else {
-      return _keyToIndex![key];
+      return _keyToIndex[key];
     }
     return null;
   }

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: A framework for writing Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2078,7 +2078,7 @@ class _TestDialogRouteWithCustomBarrierCurve<T> extends PopupRoute<T> {
     if (_barrierCurve == null) {
       return super.barrierCurve;
     }
-    return _barrierCurve!;
+    return _barrierCurve;
   }
   final Curve? _barrierCurve;
 

--- a/packages/flutter/test_private/pubspec.yaml
+++ b/packages/flutter/test_private/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_test_private
 description: Tests private interfaces of the flutter
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test_private/test/pubspec.yaml
+++ b/packages/flutter/test_private/test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animated_icons_private_test
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".


### PR DESCRIPTION
New feature in upcoming Dart 3.2. See https://github.com/dart-lang/language/issues/2020. Feature is enabled by bumping the min SDK version to 3.2.

Part of https://github.com/flutter/flutter/issues/134476.