### PR TITLE
Enable private field promotion for examples

### DIFF
--- a/examples/api/pubspec.yaml
+++ b/examples/api/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
   flutter: ">=2.5.0-6.0.pre.30 <3.0.0"
 
 dependencies:

--- a/examples/flutter_view/pubspec.yaml
+++ b/examples/flutter_view/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_view
 description: A new flutter project.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hello_world
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/image_list/pubspec.yaml
+++ b/examples/image_list/pubspec.yaml
@@ -4,7 +4,7 @@ description: Simple Flutter project used for benchmarking image loading over net
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_examples_layers
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_channel_swift/pubspec.yaml
+++ b/examples/platform_channel_swift/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel_swift
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_view/pubspec.yaml
+++ b/examples/platform_view/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_view
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/splash/pubspec.yaml
+++ b/examples/splash/pubspec.yaml
@@ -1,7 +1,7 @@
 name: splash
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/texture/pubspec.yaml
+++ b/examples/texture/pubspec.yaml
@@ -1,7 +1,7 @@
 name: texture
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
New feature in upcoming Dart 3.2. See https://github.com/dart-lang/language/issues/2020. Feature is enabled by bumping the min SDK version to 3.2.

In these packages, no private fields were found to be promotable.

Part of https://github.com/flutter/flutter/issues/134476.