### PR TITLE
Ensure OverlayPortal.overlayChild's renderObject is reachable via treewalk

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1960,7 +1960,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
         final bool mutationsToDirtySubtreesAllowed = activeLayoutRoot.owner?._debugAllowMutationsToDirtySubtrees ?? false;
         final bool doingLayoutWithCallback = activeLayoutRoot._doingThisLayoutWithCallback;
         // Mutations on this subtree is allowed when:
-        // - the subtree is being mutated in a layout callback.
+        // - the "activeLayoutRoot" subtree is being mutated in a layout callback.
         // - a different part of the render tree is doing a layout callback,
         //   and this subtree is being reparented to that subtree, as a result
         //   of global key reparenting.

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -1031,12 +1031,14 @@ class _RenderTheater extends RenderBox with ContainerRenderObjectMixin<RenderBox
   void _addDeferredChild(_RenderDeferredLayoutBox child) {
     assert(!_skipMarkNeedsLayout);
     _skipMarkNeedsLayout = true;
-
     adoptChild(child);
-    // When child has never been laid out before, mark its layout surrogate as
-    // needing layout so it's reachable via tree walk.
-    child._layoutSurrogate.markNeedsLayout();
     _skipMarkNeedsLayout = false;
+
+    // After adding `child` to the render tree, we want to make sure it will be
+    // laid out in the same frame. This is done by calling markNeedsLayout on the
+    // layout surrgate. This ensures `child` is reachable via tree walk (see
+    // _RenderLayoutSurrogateProxyBox.performLayout).
+    child._layoutSurrogate.markNeedsLayout();
   }
 
   void _removeDeferredChild(_RenderDeferredLayoutBox child) {
@@ -1048,10 +1050,9 @@ class _RenderTheater extends RenderBox with ContainerRenderObjectMixin<RenderBox
 
   @override
   void markNeedsLayout() {
-    if (_skipMarkNeedsLayout) {
-      return;
+    if (!_skipMarkNeedsLayout) {
+      super.markNeedsLayout();
     }
-    super.markNeedsLayout();
   }
 
   RenderBox? get _firstOnstageChild {
@@ -2088,7 +2089,7 @@ final class _RenderDeferredLayoutBox extends RenderProxyBox with _RenderTheaterM
   RenderObject? get debugLayoutParent => _layoutSurrogate;
 
   void layoutByLayoutSurrogate() {
-    assert(!_parentDoingLayout);
+    assert(!_theaterDoingThisLayout);
     final _RenderTheater? theater = parent as _RenderTheater?;
     if (theater == null || !attached) {
       assert(false, '$this is not attached to parent');
@@ -2097,25 +2098,26 @@ final class _RenderDeferredLayoutBox extends RenderProxyBox with _RenderTheaterM
     super.layout(BoxConstraints.tight(theater.constraints.biggest));
   }
 
-  bool _parentDoingLayout = false;
+  bool _theaterDoingThisLayout = false;
   @override
   void layout(Constraints constraints, { bool parentUsesSize = false }) {
     assert(_needsLayout == debugNeedsLayout);
     // Only _RenderTheater calls this implementation.
     assert(parent != null);
     final bool scheduleDeferredLayout = _needsLayout || this.constraints != constraints;
-    assert(!_parentDoingLayout);
-    _parentDoingLayout = true;
+    assert(!_theaterDoingThisLayout);
+    _theaterDoingThisLayout = true;
     super.layout(constraints, parentUsesSize: parentUsesSize);
-    assert(_parentDoingLayout);
-    _parentDoingLayout = false;
+    assert(_theaterDoingThisLayout);
+    _theaterDoingThisLayout = false;
     _needsLayout = false;
     assert(!debugNeedsLayout);
     if (scheduleDeferredLayout) {
       final _RenderTheater parent = this.parent! as _RenderTheater;
       // Invoking markNeedsLayout as a layout callback allows this node to be
-      // merged back to the `PipelineOwner` if it's not already dirty. Otherwise
-      // this may cause some dirty descendants to performLayout a second time.
+      // merged back to the `PipelineOwner`'s dirty list in the right order, if
+      // it's not already dirty. Otherwise this may cause some dirty descendants
+      // to performLayout a second time.
       parent.invokeLayoutCallback((BoxConstraints constraints) { markNeedsLayout(); });
     }
   }
@@ -2129,7 +2131,7 @@ final class _RenderDeferredLayoutBox extends RenderProxyBox with _RenderTheaterM
   @override
   void performLayout() {
     assert(!_debugMutationsLocked);
-    if (_parentDoingLayout) {
+    if (_theaterDoingThisLayout) {
       _needsLayout = false;
       return;
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133545

` child._layoutSurrogate.markNeedsLayout();` was called when `_skipMarkNeedsLayout` is set true so when there's no relayout boundary between the layout surrogate and the RenderTheater, no dirty render objects will be added to the PipelineOwner's dirty list.

It's ok to mark the RenderTheater dirty when there's no layout boundary between it and the layout surrogate.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
