### PR TITLE
Added a devicelab test for vulkan validation layers

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1567,6 +1567,25 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Linux_android hello_world_impeller
+    recipe: devicelab/devicelab_drone
+    presubmit: true
+    bringup: true
+    timeout: 60
+    dimensions:
+      kvm: "1"
+      cores: "8"
+      machine_type: "n1-standard-8"
+    properties:
+      device_type: "none"
+      tags: >
+        ["devicelab", "linux"]
+      task_name: hello_world_impeller
+      dependencies: >-
+        [
+          {"dependency": "android_virtual_device", "version": "34"}
+        ]
+
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone
     presubmit: true

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1569,22 +1569,13 @@ targets:
 
   - name: Linux_android hello_world_impeller
     recipe: devicelab/devicelab_drone
-    presubmit: true
+    presubmit: false
     bringup: true
     timeout: 60
-    dimensions:
-      kvm: "1"
-      cores: "8"
-      machine_type: "n1-standard-8"
     properties:
-      device_type: "none"
       tags: >
-        ["devicelab", "linux"]
+        ["devicelab", "android", "linux"]
       task_name: hello_world_impeller
-      dependencies: >-
-        [
-          {"dependency": "android_virtual_device", "version": "34"}
-        ]
 
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -135,6 +135,7 @@
 /dev/devicelab/bin/tasks/fullscreen_textfield_perf__timeline_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/hello_world__memory.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/hello_world_android__compile.dart @zanderso @flutter/tool
+/dev/devicelab/bin/tasks/hello_world_impeller.dart @gaaclarke @flutter/engine
 /dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle__benchmark.dart @eliasyishak @flutter/tool
 /dev/devicelab/bin/tasks/hybrid_android_views_integration_test.dart @stuartmorgan @flutter/plugin

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show Completer, StreamSubscription;
 import 'dart:io' show Directory, Process;
 
 import 'package:flutter_devicelab/framework/devices.dart'
@@ -23,6 +23,7 @@ Future<TaskResult> run() async {
   bool isUsingValidationLayers = false;
   bool hasValidationErrors = false;
   int impellerBackendCount = 0;
+  final Completer<void> didReceiveBackendMessage = Completer<void>();
 
   await inDirectory(appDir, () async {
     await flutter('packages', options: <String>['get']);
@@ -33,6 +34,7 @@ Future<TaskResult> run() async {
           // Sometimes more than one of these will be printed out if there is a
           // fallback.
           impellerBackendCount += 1;
+          didReceiveBackendMessage.complete();
         }
         if (data.contains(
             'Using the Impeller rendering backend (Vulkan with Validation Layers)')) {
@@ -56,6 +58,7 @@ Future<TaskResult> run() async {
       ],
     );
 
+    await didReceiveBackendMessage.future;
     // Since we are waiting for the lack of errors, there is no determinate
     // amount of time we can wait.
     await Future<void>.delayed(const Duration(seconds: 30));

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -56,7 +56,7 @@ Future<TaskResult> run() async {
 
     // Since we are waiting for the lack of errors, there is no determinate
     // amount of time we can wait.
-    await Future<void>.delayed(const Duration(seconds: 10));
+    await Future<void>.delayed(const Duration(seconds: 30));
     process.stdin.write('q');
     await adb.cancel();
   });

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -47,7 +47,6 @@ Future<TaskResult> run() async {
         if (data.contains('ImpellerValidationBreak')) {
           hasValidationErrors = true;
         }
-        print('something: $data');
       },
     );
 

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -38,6 +38,8 @@ Future<TaskResult> run() async {
             'Using the Impeller rendering backend (Vulkan with Validation Layers)')) {
           isUsingValidationLayers = true;
         }
+        // "ImpellerValidationBreak" comes from the engine:
+        // https://github.com/flutter/engine/blob/4160ebacdae2081d6f3160432f5f0dd87dbebec1/impeller/base/validation.cc#L40
         if (data.contains('ImpellerValidationBreak')) {
           hasValidationErrors = true;
         }

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -33,8 +33,10 @@ Future<TaskResult> run() async {
         if (data.contains('Using the Impeller rendering backend')) {
           // Sometimes more than one of these will be printed out if there is a
           // fallback.
+          if (impellerBackendCount == 0) {
+            didReceiveBackendMessage.complete();
+          }
           impellerBackendCount += 1;
-          didReceiveBackendMessage.complete();
         }
         if (data.contains(
             'Using the Impeller rendering backend (Vulkan with Validation Layers)')) {

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -1,0 +1,75 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async' show StreamSubscription;
+import 'dart:io' show Directory, Process;
+
+import 'package:flutter_devicelab/framework/devices.dart'
+    show Device, DeviceOperatingSystem, deviceOperatingSystem, devices;
+import 'package:flutter_devicelab/framework/framework.dart' show task;
+import 'package:flutter_devicelab/framework/task_result.dart' show TaskResult;
+import 'package:flutter_devicelab/framework/utils.dart'
+    show dir, flutter, flutterDirectory, inDirectory, startFlutter;
+import 'package:path/path.dart' as path;
+
+Future<TaskResult> run() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  final Device device = await devices.workingDevice;
+  await device.unlock();
+  final Directory appDir =
+      dir(path.join(flutterDirectory.path, 'examples/hello_world'));
+
+  bool isUsingValidationLayers = false;
+  bool hasValidationErrors = false;
+  int impellerBackendCount = 0;
+
+  await inDirectory(appDir, () async {
+    await flutter('packages', options: <String>['get']);
+
+    final StreamSubscription<String> adb = device.logcat.listen(
+      (String data) {
+        if (data.contains('Using the Impeller rendering backend')) {
+          // Sometimes more than one of these will be printed out if there is a
+          // fallback.
+          impellerBackendCount += 1;
+        }
+        if (data.contains(
+            'Using the Impeller rendering backend (Vulkan with Validation Layers)')) {
+          isUsingValidationLayers = true;
+        }
+        if (data.contains('ImpellerValidationBreak')) {
+          hasValidationErrors = true;
+        }
+        print('something: $data');
+      },
+    );
+
+    final Process process = await startFlutter(
+      'run',
+      options: <String>[
+        '--enable-impeller',
+        '-d',
+        device.deviceId,
+      ],
+    );
+
+    // Since we are waiting for the lack of errors, there is no determinate
+    // amount of time we can wait.
+    await Future<void>.delayed(const Duration(seconds: 10));
+    process.stdin.write('q');
+    await adb.cancel();
+  });
+
+  if (!isUsingValidationLayers || impellerBackendCount != 1) {
+    return TaskResult.failure('Not using Vulkan validation layers.');
+  } 
+  if (hasValidationErrors){
+    return TaskResult.failure('Impeller validation errors detected.');
+  }
+  return TaskResult.success(null);
+}
+
+Future<void> main() async {
+  await task(run);
+}

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -33,7 +33,7 @@ Future<TaskResult> run() async {
         if (data.contains('Using the Impeller rendering backend')) {
           // Sometimes more than one of these will be printed out if there is a
           // fallback.
-          if (impellerBackendCount == 0) {
+          if (!didReceiveBackendMessage.isCompleted) {
             didReceiveBackendMessage.complete();
           }
           impellerBackendCount += 1;

--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -63,7 +63,7 @@ Future<TaskResult> run() async {
 
   if (!isUsingValidationLayers || impellerBackendCount != 1) {
     return TaskResult.failure('Not using Vulkan validation layers.');
-  } 
+  }
   if (hasValidationErrors){
     return TaskResult.failure('Impeller validation errors detected.');
   }


### PR DESCRIPTION
This makes sure validation layers are being used and that there are no validation errors

fixes https://github.com/flutter/flutter/issues/134175

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
