### PR TITLE
Fix memory leak in ListWheelScrollView

### DIFF
--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../rendering/rendering_tester.dart' show TestCallbackPainter, TestClipPaintingContext;
 
@@ -1285,7 +1286,7 @@ void main() {
       expect(controller.selectedItem, 10);
     });
 
-    testWidgets('controller hot swappable', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('controller hot swappable', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -1302,14 +1303,16 @@ void main() {
       await tester.drag(find.byType(ListWheelScrollView), const Offset(0.0, -500.0));
       await tester.pump();
 
-      final FixedExtentScrollController newController =
+      final FixedExtentScrollController controller1 =
           FixedExtentScrollController(initialItem: 30);
+      addTearDown(controller1.dispose);
 
+      // Attaching first controller.
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: ListWheelScrollView(
-            controller: newController,
+            controller: controller1,
             itemExtent: 100.0,
             children: List<Widget>.generate(100, (int index) {
               return const Placeholder();
@@ -1320,13 +1323,41 @@ void main() {
 
       // initialItem doesn't do anything since the scroll position was already
       // created.
-      expect(newController.selectedItem, 5);
+      expect(controller1.selectedItem, 5);
 
-      newController.jumpToItem(50);
-      expect(newController.selectedItem, 50);
-      expect(newController.position.pixels, 5000.0);
+      controller1.jumpToItem(50);
+      expect(controller1.selectedItem, 50);
+      expect(controller1.position.pixels, 5000.0);
 
-      // Now remove the controller
+      final FixedExtentScrollController controller2 =
+          FixedExtentScrollController(initialItem: 33);
+      addTearDown(controller2.dispose);
+
+      // Attaching the second controller.
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            controller: controller2,
+            itemExtent: 100.0,
+            children: List<Widget>.generate(100, (int index) {
+              return const Placeholder();
+            }),
+          ),
+        ),
+      );
+
+      // First controller is now detached.
+      expect(controller1.hasClients, isFalse);
+      // initialItem doesn't do anything since the scroll position was already
+      // created.
+      expect(controller2.selectedItem, 50);
+
+      controller2.jumpToItem(40);
+      expect(controller2.selectedItem, 40);
+      expect(controller2.position.pixels, 4000.0);
+
+      // Now, use the internal controller.
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -1339,9 +1370,59 @@ void main() {
         ),
       );
 
-      // Internally, that same controller is still attached and still at the
-      // same place.
-      expect(newController.selectedItem, 50);
+      // Both controllers are now detached.
+      expect(controller1.hasClients, isFalse);
+      expect(controller2.hasClients, isFalse);
+    });
+
+    testWidgetsWithLeakTracking('controller can be reused', (WidgetTester tester) async {
+      final FixedExtentScrollController controller =
+          FixedExtentScrollController(initialItem: 3);
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            controller: controller,
+            itemExtent: 100.0,
+            children: List<Widget>.generate(100, (int index) {
+              return const Placeholder();
+            }),
+          ),
+        ),
+      );
+
+      // selectedItem is equal to the initialItem.
+      expect(controller.selectedItem, 3);
+      expect(controller.position.pixels, 300.0);
+
+      controller.jumpToItem(10);
+      expect(controller.selectedItem, 10);
+      expect(controller.position.pixels, 1000.0);
+
+      await tester.pumpWidget(const Center());
+
+      // Controller is now detached.
+      expect(controller.hasClients, isFalse);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            controller: controller,
+            itemExtent: 100.0,
+            children: List<Widget>.generate(100, (int index) {
+              return const Placeholder();
+            }),
+          ),
+        ),
+      );
+
+      // Controller is now attached again.
+      expect(controller.hasClients, isTrue);
+      expect(controller.selectedItem, 3);
+      expect(controller.position.pixels, 300.0);
     });
   });
 


### PR DESCRIPTION
There were a couple of bugs in `ListWheelScrollView`:
1) Internal fallback `ScrollController` was not disposed if no external controller was provided;
2) There was a case when an external controller was still attached even if it was not passed into the widget anymore;
3) `ListWheelScrollView` was able to dispose external controller in `didUpdateWidget` method.

### Description
- Fixes https://github.com/flutter/flutter/issues/134724.

### Tests
- Updates `controller hot swappable` test to ensure that external controllers are detached and attached properly;
- Adds `controller can be reused` test to ensure that the controller can be reused.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
