### PR TITLE
Swap iOS back button icon in Material app bar

### DIFF
--- a/packages/flutter/lib/src/material/action_buttons.dart
+++ b/packages/flutter/lib/src/material/action_buttons.dart
@@ -153,7 +153,7 @@ class BackButtonIcon extends StatelessWidget {
             return Icons.arrow_back;
           case TargetPlatform.iOS:
           case TargetPlatform.macOS:
-            return Icons.arrow_back_ios;
+            return Icons.arrow_back_ios_new_rounded;
         }
       },
       getAndroidSemanticsLabel: (MaterialLocalizations materialLocalization) {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -856,7 +856,7 @@ void main() {
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }));
 
     testWidgetsWithLeakTracking('Back arrow uses correct default', (WidgetTester tester) async {
-      await expectBackIcon(tester, kIsWeb ? Icons.arrow_back : Icons.arrow_back_ios);
+      await expectBackIcon(tester, kIsWeb ? Icons.arrow_back : Icons.arrow_back_ios_new_rounded);
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
   });
 


### PR DESCRIPTION
Fixes #128555.

Changes the back icon for the Material app bar when running on Apple devices from `arrow_back_ios` to `arrow_back_ios_new_rounded`, as the old version of the icon wasn't centered (https://github.com/google/material-design-icons/issues/824) and the native back icon, as well as the one in Cupertino, are rounded.

| Before | After |
| ------------- | ------------- |
| <img width="295" alt="Screenshot 2023-09-14 at 11 24 10 AM" src="https://github.com/flutter/flutter/assets/58190796/242e5fae-1107-4e1d-9749-a988462e7767"> | <img width="285" alt="Screenshot 2023-09-14 at 11 23 50 AM" src="https://github.com/flutter/flutter/assets/58190796/4df1ecaa-4313-4eb3-9cf3-335a777e133f"> |

New icon works as expected with RTL:

<img width="283" alt="Screenshot 2023-09-14 at 10 57 34 AM" src="https://github.com/flutter/flutter/assets/58190796/ae92fb35-40fd-4ee0-be60-cd452f16b2e3">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
