### PR TITLE
Fixes the transition builder changing the Cupertino transition on Android.

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -771,7 +771,7 @@ class PageTransitionsTheme with Diagnosticable {
       platform = TargetPlatform.iOS;
     }
 
-    final PageTransitionsBuilder matchingBuilder = builders[platform] ?? switch(platform) {
+    final PageTransitionsBuilder matchingBuilder = builders[platform] ?? switch (platform) {
       TargetPlatform.iOS => const CupertinoPageTransitionsBuilder(),
       TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.windows || TargetPlatform.macOS || TargetPlatform.linux => const ZoomPageTransitionsBuilder(),
     };

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -765,7 +765,7 @@ class PageTransitionsTheme with Diagnosticable {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    TargetPlatform platform = Theme.of(context).platform;
+    final TargetPlatform platform = Theme.of(context).platform;
 
     final PageTransitionsBuilder matchingBuilder =
       builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -765,7 +765,11 @@ class PageTransitionsTheme with Diagnosticable {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    final TargetPlatform platform = Theme.of(context).platform;
+    TargetPlatform platform = Theme.of(context).platform;
+
+    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) {
+      platform = TargetPlatform.iOS;
+    }
 
     PageTransitionsBuilder getTransitionBuilder() {
       late PageTransitionsBuilder defaultBuilder;

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -767,7 +767,7 @@ class PageTransitionsTheme with Diagnosticable {
   ) {
     TargetPlatform platform = Theme.of(context).platform;
 
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) {
+    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) { // The trouble maker
       platform = TargetPlatform.iOS;
     }
 

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -777,7 +777,18 @@ class PageTransitionsTheme with Diagnosticable {
       if (cupertinoTransitionInProgress) {
         return const CupertinoPageTransitionsBuilder();
       }
-      return builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());
+      late PageTransitionsBuilder defaultBuilder;
+      switch (platform) {
+        case TargetPlatform.iOS:
+          defaultBuilder = CupertinoPageTransitionsBuilder();
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.windows:
+        case TargetPlatform.macOS:
+        case TargetPlatform.linux:
+          defaultBuilder = ZoomPageTransitionsBuilder();
+      }
+      return builders[platform] ?? defaultBuilder;
     }
 
     final PageTransitionsBuilder matchingBuilder = getTransitionBuilder();

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -767,11 +767,7 @@ class PageTransitionsTheme with Diagnosticable {
   ) {
     final TargetPlatform platform = Theme.of(context).platform;
 
-    bool cupertinoTransitionInProgress = false;
-
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) {
-      cupertinoTransitionInProgress = true;
-    }
+    final bool cupertinoTransitionInProgress = CupertinoRouteTransitionMixin.isPopGestureInProgress(route);
 
     PageTransitionsBuilder getTransitionBuilder() {
       if (cupertinoTransitionInProgress) {

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -767,10 +767,6 @@ class PageTransitionsTheme with Diagnosticable {
   ) {
     TargetPlatform platform = Theme.of(context).platform;
 
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) { // The trouble maker
-      platform = TargetPlatform.iOS;
-    }
-
     final PageTransitionsBuilder matchingBuilder =
       builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -780,13 +780,13 @@ class PageTransitionsTheme with Diagnosticable {
       late PageTransitionsBuilder defaultBuilder;
       switch (platform) {
         case TargetPlatform.iOS:
-          defaultBuilder = CupertinoPageTransitionsBuilder();
+          defaultBuilder = const CupertinoPageTransitionsBuilder();
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.windows:
         case TargetPlatform.macOS:
         case TargetPlatform.linux:
-          defaultBuilder = ZoomPageTransitionsBuilder();
+          defaultBuilder = const ZoomPageTransitionsBuilder();
       }
       return builders[platform] ?? defaultBuilder;
     }

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -771,22 +771,10 @@ class PageTransitionsTheme with Diagnosticable {
       platform = TargetPlatform.iOS;
     }
 
-    PageTransitionsBuilder getTransitionBuilder() {
-      late PageTransitionsBuilder defaultBuilder;
-      switch (platform) {
-        case TargetPlatform.iOS:
-          defaultBuilder = const CupertinoPageTransitionsBuilder();
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.windows:
-        case TargetPlatform.macOS:
-        case TargetPlatform.linux:
-          defaultBuilder = const ZoomPageTransitionsBuilder();
-      }
-      return builders[platform] ?? defaultBuilder;
-    }
-
-    final PageTransitionsBuilder matchingBuilder = getTransitionBuilder();
+    final PageTransitionsBuilder matchingBuilder = builders[platform] ?? switch(platform) {
+      TargetPlatform.iOS => const CupertinoPageTransitionsBuilder(),
+      TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.windows || TargetPlatform.macOS || TargetPlatform.linux => const ZoomPageTransitionsBuilder(),
+    };
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
   }
 

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -774,7 +774,7 @@ class PageTransitionsTheme with Diagnosticable {
     }
 
     PageTransitionsBuilder getTransitionBuilder() {
-      if(cupertinoTransitionInProgress) {
+      if (cupertinoTransitionInProgress) {
         return const CupertinoPageTransitionsBuilder();
       }
       return builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -772,7 +772,7 @@ class PageTransitionsTheme with Diagnosticable {
     }
 
     final PageTransitionsBuilder matchingBuilder =
-      builders[platform] ?? const ZoomPageTransitionsBuilder();
+      builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
   }
 

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -767,12 +767,7 @@ class PageTransitionsTheme with Diagnosticable {
   ) {
     final TargetPlatform platform = Theme.of(context).platform;
 
-    final bool cupertinoTransitionInProgress = CupertinoRouteTransitionMixin.isPopGestureInProgress(route);
-
     PageTransitionsBuilder getTransitionBuilder() {
-      if (cupertinoTransitionInProgress) {
-        return const CupertinoPageTransitionsBuilder();
-      }
       late PageTransitionsBuilder defaultBuilder;
       switch (platform) {
         case TargetPlatform.iOS:

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -767,8 +767,20 @@ class PageTransitionsTheme with Diagnosticable {
   ) {
     final TargetPlatform platform = Theme.of(context).platform;
 
-    final PageTransitionsBuilder matchingBuilder =
-      builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());
+    bool cupertinoTransitionInProgress = false;
+
+    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) {
+      cupertinoTransitionInProgress = true;
+    }
+
+    PageTransitionsBuilder getTransitionBuilder() {
+      if(cupertinoTransitionInProgress) {
+        return const CupertinoPageTransitionsBuilder();
+      }
+      return builders[platform] ?? (platform == TargetPlatform.iOS ? const CupertinoPageTransitionsBuilder() : const ZoomPageTransitionsBuilder());
+    }
+
+    final PageTransitionsBuilder matchingBuilder = getTransitionBuilder();
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
   }
 


### PR DESCRIPTION
Fixes #124850.

Changes the fallback for the builder on Android. Before the error was from the platform being changed mid Cupertino transition to iOS. If a default builder wasn't set for iOS (which a developer developing only for Android might not), then it defaulted to the Zoom transition. Which changing the transition while on the fly caused issues.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
