### PR TITLE
cover more tests with leak tracing

### DIFF
--- a/packages/flutter/test/semantics/semantics_binding_test.dart
+++ b/packages/flutter/test/semantics/semantics_binding_test.dart
@@ -4,9 +4,10 @@
 
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
-  testWidgets('Listeners are called when semantics are turned on with ensureSemantics', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Listeners are called when semantics are turned on with ensureSemantics', (WidgetTester tester) async {
     expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
 
     final List<bool> status = <bool>[];
@@ -43,7 +44,7 @@ void main() {
     expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
   }, semanticsEnabled: false);
 
-  testWidgets('Listeners are called when semantics are turned on by platform', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Listeners are called when semantics are turned on by platform', (WidgetTester tester) async {
     expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
 
     final List<bool> status = <bool>[];
@@ -69,7 +70,7 @@ void main() {
     expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
   }, semanticsEnabled: false);
 
-  testWidgets('SemanticsBinding.ensureSemantics triggers creation of semantics owner.', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('SemanticsBinding.ensureSemantics triggers creation of semantics owner.', (WidgetTester tester) async {
     expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
     expect(tester.binding.pipelineOwner.semanticsOwner, isNull);
 

--- a/packages/flutter/test/semantics/semantics_elevation_test.dart
+++ b/packages/flutter/test/semantics/semantics_elevation_test.dart
@@ -5,11 +5,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('SemanticsNodes overlapping in z', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('SemanticsNodes overlapping in z', (WidgetTester tester) async {
     // Cards are semantic boundaries that always own their own SemanticNode,
     // PhysicalModels merge their semantics information into parent.
     //
@@ -97,7 +98,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('SemanticsNodes overlapping in z with switched children', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('SemanticsNodes overlapping in z with switched children', (WidgetTester tester) async {
     // Same as 'SemanticsNodes overlapping in z', but the order of children
     // is reversed
 
@@ -173,7 +174,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('single node thickness', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('single node thickness', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(const MaterialApp(
@@ -193,7 +194,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('force-merge', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('force-merge', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(MaterialApp(
@@ -247,7 +248,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('force-merge with inversed children', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('force-merge with inversed children', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/semantics/semantics_owner_test.dart
+++ b/packages/flutter/test/semantics/semantics_owner_test.dart
@@ -5,11 +5,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('Performing SemanticsAction.showOnScreen does not crash if node no longer exist', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Performing SemanticsAction.showOnScreen does not crash if node no longer exist', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/100358.
 
     final SemanticsTester semantics = SemanticsTester(tester);

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -8,11 +8,12 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   SemanticsUpdateTestBinding();
 
-  testWidgets('Semantics update does not send update for merged nodes.', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Semantics update does not send update for merged nodes.', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     // Pumps a placeholder to trigger the warm up frame.
     await tester.pumpWidget(
@@ -85,7 +86,7 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('Semantics update receives attributed text', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Semantics update receives attributed text', (WidgetTester tester) async {
     final SemanticsHandle handle = tester.ensureSemantics();
     // Pumps a placeholder to trigger the warm up frame.
     await tester.pumpWidget(

--- a/packages/flutter/test/semantics/traversal_order_test.dart
+++ b/packages/flutter/test/semantics/traversal_order_test.dart
@@ -4,11 +4,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('Traversal order handles touching elements', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Traversal order handles touching elements', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Cover tests in test/semantics with leak tracing (see [#134](https://github.com/dart-lang/leak_tracker/issues/134#issue-1870426468))

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
