### PR TITLE
Improve DropdownMenu sample code for requestFocusOnTap on mobile platforms

### DIFF
--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -74,6 +74,11 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                     DropdownMenu<ColorLabel>(
                       initialSelection: ColorLabel.green,
                       controller: colorController,
+                      // requestFocusOnTap is enabled/disabled by platforms when it is null.
+                      // On mobile platforms, this is false by default. Setting this to true will
+                      // trigger focus request on the text field and virtual keyboard will appear
+                      // afterward. On desktop platforms however, this defaults to true.
+                      requestFocusOnTap: true,
                       label: const Text('Color'),
                       onSelected: (ColorLabel? color) {
                         setState(() {
@@ -97,6 +102,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                     DropdownMenu<IconLabel>(
                       controller: iconController,
                       enableFilter: true,
+                      requestFocusOnTap: true,
                       leadingIcon: const Icon(Icons.search),
                       label: const Text('Icon'),
                       inputDecorationTheme: const InputDecorationTheme(

--- a/examples/api/test/material/dropdown_menu/dropdown_menu.0_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.0_test.dart
@@ -52,4 +52,26 @@ void main() {
 
     expect(find.text('You selected a Blue Smile'), findsOneWidget);
   });
+
+  testWidgets('DropdownMenu has focus when tapping on the text field', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.DropdownMenuExample(),
+    );
+
+    // Make sure the dropdown menus are there.
+    final Finder colorMenu = find.byType(DropdownMenu<example.ColorLabel>);
+    final Finder iconMenu = find.byType(DropdownMenu<example.IconLabel>);
+    expect(colorMenu, findsOneWidget);
+    expect(iconMenu, findsOneWidget);
+
+    // Tap on the color menu and make sure it is focused.
+    await tester.tap(colorMenu);
+    await tester.pumpAndSettle();
+    expect(FocusScope.of(tester.element(colorMenu)).hasFocus, isTrue);
+
+    // Tap on the icon menu and make sure it is focused.
+    await tester.tap(iconMenu);
+    await tester.pumpAndSettle();
+    expect(FocusScope.of(tester.element(iconMenu)).hasFocus, isTrue);
+  });
 }


### PR DESCRIPTION
### Description

This PR is to improve `DropdownMenu` sample code. By default, `requestFocusOnTap` is false on mobile platforms. When users run API sample code on mobile platforms, they can not edit the text field and think it is a bug. Although it is detailed at https://api.flutter.dev/flutter/material/DropdownMenu/requestFocusOnTap.html, users often do not pay attention to it.

### Related issue

Fixes https://github.com/flutter/flutter/issues/127672

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
