### PR TITLE
Rename `debugProfilePlatformChannels` to a constant that works in release mode

### DIFF
--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/foundation.dart';
 
 import 'hardware_keyboard.dart';
-import 'platform_channel.dart';
 
 export 'hardware_keyboard.dart' show KeyDataTransitMode;
 

--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'hardware_keyboard.dart';
+import 'platform_channel.dart';
 
 export 'hardware_keyboard.dart' show KeyDataTransitMode;
 

--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -25,10 +25,7 @@ KeyDataTransitMode? debugKeyEventSimulatorTransitModeOverride;
 /// The statistics include the total bytes transmitted and the average number of
 /// bytes per invocation in the last quantum. "Up" means in the direction of
 /// Flutter to the host platform, "down" is the host platform to flutter.
-///
-/// Contrary to other debugging toggles in this package, this will function even
-/// when [kReleaseMode] is true.
-bool debugProfilePlatformChannels = false;
+bool profilePlatformChannels = false;
 
 /// Setting to true will cause extensive logging to occur when key events are
 /// received.
@@ -49,7 +46,7 @@ bool debugAssertAllServicesVarsUnset(String reason) {
     if (debugKeyEventSimulatorTransitModeOverride != null) {
       throw FlutterError(reason);
     }
-    if (debugProfilePlatformChannels || debugPrintKeyboardEvents) {
+    if (profilePlatformChannels || debugPrintKeyboardEvents) {
       throw FlutterError(reason);
     }
     return true;

--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -25,6 +25,9 @@ KeyDataTransitMode? debugKeyEventSimulatorTransitModeOverride;
 /// The statistics include the total bytes transmitted and the average number of
 /// bytes per invocation in the last quantum. "Up" means in the direction of
 /// Flutter to the host platform, "down" is the host platform to flutter.
+///
+/// Contrary to other debugging toggles in this package, this will function even
+/// when [kReleaseMode] is true.
 bool debugProfilePlatformChannels = false;
 
 /// Setting to true will cause extensive logging to occur when key events are

--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -15,18 +15,6 @@ export 'hardware_keyboard.dart' show KeyDataTransitMode;
 /// of their extent of support for keyboard API.
 KeyDataTransitMode? debugKeyEventSimulatorTransitModeOverride;
 
-/// Profile and print statistics on Platform Channel usage.
-///
-/// When this is true statistics about the usage of Platform Channels will be
-/// printed out periodically to the console and Timeline events will show the
-/// time between sending and receiving a message (encoding and decoding time
-/// excluded).
-///
-/// The statistics include the total bytes transmitted and the average number of
-/// bytes per invocation in the last quantum. "Up" means in the direction of
-/// Flutter to the host platform, "down" is the host platform to flutter.
-bool profilePlatformChannels = false;
-
 /// Setting to true will cause extensive logging to occur when key events are
 /// received.
 ///

--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -35,7 +35,7 @@ bool debugAssertAllServicesVarsUnset(String reason) {
     if (debugKeyEventSimulatorTransitModeOverride != null) {
       throw FlutterError(reason);
     }
-    if (profilePlatformChannels || debugPrintKeyboardEvents) {
+    if (debugPrintKeyboardEvents) {
       throw FlutterError(reason);
     }
     return true;

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -32,7 +32,7 @@ export 'message_codec.dart' show MessageCodec, MethodCall, MethodCodec;
 /// The statistics include the total bytes transmitted and the average number of
 /// bytes per invocation in the last quantum. "Up" means in the direction of
 /// Flutter to the host platform, "down" is the host platform to flutter.
-bool profilePlatformChannels = false;
+const bool kProfilePlatformChannels = false;
 
 bool _profilePlatformChannelsIsRunning = false;
 const Duration _profilePlatformChannelsRate = Duration(seconds: 1);
@@ -189,7 +189,7 @@ class BasicMessageChannel<T> {
   /// [BackgroundIsolateBinaryMessenger.ensureInitialized].
   BinaryMessenger get binaryMessenger {
     final BinaryMessenger result = _binaryMessenger ?? _findBinaryMessenger();
-    return profilePlatformChannels
+    return kProfilePlatformChannels
         ? _profiledBinaryMessengers[this] ??= _ProfiledBinaryMessenger(
             // ignore: no_runtimetype_tostring
             result, runtimeType.toString(), codec.runtimeType.toString())
@@ -278,7 +278,7 @@ class MethodChannel {
   /// [BackgroundIsolateBinaryMessenger.ensureInitialized].
   BinaryMessenger get binaryMessenger {
     final BinaryMessenger result = _binaryMessenger ?? _findBinaryMessenger();
-    return profilePlatformChannels
+    return kProfilePlatformChannels
         ? _profiledBinaryMessengers[this] ??= _ProfiledBinaryMessenger(
             // ignore: no_runtimetype_tostring
             result, runtimeType.toString(), codec.runtimeType.toString())
@@ -309,7 +309,7 @@ class MethodChannel {
   Future<T?> _invokeMethod<T>(String method, { required bool missingOk, dynamic arguments }) async {
     final ByteData input = codec.encodeMethodCall(MethodCall(method, arguments));
     final ByteData? result =
-      profilePlatformChannels ?
+      kProfilePlatformChannels ?
         await (binaryMessenger as _ProfiledBinaryMessenger).sendWithPostfix(name, '#$method', input) :
         await binaryMessenger.send(name, input);
     if (result == null) {

--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -12,7 +12,6 @@ import '_background_isolate_binary_messenger_io.dart'
 
 import 'binary_messenger.dart';
 import 'binding.dart';
-import 'debug.dart';
 import 'message_codec.dart';
 import 'message_codecs.dart';
 
@@ -22,6 +21,18 @@ export '_background_isolate_binary_messenger_io.dart'
 export 'binary_messenger.dart' show BinaryMessenger;
 export 'binding.dart' show RootIsolateToken;
 export 'message_codec.dart' show MessageCodec, MethodCall, MethodCodec;
+
+/// Profile and print statistics on Platform Channel usage.
+///
+/// When this is true statistics about the usage of Platform Channels will be
+/// printed out periodically to the console and Timeline events will show the
+/// time between sending and receiving a message (encoding and decoding time
+/// excluded).
+///
+/// The statistics include the total bytes transmitted and the average number of
+/// bytes per invocation in the last quantum. "Up" means in the direction of
+/// Flutter to the host platform, "down" is the host platform to flutter.
+bool profilePlatformChannels = false;
 
 bool _profilePlatformChannelsIsRunning = false;
 const Duration _profilePlatformChannelsRate = Duration(seconds: 1);


### PR DESCRIPTION
When it comes to startup profiling, it is very helpful to look at platform channels. `debugProfilePlatformChannels` today only works in debug and profile mode. Unfortunately, using profile mode is less accurate for startup profiling, because of the service isolate introducing additional overhead.

This PR allows this toggle to work in release mode. Note that there are two parts to `debugProfilePlatformChannels`:

- Adding timeline events
- Logging statistics about platform channels

I also considered adding a separate toggle to limit the scope of this change to the former, but that seems like complexity that we might not need at this time.

Towards #102189

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
