### PR TITLE
Fix memory leak in _DarwinViewState.

### DIFF
--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -665,6 +665,9 @@ abstract class _DarwinViewState<PlatformViewT extends _DarwinView, ControllerT e
 
     if (widget.viewType != oldWidget.viewType) {
       _controller?.dispose();
+      _controller = null;
+      focusNode?.dispose();
+      focusNode = null;
       _createNewUiKitView();
       return;
     }

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -14,12 +14,13 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../services/fake_platform_views.dart';
 
 void main() {
   group('AndroidView', () {
-    testWidgets('Create Android view', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Create Android view', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -47,7 +48,7 @@ void main() {
       );
     });
 
-    testWidgets('Create Android view with params', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Create Android view with params', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -91,7 +92,7 @@ void main() {
       );
     });
 
-    testWidgets('Zero sized Android view is not created', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Zero sized Android view is not created', (WidgetTester tester) async {
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -109,7 +110,7 @@ void main() {
       );
     });
 
-    testWidgets('Resize Android view', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Resize Android view', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -167,7 +168,7 @@ void main() {
       );
     });
 
-    testWidgets('Change Android view type', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Change Android view type', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -205,7 +206,7 @@ void main() {
       );
     });
 
-    testWidgets('Dispose Android view', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Dispose Android view', (WidgetTester tester) async {
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
@@ -233,7 +234,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view survives widget tree change', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view survives widget tree change', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -271,7 +272,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view gets touch events', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view gets touch events', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -298,7 +299,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view transparent hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view transparent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -343,7 +344,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view translucent hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view translucent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -390,7 +391,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view opaque hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view opaque hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -436,7 +437,7 @@ void main() {
       );
     });
 
-    testWidgets("Android view touch events are in virtual display's coordinate system", (WidgetTester tester) async {
+    testWidgetsWithLeakTracking("Android view touch events are in virtual display's coordinate system", (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -466,7 +467,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view directionality', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view directionality', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('maps');
@@ -515,7 +516,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view ambient directionality', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view ambient directionality', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('maps');
@@ -570,7 +571,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view can lose gesture arenas', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view can lose gesture arenas', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -605,7 +606,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view drag gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view drag gesture recognizer', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -651,7 +652,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view long press gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view long press gesture recognizer', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -694,7 +695,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view tap gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view tap gesture recognizer', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -737,7 +738,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view can claim gesture after all pointers are up', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view can claim gesture after all pointers are up', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -777,7 +778,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view rebuilt during gesture', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view rebuilt during gesture', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -824,7 +825,7 @@ void main() {
       );
     });
 
-    testWidgets('Android view with eager gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Android view with eager gesture recognizer', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -866,7 +867,7 @@ void main() {
 
     // This test makes sure it doesn't crash.
     // https://github.com/flutter/flutter/issues/21514
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'RenderAndroidView reconstructed with same gestureRecognizers does not crash',
       (WidgetTester tester) async {
         final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
@@ -888,7 +889,7 @@ void main() {
       },
     );
 
-    testWidgets('AndroidView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -922,7 +923,7 @@ void main() {
       expect(factoryInvocationCount, 1);
     });
 
-    testWidgets('AndroidView has correct semantics', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidView has correct semantics', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       expect(currentViewId, greaterThanOrEqualTo(0));
@@ -977,7 +978,7 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('AndroidView can take input focus', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidView can take input focus', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1029,7 +1030,7 @@ void main() {
       expect(androidViewFocusNode.hasFocus, isTrue);
     });
 
-    testWidgets('AndroidView sets a platform view text input client when focused', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidView sets a platform view text input client when focused', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1078,7 +1079,7 @@ void main() {
       expect(lastPlatformViewTextClient['platformViewId'], currentViewId + 1);
     });
 
-    testWidgets('AndroidView clears platform focus when unfocused', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidView clears platform focus when unfocused', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1123,7 +1124,7 @@ void main() {
       expect(viewsController.lastClearedFocusViewId, currentViewId + 1);
     });
 
-    testWidgets('can set and update clipBehavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('can set and update clipBehavior', (WidgetTester tester) async {
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -1169,7 +1170,7 @@ void main() {
       }
     });
 
-    testWidgets('clip is handled correctly during resizing', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('clip is handled correctly during resizing', (WidgetTester tester) async {
       // Regressing test for https://github.com/flutter/flutter/issues/67343
 
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
@@ -1211,7 +1212,7 @@ void main() {
       expect(clipRectLayer.clipRect, const Rect.fromLTWH(0.0, 0.0, 50.0, 50.0));
     });
 
-    testWidgets('offset is sent to the platform', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('offset is sent to the platform', (WidgetTester tester) async {
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -1237,7 +1238,7 @@ void main() {
       controller = FakeAndroidViewController(0);
     });
 
-    testWidgets('AndroidViewSurface sets pointTransformer of view controller', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidViewSurface sets pointTransformer of view controller', (WidgetTester tester) async {
       final AndroidViewSurface surface = AndroidViewSurface(
         controller: controller,
         hitTestBehavior: PlatformViewHitTestBehavior.opaque,
@@ -1247,7 +1248,7 @@ void main() {
       expect(controller.pointTransformer, isNotNull);
     });
 
-    testWidgets('AndroidViewSurface defaults to texture-based rendering', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidViewSurface defaults to texture-based rendering', (WidgetTester tester) async {
       final AndroidViewSurface surface = AndroidViewSurface(
         controller: controller,
         hitTestBehavior: PlatformViewHitTestBehavior.opaque,
@@ -1260,7 +1261,7 @@ void main() {
       ), findsOneWidget);
     });
 
-    testWidgets('AndroidViewSurface uses view-based rendering when initially required', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidViewSurface uses view-based rendering when initially required', (WidgetTester tester) async {
       controller.requiresViewComposition = true;
       final AndroidViewSurface surface = AndroidViewSurface(
         controller: controller,
@@ -1274,7 +1275,7 @@ void main() {
       ), findsOneWidget);
     });
 
-    testWidgets('AndroidViewSurface can switch to view-based rendering after creation', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AndroidViewSurface can switch to view-based rendering after creation', (WidgetTester tester) async {
       final AndroidViewSurface surface = AndroidViewSurface(
         controller: controller,
         hitTestBehavior: PlatformViewHitTestBehavior.opaque,
@@ -1306,7 +1307,7 @@ void main() {
   });
 
   group('UiKitView', () {
-    testWidgets('Create UIView', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Create UIView', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1329,7 +1330,7 @@ void main() {
       );
     });
 
-    testWidgets('Change UIView view type', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Change UIView view type', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1362,7 +1363,7 @@ void main() {
       );
     });
 
-    testWidgets('Dispose UIView ', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Dispose UIView ', (WidgetTester tester) async {
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
@@ -1390,7 +1391,7 @@ void main() {
       );
     });
 
-    testWidgets('Dispose UIView before creation completed ', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Dispose UIView before creation completed ', (WidgetTester tester) async {
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
       viewsController.creationDelay = Completer<void>();
@@ -1421,7 +1422,7 @@ void main() {
       );
     });
 
-    testWidgets('UIView survives widget tree change', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UIView survives widget tree change', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1454,7 +1455,7 @@ void main() {
       );
     });
 
-    testWidgets('Create UIView with params', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Create UIView with params', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1492,7 +1493,7 @@ void main() {
       );
     });
 
-    testWidgets('UiKitView accepts gestures', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView accepts gestures', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1520,7 +1521,7 @@ void main() {
       expect(viewsController.gesturesAccepted[currentViewId + 1], 1);
     });
 
-    testWidgets('UiKitView transparent hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView transparent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1565,7 +1566,7 @@ void main() {
       expect(numPointerDownsOnParent, 1);
     });
 
-    testWidgets('UiKitView translucent hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView translucent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1610,7 +1611,7 @@ void main() {
       expect(numPointerDownsOnParent, 1);
     });
 
-    testWidgets('UiKitView opaque hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView opaque hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1653,7 +1654,7 @@ void main() {
       expect(numPointerDownsOnParent, 0);
     });
 
-    testWidgets('UiKitView can lose gesture arenas', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView can lose gesture arenas', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1691,7 +1692,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 1);
     });
 
-    testWidgets('UiKitView tap gesture recognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView tap gesture recognizers', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1735,7 +1736,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView long press gesture recognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView long press gesture recognizers', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1777,7 +1778,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView drag gesture recognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView drag gesture recognizers', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1819,7 +1820,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView can claim gesture after all pointers are up', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView can claim gesture after all pointers are up', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1859,7 +1860,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView rebuilt during gesture', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView rebuilt during gesture', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1904,7 +1905,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView with eager gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView with eager gesture recognizer', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1944,7 +1945,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView rejects gestures absorbed by siblings', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView rejects gestures absorbed by siblings', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -1974,7 +1975,7 @@ void main() {
       expect(viewsController.gesturesAccepted[currentViewId + 1], 0);
     });
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'UiKitView rejects gestures absorbed by siblings if the touch is outside of the platform view bounds but inside platform view frame',
       (WidgetTester tester) async {
         // UiKitView is positioned at (left=0, top=100, right=300, bottom=600).
@@ -2024,7 +2025,7 @@ void main() {
       },
     );
 
-    testWidgets('UiKitView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -2058,7 +2059,7 @@ void main() {
       expect(factoryInvocationCount, 1);
     });
 
-    testWidgets('UiKitView can take input focus', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView can take input focus', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2111,7 +2112,7 @@ void main() {
       expect(uiKitViewFocusNode.hasFocus, isTrue);
     });
 
-    testWidgets('UiKitView sends TextInput.setPlatformViewClient when focused', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView sends TextInput.setPlatformViewClient when focused', (WidgetTester tester) async {
 
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
@@ -2150,7 +2151,7 @@ void main() {
       expect(channelArguments['platformViewId'], currentViewId + 1);
     });
 
-    testWidgets('FocusNode is disposed on UIView dispose', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusNode is disposed on UIView dispose', (WidgetTester tester) async {
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -2178,7 +2179,7 @@ void main() {
       expect(() => ChangeNotifier.debugAssertNotDisposed(node), throwsAssertionError);
     });
 
-    testWidgets('UiKitView has correct semantics', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView has correct semantics', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       expect(currentViewId, greaterThanOrEqualTo(0));
@@ -2225,7 +2226,7 @@ void main() {
   });
 
   group('AppKitView', () {
-    testWidgets('Create AppView', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Create AppView', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2248,7 +2249,7 @@ void main() {
       );
     });
 
-    testWidgets('Change AppKitView view type', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Change AppKitView view type', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2281,7 +2282,7 @@ void main() {
       );
     });
 
-    testWidgets('Dispose AppKitView ', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Dispose AppKitView ', (WidgetTester tester) async {
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
@@ -2309,7 +2310,7 @@ void main() {
       );
     });
 
-    testWidgets('Dispose AppKitView before creation completed ', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Dispose AppKitView before creation completed ', (WidgetTester tester) async {
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
       viewsController.creationDelay = Completer<void>();
@@ -2340,7 +2341,7 @@ void main() {
       );
     });
 
-    testWidgets('AppKitView survives widget tree change', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView survives widget tree change', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2373,7 +2374,7 @@ void main() {
       );
     });
 
-    testWidgets('Create AppKitView with params', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Create AppKitView with params', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2413,7 +2414,7 @@ void main() {
 
     // TODO(schectman): De-skip the following tests once macOS gesture recognizers are present.
     // https://github.com/flutter/flutter/issues/128519
-    testWidgets('AppKitView accepts gestures', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView accepts gestures', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2441,7 +2442,7 @@ void main() {
       expect(viewsController.gesturesAccepted[currentViewId + 1], 1);
     }, skip: true); // https://github.com/flutter/flutter/issues/128519
 
-    testWidgets('AppKitView transparent hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView transparent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2486,7 +2487,7 @@ void main() {
       expect(numPointerDownsOnParent, 1);
     }, skip: true); // https://github.com/flutter/flutter/issues/128519
 
-    testWidgets('AppKitView translucent hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView translucent hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2531,7 +2532,7 @@ void main() {
       expect(numPointerDownsOnParent, 1);
     }, skip: true); // https://github.com/flutter/flutter/issues/128519
 
-    testWidgets('AppKitView opaque hit test behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView opaque hit test behavior', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2574,7 +2575,7 @@ void main() {
       expect(numPointerDownsOnParent, 0);
     }, skip: true); // https://github.com/flutter/flutter/issues/128519
 
-    testWidgets('UiKitView can lose gesture arenas', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView can lose gesture arenas', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2612,7 +2613,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 1);
     });
 
-    testWidgets('UiKitView tap gesture recognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView tap gesture recognizers', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2656,7 +2657,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView long press gesture recognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView long press gesture recognizers', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2698,7 +2699,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView drag gesture recognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView drag gesture recognizers', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2740,7 +2741,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView can claim gesture after all pointers are up', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView can claim gesture after all pointers are up', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2780,7 +2781,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView rebuilt during gesture', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView rebuilt during gesture', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2825,7 +2826,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView with eager gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView with eager gesture recognizer', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2865,7 +2866,7 @@ void main() {
       expect(viewsController.gesturesRejected[currentViewId + 1], 0);
     });
 
-    testWidgets('UiKitView rejects gestures absorbed by siblings', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView rejects gestures absorbed by siblings', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -2895,7 +2896,7 @@ void main() {
       expect(viewsController.gesturesAccepted[currentViewId + 1], 0);
     });
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'UiKitView rejects gestures absorbed by siblings if the touch is outside of the platform view bounds but inside platform view frame',
       (WidgetTester tester) async {
         // UiKitView is positioned at (left=0, top=100, right=300, bottom=600).
@@ -2945,7 +2946,7 @@ void main() {
       },
     );
 
-    testWidgets('UiKitView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('UiKitView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -2979,7 +2980,7 @@ void main() {
       expect(factoryInvocationCount, 1);
     });
 
-    testWidgets('AppKitView can take input focus', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView can take input focus', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
@@ -3032,7 +3033,7 @@ void main() {
       expect(uiKitViewFocusNode.hasFocus, isTrue);
     });
 
-    testWidgets('AppKitView sends TextInput.setPlatformViewClient when focused', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView sends TextInput.setPlatformViewClient when focused', (WidgetTester tester) async {
 
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
@@ -3071,7 +3072,7 @@ void main() {
       expect(channelArguments['platformViewId'], currentViewId + 1);
     });
 
-    testWidgets('FocusNode is disposed on UIView dispose', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('FocusNode is disposed on UIView dispose', (WidgetTester tester) async {
       final FakeMacosPlatformViewsController viewsController = FakeMacosPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -3099,7 +3100,7 @@ void main() {
       expect(() => ChangeNotifier.debugAssertNotDisposed(node), throwsAssertionError);
     });
 
-    testWidgets('AppKitView has correct semantics', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('AppKitView has correct semantics', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       expect(currentViewId, greaterThanOrEqualTo(0));
@@ -3152,7 +3153,7 @@ void main() {
       controller = FakePlatformViewController(0);
     });
 
-    testWidgets('PlatformViewSurface should create platform view layer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface should create platform view layer', (WidgetTester tester) async {
       final PlatformViewSurface surface = PlatformViewSurface(
         controller: controller,
         hitTestBehavior: PlatformViewHitTestBehavior.opaque,
@@ -3162,7 +3163,7 @@ void main() {
       expect(() => tester.layers.whereType<PlatformViewLayer>().first, returnsNormally);
     });
 
-    testWidgets('PlatformViewSurface can lose gesture arenas', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface can lose gesture arenas', (WidgetTester tester) async {
       bool verticalDragAcceptedByParent = false;
       await tester.pumpWidget(
         Align(
@@ -3198,7 +3199,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewSurface gesture recognizers dispatch events', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface gesture recognizers dispatch events', (WidgetTester tester) async {
       bool verticalDragAcceptedByParent = false;
       await tester.pumpWidget(
         Align(
@@ -3237,7 +3238,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewSurface can claim gesture after all pointers are up', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface can claim gesture after all pointers are up', (WidgetTester tester) async {
       bool verticalDragAcceptedByParent = false;
       // The long press recognizer rejects the gesture after the PlatformViewSurface gets the pointer up event.
       // This test makes sure that the PlatformViewSurface can win the gesture after it got the pointer up event.
@@ -3272,7 +3273,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewSurface rebuilt during gesture', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface rebuilt during gesture', (WidgetTester tester) async {
       await tester.pumpWidget(
         Align(
           alignment: Alignment.topLeft,
@@ -3314,7 +3315,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewSurface with eager gesture recognizer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface with eager gesture recognizer', (WidgetTester tester) async {
       await tester.pumpWidget(
         Align(
           alignment: Alignment.topLeft,
@@ -3349,7 +3350,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewRenderBox reconstructed with same gestureRecognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewRenderBox reconstructed with same gestureRecognizers', (WidgetTester tester) async {
       int factoryInvocationCount = 0;
       EagerGestureRecognizer constructRecognizer() {
         ++factoryInvocationCount;
@@ -3373,7 +3374,7 @@ void main() {
       expect(factoryInvocationCount, 2);
     });
 
-    testWidgets('PlatformViewSurface rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewSurface rebuilt with same gestureRecognizers', (WidgetTester tester) async {
       int factoryInvocationCount = 0;
       EagerGestureRecognizer constructRecognizer() {
         ++factoryInvocationCount;
@@ -3406,7 +3407,7 @@ void main() {
       expect(factoryInvocationCount, 1);
     });
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'PlatformViewLink Widget init, should create a placeholder widget before onPlatformViewCreated and a PlatformViewSurface after',
       (WidgetTester tester) async {
         final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -3450,7 +3451,7 @@ void main() {
       },
     );
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'PlatformViewLink widget should not trigger creation with an empty size',
       (WidgetTester tester) async {
         late PlatformViewController controller;
@@ -3492,7 +3493,7 @@ void main() {
       },
     );
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'PlatformViewLink calls create when needed for Android texture display modes',
       (WidgetTester tester) async {
         final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -3547,7 +3548,7 @@ void main() {
       },
     );
 
-    testWidgets('PlatformViewLink includes offset in create call when using texture layer', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink includes offset in create call when using texture layer', (WidgetTester tester) async {
       addTearDown(tester.view.reset);
 
       late FakeAndroidViewController controller;
@@ -3591,7 +3592,7 @@ void main() {
       expect(controller.createPosition, const Offset(150, 75));
     });
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'PlatformViewLink does not double-call create for Android Hybrid Composition',
       (WidgetTester tester) async {
         final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -3641,7 +3642,7 @@ void main() {
       },
     );
 
-    testWidgets('PlatformViewLink Widget dispose', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink Widget dispose', (WidgetTester tester) async {
       late FakePlatformViewController disposedController;
       final PlatformViewLink platformViewLink = PlatformViewLink(
         viewType: 'webview',
@@ -3666,7 +3667,7 @@ void main() {
       expect(disposedController.disposed, true);
     });
 
-    testWidgets('PlatformViewLink handles onPlatformViewCreated when disposed', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink handles onPlatformViewCreated when disposed', (WidgetTester tester) async {
       late PlatformViewCreationParams creationParams;
       late FakePlatformViewController controller;
       final PlatformViewLink platformViewLink = PlatformViewLink(
@@ -3692,7 +3693,7 @@ void main() {
       expect(() => creationParams.onPlatformViewCreated(creationParams.id), returnsNormally);
     });
 
-    testWidgets('PlatformViewLink widget survives widget tree change', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink widget survives widget tree change', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final List<int> ids = <int>[];
@@ -3747,7 +3748,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewLink re-initializes when view type changes', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink re-initializes when view type changes', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final List<int> ids = <int>[];
       final List<int> surfaceViewIds = <int>[];
@@ -3819,7 +3820,7 @@ void main() {
       );
     });
 
-    testWidgets('PlatformViewLink can take any widget to return in the SurfaceFactory', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink can take any widget to return in the SurfaceFactory', (WidgetTester tester) async {
       final PlatformViewLink platformViewLink = PlatformViewLink(
         viewType: 'webview',
         onCreatePlatformView: (PlatformViewCreationParams params) {
@@ -3836,7 +3837,7 @@ void main() {
       expect(() => tester.allWidgets.whereType<Container>().first, returnsNormally);
     });
 
-    testWidgets('PlatformViewLink manages the focus properly', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink manages the focus properly', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       late FakePlatformViewController controller;
       late ValueChanged<bool> focusChanged;
@@ -3901,7 +3902,7 @@ void main() {
       expect(controller.focusCleared, true);
     });
 
-    testWidgets('PlatformViewLink sets a platform view text input client when focused', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('PlatformViewLink sets a platform view text input client when focused', (WidgetTester tester) async {
       late FakePlatformViewController controller;
       late int viewId;
 
@@ -3951,7 +3952,7 @@ void main() {
     });
   });
 
-  testWidgets('Platform views respect hitTestBehavior', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Platform views respect hitTestBehavior', (WidgetTester tester) async {
     final FakePlatformViewController controller = FakePlatformViewController(0);
 
     final List<String> logs = <String>[];
@@ -4090,7 +4091,7 @@ void main() {
     expect(controller.dispatchedPointerEvents[0], isA<PointerHoverEvent>());
   });
 
-  testWidgets('HtmlElementView can be instantiated', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('HtmlElementView can be instantiated', (WidgetTester tester) async {
     late final Widget htmlElementView;
     expect(() {
       htmlElementView = const HtmlElementView(viewType: 'webview');


### PR DESCRIPTION
This PR fixes memory leak in the `_DarwinViewState`, which did not dispose old `FocusNode` before the creation of the new one in `didUpdateWidget`.

### Description
- Fixes https://github.com/flutter/flutter/issues/134936.

### Tests
- Updates `platform_view_test.dart` to use `testWidgetsWithLeakTracking`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
