### PR TITLE
Remove 'must be non-null' and 'must not be null' comments from material.

### DIFF
--- a/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons.dart
@@ -29,8 +29,8 @@ part of material_animated_icons; // ignore: use_string_in_part_of_directives
 class AnimatedIcon extends StatelessWidget {
   /// Creates an AnimatedIcon.
   ///
-  /// The [progress] and [icon] arguments must not be null.
-  /// The [size] and [color] default to the value given by the current [IconTheme].
+  /// The [size] and [color] default to the value given by the current
+  /// [IconTheme].
   const AnimatedIcon({
     super.key,
     required this.icon,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -202,8 +202,6 @@ class MaterialApp extends StatefulWidget {
   /// unsupported route.
   ///
   /// This class creates an instance of [WidgetsApp].
-  ///
-  /// The boolean arguments, [routes], and [navigatorObservers], must not be null.
   const MaterialApp({
     super.key,
     this.navigatorKey,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1436,9 +1436,6 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///  * <https://material.io/design/components/app-bars-top.html>
 class SliverAppBar extends StatefulWidget {
   /// Creates a Material Design app bar that can be placed in a [CustomScrollView].
-  ///
-  /// The arguments [forceElevated], [primary], [floating], [pinned], [snap]
-  /// and [automaticallyImplyLeading] must not be null.
   const SliverAppBar({
     super.key,
     this.leading,

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -200,8 +200,6 @@ class AppBarTheme with Diagnosticable {
 
   /// Linearly interpolate between two AppBar themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static AppBarTheme lerp(AppBarTheme? a, AppBarTheme? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -93,8 +93,8 @@ enum MaterialBannerClosedReason {
 class MaterialBanner extends StatefulWidget {
   /// Creates a [MaterialBanner].
   ///
-  /// The [actions].length must be greater than 0. The [elevation] must be null
-  /// or non-negative.
+  /// The length of the [actions] list must not be empty. The [elevation] must
+  /// be null or non-negative.
   const MaterialBanner({
     super.key,
     required this.content,

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -93,9 +93,8 @@ enum MaterialBannerClosedReason {
 class MaterialBanner extends StatefulWidget {
   /// Creates a [MaterialBanner].
   ///
-  /// The [actions], [content], and [forceActionsBelow] must be non-null.
-  /// The [actions].length must be greater than 0. The [elevation] must be null or
-  /// non-negative.
+  /// The [actions].length must be greater than 0. The [elevation] must be null
+  /// or non-negative.
   const MaterialBanner({
     super.key,
     required this.content,

--- a/packages/flutter/lib/src/material/banner_theme.dart
+++ b/packages/flutter/lib/src/material/banner_theme.dart
@@ -97,8 +97,6 @@ class MaterialBannerThemeData with Diagnosticable {
 
   /// Linearly interpolate between two Banner themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static MaterialBannerThemeData lerp(MaterialBannerThemeData? a, MaterialBannerThemeData? b, double t) {
     return MaterialBannerThemeData(

--- a/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
@@ -94,8 +94,6 @@ class BottomAppBarTheme with Diagnosticable {
 
   /// Linearly interpolate between two BAB themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static BottomAppBarTheme lerp(BottomAppBarTheme? a, BottomAppBarTheme? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -80,8 +80,8 @@ enum BottomNavigationBarLandscapeLayout {
 /// [BottomNavigationBarType.fixed] when there are less than four items, and
 /// [BottomNavigationBarType.shifting] otherwise.
 ///
-/// The length of [items] must be at least two and each item's icon and title/label
-/// must not be null.
+/// The length of [items] must be at least two and each item's icon and
+/// title/label must not be null.
 ///
 ///  * [BottomNavigationBarType.fixed], the default when there are less than
 ///    four [items]. The selected item is rendered with the
@@ -188,7 +188,7 @@ class BottomNavigationBar extends StatefulWidget {
   /// are two or three [items], [BottomNavigationBarType.shifting] otherwise.
   ///
   /// The [iconSize], [selectedFontSize], [unselectedFontSize], and [elevation]
-  /// arguments must be non-null and non-negative.
+  /// arguments must be non-negative.
   ///
   /// If [selectedLabelStyle].color and [unselectedLabelStyle].color values
   /// are non-null, they will be used instead of [selectedItemColor] and

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -81,7 +81,7 @@ enum BottomNavigationBarLandscapeLayout {
 /// [BottomNavigationBarType.shifting] otherwise.
 ///
 /// The length of [items] must be at least two and each item's icon and
-/// title/label must not be null.
+/// label must not be null.
 ///
 ///  * [BottomNavigationBarType.fixed], the default when there are less than
 ///    four [items]. The selected item is rendered with the

--- a/packages/flutter/lib/src/material/bottom_navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar_theme.dart
@@ -170,8 +170,6 @@ class BottomNavigationBarThemeData with Diagnosticable {
 
   /// Linearly interpolate between two [BottomNavigationBarThemeData].
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static BottomNavigationBarThemeData lerp(BottomNavigationBarThemeData? a, BottomNavigationBarThemeData? b, double t) {
     if (identical(a, b) && a != null) {
@@ -276,8 +274,6 @@ class BottomNavigationBarThemeData with Diagnosticable {
 class BottomNavigationBarTheme extends InheritedWidget {
   /// Constructs a bottom navigation bar theme that configures all descendant
   /// [BottomNavigationBar] widgets.
-  ///
-  /// The [data] must not be null.
   const BottomNavigationBarTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -1133,8 +1133,6 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
 /// curve specified with the [curve] argument, after the finger is released. In
 /// such a case, the value of [startingPoint] would be the progress of the
 /// animation at the time when the finger was released.
-///
-/// The [startingPoint] and [curve] arguments must not be null.
 class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
   /// Creates a suspended curve.
   const _BottomSheetSuspendedCurve(

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -40,11 +40,8 @@ import 'theme_data.dart';
 class RawMaterialButton extends StatefulWidget {
   /// Create a button based on [Semantics], [Material], and [InkWell] widgets.
   ///
-  /// The [shape], [elevation], [focusElevation], [hoverElevation],
-  /// [highlightElevation], [disabledElevation], [padding], [constraints],
-  /// [autofocus], and [clipBehavior] arguments must not be null. Additionally,
-  /// [elevation], [focusElevation], [hoverElevation], [highlightElevation], and
-  /// [disabledElevation] must be non-negative.
+  /// The [elevation], [focusElevation], [hoverElevation], [highlightElevation],
+  /// and [disabledElevation] parameters must be non-negative.
   const RawMaterialButton({
     super.key,
     required this.onPressed,
@@ -288,7 +285,7 @@ class RawMaterialButton extends StatefulWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   /// Whether detected gestures should provide acoustic and/or haptic feedback.

--- a/packages/flutter/lib/src/material/button_bar_theme.dart
+++ b/packages/flutter/lib/src/material/button_bar_theme.dart
@@ -233,8 +233,6 @@ class ButtonBarThemeData with Diagnosticable {
 class ButtonBarTheme extends InheritedWidget {
   /// Constructs a button bar theme that configures all descendent [ButtonBar]
   /// widgets.
-  ///
-  /// The [data] must not be null.
   const ButtonBarTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -89,7 +89,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   /// {@macro flutter.widgets.Focus.focusNode}

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -66,9 +66,6 @@ enum ButtonBarLayoutBehavior {
 ///    depend on any inherited themes.
 class ButtonTheme extends InheritedTheme {
   /// Creates a button theme.
-  ///
-  /// The [textTheme], [minWidth], [height], and [colorScheme] arguments
-  /// must not be null.
   ButtonTheme({
     super.key,
     ButtonTextTheme textTheme = ButtonTextTheme.normal,
@@ -108,8 +105,6 @@ class ButtonTheme extends InheritedTheme {
        );
 
   /// Creates a button theme from [data].
-  ///
-  /// The [data] argument must not be null.
   const ButtonTheme.fromButtonThemeData({
     super.key,
     required this.data,
@@ -168,9 +163,7 @@ class ButtonThemeData with Diagnosticable {
   /// Create a button theme object that can be used with [ButtonTheme]
   /// or [ThemeData].
   ///
-  /// The [textTheme], [minWidth], [height], [alignedDropdown], and
-  /// [layoutBehavior] parameters must not be null. The [minWidth] and
-  /// [height] parameters must greater than or equal to zero.
+  /// The [minWidth] and [height] parameters must greater than or equal to zero.
   ///
   /// The ButtonTheme's methods that have a [MaterialButton] parameter and
   /// have a name with a `get` prefix are used to configure a

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -1143,8 +1143,7 @@ const _DayPickerGridDelegate _dayPickerGridDelegate = _DayPickerGridDelegate();
 class YearPicker extends StatefulWidget {
   /// Creates a year picker.
   ///
-  /// The [firstDate], [lastDate], [selectedDate], and [onChanged]
-  /// arguments must be non-null. The [lastDate] must be after the [firstDate].
+  /// The [lastDate] must be after the [firstDate].
   YearPicker({
     super.key,
     DateTime? currentDate,

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -58,8 +58,7 @@ import 'theme.dart';
 class Card extends StatelessWidget {
   /// Creates a Material Design card.
   ///
-  /// The [elevation] must be null or non-negative. The [borderOnForeground]
-  /// must not be null.
+  /// The [elevation] must be null or non-negative.
   const Card({
     super.key,
     this.color,

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -110,8 +110,6 @@ class CardTheme with Diagnosticable {
 
   /// Linearly interpolate between two Card themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static CardTheme lerp(CardTheme? a, CardTheme? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -74,8 +74,6 @@ class Checkbox extends StatefulWidget {
   ///   can only be null if [tristate] is true.
   /// * [onChanged], which is called when the value of the checkbox should
   ///   change. It can be set to null to disable the checkbox.
-  ///
-  /// The values of [tristate] and [autofocus] must not be null.
   const Checkbox({
     super.key,
     required this.value,
@@ -391,7 +389,7 @@ class Checkbox extends StatefulWidget {
   /// this is true. This is only used when [ThemeData.useMaterial3] is set to true.
   /// {@endtemplate}
   ///
-  /// Must not be null. Defaults to false.
+  /// Defaults to false.
   final bool isError;
 
   /// {@template flutter.material.checkbox.semanticLabel}

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -159,8 +159,6 @@ class CheckboxListTile extends StatelessWidget {
   ///   can only be null if [tristate] is true.
   /// * [onChanged], which is called when the value of the checkbox should
   ///   change. It can be set to null to disable the checkbox.
-  ///
-  /// The value of [tristate] must not be null.
   const CheckboxListTile({
     super.key,
     required this.value,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -137,7 +137,7 @@ abstract interface class ChipAttributes {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   Clip get clipBehavior;
 
   /// {@macro flutter.widgets.Focus.focusNode}
@@ -333,7 +333,7 @@ abstract interface class SelectableChipAttributes {
   /// If [onSelected] is not null, this value will be used to determine if the
   /// select check mark will be shown or not.
   ///
-  /// Must not be null. Defaults to false.
+  /// Defaults to false.
   bool get selected;
 
   /// Called when the chip should change between selected and de-selected
@@ -561,7 +561,6 @@ abstract interface class TappableChipAttributes {
 class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttributes {
   /// Creates a Material Design chip.
   ///
-  /// The [label], [autofocus], and [clipBehavior] arguments must not be null.
   /// The [elevation] must be null or non-negative.
   const Chip({
     super.key,
@@ -707,10 +706,8 @@ class RawChip extends StatefulWidget
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
   /// the same time.
   ///
-  /// The [label], [isEnabled], [selected], [autofocus], and [clipBehavior]
-  /// arguments must not be null. The [pressElevation] and [elevation] must be
-  /// null or non-negative. Typically, [pressElevation] is greater than
-  /// [elevation].
+  /// The [pressElevation] and [elevation] must be null or non-negative.
+  /// Typically, [pressElevation] is greater than [elevation].
   const RawChip({
     super.key,
     this.defaultProperties,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -447,7 +447,7 @@ abstract interface class DisabledChipAttributes {
   /// For classes which don't have this as a constructor argument, [isEnabled]
   /// returns true if their user action callback is set.
   ///
-  /// Defaults to true. Cannot be null.
+  /// Defaults to true.
   bool get isEnabled;
 
   /// The color used for the chip's background to indicate that it is not

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -42,8 +42,6 @@ import 'theme.dart';
 ///    application.
 class ChipTheme extends InheritedTheme {
   /// Applies the given theme [data] to [child].
-  ///
-  /// The [data] and [child] arguments must not be null.
   const ChipTheme({
     super.key,
     required this.data,
@@ -489,8 +487,6 @@ class ChipThemeData with Diagnosticable {
   }
 
   /// Linearly interpolate between two chip themes.
-  ///
-  /// The arguments must not be null.
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ChipThemeData? lerp(ChipThemeData? a, ChipThemeData? b, double t) {

--- a/packages/flutter/lib/src/material/choice_chip.dart
+++ b/packages/flutter/lib/src/material/choice_chip.dart
@@ -22,8 +22,7 @@ enum _ChipVariant { flat, elevated }
 /// [ChoiceChip]s represent a single choice from a set. Choice chips contain
 /// related descriptive text or categories.
 ///
-/// Requires one of its ancestors to be a [Material] widget. The [selected] and
-/// [label] arguments must not be null.
+/// Requires one of its ancestors to be a [Material] widget.
 ///
 /// {@tool dartpad}
 /// This example shows how to create [ChoiceChip]s with [onSelected]. When the

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -36,8 +36,6 @@ typedef DataColumnSortCallback = void Function(int columnIndex, bool ascending);
 @immutable
 class DataColumn {
   /// Creates the configuration for a column of a [DataTable].
-  ///
-  /// The [label] argument must not be null.
   const DataColumn({
     required this.label,
     this.tooltip,
@@ -112,8 +110,6 @@ class DataColumn {
 @immutable
 class DataRow {
   /// Creates the configuration for a row of a [DataTable].
-  ///
-  /// The [cells] argument must not be null.
   const DataRow({
     this.key,
     this.selected = false,
@@ -126,8 +122,6 @@ class DataRow {
 
   /// Creates the configuration for a row of a [DataTable], deriving
   /// the key from a row index.
-  ///
-  /// The [cells] argument must not be null.
   DataRow.byIndex({
     int? index,
     this.selected = false,
@@ -248,8 +242,7 @@ class DataCell {
   /// Creates an object to hold the data for a cell in a [DataTable].
   ///
   /// The first argument is the widget to show for the cell, typically
-  /// a [Text] or [DropdownButton] widget; this becomes the [child]
-  /// property and must not be null.
+  /// a [Text] or [DropdownButton] widget.
   ///
   /// If the cell has no data, then a [Text] widget with placeholder
   /// text should be provided instead, and then the [placeholder]
@@ -402,7 +395,7 @@ class DataTable extends StatelessWidget {
   /// The [columns] argument must be a list of as many [DataColumn]
   /// objects as the table is to have columns, ignoring the leading
   /// checkbox column if any. The [columns] argument must have a
-  /// length greater than zero and must not be null.
+  /// length greater than zero.
   ///
   /// The [rows] argument must be a list of as many [DataRow] objects
   /// as the table is to have rows, ignoring the leading heading row
@@ -676,7 +669,7 @@ class DataTable extends StatelessWidget {
   /// The data to show in each row (excluding the row that contains
   /// the column headings).
   ///
-  /// Must be non-null, but may be empty.
+  /// The list may be empty.
   final List<DataRow> rows;
 
   /// {@template flutter.material.dataTable.dividerThickness}
@@ -712,7 +705,7 @@ class DataTable extends StatelessWidget {
   ///
   /// This can be used to clip the content within the border of the [DataTable].
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   // Set by the constructor to the index of the only Column that is

--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -162,8 +162,6 @@ class DataTableThemeData with Diagnosticable {
 
   /// Linearly interpolate between two [DataTableThemeData]s.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static DataTableThemeData lerp(DataTableThemeData a, DataTableThemeData b, double t) {
     if (identical(a, b)) {
@@ -266,8 +264,6 @@ class DataTableThemeData with Diagnosticable {
 class DataTableTheme extends InheritedWidget {
   /// Constructs a data table theme that configures all descendant
   /// [DataTable] widgets.
-  ///
-  /// The [data] must not be null.
   const DataTableTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -70,7 +70,7 @@ const double _kMaxTextScaleFactor = 1.3;
 /// An optional [initialEntryMode] argument can be used to display the date
 /// picker in the [DatePickerEntryMode.calendar] (a calendar month grid)
 /// or [DatePickerEntryMode.input] (a text input field) mode.
-/// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
+/// It defaults to [DatePickerEntryMode.calendar].
 ///
 /// {@template flutter.material.date_picker.switchToInputEntryModeIcon}
 /// An optional [switchToInputEntryModeIcon] argument can be used to
@@ -117,7 +117,6 @@ const double _kMaxTextScaleFactor = 1.3;
 /// The [context], [barrierDismissible], [barrierColor], [barrierLabel],
 /// [useRootNavigator] and [routeSettings] arguments are passed to [showDialog],
 /// the documentation for which discusses how it is used.
-/// [context], [barrierDismissible] and [useRootNavigator] must be non-null.
 ///
 /// The [builder] parameter can be used to wrap the dialog widget
 /// to add inherited widgets like [Theme].
@@ -943,7 +942,7 @@ class _DatePickerHeader extends StatelessWidget {
 /// before or on `initialDateRange.end`.
 ///
 /// The [firstDate] is the earliest allowable date. The [lastDate] is the latest
-/// allowable date. Both must be non-null.
+/// allowable date.
 ///
 /// If an initial date range is provided, `initialDateRange.start`
 /// and `initialDateRange.end` must both fall between or on [firstDate] and
@@ -957,7 +956,7 @@ class _DatePickerHeader extends StatelessWidget {
 /// An optional [initialEntryMode] argument can be used to display the date
 /// picker in the [DatePickerEntryMode.calendar] (a scrollable calendar month
 /// grid) or [DatePickerEntryMode.input] (two text input fields) mode.
-/// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
+/// It defaults to [DatePickerEntryMode.calendar].
 ///
 /// {@macro flutter.material.date_picker.switchToInputEntryModeIcon}
 ///
@@ -996,7 +995,6 @@ class _DatePickerHeader extends StatelessWidget {
 /// The [context], [barrierDismissible], [barrierColor], [barrierLabel],
 /// [useRootNavigator] and [routeSettings] arguments are passed to [showDialog],
 /// the documentation for which discusses how it is used.
-/// [context], [barrierDismissible] and [useRootNavigator] must be non-null.
 ///
 /// The [builder] parameter can be used to wrap the dialog widget
 /// to add inherited widgets like [Theme].
@@ -1237,7 +1235,7 @@ class DateRangePickerDialog extends StatefulWidget {
   /// scrollable calendar month grid) or [DatePickerEntryMode.input] (two text
   /// input fields) mode.
   ///
-  /// It defaults to [DatePickerEntryMode.calendar] and must be non-null.
+  /// It defaults to [DatePickerEntryMode.calendar].
   final DatePickerEntryMode initialEntryMode;
 
   /// The label on the cancel button for the text input mode.

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -182,7 +182,7 @@ class Dialog extends StatelessWidget {
   /// See the enum [Clip] for details of all possible options and their common
   /// use cases.
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   /// {@endtemplate}
   final Clip clipBehavior;
 
@@ -1096,8 +1096,6 @@ class SimpleDialog extends StatelessWidget {
   /// Creates a simple dialog.
   ///
   /// Typically used in conjunction with [showDialog].
-  ///
-  /// The [titlePadding] and [contentPadding] arguments must not be null.
   const SimpleDialog({
     super.key,
     this.title,

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -107,8 +107,6 @@ class DialogTheme with Diagnosticable {
 
   /// Linearly interpolate between two dialog themes.
   ///
-  /// The arguments must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static DialogTheme lerp(DialogTheme? a, DialogTheme? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/divider_theme.dart
+++ b/packages/flutter/lib/src/material/divider_theme.dart
@@ -83,8 +83,6 @@ class DividerThemeData with Diagnosticable {
 
   /// Linearly interpolate between two Divider themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static DividerThemeData lerp(DividerThemeData? a, DividerThemeData? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -310,7 +310,7 @@ class DrawerController extends StatefulWidget {
   ///
   /// Rarely used directly.
   ///
-  /// The [child] argument must not be null and is typically a [Drawer].
+  /// The [child] argument is typically a [Drawer].
   const DrawerController({
     GlobalKey? key,
     required this.child,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -730,7 +730,7 @@ class _DropdownMenuItemContainer extends StatelessWidget {
 
   /// Defines how the item is positioned within the container.
   ///
-  /// This property must not be null. It defaults to [AlignmentDirectional.centerStart].
+  /// Defaults to [AlignmentDirectional.centerStart].
   ///
   /// See also:
   ///
@@ -911,12 +911,6 @@ class DropdownButton<T> extends StatefulWidget {
   /// If [value] is null and the button is disabled, [disabledHint] will be displayed
   /// if it is non-null. If [disabledHint] is null, then [hint] will be displayed
   /// if it is non-null.
-  ///
-  /// The [elevation] and [iconSize] arguments must not be null (they both have
-  /// defaults, so do not need to be specified). The boolean [isDense] and
-  /// [isExpanded] arguments must not be null.
-  ///
-  /// The [autofocus] argument must not be null.
   ///
   /// The [dropdownColor] argument specifies the background color of the
   /// dropdown when it is open. If it is null, the current theme's
@@ -1215,7 +1209,7 @@ class DropdownButton<T> extends StatefulWidget {
 
   /// Defines how the hint or the selected item is positioned within the button.
   ///
-  /// This property must not be null. It defaults to [AlignmentDirectional.centerStart].
+  /// Defaults to [AlignmentDirectional.centerStart].
   ///
   /// See also:
   ///
@@ -1589,9 +1583,6 @@ class DropdownButtonFormField<T> extends FormField<T> {
   /// For a description of the `onSaved`, `validator`, or `autovalidateMode`
   /// parameters, see [FormField]. For the rest (other than [decoration]), see
   /// [DropdownButton].
-  ///
-  /// The `items`, `elevation`, `iconSize`, `isDense`, `isExpanded`,
-  /// `autofocus`, and `decoration`  parameters must not be null.
   DropdownButtonFormField({
     super.key,
     required List<DropdownMenuItem<T>>? items,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -39,8 +39,6 @@ const double _kDefaultHorizontalPadding = 12.0;
 /// * [DropdownMenu]
 class DropdownMenuEntry<T> {
   /// Creates an entry that is used with [DropdownMenu.dropdownMenuEntries].
-  ///
-  /// [label] must be non-null.
   const DropdownMenuEntry({
     required this.value,
     required this.label,

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -62,8 +62,6 @@ import 'theme_data.dart';
 ///  * <https://m3.material.io/components/buttons>
 class ElevatedButton extends ButtonStyleButton {
   /// Create an ElevatedButton.
-  ///
-  /// The [autofocus] and [clipBehavior] arguments must not be null.
   const ElevatedButton({
     super.key,
     required super.onPressed,
@@ -83,8 +81,6 @@ class ElevatedButton extends ButtonStyleButton {
   ///
   /// The icon and label are arranged in a row and padded by 12 logical pixels
   /// at the start, and 16 at the end, with an 8 pixel gap in between.
-  ///
-  /// The [icon] and [label] arguments must not be null.
   factory ElevatedButton.icon({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/elevated_button_theme.dart
+++ b/packages/flutter/lib/src/material/elevated_button_theme.dart
@@ -91,8 +91,6 @@ class ElevatedButtonThemeData with Diagnosticable {
 ///    [ButtonStyle] for [ElevatedButton]s below the overall [Theme].
 class ElevatedButtonTheme extends InheritedTheme {
   /// Create a [ElevatedButtonTheme].
-  ///
-  /// The [data] parameter must not be null.
   const ElevatedButtonTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -49,7 +49,7 @@ class ExpandIcon extends StatefulWidget {
 
   /// The size of the icon.
   ///
-  /// This property must not be null. It defaults to 24.0.
+  /// Defaults to 24.
   final double size;
 
   /// The callback triggered when the icon is pressed and the state changes
@@ -61,7 +61,7 @@ class ExpandIcon extends StatefulWidget {
   /// The padding around the icon. The entire padded icon will react to input
   /// gestures.
   ///
-  /// This property must not be null. It defaults to 8.0 padding on all sides.
+  /// Defaults to a padding of 8 on all sides.
   final EdgeInsetsGeometry padding;
 
   /// {@template flutter.material.ExpandIcon.color}

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -74,8 +74,6 @@ typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool
 class ExpansionPanel {
   /// Creates an expansion panel to be used as a child for [ExpansionPanelList].
   /// See [ExpansionPanelList] for an example on how to use this widget.
-  ///
-  /// The [headerBuilder], [body], and [isExpanded] arguments must not be null.
   ExpansionPanel({
     required this.headerBuilder,
     required this.body,
@@ -120,8 +118,7 @@ class ExpansionPanel {
 class ExpansionPanelRadio extends ExpansionPanel {
   /// An expansion panel that allows for radio functionality.
   ///
-  /// A unique [value] must be passed into the constructor. The
-  /// [headerBuilder], [body], [value] must not be null.
+  /// A unique [value] must be passed into the constructor.
   ExpansionPanelRadio({
     required this.value,
     required super.headerBuilder,
@@ -160,8 +157,6 @@ class ExpansionPanelRadio extends ExpansionPanel {
 class ExpansionPanelList extends StatefulWidget {
   /// Creates an expansion panel list widget. The [expansionCallback] is
   /// triggered when an expansion panel expand/collapse button is pushed.
-  ///
-  /// The [children] and [animationDuration] arguments must not be null.
   const ExpansionPanelList({
     super.key,
     this.children = const <ExpansionPanel>[],
@@ -177,10 +172,9 @@ class ExpansionPanelList extends StatefulWidget {
 
   /// Creates a radio expansion panel list widget.
   ///
-  /// This widget allows for at most one panel in the list to be open.
-  /// The expansion panel callback is triggered when an expansion panel
-  /// expand/collapse button is pushed. The [children] and [animationDuration]
-  /// arguments must not be null. The [children] objects must be instances
+  /// This widget allows for at most one panel in the list to be open. The
+  /// expansion panel callback is triggered when an expansion panel
+  /// expand/collapse button is pushed. The [children] objects must be instances
   /// of [ExpansionPanelRadio].
   ///
   /// {@tool dartpad}

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -210,8 +210,6 @@ class ExpansionTileThemeData with Diagnosticable {
 ///    [ExpansionTileTheme] for [ExpansionTile]s below the overall [Theme].
 class ExpansionTileTheme extends InheritedTheme {
   /// Applies the given theme [data] to [child].
-  ///
-  /// The [data] and [child] arguments must not be null.
   const ExpansionTileTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -64,8 +64,6 @@ enum _FilledButtonVariant { filled, tonal }
 ///  * <https://m3.material.io/components/buttons>
 class FilledButton extends ButtonStyleButton {
   /// Create a FilledButton.
-  ///
-  /// The [autofocus] and [clipBehavior] arguments must not be null.
   const FilledButton({
     super.key,
     required super.onPressed,
@@ -84,8 +82,6 @@ class FilledButton extends ButtonStyleButton {
   ///
   /// The icon and label are arranged in a row with padding at the start and end
   /// and a gap between them.
-  ///
-  /// The [icon] and [label] arguments must not be null.
   factory FilledButton.icon({
     Key? key,
     required VoidCallback? onPressed,
@@ -107,8 +103,6 @@ class FilledButton extends ButtonStyleButton {
   /// [FilledButton] and [OutlinedButton]. They’re useful in contexts where
   /// a lower-priority button requires slightly more emphasis than an
   /// outline would give, such as "Next" in an onboarding flow.
-  ///
-  /// The [autofocus] and [clipBehavior] arguments must not be null.
   const FilledButton.tonal({
     super.key,
     required super.onPressed,
@@ -127,8 +121,6 @@ class FilledButton extends ButtonStyleButton {
   ///
   /// The icon and label are arranged in a row with padding at the start and end
   /// and a gap between them.
-  ///
-  /// The [icon] and [label] arguments must not be null.
   factory FilledButton.tonalIcon({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/filled_button_theme.dart
+++ b/packages/flutter/lib/src/material/filled_button_theme.dart
@@ -91,8 +91,6 @@ class FilledButtonThemeData with Diagnosticable {
 ///    [ButtonStyle] for [FilledButton]s below the overall [Theme].
 class FilledButtonTheme extends InheritedTheme {
   /// Create a [FilledButtonTheme].
-  ///
-  /// The [data] parameter must not be null.
   const FilledButtonTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -371,9 +371,6 @@ class FlexibleSpaceBarSettings extends InheritedWidget {
   ///
   /// Used by [Scaffold] and [SliverAppBar]. [child] must have a
   /// [FlexibleSpaceBar] widget in its tree for the settings to take affect.
-  ///
-  /// The required [toolbarOpacity], [minExtent], [maxExtent], [currentExtent],
-  /// and [child] parameters must not be null.
   const FlexibleSpaceBarSettings({
     super.key,
     required this.toolbarOpacity,

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -83,9 +83,8 @@ enum _FloatingActionButtonType {
 class FloatingActionButton extends StatelessWidget {
   /// Creates a circular floating action button.
   ///
-  /// The [mini] and [clipBehavior] arguments must not be null. Additionally,
-  /// [elevation], [highlightElevation], and [disabledElevation] (if specified)
-  /// must be non-negative.
+  /// The [elevation], [highlightElevation], and [disabledElevation] parameters,
+  /// if specified, must be non-negative.
   const FloatingActionButton({
     super.key,
     this.child,
@@ -127,10 +126,8 @@ class FloatingActionButton extends StatelessWidget {
   /// This constructor overrides the default size constraints of the floating
   /// action button.
   ///
-  /// The [clipBehavior] and [autofocus] arguments must not be null.
-  /// Additionally, [elevation], [focusElevation], [hoverElevation],
-  /// [highlightElevation], and [disabledElevation] (if specified) must be
-  /// non-negative.
+  /// The [elevation], [focusElevation], [hoverElevation], [highlightElevation],
+  /// and [disabledElevation] parameters, if specified, must be non-negative.
   const FloatingActionButton.small({
     super.key,
     this.child,
@@ -172,10 +169,8 @@ class FloatingActionButton extends StatelessWidget {
   /// This constructor overrides the default size constraints of the floating
   /// action button.
   ///
-  /// The [clipBehavior] and [autofocus] arguments must not be null.
-  /// Additionally, [elevation], [focusElevation], [hoverElevation],
-  /// [highlightElevation], and [disabledElevation] (if specified) must be
-  /// non-negative.
+  /// The [elevation], [focusElevation], [hoverElevation], [highlightElevation],
+  /// and [disabledElevation] parameters, if specified, must be non-negative.
   const FloatingActionButton.large({
     super.key,
     this.child,
@@ -215,9 +210,8 @@ class FloatingActionButton extends StatelessWidget {
   /// Creates a wider [StadiumBorder]-shaped floating action button with
   /// an optional [icon] and a [label].
   ///
-  /// The [label], [autofocus], and [clipBehavior] arguments must not be null.
-  /// Additionally, [elevation], [highlightElevation], and [disabledElevation]
-  /// (if specified) must be non-negative.
+  /// The [elevation], [highlightElevation], and [disabledElevation] parameters,
+  /// if specified, must be non-negative.
   ///
   /// See also:
   ///  * <https://m3.material.io/components/extended-fab>
@@ -418,7 +412,7 @@ class FloatingActionButton extends StatelessWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   /// True if this is an "extended" floating action button.

--- a/packages/flutter/lib/src/material/floating_action_button_location.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_location.dart
@@ -1004,8 +1004,8 @@ class _ScalingFabMotionAnimator extends FloatingActionButtonAnimator {
 class _AnimationSwap<T> extends CompoundAnimation<T> {
   /// Creates an [_AnimationSwap].
   ///
-  /// Both arguments must be non-null. Either can be an [_AnimationSwap] itself
-  /// to combine multiple animations.
+  /// Either argument can be an [_AnimationSwap] itself to combine multiple
+  /// animations.
   _AnimationSwap(Animation<T> first, Animation<T> next, this.parent, this.swapThreshold) : super(first: first, next: next);
 
   final Animation<double> parent;

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -173,8 +173,6 @@ class IconButton extends StatelessWidget {
   /// Requires one of its ancestors to be a [Material] widget. This requirement
   /// no longer exists if [ThemeData.useMaterial3] is set to true.
   ///
-  /// [autofocus] argument must not be null (though it has default value).
-  ///
   /// The [icon] argument must be specified, and is typically either an [Icon]
   /// or an [ImageIcon].
   const IconButton({
@@ -361,8 +359,6 @@ class IconButton extends StatelessWidget {
   /// based on the [iconSize] and [color] properties of _this_ widget using an
   /// [IconTheme] and therefore should not be explicitly given in the icon
   /// widget.
-  ///
-  /// This property must not be null.
   ///
   /// See [Icon], [ImageIcon].
   final Widget icon;

--- a/packages/flutter/lib/src/material/icon_button_theme.dart
+++ b/packages/flutter/lib/src/material/icon_button_theme.dart
@@ -89,8 +89,6 @@ class IconButtonThemeData with Diagnosticable {
 ///    [ButtonStyle] for [IconButton]s below the overall [Theme].
 class IconButtonTheme extends InheritedTheme {
   /// Create a [IconButtonTheme].
-  ///
-  /// The [data] parameter must not be null.
   const IconButtonTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -169,9 +169,8 @@ class Ink extends StatefulWidget {
   /// properties of the [DecorationImage] of that [BoxDecoration] are set
   /// according to the arguments passed to this method.
   ///
-  /// The `image` argument must not be null. If there is no
-  /// intention to render anything on this image, consider using a
-  /// [Container] with a [BoxDecoration.image] instead. The `onImageError`
+  /// If there is no intention to render anything on this image, consider using
+  /// a [Container] with a [BoxDecoration.image] instead. The `onImageError`
   /// argument may be provided to listen for errors when resolving the image.
   ///
   /// The `alignment`, `repeat`, and `matchTextDirection` arguments must not

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -36,8 +36,6 @@ import 'theme.dart';
 /// class.
 abstract class InteractiveInkFeature extends InkFeature {
   /// Creates an InteractiveInkFeature.
-  ///
-  /// The [controller] and [referenceBox] arguments must not be null.
   InteractiveInkFeature({
     required super.controller,
     required super.referenceBox,
@@ -296,9 +294,6 @@ class InkResponse extends StatelessWidget {
   /// Creates an area of a [Material] that responds to touch.
   ///
   /// Must have an ancestor [Material] widget in which to cause ink reactions.
-  ///
-  /// The [containedInkWell], [highlightShape], [enableFeedback],
-  /// and [excludeFromSemantics] arguments must not be null.
   const InkResponse({
     super.key,
     this.child,
@@ -1455,9 +1450,6 @@ class InkWell extends InkResponse {
   /// Creates an ink well.
   ///
   /// Must have an ancestor [Material] widget in which to cause ink reactions.
-  ///
-  /// The [enableFeedback], and [excludeFromSemantics] arguments
-  /// must not be null.
   const InkWell({
     super.key,
     super.child,

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -31,10 +31,9 @@ import 'package:flutter/widgets.dart';
 abstract class InputBorder extends ShapeBorder {
   /// Creates a border for an [InputDecorator].
   ///
-  /// The [borderSide] parameter must not be null. Applications typically do
-  /// not specify a [borderSide] parameter because the input decorator
-  /// substitutes its own, using [copyWith], based on the current theme and
-  /// [InputDecorator.isFocused].
+  /// Applications typically do not specify a [borderSide] parameter because the
+  /// [InputDecorator] substitutes its own, using [copyWith], based on the
+  /// current theme and [InputDecorator.isFocused].
   const InputBorder({
     this.borderSide = BorderSide.none,
   });
@@ -149,8 +148,7 @@ class UnderlineInputBorder extends InputBorder {
   /// on the current theme and [InputDecorator.isFocused].
   ///
   /// The [borderRadius] parameter defaults to a value where the top left
-  /// and right corners have a circular radius of 4.0. The [borderRadius]
-  /// parameter must not be null.
+  /// and right corners have a circular radius of 4.0.
   const UnderlineInputBorder({
     super.borderSide = const BorderSide(),
     this.borderRadius = const BorderRadius.only(
@@ -292,10 +290,9 @@ class OutlineInputBorder extends InputBorder {
   /// value [BorderSide.none], the input decorator substitutes its own, using
   /// [copyWith], based on the current theme and [InputDecorator.isFocused].
   ///
-  /// The [borderRadius] parameter defaults to a value where all four
-  /// corners have a circular radius of 4.0. The [borderRadius] parameter
-  /// must not be null and the corner radii must be circular, i.e. their
-  /// [Radius.x] and [Radius.y] values must be the same.
+  /// The [borderRadius] parameter defaults to a value where all four corners
+  /// have a circular radius of 4.0. The corner radii must be circular, i.e.
+  /// their [Radius.x] and [Radius.y] values must be the same.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/input_chip.dart
+++ b/packages/flutter/lib/src/material/input_chip.dart
@@ -83,10 +83,8 @@ class InputChip extends StatelessWidget
   /// The [onPressed] and [onSelected] callbacks must not both be specified at
   /// the same time.
   ///
-  /// The [label], [isEnabled], [selected], [autofocus], and [clipBehavior]
-  /// arguments must not be null. The [pressElevation] and [elevation] must be
-  /// null or non-negative. Typically, [pressElevation] is greater than
-  /// [elevation].
+  /// The [pressElevation] and [elevation] must be null or non-negative.
+  /// Typically, [pressElevation] is greater than [elevation].
   const InputChip({
     super.key,
     this.avatar,

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -42,9 +42,6 @@ class InputDatePickerFormField extends StatefulWidget {
   /// for [initialDate].
   ///
   /// [firstDate] must be on or before [lastDate].
-  ///
-  /// [firstDate], [lastDate], and [autofocus] must be non-null.
-  ///
   InputDatePickerFormField({
     super.key,
     DateTime? initialDate,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1797,8 +1797,6 @@ class InputDecorator extends StatefulWidget {
   ///
   /// Null [InputDecoration] properties are initialized with the corresponding
   /// values from [ThemeData.inputDecorationTheme].
-  ///
-  /// Must not be null.
   final InputDecoration decoration;
 
   /// The style on which to base the label, hint, counter, and error styles
@@ -2555,8 +2553,6 @@ class InputDecoration {
   /// defaults [isDense] to false and [filled] to false. The default border is
   /// an instance of [UnderlineInputBorder]. If [border] is [InputBorder.none]
   /// then no border is drawn.
-  ///
-  /// The [enabled] argument must not be null.
   ///
   /// Only one of [prefix] and [prefixText] can be specified.
   ///
@@ -3834,9 +3830,6 @@ class InputDecoration {
 class InputDecorationTheme with Diagnosticable {
   /// Creates a value for [ThemeData.inputDecorationTheme] that
   /// defines default values for [InputDecorator].
-  ///
-  /// The values of [isDense], [isCollapsed], [filled], [floatingLabelAlignment],
-  /// and [border] must not be null.
   const InputDecorationTheme({
     this.labelStyle,
     this.floatingLabelStyle,

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -470,8 +470,6 @@ class ListTileTheme extends InheritedTheme {
 
   /// Creates a list tile theme that controls the color and style parameters for
   /// [ListTile]s, and merges in the current list tile theme, if any.
-  ///
-  /// The [child] argument must not be null.
   static Widget merge({
     Key? key,
     bool? dense,

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -171,9 +171,7 @@ abstract class MaterialInkController {
 class Material extends StatefulWidget {
   /// Creates a piece of material.
   ///
-  /// The [type], [elevation], [borderOnForeground],
-  /// [clipBehavior], and [animationDuration] arguments must not be null.
-  /// Additionally, [elevation] must be non-negative.
+  /// The [elevation] must be non-negative.
   ///
   /// If a [shape] is specified, then the [borderRadius] property must be
   /// null and the [type] property must not be [MaterialType.circle]. If the
@@ -324,7 +322,7 @@ class Material extends StatefulWidget {
   /// use cases.
   /// {@endtemplate}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   /// Defines the duration of animated changes for [shape], [elevation],
@@ -841,9 +839,7 @@ class ShapeBorderTween extends Tween<ShapeBorder?> {
 class _MaterialInterior extends ImplicitlyAnimatedWidget {
   /// Creates a const instance of [_MaterialInterior].
   ///
-  /// The [child], [shape], [clipBehavior], [color], and [shadowColor] arguments
-  /// must not be null. The [elevation] must be specified and greater than or
-  /// equal to zero.
+  /// The [elevation] must be specified and greater than or equal to zero.
   const _MaterialInterior({
     required this.child,
     required this.shape,
@@ -876,7 +872,7 @@ class _MaterialInterior extends ImplicitlyAnimatedWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   /// The target z-coordinate at which to place this physical object relative

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -45,10 +45,8 @@ class MaterialButton extends StatelessWidget {
   /// To create a custom Material button consider using [TextButton],
   /// [ElevatedButton], or [OutlinedButton].
   ///
-  /// The [autofocus] and [clipBehavior] arguments must not be null.
-  /// Additionally,  [elevation], [hoverElevation], [focusElevation],
-  /// [highlightElevation], and [disabledElevation] must be non-negative, if
-  /// specified.
+  /// The [elevation], [hoverElevation], [focusElevation], [highlightElevation],
+  /// and [disabledElevation] arguments must be non-negative, if specified.
   const MaterialButton({
     super.key,
     required this.onPressed,
@@ -338,7 +336,7 @@ class MaterialButton extends StatelessWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   /// {@macro flutter.widgets.Focus.focusNode}

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1907,10 +1907,6 @@ class _SubmenuButtonState extends State<SubmenuButton> {
             controller._anchor!._focusButton();
           }
         }
-<<<<<<< Updated upstream
-=======
-        // debugPrint('Rebuilding semantics with isExpanded: ${controller.isOpen}');
->>>>>>> Stashed changes
         child = MergeSemantics(
           child: Semantics(
             expanded: controller.isOpen,
@@ -3218,7 +3214,7 @@ class _MenuLayout extends SingleChildLayoutDelegate {
       } else if (offBottom(y)) {
         final double newY = anchorRect.top - childSize.height;
         if (!offTop(newY)) {
-          // Only move the menu up if its parent is horizontal (MenuAchor/MenuBar).
+          // Only move the menu up if its parent is horizontal (MenuAnchor/MenuBar).
           if (parentOrientation == Axis.horizontal) {
             y = newY - alignmentOffset.dy;
           } else {

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1907,6 +1907,10 @@ class _SubmenuButtonState extends State<SubmenuButton> {
             controller._anchor!._focusButton();
           }
         }
+<<<<<<< Updated upstream
+=======
+        // debugPrint('Rebuilding semantics with isExpanded: ${controller.isOpen}');
+>>>>>>> Stashed changes
         child = MergeSemantics(
           child: Semantics(
             expanded: controller.isOpen,

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1189,7 +1189,7 @@ class CheckboxMenuButton extends StatelessWidget {
   /// The checkbox will have different default container color and check color when
   /// this is true. This is only used when [ThemeData.useMaterial3] is set to true.
   ///
-  /// Must not be null. Defaults to false.
+  /// Defaults to false.
   final bool isError;
 
   /// Called when the value of the checkbox should change.

--- a/packages/flutter/lib/src/material/menu_button_theme.dart
+++ b/packages/flutter/lib/src/material/menu_button_theme.dart
@@ -103,8 +103,6 @@ class MenuButtonThemeData with Diagnosticable {
 ///   [Theme].
 class MenuButtonTheme extends InheritedTheme {
   /// Create a [MenuButtonTheme].
-  ///
-  /// The [data] parameter must not be null.
   const MenuButtonTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -19,8 +19,6 @@ import 'theme.dart';
 abstract class MergeableMaterialItem {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
-  ///
-  /// The argument is the [key], which must not be null.
   const MergeableMaterialItem(this.key);
 
   /// The key for this item of the list.

--- a/packages/flutter/lib/src/material/navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_bar_theme.dart
@@ -206,8 +206,6 @@ class NavigationBarThemeData with Diagnosticable {
 class NavigationBarTheme extends InheritedTheme {
   /// Creates a navigation rail theme that controls the
   /// [NavigationBarThemeData] properties for a [NavigationBar].
-  ///
-  /// The data argument must not be null.
   const NavigationBarTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/navigation_drawer_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer_theme.dart
@@ -219,8 +219,6 @@ class NavigationDrawerThemeData with Diagnosticable {
 class NavigationDrawerTheme extends InheritedTheme {
   /// Creates a navigation rail theme that controls the
   /// [NavigationDrawerThemeData] properties for a [NavigationDrawer].
-  ///
-  /// The data argument must not be null.
   const NavigationDrawerTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -80,8 +80,8 @@ class NavigationRail extends StatefulWidget {
   /// [minExtendedWidth] is specified, it must be non-negative and greater than
   /// [minWidth].
   ///
-  /// The argument [extended] must not be null. [extended] can only be set to
-  /// true when the [labelType] is null or [NavigationRailLabelType.none].
+  /// The [extended] argument can only be set to true when the [labelType] is
+  /// null or [NavigationRailLabelType.none].
   ///
   /// If [backgroundColor], [elevation], [groupAlignment], [labelType],
   /// [unselectedLabelTextStyle], [selectedLabelTextStyle],
@@ -946,9 +946,9 @@ enum NavigationRailLabelType {
 class NavigationRailDestination {
   /// Creates a destination that is used with [NavigationRail.destinations].
   ///
-  /// [icon] and [label] must be non-null. When the [NavigationRail.labelType]
-  /// is [NavigationRailLabelType.none], the label is still used for semantics,
-  /// and may still be used if [NavigationRail.extended] is true.
+  /// When the [NavigationRail.labelType] is [NavigationRailLabelType.none], the
+  /// label is still used for semantics, and may still be used if
+  /// [NavigationRail.extended] is true.
   const NavigationRailDestination({
     required this.icon,
     Widget? selectedIcon,

--- a/packages/flutter/lib/src/material/navigation_rail_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_rail_theme.dart
@@ -236,8 +236,6 @@ class NavigationRailThemeData with Diagnosticable {
 class NavigationRailTheme extends InheritedTheme {
   /// Creates a navigation rail theme that controls the
   /// [NavigationRailThemeData] properties for a [NavigationRail].
-  ///
-  /// The data argument must not be null.
   const NavigationRailTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -67,8 +67,6 @@ import 'theme_data.dart';
 ///  * <https://m3.material.io/components/buttons>
 class OutlinedButton extends ButtonStyleButton {
   /// Create an OutlinedButton.
-  ///
-  /// The [autofocus] and [clipBehavior] arguments must not be null.
   const OutlinedButton({
     super.key,
     required super.onPressed,
@@ -88,8 +86,6 @@ class OutlinedButton extends ButtonStyleButton {
   ///
   /// The icon and label are arranged in a row and padded by 12 logical pixels
   /// at the start, and 16 at the end, with an 8 pixel gap in between.
-  ///
-  /// The [icon] and [label] arguments must not be null.
   factory OutlinedButton.icon({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/outlined_button_theme.dart
+++ b/packages/flutter/lib/src/material/outlined_button_theme.dart
@@ -91,8 +91,6 @@ class OutlinedButtonThemeData with Diagnosticable {
 ///    [ButtonStyle] for [OutlinedButton]s below the overall [Theme].
 class OutlinedButtonTheme extends InheritedTheme {
   /// Create a [OutlinedButtonTheme].
-  ///
-  /// The [data] parameter must not be null.
   const OutlinedButtonTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -34,9 +34,6 @@ import 'theme.dart';
 ///  * [MaterialPage], which is a [Page] of this class.
 class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
   /// Construct a MaterialPageRoute whose contents are defined by [builder].
-  ///
-  /// The values of [builder], [maintainState], and [PageRoute.fullscreenDialog]
-  /// must not be null.
   MaterialPageRoute({
     required this.builder,
     super.settings,

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -71,15 +71,11 @@ class PaginatedDataTable extends StatefulWidget {
   /// order is ascending, this should be true (the default), otherwise it should
   /// be false.
   ///
-  /// The [source] must not be null. The [source] should be a long-lived
-  /// [DataTableSource]. The same source should be provided each time a
-  /// particular [PaginatedDataTable] widget is created; avoid creating a new
-  /// [DataTableSource] with each new instance of the [PaginatedDataTable]
-  /// widget unless the data table really is to now show entirely different
-  /// data from a new source.
-  ///
-  /// The [rowsPerPage] and [availableRowsPerPage] must not be null (they
-  /// both have defaults, though, so don't have to be specified).
+  /// The [source] should be a long-lived [DataTableSource]. The same source
+  /// should be provided each time a particular [PaginatedDataTable] widget is
+  /// created; avoid creating a new [DataTableSource] with each new instance of
+  /// the [PaginatedDataTable] widget unless the data table really is to now
+  /// show entirely different data from a new source.
   ///
   /// Themed by [DataTableTheme]. [DataTableThemeData.decoration] is ignored.
   /// To modify the border or background color of the [PaginatedDataTable], use
@@ -264,7 +260,7 @@ class PaginatedDataTable extends StatefulWidget {
   /// and no affordance will be provided to change the value.
   final ValueChanged<int?>? onRowsPerPageChanged;
 
-  /// The data source which provides data to show in each row. Must be non-null.
+  /// The data source which provides data to show in each row.
   ///
   /// This object should generally have a lifetime longer than the
   /// [PaginatedDataTable] widget itself; it should be reused each time the

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -216,8 +216,6 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   /// Creates an item for a popup menu.
   ///
   /// By default, the item is [enabled].
-  ///
-  /// The `enabled` and `height` arguments must not be null.
   const PopupMenuItem({
     super.key,
     this.value,
@@ -474,8 +472,6 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
   ///
   /// By default, the menu item is [enabled] but unchecked. To mark the item as
   /// checked, set [checked] to true.
-  ///
-  /// The `checked` and `enabled` arguments must not be null.
   const CheckedPopupMenuItem({
     super.key,
     super.value,
@@ -1101,8 +1097,6 @@ typedef PopupMenuItemBuilder<T> = List<PopupMenuEntry<T>> Function(BuildContext 
 ///  * [showMenu], a method to dynamically show a popup menu at a given location.
 class PopupMenuButton<T> extends StatefulWidget {
   /// Creates a button that shows a popup menu.
-  ///
-  /// The [itemBuilder] argument must not be null.
   const PopupMenuButton({
     super.key,
     required this.itemBuilder,
@@ -1207,11 +1201,11 @@ class PopupMenuButton<T> extends StatefulWidget {
 
   /// Whether this popup menu button is interactive.
   ///
-  /// Must be non-null, defaults to `true`
+  /// Defaults to true.
   ///
-  /// If `true` the button will respond to presses by displaying the menu.
+  /// If true, the button will respond to presses by displaying the menu.
   ///
-  /// If `false`, the button is styled with the disabled color from the
+  /// If false, the button is styled with the disabled color from the
   /// current [Theme] and will not respond to presses or show the popup
   /// menu and [onSelected], [onCanceled] and [itemBuilder] will not be called.
   ///
@@ -1289,7 +1283,7 @@ class PopupMenuButton<T> extends StatefulWidget {
   ///
   /// The [clipBehavior] argument is used the clip shape of the menu.
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
   @override

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -900,7 +900,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 
 /// Show a popup menu that contains the `items` at `position`.
 ///
-/// `items` should be non-null and not empty.
+/// The `items` parameter must not be empty.
 ///
 /// If `initialValue` is specified then the first item with a matching value
 /// will be highlighted and the value of `position` gives the rectangle whose

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -225,8 +225,6 @@ class PopupMenuThemeData with Diagnosticable {
 class PopupMenuTheme extends InheritedTheme {
   /// Creates a popup menu theme that controls the configurations for
   /// popup menus in its widget subtree.
-  ///
-  /// The data argument must not be null.
   const PopupMenuTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -109,11 +109,12 @@ class RangeSlider extends StatefulWidget {
   /// Creates a Material Design range slider.
   ///
   /// The range slider widget itself does not maintain any state. Instead, when
-  /// the state of the slider changes, the widget calls the [onChanged] callback.
-  /// Most widgets that use a range slider will listen for the [onChanged] callback
-  /// and rebuild the slider with new [values] to update the visual appearance of
-  /// the slider. To know when the value starts to change, or when it is done
-  /// changing, set the optional callbacks [onChangeStart] and/or [onChangeEnd].
+  /// the state of the slider changes, the widget calls the [onChanged]
+  /// callback. Most widgets that use a range slider will listen for the
+  /// [onChanged] callback and rebuild the slider with new [values] to update
+  /// the visual appearance of the slider. To know when the value starts to
+  /// change, or when it is done changing, set the optional callbacks
+  /// [onChangeStart] and/or [onChangeEnd].
   ///
   /// * [values], which determines currently selected values for this range
   ///   slider.
@@ -128,10 +129,15 @@ class RangeSlider extends StatefulWidget {
   /// [inactiveColor] properties, although more fine-grained control of the
   /// appearance is achieved using a [SliderThemeData].
   ///
-  /// The [min] must be less than or equal to the [max]. [values].start must be
-  /// less than or equal to [values].end. [values].start and [values].end must
-  /// be greater than or equal to the [min] and less than or equal to the [max].
-  /// The [divisions] must be null or greater than 0.
+  /// The [min] must be less than or equal to the [max].
+  ///
+  /// The [RangeValues.start] attribute of the [values] parameter must be less
+  /// than or equal to its [RangeValues.end] attribute. The [RangeValues.start]
+  /// and [RangeValues.end] attributes of the [values] parameter must be greater
+  /// than or equal to the [min] parameter and less than or equal to the [max]
+  /// parameter.
+  ///
+  /// The [divisions] parameter must be null or greater than zero.
   RangeSlider({
     super.key,
     required this.values,

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -128,11 +128,10 @@ class RangeSlider extends StatefulWidget {
   /// [inactiveColor] properties, although more fine-grained control of the
   /// appearance is achieved using a [SliderThemeData].
   ///
-  /// The [values], [min], [max] must not be null. The [min] must be less than
-  /// or equal to the [max]. [values].start must be less than or equal to
-  /// [values].end. [values].start and [values].end must be greater than or
-  /// equal to the [min] and less than or equal to the [max]. The [divisions]
-  /// must be null or greater than 0.
+  /// The [min] must be less than or equal to the [max]. [values].start must be
+  /// less than or equal to [values].end. [values].start and [values].end must
+  /// be greater than or equal to the [min] and less than or equal to the [max].
+  /// The [divisions] must be null or greater than 0.
   RangeSlider({
     super.key,
     required this.values,

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1642,7 +1642,7 @@ class Scaffold extends StatefulWidget {
   /// This is useful if the app bar's [AppBar.backgroundColor] is not
   /// completely opaque.
   ///
-  /// This property is false by default. It must not be null.
+  /// This property is false by default.
   ///
   /// See also:
   ///
@@ -2516,7 +2516,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   double get _floatingActionButtonVisibilityValue => _floatingActionButtonVisibilityController.value;
 
   /// Sets the current value of the visibility animation for the
-  /// [Scaffold.floatingActionButton]. This value must not be null.
+  /// [Scaffold.floatingActionButton].
   set _floatingActionButtonVisibilityValue(double newValue) {
     _floatingActionButtonVisibilityController.value = clampDouble(newValue,
       _floatingActionButtonVisibilityController.lowerBound,
@@ -2752,8 +2752,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   Color _bodyScrimColor = Colors.black;
 
   /// Whether to show a [ModalBarrier] over the body of the scaffold.
-  ///
-  /// The `value` parameter must not be null.
   void showBodyScrim(bool value, double opacity) {
     if (_showBodyScrim == value && _bodyScrimColor.opacity == opacity) {
       return;
@@ -3080,8 +3078,6 @@ class ScaffoldFeatureController<T extends Widget, U> {
 /// curve specified with the [curve] argument, after the finger is released. In
 /// such a case, the value of [startingPoint] would be the progress of the
 /// animation at the time when the finger was released.
-///
-/// The [startingPoint] and [curve] arguments must not be null.
 class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
   /// Creates a suspended curve.
   const _BottomSheetSuspendedCurve(

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -172,8 +172,6 @@ class ScrollbarThemeData with Diagnosticable {
 
   /// Linearly interpolate between two Scrollbar themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static ScrollbarThemeData lerp(ScrollbarThemeData? a, ScrollbarThemeData? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -142,8 +142,6 @@ class SearchAnchor extends StatefulWidget {
   ///
   /// ** See code in examples/api/lib/material/search_anchor/search_anchor.0.dart **
   /// {@end-tool}
-  ///
-  /// The [suggestionsBuilder] argument must not be null.
   factory SearchAnchor.bar({
     Widget? barLeading,
     Iterable<Widget>? barTrailing,
@@ -295,8 +293,6 @@ class SearchAnchor extends StatefulWidget {
   ///
   /// The widget returned by this builder is faded out when it is tapped.
   /// At the same time a search view route is faded in.
-  ///
-  /// This must not be null.
   final SearchAnchorChildBuilder builder;
 
   /// Called to get the suggestion list for the search view.

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -232,8 +232,8 @@ class SelectableText extends StatefulWidget {
 
   /// Creates a selectable text widget with a [TextSpan].
   ///
-  /// The [textSpan] parameter must only contain a [TextSpan] in
-  /// [textSpan].children. Other types of [InlineSpan] are not allowed.
+  /// The [TextSpan.children] attribute of the [textSpan] parameter must only
+  /// contain [TextSpan]s. Other types of [InlineSpan] are not allowed.
   const SelectableText.rich(
     TextSpan this.textSpan, {
     super.key,

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -174,9 +174,9 @@ class SelectableText extends StatefulWidget {
   /// closest enclosing [DefaultTextStyle].
   ///
 
-  /// The [showCursor], [autofocus], [dragStartBehavior], [selectionHeightStyle],
-  /// [selectionWidthStyle] and [data] parameters must not be null. If specified,
-  /// the [maxLines] argument must be greater than zero.
+  /// If the [showCursor], [autofocus], [dragStartBehavior],
+  /// [selectionHeightStyle], [selectionWidthStyle] and [data] arguments are
+  /// specified, the [maxLines] argument must be greater than zero.
   const SelectableText(
     String this.data, {
     super.key,
@@ -232,10 +232,8 @@ class SelectableText extends StatefulWidget {
 
   /// Creates a selectable text widget with a [TextSpan].
   ///
-  /// The [textSpan] parameter must not be null and only contain [TextSpan] in
-  /// [textSpan].children. Other type of [InlineSpan] is not allowed.
-  ///
-  /// The [autofocus] and [dragStartBehavior] arguments must not be null.
+  /// The [textSpan] parameter must only contain a [TextSpan] in
+  /// [textSpan].children. Other types of [InlineSpan] are not allowed.
   const SelectableText.rich(
     TextSpan this.textSpan, {
     super.key,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -49,8 +49,6 @@ import 'theme.dart';
 ///    the [RangeSlider]'s tick marks.
 class SliderTheme extends InheritedTheme {
   /// Applies the given theme [data] to [child].
-  ///
-  /// The [data] and [child] arguments must not be null.
   const SliderTheme({
     super.key,
     required this.data,
@@ -654,8 +652,6 @@ class SliderThemeData with Diagnosticable {
   }
 
   /// Linearly interpolate between two slider themes.
-  ///
-  /// The arguments must not be null.
   ///
   /// {@macro dart.ui.shadow.lerp}
   static SliderThemeData lerp(SliderThemeData a, SliderThemeData b, double t) {

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -463,7 +463,7 @@ class SnackBar extends StatefulWidget {
 
   /// The direction in which the SnackBar can be dismissed.
   ///
-  /// Cannot be null, defaults to [DismissDirection.down].
+  /// Defaults to [DismissDirection.down].
   final DismissDirection dismissDirection;
 
   /// {@macro flutter.material.Material.clipBehavior}

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -83,8 +83,6 @@ enum SnackBarClosedReason {
 ///  * <https://material.io/design/components/snackbars.html>
 class SnackBarAction extends StatefulWidget {
   /// Creates an action for a [SnackBar].
-  ///
-  /// The [label] and [onPressed] arguments must be non-null.
   const SnackBarAction({
     super.key,
     this.textColor,
@@ -127,7 +125,7 @@ class SnackBarAction extends StatefulWidget {
   /// The button label.
   final String label;
 
-  /// The callback to be called when the button is pressed. Must not be null.
+  /// The callback to be called when the button is pressed.
   ///
   /// This callback will be called at most once each time this action is
   /// displayed in a [SnackBar].
@@ -272,8 +270,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 class SnackBar extends StatefulWidget {
   /// Creates a snack bar.
   ///
-  /// The [content] argument must be non-null. The [elevation] must be null or
-  /// non-negative.
+  /// The [elevation] must be null or non-negative.
   const SnackBar({
     super.key,
     required this.content,
@@ -471,7 +468,7 @@ class SnackBar extends StatefulWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.hardEdge], and must not be null.
+  /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
   // API for ScaffoldMessengerState.showSnackBar():

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -196,8 +196,6 @@ class SnackBarThemeData with Diagnosticable {
 
   /// Linearly interpolate between two SnackBar Themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static SnackBarThemeData lerp(SnackBarThemeData? a, SnackBarThemeData? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -134,8 +134,6 @@ const double _kTriangleHeight = _kStepSize * 0.866025; // Triangle height. sqrt(
 @immutable
 class Step {
   /// Creates a step for a [Stepper].
-  ///
-  /// The [title], [content], and [state] arguments must not be null.
   const Step({
     required this.title,
     this.subtitle,
@@ -197,8 +195,6 @@ class Stepper extends StatefulWidget {
   /// This widget is not meant to be rebuilt with a different list of steps
   /// unless a key is provided in order to distinguish the old stepper from the
   /// new one.
-  ///
-  /// The [steps], [type], and [currentStep] arguments must not be null.
   const Stepper({
     super.key,
     required this.steps,

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -178,8 +178,6 @@ class Switch extends StatelessWidget {
         _switchType = _SwitchType.adaptive;
 
   /// Whether this switch is on or off.
-  ///
-  /// This property must not be null.
   final bool value;
 
   /// Called when the user toggles the switch on or off.

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -261,8 +261,6 @@ class SwitchListTile extends StatelessWidget {
        assert(inactiveThumbImage != null || onInactiveThumbImageError == null);
 
   /// Whether this switch is checked.
-  ///
-  /// This property must not be null.
   final bool value;
 
   /// Called when the user toggles the switch on or off.

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -141,8 +141,6 @@ class TabBarTheme with Diagnosticable {
 
   /// Linearly interpolate between two tab bar themes.
   ///
-  /// The arguments must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static TabBarTheme lerp(TabBarTheme a, TabBarTheme b, double t) {
     if (identical(a, b)) {

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -95,12 +95,12 @@ class TabController extends ChangeNotifier {
   /// Creates an object that manages the state required by [TabBar] and a
   /// [TabBarView].
   ///
-  /// The [length] must not be null or negative. Typically it's a value greater
-  /// than one, i.e. typically there are two or more tabs. The [length] must
-  /// match [TabBar.tabs]'s and [TabBarView.children]'s length.
+  /// The [length] must not be negative. Typically it's a value greater than
+  /// one, i.e. typically there are two or more tabs. The [length] must match
+  /// [TabBar.tabs]'s and [TabBarView.children]'s length.
   ///
-  /// The `initialIndex` must be valid given [length] and must not be null. If
-  /// [length] is zero, then `initialIndex` must be 0 (the default).
+  /// The `initialIndex` must be valid given [length]. If [length] is zero, then
+  /// `initialIndex` must be 0 (the default).
   TabController({
     int initialIndex = 0,
     Duration? animationDuration,
@@ -342,8 +342,6 @@ class DefaultTabController extends StatefulWidget {
   ///
   /// The [length] argument is typically greater than one. The [length] must
   /// match [TabBar.tabs]'s and [TabBarView.children]'s length.
-  ///
-  /// The [initialIndex] argument must not be null.
   const DefaultTabController({
     super.key,
     required this.length,

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -17,8 +17,6 @@ import 'colors.dart';
 /// or the entire tab with [TabBarIndicatorSize.tab].
 class UnderlineTabIndicator extends Decoration {
   /// Create an underline style selected tab indicator.
-  ///
-  /// The [borderSide] and [insets] arguments must not be null.
   const UnderlineTabIndicator({
     this.borderRadius,
     this.borderSide = const BorderSide(width: 2.0, color: Colors.white),

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -736,15 +736,15 @@ class _TabBarScrollController extends ScrollController {
 class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// Creates a Material Design primary tab bar.
   ///
-  /// The [tabs] argument must not be null and its length must match the [controller]'s
+  /// The length of the [tabs] argument must match the [controller]'s
   /// [TabController.length].
   ///
   /// If a [TabController] is not provided, then there must be a
   /// [DefaultTabController] ancestor.
   ///
-  /// The [indicatorWeight] parameter defaults to 2, and must not be null.
+  /// The [indicatorWeight] parameter defaults to 2.
   ///
-  /// The [indicatorPadding] parameter defaults to [EdgeInsets.zero], and must not be null.
+  /// The [indicatorPadding] parameter defaults to [EdgeInsets.zero].
   ///
   /// If [indicator] is not null or provided from [TabBarTheme],
   /// then [indicatorWeight] and [indicatorColor] are ignored.
@@ -2046,8 +2046,6 @@ class _TabBarViewState extends State<TabBarView> {
 /// Used by [TabPageSelector] to indicate the selected page.
 class TabPageSelectorIndicator extends StatelessWidget {
   /// Creates an indicator used by [TabPageSelector].
-  ///
-  /// The [backgroundColor], [borderColor], and [size] parameters must not be null.
   const TabPageSelectorIndicator({
     super.key,
     required this.backgroundColor,

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -73,9 +73,7 @@ import 'theme_data.dart';
 ///  * <https://material.io/design/components/buttons.html>
 ///  * <https://m3.material.io/components/buttons>
 class TextButton extends ButtonStyleButton {
-  /// Create a TextButton.
-  ///
-  /// The [autofocus] and [clipBehavior] arguments must not be null.
+  /// Create a [TextButton].
   const TextButton({
     super.key,
     required super.onPressed,
@@ -96,8 +94,6 @@ class TextButton extends ButtonStyleButton {
   ///
   /// The icon and label are arranged in a row and padded by 8 logical pixels
   /// at the ends, with an 8 pixel gap in between.
-  ///
-  /// The [icon] and [label] arguments must not be null.
   factory TextButton.icon({
     Key? key,
     required VoidCallback? onPressed,

--- a/packages/flutter/lib/src/material/text_button_theme.dart
+++ b/packages/flutter/lib/src/material/text_button_theme.dart
@@ -91,8 +91,6 @@ class TextButtonThemeData with Diagnosticable {
 ///    [ButtonStyle] for [TextButton]s below the overall [Theme].
 class TextButtonTheme extends InheritedTheme {
   /// Create a [TextButtonTheme].
-  ///
-  /// The [data] parameter must not be null.
   const TextButtonTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -238,13 +238,7 @@ class TextField extends StatefulWidget {
   ///
   /// The [selectionHeightStyle] and [selectionWidthStyle] properties allow
   /// changing the shape of the selection highlighting. These properties default
-  /// to [ui.BoxHeightStyle.tight] and [ui.BoxWidthStyle.tight] respectively and
-  /// must not be null.
-  ///
-  /// The [textAlign], [autofocus], [obscureText], [readOnly], [autocorrect],
-  /// [scrollPadding], [maxLines], [maxLength], [selectionHeightStyle],
-  /// [selectionWidthStyle], [enableSuggestions], and
-  /// [enableIMEPersonalizedLearning] arguments must not be null.
+  /// to [ui.BoxHeightStyle.tight] and [ui.BoxWidthStyle.tight], respectively.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/text_selection_theme.dart
+++ b/packages/flutter/lib/src/material/text_selection_theme.dart
@@ -140,8 +140,6 @@ class TextSelectionThemeData with Diagnosticable {
 class TextSelectionTheme extends InheritedTheme {
   /// Creates a text selection theme widget that specifies the text
   /// selection properties for all widgets below it in the widget tree.
-  ///
-  /// The data argument must not be null.
   const TextSelectionTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -36,8 +36,6 @@ const Duration kThemeAnimationDuration = Duration(milliseconds: 200);
 ///    the [MaterialApp.theme] argument.
 class Theme extends StatelessWidget {
   /// Applies the given theme [data] to [child].
-  ///
-  /// The [data] and [child] arguments must not be null.
   const Theme({
     super.key,
     required this.data,
@@ -201,8 +199,7 @@ class ThemeDataTween extends Tween<ThemeData> {
 class AnimatedTheme extends ImplicitlyAnimatedWidget {
   /// Creates an animated theme.
   ///
-  /// By default, the theme transition uses a linear curve. The [data] and
-  /// [child] arguments must not be null.
+  /// By default, the theme transition uses a linear curve.
   const AnimatedTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1795,8 +1795,6 @@ class ThemeData with Diagnosticable {
 
   /// Linearly interpolate between two themes.
   ///
-  /// The arguments must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static ThemeData lerp(ThemeData a, ThemeData b, double t) {
     if (identical(a, b)) {
@@ -2245,8 +2243,6 @@ class ThemeData with Diagnosticable {
 class MaterialBasedCupertinoThemeData extends CupertinoThemeData {
   /// Create a [MaterialBasedCupertinoThemeData] based on a Material [ThemeData]
   /// and its `cupertinoOverrideTheme`.
-  ///
-  /// The [materialTheme] parameter must not be null.
   MaterialBasedCupertinoThemeData({
     required ThemeData materialTheme,
   }) : this._(
@@ -2373,8 +2369,6 @@ class _FifoCache<K, V> {
 
   /// Returns the previously cached value for the given key, if available;
   /// if not, calls the given callback to obtain it first.
-  ///
-  /// The arguments must not be null.
   V putIfAbsent(K key, V Function() loader) {
     assert(key != null);
     final V? result = _cache[key];
@@ -2427,9 +2421,8 @@ class _FifoCache<K, V> {
 class VisualDensity with Diagnosticable {
   /// A const constructor for [VisualDensity].
   ///
-  /// All of the arguments must be non-null, and [horizontal] and [vertical]
-  /// must be in the interval between [minimumDensity] and [maximumDensity],
-  /// inclusive.
+  /// The [horizontal] and [vertical] arguments must be in the interval between
+  /// [minimumDensity] and [maximumDensity], inclusive.
   const VisualDensity({
     this.horizontal = 0.0,
     this.vertical = 0.0,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -784,8 +784,6 @@ class ThemeData with Diagnosticable {
   /// Create a [ThemeData] based on the colors in the given [colorScheme] and
   /// text styles of the optional [textTheme].
   ///
-  /// The [colorScheme] can not be null.
-  ///
   /// If [colorScheme].brightness is [Brightness.dark] then
   /// [ThemeData.applyElevationOverlayColor] will be set to true to support
   /// the Material dark theme method for indicating elevation by applying

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -2108,8 +2108,6 @@ typedef EntryModeChangeCallback = void Function(TimePickerEntryMode);
 /// Use [showTimePicker] to show a dialog already containing a [TimePickerDialog].
 class TimePickerDialog extends StatefulWidget {
   /// Creates a Material Design time picker.
-  ///
-  /// [initialTime] must not be null.
   const TimePickerDialog({
     super.key,
     required this.initialTime,

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -301,8 +301,6 @@ class TimePickerThemeData with Diagnosticable {
 
   /// Linearly interpolate between two time picker themes.
   ///
-  /// The argument `t` must not be null.
-  ///
   /// {@macro dart.ui.shadow.lerp}
   static TimePickerThemeData lerp(TimePickerThemeData? a, TimePickerThemeData? b, double t) {
     if (identical(a, b) && a != null) {

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -205,9 +205,8 @@ class ToggleButtons extends StatelessWidget {
   ///
   /// Both [children] and [isSelected] properties arguments are required.
   ///
-  /// [isSelected] values must be non-null. [focusNodes] must be null or a
-  /// list of non-null nodes. [renderBorder] and [direction] must not be null.
-  /// If [direction] is [Axis.vertical], [verticalDirection] must not be null.
+  /// The [focusNodes] argument must be null or a list of nodes. If [direction]
+  /// is [Axis.vertical], [verticalDirection] must not be null.
   const ToggleButtons({
     super.key,
     required this.children,

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -246,8 +246,6 @@ class ToggleButtonsThemeData with Diagnosticable {
 class ToggleButtonsTheme extends InheritedTheme {
   /// Creates a toggle buttons theme that controls the color and border
   /// parameters for [ToggleButtons].
-  ///
-  /// The data argument must not be null.
   const ToggleButtonsTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -820,8 +820,6 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 /// below a target specified in the global coordinate system.
 class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
   /// Creates a delegate for computing the layout of a tooltip.
-  ///
-  /// The arguments must not be null.
   _TooltipPositionDelegate({
     required this.target,
     required this.verticalOffset,

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -262,8 +262,6 @@ class TooltipThemeData with Diagnosticable {
 class TooltipTheme extends InheritedTheme {
   /// Creates a tooltip theme that controls the configurations for
   /// [Tooltip].
-  ///
-  /// The data argument must not be null.
   const TooltipTheme({
     super.key,
     required this.data,

--- a/packages/flutter/lib/src/material/tooltip_visibility.dart
+++ b/packages/flutter/lib/src/material/tooltip_visibility.dart
@@ -26,8 +26,6 @@ class _TooltipVisibilityScope extends InheritedWidget {
 /// continues to provide any semantic information that is provided.
 class TooltipVisibility extends StatelessWidget {
   /// Creates a widget that configures the visibility of [Tooltip].
-  ///
-  /// Both arguments must not be null.
   const TooltipVisibility({
     super.key,
     required this.visible,


### PR DESCRIPTION
## Description

This removes all of the comments that are of the form "so-and-so (must not be null|can ?not be null|must be non-null)" from the cases where those values are defines as non-nullable values.

This PR removes them from the material library.

This was done by hand, since it really didn't lend itself to scripting, so it needs to be more than just spot-checked, I think. I was careful to leave any comment that referred to parameters that were nullable, but I may have missed some.

In addition to being no longer relevant after null safety has been made the default, these comments were largely fragile, in that it was easy for them to get out of date, and not be accurate anymore anyhow.

This did create a number of constructor comments which basically say "Creates a [Foo].", but I don't really know how to avoid that in a large scale change, since there's not much you can really say in a lot of cases.  I think we might consider some leniency for constructors to the "Comment must be meaningful" style guidance (which we de facto have already, since there are a bunch of these).

## Related PRs
- https://github.com/flutter/flutter/pull/134984
- https://github.com/flutter/flutter/pull/134992
- https://github.com/flutter/flutter/pull/134993
- https://github.com/flutter/flutter/pull/134994

## Tests
 - Documentation only change.