### PR TITLE
Bring native_assets ios tests out of staging

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4103,7 +4103,6 @@ targets:
   - name: Mac_ios native_assets_ios_simulator
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # TODO(dacoharkes): Set to false in follow up PR and check that test works on CI.
     timeout: 60
     properties:
       tags: >
@@ -4113,7 +4112,6 @@ targets:
   - name: Mac_ios native_assets_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # TODO(dacoharkes): Set to false in follow up PR and check that test works on CI.
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Move test added in https://github.com/flutter/flutter/pull/130494 out of staging.

* https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.staging/Mac_ios%20native_assets_ios
* https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.staging/Mac_ios%20native_assets_ios_simulator

> Monitor the CI results of the new shard on the [Flutter build dashboard](https://flutter-dashboard.appspot.com/#/build). After 50 consecutive passing builds without any flakes, the flake bot will create a PR to remove the bringup: true parameter from .ci.yaml in the Framework tree. This will allow the test to block the tree, preventing breakages. With this change, the new shard will start running in presubmit automatically, unless specify presubmit: false.

https://github.com/flutter/flutter/wiki/Adding-a-new-Test-Shard#steps-to-add-a-new-framework-test-shard

Umbrella issue:

* https://github.com/flutter/flutter/issues/129757

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
