### PR TITLE
[iOS,macOS] Clean up obsolete PlatformView warning

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -201,11 +201,7 @@ class PlatformViewsService {
     return controller;
   }
 
-  // TODO(amirh): reference the iOS plugin API for registering a UIView factory
-  // once it lands.
-
-  /// This is work in progress, not yet ready to be used, and requires a custom
-  /// engine build. Creates a controller for a new iOS UIView.
+  /// Factory method to create a `UiKitView`.
   ///
   /// The `id` parameter is an unused unique identifier generated with
   /// [platformViewsRegistry].
@@ -218,6 +214,8 @@ class PlatformViewsService {
   /// The `onFocus` parameter is a callback that will be invoked when the UIKit
   /// view asks to get the input focus. If `creationParams` is non null then
   /// `creationParamsCodec` must not be null.
+  ///
+  /// See: https://docs.flutter.dev/platform-integration/ios/platform-views
   static Future<UiKitViewController> initUiKitView({
     required int id,
     required String viewType,
@@ -249,6 +247,8 @@ class PlatformViewsService {
     return UiKitViewController._(id, layoutDirection);
   }
 
+  // TODO(cbracken): Write and link website docs. https://github.com/flutter/website/issues/9424.
+  //
   /// Factory method to create an `AppKitView`.
   ///
   /// The `id` parameter is an unused unique identifier generated with


### PR DESCRIPTION
PlatformViews have been supported without a custom engine build on iOS for quite some time now, and are nearing support for macOS. Adds a link to the website documentation covering creation of PlatformViews for iOS and adds a TODO to do the same once the macOS PlatformView documentation is ready.

Related: https://github.com/flutter/website/issues/9424

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
