### PR TITLE
remove field override, assign to super field instead

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1335,7 +1335,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
 class TestRunCommandForUsageValues extends RunCommand {
   TestRunCommandForUsageValues({
-   List<Device>? devices,
+    List<Device>? devices,
   }) {
     this.devices = devices;
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -1335,13 +1335,10 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
 class TestRunCommandForUsageValues extends RunCommand {
   TestRunCommandForUsageValues({
-   this.devices,
-  });
-
-  @override
-  // devices is not set within usageValues, so we override the field
-  // ignore: overridden_fields
-  List<Device>? devices;
+   List<Device>? devices,
+  }) {
+    this.devices = devices;
+  }
 
   @override
   Future<BuildInfo> getBuildInfo({ BuildMode? forcedBuildMode, File? forcedTargetFile }) async {


### PR DESCRIPTION
Removes an ignore about overriding fields. Instead we just assign the value to the original field in the super class.

Related to https://github.com/dart-lang/language/issues/3332 (discovered during investigations into the violation of that lint).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.