### PR TITLE
Support ensureVisible/showOnScreen/showInViewport for 2D Scrolling

### DIFF
--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1127,7 +1127,7 @@ class RenderListWheelViewport
     Rect? rect,
     AxisDirection? axisDirection,
   }) {
-    // ListWheelViewport only support vertical axes.
+    // ListWheelViewport only supports Axis.vertical.
     assert(axisDirection == null || axisDirectionToAxis(axisDirection) == Axis.vertical);
     // `target` is only fully revealed when in the selected/center position. Therefore,
     // this method always returns the offset that shows `target` in the center position,

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1127,6 +1127,9 @@ class RenderListWheelViewport
     Rect? rect,
     Axis? axis,
   }) {
+    // One dimensional viewport has only one axis, it should match if it has
+    // been provided.
+    assert(axis == null || axis == Axis.vertical);
     // `target` is only fully revealed when in the selected/center position. Therefore,
     // this method always returns the offset that shows `target` in the center position,
     // which is the same offset for all `alignment` values.

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1125,14 +1125,11 @@ class RenderListWheelViewport
     RenderObject target,
     double alignment, {
     Rect? rect,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
-    // ListWheelViewport only supports Axis.vertical.
-    assert(axisDirection == null || axisDirectionToAxis(axisDirection) == Axis.vertical);
     // `target` is only fully revealed when in the selected/center position. Therefore,
     // this method always returns the offset that shows `target` in the center position,
     // which is the same offset for all `alignment` values.
-
     rect ??= target.paintBounds;
 
     // `child` will be the last RenderObject before the viewport when walking up from `target`.

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1121,7 +1121,14 @@ class RenderListWheelViewport
   }
 
   @override
-  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect? rect }) {
+  RevealedOffset getOffsetToReveal(
+    RenderObject target,
+    double alignment, {
+    Rect? rect,
+    AxisDirection? axisDirection,
+  }) {
+    // ListWheelViewport only support vertical axes.
+    assert(axisDirection == null || axisDirectionToAxis(axisDirection) == Axis.vertical);
     // `target` is only fully revealed when in the selected/center position. Therefore,
     // this method always returns the offset that shows `target` in the center position,
     // which is the same offset for all `alignment` values.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -108,11 +108,17 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   /// when the offset of the viewport is changed by x then `target` also moves
   /// by x within the viewport.
   ///
+  /// TODO(Piinks): Add docs on new axis param
+  ///
   /// See also:
   ///
   ///  * [RevealedOffset], which describes the return value of this method.
-  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect? rect });
-
+  RevealedOffset getOffsetToReveal(
+    RenderObject target,
+    double alignment, {
+    Rect? rect,
+    AxisDirection? axisDirection,
+  });
   /// The default value for the cache extent of the viewport.
   ///
   /// This default assumes [CacheExtentStyle.pixel].
@@ -753,7 +759,14 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
   }
 
   @override
-  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect? rect }) {
+  RevealedOffset getOffsetToReveal(
+    RenderObject target,
+    double alignment, {
+    Rect? rect,
+    AxisDirection? axisDirection,
+  }) {
+    assert(axisDirection == null || axisDirection == this.axisDirection);
+    axisDirection ??= this.axisDirection;
     // Steps to convert `rect` (from a RenderBox coordinate system) to its
     // scroll offset within this viewport (not in the exact order):
     //

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/semantics.dart';
 

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -5,7 +5,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/animation.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/semantics.dart';
 

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/semantics.dart';
 
@@ -108,7 +109,11 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   /// when the offset of the viewport is changed by x then `target` also moves
   /// by x within the viewport.
   ///
-  /// TODO(Piinks): Add docs on new axis param
+  /// The optional [axisDirection] is used by [RenderTwoDimensionalViewport] to
+  /// determine which [Axis] of the two should reveal. One dimensional
+  /// subclasses like [RenderViewportBase and [RenderListWheelViewport] will
+  /// assert that if an [axisDirection] is provided, that it matches the
+  /// [axisDirection] the viewport has been configured for.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -110,9 +110,10 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   ///
   /// The optional [Axis] is used by
   /// [RenderTwoDimensionalViewport.getOffsetToReveal] to
-  /// determine which [Axis] to compute an offset for. One dimensional
+  /// determine which of the two axes to compute an offset for. One dimensional
   /// subclasses like [RenderViewportBase] and [RenderListWheelViewport] will
-  /// ignore the `axis` value if provided, as there is only one in those cases.
+  /// assert in debug builds if the `axis` value is provided and does not match
+  /// the single [Axis] that viewport is configured for.
   ///
   /// See also:
   ///
@@ -820,8 +821,11 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     Rect? rect,
     Axis? axis,
   }) {
-    // One dimensional viewport has only one axis, override if set.
-    axis = this.axis;
+    // One dimensional viewport has only one axis, it should match if it has
+    // been provided.
+    axis ??= this.axis;
+    assert(axis == this.axis);
+
     // Steps to convert `rect` (from a RenderBox coordinate system) to its
     // scroll offset within this viewport (not in the exact order):
     //

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -123,6 +123,56 @@ abstract interface class RenderAbstractViewport extends RenderObject {
     Rect? rect,
     AxisDirection? axisDirection,
   });
+
+  /// Determines which provided leading or trailing [RevealedOffset] will be
+  /// used for [RenderViewportBase.showInViewport] accounting for the size and
+  /// already visible portion of the [RenderObject] that is being revealed.
+  ///
+  /// Also used by [RenderTwoDimensionalViewport.showInViewport] for individual
+  /// axes.
+  static RevealedOffset? applyTargetOffset({
+    required RevealedOffset leadingEdgeOffset,
+    required RevealedOffset trailingEdgeOffset,
+    required double currentOffset,
+  }) {
+    //           scrollOffset
+    //                       0 +---------+
+    //                         |         |
+    //                       _ |         |
+    //    viewport position |  |         |
+    // with `descendant` at |  |         | _
+    //        trailing edge |_ | xxxxxxx |  | viewport position
+    //                         |         |  | with `descendant` at
+    //                         |         | _| leading edge
+    //                         |         |
+    //                     800 +---------+
+    //
+    // `trailingEdgeOffset`: Distance from scrollOffset 0 to the start of the
+    //                       viewport on the left in image above.
+    // `leadingEdgeOffset`: Distance from scrollOffset 0 to the start of the
+    //                      viewport on the right in image above.
+    //
+    // The viewport position on the left is achieved by setting `offset.pixels`
+    // to `trailingEdgeOffset`, the one on the right by setting it to
+    // `leadingEdgeOffset`.
+    if (leadingEdgeOffset.offset < trailingEdgeOffset.offset) {
+      // `descendant` is too big to be visible on screen in its entirety. Let's
+      // align it with the edge that requires the least amount of scrolling.
+      final double leadingEdgeDiff = (currentOffset - leadingEdgeOffset.offset).abs();
+      final double trailingEdgeDiff = (currentOffset - trailingEdgeOffset.offset).abs();
+      return leadingEdgeDiff < trailingEdgeDiff ? leadingEdgeOffset : trailingEdgeOffset;
+    } else if (currentOffset > leadingEdgeOffset.offset) {
+      // `descendant` currently starts above the leading edge and can be shown
+      // fully on screen by scrolling down (which means: moving viewport up).
+      return leadingEdgeOffset;
+    } else if (currentOffset < trailingEdgeOffset.offset) {
+      // `descendant currently ends below the trailing edge and can be shown
+      // fully on screen by scrolling up (which means: moving viewport down)
+      return trailingEdgeOffset;
+    }
+    return null;
+  }
+
   /// The default value for the cache extent of the viewport.
   ///
   /// This default assumes [CacheExtentStyle.pixel].
@@ -1181,51 +1231,18 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     final RevealedOffset leadingEdgeOffset = viewport.getOffsetToReveal(descendant, 0.0, rect: rect);
     final RevealedOffset trailingEdgeOffset = viewport.getOffsetToReveal(descendant, 1.0, rect: rect);
     final double currentOffset = offset.pixels;
-
-    //           scrollOffset
-    //                       0 +---------+
-    //                         |         |
-    //                       _ |         |
-    //    viewport position |  |         |
-    // with `descendant` at |  |         | _
-    //        trailing edge |_ | xxxxxxx |  | viewport position
-    //                         |         |  | with `descendant` at
-    //                         |         | _| leading edge
-    //                         |         |
-    //                     800 +---------+
-    //
-    // `trailingEdgeOffset`: Distance from scrollOffset 0 to the start of the
-    //                       viewport on the left in image above.
-    // `leadingEdgeOffset`: Distance from scrollOffset 0 to the start of the
-    //                      viewport on the right in image above.
-    //
-    // The viewport position on the left is achieved by setting `offset.pixels`
-    // to `trailingEdgeOffset`, the one on the right by setting it to
-    // `leadingEdgeOffset`.
-
-    final RevealedOffset targetOffset;
-    if (leadingEdgeOffset.offset < trailingEdgeOffset.offset) {
-      // `descendant` is too big to be visible on screen in its entirety. Let's
-      // align it with the edge that requires the least amount of scrolling.
-      final double leadingEdgeDiff = (offset.pixels - leadingEdgeOffset.offset).abs();
-      final double trailingEdgeDiff = (offset.pixels - trailingEdgeOffset.offset).abs();
-      targetOffset = leadingEdgeDiff < trailingEdgeDiff ? leadingEdgeOffset : trailingEdgeOffset;
-    } else if (currentOffset > leadingEdgeOffset.offset) {
-      // `descendant` currently starts above the leading edge and can be shown
-      // fully on screen by scrolling down (which means: moving viewport up).
-      targetOffset = leadingEdgeOffset;
-    } else if (currentOffset < trailingEdgeOffset.offset) {
-      // `descendant currently ends below the trailing edge and can be shown
-      // fully on screen by scrolling up (which means: moving viewport down)
-      targetOffset = trailingEdgeOffset;
-    } else {
+    final RevealedOffset? targetOffset = RenderAbstractViewport.applyTargetOffset(
+      leadingEdgeOffset: leadingEdgeOffset,
+      trailingEdgeOffset: trailingEdgeOffset,
+      currentOffset: currentOffset,
+    );
+    if (targetOffset == null) {
       // `descendant` is between leading and trailing edge and hence already
       //  fully shown on screen. No action necessary.
       assert(viewport.parent != null);
       final Matrix4 transform = descendant.getTransformTo(viewport.parent);
       return MatrixUtils.transformRect(transform, rect ?? descendant.paintBounds);
     }
-
 
     offset.moveTo(targetOffset.offset, duration: duration, curve: curve);
     return targetOffset.rect;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -110,9 +110,9 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   ///
   /// The optional [Axis] is used by
   /// [RenderTwoDimensionalViewport.getOffstToReveal] to
-  /// determine which [Axis] of the two should reveal. One dimensional
+  /// determine which [Axis] to compute an offset for. One dimensional
   /// subclasses like [RenderViewportBase] and [RenderListWheelViewport] will
-  /// ignore the `axis` value is provided, as there is only one in those cases.
+  /// ignore the `axis` value if provided, as there is only one in those cases.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -110,7 +110,7 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   ///
   /// The optional [axisDirection] is used by [RenderTwoDimensionalViewport] to
   /// determine which [Axis] of the two should reveal. One dimensional
-  /// subclasses like [RenderViewportBase and [RenderListWheelViewport] will
+  /// subclasses like [RenderViewportBase] and [RenderListWheelViewport] will
   /// assert that if an [axisDirection] is provided, that it matches the
   /// [axisDirection] the viewport has been configured for.
   ///
@@ -124,12 +124,16 @@ abstract interface class RenderAbstractViewport extends RenderObject {
     AxisDirection? axisDirection,
   });
 
-  /// Determines which provided leading or trailing [RevealedOffset] will be
-  /// used for [RenderViewportBase.showInViewport] accounting for the size and
-  /// already visible portion of the [RenderObject] that is being revealed.
+  /// Determines which provided leading or trailing edge of the viewport, as
+  /// [RevealedOffset]s, will be used for [RenderViewportBase.showInViewport]
+  /// accounting for the size and already visible portion of the [RenderObject]
+  /// that is being revealed.
   ///
-  /// Also used by [RenderTwoDimensionalViewport.showInViewport] for individual
-  /// axes.
+  /// Also used by [RenderTwoDimensionalViewport.showInViewport] for each
+  /// horizontal and vertical [Axis].
+  ///
+  /// If the target [RenderObject] is already fully visible, this will return
+  /// null.
   static RevealedOffset? applyTargetOffset({
     required RevealedOffset leadingEdgeOffset,
     required RevealedOffset trailingEdgeOffset,

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -215,22 +215,19 @@ class RevealedOffset {
     // The viewport position on the left is achieved by setting `offset.pixels`
     // to `trailingEdgeOffset`, the one on the right by setting it to
     // `leadingEdgeOffset`.
-    if (leadingEdgeOffset.offset < trailingEdgeOffset.offset) {
-      // `descendant` is too big to be visible on screen in its entirety. Let's
-      // align it with the edge that requires the least amount of scrolling.
-      final double leadingEdgeDiff = (currentOffset - leadingEdgeOffset.offset).abs();
-      final double trailingEdgeDiff = (currentOffset - trailingEdgeOffset.offset).abs();
-      return leadingEdgeDiff < trailingEdgeDiff ? leadingEdgeOffset : trailingEdgeOffset;
-    } else if (currentOffset > leadingEdgeOffset.offset) {
-      // `descendant` currently starts above the leading edge and can be shown
-      // fully on screen by scrolling down (which means: moving viewport up).
-      return leadingEdgeOffset;
-    } else if (currentOffset < trailingEdgeOffset.offset) {
-      // `descendant currently ends below the trailing edge and can be shown
-      // fully on screen by scrolling up (which means: moving viewport down)
-      return trailingEdgeOffset;
+    final bool inverted = leadingEdgeOffset.offset < trailingEdgeOffset.offset;
+    final RevealedOffset smaller;
+    final RevealedOffset larger;
+    (smaller, larger) = inverted
+      ? (leadingEdgeOffset, trailingEdgeOffset)
+      : (trailingEdgeOffset, leadingEdgeOffset);
+    if (currentOffset > larger.offset) {
+      return larger;
+    } else if (currentOffset < smaller.offset) {
+      return smaller;
+    } else {
+      return null;
     }
-    return null;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -108,11 +108,11 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   /// when the offset of the viewport is changed by x then `target` also moves
   /// by x within the viewport.
   ///
-  /// The optional [axisDirection] is used by [RenderTwoDimensionalViewport] to
+  /// The optional [Axis] is used by
+  /// [RenderTwoDimensionalViewport.getOffstToReveal] to
   /// determine which [Axis] of the two should reveal. One dimensional
   /// subclasses like [RenderViewportBase] and [RenderListWheelViewport] will
-  /// assert that if an [axisDirection] is provided, that it matches the
-  /// [axisDirection] the viewport has been configured for.
+  /// ignore the `axis` value is provided, as there is only one in those cases.
   ///
   /// See also:
   ///
@@ -121,7 +121,7 @@ abstract interface class RenderAbstractViewport extends RenderObject {
     RenderObject target,
     double alignment, {
     Rect? rect,
-    AxisDirection? axisDirection,
+    Axis? axis,
   });
 
   /// Determines which provided leading or trailing edge of the viewport, as
@@ -821,10 +821,10 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     RenderObject target,
     double alignment, {
     Rect? rect,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
-    assert(axisDirection == null || axisDirection == this.axisDirection);
-    axisDirection ??= this.axisDirection;
+    // One dimensional viewport has only one axis, override if set.
+    axis = this.axis;
     // Steps to convert `rect` (from a RenderBox coordinate system) to its
     // scroll offset within this viewport (not in the exact order):
     //

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -109,7 +109,7 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   /// by x within the viewport.
   ///
   /// The optional [Axis] is used by
-  /// [RenderTwoDimensionalViewport.getOffstToReveal] to
+  /// [RenderTwoDimensionalViewport.getOffsetToReveal] to
   /// determine which [Axis] to compute an offset for. One dimensional
   /// subclasses like [RenderViewportBase] and [RenderListWheelViewport] will
   /// ignore the `axis` value if provided, as there is only one in those cases.

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -810,14 +810,32 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     double target;
     switch (_applyAxisDirectionToAlignmentPolicy(alignmentPolicy)) {
       case ScrollPositionAlignmentPolicy.explicit:
-        target = clampDouble(viewport.getOffsetToReveal(object, alignment, rect: targetRect).offset, minScrollExtent, maxScrollExtent);
+        target = viewport.getOffsetToReveal(
+          object,
+          alignment,
+          rect: targetRect,
+          axisDirection: axisDirection,
+        ).offset;
+        target = clampDouble(target, minScrollExtent, maxScrollExtent);
       case ScrollPositionAlignmentPolicy.keepVisibleAtEnd:
-        target = clampDouble(viewport.getOffsetToReveal(object, 1.0, rect: targetRect).offset, minScrollExtent, maxScrollExtent);
+        target = viewport.getOffsetToReveal(
+          object,
+          1.0, // Aligns to end
+          rect: targetRect,
+          axisDirection: axisDirection,
+        ).offset;
+        target = clampDouble(target, minScrollExtent, maxScrollExtent);
         if (target < pixels) {
           target = pixels;
         }
       case ScrollPositionAlignmentPolicy.keepVisibleAtStart:
-        target = clampDouble(viewport.getOffsetToReveal(object, 0.0, rect: targetRect).offset, minScrollExtent, maxScrollExtent);
+        target = viewport.getOffsetToReveal(
+          object,
+          0.0, // Aligns to start
+          rect: targetRect,
+          axisDirection: axisDirection,
+        ).offset;
+        target = clampDouble(target, minScrollExtent, maxScrollExtent);
         if (target > pixels) {
           target = pixels;
         }

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -814,7 +814,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
           object,
           alignment,
           rect: targetRect,
-          axisDirection: axisDirection,
+          axis: axis,
         ).offset;
         target = clampDouble(target, minScrollExtent, maxScrollExtent);
       case ScrollPositionAlignmentPolicy.keepVisibleAtEnd:
@@ -822,7 +822,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
           object,
           1.0, // Aligns to end
           rect: targetRect,
-          axisDirection: axisDirection,
+          axis: axis,
         ).offset;
         target = clampDouble(target, minScrollExtent, maxScrollExtent);
         if (target < pixels) {
@@ -833,7 +833,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
           object,
           0.0, // Aligns to start
           rect: targetRect,
-          axisDirection: axisDirection,
+          axis: axis,
         ).offset;
         target = clampDouble(target, minScrollExtent, maxScrollExtent);
         if (target > pixels) {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1035,6 +1035,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     RenderObject? targetRenderObject,
     AxisDirection? axisDirection,
   }) {
+    axisDirection ??= this.axisDirection;
     assert(
       axisDirection == this.axisDirection,
       'Scrollable.ensureVisible was called with an AxisDirection for a one '

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -441,6 +441,10 @@ class Scrollable extends StatefulWidget {
 
   /// Scrolls the scrollables that enclose the given context so as to make the
   /// given context visible.
+  ///
+  /// If the [Scrollable] of the provided [BuildContext] is a
+  /// [TwoDimensionalScrollable], both vertical and horizontal axes will ensure
+  /// the target is made visible.
   static Future<void> ensureVisible(
     BuildContext context, {
     double alignment = 0.0,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -44,6 +44,13 @@ typedef ViewportBuilder = Widget Function(BuildContext context, ViewportOffset p
 /// which the scrollable content is displayed.
 typedef TwoDimensionalViewportBuilder = Widget Function(BuildContext context, ViewportOffset verticalPosition, ViewportOffset horizontalPosition);
 
+// The return type of _performEnsureVisible.
+//
+// The list of futures represents each pending ScrollPosition call to
+// ensureVisible. The returned ScrollableState's context is used to find the
+// next potential ancestor Scrollable.
+typedef _EnsureVisibleResults = (List<Future<void>>, ScrollableState);
+
 /// A widget that manages scrolling in one dimension and informs the [Viewport]
 /// through which the content is viewed.
 ///
@@ -463,7 +470,7 @@ class Scrollable extends StatefulWidget {
     RenderObject? targetRenderObject;
     ScrollableState? scrollable = Scrollable.maybeOf(context);
     while (scrollable != null) {
-      late final List<Future<void>> newFutures;
+      final List<Future<void>> newFutures;
       (newFutures, scrollable) = scrollable._performEnsureVisible(
         context.findRenderObject()!,
         alignment: alignment,
@@ -1020,7 +1027,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   // Returns the Future from calling ensureVisible for the ScrollPosition, as
   // as well as this ScrollableState instance so its context can be used to
   // check for other ancestor Scrollables in executing ensureVisible.
-  (List<Future<void>>, ScrollableState) _performEnsureVisible(
+  _EnsureVisibleResults _performEnsureVisible(
     RenderObject object, {
     double alignment = 0.0,
     Duration duration = Duration.zero,
@@ -2070,7 +2077,7 @@ class _VerticalOuterDimensionState extends ScrollableState {
 
   // Implemented in the _HorizontalInnerDimension instead.
   @override
-  (List<Future<void>>, ScrollableState) _performEnsureVisible(
+  _EnsureVisibleResults _performEnsureVisible(
     RenderObject object, {
     double alignment = 0.0,
     Duration duration = Duration.zero,
@@ -2170,7 +2177,7 @@ class _HorizontalInnerDimensionState extends ScrollableState {
   // as well as the vertical ScrollableState instance so its context can be
   // used to check for other ancestor Scrollables in executing ensureVisible.
   @override
-  (List<Future<void>>, ScrollableState) _performEnsureVisible(
+  _EnsureVisibleResults _performEnsureVisible(
     RenderObject object, {
     double alignment = 0.0,
     Duration duration = Duration.zero,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -443,19 +443,14 @@ class Scrollable extends StatefulWidget {
   /// given context visible.
   ///
   /// If the [Scrollable] of the provided [BuildContext] is a
-  /// [TwoDimensionalScrollable] and a specific [Axis] is not provided,
-  /// both vertical and horizontal axes will ensure the target is made visible
-  /// using the same [alignment] value. Providing
-  /// an [Axis] allows different [alignment]s to be specified, but
-  /// will require that ensureVisible is called separately for each [Axis] of
-  /// the [TwoDimensionalScrollable].
+  /// [TwoDimensionalScrollable], both vertical and horizontal axes will ensure
+  /// the target is made visible.
   static Future<void> ensureVisible(
     BuildContext context, {
     double alignment = 0.0,
     Duration duration = Duration.zero,
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
-    Axis? axis,
   }) {
     final List<Future<void>> futures = <Future<void>>[];
 
@@ -476,7 +471,6 @@ class Scrollable extends StatefulWidget {
         curve: curve,
         alignmentPolicy: alignmentPolicy,
         targetRenderObject: targetRenderObject,
-        axis: axis,
       );
       futures.addAll(newFutures);
 
@@ -1033,7 +1027,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     RenderObject? targetRenderObject,
-    Axis? axis,
   }) {
     final Future<void> ensureVisibleFuture = position.ensureVisible(
       object,
@@ -2084,7 +2077,6 @@ class _VerticalOuterDimensionState extends ScrollableState {
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     RenderObject? targetRenderObject,
-    Axis? axis,
   }) {
     assert(
       false,
@@ -2185,39 +2177,25 @@ class _HorizontalInnerDimensionState extends ScrollableState {
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     RenderObject? targetRenderObject,
-    Axis? axis,
   }) {
     final List<Future<void>> newFutures = <Future<void>>[];
 
-    void ensureHorizontal() {
-      newFutures.add(position.ensureVisible(
-        object,
-        alignment: alignment,
-        duration: duration,
-        curve: curve,
-        alignmentPolicy: alignmentPolicy,
-      ));
-    }
+    newFutures.add(position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+    ));
 
-    void ensureVertical() {
-      newFutures.add(verticalScrollable.position.ensureVisible(
-        object,
-        alignment: alignment,
-        duration: duration,
-        curve: curve,
-        alignmentPolicy: alignmentPolicy,
-      ));
-    }
+    newFutures.add(verticalScrollable.position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+    ));
 
-    switch (axis) {
-      case Axis.vertical:
-        ensureHorizontal();
-      case Axis.horizontal:
-        ensureVertical();
-      case null:
-        ensureHorizontal();
-        ensureVertical();
-    }
     return (newFutures, verticalScrollable);
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -463,36 +463,16 @@ class Scrollable extends StatefulWidget {
     RenderObject? targetRenderObject;
     ScrollableState? scrollable = Scrollable.maybeOf(context);
     while (scrollable != null) {
-      if (scrollable is _HorizontalInnerDimensionState) {
-        // Handle ensure visible for 2D viewport.
-        // The default loop below assumes nested viewports with one scrollable for
-        // each one, while a 2D viewport contains 2 scrollables and only one
-        // viewport.
-        futures.add(scrollable.position.ensureVisible(
-          context.findRenderObject()!,
-          alignment: alignment,
-          duration: duration,
-          curve: curve,
-          alignmentPolicy: alignmentPolicy,
-        ));
-        scrollable.verticalScrollable.position.ensureVisible(
-          context.findRenderObject()!,
-          alignment: alignment,
-          duration: duration,
-          curve: curve,
-          alignmentPolicy: alignmentPolicy,
-        );
-        scrollable = scrollable.verticalScrollable;
-      } else {
-        futures.add(scrollable.position.ensureVisible(
-          context.findRenderObject()!,
-          alignment: alignment,
-          duration: duration,
-          curve: curve,
-          alignmentPolicy: alignmentPolicy,
-          targetRenderObject: targetRenderObject,
-        ));
-      }
+      late final List<Future<void>> newFutures;
+      (newFutures, scrollable) = scrollable._performEnsureVisible(
+        context.findRenderObject()!,
+        alignment: alignment,
+        duration: duration,
+        curve: curve,
+        alignmentPolicy: alignmentPolicy,
+        targetRenderObject: targetRenderObject,
+      );
+      futures.addAll(newFutures);
 
       targetRenderObject = targetRenderObject ?? context.findRenderObject();
       context = scrollable.context;
@@ -1035,6 +1015,25 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     }
 
     return result;
+  }
+
+  (List<Future<void>>, ScrollableState) _performEnsureVisible(
+    RenderObject object, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+    RenderObject? targetRenderObject,
+  }) {
+    final Future<void> ensureVisibleFuture = position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+      targetRenderObject: targetRenderObject,
+    );
+    return (<Future<void>>[ ensureVisibleFuture ], this);
   }
 
   @override
@@ -2067,6 +2066,22 @@ class _VerticalOuterDimensionState extends ScrollableState {
   DiagonalDragBehavior get diagonalDragBehavior => (widget as _VerticalOuterDimension).diagonalDragBehavior;
 
   @override
+  (List<Future<void>>, ScrollableState) _performEnsureVisible(
+    RenderObject object, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+    RenderObject? targetRenderObject,
+  }) {
+    throw FlutterError(
+      'The _performEnsureVisible method was called for the vertical scrollable '
+      'of a TwoDimensionalScrollable. This should not happen as the horizontal '
+      'scrollable handles both axes.'
+    );
+  }
+
+  @override
   void setCanDrag(bool value) {
     switch (diagonalDragBehavior) {
       case DiagonalDragBehavior.none:
@@ -2143,6 +2158,34 @@ class _HorizontalInnerDimensionState extends ScrollableState {
     verticalScrollable = Scrollable.of(context);
     assert(axisDirectionToAxis(verticalScrollable.axisDirection) == Axis.vertical);
     super.didChangeDependencies();
+  }
+
+  @override
+  (List<Future<void>>, ScrollableState) _performEnsureVisible(
+    RenderObject object, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+    RenderObject? targetRenderObject,
+  }) {
+    final List<Future<void>> newFutures = <Future<void>>[];
+    newFutures.add(position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+    ));
+    newFutures.add(verticalScrollable.position.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+    ));
+
+    return (newFutures, verticalScrollable);
   }
 
   void _evaluateLockedAxis(Offset offset) {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -468,7 +468,7 @@ class Scrollable extends StatefulWidget {
     RenderObject? targetRenderObject;
     ScrollableState? scrollable = Scrollable.maybeOf(context);
     while (scrollable != null) {
-      late final List<Future<void>> newFutures;
+      final List<Future<void>> newFutures = <Future<void>>[];
       (newFutures, scrollable) = scrollable._performEnsureVisible(
         context.findRenderObject()!,
         alignment: alignment,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -443,19 +443,19 @@ class Scrollable extends StatefulWidget {
   /// given context visible.
   ///
   /// If the [Scrollable] of the provided [BuildContext] is a
-  /// [TwoDimensionalScrollable] and [axisDirection] is not provided to specify
-  /// one [Axis], both vertical and horizontal axes will ensure
-  /// the target is made visible using the same [alignment] value. Providing
-  /// an [axisDirection] allows different [alignment]s to be specified, but
-  /// will require then that ensureVisible is called for each [Axis] of the
-  /// [TwoDimensionalScrollable].
+  /// [TwoDimensionalScrollable] and a specific [Axis] is not provided,
+  /// both vertical and horizontal axes will ensure the target is made visible
+  /// using the same [alignment] value. Providing
+  /// an [Axis] allows different [alignment]s to be specified, but
+  /// will require that ensureVisible is called separately for each [Axis] of
+  /// the [TwoDimensionalScrollable].
   static Future<void> ensureVisible(
     BuildContext context, {
     double alignment = 0.0,
     Duration duration = Duration.zero,
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
     final List<Future<void>> futures = <Future<void>>[];
 
@@ -468,7 +468,7 @@ class Scrollable extends StatefulWidget {
     RenderObject? targetRenderObject;
     ScrollableState? scrollable = Scrollable.maybeOf(context);
     while (scrollable != null) {
-      final List<Future<void>> newFutures = <Future<void>>[];
+      late final List<Future<void>> newFutures;
       (newFutures, scrollable) = scrollable._performEnsureVisible(
         context.findRenderObject()!,
         alignment: alignment,
@@ -476,7 +476,7 @@ class Scrollable extends StatefulWidget {
         curve: curve,
         alignmentPolicy: alignmentPolicy,
         targetRenderObject: targetRenderObject,
-        axisDirection: axisDirection
+        axis: axis,
       );
       futures.addAll(newFutures);
 
@@ -1033,16 +1033,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     RenderObject? targetRenderObject,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
-    axisDirection ??= this.axisDirection;
-    assert(
-      axisDirection == this.axisDirection,
-      'Scrollable.ensureVisible was called with an AxisDirection for a one '
-      'dimensional Scrollable that does not match. The provided AxisDirection '
-      'was $axisDirection, and this Scrollable has an AxisDirection of '
-      '${this.axisDirection}.',
-    );
     final Future<void> ensureVisibleFuture = position.ensureVisible(
       object,
       alignment: alignment,
@@ -2092,7 +2084,7 @@ class _VerticalOuterDimensionState extends ScrollableState {
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     RenderObject? targetRenderObject,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
     assert(
       false,
@@ -2193,7 +2185,7 @@ class _HorizontalInnerDimensionState extends ScrollableState {
     Curve curve = Curves.ease,
     ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     RenderObject? targetRenderObject,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
     final List<Future<void>> newFutures = <Future<void>>[];
 
@@ -2217,18 +2209,15 @@ class _HorizontalInnerDimensionState extends ScrollableState {
       ));
     }
 
-    switch (axisDirection) {
-      case AxisDirection.left:
-      case AxisDirection.right:
+    switch (axis) {
+      case Axis.vertical:
         ensureHorizontal();
-      case AxisDirection.up:
-      case AxisDirection.down:
+      case Axis.horizontal:
         ensureVertical();
       case null:
         ensureHorizontal();
         ensureVertical();
     }
-
     return (newFutures, verticalScrollable);
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -459,14 +459,36 @@ class Scrollable extends StatefulWidget {
     RenderObject? targetRenderObject;
     ScrollableState? scrollable = Scrollable.maybeOf(context);
     while (scrollable != null) {
-      futures.add(scrollable.position.ensureVisible(
-        context.findRenderObject()!,
-        alignment: alignment,
-        duration: duration,
-        curve: curve,
-        alignmentPolicy: alignmentPolicy,
-        targetRenderObject: targetRenderObject,
-      ));
+      if (scrollable is _HorizontalInnerDimensionState) {
+        // Handle ensure visible for 2D viewport.
+        // The default loop below assumes nested viewports with one scrollable for
+        // each one, while a 2D viewport contains 2 scrollables and only one
+        // viewport.
+        futures.add(scrollable.position.ensureVisible(
+          context.findRenderObject()!,
+          alignment: alignment,
+          duration: duration,
+          curve: curve,
+          alignmentPolicy: alignmentPolicy,
+        ));
+        scrollable.verticalScrollable.position.ensureVisible(
+          context.findRenderObject()!,
+          alignment: alignment,
+          duration: duration,
+          curve: curve,
+          alignmentPolicy: alignmentPolicy,
+        );
+        scrollable = scrollable.verticalScrollable;
+      } else {
+        futures.add(scrollable.position.ensureVisible(
+          context.findRenderObject()!,
+          alignment: alignment,
+          duration: duration,
+          curve: curve,
+          alignmentPolicy: alignmentPolicy,
+          targetRenderObject: targetRenderObject,
+        ));
+      }
 
       targetRenderObject = targetRenderObject ?? context.findRenderObject();
       context = scrollable.context;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -598,8 +598,11 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     Rect? rect,
     Axis? axis,
   }) {
-    // One dimensional viewport has only one axis, override if set.
-    axis = this.axis;
+    // One dimensional viewport has only one axis, it should match if it has
+    // been provided.
+    axis ??= this.axis;
+    assert(axis == this.axis);
+
     rect ??= target.paintBounds;
     if (target is! RenderBox) {
       return RevealedOffset(offset: offset.pixels, rect: rect);

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -596,10 +596,10 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     RenderObject target,
     double alignment, {
     Rect? rect,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
-    assert(axisDirection == null || axisDirection == this.axisDirection);
-    axisDirection ??= this.axisDirection;
+    // One dimensional viewport has only one axis, override if set.
+    axis = this.axis;
     rect ??= target.paintBounds;
     if (target is! RenderBox) {
       return RevealedOffset(offset: offset.pixels, rect: rect);

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -592,7 +592,14 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
   }
 
   @override
-  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect? rect }) {
+  RevealedOffset getOffsetToReveal(
+    RenderObject target,
+    double alignment, {
+    Rect? rect,
+    AxisDirection? axisDirection,
+  }) {
+    assert(axisDirection == null || axisDirection == this.axisDirection);
+    axisDirection ??= this.axisDirection;
     rect ??= target.paintBounds;
     if (target is! RenderBox) {
       return RevealedOffset(offset: offset.pixels, rect: rect);

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 
 import 'framework.dart';
@@ -936,7 +937,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     RenderBox? pivot;
     // Find the direct child of the viewport that contains our target
     while (child.parent != this) {
-      final RenderObject parent = child.parent! as RenderObject;
+      final RenderObject parent = child.parent!;
       if (child is RenderBox) {
         pivot = child;
       }
@@ -1026,8 +1027,142 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         targetRect = targetRect.translate(-offsetDifference, 0.0);
     }
 
-    final RevealedOffset revealedOffset = RevealedOffset(offset: targetOffset, rect: targetRect);
+    final RevealedOffset revealedOffset = RevealedOffset(
+      offset: targetOffset,
+      rect: targetRect,
+    );
     return revealedOffset;
+  }
+
+  @override
+  void showOnScreen({
+    RenderObject? descendant,
+    Rect? rect,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+  }) {
+    if (!horizontalOffset.allowImplicitScrolling && !verticalOffset.allowImplicitScrolling) {
+      // Neither axis allows for implicit scrolling.
+      return super.showOnScreen(
+        descendant: descendant,
+        rect: rect,
+        duration: duration,
+        curve: curve,
+      );
+    }
+    assert(horizontalOffset.allowImplicitScrolling || verticalOffset.allowImplicitScrolling);
+    Rect? newRect = rect;
+    // It is possible for one and not both axes to allow for implicit scrolling,
+    // so they are handled individually, updating the final rect for each.
+    if (verticalOffset.allowImplicitScrolling) {
+      newRect = RenderTwoDimensionalViewport.showInViewportForAxisDirection(
+        descendant: descendant,
+        viewport: this,
+        offset: verticalOffset,
+        axisDirection: verticalAxisDirection,
+        rect: newRect,
+        duration: duration,
+        curve: curve,
+      );
+    }
+
+    if (horizontalOffset.allowImplicitScrolling) {
+      newRect = RenderTwoDimensionalViewport.showInViewportForAxisDirection(
+        descendant: descendant,
+        viewport: this,
+        offset: horizontalOffset,
+        axisDirection: horizontalAxisDirection,
+        rect: newRect,
+        duration: duration,
+        curve: curve,
+      );
+    }
+
+    super.showOnScreen(
+      rect: newRect,
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  /// Make (a portion of) the given `descendant` of the given `viewport` fully
+  /// visible in one dimension of the `viewport` by manipulating the provided
+  /// [ViewportOffset]s `offset`.
+  ///
+  /// The optional `rect` parameter describes which area of the `descendant`
+  /// should be shown in the viewport. If `rect` is null, the entire
+  /// `descendant` will be revealed. The `rect` parameter is interpreted
+  /// relative to the coordinate system of `descendant`.
+  ///
+  /// The returned [Rect] describes the new location of `descendant` or `rect`
+  /// in the viewport after it has been revealed. See [RevealedOffset.rect]
+  /// for a full definition of this [Rect].
+  ///
+  /// The parameters `viewport`, `offset`, and `axisDirection` are
+  /// required and cannot be null. If `descendant` is null, this is a no-op and
+  /// `rect` is returned.
+  ///
+  /// If both `descendant` and `rect` are null, null is returned because there
+  /// is nothing to be shown in the viewport.
+  ///
+  /// The `duration` parameter can be set to a non-zero value to animate the
+  /// target object into the viewport with an animation defined by `curve`.
+  ///
+  /// See also:
+  ///
+  /// * [RenderObject.showOnScreen], overridden by
+  ///   [RenderTwoDimensionalViewport] to delegate to this method.
+  static Rect? showInViewportForAxisDirection({
+    RenderObject? descendant,
+    Rect? rect,
+    required RenderTwoDimensionalViewport viewport,
+    required ViewportOffset offset,
+    required AxisDirection axisDirection,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+  }) {
+    if (descendant == null) {
+      return rect;
+    }
+    final RevealedOffset leadingEdgeOffset = viewport.getOffsetToReveal(
+      descendant,
+      0.0,
+      rect: rect,
+      axisDirection: axisDirection,
+    );
+    final RevealedOffset trailingEdgeOffset = viewport.getOffsetToReveal(
+      descendant,
+      1.0,
+      rect: rect,
+      axisDirection: axisDirection,
+    );
+    final double currentOffset = offset.pixels;
+
+    final RevealedOffset targetOffset;
+    if (leadingEdgeOffset.offset < trailingEdgeOffset.offset) {
+      // `descendant` is too big to be visible on screen in its entirety. Let's
+      // align it with the edge that requires the least amount of scrolling.
+      final double leadingEdgeDiff = (offset.pixels - leadingEdgeOffset.offset).abs();
+      final double trailingEdgeDiff = (offset.pixels - trailingEdgeOffset.offset).abs();
+      targetOffset = leadingEdgeDiff < trailingEdgeDiff ? leadingEdgeOffset : trailingEdgeOffset;
+    } else if (currentOffset > leadingEdgeOffset.offset) {
+      // `descendant` currently starts above the leading edge and can be shown
+      // fully on screen by scrolling down (which means: moving viewport up).
+      targetOffset = leadingEdgeOffset;
+    } else if (currentOffset < trailingEdgeOffset.offset) {
+      // `descendant currently ends below the trailing edge and can be shown
+      // fully on screen by scrolling up (which means: moving viewport down)
+      targetOffset = trailingEdgeOffset;
+    } else {
+      // `descendant` is between leading and trailing edge and hence already
+      //  fully shown on screen. No action necessary.
+      assert(viewport.parent != null);
+      final Matrix4 transform = descendant.getTransformTo(viewport.parent);
+      return MatrixUtils.transformRect(transform, rect ?? descendant.paintBounds);
+    }
+
+    offset.moveTo(targetOffset.offset, duration: duration, curve: curve);
+    return targetOffset.rect;
   }
 
   /// Should be used by subclasses to invalidate any cached metrics for the

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -942,7 +942,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       }
       child = parent;
     }
-    final double offset = switch(axisDirectionToAxis(axisDirection!)) {
+    final double offset = switch (axisDirectionToAxis(axisDirection!)) {
       Axis.vertical => verticalOffset.pixels,
       Axis.horizontal => horizontalOffset.pixels,
     };
@@ -990,7 +990,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
 
     // The scroll offset in the viewport to `rect`.
     final TwoDimensionalViewportParentData childParentData = parentDataOf(box);
-    leadingScrollOffset += switch(axisDirection) {
+    leadingScrollOffset += switch (axisDirection) {
       AxisDirection.down => childParentData.paintOffset!.dy,
       AxisDirection.up => viewportDimension.height - childParentData.paintOffset!.dy - box.size.height,
       AxisDirection.right => childParentData.paintOffset!.dx,
@@ -1009,7 +1009,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     };
 
     final double targetOffset = leadingScrollOffset - (mainAxisExtent - targetMainAxisExtent) * alignment;
-    final double offsetDifference = switch(axisDirectionToAxis(axisDirection)){
+    final double offsetDifference = switch (axisDirectionToAxis(axisDirection)){
       Axis.vertical => verticalOffset.pixels - targetOffset,
       Axis.horizontal => horizontalOffset.pixels - targetOffset,
     };

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1198,7 +1198,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     );
     final double currentOffset = offset.pixels;
 
-    final RevealedOffset? targetOffset = RenderAbstractViewport.applyTargetOffset(
+    final RevealedOffset? targetOffset = RevealedOffset.clampOffset(
       leadingEdgeOffset: leadingEdgeOffset,
       trailingEdgeOffset: trailingEdgeOffset,
       currentOffset: currentOffset,

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -497,7 +497,6 @@ class TwoDimensionalViewportParentData extends ParentData  with KeepAliveParentD
 ///
 /// Subclasses should not override [performLayout], as it handles housekeeping
 /// on either side of the call to [layoutChildSequence].
-// TODO(Piinks): ensureVisible https://github.com/flutter/flutter/issues/126299
 abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderAbstractViewport {
   /// Initializes fields for subclasses.
   ///
@@ -921,9 +920,119 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   }
 
   @override
-  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect? rect }) {
-    // TODO(Piinks): Add this back in follow up change (ensureVisible), https://github.com/flutter/flutter/issues/126299
-    return const RevealedOffset(offset: 0.0, rect: Rect.zero);
+  RevealedOffset getOffsetToReveal(
+    RenderObject target,
+    double alignment, {
+    Rect? rect,
+    AxisDirection? axisDirection,
+  }) {
+    // We must know which axis we are revealing for.
+    assert(axisDirection != null);
+
+    // Starting at `target` and walking towards the root:
+    //  - `child` will be the last object before we reach this viewport, and
+    //  - `pivot` will be the last RenderBox before we reach this viewport.
+    RenderObject child = target;
+    RenderBox? pivot;
+    // Find the direct child of the viewport that contains our target
+    while (child.parent != this) {
+      final RenderObject parent = child.parent! as RenderObject;
+      if (child is RenderBox) {
+        pivot = child;
+      }
+      child = parent;
+    }
+    final double offset = switch(axisDirectionToAxis(axisDirection!)) {
+      Axis.vertical => verticalOffset.pixels,
+      Axis.horizontal => horizontalOffset.pixels,
+    };
+
+    // `rect` in the new intermediate coordinate system.
+    final Rect rectLocal;
+    // Our new reference frame render object's main axis extent.
+    final double pivotExtent;
+    if (pivot != null) {
+      assert(pivot.parent != null);
+      assert(pivot.parent != this);
+      assert(pivot != this);
+      assert(pivot.parent is RenderBox);
+      pivotExtent = switch (axisDirectionToAxis(axisDirection)) {
+        Axis.horizontal => pivot.size.width,
+        Axis.vertical => pivot.size.height,
+      };
+      rect ??= target.paintBounds;
+      rectLocal = MatrixUtils.transformRect(target.getTransformTo(pivot), rect);
+    } else {
+      assert(rect != null);
+      return RevealedOffset(offset: offset, rect: rect!);
+    }
+
+    assert(child.parent == this);
+    final RenderBox box = child as RenderBox;
+
+    final double targetMainAxisExtent;
+    double leadingScrollOffset = offset;
+    // The scroll offset of `rect` within `child`.
+    switch (axisDirection) {
+      case AxisDirection.up:
+        leadingScrollOffset += pivotExtent - rectLocal.bottom;
+        targetMainAxisExtent = rectLocal.height;
+      case AxisDirection.right:
+        leadingScrollOffset += rectLocal.left;
+        targetMainAxisExtent = rectLocal.width;
+      case AxisDirection.down:
+        leadingScrollOffset += rectLocal.top;
+        targetMainAxisExtent = rectLocal.height;
+      case AxisDirection.left:
+        leadingScrollOffset += pivotExtent - rectLocal.right;
+        targetMainAxisExtent = rectLocal.width;
+    }
+
+    // So far leadingScrollOffset is the scroll offset of `rect` in the `child`
+    // sliver's sliver coordinate system. The sign of this value indicates
+    // whether the `rect` protrudes the leading edge of the `child` sliver. When
+    // this value is non-negative and `child`'s `maxScrollObstructionExtent` is
+    // greater than 0, we assume `rect` can't be obstructed by the leading edge
+    // of the viewport (i.e. its pinned to the leading edge).
+
+    // The scroll offset in the viewport to `rect`.
+    final TwoDimensionalViewportParentData childParentData = parentDataOf(box);
+    leadingScrollOffset += switch(axisDirection) {
+      AxisDirection.down => childParentData.paintOffset!.dy,
+      AxisDirection.up => viewportDimension.height - childParentData.paintOffset!.dy - box.size.height,
+      AxisDirection.right => childParentData.paintOffset!.dx,
+      AxisDirection.left => viewportDimension.width - childParentData.paintOffset!.dx - box.size.width,
+    };
+
+    // This step assumes the viewport's layout is up-to-date, i.e., if
+    // the position is changed after the last performLayout, the new scroll
+    // position will not be accounted for.
+    final Matrix4 transform = target.getTransformTo(this);
+    Rect targetRect = MatrixUtils.transformRect(transform, rect);
+
+    final double mainAxisExtent = switch (axisDirectionToAxis(axisDirection)) {
+      Axis.horizontal => viewportDimension.width,
+      Axis.vertical => viewportDimension.height,
+    };
+
+    final double targetOffset = leadingScrollOffset - (mainAxisExtent - targetMainAxisExtent) * alignment;
+    final double offsetDifference = switch(axisDirectionToAxis(axisDirection)){
+      Axis.vertical => verticalOffset.pixels - targetOffset,
+      Axis.horizontal => horizontalOffset.pixels - targetOffset,
+    };
+    switch (axisDirection) {
+      case AxisDirection.down:
+        targetRect = targetRect.translate(0.0, offsetDifference);
+      case AxisDirection.right:
+        targetRect = targetRect.translate(offsetDifference, 0.0);
+      case AxisDirection.up:
+        targetRect = targetRect.translate(0.0, -offsetDifference);
+      case AxisDirection.left:
+        targetRect = targetRect.translate(-offsetDifference, 0.0);
+    }
+
+    final RevealedOffset revealedOffset = RevealedOffset(offset: targetOffset, rect: targetRect);
+    return revealedOffset;
   }
 
   /// Should be used by subclasses to invalidate any cached metrics for the

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -988,13 +988,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         targetMainAxisExtent = rectLocal.width;
     }
 
-    // So far leadingScrollOffset is the scroll offset of `rect` in the `child`
-    // sliver's sliver coordinate system. The sign of this value indicates
-    // whether the `rect` protrudes the leading edge of the `child` sliver. When
-    // this value is non-negative and `child`'s `maxScrollObstructionExtent` is
-    // greater than 0, we assume `rect` can't be obstructed by the leading edge
-    // of the viewport (i.e. its pinned to the leading edge).
-
     // The scroll offset in the viewport to `rect`.
     final TwoDimensionalViewportParentData childParentData = parentDataOf(box);
     leadingScrollOffset += switch(axisDirection) {

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -921,11 +921,11 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     RenderObject target,
     double alignment, {
     Rect? rect,
-    AxisDirection? axisDirection,
+    Axis? axis,
   }) {
     // We must know which axis we are revealing for, since Offset refers to only
     // one of two scroll positions.
-    assert(axisDirection != null);
+    assert(axis != null);
 
     // Starting at `target` and walking towards the root:
     //  - `child` will be the last object before we reach this viewport, and
@@ -941,9 +941,11 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       child = parent;
     }
 
-    final double offset = switch (axisDirectionToAxis(axisDirection!)) {
-      Axis.vertical => verticalOffset.pixels,
-      Axis.horizontal => horizontalOffset.pixels,
+    late final double offset;
+    late final AxisDirection axisDirection;
+    (offset, axisDirection) = switch (axis!) {
+      Axis.vertical => (verticalOffset.pixels, verticalAxisDirection),
+      Axis.horizontal => (horizontalOffset.pixels, horizontalAxisDirection)
     };
 
     // `rect` in the new intermediate coordinate system.
@@ -955,7 +957,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       assert(pivot.parent != this);
       assert(pivot != this);
       assert(pivot.parent is RenderBox);
-      pivotExtent = switch (axisDirectionToAxis(axisDirection)) {
+      pivotExtent = switch (axis) {
         Axis.horizontal => pivot.size.width,
         Axis.vertical => pivot.size.height,
       };
@@ -1125,7 +1127,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       return RenderTwoDimensionalViewport._showInViewportForAxisDirection(
         descendant: descendant,
         viewport: viewport,
-        axisDirection: viewport.verticalAxisDirection,
+        axis: Axis.vertical,
         rect: rect,
         duration: duration,
         curve: curve,
@@ -1136,7 +1138,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       return RenderTwoDimensionalViewport._showInViewportForAxisDirection(
         descendant: descendant,
         viewport: viewport,
-        axisDirection: viewport.horizontalAxisDirection,
+        axis: Axis.horizontal,
         rect: rect,
         duration: duration,
         curve: curve,
@@ -1173,11 +1175,11 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     required RenderObject descendant,
     Rect? rect,
     required RenderTwoDimensionalViewport viewport,
-    required AxisDirection axisDirection,
+    required Axis axis,
     Duration duration = Duration.zero,
     Curve curve = Curves.ease,
   }) {
-    final ViewportOffset offset = switch (axisDirectionToAxis(axisDirection)) {
+    final ViewportOffset offset = switch (axis) {
       Axis.vertical => viewport.verticalOffset,
       Axis.horizontal => viewport.horizontalOffset,
     };
@@ -1186,13 +1188,13 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       descendant,
       0.0,
       rect: rect,
-      axisDirection: axisDirection,
+      axis: axis,
     );
     final RevealedOffset trailingEdgeOffset = viewport.getOffsetToReveal(
       descendant,
       1.0,
       rect: rect,
-      axisDirection: axisDirection,
+      axis: axis,
     );
     final double currentOffset = offset.pixels;
 

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1046,13 +1046,13 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     AxisDirection? axisDirection;
     switch ((allowHorizontal, allowVertical)) {
       case (true, true):
-        // Both allow implicit scrolling
+        // Both allow implicit scrolling.
         break;
       case (false, true):
-        // Only the vertical Axis allows implicit scrolling
+        // Only the vertical Axis allows implicit scrolling.
         axisDirection = verticalAxisDirection;
       case (true, false):
-        // Only the horizontal Axis allows implicit scrolling
+        // Only the horizontal Axis allows implicit scrolling.
         axisDirection = horizontalAxisDirection;
       case (false, false):
         // Neither axis allows for implicit scrolling.
@@ -1083,6 +1083,10 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   /// Make (a portion of) the given `descendant` of the given `viewport` fully
   /// visible in one or both dimensions of the `viewport` by manipulating the
   /// [ViewportOffset]s.
+  ///
+  /// The `axisDirection` determines from which axes the `descendant` will be
+  /// revealed. When the `axisDirection` is null, both axes will be updated to
+  /// reveal the descendant.
   ///
   /// The optional `rect` parameter describes which area of the `descendant`
   /// should be shown in the viewport. If `rect` is null, the entire

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -942,6 +942,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       }
       child = parent;
     }
+
     final double offset = switch (axisDirectionToAxis(axisDirection!)) {
       Axis.vertical => verticalOffset.pixels,
       Axis.horizontal => horizontalOffset.pixels,
@@ -1009,6 +1010,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     };
 
     final double targetOffset = leadingScrollOffset - (mainAxisExtent - targetMainAxisExtent) * alignment;
+
     final double offsetDifference = switch (axisDirectionToAxis(axisDirection)){
       Axis.vertical => verticalOffset.pixels - targetOffset,
       Axis.horizontal => horizontalOffset.pixels - targetOffset,

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -924,8 +924,8 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     Rect? rect,
     Axis? axis,
   }) {
-    // We must know which axis we are revealing for, since Offset refers to only
-    // one of two scroll positions.
+    // We must know which axis we are revealing for, since RevealedOffset
+    // refers to only one of two scroll positions.
     assert(axis != null);
 
     late final double offset;

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -928,9 +928,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     // refers to only one of two scroll positions.
     assert(axis != null);
 
-    late final double offset;
-    late final AxisDirection axisDirection;
-    (offset, axisDirection) = switch (axis!) {
+    final (double offset, AxisDirection axisDirection) = switch (axis!) {
       Axis.vertical => (verticalOffset.pixels, verticalAxisDirection),
       Axis.horizontal => (horizontalOffset.pixels, horizontalAxisDirection),
     };

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1042,7 +1042,6 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     // so handling is split between the options for allowed implicit scrolling.
     final bool allowHorizontal = horizontalOffset.allowImplicitScrolling;
     final bool allowVertical = verticalOffset.allowImplicitScrolling;
-    Rect? newRect;
     AxisDirection? axisDirection;
     switch ((allowHorizontal, allowVertical)) {
       case (true, true):
@@ -1064,7 +1063,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         );
     }
 
-    newRect = RenderTwoDimensionalViewport.showInViewport(
+    final Rect? newRect = RenderTwoDimensionalViewport.showInViewport(
       descendant: descendant,
       viewport: this,
       axisDirection: axisDirection,
@@ -1122,7 +1121,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       return rect;
     }
 
-    Rect? showVertical() {
+    Rect? showVertical(Rect? rect) {
       return RenderTwoDimensionalViewport._showInViewportForAxisDirection(
         descendant: descendant,
         viewport: viewport,
@@ -1133,7 +1132,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       );
     }
 
-    Rect? showHorizontal() {
+    Rect? showHorizontal(Rect? rect) {
       return RenderTwoDimensionalViewport._showInViewportForAxisDirection(
         descendant: descendant,
         viewport: viewport,
@@ -1147,15 +1146,15 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     switch (axisDirection) {
       case AxisDirection.left:
       case AxisDirection.right:
-        return showHorizontal();
+        return showHorizontal(rect);
       case AxisDirection.up:
       case AxisDirection.down:
-        return showVertical();
+        return showVertical(rect);
       case null:
         // Update rect after revealing in one axis before revealing in the next.
-        rect = showHorizontal() ?? rect;
+        rect = showHorizontal(rect) ?? rect;
         // We only return the final rect after both have been revealed.
-        rect = showVertical();
+        rect = showVertical(rect);
         if (rect == null) {
           // `descendant` is between leading and trailing edge and hence already
           //  fully shown on screen.

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1178,7 +1178,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     Duration duration = Duration.zero,
     Curve curve = Curves.ease,
   }) {
-    final ViewportOffset offset = switch(axisDirectionToAxis(axisDirection)) {
+    final ViewportOffset offset = switch (axisDirectionToAxis(axisDirection)) {
       Axis.vertical => viewport.verticalOffset,
       Axis.horizontal => viewport.horizontalOffset,
     };

--- a/packages/flutter/test/widgets/ensure_visible_test.dart
+++ b/packages/flutter/test/widgets/ensure_visible_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'two_dimensional_utils.dart';
+
 Finder findKey(int i) => find.byKey(ValueKey<int>(i), skipOffstage: false);
 
 Widget buildSingleChildScrollView(Axis scrollDirection, { bool reverse = false }) {
@@ -1049,6 +1051,281 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1020));
       expect(tester.getTopLeft(findKey(-3)).dy, equals(100.0));
+    });
+  });
+
+  group('TwoDimensionalViewport ensureVisible', () {
+    Finder findKey(ChildVicinity vicinity) {
+      return find.byKey(ValueKey<ChildVicinity>(vicinity));
+    }
+
+    BuildContext findContext(WidgetTester tester, ChildVicinity vicinity) {
+      return tester.element(findKey(vicinity));
+    }
+
+    testWidgets('Axis.vertical', (WidgetTester tester) async {
+      await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 0)),
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+        equals(0.0),
+      );
+      // (0, 3) is in the cache extent, and will be brought into view next
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+        equals(600.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 3)),
+      );
+      await tester.pump();
+      // Now in view at top edge of viewport
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+        equals(0.0),
+      );
+
+      // If already visible, no change
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 3)),
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+        equals(0.0),
+      );
+    });
+
+    testWidgets('Axis.horizontal', (WidgetTester tester) async {
+      await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 1, yIndex: 0)),
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 1, yIndex: 0))).dx,
+        equals(0.0),
+      );
+      // (5, 0) is now in the cache extent, and will be brought into view next
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 5, yIndex: 0))).dx,
+        equals(800.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 5, yIndex: 0)),
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+      );
+      await tester.pump();
+      // Now in view at trailing edge of viewport
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 5, yIndex: 0))).dx,
+        equals(600.0),
+      );
+
+      // If already in position, no change
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 5, yIndex: 0)),
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 5, yIndex: 0))).dx,
+        equals(600.0),
+      );
+    });
+
+    testWidgets('both axes', (WidgetTester tester) async {
+      await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 1, yIndex: 1)),
+      );
+      await tester.pump();
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 1, yIndex: 1))),
+        const Rect.fromLTRB(0.0, 0.0, 200.0, 200.0),
+      );
+      // (5, 4) is in the cache extent, and will be brought into view next
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+        const Rect.fromLTRB(800.0, 600.0, 1000.0, 800.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 5, yIndex: 4)),
+        alignment: 1.0, // Same as ScrollAlignmentPolicy.keepVisibleAtEnd
+      );
+      await tester.pump();
+      // Now in view at bottom trailing corner of viewport
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+        const Rect.fromLTRB(600.0, 400.0, 800.0, 600.0),
+      );
+
+      // If already visible, no change
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 5, yIndex: 4)),
+        alignment: 1.0,
+      );
+      await tester.pump();
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+        const Rect.fromLTRB(600.0, 400.0, 800.0, 600.0),
+      );
+    });
+
+    testWidgets('Axis.vertical reverse', (WidgetTester tester) async {
+      await tester.pumpWidget(simpleBuilderTest(
+        verticalDetails: const ScrollableDetails.vertical(reverse: true),
+        useCacheExtent: true,
+      ));
+
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+        equals(400.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 0)),
+      );
+      await tester.pump();
+      // Already visible so no change.
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+        equals(400.0),
+      );
+      // (0, 3) is in the cache extent, and will be brought into view next
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+        equals(-200.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 3)),
+      );
+      await tester.pump();
+      // Now in view at bottom edge of viewport since we are reversed
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+        equals(400.0),
+      );
+
+      // If already visible, no change
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 3)),
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+        equals(400.0),
+      );
+    });
+
+    testWidgets('Axis.horizontal reverse', (WidgetTester tester) async {
+      await tester.pumpWidget(simpleBuilderTest(
+        horizontalDetails: const ScrollableDetails.horizontal(reverse: true),
+        useCacheExtent: true,
+      ));
+
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dx,
+        equals(600.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 0, yIndex: 0)),
+      );
+      await tester.pump();
+      // Already visible so no change.
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dx,
+        equals(600.0),
+      );
+      // (4, 0) is in the cache extent, and will be brought into view next
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 4, yIndex: 0))).dx,
+        equals(-200.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 4, yIndex: 0)),
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 4, yIndex: 0))).dx,
+        equals(200.0),
+      );
+
+      // If already visible, no change
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 4, yIndex: 0)),
+      );
+      await tester.pump();
+      expect(
+        tester.getTopLeft(findKey(const ChildVicinity(xIndex: 4, yIndex: 0))).dx,
+        equals(200.0),
+      );
+    });
+
+    testWidgets('both axes reverse', (WidgetTester tester) async {
+      await tester.pumpWidget(simpleBuilderTest(
+        verticalDetails: const ScrollableDetails.vertical(reverse: true),
+        horizontalDetails: const ScrollableDetails.horizontal(reverse: true),
+        useCacheExtent: true,
+      ));
+
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 1, yIndex: 1)),
+      );
+      await tester.pump();
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 1, yIndex: 1))),
+        const Rect.fromLTRB(600.0, 400.0, 800.0, 600.0),
+      );
+      // (5, 4) is in the cache extent, and will be brought into view next
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+        const Rect.fromLTRB(-200.0, -200.0, 0.0, 0.0),
+      );
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 5, yIndex: 4)),
+        alignment: 1.0, // Same as ScrollAlignmentPolicy.keepVisibleAtEnd
+      );
+      await tester.pump();
+      // Now in view at trailing corner of viewport
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+        const Rect.fromLTRB(0.0, 0.0, 200.0, 200.0),
+      );
+
+      // If already visible, no change
+      Scrollable.ensureVisible(findContext(
+        tester,
+        const ChildVicinity(xIndex: 5, yIndex: 4)),
+        alignment: 1.0,
+      );
+      await tester.pump();
+      expect(
+        tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+        const Rect.fromLTRB(0.0, 0.0, 200.0, 200.0),
+      );
     });
   });
 }

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -17,6 +17,7 @@ final TwoDimensionalChildBuilderDelegate builderDelegate = TwoDimensionalChildBu
   maxYIndex: 5,
   builder: (BuildContext context, ChildVicinity vicinity) {
     return Container(
+      key: ValueKey<ChildVicinity>(vicinity),
       color: vicinity.xIndex.isEven && vicinity.yIndex.isEven
         ? Colors.amber[100]
         : (vicinity.xIndex.isOdd && vicinity.yIndex.isOdd

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2365,6 +2365,275 @@ void main() {
         ),
       );
     }, variant: TargetPlatformVariant.all());
+
+    group('TwoDimensionalViewport showOnScreen & showInViewport', () {
+      Finder findKey(ChildVicinity vicinity) {
+        return find.byKey(ValueKey<ChildVicinity>(vicinity));
+      }
+
+      testWidgets('Axis.vertical', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+        // Child visible at origin
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+          equals(0.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+          equals(0.0),
+        );
+        // (0, 3) is in the cache extent, and will be brought into view next
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+          equals(600.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 3)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Now in view
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+          equals(400.0),
+        );
+
+        // If already visible, no change
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 3)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+          equals(400.0),
+        );
+      });
+
+      testWidgets('Axis.horizontal', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 1, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 1, yIndex: 0))).dx,
+          equals(200.0), // No change since already fully visible
+        );
+        // (5, 0) is now in the cache extent, and will be brought into view next
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 5, yIndex: 0))).dx,
+          equals(1000.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 5, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Now in view
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 5, yIndex: 0))).dx,
+          equals(600.0),
+        );
+
+        // If already in position, no change
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 5, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 5, yIndex: 0))).dx,
+          equals(600.0),
+        );
+      });
+
+      testWidgets('both axes', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 1, yIndex: 1)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 1, yIndex: 1))),
+          const Rect.fromLTRB(200.0, 200.0, 400.0, 400.0),
+        );
+        // (5, 4) is in the cache extent, and will be brought into view next
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+          const Rect.fromLTRB(1000.0, 800.0, 1200.0, 1000.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 5, yIndex: 4)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Now in view
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+          const Rect.fromLTRB(600.0, 200.0, 800.0, 400.0),
+        );
+
+        // If already visible, no change
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 5, yIndex: 4)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+          const Rect.fromLTRB(600.0, 200.0, 800.0, 400.0),
+        );
+      });
+
+      testWidgets('Axis.vertical reverse', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(
+          verticalDetails: const ScrollableDetails.vertical(reverse: true),
+          useCacheExtent: true,
+        ));
+
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+          equals(400.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Already visible so no change.
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dy,
+          equals(400.0),
+        );
+        // (0, 3) is in the cache extent, and will be brought into view next
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+          equals(-200.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 3)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Now in view
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+          equals(0.0),
+        );
+
+        // If already visible, no change
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 3)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 3))).dy,
+          equals(0.0),
+        );
+      });
+
+      testWidgets('Axis.horizontal reverse', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(
+          horizontalDetails: const ScrollableDetails.horizontal(reverse: true),
+          useCacheExtent: true,
+        ));
+
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dx,
+          equals(600.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 0, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Already visible so no change.
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 0, yIndex: 0))).dx,
+          equals(600.0),
+        );
+        // (4, 0) is in the cache extent, and will be brought into view next
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 4, yIndex: 0))).dx,
+          equals(-200.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 4, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 4, yIndex: 0))).dx,
+          equals(0.0),
+        );
+
+        // If already visible, no change
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 4, yIndex: 0)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getTopLeft(findKey(const ChildVicinity(xIndex: 4, yIndex: 0))).dx,
+          equals(0.0),
+        );
+      });
+
+      testWidgets('both axes reverse', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(
+          verticalDetails: const ScrollableDetails.vertical(reverse: true),
+          horizontalDetails: const ScrollableDetails.horizontal(reverse: true),
+          useCacheExtent: true,
+        ));
+
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 1, yIndex: 1)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 1, yIndex: 1))),
+          const Rect.fromLTRB(400.0, 200.0, 600.0, 400.0),
+        );
+        // (5, 4) is in the cache extent, and will be brought into view next
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+          const Rect.fromLTRB(-400.0, -400.0, -200.0, -200.0),
+        );
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 5, yIndex: 4)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        // Now in view
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+          const Rect.fromLTRB(0.0, 200.0, 200.0, 400.0),
+        );
+
+        // If already visible, no change
+        tester.renderObject(find.byKey(
+          const ValueKey<ChildVicinity>(ChildVicinity(xIndex: 5, yIndex: 4)),
+          skipOffstage: false,
+        )).showOnScreen();
+        await tester.pump();
+        expect(
+          tester.getRect(findKey(const ChildVicinity(xIndex: 5, yIndex: 4))),
+          const Rect.fromLTRB(0.0, 200.0, 200.0, 400.0),
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Original PR for reference: https://github.com/flutter/flutter/pull/128812

Fixes https://github.com/flutter/flutter/issues/126299

This will enable default focus traversal and implicit scrolling in 2D. 

I followed the same convention we have established for updating `Scrollable` methods to support 2D - by adding axisDirection parameters that are nullable. This allows developers to target a specific axis, or when null just behave naturally in 1D or handle both axes automatically in 2D.

Overview

- Scrollable.ensureVisible is updated to call on private _performEnsureVisible for 1D and 2D scrollables. Not providing an axisDirection will automatically handle both axes in 2D, specifying an axisDirection allows users to have different alignments to reveal at.
- ScrollPosition is updated to call viewport.getOffetToReveal with an axisDirection for 2D
- RenderTwoDimensionalViewport now has
  - showOnScreen
  - showInViewport
  - getOffsetToReveal
- I refactored some logic out of RenderViewportBase.showInViewport and moved it to (new) RenderAbstractViewport.applyTargetOffset so it could be reused in RenderTwoDimensionalViewport.showInViewport. This is because RenderTwoDimensionalViewport is a subclass of RenderAbstractViewport, not RenderViewportBase.

https://github.com/flutter/flutter/assets/16964204/75ff8420-11bb-413e-91d7-baaa60ca33dc

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
