### PR TITLE
[documentation] remove repeated "For example," in RenderSliverEdgeInsetsPadding documentation

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -18,7 +18,7 @@ import 'sliver.dart';
 ///
 /// {@template flutter.rendering.RenderSliverEdgeInsetsPadding}
 /// Applying padding in the main extent of the viewport to slivers that have scroll effects is likely to have
-/// undesired effects. For example, For example, wrapping a [SliverPersistentHeader] with
+/// undesired effects. For example, wrapping a [SliverPersistentHeader] with
 /// `pinned:true` will cause only the appbar to stay pinned while the padding will scroll away.
 /// {@endtemplate}
 abstract class RenderSliverEdgeInsetsPadding extends RenderSliver with RenderObjectWithChildMixin<RenderSliver> {


### PR DESCRIPTION
There was a repeated "For example," in the documentation of `RenderSliverEdgeInsetsPadding`. This PR fix this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
