### PR TITLE
Stop reporting new_gen_gc_count to SkiaPerf

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1357,7 +1357,6 @@ const List<String> _kCommonScoreKeys = <String>[
   '90th_percentile_picture_cache_memory',
   '99th_percentile_picture_cache_memory',
   'worst_picture_cache_memory',
-  'new_gen_gc_count',
   'old_gen_gc_count',
 ];
 


### PR DESCRIPTION
Movement in this metric is mostly noise, creates many false alerts, and is neither the cause nor effect of changes in other metrics.