### PR TITLE
Leak track cupertino widgets

### DIFF
--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -11,13 +11,14 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/semantics_tester.dart';
 
 int count = 0;
 
 void main() {
-  testWidgets('Middle still in center with asymmetrical actions', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Middle still in center with asymmetrical actions', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -34,7 +35,7 @@ void main() {
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
   });
 
-  testWidgets('Middle still in center with back button', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Middle still in center with back button', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -89,7 +90,7 @@ void main() {
     expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.darkColor));
   });
 
-  testWidgets('Non-opaque background adds blur effects', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Non-opaque background adds blur effects', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -100,7 +101,7 @@ void main() {
     expect(find.byType(BackdropFilter), findsOneWidget);
   });
 
-  testWidgets('Nav bar displays correctly', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Nav bar displays correctly', (WidgetTester tester) async {
     final GlobalKey<NavigatorState> navigator = GlobalKey<NavigatorState>();
     await tester.pumpWidget(
       CupertinoApp(
@@ -130,7 +131,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Can specify custom padding', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Can specify custom padding', (WidgetTester tester) async {
     final Key middleBox = GlobalKey();
     await tester.pumpWidget(
       CupertinoApp(
@@ -187,7 +188,7 @@ void main() {
   }
 
   // Regression test for https://github.com/flutter/flutter/issues/119270
-  testWidgets('System navigation bar properties are not overridden', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('System navigation bar properties are not overridden', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -198,7 +199,7 @@ void main() {
     expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets('Can specify custom brightness', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Can specify custom brightness', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -250,7 +251,7 @@ void main() {
     expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets('Padding works in RTL', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Padding works in RTL', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Directionality(
@@ -280,7 +281,7 @@ void main() {
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
   });
 
-  testWidgets('Nav bar uses theme defaults', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Nav bar uses theme defaults', (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(
@@ -300,7 +301,7 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('Nav bar respects themes', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Nav bar respects themes', (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(
@@ -321,7 +322,7 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('Theme active color can be overridden', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Theme active color can be overridden', (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(
@@ -342,7 +343,7 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('No slivers with no large titles', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('No slivers with no large titles', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -357,8 +358,9 @@ void main() {
     expect(find.byType(SliverPersistentHeader), findsNothing);
   });
 
-  testWidgets('Media padding is applied to CupertinoSliverNavigationBar', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Media padding is applied to CupertinoSliverNavigationBar', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
     final Key leadingKey = GlobalKey();
     final Key middleKey = GlobalKey();
     final Key trailingKey = GlobalKey();
@@ -405,8 +407,9 @@ void main() {
     expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(16.0 + 20.0, 54.0 + 10.0));
   });
 
-  testWidgets('Large title nav bar scrolls', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Large title nav bar scrolls', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
@@ -485,8 +488,9 @@ void main() {
     expect(tester.getSize(find.widgetWithText(ClipRect, 'Title').first).height, 0.0);
   });
 
-  testWidgets('User specified middle is always visible in sliver', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('User specified middle is always visible in sliver', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
     final Key segmentedControlsKey = UniqueKey();
     await tester.pumpWidget(
       CupertinoApp(
@@ -542,8 +546,9 @@ void main() {
     );
   });
 
-  testWidgets('User specified middle is only visible when sliver is collapsed if alwaysShowMiddle is false', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('User specified middle is only visible when sliver is collapsed if alwaysShowMiddle is false', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
@@ -588,8 +593,9 @@ void main() {
     expect(middleOpacity.opacity.value, 0.0);
   });
 
-  testWidgets('Small title can be overridden', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Small title can be overridden', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
@@ -652,7 +658,7 @@ void main() {
     expect(tester.getBottomLeft(find.text('Title')).dy, 44.0); // Extension gone.
   });
 
-  testWidgets('Auto back/close button', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Auto back/close button', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -707,7 +713,7 @@ void main() {
     expect(find.text('Home page'), findsOneWidget);
   });
 
-  testWidgets('Long back label turns into "back"', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Long back label turns into "back"', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Placeholder(),
@@ -750,7 +756,7 @@ void main() {
     expect(find.widgetWithText(CupertinoButton, 'Back'), findsOneWidget);
   });
 
-  testWidgets('Border should be displayed by default', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Border should be displayed by default', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -772,7 +778,7 @@ void main() {
     expect(side, isNotNull);
   });
 
-  testWidgets('Overrides border color', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Overrides border color', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -801,7 +807,7 @@ void main() {
     expect(side.color, const Color(0xFFAABBCC));
   });
 
-  testWidgets('Border should not be displayed when null', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Border should not be displayed when null', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -821,7 +827,7 @@ void main() {
     expect(decoration.border, isNull);
   });
 
-  testWidgets('Border is displayed by default in sliver nav bar', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Border is displayed by default in sliver nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -849,7 +855,7 @@ void main() {
     expect(bottom, isNotNull);
   });
 
-  testWidgets('Border is not displayed when null in sliver nav bar', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Border is not displayed when null in sliver nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -875,7 +881,7 @@ void main() {
     expect(decoration.border, isNull);
   });
 
-  testWidgets('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(const CupertinoApp(
@@ -900,7 +906,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(CupertinoApp(
@@ -921,7 +927,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('Border can be overridden in sliver nav bar', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Border can be overridden in sliver nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -959,7 +965,7 @@ void main() {
     expect(bottom.color, const Color(0xFFAABBCC));
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'Standard title golden',
     (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -982,7 +988,7 @@ void main() {
     },
   );
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'Large title golden',
     (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -1013,7 +1019,7 @@ void main() {
     },
   );
 
-  testWidgets('NavBar draws a light system bar for a dark background', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('NavBar draws a light system bar for a dark background', (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -1033,7 +1039,7 @@ void main() {
     expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.light);
   });
 
-  testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -1053,7 +1059,7 @@ void main() {
     expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoNavigationBarBackButton());
 
     final dynamic exception = tester.takeException();
@@ -1061,7 +1067,7 @@ void main() {
     expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBarBackButton(),
@@ -1073,7 +1079,7 @@ void main() {
     expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets('CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere', (WidgetTester tester) async {
     bool backPressed = false;
 
     await tester.pumpWidget(
@@ -1092,7 +1098,7 @@ void main() {
     expect(backPressed, true);
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'Manually inserted CupertinoNavigationBarBackButton still automatically '
         'show previous page title when possible',
     (WidgetTester tester) async {
@@ -1133,7 +1139,7 @@ void main() {
     },
   );
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'CupertinoNavigationBarBackButton onPressed overrides default pop behavior',
     (WidgetTester tester) async {
       bool backPressed = false;
@@ -1188,7 +1194,7 @@ void main() {
     },
   );
 
-  testWidgets('textScaleFactor is set to 1.0', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('textScaleFactor is set to 1.0', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(
         home: Builder(builder: (BuildContext context) {
@@ -1267,7 +1273,7 @@ void main() {
     expect(barItems2.any((RichText t) => t.textScaleFactor != 1), isFalse);
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'CupertinoSliverNavigationBar stretches upon over-scroll and bounces back once over-scroll ends',
     (WidgetTester tester) async {
       const Text trailingText = Text('Bar Button');
@@ -1322,7 +1328,7 @@ void main() {
     },
   );
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'CupertinoSliverNavigationBar does not stretch upon over-scroll if stretch parameter is false',
     (WidgetTester tester) async {
       const Text trailingText = Text('Bar Button');
@@ -1376,7 +1382,7 @@ void main() {
     },
   );
 
-  testWidgets('Null NavigationBar border transition', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Null NavigationBar border transition', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/71389
     await tester.pumpWidget(
       const CupertinoApp(
@@ -1416,7 +1422,7 @@ void main() {
     expect(find.text('Page 2'), findsNothing);
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'CupertinoSliverNavigationBar magnifies upon over-scroll and shrinks back once over-scroll ends',
     (WidgetTester tester) async {
       const Text titleText = Text('Large Title');
@@ -1474,7 +1480,7 @@ void main() {
     },
   );
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'CupertinoSliverNavigationBar large title text does not get clipped when magnified',
     (WidgetTester tester) async {
       const Text titleText = Text('Very very very long large title');
@@ -1521,10 +1527,11 @@ void main() {
     },
   );
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'CupertinoSliverNavigationBar large title can be hit tested when magnified',
     (WidgetTester tester) async {
       final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
 
       await tester.pumpWidget(
         CupertinoApp(

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -6,12 +6,13 @@ import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../image_data.dart';
 
 /// Integration tests testing both [CupertinoPageScaffold] and [CupertinoTabScaffold].
 void main() {
-  testWidgets('Contents are behind translucent bar', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Contents are behind translucent bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -27,7 +28,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(Center)), Offset.zero);
   });
 
-  testWidgets('Opaque bar pushes contents down', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Opaque bar pushes contents down', (WidgetTester tester) async {
     late BuildContext childContext;
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -102,7 +103,7 @@ void main() {
     expect(find.byType(CupertinoPageScaffold), paints..rect(color: backgroundColor.darkColor));
   });
 
-  testWidgets('Contents padding from viewInsets', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Contents padding from viewInsets', (WidgetTester tester) async {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: MediaQuery(
@@ -160,7 +161,7 @@ void main() {
     expect(tester.getSize(find.byType(Container)).height, 600.0);
   });
 
-  testWidgets('Contents bottom padding are not consumed by viewInsets when resizeToAvoidBottomInset overridden', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Contents bottom padding are not consumed by viewInsets when resizeToAvoidBottomInset overridden', (WidgetTester tester) async {
     const Widget child = CupertinoPageScaffold(
       resizeToAvoidBottomInset: false,
       navigationBar: CupertinoNavigationBar(
@@ -198,7 +199,7 @@ void main() {
     expect(initialPoint, finalPoint);
   });
 
-  testWidgets('Contents are between opaque bars', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Contents are between opaque bars', (WidgetTester tester) async {
     const Center page1Center = Center();
 
     await tester.pumpWidget(
@@ -235,7 +236,7 @@ void main() {
     expect(tester.getSize(find.byWidget(page1Center)).height, 600.0 - 44.0 - 50.0);
   });
 
-  testWidgets('Contents have automatic sliver padding between translucent bars', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Contents have automatic sliver padding between translucent bars', (WidgetTester tester) async {
     const SizedBox content = SizedBox(height: 600.0, width: 600.0);
 
     await tester.pumpWidget(
@@ -289,7 +290,7 @@ void main() {
     expect(tester.getBottomLeft(find.byWidget(content)).dy, 600 - 20.0 - 50.0);
   });
 
-  testWidgets('iOS independent tab navigation', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('iOS independent tab navigation', (WidgetTester tester) async {
     // A full on iOS information architecture app with 2 tabs, and 2 pages
     // in each with independent navigation states.
     await tester.pumpWidget(
@@ -398,7 +399,7 @@ void main() {
     expect(find.text('Page 2 of tab 1', skipOffstage: false), isOffstage);
   });
 
-  testWidgets('Decorated with white background by default', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Decorated with white background by default', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -414,7 +415,7 @@ void main() {
     expect(decoration.color, isSameColorAs(CupertinoColors.white));
   });
 
-  testWidgets('Overrides background color', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Overrides background color', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -431,7 +432,7 @@ void main() {
     expect(decoration.color, const Color(0xFF010203));
   });
 
-  testWidgets('Lists in CupertinoPageScaffold scroll to the top when status bar tapped', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Lists in CupertinoPageScaffold scroll to the top when status bar tapped', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(
         builder: (BuildContext context, Widget? child) {
@@ -483,7 +484,7 @@ void main() {
     expect(find.text('12'), findsNothing);
   });
 
-  testWidgets('resizeToAvoidBottomInset is supported even when no navigationBar', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('resizeToAvoidBottomInset is supported even when no navigationBar', (WidgetTester tester) async {
     Widget buildFrame(bool showNavigationBar, bool showKeyboard) {
       return CupertinoApp(
         home: MediaQuery(
@@ -528,7 +529,7 @@ void main() {
     expect(positionWithInsetNoNavBar, equals(positionWithInsetWithNavBar));
   });
 
-  testWidgets('textScaleFactor is set to 1.0', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('textScaleFactor is set to 1.0', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(
         home: Builder(builder: (BuildContext context) {


### PR DESCRIPTION
Adds leak tracking to cupertino/scaffold_test.dart as well as cupertino/nav_bar_test.dart and fix leaks ([#134](https://github.com/dart-lang/leak_tracker/issues/134)).

Each file has a test case that has not been covered yet, as they depend on #134661 to be fixed.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
