### PR TITLE
Fix failing test at master.

### DIFF
--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -549,8 +549,11 @@ void main() {
 
   testWidgetsWithLeakTracking('Can autofocus a TextField nested in a Focus in a route.', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
 
     final FocusNode focusNode = FocusNode(debugLabel: 'Test Node');
+    addTearDown(focusNode.dispose);
+
     await tester.pumpWidget(
       Material(
         child: MaterialApp(


### PR DESCRIPTION
Failure: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8769055855363356449/+/u/run_test.dart_for_framework_tests_shard_and_subshard_widgets/test_stdout