### PR TITLE
✨ `flutter config --list`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -15,7 +15,11 @@ import '../runner/flutter_command_runner.dart';
 
 class ConfigCommand extends FlutterCommand {
   ConfigCommand({ bool verboseHelp = false }) {
-    argParser.addFlag('list', help: 'List all settings and their current values.');
+    argParser.addFlag(
+      'list',
+      help: 'List all settings and their current values.',
+      negatable: false,
+    );
     argParser.addFlag('analytics',
       hide: !verboseHelp,
       help: 'Enable or disable reporting anonymously tool usage statistics and crash reports.\n'

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -15,6 +15,7 @@ import '../runner/flutter_command_runner.dart';
 
 class ConfigCommand extends FlutterCommand {
   ConfigCommand({ bool verboseHelp = false }) {
+    argParser.addFlag('list', help: 'List all settings and their current values.');
     argParser.addFlag('analytics',
       hide: !verboseHelp,
       help: 'Enable or disable reporting anonymously tool usage statistics and crash reports.\n'
@@ -73,37 +74,7 @@ class ConfigCommand extends FlutterCommand {
   bool get shouldUpdateCache => false;
 
   @override
-  String get usageFooter {
-    // List all config settings. for feature flags, include whether they
-    // are available.
-    final Map<String, Feature> featuresByName = <String, Feature>{};
-    final String channel = globals.flutterVersion.channel;
-    for (final Feature feature in allFeatures) {
-      final String? configSetting = feature.configSetting;
-      if (configSetting != null) {
-        featuresByName[configSetting] = feature;
-      }
-    }
-    String values = globals.config.keys
-        .map<String>((String key) {
-          String configFooter = '';
-          if (featuresByName.containsKey(key)) {
-            final FeatureChannelSetting setting = featuresByName[key]!.getSettingForChannel(channel);
-            if (!setting.available) {
-              configFooter = '(Unavailable)';
-            }
-          }
-          return '  $key: ${globals.config.getValue(key)} $configFooter';
-        }).join('\n');
-    if (values.isEmpty) {
-      values = '  No settings have been configured.';
-    }
-    final bool analyticsEnabled = globals.flutterUsage.enabled &&
-                                  !globals.flutterUsage.suppressAnalytics;
-    return
-      '\nSettings:\n$values\n\n'
-      'Analytics reporting is currently ${analyticsEnabled ? 'enabled' : 'disabled'}.';
-  }
+  String get usageFooter => '\n$analyticsUsage';
 
   /// Return null to disable analytics recording of the `config` command.
   @override
@@ -121,6 +92,11 @@ class ConfigCommand extends FlutterCommand {
           '    flutter config --android-studio-dir "/opt/Android Studio"');
     }
 
+    if (boolArg('list')) {
+      globals.printStatus(settingsText);
+      return FlutterCommandResult.success();
+    }
+
     if (boolArg('machine')) {
       await handleMachine();
       return FlutterCommandResult.success();
@@ -133,6 +109,7 @@ class ConfigCommand extends FlutterCommand {
           globals.config.removeValue(configSetting);
         }
       }
+      globals.printStatus(requireReloadTipText);
       return FlutterCommandResult.success();
     }
 
@@ -195,7 +172,7 @@ class ConfigCommand extends FlutterCommand {
     if (argResults == null || argResults!.arguments.isEmpty) {
       globals.printStatus(usage);
     } else {
-      globals.printStatus('\nYou may need to restart any open editors for them to read new settings.');
+      globals.printStatus('\n$requireReloadTipText');
     }
 
     return FlutterCommandResult.success();
@@ -234,4 +211,50 @@ class ConfigCommand extends FlutterCommand {
       globals.printStatus('Setting "$keyName" value to "$keyValue".');
     }
   }
+
+  /// List all config settings. for feature flags, include whether they are available.
+  String get settingsText {
+    final Map<String, Feature> featuresByName = <String, Feature>{};
+    final String channel = globals.flutterVersion.channel;
+    for (final Feature feature in allFeatures) {
+      final String? configSetting = feature.configSetting;
+      if (configSetting != null) {
+        featuresByName[configSetting] = feature;
+      }
+    }
+    final Set<String> keys = <String>{
+      ...allFeatures.map((Feature e) => e.configSetting).whereType<String>(),
+      ...globals.config.keys,
+    };
+    final Iterable<String> settings = keys.map<String>((String key) {
+      Object? value = globals.config.getValue(key);
+      value ??= '(Not set)';
+      final StringBuffer buffer = StringBuffer('  $key: $value');
+      if (featuresByName.containsKey(key)) {
+        final FeatureChannelSetting setting = featuresByName[key]!.getSettingForChannel(channel);
+        if (!setting.available) {
+          buffer.write(' (Unavailable)');
+        }
+      }
+      return buffer.toString();
+    });
+    final StringBuffer buffer = StringBuffer();
+    buffer.writeln('All Settings:');
+    if (settings.isEmpty) {
+      buffer.writeln('  No configs have been configured.');
+    } else {
+      buffer.writeln(settings.join('\n'));
+    }
+    return buffer.toString();
+  }
+
+  /// List the status of the analytics reporting.
+  String get analyticsUsage {
+    final bool analyticsEnabled =
+        globals.flutterUsage.enabled && !globals.flutterUsage.suppressAnalytics;
+    return 'Analytics reporting is currently ${analyticsEnabled ? 'enabled' : 'disabled'}.';
+  }
+
+  /// Raising the reload tip for setting changes.
+  final String requireReloadTipText = 'You may need to restart any open editors for them to read new settings.';
 }

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -71,11 +71,12 @@ void main() {
     expect(result.stdout, contains('Shutdown hooks complete'));
   });
 
-  testWithoutContext('flutter config contains all features', () async {
+  testWithoutContext('flutter config --list contains all features', () async {
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       'config',
+      '--list'
     ]);
 
     // contains all of the experiments in features.dart


### PR DESCRIPTION
Resolves #81831.

The PR improves the `config` command in below ways:
- Does not print the settings in usages or other options.
- Adds the `--list` flag to print the full settings list.
- Separates usages for settings and analytics.
- Prints the restart tip when clearing features.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
