### PR TITLE
Spell check

### DIFF
--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -11610,15 +11610,21 @@ void main() {
         ),
       ));
 
+      // The initial text should be formatted when spell checking.
+      final dynamic error1 = tester.takeException();
+      expect(error1, isFlutterError);
+      expect(error1.toString(), contains(errorText));
+      expect(controller.text, 'flutter is the best!');
+
       // Interact with the field to establish the input connection.
       await tester.tap(find.byType(EditableText));
       await tester.pump();
 
       await tester.enterText(find.byType(EditableText), 'text');
 
-      final dynamic error = tester.takeException();
-      expect(error, isFlutterError);
-      expect(error.toString(), contains(errorText));
+      final dynamic error2 = tester.takeException();
+      expect(error2, isFlutterError);
+      expect(error2.toString(), contains(errorText));
       expect(controller.text, 'text');
     });
   });


### PR DESCRIPTION
Changed to perform spell check when initial text is set in TextField Controller.

Resolve #132270 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
