### PR TITLE
_TabBarViewState should not recreate page controller

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1851,10 +1851,14 @@ class _TabBarViewState extends State<TabBarView> {
     super.didChangeDependencies();
     _updateTabController();
     _currentIndex = _controller!.index;
-    _pageController ??= PageController(
-      initialPage: _currentIndex!,
-      viewportFraction: widget.viewportFraction,
-    );
+    if (_pageController == null) {
+      _pageController = PageController(
+        initialPage: _currentIndex!,
+        viewportFraction: widget.viewportFraction,
+      );
+    } else {
+      _pageController!.jumpToPage(_currentIndex!);
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1851,9 +1851,7 @@ class _TabBarViewState extends State<TabBarView> {
     super.didChangeDependencies();
     _updateTabController();
     _currentIndex = _controller!.index;
-    // TODO(chunhtai): https://github.com/flutter/flutter/issues/134253
-    _pageController?.dispose();
-    _pageController = PageController(
+    _pageController ??= PageController(
       initialPage: _currentIndex!,
       viewportFraction: widget.viewportFraction,
     );

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -4186,6 +4186,38 @@ void main() {
     expect(tester.getCenter(find.byKey(lastTabKey)).dx, equals(750.0));
   });
 
+  testWidgets('DefaultTabController changes does not recreate PageController', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/134253.
+    Widget buildFrame(int length) {
+      return boilerplate(
+        child: DefaultTabController(
+          length: length,
+          initialIndex: length - 1,
+          child: TabBarView(
+            physics: const TestScrollPhysics(),
+            children: List<Widget>.generate(
+              length,
+              (int index) {
+                return Center(child: Text('Page $index'));
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(10));
+    PageView pageView = tester.widget(find.byType(PageView));
+    final PageController pageController1 = pageView.controller;
+
+    // Rebuild with a new default tab controller with more tabs.
+    await tester.pumpWidget(buildFrame(15));
+    pageView = tester.widget(find.byType(PageView));
+    final PageController pageController2 = pageView.controller;
+
+    expect(pageController1, equals(pageController2));
+  });
+
   testWidgets('Do not throw when switching between a scrollable TabBar and a non-scrollable TabBar', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/120649
     final TabController controller1 = _tabController(

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -4206,14 +4206,20 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildFrame(10));
+    await tester.pumpWidget(buildFrame(15));
     PageView pageView = tester.widget(find.byType(PageView));
     final PageController pageController1 = pageView.controller;
+    TabController tabController = DefaultTabController.of(tester.element(find.text('Page 14')));
+    expect(tabController.index, 14);
+    expect(pageController1.page, 14);
 
     // Rebuild with a new default tab controller with more tabs.
-    await tester.pumpWidget(buildFrame(15));
+    await tester.pumpWidget(buildFrame(10));
     pageView = tester.widget(find.byType(PageView));
     final PageController pageController2 = pageView.controller;
+    tabController = DefaultTabController.of(tester.element(find.text('Page 9')));
+    expect(tabController.index, 9);
+    expect(pageController2.page, 9);
 
     expect(pageController1, equals(pageController2));
   });


### PR DESCRIPTION
## Description

This PR replaces the unconditional instantiation of `PageController` in `_TabBarViewState.didChangeDependencies` as suggested in https://github.com/flutter/flutter/pull/134091#discussion_r1319177744.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/134253.

## Tests

Adds 1 test.