### PR TITLE
Remove assertions on getOffsetToReveal

### DIFF
--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1125,11 +1125,8 @@ class RenderListWheelViewport
     RenderObject target,
     double alignment, {
     Rect? rect,
-    Axis? axis,
+    Axis? axis, // Unused, only Axis.vertical supported by this viewport.
   }) {
-    // One dimensional viewport has only one axis, it should match if it has
-    // been provided.
-    assert(axis == null || axis == Axis.vertical);
     // `target` is only fully revealed when in the selected/center position. Therefore,
     // this method always returns the offset that shows `target` in the center position,
     // which is the same offset for all `alignment` values.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -821,10 +821,9 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     Rect? rect,
     Axis? axis,
   }) {
-    // One dimensional viewport has only one axis, it should match if it has
-    // been provided.
-    axis ??= this.axis;
-    assert(axis == this.axis);
+    // One dimensional viewport has only one axis, override if it was
+    // provided/may be mismatched.
+    axis = this.axis;
 
     // Steps to convert `rect` (from a RenderBox coordinate system) to its
     // scroll offset within this viewport (not in the exact order):

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -112,7 +112,7 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   /// [RenderTwoDimensionalViewport.getOffsetToReveal] to
   /// determine which of the two axes to compute an offset for. One dimensional
   /// subclasses like [RenderViewportBase] and [RenderListWheelViewport]
-  /// will ignore the `axis` value is provided, since there is only one [Axis].
+  /// will ignore the `axis` value if provided, since there is only one [Axis].
   ///
   /// If the `axis` is omitted when called on [RenderTwoDimensionalViewport],
   /// the [RenderTwoDimensionalViewport.mainAxis] is used. To reveal an object

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -111,9 +111,14 @@ abstract interface class RenderAbstractViewport extends RenderObject {
   /// The optional [Axis] is used by
   /// [RenderTwoDimensionalViewport.getOffsetToReveal] to
   /// determine which of the two axes to compute an offset for. One dimensional
-  /// subclasses like [RenderViewportBase] and [RenderListWheelViewport] will
-  /// assert in debug builds if the `axis` value is provided and does not match
-  /// the single [Axis] that viewport is configured for.
+  /// subclasses like [RenderViewportBase] and [RenderListWheelViewport]
+  /// will ignore the `axis` value is provided, since there is only one [Axis].
+  ///
+  /// If the `axis` is omitted when called on [RenderTwoDimensionalViewport],
+  /// the [RenderTwoDimensionalViewport.mainAxis] is used. To reveal an object
+  /// properly in both axes, this method should be called for each [Axis] as the
+  /// returned [RevealedOffset.offset] only represents the offset of one of the
+  /// the two [ScrollPosition]s.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -598,10 +598,9 @@ class _RenderSingleChildViewport extends RenderBox with RenderObjectWithChildMix
     Rect? rect,
     Axis? axis,
   }) {
-    // One dimensional viewport has only one axis, it should match if it has
-    // been provided.
-    axis ??= this.axis;
-    assert(axis == this.axis);
+    // One dimensional viewport has only one axis, override if it was
+    // provided/may be mismatched.
+    axis = this.axis;
 
     rect ??= target.paintBounds;
     if (target is! RenderBox) {

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -924,9 +924,8 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     Rect? rect,
     Axis? axis,
   }) {
-    // We must know which axis we are revealing for, since RevealedOffset
-    // refers to only one of two scroll positions.
-    assert(axis != null);
+    // If an axis has not been specified, use the mainAxis.
+    axis ??= mainAxis;
 
     final (double offset, AxisDirection axisDirection) = switch (axis!) {
       Axis.vertical => (verticalOffset.pixels, verticalAxisDirection),

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -927,7 +927,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     // If an axis has not been specified, use the mainAxis.
     axis ??= mainAxis;
 
-    final (double offset, AxisDirection axisDirection) = switch (axis!) {
+    final (double offset, AxisDirection axisDirection) = switch (axis) {
       Axis.vertical => (verticalOffset.pixels, verticalAxisDirection),
       Axis.horizontal => (horizontalOffset.pixels, horizontalAxisDirection),
     };

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1586,6 +1586,14 @@ void main() {
       final double revealOffset = viewport.getOffsetToReveal(target, 0.0).offset;
       expect(revealOffset, -(300.0 + padding.horizontal)  * 5 + 34.0 * 2);
     });
+
+    testWidgets('will not assert on mismatched axis', (WidgetTester tester) async {
+      await tester.pumpWidget(buildList(axis: Axis.vertical, reverse: true, reverseGrowth: true));
+      final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+
+      final RenderObject target = tester.renderObject(find.text('Tile 0', skipOffstage: false));
+      viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
+    });
   });
 
   testWidgets('RenderViewportBase.showOnScreen reports the correct targetRect', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -1599,9 +1599,6 @@ void main() {
   });
 
   testWidgets('will not assert on getOffsetToReveal Axis', (WidgetTester tester) async {
-    List<Widget> outerChildren;
-    final List<Widget> innerChildren = List<Widget>.generate(10, (int index) => Container());
-
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -1612,9 +1609,9 @@ void main() {
             child: ListWheelScrollView(
               controller: ScrollController(initialScrollOffset: 300.0),
               itemExtent: 100.0,
-              children: outerChildren = List<Widget>.generate(10, (int i) {
+              children: List<Widget>.generate(10, (int i) {
                 return Center(
-                  child: innerChildren[i] = SizedBox(
+                  child: SizedBox(
                     height: 50.0,
                     width: 50.0,
                     child: Text('Item $i'),
@@ -1628,9 +1625,7 @@ void main() {
     );
 
     final RenderListWheelViewport viewport = tester.allRenderObjects.whereType<RenderListWheelViewport>().first;
-
-    // direct child of viewport
-    final RenderObject target = tester.renderObject(find.byWidget(outerChildren[5]));
+    final RenderObject target = tester.renderObject(find.text('Item 5'));
     viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
   });
 

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -1598,6 +1598,42 @@ void main() {
     expect(revealed.rect, const Rect.fromLTWH(165.0, 265.0, 10.0, 10.0));
   });
 
+  testWidgets('will not assert on getOffsetToReveal Axis', (WidgetTester tester) async {
+    List<Widget> outerChildren;
+    final List<Widget> innerChildren = List<Widget>.generate(10, (int index) => Container());
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            height: 500.0,
+            width: 300.0,
+            child: ListWheelScrollView(
+              controller: ScrollController(initialScrollOffset: 300.0),
+              itemExtent: 100.0,
+              children: outerChildren = List<Widget>.generate(10, (int i) {
+                return Center(
+                  child: innerChildren[i] = SizedBox(
+                    height: 50.0,
+                    width: 50.0,
+                    child: Text('Item $i'),
+                  ),
+                );
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderListWheelViewport viewport = tester.allRenderObjects.whereType<RenderListWheelViewport>().first;
+
+    // direct child of viewport
+    final RenderObject target = tester.renderObject(find.byWidget(outerChildren[5]));
+    viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
+  });
+
   testWidgets('ListWheelScrollView showOnScreen', (WidgetTester tester) async {
     List<Widget> outerChildren;
     final List<Widget> innerChildren = List<Widget>.generate(10, (int index) => Container());

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -486,6 +486,40 @@ void main() {
     expect(semanticsClip.size.width, length);
   });
 
+  testWidgetsWithLeakTracking('SingleChildScrollView getOffsetToReveal - will not assert on axis mismatch', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
+    addTearDown(controller.dispose);
+    List<Widget> children;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            height: 200.0,
+            width: 300.0,
+            child: SingleChildScrollView(
+              controller: controller,
+              child: Column(
+                children: children = List<Widget>.generate(20, (int i) {
+                  return SizedBox(
+                    height: 100.0,
+                    width: 300.0,
+                    child: Text('Tile $i'),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+
+    final RenderObject target = tester.renderObject(find.byWidget(children[5]));
+    viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
+  });
+
   testWidgetsWithLeakTracking('SingleChildScrollView getOffsetToReveal - down', (WidgetTester tester) async {
     final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2366,10 +2366,52 @@ void main() {
       );
     }, variant: TargetPlatformVariant.all());
 
-    group('TwoDimensionalViewport showOnScreen & showInViewport', () {
+    group('showOnScreen & showInViewport', () {
       Finder findKey(ChildVicinity vicinity) {
         return find.byKey(ValueKey<ChildVicinity>(vicinity));
       }
+
+      testWidgets('getOffsetToReveal', (WidgetTester tester) async {
+        await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));
+
+        RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+        final RevealedOffset verticalOffset = viewport.getOffsetToReveal(
+          tester.renderObject(findKey(const ChildVicinity(xIndex: 5, yIndex: 5))),
+          1.0,
+          axis: Axis.vertical,
+        );
+        final RevealedOffset horizontalOffset = viewport.getOffsetToReveal(
+          tester.renderObject(findKey(const ChildVicinity(xIndex: 5, yIndex: 5))),
+          1.0,
+          axis: Axis.horizontal,
+        );
+        expect(verticalOffset.offset, 600.0);
+        expect(verticalOffset.rect, const Rect.fromLTRB(1000.0, 400.0, 1200.0, 600.0));
+        expect(horizontalOffset.offset, 400.0);
+        expect(horizontalOffset.rect, const Rect.fromLTRB(600.0, 1000.0, 800.0, 1200.0));
+
+        // default is to use mainAxis when axis is not provided, mainAxis
+        // defaults to Axis.vertical.
+        RevealedOffset defaultOffset = viewport.getOffsetToReveal(
+          tester.renderObject(findKey(const ChildVicinity(xIndex: 5, yIndex: 5))),
+          1.0,
+        );
+        expect(defaultOffset.offset, verticalOffset.offset);
+        expect(defaultOffset.rect, verticalOffset.rect);
+
+        // mainAxis as Axis.horizontal
+        await tester.pumpWidget(simpleBuilderTest(
+          useCacheExtent: true,
+          mainAxis: Axis.horizontal,
+        ));
+        viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+        defaultOffset = viewport.getOffsetToReveal(
+          tester.renderObject(findKey(const ChildVicinity(xIndex: 5, yIndex: 5))),
+          1.0,
+        );
+        expect(defaultOffset.offset, horizontalOffset.offset);
+        expect(defaultOffset.rect, horizontalOffset.rect);
+      });
 
       testWidgets('Axis.vertical', (WidgetTester tester) async {
         await tester.pumpWidget(simpleBuilderTest(useCacheExtent: true));


### PR DESCRIPTION
Loosens up getOffsetToReveal by removing assertions from #135182

I have been playing around with some diagrams for all of the viewports Flutter has, since I have found some can create issues from inconsistencies if you only have a RenderAbstractViewport object and do not know what kind it is. Maybe an opportunity (or several) to improve here.

```mermaid
graph TB;
  id1((RenderAbstractViewport)) --> RenderListWheelViewport
  id1((RenderAbstractViewport)) --> _RenderSingleChildViewport
  id1((RenderAbstractViewport)) --> id2((RenderTwoDimensionalViewport))
  id1((RenderAbstractViewport)) --> id3((RenderViewportBase))
  id3((RenderViewportBase)) --> RenderShrinkWrappingViewport
  id3((RenderViewportBase)) --> RenderViewport
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
