### PR TITLE
Upload generated frame-request-pending stats

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1358,6 +1358,9 @@ const List<String> _kCommonScoreKeys = <String>[
   '99th_percentile_picture_cache_memory',
   'worst_picture_cache_memory',
   'old_gen_gc_count',
+  'average_frame_request_pending_latency',
+  '90th_percentile_frame_request_pending_latency',
+  '99th_percentile_frame_request_pending_latency'
 ];
 
 /// Measures how long it takes to compile a Flutter app to JavaScript and how

--- a/dev/devicelab/test/perf_tests_test.dart
+++ b/dev/devicelab/test/perf_tests_test.dart
@@ -58,6 +58,9 @@ void main() {
       'average_vsync_transitions_missed': 1,
       '90th_percentile_vsync_transitions_missed': 1,
       '99th_percentile_vsync_transitions_missed': 1,
+      'average_frame_request_pending_latency': 0.1,
+      '90th_percentile_frame_request_pending_latency': 0.1,
+      '99th_percentile_frame_request_pending_latency': 0.1,
     };
     const String resultFileName = 'fake_result';
     void driveCallback(List<String> arguments) {
@@ -108,6 +111,9 @@ void main() {
       '90hz_frame_percentage': 0.4,
       '120hz_frame_percentage': 0.6,
       'illegal_refresh_rate_frame_count': 10,
+      'average_frame_request_pending_latency': 0.1,
+      '90th_percentile_frame_request_pending_latency': 0.1,
+      '99th_percentile_frame_request_pending_latency': 0.1,
     };
     const String resultFileName = 'fake_result';
     void driveCallback(List<String> arguments) {


### PR DESCRIPTION
These values are generated since https://github.com/flutter/flutter/pull/135279, but I didn't know to add the new keys to this list to get them to upload.

Part of https://github.com/flutter/flutter/issues/129150

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
