### PR TITLE
Expose onAttach and onDetach in ScrollController subclasses

### DIFF
--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -217,6 +217,8 @@ class FixedExtentScrollController extends ScrollController {
   /// [initialItem] defaults to zero.
   FixedExtentScrollController({
     this.initialItem = 0,
+    super.onAttach,
+    super.onDetach,
   });
 
   /// The page to show when first creating the scroll view.

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -116,6 +116,8 @@ class PageController extends ScrollController {
     this.initialPage = 0,
     this.keepPage = true,
     this.viewportFraction = 1.0,
+    super.onAttach,
+    super.onDetach,
   }) : assert(viewportFraction > 0.0);
 
   /// The page to show when first creating the [PageView].

--- a/packages/flutter/lib/src/widgets/scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/scroll_controller.dart
@@ -380,6 +380,8 @@ class TrackingScrollController extends ScrollController {
     super.initialScrollOffset,
     super.keepScrollOffset,
     super.debugLabel,
+    super.onAttach,
+    super.onDetach,
   });
 
   final Map<ScrollPosition, VoidCallback> _positionToListener = <ScrollPosition, VoidCallback>{};

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -83,6 +83,37 @@ void main() {
       expect(tester.getSize(find.byType(ListWheelScrollView)), const Size(800.0, 600.0));
     });
 
+    testWidgetsWithLeakTracking('FixedExtentScrollController onAttach, onDetach', (WidgetTester tester) async {
+      int attach = 0;
+      int detach = 0;
+      final FixedExtentScrollController controller = FixedExtentScrollController(
+        onAttach: (_) { attach++; },
+        onDetach: (_) { detach++; },
+      );
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ListWheelScrollView(
+            controller: controller,
+            itemExtent: 50.0,
+            children: const <Widget>[],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(attach, 1);
+      expect(detach, 0);
+
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle();
+
+      expect(attach, 1);
+      expect(detach, 1);
+    });
+
     testWidgets('ListWheelScrollView needs positive magnification', (WidgetTester tester) async {
       expect(
         () {

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -1265,4 +1265,39 @@ void main() {
     // Check the stretch factor in the first element of the transform matrix.
     expect(transform.transform.storage.first, 1.0);
   });
+
+  testWidgetsWithLeakTracking('PageController onAttach, onDetach', (WidgetTester tester) async {
+    int attach = 0;
+    int detach = 0;
+    final PageController controller = PageController(
+      onAttach: (_) { attach++; },
+      onDetach: (_) { detach++; },
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: Center(
+        child: PageView(
+          controller: controller,
+          physics: const PageScrollPhysics().applyTo(const ClampingScrollPhysics()),
+          children: const <Widget>[
+            Center(child: Text('First Page')),
+            Center(child: Text('Second Page')),
+            Center(child: Text('Third Page')),
+          ],
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(attach, 1);
+    expect(detach, 0);
+
+    await tester.pumpWidget(Container());
+    await tester.pumpAndSettle();
+
+    expect(attach, 1);
+    expect(detach, 1);
+  });
 }

--- a/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
+++ b/packages/flutter/test/widgets/tracking_scroll_controller_test.dart
@@ -60,4 +60,43 @@ void main() {
 
     expect(controller.initialScrollOffset, 0.0);
   });
+
+  testWidgetsWithLeakTracking('TrackingScrollController saves offset', (WidgetTester tester) async {
+    int attach = 0;
+    int detach = 0;
+    final TrackingScrollController controller = TrackingScrollController(
+      onAttach: (_) { attach++; },
+      onDetach: (_) { detach++; },
+    );
+    addTearDown(controller.dispose);
+    const double listItemHeight = 100.0;
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: PageView.builder(
+        itemBuilder: (BuildContext context, int index) {
+          return ListView(
+            controller: controller,
+            children: List<Widget>.generate(
+              10,
+              (int i) => SizedBox(
+                height: listItemHeight,
+                child: Text('Page$index-Item$i'),
+              ),
+            ).toList(),
+          );
+        },
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(attach, 1);
+    expect(detach, 0);
+
+    await tester.pumpWidget(Container());
+    await tester.pumpAndSettle();
+
+    expect(attach, 1);
+    expect(detach, 1);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/135574
This exposes the onAttach and onDetach callbacks of ScrollController in all of its subclasses.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
