### PR TITLE
[Windows Arm64] Remove start up benchmarks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5177,20 +5177,6 @@ targets:
         ]
       task_name: flutter_gallery_win_desktop__start_up
 
-  - name: Windows_arm64 flutter_gallery_win_desktop__start_up
-    recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/134083
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "hostonly", "windows", "arm64"]
-      dependencies: >-
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      task_name: flutter_gallery_win_desktop__start_up
-
   - name: Windows complex_layout_win_desktop__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -5198,20 +5184,6 @@ targets:
     properties:
       tags: >
         ["devicelab", "hostonly", "windows"]
-      dependencies: >-
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      task_name: complex_layout_win_desktop__start_up
-
-  - name: Windows_arm64 complex_layout_win_desktop__start_up
-    recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/134083
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "hostonly", "windows", "arm64"]
       dependencies: >-
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -5231,20 +5203,6 @@ targets:
         ]
       task_name: flutter_view_win_desktop__start_up
 
-  - name: Windows_arm64 flutter_view_win_desktop__start_up
-    recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/134083
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "hostonly", "windows", "arm64"]
-      dependencies: >-
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      task_name: flutter_view_win_desktop__start_up
-
   - name: Windows platform_view_win_desktop__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -5252,20 +5210,6 @@ targets:
     properties:
       tags: >
         ["devicelab", "hostonly", "windows"]
-      dependencies: >-
-        [
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      task_name: platform_view_win_desktop__start_up
-
-  - name: Windows_arm64 platform_view_win_desktop__start_up
-    recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/134083
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "hostonly", "windows", "arm64"]
       dependencies: >-
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -5372,16 +5316,6 @@ targets:
     properties:
       tags: >
         ["devicelab", "hostonly", "windows"]
-      task_name: flutter_tool_startup
-
-  - name: Windows_arm64 flutter_tool_startup__windows
-    recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/134083
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "hostonly", "windows", "arm64"]
       task_name: flutter_tool_startup
 
   - name: Linux flutter_tool_startup__linux


### PR DESCRIPTION
Remove all Windows Arm64 benchmarks as they are incorrectly bucketed with the Windows x64 benchmarks, making us unable to catch performance regressions in Windows x64. See: https://github.com/flutter/flutter/issues/135722

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
