### PR TITLE
Add arch property for windows_arm64 platform

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -199,6 +199,7 @@ platform_properties:
       device_type: none
   windows_arm64:
     properties:
+      arch: arm64
       dependencies: >-
         [
           {"dependency": "certs", "version": "version:9563bb"}

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -199,6 +199,7 @@ platform_properties:
       device_type: none
   windows_arm64:
     properties:
+      # The arch can be removed after https://github.com/flutter/flutter/issues/135722.
       arch: arm64
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -200,7 +200,7 @@ platform_properties:
   windows_arm64:
     properties:
       # The arch can be removed after https://github.com/flutter/flutter/issues/135722.
-      arch: arm64
+      arch: arm
       dependencies: >-
         [
           {"dependency": "certs", "version": "version:9563bb"}


### PR DESCRIPTION
Window arm64 bots are using x64 built python, which gave incorrect arch info. This PR adds the arch info explicitly so that recipes can get this value and populate to benchmark tags.

Part of https://github.com/flutter/flutter/issues/135722