### PR TITLE
Update `Drawer` tests for M2/M3

### DIFF
--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -10,7 +10,7 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgetsWithLeakTracking('Drawer control test', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material2 - Drawer control test', (WidgetTester tester) async {
     const Key containerKey = Key('container');
 
     await tester.pumpWidget(
@@ -54,6 +54,54 @@ void main() {
     box = tester.renderObject(find.byKey(containerKey));
     expect(box.size.width, equals(drawerWidth - 2 * 16.0));
     expect(box.size.height, equals(drawerHeight - 2 * 16.0));
+
+    expect(find.text('header'), findsOneWidget);
+  });
+
+  testWidgetsWithLeakTracking('Material3 - Drawer control test', (WidgetTester tester) async {
+    const Key containerKey = Key('container');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: Scaffold(
+          drawer: Drawer(
+            child: ListView(
+              children: <Widget>[
+                DrawerHeader(
+                  child: Container(
+                    key: containerKey,
+                    child: const Text('header'),
+                  ),
+                ),
+                const ListTile(
+                  leading: Icon(Icons.archive),
+                  title: Text('Archive'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Archive'), findsNothing);
+    final ScaffoldState state = tester.firstState(find.byType(Scaffold));
+    state.openDrawer();
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Archive'), findsOneWidget);
+
+    RenderBox box = tester.renderObject(find.byType(DrawerHeader));
+    expect(box.size.height, equals(160.0 + 8.0 + 1.0)); // height + bottom margin + bottom edge
+
+    final double drawerWidth = box.size.width;
+    final double drawerHeight = box.size.height;
+
+    box = tester.renderObject(find.byKey(containerKey));
+    expect(box.size.width, equals(drawerWidth - 2 * 16.0));
+    expect(box.size.height, equals(drawerHeight - 2 * 16.0 - 1.0)); // Header divider thickness is 1.0 in Material 3.
 
     expect(find.text('header'), findsOneWidget);
   });
@@ -570,7 +618,7 @@ void main() {
     expect(box.size.width, equals(smallWidth));
   });
 
-  testWidgetsWithLeakTracking('Drawer default shape (ltr)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Drawer default shape (ltr)', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: true),
@@ -630,7 +678,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('Drawer default shape (rtl)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Drawer default shape (rtl)', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: true),
@@ -690,7 +738,7 @@ void main() {
     );
   });
 
-  testWidgetsWithLeakTracking('Drawer clip behavior', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Material3 - Drawer clip behavior', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: true),
@@ -746,7 +794,7 @@ void main() {
     // support is deprecated and the APIs are removed, these tests
     // can be deleted.
 
-    testWidgetsWithLeakTracking('Drawer default shape', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - Drawer default shape', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(useMaterial3: false),
@@ -787,7 +835,7 @@ void main() {
       expect(material.shape, null);
     });
 
-    testWidgetsWithLeakTracking('Drawer clip behavior', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Material2 - Drawer clip behavior', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(useMaterial3: false),


### PR DESCRIPTION
Updated unit tests for `Drawer` to have M2 and M3 versions.

More info in #127064

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
