### PR TITLE
Added `animationDuration` parameter to `showMenu` and `PopupMenuButton`.

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -809,6 +809,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     required this.capturedThemes,
     this.constraints,
     required this.clipBehavior,
+    this.animationDuration,
     super.settings,
   }) : itemSizes = List<Size?>.filled(items.length, null),
        // Menus always cycle focus through their items irrespective of the
@@ -828,6 +829,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   final CapturedThemes capturedThemes;
   final BoxConstraints? constraints;
   final Clip clipBehavior;
+  final Duration? animationDuration;
 
   @override
   Animation<double> createAnimation() {
@@ -839,7 +841,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   }
 
   @override
-  Duration get transitionDuration => _kMenuDuration;
+  Duration get transitionDuration => animationDuration ?? _kMenuDuration;
 
   @override
   bool get barrierDismissible => true;
@@ -947,6 +949,9 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 /// The `clipBehavior` argument is used to clip the shape of the menu. Defaults to
 /// [Clip.none].
 ///
+/// The `animationDuration` argument determines the duration of time it takes for the
+/// popup menu transition to complete. The default value is 300 ms.
+///
 /// See also:
 ///
 ///  * [PopupMenuItem], a popup menu entry for a single value.
@@ -971,6 +976,7 @@ Future<T?> showMenu<T>({
   BoxConstraints? constraints,
   Clip clipBehavior = Clip.none,
   RouteSettings? routeSettings,
+  Duration? animationDuration,
 }) {
   assert(items.isNotEmpty);
   assert(debugCheckHasMaterialLocalizations(context));
@@ -1002,6 +1008,7 @@ Future<T?> showMenu<T>({
     constraints: constraints,
     clipBehavior: clipBehavior,
     settings: routeSettings,
+    animationDuration: animationDuration,
   ));
 }
 
@@ -1122,6 +1129,7 @@ class PopupMenuButton<T> extends StatefulWidget {
     this.constraints,
     this.position,
     this.clipBehavior = Clip.none,
+    this.animationDuration,
   }) : assert(
          !(child != null && icon != null),
          'You can only pass [child] or [icon], not both.',
@@ -1279,6 +1287,10 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// over the button that was used to create it.
   final PopupMenuPosition? position;
 
+  /// Determines the duration of time it takes for the popup menu transition to
+  /// complete. The default value is 300 ms.
+  final Duration? animationDuration;
+
   /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// The [clipBehavior] argument is used the clip shape of the menu.
@@ -1342,6 +1354,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
         color: widget.color ?? popupMenuTheme.color,
         constraints: widget.constraints,
         clipBehavior: widget.clipBehavior,
+        animationDuration: widget.animationDuration,
       )
       .then<void>((T? newValue) {
         if (!mounted) {

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3785,6 +3785,117 @@ void main() {
     await tester.pumpAndSettle();
     expect(count, 1);
   });
+
+  testWidgetsWithLeakTracking('animationDuration works as expected in showMenu', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  key: buttonKey,
+                  child: const Text('Tap'),
+                  onPressed: () {
+                    showMenu(
+                      context: context,
+                      animationDuration: const Duration(milliseconds: 400),
+                      position: RelativeRect.fill,
+                      items: <PopupMenuItem<String>>[
+                        const PopupMenuItem<String>(
+                          child: Text('Item 0'),
+                        ),
+                        const PopupMenuItem<String>(
+                          child: Text('Item 1'),
+                        ),
+                      ]
+                    );
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      )
+    );
+
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Item 1'), findsNothing);
+
+    // Show the menu.
+    await tester.tap(find.byKey(buttonKey));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 1'), findsOneWidget);
+
+    // Close the menu.
+    await tester.tapAt(const Offset(20.0, 20.0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    // Items should be visible during the transition.
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 1'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 51));
+
+    // Menu should not be visible after 401 milliseconds.
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Item 1'), findsNothing);
+  });
+
+  testWidgetsWithLeakTracking('animationDuration works as expected in PopupMenuButton', (WidgetTester tester) async {
+    final Key popupMenuButtonKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              key: popupMenuButtonKey,
+              animationDuration: const Duration(milliseconds: 400),
+              itemBuilder: (BuildContext context) {
+                return <PopupMenuEntry<String>>[
+                   const PopupMenuItem<String>(
+                    child: Text('Item 0'),
+                  ),
+                  const PopupMenuItem<String>(
+                    child: Text('Item 1'),
+                  ),
+                ];
+              },
+            ),
+          ),
+        ),
+      )
+    );
+
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Item 1'), findsNothing);
+
+    // Show the menu.
+    await tester.tap(find.byKey(popupMenuButtonKey));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 1'), findsOneWidget);
+
+    // Close the menu.
+    await tester.tapAt(const Offset(20.0, 20.0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    // Items should be visible during the transition.
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 1'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 51));
+
+    // Menu should not be visible after 401 milliseconds.
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Item 1'), findsNothing);
+  });
 }
 
 class TestApp extends StatelessWidget {


### PR DESCRIPTION
*List which issues are fixed by this PR. You must list at least one issue.*
Fixes: #135638 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
