### PR TITLE
Fix a couple of CupertinoTextField tests to avoid leak-tracking test failures.

### DIFF
--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2485,13 +2485,11 @@ void main() {
       await gesture.up();
       await tester.pump();
       expect(find.byType(CupertinoButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(4));
+
+      // Skip the magnifier hide animation, so it can release resources.
+      await tester.pump(const Duration(milliseconds: 150));
     },
-    // TODO(derdilla): remove after fixing and leak track other failing tests in
-    // this file. https://github.com/flutter/flutter/issues/135803
-    leakTrackingTestConfig: const LeakTrackingTestConfig(notDisposedAllowList:
-    <String, int?>{'ValueNotifier<_OverlayEntryWidgetState?>': 1})
   );
-  //
 
   testWidgetsWithLeakTracking('Readonly text field does not have tap action', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
@@ -5816,7 +5814,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Can move cursor when dragging, when tap is on collapsed selection (iOS)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
     addTearDown(controller.dispose);
 
@@ -5860,11 +5858,17 @@ void main() {
 
     expect(controller.selection.isCollapsed, true);
     expect(controller.selection.baseOffset, testValue.indexOf('i'));
+
+    // End gesture and skip the magnifier hide animation, so it can release
+    // resources.
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('Can move cursor when dragging, when tap is on collapsed selection (iOS) - multiline', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Can move cursor when dragging, when tap is on collapsed selection (iOS) - multiline', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
     addTearDown(controller.dispose);
 
@@ -5909,6 +5913,12 @@ void main() {
 
     expect(controller.selection.isCollapsed, true);
     expect(controller.selection.baseOffset, testValue.indexOf('i'));
+
+    // End gesture and skip the magnifier hide animation, so it can release
+    // resources.
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
@@ -5990,7 +6000,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('Can move cursor when dragging (Android)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Can move cursor when dragging (Android)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController();
     addTearDown(controller.dispose);
 
@@ -6031,6 +6041,12 @@ void main() {
 
     expect(controller.selection.isCollapsed, true);
     expect(controller.selection.baseOffset, testValue.indexOf('g'));
+
+    // End gesture and skip the magnifier hide animation, so it can release
+    // resources.
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }),
   );


### PR DESCRIPTION
### Description
This PR fixes a couple of `CupertinoTextField` tests to avoid leak-tracking test failures.
Fixes: https://github.com/flutter/flutter/issues/135803.

It happened that `MagnifierController` awaits the hide animation before removing and disposing an `OverlayEntry`.
https://github.com/flutter/flutter/blob/57ed72417780ae7c6f371b33e30e62ba489b0a18/packages/flutter/lib/src/widgets/magnifier.dart#L283-L295

The duration of this animation in `CupertinoMagnifier` according to the source code is 150 milliseconds:
https://github.com/flutter/flutter/blob/57ed72417780ae7c6f371b33e30e62ba489b0a18/packages/flutter/lib/src/cupertino/magnifier.dart#L278

To fix leak-tracking test failures I added skips of the hide animation by pumping 150 milliseconds in failing tests. 

### Tests
- Updates `cupertino/text_field_test.dart` to fix leak-tracking test failures.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
