### PR TITLE
update asset manifest file name referenced in `WebServiceWorker`

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -311,7 +311,7 @@ Future<void> runWebServiceWorkerTest({
       'main.dart.js': 1,
       'flutter_service_worker.js': 1,
       'assets/FontManifest.json': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.ico'.
@@ -353,7 +353,7 @@ Future<void> runWebServiceWorkerTest({
         'flutter.js': 1,
       'flutter_service_worker.js': 2,
       'main.dart.js': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/FontManifest.json': 1,
       'CLOSE': 1,
       if (!headless)
@@ -383,7 +383,7 @@ Future<void> runWebServiceWorkerTest({
       'main.dart.js': 1,
       'assets/FontManifest.json': 1,
       'flutter_service_worker.js': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.ico'.
@@ -436,7 +436,7 @@ Future<void> runWebServiceWorkerTest({
         'flutter.js': 1,
       'flutter_service_worker.js': 2,
       'main.dart.js': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/FontManifest.json': 1,
       'CLOSE': 1,
       if (!headless)
@@ -541,7 +541,7 @@ Future<void> runWebServiceWorkerTestWithCachingResources({
       'main.dart.js': 1,
       'flutter_service_worker.js': 1,
       'assets/FontManifest.json': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.ico'.
       if (!headless)
@@ -600,7 +600,7 @@ Future<void> runWebServiceWorkerTestWithCachingResources({
       'main.dart.js': 1,
       'flutter_service_worker.js': 2,
       'assets/FontManifest.json': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.ico'.
       if (!headless)
@@ -777,7 +777,7 @@ Future<void> runWebServiceWorkerTestWithCustomServiceWorkerVersion({
       'CLOSE': 1,
       'flutter_service_worker.js': 1,
       'assets/FontManifest.json': 1,
-      'assets/AssetManifest.json': 1,
+      'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.ico'.
       if (!headless)

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -605,7 +605,7 @@ class WebServiceWorker extends Target {
         'main.dart.js',
         'index.html',
         if (urlToHash.containsKey('assets/AssetManifest.bin.json'))
-          'assets/AssetManifest.json',
+          'assets/AssetManifest.bin.json',
         if (urlToHash.containsKey('assets/FontManifest.json'))
           'assets/FontManifest.json',
       ],

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -604,7 +604,7 @@ class WebServiceWorker extends Target {
       <String>[
         'main.dart.js',
         'index.html',
-        if (urlToHash.containsKey('assets/AssetManifest.json'))
+        if (urlToHash.containsKey('assets/AssetManifest.bin.json'))
           'assets/AssetManifest.json',
         if (urlToHash.containsKey('assets/FontManifest.json'))
           'assets/FontManifest.json',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -191,7 +191,7 @@ void main() {
     expect(environment.outputDir.childFile('main.dart.js')
       .existsSync(), true);
     expect(environment.outputDir.childDirectory('assets')
-      .childFile('AssetManifest.json').existsSync(), true);
+      .childFile('AssetManifest.bin.json').existsSync(), true);
 
     // Update to arbitrary resource file triggers rebuild.
     webResources.childFile('foo.txt').writeAsStringSync('B');


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/130455.

Updates the name `WebServiceWorker` uses to reference the asset manifest file to the name of the new file generated since   https://github.com/flutter/flutter/pull/131382. This will make Flutter web apps correctly prefetch the asset manifest file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
