### PR TITLE
Fix `FlexibleSpaceBar` does compositing with near zero opacity.

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -468,7 +468,7 @@ class _RenderFlexibleSpaceHeaderOpacity extends RenderOpacity {
     if (child == null) {
       return;
     }
-    if (opacity == 0 || !needsCompositing) {
+    if ((opacity * 255).roundToDouble() <= 0) {
       layer = null;
       return;
     }

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -468,7 +468,7 @@ class _RenderFlexibleSpaceHeaderOpacity extends RenderOpacity {
     if (child == null) {
       return;
     }
-    if (opacity == 0) {
+    if (opacity == 0 || !needsCompositing) {
       layer = null;
       return;
     }


### PR DESCRIPTION
fixes [`flexible_space_bar.dart': Failed assertion: line 475 pos 12: 'needsCompositing': is not true.` is thrown when scrolling down in the list and then up](https://github.com/flutter/flutter/issues/135698) 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
