### PR TITLE
Delete simulator after plugin_test_ios

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -263,17 +263,23 @@ public class $pluginClass: NSObject, FlutterPlugin {
           throw TaskResult.failure('Platform unit tests failed');
         }
       case 'ios':
-        await testWithNewIOSSimulator('TestNativeUnitTests', (String deviceId) async {
-          if (!await runXcodeTests(
-            platformDirectory: path.join(rootPath, 'ios'),
-            destination: 'id=$deviceId',
-            configuration: 'Debug',
-            testName: 'native_plugin_unit_tests_ios',
-            skipCodesign: true,
-          )) {
-            throw TaskResult.failure('Platform unit tests failed');
-          }
-        });
+        String? simulatorDeviceId;
+        try {
+          await testWithNewIOSSimulator('TestNativeUnitTests', (String deviceId) async {
+            simulatorDeviceId = deviceId;
+            if (!await runXcodeTests(
+              platformDirectory: path.join(rootPath, 'ios'),
+              destination: 'id=$deviceId',
+              configuration: 'Debug',
+              testName: 'native_plugin_unit_tests_ios',
+              skipCodesign: true,
+            )) {
+              throw TaskResult.failure('Platform unit tests failed');
+            }
+          });
+        } finally {
+          await removeIOSimulator(simulatorDeviceId);
+        }
       case 'linux':
         if (await exec(
           path.join(rootPath, 'build', 'linux', 'x64', 'release', 'plugins', 'plugintest', 'plugintest_test'),


### PR DESCRIPTION
Remove simulator once it's no longer needed for test `plugin_test_ios` .

Fixes https://github.com/flutter/flutter/issues/136224

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
