### PR TITLE
extend timeout from default 30 min to 1 hour for windows build tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -234,7 +234,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      test_timeout_secs: "3600"
+      test_timeout_secs: "3600" # 1 hour
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -4481,6 +4481,7 @@ targets:
       subshard: "1_5"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "3600" # 1 hour
 
   - name: Windows build_tests_2_5
     recipe: flutter/flutter_drone
@@ -4499,6 +4500,7 @@ targets:
       subshard: "2_5"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "3600" # 1 hour
 
   - name: Windows build_tests_3_5
     recipe: flutter/flutter_drone
@@ -4517,6 +4519,7 @@ targets:
       subshard: "3_5"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "3600" # 1 hour
 
   - name: Windows build_tests_4_5
     recipe: flutter/flutter_drone
@@ -4535,6 +4538,7 @@ targets:
       subshard: "4_5"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "3600" # 1 hour
 
   - name: Windows build_tests_5_5
     recipe: flutter/flutter_drone
@@ -4553,6 +4557,7 @@ targets:
       subshard: "5_5"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
+      test_timeout_secs: "3600" # 1 hour
 
   - name: Windows customer_testing
     enabled_branches:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/136299