### PR TITLE
Floating `SnackBar` should always float above the bottom widgets

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1165,7 +1165,11 @@ class _ScaffoldLayout extends MultiChildLayoutDelegate {
         FloatingActionButtonLocation() => true,
       };
       if (floatingActionButtonRect.size != Size.zero && isSnackBarFloating && showAboveFab) {
-        snackBarYOffsetBase = floatingActionButtonRect.top;
+        if (bottomNavigationBarTop != null) {
+          snackBarYOffsetBase = math.min(bottomNavigationBarTop, floatingActionButtonRect.top);
+        } else {
+          snackBarYOffsetBase = floatingActionButtonRect.top;
+        }
       } else {
         // SnackBarBehavior.fixed applies a SafeArea automatically.
         // SnackBarBehavior.floating does not since the positioning is affected

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2262,6 +2262,44 @@ void main() {
       },
     );
 
+    testWidgetsWithLeakTracking(
+      '${SnackBarBehavior.floating} should align SnackBar with the top of Scaffold '
+          'when Scaffold has both BottomNavigationBar and FloatingActionButton and '
+          'BottomNavigationBar.top is higher than FloatingActionButton.top',
+          (WidgetTester tester) async {
+        final UniqueKey boxKey = UniqueKey();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Container(),
+              bottomNavigationBar: SizedBox(key: boxKey, width: 800, height: 200),
+              floatingActionButton: FloatingActionButton(onPressed: () {}),
+              floatingActionButtonLocation: FloatingActionButtonLocation.endContained,
+            ),
+          ),
+        );
+
+        final ScaffoldMessengerState scaffoldMessengerState = tester.state(find.byType(ScaffoldMessenger));
+        scaffoldMessengerState.showSnackBar(
+          const SnackBar(
+            content: Text('SnackBar text'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+
+        await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+        final Offset snackBarBottomRight = tester.getBottomRight(find.byType(SnackBar));
+        final Offset fabTopRight = tester.getTopRight(find.byType(FloatingActionButton));
+        final Offset navBarTopRight = tester.getTopRight(find.byKey(boxKey));
+
+        // Test the top of the navigation bar is higher than the top of the floating action button.
+        expect(fabTopRight.dy, greaterThan(navBarTopRight.dy));
+
+        expect(snackBarBottomRight.dy, equals(navBarTopRight.dy));
+      },
+    );
+
     Future<void> openFloatingSnackBar(WidgetTester tester) async {
       final ScaffoldMessengerState scaffoldMessengerState = tester.state(find.byType(ScaffoldMessenger));
       scaffoldMessengerState.showSnackBar(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2263,7 +2263,7 @@ void main() {
     );
 
     testWidgetsWithLeakTracking(
-      '${SnackBarBehavior.floating} should align SnackBar with the top of Scaffold '
+      '${SnackBarBehavior.floating} should align SnackBar with the top of BottomNavigationBar '
           'when Scaffold has both BottomNavigationBar and FloatingActionButton and '
           'BottomNavigationBar.top is higher than FloatingActionButton.top',
           (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #136162

This PR is to fix the floating `SnackBar` issue so that when the top of the bottom bar is higher than the top of the FAB, the snack bar will still float and not be clipped.

| Before fix | After fix |
|--------|--------|
| ![Screenshot 2023-10-11 at 1 54 30 PM](https://github.com/flutter/flutter/assets/36861262/dbe02312-1a80-4532-9bad-a8f162a6a942) | ![Screenshot 2023-10-11 at 1 54 52 PM](https://github.com/flutter/flutter/assets/36861262/68211de0-f04f-4b1a-b554-baf6a8e2f947)
 | 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
