### PR TITLE
Allow `onWillAcceptWithDetails` and `onAcceptWithDetails` callbacks in `DragTarget` to accept null in `data` field.

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -24,7 +24,7 @@ typedef DragTargetWillAccept<T> = bool Function(T? data);
 /// based on provided information.
 ///
 /// Used by [DragTarget.onWillAcceptWithDetails].
-typedef DragTargetWillAcceptWithDetails<T> = bool Function(DragTargetDetails<T> details);
+typedef DragTargetWillAcceptWithDetails<T> = bool Function(DragTargetDetails<T>? details);
 
 /// Signature for causing a [DragTarget] to accept the given data.
 ///
@@ -34,7 +34,7 @@ typedef DragTargetAccept<T> = void Function(T data);
 /// Signature for determining information about the acceptance by a [DragTarget].
 ///
 /// Used by [DragTarget.onAcceptWithDetails].
-typedef DragTargetAcceptWithDetails<T> = void Function(DragTargetDetails<T> details);
+typedef DragTargetAcceptWithDetails<T> = void Function(DragTargetDetails<T>? details);
 
 /// Signature for building children of a [DragTarget].
 ///
@@ -645,6 +645,8 @@ class DragTarget<T extends Object> extends StatefulWidget {
   /// either [onAccept] and [onAcceptWithDetails], if the data is dropped, or
   /// [onLeave], if the drag leaves the target.
   ///
+  /// Called with `null` details, if [Draggable.data] is null.
+  ///
   /// Equivalent to [onWillAccept], but with information, including the data,
   /// in a [DragTargetDetails].
   ///
@@ -657,6 +659,8 @@ class DragTarget<T extends Object> extends StatefulWidget {
   final DragTargetAccept<T>? onAccept;
 
   /// Called when an acceptable piece of data was dropped over this drag target.
+  ///
+  /// Called with `null` details, if [Draggable.data] is null.
   ///
   /// Equivalent to [onAccept], but with information, including the data, in a
   /// [DragTargetDetails].
@@ -707,7 +711,7 @@ class _DragTargetState<T extends Object> extends State<DragTarget<T>> {
                                     (widget.onWillAccept != null &&
                                     widget.onWillAccept!(avatar.data as T?)) ||
                                     (widget.onWillAcceptWithDetails != null &&
-                                    widget.onWillAcceptWithDetails!(DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset!)));
+                                    widget.onWillAcceptWithDetails!(avatar.data == null ? null : DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset!)));
     if (resolvedWillAccept) {
       setState(() {
         _candidateAvatars.add(avatar);
@@ -742,7 +746,7 @@ class _DragTargetState<T extends Object> extends State<DragTarget<T>> {
       _candidateAvatars.remove(avatar);
     });
     widget.onAccept?.call(avatar.data! as T);
-    widget.onAcceptWithDetails?.call(DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset!));
+    widget.onAcceptWithDetails?.call(avatar.data == null ? null : DragTargetDetails<T>(data: avatar.data! as T, offset: avatar._lastOffset!));
   }
 
   void didMove(_DragAvatar<Object> avatar) {

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -21,7 +21,7 @@ import 'semantics_tester.dart';
 void main() {
   testWidgetsWithLeakTracking('Drag and drop - control test', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     int dragStartedCount = 0;
     int moveCount = 0;
 
@@ -85,7 +85,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -425,7 +425,7 @@ void main() {
                 onAccept: (int? data) {
                   events.add('drop');
                 },
-                onAcceptWithDetails: (DragTargetDetails<int> _) {
+                onAcceptWithDetails: (DragTargetDetails<int>? _) {
                   events.add('details');
                 },
               ),
@@ -513,7 +513,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -564,7 +564,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -613,7 +613,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -660,7 +660,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop $data');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -771,7 +771,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop $data');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -881,7 +881,7 @@ void main() {
               onAccept: (int? data) {
                 events.add('drop $data');
               },
-              onAcceptWithDetails: (DragTargetDetails<int> _) {
+              onAcceptWithDetails: (DragTargetDetails<int>? _) {
                 events.add('details');
               },
             ),
@@ -1151,7 +1151,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDraggableCanceled not called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDraggableCanceledCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1210,7 +1210,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1219,7 +1219,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDraggableCanceled called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDraggableCanceledCalled = false;
     late Velocity onDraggableCanceledVelocity;
     late Offset onDraggableCanceledOffset;
@@ -1296,7 +1296,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDraggableCanceled called if dropped on non-accepting target with details', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDraggableCanceledCalled = false;
     late Velocity onDraggableCanceledVelocity;
     late Offset onDraggableCanceledOffset;
@@ -1321,7 +1321,7 @@ void main() {
                 child: Text('Target'),
               );
             },
-            onWillAcceptWithDetails: (DragTargetDetails<int> details) => false,
+            onWillAcceptWithDetails: (DragTargetDetails<int>? details) => false,
             onAccept: accepted.add,
             onAcceptWithDetails: acceptedDetails.add,
           ),
@@ -1373,7 +1373,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDraggableCanceled called if dropped on non-accepting target with correct velocity', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDraggableCanceledCalled = false;
     late Velocity onDraggableCanceledVelocity;
     late Offset onDraggableCanceledOffset;
@@ -1425,7 +1425,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDragEnd not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragEndCalled = false;
     late DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -1501,7 +1501,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDragEnd not called if dropped on non-accepting target with details', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragEndCalled = false;
     late DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -1520,7 +1520,7 @@ void main() {
             builder: (BuildContext context, List<int?> data, List<dynamic> rejects) {
               return const SizedBox(height: 100.0, child: Text('Target'));
             },
-            onWillAcceptWithDetails: (DragTargetDetails<int> data) => false,
+            onWillAcceptWithDetails: (DragTargetDetails<int>? data) => false,
             onAccept: accepted.add,
             onAcceptWithDetails: acceptedDetails.add,
           ),
@@ -1713,7 +1713,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDragCompleted not called if dropped on non-accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1784,7 +1784,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDragCompleted not called if dropped on non-accepting target with details', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -1805,7 +1805,7 @@ void main() {
                 child: Text('Target'),
               );
             },
-            onWillAcceptWithDetails: (DragTargetDetails<int> data) => false,
+            onWillAcceptWithDetails: (DragTargetDetails<int>? data) => false,
             onAccept: accepted.add,
             onAcceptWithDetails: acceptedDetails.add,
           ),
@@ -1855,7 +1855,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDragEnd called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragEndCalled = false;
     late DraggableDetails onDragEndDraggableDetails;
     await tester.pumpWidget(MaterialApp(
@@ -1918,7 +1918,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -1951,7 +1951,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -1997,7 +1997,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - onDragCompleted called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -2056,7 +2056,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2065,9 +2065,9 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - allow pass through of unaccepted data test', (WidgetTester tester) async {
     final List<int> acceptedInts = <int>[];
-    final List<DragTargetDetails<int>> acceptedIntsDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedIntsDetails = <DragTargetDetails<int>?>[];
     final List<double> acceptedDoubles = <double>[];
-    final List<DragTargetDetails<double>> acceptedDoublesDetails = <DragTargetDetails<double>>[];
+    final List<DragTargetDetails<double>?> acceptedDoublesDetails = <DragTargetDetails<double>?>[];
 
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -2157,7 +2157,7 @@ void main() {
     expect(acceptedIntsDetails, isEmpty);
     expect(acceptedDoubles, equals(<double>[1.0]));
     expect(acceptedDoublesDetails, hasLength(1));
-    expect(acceptedDoublesDetails.first.offset, const Offset(112.0, 122.0));
+    expect(acceptedDoublesDetails.first!.offset, const Offset(112.0, 122.0));
     expect(find.text('IntDragging'), findsNothing);
     expect(find.text('DoubleDragging'), findsNothing);
 
@@ -2190,7 +2190,7 @@ void main() {
 
     expect(acceptedInts, equals(<int>[1]));
     expect(acceptedIntsDetails, hasLength(1));
-    expect(acceptedIntsDetails.first.offset, const Offset(184.0, 122.0));
+    expect(acceptedIntsDetails.first!.offset, const Offset(184.0, 122.0));
     expect(acceptedDoubles, isEmpty);
     expect(acceptedDoublesDetails, isEmpty);
     expect(find.text('IntDragging'), findsNothing);
@@ -2199,9 +2199,9 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - allow pass through of unaccepted data twice test', (WidgetTester tester) async {
     final List<DragTargetData> acceptedDragTargetDatas = <DragTargetData>[];
-    final List<DragTargetDetails<DragTargetData>> acceptedDragTargetDataDetails = <DragTargetDetails<DragTargetData>>[];
+    final List<DragTargetDetails<DragTargetData>?> acceptedDragTargetDataDetails = <DragTargetDetails<DragTargetData>?>[];
     final List<ExtendedDragTargetData> acceptedExtendedDragTargetDatas = <ExtendedDragTargetData>[];
-    final List<DragTargetDetails<ExtendedDragTargetData>> acceptedExtendedDragTargetDataDetails = <DragTargetDetails<ExtendedDragTargetData>>[];
+    final List<DragTargetDetails<ExtendedDragTargetData>?> acceptedExtendedDragTargetDataDetails = <DragTargetDetails<ExtendedDragTargetData>?>[];
     final DragTargetData dragTargetData = DragTargetData();
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -2255,7 +2255,7 @@ void main() {
 
       expect(acceptedDragTargetDatas, equals(<DragTargetData>[dragTargetData]));
       expect(acceptedDragTargetDataDetails, hasLength(1));
-      expect(acceptedDragTargetDataDetails.first.offset, const Offset(256.0, 74.0));
+      expect(acceptedDragTargetDataDetails.first!.offset, const Offset(256.0, 74.0));
       expect(acceptedExtendedDragTargetDatas, isEmpty);
       expect(acceptedExtendedDragTargetDataDetails, isEmpty);
 
@@ -2267,7 +2267,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - maxSimultaneousDrags', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
 
     Widget build(int maxSimultaneousDrags) {
       return MaterialApp(
@@ -2364,7 +2364,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsOneWidget);
     expect(find.text('Target'), findsOneWidget);
@@ -2374,8 +2374,8 @@ void main() {
 
     expect(accepted, equals(<int>[1, 1]));
     expect(acceptedDetails, hasLength(2));
-    expect(acceptedDetails[0].offset, const Offset(256.0, 74.0));
-    expect(acceptedDetails[1].offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails[0]!.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails[1]!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2385,8 +2385,8 @@ void main() {
 
     expect(accepted, equals(<int>[1, 1]));
     expect(acceptedDetails, hasLength(2));
-    expect(acceptedDetails[0].offset, const Offset(256.0, 74.0));
-    expect(acceptedDetails[1].offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails[0]!.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails[1]!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2490,7 +2490,7 @@ void main() {
             onAccept: (int? data) {
               events.add('drop');
             },
-            onAcceptWithDetails: (DragTargetDetails<int> _) {
+            onAcceptWithDetails: (DragTargetDetails<int>? _) {
               events.add('details');
             },
           ),
@@ -2535,7 +2535,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Drag and drop - remove draggable', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
 
     await tester.pumpWidget(MaterialApp(
       home: Column(
@@ -2607,7 +2607,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 26.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 26.0));
     expect(find.text('Source'), findsNothing);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2639,7 +2639,7 @@ void main() {
 
   testWidgetsWithLeakTracking('long-press draggable calls onDragEnd called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragEndCalled = false;
     late DraggableDetails onDragEndDraggableDetails;
 
@@ -2713,7 +2713,7 @@ void main() {
 
     expect(accepted, equals(<int>[1]));
     expect(acceptedDetails, hasLength(1));
-    expect(acceptedDetails.first.offset, expectedDropOffset);
+    expect(acceptedDetails.first!.offset, expectedDropOffset);
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -2726,7 +2726,7 @@ void main() {
 
   testWidgetsWithLeakTracking('long-press draggable calls onDragCompleted called if dropped on accepting target', (WidgetTester tester) async {
     final List<int> accepted = <int>[];
-    final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+    final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
     bool onDragCompletedCalled = false;
 
     await tester.pumpWidget(MaterialApp(
@@ -2793,7 +2793,7 @@ void main() {
     await tester.pump();
 
     expect(accepted, equals(<int>[1]));
-    expect(acceptedDetails.first.offset, const Offset(256.0, 74.0));
+    expect(acceptedDetails.first!.offset, const Offset(256.0, 74.0));
     expect(find.text('Source'), findsOneWidget);
     expect(find.text('Dragging'), findsNothing);
     expect(find.text('Target'), findsOneWidget);
@@ -3492,9 +3492,88 @@ void main() {
         return const SizedBox(height: 100.0, child: Text('Target'));
       },
       onWillAccept: (int? data) => true,
-      onWillAcceptWithDetails: (DragTargetDetails<int> details) => false,
+      onWillAcceptWithDetails: (DragTargetDetails<int>? details) => false,
     ), throwsAssertionError);
  });
+
+  testWidgetsWithLeakTracking('DragTarget onAcceptWithDetails does not throw error when data is null', (WidgetTester tester) async {
+    bool isOnAcceptWithDetailsCalled = false;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Column(
+        children: <Widget>[
+          const Draggable<int>(
+            feedback: Text('Dragging'),
+            child: Text('Source'),
+          ),
+          DragTarget<int>(
+            builder: (BuildContext context, List<int?> data, List<dynamic> rejects) {
+              return const SizedBox(height: 100.0, child: Text('Target'));
+            },
+            onAcceptWithDetails: (DragTargetDetails<int>? details) {
+              isOnAcceptWithDetailsCalled = true;
+            },
+          ),
+        ],
+      ),
+    ));
+
+    expect(find.text('Source'), findsOneWidget);
+    expect(find.text('Dragging'), findsNothing);
+    expect(find.text('Target'), findsOneWidget);
+
+    final Offset firstLocation = tester.getCenter(find.text('Source'));
+    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+
+    final Offset secondLocation = tester.getCenter(find.text('Target'));
+    await gesture.moveTo(secondLocation);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(isOnAcceptWithDetailsCalled, isTrue);
+  });
+
+  testWidgetsWithLeakTracking('DragTarget onWillAcceptWithDetails does not throw error when data is null', (WidgetTester tester) async {
+    bool isOnWillAcceptWithDetailsCalled = false;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Column(
+        children: <Widget>[
+          const Draggable<int>(
+            feedback: Text('Dragging'),
+            child: Text('Source'),
+          ),
+          DragTarget<int>(
+            builder: (BuildContext context, List<int?> data, List<dynamic> rejects) {
+              return const SizedBox(height: 100.0, child: Text('Target'));
+            },
+            onWillAcceptWithDetails: (DragTargetDetails<int>? details) {
+              isOnWillAcceptWithDetailsCalled = true;
+              return true;
+            },
+          ),
+        ],
+      ),
+    ));
+
+    expect(find.text('Source'), findsOneWidget);
+    expect(find.text('Dragging'), findsNothing);
+    expect(find.text('Target'), findsOneWidget);
+
+    final Offset firstLocation = tester.getCenter(find.text('Source'));
+    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+
+    final Offset secondLocation = tester.getCenter(find.text('Target'));
+    await gesture.moveTo(secondLocation);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(isOnWillAcceptWithDetailsCalled, isTrue);
+  });
 }
 
 Future<void> _testLongPressDraggableHapticFeedback({ required WidgetTester tester, required bool hapticFeedbackOnStart, required int expectedHapticFeedbackCount }) async {
@@ -3546,7 +3625,7 @@ Future<void> _testLongPressDraggableHapticFeedback({ required WidgetTester teste
 
 Future<void> _testChildAnchorFeedbackPosition({ required WidgetTester tester, double top = 0.0, double left = 0.0 }) async {
   final List<int> accepted = <int>[];
-  final List<DragTargetDetails<int>> acceptedDetails = <DragTargetDetails<int>>[];
+  final List<DragTargetDetails<int>?> acceptedDetails = <DragTargetDetails<int>?>[];
   int dragStartedCount = 0;
 
   await tester.pumpWidget(


### PR DESCRIPTION
*List which issues are fixed by this PR. You must list at least one issue.*

Fixes: #136412

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
