### PR TITLE
Change some tests to run on macs without iOS devices attached

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2947,7 +2947,7 @@ targets:
 
   - name: Mac_arm64 build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -3330,7 +3330,7 @@ targets:
 
   - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -3401,7 +3401,7 @@ targets:
 
   - name: Mac_arm64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -3981,7 +3981,7 @@ targets:
 
   - name: Mac_x64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -3997,7 +3997,7 @@ targets:
 
   - name: Mac_arm64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -4142,7 +4142,7 @@ targets:
 
   - name: Mac_x64 macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -4153,13 +4153,17 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: macos_chrome_dev_mode
 
-  - name: Mac_arm64_ios macos_chrome_dev_mode
+  - name: Mac_arm64 macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: macos_chrome_dev_mode
 
   - name: Mac_ios microbenchmarks_ios
@@ -4188,7 +4192,7 @@ targets:
 
   - name: Mac native_assets_ios_simulator
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -4336,7 +4340,7 @@ targets:
 
   - name: Mac_x64 hot_mode_dev_cycle_ios_simulator
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -4465,7 +4469,7 @@ targets:
 
   - name: Mac_arm64 run_debug_test_macos
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -4501,7 +4505,7 @@ targets:
 
   - name: Mac_arm64 run_release_test_macos
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2945,13 +2945,17 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_arm64_ios build_ios_framework_module_test
+  - name: Mac_arm64 build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: build_ios_framework_module_test
     runIf:
       - dev/**
@@ -3324,13 +3328,17 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_arm64_ios module_test_ios
+  - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: module_test_ios
     runIf:
       - dev/**
@@ -3391,13 +3399,17 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_arm64_ios plugin_lint_mac
+  - name: Mac_arm64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: plugin_lint_mac
     runIf:
       - dev/**
@@ -3967,24 +3979,33 @@ targets:
         ["devicelab", "ios", "mac", "arm64"]
       task_name: hello_world_ios__compile
 
-  - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
+  - name: Mac_x64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - dev/**
       - .ci.yaml
 
-  - name: Mac_arm64_ios hot_mode_dev_cycle_macos_target__benchmark
+  - name: Mac_arm64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - dev/**
@@ -4119,13 +4140,17 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: large_image_changer_perf_ios
 
-  - name: Mac_ios macos_chrome_dev_mode
+  - name: Mac_x64 macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: macos_chrome_dev_mode
 
   - name: Mac_arm64_ios macos_chrome_dev_mode
@@ -4161,13 +4186,17 @@ targets:
         }
     bringup: true
 
-  - name: Mac_ios native_assets_ios_simulator
+  - name: Mac native_assets_ios_simulator
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: native_assets_ios_simulator
 
   - name: Mac_ios native_assets_ios
@@ -4305,13 +4334,17 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
 
-  - name: Mac_ios hot_mode_dev_cycle_ios_simulator
+  - name: Mac_x64 hot_mode_dev_cycle_ios_simulator
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly", "mac"]
       task_name: hot_mode_dev_cycle_ios_simulator
 
   - name: Mac_ios fullscreen_textfield_perf_ios__e2e_summary
@@ -4430,12 +4463,17 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_arm64_ios run_debug_test_macos
+  - name: Mac_arm64 run_debug_test_macos
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: run_debug_test_macos
     runIf:
       - dev/**
@@ -4461,13 +4499,17 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_arm64_ios run_release_test_macos
+  - name: Mac_arm64 run_release_test_macos
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       tags: >
-        ["devicelab", "ios", "mac", "arm64"]
+        ["devicelab", "hostonly", "mac", "arm64"]
       task_name: run_release_test_macos
     runIf:
       - dev/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3328,17 +3328,13 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_arm64 module_test_ios
+  - name: Mac_arm64_ios module_test_ios # Must be run on devicelab bot for codesigning https://github.com/flutter/flutter/issues/112033
     recipe: devicelab/devicelab_drone
-    bringup: true
+    presubmit: false
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
       tags: >
-        ["devicelab", "hostonly", "mac", "arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: module_test_ios
     runIf:
       - dev/**


### PR DESCRIPTION
Some tests have been running on devicelab bots with iOS devices attached, however, they don't require an iOS device. So moving them to run on bots without iOS devices.

Fixes https://github.com/flutter/flutter/issues/136415.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
