### PR TITLE
increase windows build test sharding, revert timeout 30 mins

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4517,7 +4517,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Windows build_tests_1_5
+  - name: Windows build_tests_1_6
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4531,12 +4531,11 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
       shard: build_tests
-      subshard: "1_5"
+      subshard: "1_6"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "3600" # 1 hour
 
-  - name: Windows build_tests_2_5
+  - name: Windows build_tests_2_6
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4550,12 +4549,11 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
       shard: build_tests
-      subshard: "2_5"
+      subshard: "2_6"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "3600" # 1 hour
 
-  - name: Windows build_tests_3_5
+  - name: Windows build_tests_3_6
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4569,12 +4567,11 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
       shard: build_tests
-      subshard: "3_5"
+      subshard: "3_6"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "3600" # 1 hour
 
-  - name: Windows build_tests_4_5
+  - name: Windows build_tests_4_6
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4588,12 +4585,11 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
       shard: build_tests
-      subshard: "4_5"
+      subshard: "4_6"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "3600" # 1 hour
 
-  - name: Windows build_tests_5_5
+  - name: Windows build_tests_5_6
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4607,10 +4603,27 @@ targets:
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
       shard: build_tests
-      subshard: "5_5"
+      subshard: "5_6"
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      test_timeout_secs: "3600" # 1 hour
+
+  - name: Windows build_tests_6_6
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:33v6"},
+          {"dependency": "chrome_and_driver", "version": "version:118.0.5993.70"},
+          {"dependency": "open_jdk", "version": "version:17"},
+          {"dependency": "goldctl", "version": "git_revision:f808dcff91b221ae313e540c09d79696cd08b8de"},
+          {"dependency": "vs_build", "version": "version:vs2019"}
+        ]
+      shard: build_tests
+      subshard: "6_6"
+      tags: >
+        ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows customer_testing
     enabled_branches:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4520,6 +4520,7 @@ targets:
   - name: Windows build_tests_1_6
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4538,6 +4539,7 @@ targets:
   - name: Windows build_tests_2_6
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4556,6 +4558,7 @@ targets:
   - name: Windows build_tests_3_6
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4574,6 +4577,7 @@ targets:
   - name: Windows build_tests_4_6
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4592,6 +4596,7 @@ targets:
   - name: Windows build_tests_5_6
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-
@@ -4610,6 +4615,7 @@ targets:
   - name: Windows build_tests_6_6
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       add_recipes_cq: "true"
       dependencies: >-


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/136300 I increased the timeout. This is a revert of that, which also adds an additional shard.