### PR TITLE
Test cover cupertino for memory leaks tracking -2 

### DIFF
--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -59,7 +59,7 @@ void main() {
     expect(tester.getCenter(find.text('Page 2')).dx, 400.0);
   });
 
-  testWidgets('Opaque background does not add blur effects, non-opaque background adds blur effects', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('Opaque background does not add blur effects, non-opaque background adds blur effects', (WidgetTester tester) async {
     const CupertinoDynamicColor background = CupertinoDynamicColor.withBrightness(
       color: Color(0xFFE5E5E5),
       darkColor: Color(0xF3E5E5E5),

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -56,7 +56,7 @@ void main() {
     expect(tester.getRect(find.byType(Container)), const Rect.fromLTRB(0, 44, 800, 600));
   });
 
-  testWidgets('dark mode and obstruction work', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('dark mode and obstruction work', (WidgetTester tester) async {
     const Color dynamicColor = CupertinoDynamicColor.withBrightness(
       color: Color(0xFFF8F8F8),
       darkColor: Color(0xEE333333),

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../widgets/clipboard_utils.dart';
 import '../widgets/editable_text_utils.dart' show findRenderEditable, textOffsetToPosition;
@@ -94,11 +95,15 @@ void main() {
     }) {
       final TextEditingController controller = TextEditingController(text: text)
         ..selection = selection ?? const TextSelection.collapsed(offset: -1);
+      addTearDown(controller.dispose);
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
       return CupertinoApp(
         home: EditableText(
           key: key,
           controller: controller,
-          focusNode: FocusNode(),
+          focusNode: focusNode,
           style: const TextStyle(),
           cursorColor: const Color.fromARGB(0, 0, 0, 0),
           backgroundCursorColor: const Color.fromARGB(0, 0, 0, 0),
@@ -106,13 +111,13 @@ void main() {
       );
     }
 
-    testWidgets('should return false when there is no text', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('should return false when there is no text', (WidgetTester tester) async {
       final GlobalKey<EditableTextState> key = GlobalKey();
       await tester.pumpWidget(createEditableText(key: key));
       expect(cupertinoTextSelectionControls.canSelectAll(key.currentState!), false);
     });
 
-    testWidgets('should return true when there is text and collapsed selection', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('should return true when there is text and collapsed selection', (WidgetTester tester) async {
       final GlobalKey<EditableTextState> key = GlobalKey();
       await tester.pumpWidget(createEditableText(
         key: key,
@@ -121,7 +126,7 @@ void main() {
       expect(cupertinoTextSelectionControls.canSelectAll(key.currentState!), true);
     });
 
-    testWidgets('should return false when there is text and partial uncollapsed selection', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('should return false when there is text and partial uncollapsed selection', (WidgetTester tester) async {
       final GlobalKey<EditableTextState> key = GlobalKey();
       await tester.pumpWidget(createEditableText(
         key: key,
@@ -131,7 +136,7 @@ void main() {
       expect(cupertinoTextSelectionControls.canSelectAll(key.currentState!), false);
     });
 
-    testWidgets('should return false when there is text and full selection', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('should return false when there is text and full selection', (WidgetTester tester) async {
       final GlobalKey<EditableTextState> key = GlobalKey();
       await tester.pumpWidget(createEditableText(
         key: key,
@@ -143,7 +148,7 @@ void main() {
   });
 
   group('cupertino handles', () {
-    testWidgets('draws transparent handle correctly', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('draws transparent handle correctly', (WidgetTester tester) async {
       await tester.pumpWidget(RepaintBoundary(
         child: CupertinoTheme(
           data: const CupertinoThemeData(
@@ -191,8 +196,9 @@ void main() {
       '${widget.painter?.runtimeType}' == '_LeftCupertinoChevronPainter',
     );
 
-    testWidgets('All menu items show when they fit.', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('All menu items show when they fit.', (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
       await tester.pumpWidget(CupertinoApp(
         home: Directionality(
             textDirection: TextDirection.ltr,
@@ -248,12 +254,13 @@ void main() {
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
-    testWidgets("When a menu item doesn't fit, a second page is used.", (WidgetTester tester) async {
+    testWidgetsWithLeakTracking("When a menu item doesn't fit, a second page is used.", (WidgetTester tester) async {
       // Set the screen size to more narrow, so that Paste can't fit.
       tester.view.physicalSize = const Size(1000, 800);
       addTearDown(tester.view.reset);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
       await tester.pumpWidget(CupertinoApp(
         home: Directionality(
             textDirection: TextDirection.ltr,
@@ -355,13 +362,14 @@ void main() {
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
-    testWidgets('A smaller menu puts each button on its own page.', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('A smaller menu puts each button on its own page.', (WidgetTester tester) async {
       // Set the screen size to more narrow, so that two buttons can't fit on
       // the same page.
       tester.view.physicalSize = const Size(640, 800);
       addTearDown(tester.view.reset);
 
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
       await tester.pumpWidget(CupertinoApp(
         home: Directionality(
             textDirection: TextDirection.ltr,
@@ -500,8 +508,9 @@ void main() {
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
-    testWidgets('Handles very long locale strings', (WidgetTester tester) async {
+    testWidgetsWithLeakTracking('Handles very long locale strings', (WidgetTester tester) async {
       final TextEditingController controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
       await tester.pumpWidget(CupertinoApp(
         locale: const Locale('en', 'us'),
         localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
@@ -611,10 +620,11 @@ void main() {
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
-    testWidgets(
+    testWidgetsWithLeakTracking(
       'When selecting multiple lines over max lines',
       (WidgetTester tester) async {
         final TextEditingController controller = TextEditingController(text: 'abc\ndef\nghi\njkl\nmno\npqr');
+        addTearDown(controller.dispose);
         await tester.pumpWidget(CupertinoApp(
           home: Directionality(
               textDirection: TextDirection.ltr,
@@ -679,7 +689,7 @@ void main() {
     );
   });
 
-  testWidgets('iOS selection handles scale with rich text (selection style 1)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('iOS selection handles scale with rich text (selection style 1)', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Center(
@@ -759,7 +769,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('iOS selection handles scale with rich text (selection style 2)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('iOS selection handles scale with rich text (selection style 2)', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Center(
@@ -843,7 +853,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('iOS selection handles scale with rich text (grapheme clusters)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('iOS selection handles scale with rich text (grapheme clusters)', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Center(
@@ -924,7 +934,8 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('iOS selection handles scaling falls back to preferredLineHeight when the current frame does not match the previous', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking(
+    'iOS selection handles scaling falls back to preferredLineHeight when the current frame does not match the previous', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Center(


### PR DESCRIPTION
### Description
As a part of Issue: [#134](https://github.com/dart-lang/leak_tracker/issues/134) this PR includes coverage for `test/cupertino/` by changing `testWidgets` to `testWidgetsWithLeakTracking` .
### Tests
- Updates `text_selection_test.dart` to use `testWidgetsWithLeakTracking`.
- Updates `nav_bar_test.dart` to use `testWidgetsWithLeakTracking`.
- Updates `scaffold_test.dart` to use `testWidgetsWithLeakTracking`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
