### PR TITLE
[web] cache the base URL as root index.html

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -586,7 +586,7 @@ class WebServiceWorker extends Target {
       final String hash = md5.convert(await file.readAsBytes()).toString();
       urlToHash[url] = hash;
       // Add an additional entry for the base URL.
-      if (environment.fileSystem.path.basename(url) == 'index.html') {
+      if (url == 'index.html') {
         urlToHash['/'] = hash;
       }
     }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1020,14 +1020,22 @@ void main() {
     environment.outputDir
       .childFile('index.html')
       .createSync(recursive: true);
+    environment.outputDir
+      .childFile('assets/index.html')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('A');
     await WebServiceWorker(globals.fs, WebRendererMode.auto, isWasm: false).build(environment);
 
     expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
-    // Contains file hash for both `/` and index.html.
+    // Contains the same file hash for both `/` and root index.html.
+    const String rootIndexHash = 'd41d8cd98f00b204e9800998ecf8427e';
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
-      contains('"/": "d41d8cd98f00b204e9800998ecf8427e"'));
+      contains('"/": "$rootIndexHash"'));
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
-      contains('"index.html": "d41d8cd98f00b204e9800998ecf8427e"'));
+      contains('"index.html": "$rootIndexHash"'));
+    // make sure `assets/index.html` has different hash
+    expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
+      contains('"assets/index.html": "7fc56270e7a70fa81a5935b72eacbe29"'));
     expect(environment.buildDir.childFile('service_worker.d'), exists);
   }));
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1027,13 +1027,13 @@ void main() {
     await WebServiceWorker(globals.fs, WebRendererMode.auto, isWasm: false).build(environment);
 
     expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
-    // Contains the same file hash for both `/` and root index.html.
+    // Contains the same file hash for both `/` and the root index.html file.
     const String rootIndexHash = 'd41d8cd98f00b204e9800998ecf8427e';
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
       contains('"/": "$rootIndexHash"'));
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
       contains('"index.html": "$rootIndexHash"'));
-    // make sure `assets/index.html` has different hash
+    // Make sure `assets/index.html` has a different hash than `index.html`.
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
       contains('"assets/index.html": "7fc56270e7a70fa81a5935b72eacbe29"'));
     expect(environment.buildDir.childFile('service_worker.d'), exists);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/136593

Caching of the base url was introduced in https://github.com/flutter/flutter/pull/53666 but resources can contain multiple `index.html` files, and currently hash of the **latest** asset will be assigned to the base url, which is not necessarily the root index.html

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
