### PR TITLE
Do not hold on to stale canvas reference in _RenderSegmentedButton

### DIFF
--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -654,7 +654,6 @@ class _RenderSegmentedButton<T> extends RenderBox with
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final Canvas canvas = context.canvas;
     final Rect borderRect = offset & size;
     final Path borderClipPath = enabledBorder.getInnerPath(borderRect, textDirection: textDirection);
     RenderBox? child = firstChild;
@@ -663,14 +662,14 @@ class _RenderSegmentedButton<T> extends RenderBox with
     Path? enabledClipPath;
     Path? disabledClipPath;
 
-    canvas..save()..clipPath(borderClipPath);
+    context.canvas..save()..clipPath(borderClipPath);
     while (child != null) {
       final _SegmentedButtonContainerBoxParentData childParentData = child.parentData! as _SegmentedButtonContainerBoxParentData;
       final Rect childRect = childParentData.surroundingRect!.outerRect.shift(offset);
 
-      canvas..save()..clipRect(childRect);
+      context.canvas..save()..clipRect(childRect);
       context.paintChild(child, childParentData.offset + offset);
-      canvas.restore();
+      context.canvas.restore();
 
       // Compute a clip rect for the outer border of the child.
       late final double segmentLeft;
@@ -705,14 +704,14 @@ class _RenderSegmentedButton<T> extends RenderBox with
           : disabledBorder.side.copyWith(strokeAlign: 0.0);
         final Offset top = Offset(dividerPos, childRect.top);
         final Offset bottom = Offset(dividerPos, childRect.bottom);
-        canvas.drawLine(top, bottom, divider.toPaint());
+        context.canvas.drawLine(top, bottom, divider.toPaint());
       }
 
       previousChild = child;
       child = childAfter(child);
       index += 1;
     }
-    canvas.restore();
+    context.canvas.restore();
 
     // Paint the outer border for both disabled and enabled clip rect if needed.
     if (disabledClipPath == null) {
@@ -723,11 +722,11 @@ class _RenderSegmentedButton<T> extends RenderBox with
       disabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
     } else {
       // Paint both of them clipped appropriately for the children segments.
-      canvas..save()..clipPath(enabledClipPath);
+      context.canvas..save()..clipPath(enabledClipPath);
       enabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
-      canvas..restore()..save()..clipPath(disabledClipPath);
+      context.canvas..restore()..save()..clipPath(disabledClipPath);
       disabledBorder.paint(context.canvas, borderRect, textDirection: textDirection);
-      canvas.restore();
+      context.canvas.restore();
     }
   }
 

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -21,6 +21,36 @@ Widget boilerplate({required Widget child}) {
 }
 
 void main() {
+  testWidgetsWithLeakTracking('SegmentsButton when compositing does not crash', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/135747
+    // If the render object holds on to a stale canvas reference, this will
+    // throw an exception.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SegmentedButton<int>(
+            segments: const <ButtonSegment<int>>[
+              ButtonSegment<int>(
+                value: 0,
+                label: Opacity(
+                  opacity: 0.5,
+                  child: Text('option'),
+                ),
+                icon: Opacity(
+                  opacity: 0.5,
+                  child: Icon(Icons.add),
+                ),
+              ),
+            ],
+            selected: const <int>{0},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(SegmentedButton<int>), findsOneWidget);
+  });
+
   testWidgetsWithLeakTracking('SegmentedButton releases state controllers for deleted segments', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     final Key key = UniqueKey();

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -49,6 +49,7 @@ void main() {
     );
 
     expect(find.byType(SegmentedButton<int>), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgetsWithLeakTracking('SegmentedButton releases state controllers for deleted segments', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/135747

Before this change, the render object was storing the `context.canvas` and using it after painting children. If those children were composited (e.g. because of an `Opacity` layer), the canvas it stored was disposed and not valid for use anymore.