### PR TITLE
Avoid use of Platform.script in isolates_test.dart

### DIFF
--- a/packages/flutter/test/foundation/isolates_test.dart
+++ b/packages/flutter/test/foundation/isolates_test.dart
@@ -89,9 +89,8 @@ Future<void> expectFileSuccessfullyCompletes(String filename) async {
   final String flutterRoot = platform.environment['FLUTTER_ROOT']!;
   final String dartPath =
       fs.path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
-  final String packageRoot = fs.path.dirname(fs.path.fromUri(platform.script));
   final String scriptPath =
-      fs.path.join(packageRoot, 'test', 'foundation', filename);
+      fs.path.join(flutterRoot, 'packages', 'flutter', 'test', 'foundation', filename);
 
   // Enable asserts to also catch potentially invalid assertions.
   final ProcessResult result = await Process.run(


### PR DESCRIPTION
Avoid using string replacement on a bogus string to get the relative directory of this test.

https://github.com/flutter/engine/pull/46911 will fix the behavior of Platform.script so it actually has the file being executed, but that will not be the file the test author wrote, it will be `listener.dart.dill` generated by tool code and running in a temp directory for this particular test.

We may want to come up with a more robust way of providing the test for framework test users, but we should do so in a way that will not limit the ability to run multiple tests in a single process if that offers performance benefits.