### PR TITLE
Add `InputDatePickerFormField.focusNode` prop

### DIFF
--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -57,6 +57,7 @@ class InputDatePickerFormField extends StatefulWidget {
     this.keyboardType,
     this.autofocus = false,
     this.acceptEmptyDate = false,
+    this.focusNode,
   }) : initialDate = initialDate != null ? DateUtils.dateOnly(initialDate) : null,
        firstDate = DateUtils.dateOnly(firstDate),
        lastDate = DateUtils.dateOnly(lastDate) {
@@ -135,6 +136,9 @@ class InputDatePickerFormField extends StatefulWidget {
   ///
   /// If true, [errorFormatText] is not shown when the date input field is empty.
   final bool acceptEmptyDate;
+
+  /// {@macro flutter.widgets.Focus.focusNode}
+  final FocusNode? focusNode;
 
   @override
   State<InputDatePickerFormField> createState() => _InputDatePickerFormFieldState();
@@ -266,6 +270,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
       onFieldSubmitted: _handleSubmitted,
       autofocus: widget.autofocus,
       controller: _controller,
+      focusNode: widget.focusNode,
     );
   }
 }

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -51,6 +51,7 @@ void main() {
     ThemeData? theme,
     Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
     bool acceptEmptyDate = false,
+    FocusNode? focusNode,
   }) {
     return MaterialApp(
       theme: theme ?? ThemeData.from(colorScheme: const ColorScheme.light()),
@@ -72,6 +73,7 @@ void main() {
             fieldLabelText: fieldLabelText,
             autofocus: autofocus,
             acceptEmptyDate: acceptEmptyDate,
+            focusNode: focusNode,
           ),
         ),
       ),
@@ -377,5 +379,19 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text(errorFormatText), findsOneWidget);
     });
+  });
+
+  testWidgets('FocusNode can request focus', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    await tester.pumpWidget(inputDatePickerField(
+      focusNode: focusNode,
+    ));
+    expect(focusNode.hasFocus, isFalse);
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+    focusNode.unfocus();
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
   });
 }

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -386,6 +386,7 @@ void main() {
     await tester.pumpWidget(inputDatePickerField(
       focusNode: focusNode,
     ));
+    expect((tester.widget(find.byType(TextField)) as TextField).focusNode, focusNode);
     expect(focusNode.hasFocus, isFalse);
     focusNode.requestFocus();
     await tester.pumpAndSettle();


### PR DESCRIPTION
Adds `focusNode` prop to `InputDatePickerFormField` widget.

Fixes #105881 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
