### PR TITLE
give `throwsToolExit` a more useful description

### DIFF
--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -21,5 +21,12 @@ class ToolExit implements Exception {
   final int? exitCode;
 
   @override
-  String toString() => 'Exception: $message'; // TODO(ianh): Really this should say "Error".
+  String toString() {
+    final List<String> parts = <String>[
+      if (exitCode != null) 'Exit code: $exitCode',
+      'Exception: $message',
+    ];
+
+    return parts.join('. ');
+  }
 }

--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -21,12 +21,5 @@ class ToolExit implements Exception {
   final int? exitCode;
 
   @override
-  String toString() {
-    final List<String> parts = <String>[
-      if (exitCode != null) 'Exit code: $exitCode',
-      'Error: $message',
-    ];
-
-    return parts.join('. ');
-  }
+  String toString() => 'Error: $message';
 }

--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -24,7 +24,7 @@ class ToolExit implements Exception {
   String toString() {
     final List<String> parts = <String>[
       if (exitCode != null) 'Exit code: $exitCode',
-      'Exception: $message',
+      'Error: $message',
     ];
 
     return parts.join('. ');

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1298,7 +1298,7 @@ flutter:
 
     await residentRunner.runSourceGenerators();
 
-    expect(testLogger.errorText, allOf(contains('Exception')));
+    expect(testLogger.errorText, contains('Error'));
     expect(testLogger.statusText, isEmpty);
   }));
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -184,7 +184,7 @@ void main() {
 
       final String output = _uniqueOutputLines(outputEvents);
       expect(output, contains('this code does not compile'));
-      expect(output, contains('Exception: Failed to build'));
+      expect(output, contains('Error: Failed to build'));
       expect(output, contains('Exited (1)'));
     });
 

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -93,19 +93,20 @@ Future<StringBuffer> capturedConsolePrint(Future<void> Function() body) async {
 final Matcher throwsAssertionError = throwsA(isA<AssertionError>());
 
 /// Matcher for functions that throw [ToolExit].
+///
+/// [message] is matched using the [contains] matcher.
 Matcher throwsToolExit({ int? exitCode, Pattern? message }) {
-  Matcher matcher = _isToolExit;
+  TypeMatcher<ToolExit> result = const TypeMatcher<ToolExit>();
+
   if (exitCode != null) {
-    matcher = allOf(matcher, (ToolExit e) => e.exitCode == exitCode);
+    result = result.having((ToolExit e) => e.exitCode, 'exitCode', equals(exitCode));
   }
   if (message != null) {
-    matcher = allOf(matcher, (ToolExit e) => e.message?.contains(message) ?? false);
+    result = result.having((ToolExit e) => e.message, 'message', contains(message));
   }
-  return throwsA(matcher);
-}
 
-/// Matcher for [ToolExit]s.
-final TypeMatcher<ToolExit> _isToolExit = isA<ToolExit>();
+  return throwsA(result);
+}
 
 /// Matcher for functions that throw [UsageException].
 Matcher throwsUsageException({Pattern? message }) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/136698.

Alters how `throwToolExit` creates its matcher. This results is an improved description of the matcher.

The mismatch description isn't improved by this, but I writing an entirely custom matcher to fix this isn't ideal either. We can instead mitigate the issue by augmenting the `toString` implementation of `ToolExit` to include the exit code, if it is non-null.

With these changes, the first few lines of output from a test would look like this:

```
Expected: throws <Instance of 'ToolExit'> with `exitCode`: <42> and `message`: contains 'message'
  Actual: <Closure: () => Never>
   Which: threw ToolExit:<Exit code: 41232. Error: message>
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
