### PR TITLE
Provide more information in 'unsupported class file' gradle error

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -685,12 +685,24 @@ final GradleHandledError incompatibleJavaAndGradleVersionsHandler = GradleHandle
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
+    final File gradlePropertiesFile = project.directory
+        .childDirectory('android')
+        .childDirectory('gradle')
+        .childDirectory('wrapper')
+        .childFile('gradle-wrapper.properties');
     // TODO(reidbaker): Replace URL with constant defined in
     // https://github.com/flutter/flutter/pull/123916.
     globals.printBox(
       "${globals.logger.terminal.warningMark} Your project's Gradle version "
       'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
-      'To fix this issue, consult the migration guide at docs.flutter.dev/go/android-java-gradle-error.',
+          'If you recently upgraded Android Studio, consult the migration guide '
+          'at docs.flutter.dev/go/android-java-gradle-error.\n\n'
+          'Otherwise, to fix this issue, first, check the Java version used by Flutter by '
+          'running `flutter doctor --verbose`.\n\n'
+          'Then, update the Gradle version specified in ${gradlePropertiesFile.path} '
+          'to be compatible with that Java version. '
+          'See the link below for more information on compatible Java/Gradle versions:\n'
+          'https://docs.gradle.org/current/userguide/compatibility.html#java\n\n',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -694,7 +694,7 @@ final GradleHandledError incompatibleJavaAndGradleVersionsHandler = GradleHandle
     // https://github.com/flutter/flutter/pull/123916.
     globals.printBox(
       "${globals.logger.terminal.warningMark} Your project's Gradle version "
-      'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
+          'is incompatible with the Java version that Flutter is using for Gradle.\n\n'
           'If you recently upgraded Android Studio, consult the migration guide '
           'at docs.flutter.dev/go/android-java-gradle-error.\n\n'
           'Otherwise, to fix this issue, first, check the Java version used by Flutter by '

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -1376,9 +1376,12 @@ Could not compile build file '…/example/android/build.gradle'.
         multidexEnabled: true,
       );
 
-      // Ensure the error notes the incompatible Gradle/AGP/Java versions and links to related resources.
+      // Ensure the error notes the incompatible Gradle/AGP/Java versions, links to related resources,
+      // and a portion of the path to where to change their gradle version.
       expect(testLogger.statusText, contains('Gradle version is incompatible with the Java version'));
       expect(testLogger.statusText, contains('docs.flutter.dev/go/android-java-gradle-error'));
+      expect(testLogger.statusText, contains('gradle-wrapper.properties'));
+      expect(testLogger.statusText, contains('https://docs.gradle.org/current/userguide/compatibility.html#java'));
     }, overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
       Platform: () => fakePlatform('android'),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/130808. Short context is that the migration guide doesn't help when a user has a newer java version than 17, and this tells them how to fix the error in that situation.

This is an alternative to https://github.com/flutter/flutter/pull/131354, because I think it is a bad idea to introduce branching in how we handle this error with some specialized regexp.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
