### PR TITLE
Implement GApplication:shutdown so a Flutter developer knows where to put code that should occur on application shutdown.

### DIFF
--- a/packages/flutter_tools/templates/app_shared/linux.tmpl/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app_shared/linux.tmpl/my_application.cc.tmpl
@@ -81,6 +81,13 @@ static gboolean my_application_local_command_line(GApplication* application, gch
   return TRUE;
 }
 
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  //MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+}
+
 // Implements GObject::dispose.
 static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
@@ -91,6 +98,7 @@ static void my_application_dispose(GObject* object) {
 static void my_application_class_init(MyApplicationClass* klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
   G_APPLICATION_CLASS(klass)->local_command_line = my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 


### PR DESCRIPTION
This was added because the dispose method doesn't seem to be called - something must still have a reference to the application after shutdown.

Solution for https://github.com/flutter/flutter/issues/136582
