### PR TITLE
fix SliverReorderableLists item wrong offset

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -730,6 +730,9 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   }
 
   void _registerItem(_ReorderableItemState item) {
+    if (_dragInfo != null && _items[item.index] == null) {
+      item.updateForGap(_dragInfo!.index, _dragInfo!.itemExtent, false, _reverse);
+    }
     _items[item.index] = item;
     if (item.index == _dragInfo?.index) {
       item.dragging = true;

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -730,7 +730,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   }
 
   void _registerItem(_ReorderableItemState item) {
-    if (_dragInfo != null && _items[item.index] == null) {
+    if (_dragInfo != null && _items[item.index] != item) {
       item.updateForGap(_dragInfo!.index, _dragInfo!.itemExtent, false, _reverse);
     }
     _items[item.index] = item;

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -1356,6 +1356,55 @@ void main() {
 
     expect(tester.takeException(), null);
   });
+
+  testWidgets(
+    'When creating a new item, be in the correct position',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: LayoutBuilder(
+            builder: (_, BoxConstraints view) {
+              // The third one just appears on the screen
+              final double itemSize = view.maxWidth / 2 - 20;
+              return Scaffold(
+                body: CustomScrollView(
+                  scrollDirection: Axis.horizontal,
+                  cacheExtent: 0, // The fourth one will not be created in the initial state.
+                  slivers: <Widget>[
+                    SliverReorderableList(
+                      itemBuilder: (BuildContext context, int index) {
+                        return ReorderableDragStartListener(
+                          key: ValueKey<int>(index),
+                          index: index,
+                          child: Builder(
+                            builder: (BuildContext context) {
+                              return SizedBox(
+                                width: itemSize,
+                                child: Text('$index'),
+                              );
+                            },
+                          ),
+                        );
+                      },
+                      itemCount: 4,
+                      onReorder: (int fromIndex, int toIndex) {},
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('0')));
+      await tester.pump(kLongPressTimeout);
+      await drag.moveBy(const Offset(20, 0));
+      await tester.pump();
+      expect(find.text('3').hitTestable(at: Alignment.topLeft), findsNothing);
+      await drag.up();
+      await tester.pumpAndSettle();
+    },
+  );
 }
 
 class TestList extends StatelessWidget {

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -1357,7 +1357,7 @@ void main() {
     expect(tester.takeException(), null);
   });
 
-  testWidgets(
+  testWidgetsWithLeakTracking(
     'When creating a new item, be in the correct position',
     (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
This PR fixes the issue of items being created at the wrong position during dragging.

Fixes #135819 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
