### PR TITLE
Add `onSubmitted` and `onChanged` for `SearchAnchor` and `SearchAnchor.bar`

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -127,6 +127,8 @@ class SearchAnchor extends StatefulWidget {
     this.dividerColor,
     this.viewConstraints,
     this.textCapitalization,
+    this.viewOnChanged,
+    this.viewOnSubmitted,
     required this.builder,
     required this.suggestionsBuilder,
   });
@@ -147,6 +149,8 @@ class SearchAnchor extends StatefulWidget {
     Iterable<Widget>? barTrailing,
     String? barHintText,
     GestureTapCallback? onTap,
+    ValueChanged<String>? viewOnChanged,
+    ValueChanged<String>? viewOnSubmitted,
     MaterialStateProperty<double?>? barElevation,
     MaterialStateProperty<Color?>? barBackgroundColor,
     MaterialStateProperty<Color?>? barOverlayColor,
@@ -289,6 +293,13 @@ class SearchAnchor extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textCapitalization}
   final TextCapitalization? textCapitalization;
 
+  /// Invoked upon user input on the search view.
+  final ValueChanged<String>? viewOnChanged;
+
+  /// Called when the user indicates that they are done editing the text in the
+  /// text field of a search view.
+  final ValueChanged<String>? viewOnSubmitted;
+
   /// Called to create a widget which can open a search view route when it is tapped.
   ///
   /// The widget returned by this builder is faded out when it is tapped.
@@ -351,6 +362,8 @@ class _SearchAnchorState extends State<SearchAnchor> {
   void _openView() {
     final NavigatorState navigator = Navigator.of(context);
     navigator.push(_SearchViewRoute(
+      viewOnChanged: widget.viewOnChanged,
+      viewOnSubmitted: widget.viewOnSubmitted,
       viewLeading: widget.viewLeading,
       viewTrailing: widget.viewTrailing,
       viewHintText: widget.viewHintText,
@@ -422,6 +435,8 @@ class _SearchAnchorState extends State<SearchAnchor> {
 
 class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
   _SearchViewRoute({
+    this.viewOnChanged,
+    this.viewOnSubmitted,
     this.toggleVisibility,
     this.textDirection,
     this.viewBuilder,
@@ -445,6 +460,8 @@ class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
     required this.capturedThemes,
   });
 
+  final ValueChanged<String>? viewOnChanged;
+  final ValueChanged<String>? viewOnSubmitted;
   final ValueGetter<bool>? toggleVisibility;
   final TextDirection? textDirection;
   final ViewBuilder? viewBuilder;
@@ -587,6 +604,8 @@ class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
             ),
             child: capturedThemes.wrap(
               _ViewContent(
+                viewOnChanged: viewOnChanged,
+                viewOnSubmitted: viewOnSubmitted,
                 viewLeading: viewLeading,
                 viewTrailing: viewTrailing,
                 viewHintText: viewHintText,
@@ -621,6 +640,8 @@ class _SearchViewRoute extends PopupRoute<_SearchViewRoute> {
 
 class _ViewContent extends StatefulWidget {
   const _ViewContent({
+    this.viewOnChanged,
+    this.viewOnSubmitted,
     this.viewBuilder,
     this.viewLeading,
     this.viewTrailing,
@@ -643,6 +664,8 @@ class _ViewContent extends StatefulWidget {
     required this.suggestionsBuilder,
   });
 
+  final ValueChanged<String>? viewOnChanged;
+  final ValueChanged<String>? viewOnSubmitted;
   final ViewBuilder? viewBuilder;
   final Widget? viewLeading;
   final Iterable<Widget>? viewTrailing;
@@ -842,8 +865,12 @@ class _ViewContentState extends State<_ViewContent> {
                             textStyle: MaterialStatePropertyAll<TextStyle?>(effectiveTextStyle),
                             hintStyle: MaterialStatePropertyAll<TextStyle?>(effectiveHintStyle),
                             controller: _controller,
-                            onChanged: (_) {
+                            onChanged: (String value) {
+                              widget.viewOnChanged?.call(value);
                               updateSuggestions();
+                            },
+                            onSubmitted: (String value) {
+                              widget.viewOnSubmitted?.call(value);
                             },
                             textCapitalization: widget.textCapitalization,
                           ),
@@ -907,11 +934,19 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     super.isFullScreen,
     super.searchController,
     super.textCapitalization,
+    ValueChanged<String>? viewOnChanged,
+    ValueChanged<String>? viewOnSubmitted,
     required super.suggestionsBuilder
   }) : super(
     viewHintText: viewHintText ?? barHintText,
     headerTextStyle: viewHeaderTextStyle,
     headerHintStyle: viewHeaderHintStyle,
+    viewOnChanged: (String value) {
+      viewOnChanged?.call(value);
+    },
+    viewOnSubmitted: (String value) {
+      viewOnSubmitted?.call(value);
+    },
     builder: (BuildContext context, SearchController controller) {
       return SearchBar(
         constraints: constraints,

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -880,9 +880,7 @@ class _ViewContentState extends State<_ViewContent> {
                               widget.viewOnChanged?.call(value);
                               updateSuggestions();
                             },
-                            onSubmitted: (String value) {
-                              widget.viewOnSubmitted?.call(value);
-                            },
+                            onSubmitted: widget.viewOnSubmitted,
                             textCapitalization: widget.textCapitalization,
                           ),
                         ),
@@ -945,19 +943,13 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     super.isFullScreen,
     super.searchController,
     super.textCapitalization,
-    ValueChanged<String>? viewOnChanged,
-    ValueChanged<String>? viewOnSubmitted,
+    super.viewOnChanged,
+    super.viewOnSubmitted,
     required super.suggestionsBuilder
   }) : super(
     viewHintText: viewHintText ?? barHintText,
     headerTextStyle: viewHeaderTextStyle,
     headerHintStyle: viewHeaderHintStyle,
-    viewOnChanged: (String value) {
-      viewOnChanged?.call(value);
-    },
-    viewOnSubmitted: (String value) {
-      viewOnSubmitted?.call(value);
-    },
     builder: (BuildContext context, SearchController controller) {
       return SearchBar(
         constraints: constraints,

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -293,11 +293,22 @@ class SearchAnchor extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textCapitalization}
   final TextCapitalization? textCapitalization;
 
-  /// Invoked upon user input on the search view.
+  /// Called each time the user modifies the search view's text field.
+  ///
+  /// See also:
+  ///
+  ///  * [viewOnSubmitted], which is called when the user indicates that they
+  ///  are done editing the search view's text field.
   final ValueChanged<String>? viewOnChanged;
 
   /// Called when the user indicates that they are done editing the text in the
-  /// text field of a search view.
+  /// text field of a search view. Typically this is called when the user presses
+  /// the enter key.
+  ///
+  /// See also:
+  ///
+  /// * [viewOnChanged], which is called when the user modifies the text field
+  /// of the search view.
   final ValueChanged<String>? viewOnSubmitted;
 
   /// Called to create a widget which can open a search view route when it is tapped.

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -159,6 +159,7 @@ class SearchAnchor extends StatefulWidget {
     MaterialStateProperty<EdgeInsetsGeometry?>? barPadding,
     MaterialStateProperty<TextStyle?>? barTextStyle,
     MaterialStateProperty<TextStyle?>? barHintStyle,
+    ValueChanged<String>? barOnSubmitted,
     Widget? viewLeading,
     Iterable<Widget>? viewTrailing,
     String? viewHintText,
@@ -928,6 +929,7 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     MaterialStateProperty<EdgeInsetsGeometry?>? barPadding,
     MaterialStateProperty<TextStyle?>? barTextStyle,
     MaterialStateProperty<TextStyle?>? barHintStyle,
+    ValueChanged<String>? barOnSubmitted,
     super.viewLeading,
     super.viewTrailing,
     String? viewHintText,
@@ -961,6 +963,7 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
         onChanged: (_) {
           controller.openView();
         },
+        onSubmitted: barOnSubmitted,
         hintText: barHintText,
         hintStyle: barHintStyle,
         textStyle: barTextStyle,

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -149,8 +149,8 @@ class SearchAnchor extends StatefulWidget {
     Iterable<Widget>? barTrailing,
     String? barHintText,
     GestureTapCallback? onTap,
-    ValueChanged<String>? viewOnChanged,
-    ValueChanged<String>? viewOnSubmitted,
+    ValueChanged<String>? onSubmitted,
+    ValueChanged<String>? onChanged,
     MaterialStateProperty<double?>? barElevation,
     MaterialStateProperty<Color?>? barBackgroundColor,
     MaterialStateProperty<Color?>? barOverlayColor,
@@ -159,7 +159,6 @@ class SearchAnchor extends StatefulWidget {
     MaterialStateProperty<EdgeInsetsGeometry?>? barPadding,
     MaterialStateProperty<TextStyle?>? barTextStyle,
     MaterialStateProperty<TextStyle?>? barHintStyle,
-    ValueChanged<String>? barOnSubmitted,
     Widget? viewLeading,
     Iterable<Widget>? viewTrailing,
     String? viewHintText,
@@ -929,7 +928,6 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     MaterialStateProperty<EdgeInsetsGeometry?>? barPadding,
     MaterialStateProperty<TextStyle?>? barTextStyle,
     MaterialStateProperty<TextStyle?>? barHintStyle,
-    ValueChanged<String>? barOnSubmitted,
     super.viewLeading,
     super.viewTrailing,
     String? viewHintText,
@@ -945,13 +943,15 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     super.isFullScreen,
     super.searchController,
     super.textCapitalization,
-    super.viewOnChanged,
-    super.viewOnSubmitted,
+    ValueChanged<String>? onChanged,
+    ValueChanged<String>? onSubmitted,
     required super.suggestionsBuilder
   }) : super(
     viewHintText: viewHintText ?? barHintText,
     headerTextStyle: viewHeaderTextStyle,
     headerHintStyle: viewHeaderHintStyle,
+    viewOnSubmitted: onSubmitted,
+    viewOnChanged: onChanged,
     builder: (BuildContext context, SearchController controller) {
       return SearchBar(
         constraints: constraints,
@@ -960,10 +960,10 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
           controller.openView();
           onTap?.call();
         },
-        onChanged: (_) {
+        onChanged: (String value) {
           controller.openView();
         },
-        onSubmitted: barOnSubmitted,
+        onSubmitted: onSubmitted,
         hintText: barHintText,
         hintStyle: barHintStyle,
         textStyle: barTextStyle,

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -931,7 +931,8 @@ void main() {
     final SearchController controller = SearchController();
     addTearDown(controller.dispose);
     int onChangedCalled = 0;
-    int onSubmittedCalled = 0;
+    int viewOnSubmittedCalled = 0;
+    int barOnSubmittedCalled = 0;
     await tester.pumpWidget(MaterialApp(
       home: StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
@@ -939,6 +940,11 @@ void main() {
             child: Material(
               child: SearchAnchor.bar(
                 searchController: controller,
+                barOnSubmitted: (String value) {
+                  setState(() {
+                    barOnSubmittedCalled = barOnSubmittedCalled + 1;
+                  });
+                },
                 viewOnChanged: (String value) {
                   setState(() {
                     onChangedCalled = onChangedCalled + 1;
@@ -946,7 +952,7 @@ void main() {
                 },
                 viewOnSubmitted: (String value) {
                   setState(() {
-                    onSubmittedCalled = onSubmittedCalled + 1;
+                    viewOnSubmittedCalled = viewOnSubmittedCalled + 1;
                   });
                   controller.closeView(value);
                 },
@@ -973,8 +979,13 @@ void main() {
     expect(onChangedCalled, 2);
 
     await tester.testTextInput.receiveAction(TextInputAction.done);
-    expect(onSubmittedCalled, 1);
+    expect(viewOnSubmittedCalled, 1); // View's onSubmitted is called.
+    expect(barOnSubmittedCalled, 0); // Bar's onSubmitted is not called.
     expect(controller.isOpen, false);
+
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    expect(viewOnSubmittedCalled, 1); // View's onSubmitted is not called.
+    expect(barOnSubmittedCalled, 1); // Bar's onSubmitted is called.
   });
 
   testWidgetsWithLeakTracking('hintStyle can override textStyle for hintText', (WidgetTester tester) async {

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -841,6 +841,7 @@ void main() {
 
   testWidgetsWithLeakTracking('SearchAnchor respects viewOnChanged and viewOnSubmitted properties', (WidgetTester tester) async {
     final SearchController controller = SearchController();
+    addTearDown(controller.dispose);
     int onChangedCalled = 0;
     int onSubmittedCalled = 0;
     await tester.pumpWidget(MaterialApp(
@@ -928,6 +929,7 @@ void main() {
 
   testWidgetsWithLeakTracking('SearchAnchor.bar respects viewOnChanged and viewOnSubmitted properties', (WidgetTester tester) async {
     final SearchController controller = SearchController();
+    addTearDown(controller.dispose);
     int onChangedCalled = 0;
     int onSubmittedCalled = 0;
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -5,11 +5,8 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
-
-import '../widgets/editable_text_utils.dart';
 
 void main() {
   testWidgetsWithLeakTracking('SearchBar defaults', (WidgetTester tester) async {

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -927,12 +927,11 @@ void main() {
     expect(textField.textCapitalization, TextCapitalization.characters);
   });
 
-  testWidgetsWithLeakTracking('SearchAnchor.bar respects viewOnChanged and viewOnSubmitted properties', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('SearchAnchor.bar respects onChanged and onSubmitted properties', (WidgetTester tester) async {
     final SearchController controller = SearchController();
     addTearDown(controller.dispose);
     int onChangedCalled = 0;
-    int viewOnSubmittedCalled = 0;
-    int barOnSubmittedCalled = 0;
+    int onSubmittedCalled = 0;
     await tester.pumpWidget(MaterialApp(
       home: StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
@@ -940,21 +939,16 @@ void main() {
             child: Material(
               child: SearchAnchor.bar(
                 searchController: controller,
-                barOnSubmitted: (String value) {
+                onSubmitted: (String value) {
                   setState(() {
-                    barOnSubmittedCalled = barOnSubmittedCalled + 1;
+                    onSubmittedCalled = onSubmittedCalled + 1;
                   });
+                  controller.closeView(value);
                 },
-                viewOnChanged: (String value) {
+                onChanged: (String value) {
                   setState(() {
                     onChangedCalled = onChangedCalled + 1;
                   });
-                },
-                viewOnSubmitted: (String value) {
-                  setState(() {
-                    viewOnSubmittedCalled = viewOnSubmittedCalled + 1;
-                  });
-                  controller.closeView(value);
                 },
                 suggestionsBuilder: (BuildContext context, SearchController controller) {
                   return <Widget>[];
@@ -979,13 +973,11 @@ void main() {
     expect(onChangedCalled, 2);
 
     await tester.testTextInput.receiveAction(TextInputAction.done);
-    expect(viewOnSubmittedCalled, 1); // View's onSubmitted is called.
-    expect(barOnSubmittedCalled, 0); // Bar's onSubmitted is not called.
+    expect(onSubmittedCalled, 1);
     expect(controller.isOpen, false);
 
     await tester.testTextInput.receiveAction(TextInputAction.done);
-    expect(viewOnSubmittedCalled, 1); // View's onSubmitted is not called.
-    expect(barOnSubmittedCalled, 1); // Bar's onSubmitted is called.
+    expect(onSubmittedCalled, 2);
   });
 
   testWidgetsWithLeakTracking('hintStyle can override textStyle for hintText', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #130687 and #132915

This PR is to add two properties: `viewOnChanged` and `viewOnSubmitted` to `SearchAnchor` and `SearchAnchor.bar` so we can control the search bar on the search view.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
