### PR TITLE
Add `isLogicalKeyPressed` to `HardwareKeyboard`

### DIFF
--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -459,11 +459,11 @@ class HardwareKeyboard {
 
   /// Returns true if the given [LogicalKeyboardKey] is pressed, according to
   /// the [HardwareKeyboard].
-  bool isLogicalKeyPressed(LogicalKeyboardKey key) => logicalKeysPressed.contains(key);
+  bool isLogicalKeyPressed(LogicalKeyboardKey key) => _pressedKeys.values.contains(key);
 
   /// Returns true if the given [PhysicalKeyboardKey] is pressed, according to
   /// the [HardwareKeyboard].
-  bool isPhysicalKeyPressed(PhysicalKeyboardKey key) => physicalKeysPressed.contains(key);
+  bool isPhysicalKeyPressed(PhysicalKeyboardKey key) => _pressedKeys.containsKey(key);
 
   /// Returns true if a logical CTRL modifier key is pressed, regardless of
   /// which side of the keyboard it is on.

--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -225,6 +225,49 @@ abstract class KeyEvent with Diagnosticable {
   /// Defaults to false.
   final bool synthesized;
 
+  /// Returns true if the given [LogicalKeyboardKey] is pressed, according to
+  /// the [HardwareKeyboard].
+  bool isLogicalKeyPressed(LogicalKeyboardKey key) => HardwareKeyboard.instance.logicalKeysPressed.contains(key);
+
+  /// Returns true if a logical CTRL modifier key is pressed, regardless of
+  /// which side of the keyboard it is on.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which control key was
+  /// pressed.
+  bool get isControlPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.controlLeft) || isLogicalKeyPressed(LogicalKeyboardKey.controlRight);
+  }
+
+  /// Returns true if a logical SHIFT modifier key is pressed, regardless of
+  /// which side of the keyboard it is on.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which shift key was pressed.
+  bool get isShiftPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.shiftLeft) || isLogicalKeyPressed(LogicalKeyboardKey.shiftRight);
+  }
+
+  /// Returns true if a logical ALT modifier key is pressed, regardless of which
+  /// side of the keyboard it is on.
+  ///
+  /// The `AltGr` key that appears on some keyboards is considered to be the
+  /// same as [LogicalKeyboardKey.altRight] on some platforms (notably Android).
+  /// On platforms that can distinguish between `altRight` and `altGr`, a press
+  /// of `AltGr` will not return true here, and will need to be tested for
+  /// separately.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which alt key was pressed.
+  bool get isAltPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.altLeft) || isLogicalKeyPressed(LogicalKeyboardKey.altRight);
+  }
+
+  /// Returns true if a logical META modifier key is pressed, regardless of
+  /// which side of the keyboard it is on.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which meta key was pressed.
+  bool get isMetaPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.metaLeft) || isLogicalKeyPressed(LogicalKeyboardKey.metaRight);
+  }
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);

--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -229,6 +229,10 @@ abstract class KeyEvent with Diagnosticable {
   /// the [HardwareKeyboard].
   bool isLogicalKeyPressed(LogicalKeyboardKey key) => HardwareKeyboard.instance.logicalKeysPressed.contains(key);
 
+  /// Returns true if the given [PhysicalKeyboardKey] is pressed, according to
+  /// the [HardwareKeyboard].
+  bool isPhysicalKeyPressed(PhysicalKeyboardKey key) => HardwareKeyboard.instance.physicalKeysPressed.contains(key);
+
   /// Returns true if a logical CTRL modifier key is pressed, regardless of
   /// which side of the keyboard it is on.
   ///

--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -225,53 +225,6 @@ abstract class KeyEvent with Diagnosticable {
   /// Defaults to false.
   final bool synthesized;
 
-  /// Returns true if the given [LogicalKeyboardKey] is pressed, according to
-  /// the [HardwareKeyboard].
-  bool isLogicalKeyPressed(LogicalKeyboardKey key) => HardwareKeyboard.instance.logicalKeysPressed.contains(key);
-
-  /// Returns true if the given [PhysicalKeyboardKey] is pressed, according to
-  /// the [HardwareKeyboard].
-  bool isPhysicalKeyPressed(PhysicalKeyboardKey key) => HardwareKeyboard.instance.physicalKeysPressed.contains(key);
-
-  /// Returns true if a logical CTRL modifier key is pressed, regardless of
-  /// which side of the keyboard it is on.
-  ///
-  /// Use [isLogicalKeyPressed] if you need to know which control key was
-  /// pressed.
-  bool get isControlPressed {
-    return isLogicalKeyPressed(LogicalKeyboardKey.controlLeft) || isLogicalKeyPressed(LogicalKeyboardKey.controlRight);
-  }
-
-  /// Returns true if a logical SHIFT modifier key is pressed, regardless of
-  /// which side of the keyboard it is on.
-  ///
-  /// Use [isLogicalKeyPressed] if you need to know which shift key was pressed.
-  bool get isShiftPressed {
-    return isLogicalKeyPressed(LogicalKeyboardKey.shiftLeft) || isLogicalKeyPressed(LogicalKeyboardKey.shiftRight);
-  }
-
-  /// Returns true if a logical ALT modifier key is pressed, regardless of which
-  /// side of the keyboard it is on.
-  ///
-  /// The `AltGr` key that appears on some keyboards is considered to be the
-  /// same as [LogicalKeyboardKey.altRight] on some platforms (notably Android).
-  /// On platforms that can distinguish between `altRight` and `altGr`, a press
-  /// of `AltGr` will not return true here, and will need to be tested for
-  /// separately.
-  ///
-  /// Use [isLogicalKeyPressed] if you need to know which alt key was pressed.
-  bool get isAltPressed {
-    return isLogicalKeyPressed(LogicalKeyboardKey.altLeft) || isLogicalKeyPressed(LogicalKeyboardKey.altRight);
-  }
-
-  /// Returns true if a logical META modifier key is pressed, regardless of
-  /// which side of the keyboard it is on.
-  ///
-  /// Use [isLogicalKeyPressed] if you need to know which meta key was pressed.
-  bool get isMetaPressed {
-    return isLogicalKeyPressed(LogicalKeyboardKey.metaLeft) || isLogicalKeyPressed(LogicalKeyboardKey.metaRight);
-  }
-
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -503,6 +456,53 @@ class HardwareKeyboard {
   /// If called from a key event handler, the result will already include the effect
   /// of the event.
   Set<KeyboardLockMode> get lockModesEnabled => _lockModes;
+
+  /// Returns true if the given [LogicalKeyboardKey] is pressed, according to
+  /// the [HardwareKeyboard].
+  bool isLogicalKeyPressed(LogicalKeyboardKey key) => logicalKeysPressed.contains(key);
+
+  /// Returns true if the given [PhysicalKeyboardKey] is pressed, according to
+  /// the [HardwareKeyboard].
+  bool isPhysicalKeyPressed(PhysicalKeyboardKey key) => physicalKeysPressed.contains(key);
+
+  /// Returns true if a logical CTRL modifier key is pressed, regardless of
+  /// which side of the keyboard it is on.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which control key was
+  /// pressed.
+  bool get isControlPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.controlLeft) || isLogicalKeyPressed(LogicalKeyboardKey.controlRight);
+  }
+
+  /// Returns true if a logical SHIFT modifier key is pressed, regardless of
+  /// which side of the keyboard it is on.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which shift key was pressed.
+  bool get isShiftPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.shiftLeft) || isLogicalKeyPressed(LogicalKeyboardKey.shiftRight);
+  }
+
+  /// Returns true if a logical ALT modifier key is pressed, regardless of which
+  /// side of the keyboard it is on.
+  ///
+  /// The `AltGr` key that appears on some keyboards is considered to be the
+  /// same as [LogicalKeyboardKey.altRight] on some platforms (notably Android).
+  /// On platforms that can distinguish between `altRight` and `altGr`, a press
+  /// of `AltGr` will not return true here, and will need to be tested for
+  /// separately.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which alt key was pressed.
+  bool get isAltPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.altLeft) || isLogicalKeyPressed(LogicalKeyboardKey.altRight);
+  }
+
+  /// Returns true if a logical META modifier key is pressed, regardless of
+  /// which side of the keyboard it is on.
+  ///
+  /// Use [isLogicalKeyPressed] if you need to know which meta key was pressed.
+  bool get isMetaPressed {
+    return isLogicalKeyPressed(LogicalKeyboardKey.metaLeft) || isLogicalKeyPressed(LogicalKeyboardKey.metaRight);
+  }
 
   void _assertEventIsRegular(KeyEvent event) {
     assert(() {

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -407,7 +407,7 @@ abstract class RawKeyEvent with Diagnosticable {
     }
   }
 
-  /// Returns true if the given [KeyboardKey] is pressed.
+  /// Returns true if the given [LogicalKeyboardKey] is pressed.
   bool isKeyPressed(LogicalKeyboardKey key) => RawKeyboard.instance.keysPressed.contains(key);
 
   /// Returns true if a CTRL modifier key is pressed, regardless of which side

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 
 import 'binding.dart';
 import 'hardware_keyboard.dart';
-import 'keyboard_key.g.dart';
 import 'raw_keyboard_android.dart';
 import 'raw_keyboard_fuchsia.dart';
 import 'raw_keyboard_ios.dart';

--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -69,6 +69,47 @@ void main() {
       equals(<KeyboardLockMode>{}));
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
+  testWidgetsWithLeakTracking('KeyEvent can tell which keys are pressed', (WidgetTester tester) async {
+    KeyEvent? event;
+
+    FocusManager.instance.addEarlyKeyEventHandler((KeyEvent newEvent) {
+      event = newEvent;
+      return KeyEventResult.handled;
+    });
+
+    await tester.pumpWidget(const Focus(autofocus: true, child: SizedBox()));
+    await tester.pump();
+
+    await simulateKeyDownEvent(LogicalKeyboardKey.numLock, platform: 'windows');
+
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isTrue);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isTrue);
+
+    await simulateKeyDownEvent(LogicalKeyboardKey.numpad1, platform: 'windows');
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
+
+    await simulateKeyRepeatEvent(LogicalKeyboardKey.numpad1, platform: 'windows');
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
+
+    await simulateKeyUpEvent(LogicalKeyboardKey.numLock);
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
+
+    await simulateKeyDownEvent(LogicalKeyboardKey.numLock, platform: 'windows');
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isTrue);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isTrue);
+
+    await simulateKeyUpEvent(LogicalKeyboardKey.numpad1, platform: 'windows');
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isFalse);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isFalse);
+
+    await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'windows');
+    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isFalse);
+    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isFalse);
+  }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
+
   testWidgetsWithLeakTracking('KeyboardManager synthesizes modifier keys in rawKeyData mode', (WidgetTester tester) async {
     final List<KeyEvent> events = <KeyEvent>[];
     HardwareKeyboard.instance.addHandler((KeyEvent event) {

--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -70,44 +70,37 @@ void main() {
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
   testWidgetsWithLeakTracking('KeyEvent can tell which keys are pressed', (WidgetTester tester) async {
-    KeyEvent? event;
-
-    FocusManager.instance.addEarlyKeyEventHandler((KeyEvent newEvent) {
-      event = newEvent;
-      return KeyEventResult.handled;
-    });
-
     await tester.pumpWidget(const Focus(autofocus: true, child: SizedBox()));
     await tester.pump();
 
     await simulateKeyDownEvent(LogicalKeyboardKey.numLock, platform: 'windows');
 
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isTrue);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isTrue);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isTrue);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isTrue);
 
     await simulateKeyDownEvent(LogicalKeyboardKey.numpad1, platform: 'windows');
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
 
     await simulateKeyRepeatEvent(LogicalKeyboardKey.numpad1, platform: 'windows');
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
 
     await simulateKeyUpEvent(LogicalKeyboardKey.numLock);
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isTrue);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isTrue);
 
     await simulateKeyDownEvent(LogicalKeyboardKey.numLock, platform: 'windows');
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isTrue);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isTrue);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isTrue);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isTrue);
 
     await simulateKeyUpEvent(LogicalKeyboardKey.numpad1, platform: 'windows');
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isFalse);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isFalse);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numpad1), isFalse);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numpad1), isFalse);
 
     await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'windows');
-    expect(event?.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isFalse);
-    expect(event?.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isFalse);
+    expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isFalse);
+    expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isFalse);
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
   testWidgetsWithLeakTracking('KeyboardManager synthesizes modifier keys in rawKeyData mode', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Adds some convenience methods to `HarwareKeyboard` that allow testing to see if a logical or physical key is pressed from the event object. These are similar to the ones already on `RawKeyEvent`, and will make migration the to `KeyEvent` system easier (so it could more easily be a `flutter fix` migration).

Added:

- `bool isLogicalKeyPressed(LogicalKeyboardKey key)`
- `bool isPhysicalKeyPressed(PhysicalKeyboardKey key)`
- `bool get isControlPressed`
- `bool get isShiftPressed`
- `bool get isAltPressed`
- `bool get isMetaPressed`

## Related Issues
 - https://github.com/flutter/flutter/issues/136419

## Tests
 - Added tests for the new methods.