### PR TITLE
[web] dispatch corresponding keyup events in text editing integrations

### DIFF
--- a/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
@@ -80,9 +80,14 @@ void main() {
     expect(textFormFieldsFinder, findsOneWidget);
     await tester.tap(find.byKey(const Key('input2')));
 
-    // // Press Tab. This should trigger `onFieldSubmitted` of TextField.
+    // Press Tab. This should trigger `onFieldSubmitted` of TextField.
     final InputElement input = findElements('input')[0] as InputElement;
     dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
+      'keyCode': 13, // Enter.
+      'cancelable': true,
+    });
+    // Release Tab.
+    dispatchKeyboardEvent(input, 'keyup', <String, dynamic>{
       'keyCode': 13, // Enter.
       'cancelable': true,
     });
@@ -112,6 +117,14 @@ void main() {
 
     // Press Tab. The focus should move to the next TextFormField.
     dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
+      'key': 'Tab',
+      'code': 'Tab',
+      'bubbles': true,
+      'cancelable': true,
+      'composed': true,
+    });
+    // Release tab.
+    dispatchKeyboardEvent(input, 'keyup', <String, dynamic>{
       'key': 'Tab',
       'code': 'Tab',
       'bubbles': true,
@@ -159,6 +172,14 @@ void main() {
 
     // Press Tab. The focus should move to the next TextFormField.
     dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
+      'key': 'Tab',
+      'code': 'Tab',
+      'bubbles': true,
+      'cancelable': true,
+      'composed': true,
+    });
+    // Release Tab.
+    dispatchKeyboardEvent(input, 'keyup', <String, dynamic>{
       'key': 'Tab',
       'code': 'Tab',
       'bubbles': true,


### PR DESCRIPTION
https://github.com/flutter/engine/pull/46829 changed event handling sequence on web so that KeyboardBinding/RawKeyboard handles the text event first before it reaches IME. That means when dispatching synthetised events to IME every keydown event must have a corresponding keyup, otherwise consistency assertions in `KeyboardBindings` are triggered.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
