### PR TITLE
Ensure `flutter build apk --release` optimizes+shrinks platform code

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -308,7 +308,7 @@ class FlutterPlugin implements Plugin<Project> {
                     shrinkResources isBuiltAsApp(project)
                     // Fallback to `android/app/proguard-rules.pro`.
                     // This way, custom Proguard rules can be configured as needed.
-                    proguardFiles project.android.getDefaultProguardFile("proguard-android.txt"), flutterProguardRules, "proguard-rules.pro"
+                    proguardFiles project.android.getDefaultProguardFile("proguard-android-optimize.txt"), flutterProguardRules, "proguard-rules.pro"
                 }
             }
         }


### PR DESCRIPTION
Since the original PR that supposedly enabled proguard, it was using the android proguard rules that disable optimizations. See initial PR in [0]

This PR changes the flutter gradle plugin to use the `proguard-android-optimize.txt` (instead of `proguard-android.txt`) which will enable optimizations/shrinking of platform code (i.e. java/kotlin).

For a simple flutter hello world this results in a 25% reduction in the resulting DEX file (`classes.dex` of the APK).

[0] f098de1fdedec2232aa740a6413f318166762795

Fixes https://github.com/flutter/flutter/issues/136879