### PR TITLE
Reland: "Add code for updating `focusedChild` when removing grandchildren from scope"

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -964,7 +964,13 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     assert(node._manager == _manager);
 
     if (removeScopeFocus) {
-      node.enclosingScope?._focusedChildren.remove(node);
+      final FocusScopeNode? nodeScope = node.enclosingScope;
+      if (nodeScope != null) {
+        nodeScope._focusedChildren.remove(node);
+        node.descendants.where((FocusNode descendant) {
+          return descendant.enclosingScope == nodeScope;
+        }).forEach(nodeScope._focusedChildren.remove);
+      }
     }
 
     node._parent = null;


### PR DESCRIPTION
Reverts flutter/flutter#136862, to re-land #136771, which doesn't appear to have caused the build failure after all.
