### PR TITLE
[flutter_tools] toolexit when using plugins with preview device

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 import 'dart:async';
 
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -150,7 +150,7 @@ abstract class Pub {
     String? flutterRootOverride,
     bool checkUpToDate = false,
     bool shouldSkipThirdPartyGenerator = true,
-    PubOutputMode outputMode = PubOutputMode.all
+    PubOutputMode outputMode = PubOutputMode.all,
   });
 
   /// Runs pub in 'batch' mode.
@@ -255,7 +255,7 @@ class _DefaultPub implements Pub {
     String? flutterRootOverride,
     bool checkUpToDate = false,
     bool shouldSkipThirdPartyGenerator = true,
-    PubOutputMode outputMode = PubOutputMode.all
+    PubOutputMode outputMode = PubOutputMode.all,
   }) async {
     final String directory = project.directory.path;
     final File packageConfigFile = project.packageConfigFile;

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -948,12 +948,6 @@ Future<void> writeWindowsPluginFiles(
     'ffiPlugins': windowsFfiPlugins,
     'pluginsDir': _cmakeRelativePluginSymlinkDirectoryPath(project.windows),
   };
-  print('all plugins: ${plugins.map((Plugin p) => p.name).toList()}');
-  print('methodChannelPlugins: ${methodChannelPlugins.map((Plugin p) => p.name).toList()}');
-  print('win32plugins: ${win32Plugins.map((Plugin p) => p.name).toList()}');
-  print('ffiPlugins: ${ffiPlugins.map((Plugin p) => p.name).toList()}');
-  print('windowsFfiPlugins: ${windowsFfiPlugins.map((Map<String, Object?> map) => map.keys).toList()}');
-  throwToolExit('foo');
   await _writeCppPluginRegistrant(project.windows.managedDirectory, context, templateRenderer);
   await _writePluginCmakefile(project.windows.generatedPluginCmakeFile, context, templateRenderer);
 }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -938,7 +938,7 @@ Future<void> writeWindowsPluginFiles(
       buffer.writeln(disallowedPlugins.map((Plugin p) => p.name).toList().toString());
       buffer.writeln();
       buffer.writeln('In order to build a Flutter app with plugins, you must use another target platform,');
-      buffer.writeln('Such as Windows. Type `flutter doctor` into your terminal to see which target platforms');
+      buffer.writeln('such as Windows. Type `flutter doctor` into your terminal to see which target platforms');
       buffer.writeln('are ready to be used, and how to get required dependencies for other platforms.');
       throwToolExit(buffer.toString());
     }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -932,10 +932,15 @@ Future<void> writeWindowsPluginFiles(
         .toList()
         ..removeWhere((Plugin plugin) => allowedPlugins.contains(plugin.name));
     if (disallowedPlugins.isNotEmpty) {
-      throwToolExit(
-        'The Flutter Preview device does not support plugins with method channels: '
-        '${disallowedPlugins.map((Plugin p) => p.name).toList()}',
-      );
+      final StringBuffer buffer = StringBuffer();
+      buffer.writeln('The Flutter Preview device does not support the following plugins from your pubspec.yaml:');
+      buffer.writeln();
+      buffer.writeln(disallowedPlugins.map((Plugin p) => p.name).toList().toString());
+      buffer.writeln();
+      buffer.writeln('In order to build a Flutter app with plugins, you must use another target platform,');
+      buffer.writeln('Such as Windows. Type `flutter doctor` into your terminal to see which target platforms');
+      buffer.writeln('are ready to be used, and how to get required dependencies for other platforms.');
+      throwToolExit(buffer.toString());
     }
   }
   final List<Plugin> win32Plugins = _filterPluginsByVariant(methodChannelPlugins, WindowsPlugin.kConfigKey, PluginPlatformVariant.win32);

--- a/packages/flutter_tools/lib/src/preview_device.dart
+++ b/packages/flutter_tools/lib/src/preview_device.dart
@@ -123,6 +123,11 @@ class PreviewDevice extends Device {
   final Artifacts _artifacts;
   final File _previewBinary;
 
+  /// The set of plugins that are allowed to be used by Preview users.
+  ///
+  /// Currently no plugins are supported.
+  static const List<String> supportedPubPlugins = <String>[];
+
   @override
   void clearLogs() { }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -329,7 +329,10 @@ class FlutterProject {
   /// registrants for app and module projects only.
   ///
   /// Will not create project platform directories if they do not already exist.
-  Future<void> regeneratePlatformSpecificTooling({DeprecationBehavior deprecationBehavior = DeprecationBehavior.none}) async {
+  Future<void> regeneratePlatformSpecificTooling({
+    DeprecationBehavior deprecationBehavior = DeprecationBehavior.none,
+    Iterable<String>? allowedPlugins,
+  }) async {
     return ensureReadyForPlatformSpecificTooling(
       androidPlatform: android.existsSync(),
       iosPlatform: ios.existsSync(),
@@ -340,6 +343,7 @@ class FlutterProject {
       windowsPlatform: featureFlags.isWindowsEnabled && windows.existsSync(),
       webPlatform: featureFlags.isWebEnabled && web.existsSync(),
       deprecationBehavior: deprecationBehavior,
+      allowedPlugins: allowedPlugins,
     );
   }
 
@@ -353,6 +357,7 @@ class FlutterProject {
     bool windowsPlatform = false,
     bool webPlatform = false,
     DeprecationBehavior deprecationBehavior = DeprecationBehavior.none,
+    Iterable<String>? allowedPlugins,
   }) async {
     if (!directory.existsSync() || isPlugin) {
       return;
@@ -383,6 +388,7 @@ class FlutterProject {
       linuxPlatform: linuxPlatform,
       macOSPlatform: macOSPlatform,
       windowsPlatform: windowsPlatform,
+      allowedPlugins: allowedPlugins,
     );
   }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -329,6 +329,10 @@ class FlutterProject {
   /// registrants for app and module projects only.
   ///
   /// Will not create project platform directories if they do not already exist.
+  ///
+  /// If [allowedPlugins] is non-null, all plugins with method channels in the
+  /// project's pubspec.yaml will be validated to be in that set, or else a
+  /// [ToolExit] will be thrown.
   Future<void> regeneratePlatformSpecificTooling({
     DeprecationBehavior deprecationBehavior = DeprecationBehavior.none,
     Iterable<String>? allowedPlugins,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -27,6 +27,7 @@ import '../dart/pub.dart';
 import '../device.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
+import '../preview_device.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../web/compile.dart';
@@ -1669,7 +1670,6 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
     project.checkForDeprecation(deprecationBehavior: deprecationBehavior);
 
     if (shouldRunPub) {
-      // TODO
       final Environment environment = Environment(
         artifacts: globals.artifacts!,
         logger: globals.logger,
@@ -1696,10 +1696,11 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
         checkUpToDate: cachePubGet,
       );
 
+      // null implicitly means all plugins are allowed
       List<String>? allowedPlugins;
       if (stringArg(FlutterGlobalOptions.kDeviceIdOption, global: true) == 'preview') {
         // The preview device does not currently support any plugins.
-        allowedPlugins = const <String>[];
+        allowedPlugins = PreviewDevice.supportedPubPlugins;
       }
       await project.regeneratePlatformSpecificTooling(allowedPlugins: allowedPlugins);
       if (reportNullSafety) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1669,6 +1669,7 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
     project.checkForDeprecation(deprecationBehavior: deprecationBehavior);
 
     if (shouldRunPub) {
+      // TODO
       final Environment environment = Environment(
         artifacts: globals.artifacts!,
         logger: globals.logger,
@@ -1694,7 +1695,13 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
         project: project,
         checkUpToDate: cachePubGet,
       );
-      await project.regeneratePlatformSpecificTooling();
+
+      List<String>? allowedPlugins;
+      if (stringArg(FlutterGlobalOptions.kDeviceIdOption, global: true) == 'preview') {
+        // The preview device does not currently support any plugins.
+        allowedPlugins = const <String>[];
+      }
+      await project.regeneratePlatformSpecificTooling(allowedPlugins: allowedPlugins);
       if (reportNullSafety) {
         await _sendNullSafetyAnalyticsEvents(project);
       }

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/plugins.dart';
+import 'package:flutter_tools/src/preview_device.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:test/fake.dart';
@@ -210,7 +211,7 @@ void main() {
             ? fakePubCache.childDirectory(name)
             : fileSystem.directory(nameOrPath);
         packagesFile.writeAsStringSync(
-            '$name:file://${pluginDirectory.childFile('lib').uri}\n',
+            '$name:${pluginDirectory.childFile('lib').uri}\n',
             mode: FileMode.writeOnlyAppend);
         pluginDirectory.childFile('pubspec.yaml')
             ..createSync(recursive: true)
@@ -1437,6 +1438,29 @@ flutter:
       }, overrides: <Type, Generator>{
         FileSystem: () => fsWindows,
         ProcessManager: () => FakeProcessManager.any(),
+      });
+
+      testUsingContext('injectPlugins will validate if all plugins in the project are part of the passed allowedPlugins', () async {
+        // Re-run the setup using the Windows filesystem.
+        setUpProject(fsWindows);
+        createFakePlugins(fsWindows, const <String>['plugin_one', 'plugin_two']);
+
+        expect(
+          () => injectPlugins(
+            flutterProject,
+            linuxPlatform: true,
+            windowsPlatform: true,
+            allowedPlugins: PreviewDevice.supportedPubPlugins,
+          ),
+          throwsToolExit(message: '''
+The Flutter Preview device does not support the following plugins from your pubspec.yaml:
+
+[plugin_one, plugin_two]
+'''),
+        );
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fsWindows,
+        ProcessManager: () => FakeProcessManager.empty(),
       });
     });
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/130277

Without this, if a user runs an app that has plugins that call method channels with the `preview` device, the app will build successfully, however, they will get a runtime error when their dart code tries to call the method channel that does not exist in the native build (which was pre-built and thus does not include the plugin code).

This change adds a validation when injecting plugins that will tool exit if the device-id is `preview` and their project contains plugins with method channels.