### PR TITLE
[docs] Expand categories for automated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,13 +6,60 @@ changelog:
     labels:
       - passed first triage
       - passed secondary triage
+      - team-release
+      - "team: flakes"
+      - revert
   categories:
     - title: Framework
       labels:
         - framework
-    - title: Tooling
+        - "a: text input"
+        - "f: scrolling"
+        - "f: routes"
+        - "f: selection"
+      exclude:
+        labels:
+          - "f: material"
+    - title: Material
       labels:
-        - tool
+        - "f: material"
+    # Mobile
+    - title: iOS
+      labels:
+        - platform-ios
+        - "f: cupertino"
+    - title: Android
+      labels:
+        - platform-android
+    # Desktop
     - title: MacOS
       labels:
         - platform-mac
+    - title: Windows
+      labels:
+        - platform-windows
+    - title: Linux
+      labels:
+        - platform-linux
+    # Web
+    - title: Web
+      labels:
+        - platform-web
+        - "browser: chrome-desktop"
+        - "browser: edge"
+        - "browser: firefox"
+        - "browser: safari-macos"
+    # Misc
+    - title: Tooling
+      labels:
+        - tool
+    - title: DevTools
+        - "d: devtools"
+        - "d: intellij"
+    - title: Documentation
+      labels:
+        - "d: examples"
+        - "d: api docs"
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
Updates release.yml to expand categories for automated release notes utilizing updated labels. 

For more information on automated release notes see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

CC: @MaryaBelanger @atsansone 