### PR TITLE
[Impeller] add OpenGL GPU tracing to devicelab tests.

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -772,6 +772,9 @@ Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations
 /// <meta-data
 ///   android:name="io.flutter.embedding.android.ImpellerBackend"
 ///   android:value="opengles" />
+/// <meta-data
+///   android:name="io.flutter.embedding.android.EnableOpenGLGPUTracing"
+///   android:value="true" />
 void _addOpenGLESToManifest(String testDirectory) {
   final String manifestPath = path.join(
       testDirectory, 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
@@ -783,30 +786,34 @@ void _addOpenGLESToManifest(String testDirectory) {
 
   final String xmlStr = file.readAsStringSync();
   final XmlDocument xmlDoc = XmlDocument.parse(xmlStr);
-  const String key = 'io.flutter.embedding.android.ImpellerBackend';
-  const String value = 'opengles';
+  final List<(String, String)> keyPairs = <(String, String)>[
+    ('io.flutter.embedding.android.ImpellerBackend', 'opengles'),
+    ('io.flutter.embedding.android.EnableOpenGLGPUTracing', 'true')
+  ];
 
   final XmlElement applicationNode =
       xmlDoc.findAllElements('application').first;
 
   // Check if the meta-data node already exists.
-  final Iterable<XmlElement> existingMetaData = applicationNode
-      .findAllElements('meta-data')
-      .where((XmlElement node) => node.getAttribute('android:name') == key);
+  for (final (String key, String value) in keyPairs) {
+    final Iterable<XmlElement> existingMetaData = applicationNode
+        .findAllElements('meta-data')
+        .where((XmlElement node) => node.getAttribute('android:name') == key);
 
-  if (existingMetaData.isNotEmpty) {
-    final XmlElement existingEntry = existingMetaData.first;
-    existingEntry.setAttribute('android:value', value);
-  } else {
-    final XmlElement metaData = XmlElement(
-      XmlName('meta-data'),
-      <XmlAttribute>[
-        XmlAttribute(XmlName('android:name'), key),
-        XmlAttribute(XmlName('android:value'), value)
-      ],
-    );
+    if (existingMetaData.isNotEmpty) {
+      final XmlElement existingEntry = existingMetaData.first;
+      existingEntry.setAttribute('android:value', value);
+    } else {
+      final XmlElement metaData = XmlElement(
+        XmlName('meta-data'),
+        <XmlAttribute>[
+          XmlAttribute(XmlName('android:name'), key),
+          XmlAttribute(XmlName('android:value'), value)
+        ],
+      );
 
-    applicationNode.children.add(metaData);
+      applicationNode.children.add(metaData);
+    }
   }
 
   file.writeAsStringSync(xmlDoc.toXmlString(pretty: true, indent: '    '));


### PR DESCRIPTION
Adds the metadata key required to enable OpenGLES GPU tracing. This is off by default because the API crashes on some GPU models, but it should be safe on the Pixel 7 (others TBD based on testing results).
