### PR TITLE
Bump dartdoc to 7.0.1 and clean-up

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -399,17 +399,20 @@ targets:
       firebase_project: ""
       release_ref: ""
       tags: >
-        ["framework","hostonly", "linux"]
+        ["framework", "hostonly", "linux"]
       validation: docs
       validation_name: Docs
     runIf:
+      - bin/**
       - dev/**
       - packages/flutter/**
-      - packages/flutter_test/**
       - packages/flutter_drive/**
       - packages/flutter_localizations/**
-      - bin/**
+      - packages/flutter_test/**
+      - packages/flutter_web_plugins/**
+      - packages/integration_test/**
       - .ci.yaml
+      - dartdoc_options.yaml
 
   - name: Linux engine_dependency_proxy_test
     recipe: devicelab/devicelab_drone

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -34,7 +34,7 @@ dartdoc:
     - not-implemented
     - orphaned-file
     - reexported-private-api-across-packages
-    # - unknown-directive  # Disabled due to https://github.com/dart-lang/dartdoc/issues/2353
+    - unknown-directive
     - unknown-file
     - unknown-macro
     - unresolved-doc-reference

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -17,7 +17,6 @@ dartdoc:
     # Default errors of dartdoc:
     - duplicate-file
     - invalid-parameter
-    - no-defining-library-found
     - tool-error
     - unresolved-export
     # Warnings that are elevated to errors:
@@ -31,10 +30,12 @@ dartdoc:
     - no-canonical-found
     - no-documentable-libraries
     - no-library-level-docs
-    - not-implemented
     - orphaned-file
     - reexported-private-api-across-packages
-    - unknown-directive
     - unknown-file
     - unknown-macro
     - unresolved-doc-reference
+    # Ignores that are elevated to errors:
+    - type-as-html
+    - missing-constant-constructor
+    - missing-code-block-language

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -14,12 +14,12 @@ dartdoc:
       command: ["bin/cache/dart-sdk/bin/dart", "pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=dartpad"]
       description: "Creates full application sample code documentation output from embedded documentation samples and displays it in an embedded DartPad."
   errors:
-    # Default errors of dartdoc:
+    ## Default errors of dartdoc:
     - duplicate-file
     - invalid-parameter
     - tool-error
     - unresolved-export
-    # Warnings that are elevated to errors:
+    ## Warnings that are elevated to errors:
     - ambiguous-doc-reference
     - ambiguous-reexport
     - broken-link
@@ -35,7 +35,7 @@ dartdoc:
     - unknown-file
     - unknown-macro
     - unresolved-doc-reference
-    # Ignores that are elevated to errors:
-    - type-as-html
-    - missing-constant-constructor
-    - missing-code-block-language
+    ## Ignores that are elevated to errors:
+    # - type-as-html # not yet tested
+    # - missing-constant-constructor # not yet tested
+    # - missing-code-block-language # not yet tested

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -111,7 +111,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 6.3.0
+    "$DART" pub global activate dartdoc 7.0.1
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
These warnings/errors have been removed from dartdoc. Removing them from the flutter config as well.

Also fixes CI to actually test doc generation for all documented packages and on dartdoc config changes.