### PR TITLE
Provide exception for listing an issue.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 *Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
 
-*List which issues are fixed by this PR. You must list at least one issue.*
+*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
 
 *If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
 


### PR DESCRIPTION
Latest example of an issue about a typo: https://github.com/flutter/flutter/issues/137080. I don't think these are helpful, so we shouldn't be encouraging people to file these in order to submit a PR to fix 'em.