### PR TITLE
WIP: [macOS] Unquarantine app during build

### DIFF
--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -118,6 +118,7 @@ abstract class DesktopDevice extends Device {
     if (!prebuiltApplication) {
       await buildForDevice(
         buildInfo: debuggingOptions.buildInfo,
+        package: package,
         mainPath: mainPath,
       );
     }
@@ -198,6 +199,7 @@ abstract class DesktopDevice extends Device {
   /// Builds the current project for this device, with the given options.
   Future<void> buildForDevice({
     required BuildInfo buildInfo,
+    required ApplicationPackage package,
     String? mainPath,
   });
 

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -60,8 +60,9 @@ class LinuxDevice extends DesktopDevice {
 
   @override
   Future<void> buildForDevice({
-    String? mainPath,
     required BuildInfo buildInfo,
+    required covariant LinuxApp package,
+    String? mainPath,
   }) async {
     await buildLinux(
       FlutterProject.current().linux,

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -79,8 +79,9 @@ class MacOSDesignedForIPadDevice extends DesktopDevice {
 
   @override
   Future<void> buildForDevice({
-    String? mainPath,
     required BuildInfo buildInfo,
+    required covariant ApplicationPackage package,
+    String? mainPath,
   }) async {
     // Only attaching to a running app launched from Xcode is supported.
     throw UnimplementedError('Building for "$name" is not supported.');

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -50,8 +50,9 @@ class WindowsDevice extends DesktopDevice {
 
   @override
   Future<void> buildForDevice({
-    String? mainPath,
     required BuildInfo buildInfo,
+    required covariant WindowsApp package,
+    String? mainPath,
   }) async {
     await buildWindows(
       FlutterProject.current().windows,

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -406,6 +406,9 @@ class FakeDesktopDevice extends DesktopDevice {
   /// The [buildInfo] last passed to [buildForDevice].
   BuildInfo? lastBuildInfo;
 
+  /// The [package] last passed to [buildForDevice].
+  FakeApplicationPackage? lastPackage;
+
   final bool nullExecutablePathForDevice;
 
   @override
@@ -422,11 +425,13 @@ class FakeDesktopDevice extends DesktopDevice {
 
   @override
   Future<void> buildForDevice({
+    required BuildInfo buildInfo,
+    required covariant FakeApplicationPackage package,
     String? mainPath,
-    BuildInfo? buildInfo,
   }) async {
-    lastBuiltMainPath = mainPath;
     lastBuildInfo = buildInfo;
+    lastPackage = package;
+    lastBuiltMainPath = mainPath;
   }
 
   // Dummy implementation that just returns the build mode name.

--- a/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
@@ -141,7 +141,7 @@ void main() {
       ),
       throwsA(isA<UnimplementedError>()),
     );
-    await expectLater(() => device.buildForDevice(buildInfo: BuildInfo.debug), throwsA(isA<UnimplementedError>()));
+    await expectLater(() => device.buildForDevice(buildInfo: BuildInfo.debug, package: FakeIOSApp()), throwsA(isA<UnimplementedError>()));
     expect(device.executablePathForDevice(FakeIOSApp(), BuildInfo.debug), null);
   });
 }


### PR DESCRIPTION
As of macOS 14 (Sonoma), macOS marks newly-compiled binaries as quarantined and displays a warning about running an unsigned app before launching them on every rebuild. Since these binaries are compiled and run at the developers request, the author is aware that they're unsigned, mark them as unquarantined.

This also cleans up `buildApp` parameter order for consistency.

See: https://github.com/flutter/flutter/issues/136888

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
