### PR TITLE
[flutter_tools] - Add `queries` section to Android manifest file

### DIFF
--- a/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -31,4 +31,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -31,4 +31,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/AndroidManifest.xml
@@ -35,4 +35,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_views/android/app/src/main/AndroidManifest.xml
@@ -32,4 +32,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
@@ -34,4 +34,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
@@ -42,4 +42,15 @@ found in the LICENSE file. -->
             android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping"
             android:value="2:component1" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/external_ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/external_ui/android/app/src/main/AndroidManifest.xml
@@ -28,4 +28,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/flavors/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/flavors/android/app/src/main/AndroidManifest.xml
@@ -27,4 +27,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/flutter_gallery/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/flutter_gallery/android/app/src/main/AndroidManifest.xml
@@ -28,4 +28,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/src/main/AndroidManifest.xml
@@ -28,4 +28,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
@@ -30,4 +30,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/non_nullable/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/non_nullable/android/app/src/main/AndroidManifest.xml
@@ -40,4 +40,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
@@ -35,4 +35,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/release_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/release_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -40,4 +40,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/spell_check/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/spell_check/android/app/src/main/AndroidManifest.xml
@@ -34,4 +34,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
@@ -34,4 +34,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/api/android/app/src/main/AndroidManifest.xml
+++ b/examples/api/android/app/src/main/AndroidManifest.xml
@@ -34,4 +34,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/flutter_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter_view/android/app/src/main/AndroidManifest.xml
@@ -26,4 +26,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/hello_world/android/app/src/main/AndroidManifest.xml
+++ b/examples/hello_world/android/app/src/main/AndroidManifest.xml
@@ -28,4 +28,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/image_list/android/app/src/main/AndroidManifest.xml
+++ b/examples/image_list/android/app/src/main/AndroidManifest.xml
@@ -27,4 +27,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/layers/android/app/src/main/AndroidManifest.xml
+++ b/examples/layers/android/app/src/main/AndroidManifest.xml
@@ -28,4 +28,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/platform_channel/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel/android/app/src/main/AndroidManifest.xml
@@ -30,4 +30,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/examples/platform_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_view/android/app/src/main/AndroidManifest.xml
@@ -36,4 +36,15 @@ found in the LICENSE file. -->
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/packages/flutter/lib/src/services/process_text.dart
+++ b/packages/flutter/lib/src/services/process_text.dart
@@ -60,7 +60,31 @@ abstract class ProcessTextService {
 /// Any widget may use this service to get a list of text processing actions
 /// and send requests to activate these text actions.
 ///
-/// This is currently only supported by Android.
+/// This is currently only supported on Android and it requires adding the
+/// following '<queries>' element to the Android manifest file:
+///
+/// <manifest ...>
+///     <application ...>
+///       ...
+///     </application>
+///     <!-- Required to query activities that can process text, see:
+///           https://developer.android.com/training/package-visibility?hl=en and
+///           https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+///
+///           In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+///     <queries>
+///         <intent>
+///             <action android:name="android.intent.action.PROCESS_TEXT"/>
+///             <data android:mimeType="text/plain"/>
+///         </intent>
+///     </queries>
+/// </manifest>
+///
+/// The '<queries>' element is part of the Android manifest file generated when
+/// running the 'flutter create' command.
+///
+/// If the '<queries>' element is not found, `queryTextActions()` will return an
+/// empty list of `ProcessTextAction`.
 ///
 /// See also:
 ///

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/AndroidManifest.xml.tmpl
@@ -30,4 +30,15 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/AndroidManifest.xml.tmpl
@@ -37,4 +37,15 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <!-- Required to query activities that can process text, see:
+         https://developer.android.com/training/package-visibility?hl=en and
+         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
+
+         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT"/>
+            <data android:mimeType="text/plain"/>
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
## Description

This PR adds a new section to the Android manifest file.
This section is required for https://github.com/flutter/engine/pull/44579 (because it uses `PackageManager.queryIntentActivities` API ), see:

1. https://developer.android.com/training/package-visibility?hl=en
2. https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT
3. https://developer.android.com/reference/android/content/pm/PackageManager?hl=en#queryIntentActivities(android.content.Intent,%20android.content.pm.PackageManager.ResolveInfoFlags)

## Related Issue

Android manifest update for https://github.com/flutter/flutter/issues/139361.

## Tests

This PR updates the integration tests and examples Android manifest files, this will help catch error or warning related to this change.
