### PR TITLE
Update `DataTable` test when data row is pressed for Material 3

### DIFF
--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
 @TestOn('!chrome')
 library;
 
@@ -1725,16 +1728,11 @@ void main() {
     ));
 
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Content1')));
-    await tester.pump(const Duration(milliseconds: 200)); // splash is well underway
-    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))as RenderBox;
+    await tester.pump(); // start the splash animation
+    await tester.pump(const Duration(milliseconds: 100)); // splash is underway
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
-    // the effect with paint methods.
-    expect(
-      box,
-      paints
-        ..rect()
-        ..rect(rect: const Rect.fromLTRB(0.0, 56.0, 800.0, 104.0), color: pressedColor.withOpacity(0.0)),
-    );
+    // the effect with paint methods. Use a golden test instead.
+    await expectLater(find.byType(InkWell), matchesGoldenFile('data_table_test.data_row_pressed.png'));
     await gesture.up();
   });
 
@@ -2033,7 +2031,7 @@ void main() {
     );
 
     // Go without crashes.
-
+    expect(tester.takeException(), isNull);
   });
 
   testWidgetsWithLeakTracking('DataTable clip behavior', (WidgetTester tester) async {


### PR DESCRIPTION
This updates one of them M3 test to use golden test from https://github.com/flutter/flutter/pull/135901
Keeping it consistent with this [update](https://github.com/flutter/flutter/pull/136809#discussion_r1365053630)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
