### PR TITLE
Refactor to use Apple system fonts

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
@@ -153,7 +153,7 @@ class _CupertinoTextFieldDemoState extends State<CupertinoTextFieldDemo> {
   Widget build(BuildContext context) {
     return DefaultTextStyle(
       style: const TextStyle(
-        fontFamily: '.SF UI Text',
+        fontFamily: 'CupertinoSystemText',
         inherit: false,
         fontSize: 17.0,
         color: CupertinoColors.black,

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -57,7 +57,7 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
   );
   static const double _kButtonHeight = 43;
   static const TextStyle _kActionSheetActionStyle = TextStyle(
-    fontFamily: '.SF UI Text',
+    fontFamily: 'CupertinoSystemText',
     inherit: false,
     fontSize: 16.0,
     fontWeight: FontWeight.w400,

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 // Apple Design Resources(https://developer.apple.com/design/resources/).
 // However the values are not exactly the same as native, so eyeballing is needed.
 const TextStyle _kCupertinoDialogTitleStyle = TextStyle(
-  fontFamily: '.SF UI Display',
+  fontFamily: 'CupertinoSystemDisplay',
   inherit: false,
   fontSize: 17.0,
   fontWeight: FontWeight.w600,
@@ -33,7 +33,7 @@ const TextStyle _kCupertinoDialogTitleStyle = TextStyle(
 );
 
 const TextStyle _kCupertinoDialogContentStyle = TextStyle(
-  fontFamily: '.SF UI Text',
+  fontFamily: 'CupertinoSystemText',
   inherit: false,
   fontSize: 13.0,
   fontWeight: FontWeight.w400,
@@ -43,7 +43,7 @@ const TextStyle _kCupertinoDialogContentStyle = TextStyle(
 );
 
 const TextStyle _kCupertinoDialogActionStyle = TextStyle(
-  fontFamily: '.SF UI Text',
+  fontFamily: 'CupertinoSystemText',
   inherit: false,
   fontSize: 16.8,
   fontWeight: FontWeight.w400,
@@ -52,7 +52,7 @@ const TextStyle _kCupertinoDialogActionStyle = TextStyle(
 
 // CupertinoActionSheet-specific text styles.
 const TextStyle _kActionSheetActionStyle = TextStyle(
-  fontFamily: '.SF UI Text',
+  fontFamily: 'CupertinoSystemText',
   inherit: false,
   fontSize: 20.0,
   fontWeight: FontWeight.w400,
@@ -60,7 +60,7 @@ const TextStyle _kActionSheetActionStyle = TextStyle(
 );
 
 const TextStyle _kActionSheetContentStyle = TextStyle(
-  fontFamily: '.SF UI Text',
+  fontFamily: 'CupertinoSystemText',
   inherit: false,
   fontSize: 13.0,
   fontWeight: FontWeight.w400,

--- a/packages/flutter/lib/src/cupertino/text_theme.dart
+++ b/packages/flutter/lib/src/cupertino/text_theme.dart
@@ -14,7 +14,7 @@ import 'colors.dart';
 // Values derived from https://developer.apple.com/design/resources/.
 const TextStyle _kDefaultTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Text',
+  fontFamily: 'CupertinoSystemText',
   fontSize: 17.0,
   letterSpacing: -0.41,
   color: CupertinoColors.label,
@@ -28,7 +28,7 @@ const TextStyle _kDefaultTextStyle = TextStyle(
 // Values derived from https://developer.apple.com/design/resources/.
 const TextStyle _kDefaultActionTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Text',
+  fontFamily: 'CupertinoSystemText',
   fontSize: 17.0,
   letterSpacing: -0.41,
   color: CupertinoColors.activeBlue,
@@ -42,7 +42,7 @@ const TextStyle _kDefaultActionTextStyle = TextStyle(
 // Values derived from https://developer.apple.com/design/resources/.
 const TextStyle _kDefaultTabLabelTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Text',
+  fontFamily: 'CupertinoSystemText',
   fontSize: 10.0,
   fontWeight: FontWeight.w500,
   letterSpacing: -0.24,
@@ -51,7 +51,7 @@ const TextStyle _kDefaultTabLabelTextStyle = TextStyle(
 
 const TextStyle _kDefaultMiddleTitleTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Text',
+  fontFamily: 'CupertinoSystemText',
   fontSize: 17.0,
   fontWeight: FontWeight.w600,
   letterSpacing: -0.41,
@@ -60,10 +60,10 @@ const TextStyle _kDefaultMiddleTitleTextStyle = TextStyle(
 
 const TextStyle _kDefaultLargeTitleTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Display',
+  fontFamily: 'CupertinoSystemDisplay',
   fontSize: 34.0,
   fontWeight: FontWeight.w700,
-  letterSpacing: 0.41,
+  letterSpacing: 0.38,
   color: CupertinoColors.label,
 );
 
@@ -80,7 +80,7 @@ const TextStyle _kDefaultLargeTitleTextStyle = TextStyle(
 // * https://github.com/flutter/flutter/pull/65501#discussion_r486557093
 const TextStyle _kDefaultPickerTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Display',
+  fontFamily: 'CupertinoSystemDisplay',
   fontSize: 21.0,
   fontWeight: FontWeight.w400,
   letterSpacing: -0.6,
@@ -95,8 +95,9 @@ const TextStyle _kDefaultPickerTextStyle = TextStyle(
 // Value extracted from off-center labels. Centered labels have a font size of 25pt.
 const TextStyle _kDefaultDateTimePickerTextStyle = TextStyle(
   inherit: false,
-  fontFamily: '.SF Pro Display',
+  fontFamily: 'CupertinoSystemDisplay',
   fontSize: 21,
+  letterSpacing: 0.4,
   fontWeight: FontWeight.normal,
   color: CupertinoColors.label,
 );

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -507,21 +507,21 @@ class Typography with Diagnosticable {
   ///
   /// This theme uses the iOS version of the font names.
   static const TextTheme blackCupertino = TextTheme(
-    displayLarge: TextStyle(debugLabel: 'blackCupertino displayLarge', fontFamily: '.SF UI Display', color: Colors.black54, decoration: TextDecoration.none),
-    displayMedium: TextStyle(debugLabel: 'blackCupertino displayMedium', fontFamily: '.SF UI Display', color: Colors.black54, decoration: TextDecoration.none),
-    displaySmall: TextStyle(debugLabel: 'blackCupertino displaySmall', fontFamily: '.SF UI Display', color: Colors.black54, decoration: TextDecoration.none),
-    headlineLarge: TextStyle(debugLabel: 'blackCupertino headlineLarge', fontFamily: '.SF UI Display', color: Colors.black54, decoration: TextDecoration.none),
-    headlineMedium: TextStyle(debugLabel: 'blackCupertino headlineMedium', fontFamily: '.SF UI Display', color: Colors.black54, decoration: TextDecoration.none),
-    headlineSmall: TextStyle(debugLabel: 'blackCupertino headlineSmall', fontFamily: '.SF UI Display', color: Colors.black87, decoration: TextDecoration.none),
-    titleLarge: TextStyle(debugLabel: 'blackCupertino titleLarge', fontFamily: '.SF UI Display', color: Colors.black87, decoration: TextDecoration.none),
-    titleMedium: TextStyle(debugLabel: 'blackCupertino titleMedium', fontFamily: '.SF UI Text', color: Colors.black87, decoration: TextDecoration.none),
-    titleSmall: TextStyle(debugLabel: 'blackCupertino titleSmall', fontFamily: '.SF UI Text', color: Colors.black, decoration: TextDecoration.none),
-    bodyLarge: TextStyle(debugLabel: 'blackCupertino bodyLarge', fontFamily: '.SF UI Text', color: Colors.black87, decoration: TextDecoration.none),
-    bodyMedium: TextStyle(debugLabel: 'blackCupertino bodyMedium', fontFamily: '.SF UI Text', color: Colors.black87, decoration: TextDecoration.none),
-    bodySmall: TextStyle(debugLabel: 'blackCupertino bodySmall', fontFamily: '.SF UI Text', color: Colors.black54, decoration: TextDecoration.none),
-    labelLarge: TextStyle(debugLabel: 'blackCupertino labelLarge', fontFamily: '.SF UI Text', color: Colors.black87, decoration: TextDecoration.none),
-    labelMedium: TextStyle(debugLabel: 'blackCupertino labelMedium', fontFamily: '.SF UI Text', color: Colors.black, decoration: TextDecoration.none),
-    labelSmall: TextStyle(debugLabel: 'blackCupertino labelSmall', fontFamily: '.SF UI Text', color: Colors.black, decoration: TextDecoration.none),
+    displayLarge: TextStyle(debugLabel: 'blackCupertino displayLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.black54, decoration: TextDecoration.none),
+    displayMedium: TextStyle(debugLabel: 'blackCupertino displayMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.black54, decoration: TextDecoration.none),
+    displaySmall: TextStyle(debugLabel: 'blackCupertino displaySmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.black54, decoration: TextDecoration.none),
+    headlineLarge: TextStyle(debugLabel: 'blackCupertino headlineLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.black54, decoration: TextDecoration.none),
+    headlineMedium: TextStyle(debugLabel: 'blackCupertino headlineMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.black54, decoration: TextDecoration.none),
+    headlineSmall: TextStyle(debugLabel: 'blackCupertino headlineSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.black87, decoration: TextDecoration.none),
+    titleLarge: TextStyle(debugLabel: 'blackCupertino titleLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.black87, decoration: TextDecoration.none),
+    titleMedium: TextStyle(debugLabel: 'blackCupertino titleMedium', fontFamily: 'CupertinoSystemText', color: Colors.black87, decoration: TextDecoration.none),
+    titleSmall: TextStyle(debugLabel: 'blackCupertino titleSmall', fontFamily: 'CupertinoSystemText', color: Colors.black, decoration: TextDecoration.none),
+    bodyLarge: TextStyle(debugLabel: 'blackCupertino bodyLarge', fontFamily: 'CupertinoSystemText', color: Colors.black87, decoration: TextDecoration.none),
+    bodyMedium: TextStyle(debugLabel: 'blackCupertino bodyMedium', fontFamily: 'CupertinoSystemText', color: Colors.black87, decoration: TextDecoration.none),
+    bodySmall: TextStyle(debugLabel: 'blackCupertino bodySmall', fontFamily: 'CupertinoSystemText', color: Colors.black54, decoration: TextDecoration.none),
+    labelLarge: TextStyle(debugLabel: 'blackCupertino labelLarge', fontFamily: 'CupertinoSystemText', color: Colors.black87, decoration: TextDecoration.none),
+    labelMedium: TextStyle(debugLabel: 'blackCupertino labelMedium', fontFamily: 'CupertinoSystemText', color: Colors.black, decoration: TextDecoration.none),
+    labelSmall: TextStyle(debugLabel: 'blackCupertino labelSmall', fontFamily: 'CupertinoSystemText', color: Colors.black, decoration: TextDecoration.none),
   );
 
   /// A Material Design text theme with light glyphs based on San Francisco.
@@ -530,21 +530,21 @@ class Typography with Diagnosticable {
   ///
   /// This theme uses the iOS version of the font names.
   static const TextTheme whiteCupertino = TextTheme(
-    displayLarge: TextStyle(debugLabel: 'whiteCupertino displayLarge', fontFamily: '.SF UI Display', color: Colors.white70, decoration: TextDecoration.none),
-    displayMedium: TextStyle(debugLabel: 'whiteCupertino displayMedium', fontFamily: '.SF UI Display', color: Colors.white70, decoration: TextDecoration.none),
-    displaySmall: TextStyle(debugLabel: 'whiteCupertino displaySmall', fontFamily: '.SF UI Display', color: Colors.white70, decoration: TextDecoration.none),
-    headlineLarge: TextStyle(debugLabel: 'whiteCupertino headlineLarge', fontFamily: '.SF UI Display', color: Colors.white70, decoration: TextDecoration.none),
-    headlineMedium: TextStyle(debugLabel: 'whiteCupertino headlineMedium', fontFamily: '.SF UI Display', color: Colors.white70, decoration: TextDecoration.none),
-    headlineSmall: TextStyle(debugLabel: 'whiteCupertino headlineSmall', fontFamily: '.SF UI Display', color: Colors.white, decoration: TextDecoration.none),
-    titleLarge: TextStyle(debugLabel: 'whiteCupertino titleLarge', fontFamily: '.SF UI Display', color: Colors.white, decoration: TextDecoration.none),
-    titleMedium: TextStyle(debugLabel: 'whiteCupertino titleMedium', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
-    titleSmall: TextStyle(debugLabel: 'whiteCupertino titleSmall', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
-    bodyLarge: TextStyle(debugLabel: 'whiteCupertino bodyLarge', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
-    bodyMedium: TextStyle(debugLabel: 'whiteCupertino bodyMedium', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
-    bodySmall: TextStyle(debugLabel: 'whiteCupertino bodySmall', fontFamily: '.SF UI Text', color: Colors.white70, decoration: TextDecoration.none),
-    labelLarge: TextStyle(debugLabel: 'whiteCupertino labelLarge', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
-    labelMedium: TextStyle(debugLabel: 'whiteCupertino labelMedium', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
-    labelSmall: TextStyle(debugLabel: 'whiteCupertino labelSmall', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
+    displayLarge: TextStyle(debugLabel: 'whiteCupertino displayLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
+    displayMedium: TextStyle(debugLabel: 'whiteCupertino displayMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
+    displaySmall: TextStyle(debugLabel: 'whiteCupertino displaySmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
+    headlineLarge: TextStyle(debugLabel: 'whiteCupertino headlineLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
+    headlineMedium: TextStyle(debugLabel: 'whiteCupertino headlineMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
+    headlineSmall: TextStyle(debugLabel: 'whiteCupertino headlineSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    titleLarge: TextStyle(debugLabel: 'whiteCupertino titleLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    titleMedium: TextStyle(debugLabel: 'whiteCupertino titleMedium', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
+    titleSmall: TextStyle(debugLabel: 'whiteCupertino titleSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    bodyLarge: TextStyle(debugLabel: 'whiteCupertino bodyLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    bodyMedium: TextStyle(debugLabel: 'whiteCupertino bodyMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    bodySmall: TextStyle(debugLabel: 'whiteCupertino bodySmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
+    labelLarge: TextStyle(debugLabel: 'whiteCupertino labelLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    labelMedium: TextStyle(debugLabel: 'whiteCupertino labelMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    labelSmall: TextStyle(debugLabel: 'whiteCupertino labelSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
   );
 
   /// A Material Design text theme with dark glyphs based on San Francisco.

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -538,13 +538,13 @@ class Typography with Diagnosticable {
     headlineSmall: TextStyle(debugLabel: 'whiteCupertino headlineSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
     titleLarge: TextStyle(debugLabel: 'whiteCupertino titleLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
     titleMedium: TextStyle(debugLabel: 'whiteCupertino titleMedium', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
-    titleSmall: TextStyle(debugLabel: 'whiteCupertino titleSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
-    bodyLarge: TextStyle(debugLabel: 'whiteCupertino bodyLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
-    bodyMedium: TextStyle(debugLabel: 'whiteCupertino bodyMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
-    bodySmall: TextStyle(debugLabel: 'whiteCupertino bodySmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white70, decoration: TextDecoration.none),
-    labelLarge: TextStyle(debugLabel: 'whiteCupertino labelLarge', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
-    labelMedium: TextStyle(debugLabel: 'whiteCupertino labelMedium', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
-    labelSmall: TextStyle(debugLabel: 'whiteCupertino labelSmall', fontFamily: 'CupertinoSystemDisplay', color: Colors.white, decoration: TextDecoration.none),
+    titleSmall: TextStyle(debugLabel: 'whiteCupertino titleSmall', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
+    bodyLarge: TextStyle(debugLabel: 'whiteCupertino bodyLarge', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
+    bodyMedium: TextStyle(debugLabel: 'whiteCupertino bodyMedium', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
+    bodySmall: TextStyle(debugLabel: 'whiteCupertino bodySmall', fontFamily: 'CupertinoSystemText', color: Colors.white70, decoration: TextDecoration.none),
+    labelLarge: TextStyle(debugLabel: 'whiteCupertino labelLarge', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
+    labelMedium: TextStyle(debugLabel: 'whiteCupertino labelMedium', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
+    labelSmall: TextStyle(debugLabel: 'whiteCupertino labelSmall', fontFamily: 'CupertinoSystemText', color: Colors.white, decoration: TextDecoration.none),
   );
 
   /// A Material Design text theme with dark glyphs based on San Francisco.

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -477,10 +477,12 @@ class TextStyle with Diagnosticable {
   /// [fontFamily] property.
   ///
   /// On Apple devices the strings 'CupertinoSystemText' and
-  /// 'CupertinoSystemDisplay' are used as proxies for the Apple system fonts.
-  /// They currently redirect to the equivilant of SF Pro Text and SF Pro Display
-  /// respectively. 'CupertinoSystemText' is designed for fonts below 20 point
-  /// size, and 'CupertinoSystemDisplay' is recommended for sizes 20 and above.
+  /// 'CupertinoSystemDisplay' are used in [fontFamily] as proxies for the
+  /// Apple system fonts. They currently redirect to the equivilant of SF Pro
+  /// Text and SF Pro Display respectively. 'CupertinoSystemText' is designed
+  /// for fonts below 20 point size, and 'CupertinoSystemDisplay' is recommended
+  /// for sizes 20 and above. When used on non-Apple platforms, these strings
+  /// will fail and return the fallback font family as normal.
   const TextStyle({
     this.inherit = true,
     this.color,
@@ -578,6 +580,8 @@ class TextStyle with Diagnosticable {
   /// They currently redirect to the equivilant of SF Pro Text and SF Pro Display
   /// respectively. 'CupertinoSystemText' is designed for fonts below 20 point
   /// size, and 'CupertinoSystemDisplay' is recommended for sizes 20 and above.
+  /// When used on non-Apple platforms, these strings will fail and return the
+  /// fallback font family as normal.
   final String? fontFamily;
 
   /// The ordered list of font families to fall back on when a glyph cannot be

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -482,7 +482,7 @@ class TextStyle with Diagnosticable {
   /// Text and SF Pro Display respectively. 'CupertinoSystemText' is designed
   /// for fonts below 20 point size, and 'CupertinoSystemDisplay' is recommended
   /// for sizes 20 and above. When used on non-Apple platforms, these strings
-  /// will fail and return the fallback font family as normal.
+  /// will return the regular fallback font family instead.
   const TextStyle({
     this.inherit = true,
     this.color,
@@ -580,8 +580,8 @@ class TextStyle with Diagnosticable {
   /// They currently redirect to the equivilant of SF Pro Text and SF Pro Display
   /// respectively. 'CupertinoSystemText' is designed for fonts below 20 point
   /// size, and 'CupertinoSystemDisplay' is recommended for sizes 20 and above.
-  /// When used on non-Apple platforms, these strings will fail and return the
-  /// fallback font family as normal.
+  /// When used on non-Apple platforms, these strings will return the regular
+  /// fallback font family instead.
   final String? fontFamily;
 
   /// The ordered list of font families to fall back on when a glyph cannot be

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -438,7 +438,7 @@ const double _kDefaultFontSize = 14.0;
 /// By default, fonts differ depending on the platform.
 ///
 ///  * The default font-family for `Android`,`Fuchsia` and `Linux` is `Roboto`.
-///  * The default font-family for `iOS` is `.SF UI Display`/`.SF UI Text`.
+///  * The default font-family for `iOS` is `SF Pro Display`/`SF Pro Text`.
 ///  * The default font-family for `MacOS` is `.AppleSystemUIFont`.
 ///  * The default font-family for `Windows` is `Segoe UI`.
 //
@@ -566,6 +566,12 @@ class TextStyle with Diagnosticable {
   /// first value in [fontFamilyFallback] acts as the preferred/first font
   /// family. When neither is provided, then the default platform font will
   /// be used.
+  ///
+  /// When running on Apple devices, the strings 'CupertinoSystemText' and
+  /// 'CupertinoSystemDisplay' are used as proxies for the Apple system fonts.
+  /// They currently redirect to the equivilant of SF Pro Text and SF Pro Display
+  /// respectively. 'CupertinoSystemText' is designed for fonts below 20 point
+  /// size, and 'CupertinoSystemDisplay' is recommended for sizes 20 and above.
   final String? fontFamily;
 
   /// The ordered list of font families to fall back on when a glyph cannot be

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -475,6 +475,12 @@ class TextStyle with Diagnosticable {
   /// The `package` argument must be non-null if the font family is defined in a
   /// package. It is combined with the `fontFamily` argument to set the
   /// [fontFamily] property.
+  ///
+  /// On Apple devices the strings 'CupertinoSystemText' and
+  /// 'CupertinoSystemDisplay' are used as proxies for the Apple system fonts.
+  /// They currently redirect to the equivilant of SF Pro Text and SF Pro Display
+  /// respectively. 'CupertinoSystemText' is designed for fonts below 20 point
+  /// size, and 'CupertinoSystemDisplay' is recommended for sizes 20 and above.
   const TextStyle({
     this.inherit = true,
     this.color,

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -599,7 +599,7 @@ void main() {
           home: Center(
             child: SizedBox(
               height: 400.0,
-              width: 500.0,
+              width: 400.0,
               child: CupertinoDatePicker(
                 mode: CupertinoDatePickerMode.time,
                 onDateTimeChanged: (_) { },
@@ -633,7 +633,7 @@ void main() {
       // Distance between the first and the last column should be the same.
       expect(
         tester.getCenter(find.text('10')).dx - tester.getCenter(find.text('AM')).dx,
-        distance,
+        closeTo(distance, 0.00000001),
       );
     });
 

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -599,7 +599,7 @@ void main() {
           home: Center(
             child: SizedBox(
               height: 400.0,
-              width: 400.0,
+              width: 450.0,
               child: CupertinoDatePicker(
                 mode: CupertinoDatePickerMode.time,
                 onDateTimeChanged: (_) { },

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -633,7 +633,7 @@ void main() {
       // Distance between the first and the last column should be the same.
       expect(
         tester.getCenter(find.text('10')).dx - tester.getCenter(find.text('AM')).dx,
-        closeTo(distance, 0.00000001),
+        moreOrLessEquals(distance),
       );
     });
 

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -599,7 +599,7 @@ void main() {
           home: Center(
             child: SizedBox(
               height: 400.0,
-              width: 450.0,
+              width: 500.0,
               child: CupertinoDatePicker(
                 mode: CupertinoDatePickerMode.time,
                 onDateTimeChanged: (_) { },

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -1581,7 +1581,7 @@ class _ExpectStyles extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextStyle style = DefaultTextStyle.of(context).style;
     expect(style.color, isSameColorAs(color));
-    expect(style.fontFamily, '.SF Pro Text');
+    expect(style.fontFamily, 'CupertinoSystemText');
     expect(style.fontSize, 17.0);
     expect(style.letterSpacing, -0.41);
     count += index;

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -219,7 +219,7 @@ void main() {
         tester.renderObject(flying(tester, find.text('Page 1')).first);
     expect(bottomMiddle.text.style!.color, const Color(0xff000306));
     expect(bottomMiddle.text.style!.fontWeight, FontWeight.w600);
-    expect(bottomMiddle.text.style!.fontFamily, '.SF Pro Text');
+    expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.9404401779174805);
@@ -230,7 +230,7 @@ void main() {
         tester.renderObject(flying(tester, find.text('Page 1')).last);
     expect(topBackLabel.text.style!.color, const Color(0xff000306));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w600);
-    expect(topBackLabel.text.style!.fontFamily, '.SF Pro Text');
+    expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).last, 0.0);
@@ -239,14 +239,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomMiddle.text.style!.color, const Color(0xff005ec5));
     expect(bottomMiddle.text.style!.fontWeight, FontWeight.w400);
-    expect(bottomMiddle.text.style!.fontFamily, '.SF Pro Text');
+    expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.0);
 
     expect(topBackLabel.text.style!.color, const Color(0xff005ec5));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w400);
-    expect(topBackLabel.text.style!.fontFamily, '.SF Pro Text');
+    expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).last, 0.5292819738388062);
@@ -267,7 +267,7 @@ void main() {
         tester.renderObject(flying(tester, find.text('Page 1')).first);
     expect(bottomMiddle.text.style!.color, const Color(0xfff8fbff));
     expect(bottomMiddle.text.style!.fontWeight, FontWeight.w600);
-    expect(bottomMiddle.text.style!.fontFamily, '.SF Pro Text');
+    expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.9404401779174805);
@@ -278,7 +278,7 @@ void main() {
         tester.renderObject(flying(tester, find.text('Page 1')).last);
     expect(topBackLabel.text.style!.color, const Color(0xfff8fbff));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w600);
-    expect(topBackLabel.text.style!.fontFamily, '.SF Pro Text');
+    expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).last, 0.0);
@@ -287,14 +287,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomMiddle.text.style!.color, const Color(0xff409fff));
     expect(bottomMiddle.text.style!.fontWeight, FontWeight.w400);
-    expect(bottomMiddle.text.style!.fontFamily, '.SF Pro Text');
+    expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.0);
 
     expect(topBackLabel.text.style!.color, const Color(0xff409fff));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w400);
-    expect(topBackLabel.text.style!.fontFamily, '.SF Pro Text');
+    expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).last, 0.5292819738388062);
@@ -1121,7 +1121,7 @@ void main() {
         tester.renderObject(flying(tester, find.text('Page 1')).first);
     expect(bottomLargeTitle.text.style!.color, const Color(0xff000306));
     expect(bottomLargeTitle.text.style!.fontWeight, FontWeight.w700);
-    expect(bottomLargeTitle.text.style!.fontFamily, '.SF Pro Display');
+    expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemDisplay');
     expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(0.38890619069337845));
 
     // The top back label is styled exactly the same way.
@@ -1129,19 +1129,19 @@ void main() {
         tester.renderObject(flying(tester, find.text('Page 1')).last);
     expect(topBackLabel.text.style!.color, const Color(0xff000306));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w700);
-    expect(topBackLabel.text.style!.fontFamily, '.SF Pro Display');
+    expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemDisplay');
     expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(0.38890619069337845));
 
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomLargeTitle.text.style!.color, const Color(0xff005ec5));
     expect(bottomLargeTitle.text.style!.fontWeight, FontWeight.w500);
-    expect(bottomLargeTitle.text.style!.fontFamily, '.SF Pro Text');
+    expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(-0.2259759941697121));
 
     expect(topBackLabel.text.style!.color, const Color(0xff005ec5));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w500);
-    expect(topBackLabel.text.style!.fontFamily, '.SF Pro Text');
+    expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(-0.2259759941697121));
   });
 

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -1122,7 +1122,7 @@ void main() {
     expect(bottomLargeTitle.text.style!.color, const Color(0xff000306));
     expect(bottomLargeTitle.text.style!.fontWeight, FontWeight.w700);
     expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemDisplay');
-    expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(0.38890619069337845));
+    expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(0.35967791542410854));
 
     // The top back label is styled exactly the same way.
     final RenderParagraph topBackLabel =
@@ -1130,19 +1130,19 @@ void main() {
     expect(topBackLabel.text.style!.color, const Color(0xff000306));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w700);
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemDisplay');
-    expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(0.38890619069337845));
+    expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(0.35967791542410854));
 
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomLargeTitle.text.style!.color, const Color(0xff005ec5));
     expect(bottomLargeTitle.text.style!.fontWeight, FontWeight.w500);
     expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemText');
-    expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(-0.2259759941697121));
+    expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(-0.23270857974886894));
 
     expect(topBackLabel.text.style!.color, const Color(0xff005ec5));
     expect(topBackLabel.text.style!.fontWeight, FontWeight.w500);
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
-    expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(-0.2259759941697121));
+    expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(-0.23270857974886894));
   });
 
   testWidgetsWithLeakTracking('Top middle fades in and slides in from the right', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -48,7 +48,7 @@ void main() {
     expect(paragraph.text.style!.color, isSameColorAs(CupertinoColors.black));
     expect(paragraph.text.style!.copyWith(color: CupertinoColors.black), const TextStyle(
       inherit: false,
-      fontFamily: '.SF Pro Display',
+      fontFamily: 'CupertinoSystemDisplay',
       fontSize: 21.0,
       fontWeight: FontWeight.w400,
       letterSpacing: -0.6,

--- a/packages/flutter/test/cupertino/text_theme_test.dart
+++ b/packages/flutter/test/cupertino/text_theme_test.dart
@@ -44,7 +44,7 @@ void main() {
     // NavLargeTitle Bold 34 0.41
     expect(theme.navLargeTitleTextStyle.fontSize, 34);
     expect(theme.navLargeTitleTextStyle.fontFamily, 'CupertinoSystemDisplay');
-    expect(theme.navLargeTitleTextStyle.letterSpacing, 0.41);
+    expect(theme.navLargeTitleTextStyle.letterSpacing, 0.38);
     expect(theme.navLargeTitleTextStyle.fontWeight, bold);
 
     // Picker Regular 21 -0.6
@@ -56,7 +56,7 @@ void main() {
     // DateTimePicker Normal 21
     expect(theme.dateTimePickerTextStyle.fontSize, 21);
     expect(theme.dateTimePickerTextStyle.fontFamily, 'CupertinoSystemDisplay');
-    expect(theme.dateTimePickerTextStyle.letterSpacing, null);
+    expect(theme.dateTimePickerTextStyle.letterSpacing, 0.4);
     expect(theme.dateTimePickerTextStyle.fontWeight, normal);
   });
 }

--- a/packages/flutter/test/cupertino/text_theme_test.dart
+++ b/packages/flutter/test/cupertino/text_theme_test.dart
@@ -19,43 +19,43 @@ void main() {
 
     // TextStyle 17 -0.41
     expect(theme.textStyle.fontSize, 17);
-    expect(theme.textStyle.fontFamily, '.SF Pro Text');
+    expect(theme.textStyle.fontFamily, 'CupertinoSystemText');
     expect(theme.textStyle.letterSpacing, -0.41);
     expect(theme.textStyle.fontWeight, null);
 
     // ActionTextStyle 17 -0.41
     expect(theme.actionTextStyle.fontSize, 17);
-    expect(theme.actionTextStyle.fontFamily, '.SF Pro Text');
+    expect(theme.actionTextStyle.fontFamily, 'CupertinoSystemText');
     expect(theme.actionTextStyle.letterSpacing, -0.41);
     expect(theme.actionTextStyle.fontWeight, null);
 
     // TextStyle 17 -0.41
     expect(theme.tabLabelTextStyle.fontSize, 10);
-    expect(theme.tabLabelTextStyle.fontFamily, '.SF Pro Text');
+    expect(theme.tabLabelTextStyle.fontFamily, 'CupertinoSystemText');
     expect(theme.tabLabelTextStyle.letterSpacing, -0.24);
     expect(theme.tabLabelTextStyle.fontWeight, medium);
 
     // NavTitle SemiBold 17 -0.41
     expect(theme.navTitleTextStyle.fontSize, 17);
-    expect(theme.navTitleTextStyle.fontFamily, '.SF Pro Text');
+    expect(theme.navTitleTextStyle.fontFamily, 'CupertinoSystemText');
     expect(theme.navTitleTextStyle.letterSpacing, -0.41);
     expect(theme.navTitleTextStyle.fontWeight, semiBold);
 
     // NavLargeTitle Bold 34 0.41
     expect(theme.navLargeTitleTextStyle.fontSize, 34);
-    expect(theme.navLargeTitleTextStyle.fontFamily, '.SF Pro Display');
+    expect(theme.navLargeTitleTextStyle.fontFamily, 'CupertinoSystemDisplay');
     expect(theme.navLargeTitleTextStyle.letterSpacing, 0.41);
     expect(theme.navLargeTitleTextStyle.fontWeight, bold);
 
     // Picker Regular 21 -0.6
     expect(theme.pickerTextStyle.fontSize, 21);
-    expect(theme.pickerTextStyle.fontFamily, '.SF Pro Display');
+    expect(theme.pickerTextStyle.fontFamily, 'CupertinoSystemDisplay');
     expect(theme.pickerTextStyle.letterSpacing, -0.6);
     expect(theme.pickerTextStyle.fontWeight, regular);
 
     // DateTimePicker Normal 21
     expect(theme.dateTimePickerTextStyle.fontSize, 21);
-    expect(theme.dateTimePickerTextStyle.fontFamily, '.SF Pro Display');
+    expect(theme.dateTimePickerTextStyle.fontFamily, 'CupertinoSystemDisplay');
     expect(theme.dateTimePickerTextStyle.letterSpacing, null);
     expect(theme.dateTimePickerTextStyle.fontWeight, normal);
   });

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -590,7 +590,7 @@ void main() {
       expect(themeM2.primaryColor, Colors.blue);
       expect(themeM2.scaffoldBackgroundColor, Colors.grey[50]);
       expect(themeM2.primaryContrastingColor, Colors.white);
-      expect(themeM2.textTheme.textStyle.fontFamily, '.SF Pro Text');
+      expect(themeM2.textTheme.textStyle.fontFamily, 'CupertinoSystemText');
       expect(themeM2.textTheme.textStyle.fontSize, 17.0);
     });
 
@@ -601,7 +601,7 @@ void main() {
       expect(themeM3.primaryColor, const Color(0xff6750a4));
       expect(themeM3.scaffoldBackgroundColor, const Color(0xfffffbfe)); // ColorScheme.background
       expect(themeM3.primaryContrastingColor, Colors.white);
-      expect(themeM3.textTheme.textStyle.fontFamily, '.SF Pro Text');
+      expect(themeM3.textTheme.textStyle.fontFamily, 'CupertinoSystemText');
       expect(themeM3.textTheme.textStyle.fontSize, 17.0);
     });
 
@@ -612,7 +612,7 @@ void main() {
       expect(themeM2.primaryColor, Colors.blue);
       expect(themeM2.primaryContrastingColor, Colors.white);
       expect(themeM2.scaffoldBackgroundColor, Colors.grey[850]);
-      expect(themeM2.textTheme.textStyle.fontFamily, '.SF Pro Text');
+      expect(themeM2.textTheme.textStyle.fontFamily, 'CupertinoSystemText');
       expect(themeM2.textTheme.textStyle.fontSize, 17.0);
     });
 
@@ -623,7 +623,7 @@ void main() {
       expect(themeM3.primaryColor, const Color(0xffd0bcff));
       expect(themeM3.primaryContrastingColor, const Color(0xff381e72));
       expect(themeM3.scaffoldBackgroundColor, const Color(0xff1c1b1f));
-      expect(themeM3.textTheme.textStyle.fontFamily, '.SF Pro Text');
+      expect(themeM3.textTheme.textStyle.fontFamily, 'CupertinoSystemText');
       expect(themeM3.textTheme.textStyle.fontSize, 17.0);
     });
 
@@ -662,7 +662,7 @@ void main() {
       expect(themeM2.primaryColor, Colors.blue);
       expect(themeM2.primaryContrastingColor, Colors.white);
       expect(themeM2.scaffoldBackgroundColor, CupertinoColors.lightBackgroundGray);
-      expect(themeM2.textTheme.textStyle.fontFamily, '.SF Pro Text');
+      expect(themeM2.textTheme.textStyle.fontFamily, 'CupertinoSystemText');
       expect(themeM2.textTheme.textStyle.fontSize, 17.0);
     });
 
@@ -680,7 +680,7 @@ void main() {
       expect(themeM3.primaryColor, const Color(0xff6750a4));
       expect(themeM3.primaryContrastingColor, Colors.white);
       expect(themeM3.scaffoldBackgroundColor, CupertinoColors.lightBackgroundGray);
-      expect(themeM3.textTheme.textStyle.fontFamily, '.SF Pro Text');
+      expect(themeM3.textTheme.textStyle.fontFamily, 'CupertinoSystemText');
       expect(themeM3.textTheme.textStyle.fontSize, 17.0);
     });
 

--- a/packages/flutter/test/material/typography_test.dart
+++ b/packages/flutter/test/material/typography_test.dart
@@ -37,11 +37,11 @@ void main() {
 
   // Ref: https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
   final Matcher isSanFranciscoDisplayFont = predicate((TextStyle s) {
-    return s.fontFamily == '.SF UI Display';
+    return s.fontFamily == 'CupertinoSystemDisplay';
   }, 'Uses SF Display font');
 
   final Matcher isSanFranciscoTextFont = predicate((TextStyle s) {
-    return s.fontFamily == '.SF UI Text';
+    return s.fontFamily == 'CupertinoSystemText';
   }, 'Uses SF Text font');
 
   final Matcher isMacOSSanFranciscoMetaFont = predicate((TextStyle s) {


### PR DESCRIPTION
Addresses #63507, and is a follow up to the engine PR https://github.com/flutter/engine/pull/46857

Changes the font family string when attempting to use Apple system fonts to the new proxies added by the engine. For the "Text" font this will be more secure in the future against possible changes to Apple's API. For the "Display" font, this will now work correctly when it didn't before.

I checked the letter spacing values against a native app for all font sizes between 17-28. I made a few adjustments to better match native, but especially for the "Text" font we were either really close, or close enough to not make a large breaking change to default fonts worth it.

| Before  | After |
| ------------- | ------------- |
| <img width="466" alt="Screenshot 2023-11-02 at 11 45 12 AM" src="https://github.com/flutter/flutter/assets/58190796/627ed8ac-d848-4f71-aa62-a467b8aac62d"> | <img width="383" alt="Screenshot 2023-11-02 at 11 46 25 AM" src="https://github.com/flutter/flutter/assets/58190796/9a502021-7d2b-4e14-98f1-86971b3830a5"> |

The smaller text in both the before and after should be the same. The large system font that Flutter used before was incorrect, which caused it to look more spread out. Now we use the correct font. 
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
