### PR TITLE
Introduce `iconAlignment` for the buttons with icon

### DIFF
--- a/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
+++ b/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
@@ -16,7 +16,7 @@ class ButtonStyleButtonIconAlignmentExampleApp extends StatelessWidget {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(
-          title: const Text('ButtonStyleButton iconAlignment Sample'),
+          title: const Text('ButtonStyleButton.iconAlignment'),
         ),
         body: const ButtonStyleButtonIconAlignmentExample(),
       ),
@@ -32,17 +32,16 @@ class ButtonStyleButtonIconAlignmentExample extends StatefulWidget {
 }
 
 class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButtonIconAlignmentExample> {
-  IconAlignment iconAlignment = IconAlignment.start;
-  TextDirection textDirection = TextDirection.ltr;
+  TextDirection _textDirection = TextDirection.ltr;
+  IconAlignment _iconAlignment = IconAlignment.start;
 
   @override
   Widget build(BuildContext context) {
-    return Directionality(
-      key: const Key('Directionality'),
-      textDirection: textDirection,
-      child: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
+    return SafeArea(
+      child: Directionality(
+        key: const Key('Directionality'),
+        textDirection: _textDirection,
+        child: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.center,
@@ -54,88 +53,63 @@ class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButto
                 alignment: MainAxisAlignment.center,
                 overflowAlignment: OverflowBarAlignment.center,
                 children: <Widget>[
-                  ...IconAlignment.values.map((IconAlignment e) {
-                    return ChoiceChip(
-                      label: Text(e.toString()),
-                      selected: iconAlignment == e,
-                      onSelected: (bool isSelected) {
-                        if (isSelected) {
-                          setState(() {
-                            iconAlignment = e;
-                          });
-                        }
-                      },
-                    );
-                  }),
-                ],
-              ),
-              const SizedBox(height: 30),
-              OverflowBar(
-                spacing: 10,
-                overflowSpacing: 20,
-                alignment: MainAxisAlignment.center,
-                overflowAlignment: OverflowBarAlignment.center,
-                children: <Widget>[
-                  ...TextDirection.values.map((TextDirection e) {
-                    return ChoiceChip(
-                      label: Text(e.toString()),
-                      selected: textDirection == e,
-                      onSelected: (bool isSelected) {
-                        if (isSelected) {
-                          setState(() {
-                            textDirection = e;
-                          });
-                        }
-                      },
-                    );
-                  }),
-                ],
-              ),
-              const Spacer(),
-              OverflowBar(
-                spacing: 10,
-                overflowSpacing: 20,
-                alignment: MainAxisAlignment.center,
-                overflowAlignment: OverflowBarAlignment.center,
-                children: <Widget>[
                   ElevatedButton.icon(
-                    key: const Key('ElevatedButton.icon'),
                     onPressed: () {},
-                    icon: const Icon(Icons.add),
-                    label: const Text('ElevatedButton.icon'),
-                    iconAlignment: iconAlignment,
+                    icon: const Icon(Icons.sunny),
+                    label: const Text('ElevatedButton'),
+                    iconAlignment: _iconAlignment,
                   ),
                   FilledButton.icon(
-                    key: const Key('FilledButton.icon'),
                     onPressed: () {},
-                    icon: const Icon(Icons.add),
-                    label: const Text('FilledButton.icon'),
-                    iconAlignment: iconAlignment,
+                  icon: const Icon(Icons.beach_access),
+                    label: const Text('FilledButton'),
+                    iconAlignment: _iconAlignment,
                   ),
                   FilledButton.tonalIcon(
-                    key: const Key('FilledButton.tonalIcon'),
                     onPressed: () {},
-                    icon: const Icon(Icons.add),
-                    label: const Text('FilledButton.tonalIcon'),
-                    iconAlignment: iconAlignment,
+                    icon: const Icon(Icons.cloud),
+                    label: const Text('FilledButton Tonal'),
+                    iconAlignment: _iconAlignment,
                   ),
                   OutlinedButton.icon(
-                    key: const Key('OutlinedButton.icon'),
                     onPressed: () {},
-                    icon: const Icon(Icons.add),
-                    label: const Text('OutlinedButton.icon'),
-                    iconAlignment: iconAlignment,
+                    icon: const Icon(Icons.light),
+                    label: const Text('OutlinedButton'),
+                    iconAlignment: _iconAlignment,
                   ),
                   TextButton.icon(
-                    key: const Key('TextButton.icon'),
                     onPressed: () {},
-                    icon: const Icon(Icons.add),
-                    label: const Text('TextButton.icon'),
-                    iconAlignment: iconAlignment,
+                    icon: const Icon(Icons.flight_takeoff),
+                    label: const Text('TextButton'),
+                    iconAlignment: _iconAlignment,
                   ),
                 ],
               ),
               const Spacer(),
+              const Text('Icon alignment'),
+              SegmentedButton<IconAlignment>(
+                onSelectionChanged: (Set<IconAlignment> value) {
+                  setState(() {
+                    _iconAlignment = value.first;
+                  });
+                },
+                selected: <IconAlignment>{ _iconAlignment },
+                segments: IconAlignment.values.map((IconAlignment iconAlignment) {
+                  return ButtonSegment<IconAlignment>(
+                    value: iconAlignment,
+                    label: Text(iconAlignment.name),
+                  );
+                }).toList(),
+              ),
+              SwitchListTile(
+                title: const Text('RTL'),
+                value: _textDirection == TextDirection.rtl,
+                onChanged: (bool value) {
+                  setState(() {
+                    _textDirection = value ? TextDirection.rtl : TextDirection.ltr;
+                  });
+                },
+              ),
             ],
           ),
         ),

--- a/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
+++ b/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
@@ -1,0 +1,145 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for using [ButtonStyleButton.iconAlignment] parameter.
+
+void main() => runApp(const ButtonStyleButtonIconAlignmentExampleApp());
+
+class ButtonStyleButtonIconAlignmentExampleApp extends StatelessWidget {
+  const ButtonStyleButtonIconAlignmentExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('ButtonStyleButton iconAlignment Sample'),
+        ),
+        body: const ButtonStyleButtonIconAlignmentExample(),
+      ),
+    );
+  }
+}
+
+class ButtonStyleButtonIconAlignmentExample extends StatefulWidget {
+  const ButtonStyleButtonIconAlignmentExample({super.key});
+
+  @override
+  State<ButtonStyleButtonIconAlignmentExample> createState() => _ButtonStyleButtonIconAlignmentExampleState();
+}
+
+class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButtonIconAlignmentExample> {
+  IconAlignment iconAlignment = IconAlignment.start;
+  TextDirection textDirection = TextDirection.ltr;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      key: const Key('Directionality'),
+      textDirection: textDirection,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              const Spacer(),
+              OverflowBar(
+                spacing: 10,
+                overflowSpacing: 20,
+                alignment: MainAxisAlignment.center,
+                overflowAlignment: OverflowBarAlignment.center,
+                children: <Widget>[
+                  ...IconAlignment.values.map((IconAlignment e) {
+                    return ChoiceChip(
+                      label: Text(e.toString()),
+                      selected: iconAlignment == e,
+                      onSelected: (bool isSelected) {
+                        if (isSelected) {
+                          setState(() {
+                            iconAlignment = e;
+                          });
+                        }
+                      },
+                    );
+                  }),
+                ],
+              ),
+              const SizedBox(height: 30),
+              OverflowBar(
+                spacing: 10,
+                overflowSpacing: 20,
+                alignment: MainAxisAlignment.center,
+                overflowAlignment: OverflowBarAlignment.center,
+                children: <Widget>[
+                  ...TextDirection.values.map((TextDirection e) {
+                    return ChoiceChip(
+                      label: Text(e.toString()),
+                      selected: textDirection == e,
+                      onSelected: (bool isSelected) {
+                        if (isSelected) {
+                          setState(() {
+                            textDirection = e;
+                          });
+                        }
+                      },
+                    );
+                  }),
+                ],
+              ),
+              const Spacer(),
+              OverflowBar(
+                spacing: 10,
+                overflowSpacing: 20,
+                alignment: MainAxisAlignment.center,
+                overflowAlignment: OverflowBarAlignment.center,
+                children: <Widget>[
+                  ElevatedButton.icon(
+                    key: const Key('ElevatedButton.icon'),
+                    onPressed: () {},
+                    icon: const Icon(Icons.add),
+                    label: const Text('ElevatedButton.icon'),
+                    iconAlignment: iconAlignment,
+                  ),
+                  FilledButton.icon(
+                    key: const Key('FilledButton.icon'),
+                    onPressed: () {},
+                    icon: const Icon(Icons.add),
+                    label: const Text('FilledButton.icon'),
+                    iconAlignment: iconAlignment,
+                  ),
+                  FilledButton.tonalIcon(
+                    key: const Key('FilledButton.tonalIcon'),
+                    onPressed: () {},
+                    icon: const Icon(Icons.add),
+                    label: const Text('FilledButton.tonalIcon'),
+                    iconAlignment: iconAlignment,
+                  ),
+                  OutlinedButton.icon(
+                    key: const Key('OutlinedButton.icon'),
+                    onPressed: () {},
+                    icon: const Icon(Icons.add),
+                    label: const Text('OutlinedButton.icon'),
+                    iconAlignment: iconAlignment,
+                  ),
+                  TextButton.icon(
+                    key: const Key('TextButton.icon'),
+                    onPressed: () {},
+                    icon: const Icon(Icons.add),
+                    label: const Text('TextButton.icon'),
+                    iconAlignment: iconAlignment,
+                  ),
+                ],
+              ),
+              const Spacer(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
+++ b/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
@@ -129,7 +129,7 @@ class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButto
                           ),
                           ButtonSegment<TextDirection>(
                             value: TextDirection.rtl,
-                            label: Text('LTR'),
+                            label: Text('RTL'),
                           ),
                         ],
                       ),

--- a/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
+++ b/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
@@ -60,7 +60,7 @@ class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButto
                   ),
                   FilledButton.icon(
                     onPressed: () {},
-                  icon: const Icon(Icons.beach_access),
+                    icon: const Icon(Icons.beach_access),
                     label: const Text('FilledButton'),
                     iconAlignment: _iconAlignment,
                   ),

--- a/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
+++ b/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
@@ -6,19 +6,18 @@ import 'package:flutter/material.dart';
 
 /// Flutter code sample for using [ButtonStyleButton.iconAlignment] parameter.
 
-void main() => runApp(const ButtonStyleButtonIconAlignmentExampleApp());
+void main() {
+  runApp(const ButtonStyleButtonIconAlignmentApp());
+}
 
-class ButtonStyleButtonIconAlignmentExampleApp extends StatelessWidget {
-  const ButtonStyleButtonIconAlignmentExampleApp({super.key});
+class ButtonStyleButtonIconAlignmentApp extends StatelessWidget {
+  const ButtonStyleButtonIconAlignmentApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('ButtonStyleButton.iconAlignment'),
-        ),
-        body: const ButtonStyleButtonIconAlignmentExample(),
+        body: ButtonStyleButtonIconAlignmentExample(),
       ),
     );
   }
@@ -86,30 +85,59 @@ class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButto
                 ],
               ),
               const Spacer(),
-              const Text('Icon alignment'),
-              SegmentedButton<IconAlignment>(
-                onSelectionChanged: (Set<IconAlignment> value) {
-                  setState(() {
-                    _iconAlignment = value.first;
-                  });
-                },
-                selected: <IconAlignment>{ _iconAlignment },
-                segments: IconAlignment.values.map((IconAlignment iconAlignment) {
-                  return ButtonSegment<IconAlignment>(
-                    value: iconAlignment,
-                    label: Text(iconAlignment.name),
-                  );
-                }).toList(),
+              OverflowBar(
+                alignment: MainAxisAlignment.spaceEvenly,
+                overflowAlignment: OverflowBarAlignment.center,
+                spacing: 10,
+                overflowSpacing: 10,
+                children: <Widget>[
+                  Column(
+                    children: <Widget>[
+                      const Text('Icon alignment'),
+                      const SizedBox(height: 10),
+                      SegmentedButton<IconAlignment>(
+                        onSelectionChanged: (Set<IconAlignment> value) {
+                          setState(() {
+                            _iconAlignment = value.first;
+                          });
+                        },
+                        selected: <IconAlignment>{ _iconAlignment },
+                        segments: IconAlignment.values.map((IconAlignment iconAlignment) {
+                          return ButtonSegment<IconAlignment>(
+                            value: iconAlignment,
+                            label: Text(iconAlignment.name),
+                          );
+                        }).toList(),
+                      ),
+                    ],
+                  ),
+                  Column(
+                    children: <Widget>[
+                      const Text('Text direction'),
+                      const SizedBox(height: 10),
+                      SegmentedButton<TextDirection>(
+                        onSelectionChanged: (Set<TextDirection> value) {
+                          setState(() {
+                            _textDirection = value.first;
+                          });
+                        },
+                        selected: <TextDirection>{ _textDirection },
+                        segments: const <ButtonSegment<TextDirection>>[
+                          ButtonSegment<TextDirection>(
+                            value: TextDirection.ltr,
+                            label: Text('RTL'),
+                          ),
+                          ButtonSegment<TextDirection>(
+                            value: TextDirection.rtl,
+                            label: Text('LTR'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
               ),
-              SwitchListTile(
-                title: const Text('RTL'),
-                value: _textDirection == TextDirection.rtl,
-                onChanged: (bool value) {
-                  setState(() {
-                    _textDirection = value ? TextDirection.rtl : TextDirection.ltr;
-                  });
-                },
-              ),
+              const Spacer(),
             ],
           ),
         ),

--- a/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
+++ b/examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart
@@ -125,7 +125,7 @@ class _ButtonStyleButtonIconAlignmentExampleState extends State<ButtonStyleButto
                         segments: const <ButtonSegment<TextDirection>>[
                           ButtonSegment<TextDirection>(
                             value: TextDirection.ltr,
-                            label: Text('RTL'),
+                            label: Text('LTR'),
                           ),
                           ButtonSegment<TextDirection>(
                             value: TextDirection.rtl,

--- a/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
+++ b/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
@@ -72,7 +72,7 @@ void main() {
     }
 
     // Test initial icon alignment in LTR.
-    expectedLeftIconPosition(iconOffset: 16, textButtonIconOffset: 12) ;
+    expectedLeftIconPosition(iconOffset: 16, textButtonIconOffset: 12);
 
     // Update icon alignment to end.
     await tester.tap(find.text('end'));

--- a/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
+++ b/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
@@ -1,0 +1,213 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/button_style_button/button_style_button.icon_alignment.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('ButtonStyleButton iconAlignment Example Test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ButtonStyleButtonIconAlignmentExampleApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'ButtonStyleButton iconAlignment Sample'), findsOneWidget);
+    expect(find.text('ElevatedButton.icon'), findsOneWidget);
+    expect(find.text('FilledButton.icon'), findsOneWidget);
+    expect(find.text('FilledButton.tonalIcon'), findsOneWidget);
+    expect(find.text('OutlinedButton.icon'), findsOneWidget);
+    expect(find.text('TextButton.icon'), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsNWidgets(5));
+
+    final Finder iconAlignmentStartCc = find.widgetWithText(ChoiceChip, 'IconAlignment.start');
+    final Finder iconAlignmentEndCc = find.widgetWithText(ChoiceChip, 'IconAlignment.end');
+    await tester.tap(iconAlignmentStartCc);
+    await tester.pumpAndSettle();
+    expect(tester.widget<ChoiceChip>(iconAlignmentStartCc).selected, isTrue);
+    expect(tester.widget<ChoiceChip>(iconAlignmentEndCc).selected, isFalse);
+    await tester.tap(iconAlignmentEndCc);
+    await tester.pumpAndSettle();
+    expect(tester.widget<ChoiceChip>(iconAlignmentStartCc).selected, isFalse);
+    expect(tester.widget<ChoiceChip>(iconAlignmentEndCc).selected, isTrue);
+
+    final Finder textDirectionLtrCc = find.widgetWithText(ChoiceChip, 'TextDirection.ltr');
+    final Finder textDirectionRtlCc = find.widgetWithText(ChoiceChip, 'TextDirection.rtl');
+    await tester.tap(textDirectionLtrCc);
+    await tester.pumpAndSettle();
+    expect(tester.widget<ChoiceChip>(textDirectionLtrCc).selected, isTrue);
+    expect(tester.widget<ChoiceChip>(textDirectionRtlCc).selected, isFalse);
+    await tester.tap(textDirectionRtlCc);
+    await tester.pumpAndSettle();
+    expect(tester.widget<ChoiceChip>(textDirectionLtrCc).selected, isFalse);
+    expect(tester.widget<ChoiceChip>(textDirectionRtlCc).selected, isTrue);
+
+    // IconAlignment.start & TextDirection.ltr
+    await tester.tap(iconAlignmentStartCc);
+    await tester.pumpAndSettle();
+    await tester.tap(textDirectionLtrCc);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<ElevatedButton>(
+        find.byKey(const Key('ElevatedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('FilledButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('FilledButton.tonalIcon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<OutlinedButton>(
+        find.byKey(const Key('OutlinedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<TextButton>(
+        find.byKey(const Key('TextButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<Directionality>(
+        find.byKey(const Key('Directionality')),
+      ).textDirection,
+      TextDirection.ltr,
+    );
+
+    // IconAlignment.end & TextDirection.ltr
+    await tester.tap(iconAlignmentEndCc);
+    await tester.pumpAndSettle();
+    await tester.tap(textDirectionLtrCc);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<ElevatedButton>(
+        find.byKey(const Key('ElevatedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('FilledButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    // expect(
+    //   tester.widget<FilledButton>(
+    //     find.byKey(const Key('FilledButton.tonalIcon')),
+    //   ).iconAlignment,
+    //   IconAlignment.end,
+    // );
+    expect(
+      tester.widget<OutlinedButton>(
+        find.byKey(const Key('OutlinedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    expect(
+      tester.widget<TextButton>(
+        find.byKey(const Key('TextButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    expect(
+      tester.widget<Directionality>(
+        find.byKey(const Key('Directionality')),
+      ).textDirection,
+      TextDirection.ltr,
+    );
+
+    // IconAlignment.start & TextDirection.rtl
+    await tester.tap(iconAlignmentStartCc);
+    await tester.pumpAndSettle();
+    await tester.tap(textDirectionRtlCc);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<ElevatedButton>(
+        find.byKey(const Key('ElevatedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('FilledButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('FilledButton.tonalIcon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<OutlinedButton>(
+        find.byKey(const Key('OutlinedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<TextButton>(
+        find.byKey(const Key('TextButton.icon')),
+      ).iconAlignment,
+      IconAlignment.start,
+    );
+    expect(
+      tester.widget<Directionality>(
+        find.byKey(const Key('Directionality')),
+      ).textDirection,
+      TextDirection.rtl,
+    );
+
+    // IconAlignment.end & TextDirection.rtl
+    await tester.tap(iconAlignmentEndCc);
+    await tester.pumpAndSettle();
+    await tester.tap(textDirectionRtlCc);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<ElevatedButton>(
+        find.byKey(const Key('ElevatedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('FilledButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    // expect(
+    //   tester.widget<FilledButton>(
+    //     find.byKey(const Key('FilledButton.tonalIcon')),
+    //   ).iconAlignment,
+    //   IconAlignment.end,
+    // );
+    expect(
+      tester.widget<OutlinedButton>(
+        find.byKey(const Key('OutlinedButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    expect(
+      tester.widget<TextButton>(
+        find.byKey(const Key('TextButton.icon')),
+      ).iconAlignment,
+      IconAlignment.end,
+    );
+    expect(
+      tester.widget<Directionality>(
+        find.byKey(const Key('Directionality')),
+      ).textDirection,
+      TextDirection.rtl,
+    );
+  });
+}

--- a/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
+++ b/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
@@ -90,7 +90,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Test icon alignment start in LTR.
-    expectedRightIconPosition(iconOffset: 16, textButtonIconOffset: 12) ;
+    expectedRightIconPosition(iconOffset: 16, textButtonIconOffset: 12);
 
     // Update icon alignment to end.
     await tester.tap(find.text('end'));

--- a/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
+++ b/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('ButtonStyleButton.iconAlignment updates button icons alignment', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const example.ButtonStyleButtonIconAlignmentExampleApp(),
+      const example.ButtonStyleButtonIconAlignmentApp(),
     );
 
     Finder findButtonMaterial(String text) {
@@ -71,7 +71,6 @@ void main() {
       );
     }
 
-
     // Test initial icon alignment in LTR.
     expectedLeftIconPosition(iconOffset: 16, textButtonIconOffset: 12) ;
 
@@ -90,7 +89,7 @@ void main() {
     await tester.tap(find.text('RTL'));
     await tester.pumpAndSettle();
 
-    // // Test icon alignment start in LTR.
+    // Test icon alignment start in LTR.
     expectedRightIconPosition(iconOffset: 16, textButtonIconOffset: 12) ;
 
     // Update icon alignment to end.

--- a/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
+++ b/examples/api/test/material/button_style_button/button_style_button.icon_alignment.0_test.dart
@@ -7,207 +7,97 @@ import 'package:flutter_api_samples/material/button_style_button/button_style_bu
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('ButtonStyleButton iconAlignment Example Test', (WidgetTester tester) async {
+  testWidgets('ButtonStyleButton.iconAlignment updates button icons alignment', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.ButtonStyleButtonIconAlignmentExampleApp(),
     );
 
-    expect(find.widgetWithText(AppBar, 'ButtonStyleButton iconAlignment Sample'), findsOneWidget);
-    expect(find.text('ElevatedButton.icon'), findsOneWidget);
-    expect(find.text('FilledButton.icon'), findsOneWidget);
-    expect(find.text('FilledButton.tonalIcon'), findsOneWidget);
-    expect(find.text('OutlinedButton.icon'), findsOneWidget);
-    expect(find.text('TextButton.icon'), findsOneWidget);
-    expect(find.byIcon(Icons.add), findsNWidgets(5));
+    Finder findButtonMaterial(String text) {
+      return find.ancestor(
+        of: find.text(text),
+        matching: find.byType(Material),
+      ).first;
+    }
 
-    final Finder iconAlignmentStartCc = find.widgetWithText(ChoiceChip, 'IconAlignment.start');
-    final Finder iconAlignmentEndCc = find.widgetWithText(ChoiceChip, 'IconAlignment.end');
-    await tester.tap(iconAlignmentStartCc);
-    await tester.pumpAndSettle();
-    expect(tester.widget<ChoiceChip>(iconAlignmentStartCc).selected, isTrue);
-    expect(tester.widget<ChoiceChip>(iconAlignmentEndCc).selected, isFalse);
-    await tester.tap(iconAlignmentEndCc);
-    await tester.pumpAndSettle();
-    expect(tester.widget<ChoiceChip>(iconAlignmentStartCc).selected, isFalse);
-    expect(tester.widget<ChoiceChip>(iconAlignmentEndCc).selected, isTrue);
+    void expectedLeftIconPosition({
+      required double iconOffset,
+      required double textButtonIconOffset,
+    }) {
+      expect(
+        tester.getTopLeft(findButtonMaterial('ElevatedButton')).dx,
+        tester.getTopLeft(find.byIcon(Icons.sunny)).dx - iconOffset,
+      );
+      expect(
+        tester.getTopLeft(findButtonMaterial('FilledButton')).dx,
+        tester.getTopLeft(find.byIcon(Icons.beach_access)).dx - iconOffset,
+      );
+      expect(
+        tester.getTopLeft(findButtonMaterial('FilledButton Tonal')).dx,
+        tester.getTopLeft(find.byIcon(Icons.cloud)).dx - iconOffset,
+      );
+      expect(
+        tester.getTopLeft(findButtonMaterial('OutlinedButton')).dx,
+        tester.getTopLeft(find.byIcon(Icons.light)).dx - iconOffset,
+      );
+      expect(
+        tester.getTopLeft(findButtonMaterial('TextButton')).dx,
+        tester.getTopLeft(find.byIcon(Icons.flight_takeoff)).dx - textButtonIconOffset,
+      );
+    }
 
-    final Finder textDirectionLtrCc = find.widgetWithText(ChoiceChip, 'TextDirection.ltr');
-    final Finder textDirectionRtlCc = find.widgetWithText(ChoiceChip, 'TextDirection.rtl');
-    await tester.tap(textDirectionLtrCc);
-    await tester.pumpAndSettle();
-    expect(tester.widget<ChoiceChip>(textDirectionLtrCc).selected, isTrue);
-    expect(tester.widget<ChoiceChip>(textDirectionRtlCc).selected, isFalse);
-    await tester.tap(textDirectionRtlCc);
-    await tester.pumpAndSettle();
-    expect(tester.widget<ChoiceChip>(textDirectionLtrCc).selected, isFalse);
-    expect(tester.widget<ChoiceChip>(textDirectionRtlCc).selected, isTrue);
+    void expectedRightIconPosition({
+      required double iconOffset,
+      required double textButtonIconOffset,
+    }) {
+      expect(
+        tester.getTopRight(findButtonMaterial('ElevatedButton')).dx,
+        tester.getTopRight(find.byIcon(Icons.sunny)).dx + iconOffset,
+      );
+      expect(
+        tester.getTopRight(findButtonMaterial('FilledButton')).dx,
+        tester.getTopRight(find.byIcon(Icons.beach_access)).dx + iconOffset,
+      );
+      expect(
+        tester.getTopRight(findButtonMaterial('FilledButton Tonal')).dx,
+        tester.getTopRight(find.byIcon(Icons.cloud)).dx + iconOffset,
+      );
+      expect(
+        tester.getTopRight(findButtonMaterial('OutlinedButton')).dx,
+        tester.getTopRight(find.byIcon(Icons.light)).dx + iconOffset,
+      );
+      expect(
+        tester.getTopRight(findButtonMaterial('TextButton')).dx,
+        tester.getTopRight(find.byIcon(Icons.flight_takeoff)).dx + textButtonIconOffset,
+      );
+    }
 
-    // IconAlignment.start & TextDirection.ltr
-    await tester.tap(iconAlignmentStartCc);
-    await tester.pumpAndSettle();
-    await tester.tap(textDirectionLtrCc);
-    await tester.pumpAndSettle();
-    expect(
-      tester.widget<ElevatedButton>(
-        find.byKey(const Key('ElevatedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<FilledButton>(
-        find.byKey(const Key('FilledButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<FilledButton>(
-        find.byKey(const Key('FilledButton.tonalIcon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<OutlinedButton>(
-        find.byKey(const Key('OutlinedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<TextButton>(
-        find.byKey(const Key('TextButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<Directionality>(
-        find.byKey(const Key('Directionality')),
-      ).textDirection,
-      TextDirection.ltr,
-    );
 
-    // IconAlignment.end & TextDirection.ltr
-    await tester.tap(iconAlignmentEndCc);
-    await tester.pumpAndSettle();
-    await tester.tap(textDirectionLtrCc);
-    await tester.pumpAndSettle();
-    expect(
-      tester.widget<ElevatedButton>(
-        find.byKey(const Key('ElevatedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    expect(
-      tester.widget<FilledButton>(
-        find.byKey(const Key('FilledButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    // expect(
-    //   tester.widget<FilledButton>(
-    //     find.byKey(const Key('FilledButton.tonalIcon')),
-    //   ).iconAlignment,
-    //   IconAlignment.end,
-    // );
-    expect(
-      tester.widget<OutlinedButton>(
-        find.byKey(const Key('OutlinedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    expect(
-      tester.widget<TextButton>(
-        find.byKey(const Key('TextButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    expect(
-      tester.widget<Directionality>(
-        find.byKey(const Key('Directionality')),
-      ).textDirection,
-      TextDirection.ltr,
-    );
+    // Test initial icon alignment in LTR.
+    expectedLeftIconPosition(iconOffset: 16, textButtonIconOffset: 12) ;
 
-    // IconAlignment.start & TextDirection.rtl
-    await tester.tap(iconAlignmentStartCc);
+    // Update icon alignment to end.
+    await tester.tap(find.text('end'));
     await tester.pumpAndSettle();
-    await tester.tap(textDirectionRtlCc);
-    await tester.pumpAndSettle();
-    expect(
-      tester.widget<ElevatedButton>(
-        find.byKey(const Key('ElevatedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<FilledButton>(
-        find.byKey(const Key('FilledButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<FilledButton>(
-        find.byKey(const Key('FilledButton.tonalIcon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<OutlinedButton>(
-        find.byKey(const Key('OutlinedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<TextButton>(
-        find.byKey(const Key('TextButton.icon')),
-      ).iconAlignment,
-      IconAlignment.start,
-    );
-    expect(
-      tester.widget<Directionality>(
-        find.byKey(const Key('Directionality')),
-      ).textDirection,
-      TextDirection.rtl,
-    );
 
-    // IconAlignment.end & TextDirection.rtl
-    await tester.tap(iconAlignmentEndCc);
+    // Test icon alignment end in LTR.
+    expectedRightIconPosition(iconOffset: 24, textButtonIconOffset: 16);
+
+    // Reset icon alignment to start.
+    await tester.tap(find.text('start'));
     await tester.pumpAndSettle();
-    await tester.tap(textDirectionRtlCc);
+
+    // Change text direction to RTL.
+    await tester.tap(find.text('RTL'));
     await tester.pumpAndSettle();
-    expect(
-      tester.widget<ElevatedButton>(
-        find.byKey(const Key('ElevatedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    expect(
-      tester.widget<FilledButton>(
-        find.byKey(const Key('FilledButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    // expect(
-    //   tester.widget<FilledButton>(
-    //     find.byKey(const Key('FilledButton.tonalIcon')),
-    //   ).iconAlignment,
-    //   IconAlignment.end,
-    // );
-    expect(
-      tester.widget<OutlinedButton>(
-        find.byKey(const Key('OutlinedButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    expect(
-      tester.widget<TextButton>(
-        find.byKey(const Key('TextButton.icon')),
-      ).iconAlignment,
-      IconAlignment.end,
-    );
-    expect(
-      tester.widget<Directionality>(
-        find.byKey(const Key('Directionality')),
-      ).textDirection,
-      TextDirection.rtl,
-    );
+
+    // // Test icon alignment start in LTR.
+    expectedRightIconPosition(iconOffset: 16, textButtonIconOffset: 12) ;
+
+    // Update icon alignment to end.
+    await tester.tap(find.text('end'));
+    await tester.pumpAndSettle();
+
+    // Test icon alignment end in LTR.
+    expectedLeftIconPosition(iconOffset: 24, textButtonIconOffset: 16);
   });
 }

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -37,7 +37,7 @@ import 'theme_data.dart';
 ///
 /// {@tool dartpad}
 /// This sample demonstrates how to use `iconAlignment` to align the button icon to the start
-// or the end of the button.
+/// or the end of the button.
 ///
 /// ** See code in examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -36,7 +36,8 @@ import 'theme_data.dart';
 /// Defaults to [IconAlignment.start].
 ///
 /// {@tool dartpad}
-/// This sample demonstrates the usage of iconAlignment.
+/// This sample demonstrates how to use `iconAlignment` to align the button icon to the start
+// or the end of the button.
 ///
 /// ** See code in examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -22,11 +22,11 @@ import 'theme_data.dart';
 
 /// {@template flutter.material.ButtonStyleButton.iconAlignment}
 /// Determines the alignment of the icon within the widgets such as:
-///   - [TextButton.icon],
 ///   - [ElevatedButton.icon],
-///   - [OutlinedButton.icon],
 ///   - [FilledButton.icon],
 ///   - [FilledButton.tonalIcon].
+///   - [OutlinedButton.icon],
+///   - [TextButton.icon],
 ///
 /// The effect of `iconAlignment` depends on [TextDirection]. If textDirection is
 /// [TextDirection.ltr] then [IconAlignment.start] and [IconAlignment.end] align the

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -34,6 +34,13 @@ import 'theme_data.dart';
 /// the alignments are reversed.
 ///
 /// Defaults to [IconAlignment.start].
+///
+/// {@tool dartpad}
+/// This sample demonstrates the usage of iconAlignment.
+///
+/// ** See code in examples/api/lib/material/button_style_button/button_style_button.icon_alignment.0.dart **
+/// {@end-tool}
+///
 /// {@endtemplate}
 enum IconAlignment {
   /// The icon is placed at the start of the button.

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -11,10 +11,37 @@ import 'package:flutter/widgets.dart';
 import 'button_style.dart';
 import 'colors.dart';
 import 'constants.dart';
+import 'elevated_button.dart';
+import 'filled_button.dart';
 import 'ink_well.dart';
 import 'material.dart';
 import 'material_state.dart';
+import 'outlined_button.dart';
+import 'text_button.dart';
 import 'theme_data.dart';
+
+/// {@template flutter.material.ButtonStyleButton.iconAlignment}
+/// Determines the alignment of the icon within the widgets such as:
+///   - [TextButton.icon],
+///   - [ElevatedButton.icon],
+///   - [OutlinedButton.icon],
+///   - [FilledButton.icon],
+///   - [FilledButton.tonalIcon].
+///
+/// The effect of `iconAlignment` depends on [TextDirection]. If textDirection is
+/// [TextDirection.ltr] then [IconAlignment.start] and [IconAlignment.end] align the
+/// icon on the left or right respectively.  If textDirection is [TextDirection.rtl] the
+/// the alignments are reversed.
+///
+/// Defaults to [IconAlignment.start].
+/// {@endtemplate}
+enum IconAlignment {
+  /// The icon is placed at the start of the button.
+  start,
+
+  /// The icon is placed at the end of the button.
+  end,
+}
 
 /// The base [StatefulWidget] class for buttons whose style is defined by a [ButtonStyle] object.
 ///
@@ -44,6 +71,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
     this.statesController,
     this.isSemanticButton = true,
     required this.child,
+    this.iconAlignment = IconAlignment.start,
   });
 
   /// Called when the button is tapped or otherwise activated.
@@ -116,6 +144,9 @@ abstract class ButtonStyleButton extends StatefulWidget {
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
+
+  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  final IconAlignment iconAlignment;
 
   /// Returns a non-null [ButtonStyle] that's based primarily on the [Theme]'s
   /// [ThemeData.textTheme] and [ThemeData.colorScheme].

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -74,6 +74,7 @@ class ElevatedButton extends ButtonStyleButton {
     super.clipBehavior,
     super.statesController,
     required super.child,
+    super.iconAlignment,
   });
 
   /// Create an elevated button from a pair of widgets that serve as the button's
@@ -83,6 +84,9 @@ class ElevatedButton extends ButtonStyleButton {
   /// at the start, and 16 at the end, with an 8 pixel gap in between.
   ///
   /// If [icon] is null, will create an [ElevatedButton] instead.
+  ///
+  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  ///
   factory ElevatedButton.icon({
     Key? key,
     required VoidCallback? onPressed,
@@ -96,6 +100,7 @@ class ElevatedButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
+    IconAlignment iconAlignment = IconAlignment.start,
   }) {
     if (icon == null) {
       return ElevatedButton(
@@ -125,6 +130,7 @@ class ElevatedButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
+      iconAlignment: iconAlignment,
     );
   }
 
@@ -532,9 +538,15 @@ class _ElevatedButtonWithIcon extends ElevatedButton {
     super.statesController,
     required Widget icon,
     required Widget label,
+    super.iconAlignment,
   }) : super(
          autofocus: autofocus ?? false,
-         child: _ElevatedButtonWithIconChild(icon: icon, label: label, buttonStyle: style),
+         child: _ElevatedButtonWithIconChild(
+           icon: icon,
+           label: label,
+           buttonStyle: style,
+           iconAlignment: iconAlignment,
+         ),
       );
 
   @override
@@ -563,11 +575,17 @@ class _ElevatedButtonWithIcon extends ElevatedButton {
 }
 
 class _ElevatedButtonWithIconChild extends StatelessWidget {
-  const _ElevatedButtonWithIconChild({ required this.label, required this.icon, required this.buttonStyle });
+  const _ElevatedButtonWithIconChild({
+    required this.label,
+    required this.icon,
+    required this.buttonStyle,
+    required this.iconAlignment,
+  });
 
   final Widget label;
   final Widget icon;
   final ButtonStyle? buttonStyle;
+  final IconAlignment iconAlignment;
 
   @override
   Widget build(BuildContext context) {
@@ -576,7 +594,9 @@ class _ElevatedButtonWithIconChild extends StatelessWidget {
     final double gap = lerpDouble(8, 4, scale)!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child: label)],
+      children: iconAlignment == IconAlignment.start
+        ? <Widget>[icon, SizedBox(width: gap), Flexible(child: label)]
+        : <Widget>[Flexible(child: label), SizedBox(width: gap), icon],
     );
   }
 }

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -75,6 +75,7 @@ class FilledButton extends ButtonStyleButton {
     super.clipBehavior = Clip.none,
     super.statesController,
     required super.child,
+    super.iconAlignment,
   }) : _variant = _FilledButtonVariant.filled;
 
   /// Create a filled button from [icon] and [label].
@@ -83,6 +84,9 @@ class FilledButton extends ButtonStyleButton {
   /// and a gap between them.
   ///
   /// If [icon] is null, will create a [FilledButton] instead.
+  ///
+  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  ///
   factory FilledButton.icon({
     Key? key,
     required VoidCallback? onPressed,
@@ -96,6 +100,7 @@ class FilledButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
+    IconAlignment iconAlignment = IconAlignment.start,
   }) {
      if (icon == null) {
       return FilledButton(
@@ -125,6 +130,7 @@ class FilledButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
+      iconAlignment: iconAlignment,
     );
   }
 
@@ -167,6 +173,7 @@ class FilledButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
+    IconAlignment iconAlignment = IconAlignment.start,
   }) {
     if (icon == null) {
       return FilledButton.tonal(
@@ -196,6 +203,7 @@ class FilledButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
+      iconAlignment: iconAlignment,
     );
   }
 
@@ -535,9 +543,15 @@ class _FilledButtonWithIcon extends FilledButton {
     super.statesController,
     required Widget icon,
     required Widget label,
+    super.iconAlignment,
   }) : super(
          autofocus: autofocus ?? false,
-         child: _FilledButtonWithIconChild(icon: icon, label: label, buttonStyle: style)
+         child: _FilledButtonWithIconChild(
+           icon: icon,
+           label: label,
+           buttonStyle: style,
+           iconAlignment: iconAlignment,
+         ),
       );
 
   _FilledButtonWithIcon.tonal({
@@ -553,9 +567,15 @@ class _FilledButtonWithIcon extends FilledButton {
     super.statesController,
     required Widget icon,
     required Widget label,
+    required IconAlignment iconAlignment,
   }) : super.tonal(
          autofocus: autofocus ?? false,
-         child: _FilledButtonWithIconChild(icon: icon, label: label, buttonStyle: style)
+         child: _FilledButtonWithIconChild(
+           icon: icon,
+           label: label,
+           buttonStyle: style,
+           iconAlignment: iconAlignment,
+         ),
        );
 
   @override
@@ -584,11 +604,17 @@ class _FilledButtonWithIcon extends FilledButton {
 }
 
 class _FilledButtonWithIconChild extends StatelessWidget {
-  const _FilledButtonWithIconChild({ required this.label, required this.icon, required this.buttonStyle });
+  const _FilledButtonWithIconChild({
+    required this.label,
+    required this.icon,
+    required this.buttonStyle,
+    required this.iconAlignment,
+  });
 
   final Widget label;
   final Widget icon;
   final ButtonStyle? buttonStyle;
+  final IconAlignment iconAlignment;
 
   @override
   Widget build(BuildContext context) {
@@ -599,7 +625,9 @@ class _FilledButtonWithIconChild extends StatelessWidget {
     final double gap = lerpDouble(8, 4, scale)!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child: label)],
+      children: iconAlignment == IconAlignment.start
+        ? <Widget>[icon, SizedBox(width: gap), Flexible(child: label)]
+        : <Widget>[Flexible(child: label), SizedBox(width: gap), icon],
     );
   }
 }

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -78,6 +78,7 @@ class OutlinedButton extends ButtonStyleButton {
     super.clipBehavior,
     super.statesController,
     required super.child,
+    super.iconAlignment,
   });
 
   /// Create a text button from a pair of widgets that serve as the button's
@@ -87,7 +88,10 @@ class OutlinedButton extends ButtonStyleButton {
   /// at the start, and 16 at the end, with an 8 pixel gap in between.
   ///
   /// If [icon] is null, will create an [OutlinedButton] instead.
- factory OutlinedButton.icon({
+  ///
+  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  ///
+  factory OutlinedButton.icon({
     Key? key,
     required VoidCallback? onPressed,
     VoidCallback? onLongPress,
@@ -98,6 +102,7 @@ class OutlinedButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
+    IconAlignment iconAlignment = IconAlignment.start,
   }) {
     if (icon == null) {
       return OutlinedButton(
@@ -123,6 +128,7 @@ class OutlinedButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
+      iconAlignment: iconAlignment,
     );
   }
 
@@ -455,9 +461,15 @@ class _OutlinedButtonWithIcon extends OutlinedButton {
     super.statesController,
     required Widget icon,
     required Widget label,
+    super.iconAlignment,
   }) : super(
          autofocus: autofocus ?? false,
-         child: _OutlinedButtonWithIconChild(icon: icon, label: label, buttonStyle: style),
+         child: _OutlinedButtonWithIconChild(
+           icon: icon,
+           label: label,
+           buttonStyle: style,
+           iconAlignment: iconAlignment,
+         ),
       );
 
   @override
@@ -486,11 +498,13 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
     required this.label,
     required this.icon,
     required this.buttonStyle,
+    required this.iconAlignment,
   });
 
   final Widget label;
   final Widget icon;
   final ButtonStyle? buttonStyle;
+  final IconAlignment iconAlignment;
 
   @override
   Widget build(BuildContext context) {
@@ -499,7 +513,9 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
     final double gap = lerpDouble(8, 4, scale)!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child: label)],
+      children: iconAlignment == IconAlignment.start
+        ? <Widget>[icon, SizedBox(width: gap), Flexible(child: label)]
+        : <Widget>[Flexible(child: label), SizedBox(width: gap), icon],
     );
   }
 }

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -87,6 +87,7 @@ class TextButton extends ButtonStyleButton {
     super.statesController,
     super.isSemanticButton,
     required Widget super.child,
+    super.iconAlignment,
   });
 
   /// Create a text button from a pair of widgets that serve as the button's
@@ -94,6 +95,11 @@ class TextButton extends ButtonStyleButton {
   ///
   /// The icon and label are arranged in a row and padded by 8 logical pixels
   /// at the ends, with an 8 pixel gap in between.
+  ///
+  /// If [icon] is null, will create a [TextButton] instead.
+  ///
+  /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
+  ///
   factory TextButton.icon({
     Key? key,
     required VoidCallback? onPressed,
@@ -107,6 +113,7 @@ class TextButton extends ButtonStyleButton {
     MaterialStatesController? statesController,
     Widget? icon,
     required Widget label,
+    IconAlignment iconAlignment = IconAlignment.start,
   }) {
      if (icon == null) {
       return TextButton(
@@ -135,6 +142,7 @@ class TextButton extends ButtonStyleButton {
       statesController: statesController,
       icon: icon,
       label: label,
+      iconAlignment: iconAlignment,
     );
   }
 
@@ -497,9 +505,15 @@ class _TextButtonWithIcon extends TextButton {
     super.statesController,
     required Widget icon,
     required Widget label,
+    super.iconAlignment,
   }) : super(
          autofocus: autofocus ?? false,
-         child: _TextButtonWithIconChild(icon: icon, label: label, buttonStyle: style),
+         child: _TextButtonWithIconChild(
+           icon: icon,
+           label: label,
+           buttonStyle: style,
+           iconAlignment: iconAlignment,
+         ),
       );
 
   @override
@@ -525,11 +539,13 @@ class _TextButtonWithIconChild extends StatelessWidget {
     required this.label,
     required this.icon,
     required this.buttonStyle,
+    required this.iconAlignment,
   });
 
   final Widget label;
   final Widget icon;
   final ButtonStyle? buttonStyle;
+  final IconAlignment iconAlignment;
 
   @override
   Widget build(BuildContext context) {
@@ -538,7 +554,9 @@ class _TextButtonWithIconChild extends StatelessWidget {
     final double gap = lerpDouble(8, 4, scale)!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child: label)],
+      children: iconAlignment == IconAlignment.start
+        ? <Widget>[icon, SizedBox(width: gap), Flexible(child: label)]
+        : <Widget>[Flexible(child: label), SizedBox(width: gap), icon],
     );
   }
 }

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -2234,7 +2234,7 @@ void main() {
       );
     }
 
-    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2248,7 +2248,7 @@ void main() {
     // The icon is aligned to the left of the button.
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2262,7 +2262,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,
@@ -2276,7 +2276,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -2235,7 +2235,12 @@ void main() {
     }
 
     // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
@@ -2244,7 +2249,12 @@ void main() {
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
     Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2253,7 +2263,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     buttonTopRight = tester.getTopRight(find.byType(Material).last);
     iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2262,7 +2277,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -2178,6 +2178,98 @@ void main() {
 
     focusNode.dispose();
   });
+
+  testWidgets('Default iconAlignment', (WidgetTester tester) async {
+    Widget buildWidget({ required TextDirection textDirection }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: ElevatedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Test default iconAlignment when textDirection is ltr.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr));
+
+    final Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    final Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // Test default iconAlignment when textDirection is rtl.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl));
+
+    final Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    final Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+  });
+
+  testWidgets('iconAlignment can be customized', (WidgetTester tester) async {
+    Widget buildWidget({
+      required TextDirection textDirection,
+      required IconAlignment iconAlignment,
+    }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: ElevatedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+              iconAlignment: iconAlignment,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+
+    Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+
+    Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+
+    buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+
+    buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 24.0); // 24.0 - padding between icon and button edge.
+  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -2149,7 +2149,6 @@ void main() {
     expect(textChildOf(decorations.at(1)).data, 'button');
   });
 
-
   testWidgets('FilledButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
     const Color backgroundColor = Color(0xFF000011);
     const Color foregroundColor = Color(0xFF000022);
@@ -2287,6 +2286,190 @@ void main() {
     expect(sameStates(focusedHoveredPressedStates, foregroundStates), isTrue);
 
     focusNode.dispose();
+  });
+
+  testWidgets('Default iconAlignment', (WidgetTester tester) async {
+    Widget buildWidget({ required TextDirection textDirection }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: FilledButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Test default iconAlignment when textDirection is ltr.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr));
+
+    final Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    final Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // Test default iconAlignment when textDirection is rtl.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl));
+
+    final Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    final Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+  });
+
+  testWidgets('iconAlignment can be customized', (WidgetTester tester) async {
+    Widget buildWidget({
+      required TextDirection textDirection,
+      required IconAlignment iconAlignment,
+    }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: FilledButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+              iconAlignment: iconAlignment,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+
+    Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+
+    Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+
+    buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+
+    buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 24.0); // 24.0 - padding between icon and button edge.
+  });
+
+  testWidgets('Tonal icon default iconAlignment', (WidgetTester tester) async {
+    Widget buildWidget({ required TextDirection textDirection }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: FilledButton.tonalIcon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Test default iconAlignment when textDirection is ltr.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr));
+
+    final Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    final Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // Test default iconAlignment when textDirection is rtl.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl));
+
+    final Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    final Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+  });
+
+  testWidgets('Tonal icon iconAlignment can be customized', (WidgetTester tester) async {
+    Widget buildWidget({
+      required TextDirection textDirection,
+      required IconAlignment iconAlignment,
+    }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: FilledButton.tonalIcon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+              iconAlignment: iconAlignment,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+
+    Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+
+    Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+
+    buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+
+    buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 24.0); // 24.0 - padding between icon and button edge.
   });
 }
 

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -2343,7 +2343,7 @@ void main() {
       );
     }
 
-    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2357,7 +2357,7 @@ void main() {
     // The icon is aligned to the left of the button.
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2371,7 +2371,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,
@@ -2385,7 +2385,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,
@@ -2455,7 +2455,7 @@ void main() {
       );
     }
 
-    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2469,7 +2469,7 @@ void main() {
     // The icon is aligned to the left of the button.
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2483,7 +2483,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,
@@ -2497,7 +2497,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -2344,7 +2344,12 @@ void main() {
     }
 
     // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
@@ -2353,7 +2358,12 @@ void main() {
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
     Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2362,7 +2372,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     buttonTopRight = tester.getTopRight(find.byType(Material).last);
     iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2371,7 +2386,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
@@ -2436,7 +2456,12 @@ void main() {
     }
 
     // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
@@ -2445,7 +2470,12 @@ void main() {
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
     Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2454,7 +2484,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     buttonTopRight = tester.getTopRight(find.byType(Material).last);
     iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2463,7 +2498,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -2412,7 +2412,12 @@ void main() {
     }
 
     // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
@@ -2421,7 +2426,12 @@ void main() {
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
     Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2430,7 +2440,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     buttonTopRight = tester.getTopRight(find.byType(Material).last);
     iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2439,7 +2454,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -2411,7 +2411,7 @@ void main() {
       );
     }
 
-    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2425,7 +2425,7 @@ void main() {
     // The icon is aligned to the left of the button.
     expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2439,7 +2439,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,
@@ -2453,7 +2453,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -2189,7 +2189,6 @@ void main() {
     expect(textChildOf(decorations.at(1)).data, 'button');
   });
 
-
   testWidgets('OutlinedButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
     const Color backgroundColor = Color(0xFF000011);
     const Color foregroundColor = Color(0xFF000022);
@@ -2318,7 +2317,6 @@ void main() {
     expect(sameStates(focusedHoveredStates, backgroundStates), isTrue);
     expect(sameStates(focusedHoveredStates, foregroundStates), isTrue);
 
-
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pump(); // Start the splash and highlight animations.
@@ -2356,6 +2354,98 @@ void main() {
 
     await tester.pumpWidget(buildFrame()); // onPressed: null - disabled
     expect(material.color, backgroundColor);
+  });
+
+  testWidgets('Default iconAlignment', (WidgetTester tester) async {
+    Widget buildWidget({ required TextDirection textDirection }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: OutlinedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Test default iconAlignment when textDirection is ltr.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr));
+
+    final Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    final Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // Test default iconAlignment when textDirection is rtl.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl));
+
+    final Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    final Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+  });
+
+  testWidgets('iconAlignment can be customized', (WidgetTester tester) async {
+    Widget buildWidget({
+      required TextDirection textDirection,
+      required IconAlignment iconAlignment,
+    }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: OutlinedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+              iconAlignment: iconAlignment,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+
+    Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+
+    Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 24.0); // 24.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+
+    buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+
+    buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 24.0); // 24.0 - padding between icon and button edge.
   });
 }
 

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2244,7 +2244,7 @@ void main() {
       );
     }
 
-    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2258,7 +2258,7 @@ void main() {
     // The icon is aligned to the left of the button.
     expect(buttonTopLeft.dx, iconTopLeft.dx - 12.0); // 12.0 - padding between icon and button edge.
 
-    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is ltr.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.ltr,
@@ -2272,7 +2272,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,
@@ -2286,7 +2286,7 @@ void main() {
     // The icon is aligned to the right of the button.
     expect(buttonTopRight.dx, iconTopRight.dx + 12.0); // 12.0 - padding between icon and button edge.
 
-    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    // Test iconAlignment when textDirection is rtl.
     await tester.pumpWidget(
       buildWidget(
         textDirection: TextDirection.rtl,

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2245,7 +2245,12 @@ void main() {
     }
 
     // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
@@ -2254,7 +2259,12 @@ void main() {
     expect(buttonTopLeft.dx, iconTopLeft.dx - 12.0); // 12.0 - padding between icon and button edge.
 
     // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.ltr,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
     Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2263,7 +2273,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.start,
+      ),
+    );
 
     buttonTopRight = tester.getTopRight(find.byType(Material).last);
     iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
@@ -2272,7 +2287,12 @@ void main() {
     expect(buttonTopRight.dx, iconTopRight.dx + 12.0); // 12.0 - padding between icon and button edge.
 
     // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
-    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+    await tester.pumpWidget(
+      buildWidget(
+        textDirection: TextDirection.rtl,
+        iconAlignment: IconAlignment.end,
+      ),
+    );
 
     buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
     iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2022,7 +2022,6 @@ void main() {
     expect(textChildOf(decorations.at(1)).data, 'button');
   });
 
-
   testWidgets('TextButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
     const Color backgroundColor = Color(0xFF000011);
     const Color foregroundColor = Color(0xFF000022);
@@ -2151,7 +2150,6 @@ void main() {
     expect(sameStates(focusedHoveredStates, backgroundStates), isTrue);
     expect(sameStates(focusedHoveredStates, foregroundStates), isTrue);
 
-
     // Highlighted (pressed).
     await gesture.down(center);
     await tester.pump(); // Start the splash and highlight animations.
@@ -2189,6 +2187,98 @@ void main() {
 
     await tester.pumpWidget(buildFrame()); // onPressed: null - disabled
     expect(material.color, backgroundColor);
+  });
+
+  testWidgets('Default iconAlignment', (WidgetTester tester) async {
+    Widget buildWidget({ required TextDirection textDirection }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: TextButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Test default iconAlignment when textDirection is ltr.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr));
+
+    final Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    final Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 12.0); // 12.0 - padding between icon and button edge.
+
+    // Test default iconAlignment when textDirection is rtl.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl));
+
+    final Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    final Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 12.0); // 12.0 - padding between icon and button edge.
+  });
+
+  testWidgets('iconAlignment can be customized', (WidgetTester tester) async {
+    Widget buildWidget({
+      required TextDirection textDirection,
+      required IconAlignment iconAlignment,
+    }) {
+      return MaterialApp(
+        home: Directionality(
+          textDirection: textDirection,
+          child: Center(
+            child: TextButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('button'),
+              iconAlignment: iconAlignment,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // When the layout is ltr and iconAlignment is start, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.start));
+
+    Offset buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    Offset iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 12.0); // 12.0 - padding between icon and button edge.
+
+    // When the layout is ltr and iconAlignment is end, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.ltr, iconAlignment: IconAlignment.end));
+
+    Offset buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    Offset iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 16.0); // 16.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is start, the icon is aligned to the right of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.start));
+
+    buttonTopRight = tester.getTopRight(find.byType(Material).last);
+    iconTopRight = tester.getTopRight(find.byIcon(Icons.add));
+
+    // The icon is aligned to the right of the button.
+    expect(buttonTopRight.dx, iconTopRight.dx + 12.0); // 12.0 - padding between icon and button edge.
+
+    // When the layout is rtl and iconAlignment is end, the icon is aligned to the left of the button.
+    await tester.pumpWidget(buildWidget(textDirection: TextDirection.rtl, iconAlignment: IconAlignment.end));
+
+    buttonTopLeft = tester.getTopLeft(find.byType(Material).last);
+    iconTopLeft = tester.getTopLeft(find.byIcon(Icons.add));
+
+    // The icon is aligned to the left of the button.
+    expect(buttonTopLeft.dx, iconTopLeft.dx - 16.0); // 16.0 - padding between icon and button edge.
   });
 }
 


### PR DESCRIPTION
Adds `iconAlignment` property to `ButtonStyleButton` widget.

Fixes #89564

### Example

https://github.com/flutter/flutter/assets/13456345/1b5236c4-5c60-4915-b3c6-0a56c43f8a19

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
