### PR TITLE
Add an optional route information codec

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
@@ -181,7 +183,8 @@ class CupertinoApp extends StatefulWidget {
       'This feature was deprecated after v3.7.0-29.0.pre.'
     )
     this.useInheritedMediaQuery = false,
-  }) : routeInformationProvider = null,
+  }) : routeInformationCodec = null,
+       routeInformationProvider = null,
        routeInformationParser = null,
        routerDelegate = null,
        backButtonDispatcher = null,
@@ -192,6 +195,7 @@ class CupertinoApp extends StatefulWidget {
   /// {@macro flutter.widgets.WidgetsApp.router}
   const CupertinoApp.router({
     super.key,
+    this.routeInformationCodec,
     this.routeInformationProvider,
     this.routeInformationParser,
     this.routerDelegate,
@@ -273,6 +277,9 @@ class CupertinoApp extends StatefulWidget {
 
   /// {@macro flutter.widgets.widgetsApp.navigatorObservers}
   final List<NavigatorObserver>? navigatorObservers;
+
+  /// {@macro flutter.widgets.widgetsApp.routeInformationCodec}
+  final Codec<RouteInformation?, Object?>? routeInformationCodec;
 
   /// {@macro flutter.widgets.widgetsApp.routeInformationProvider}
   final RouteInformationProvider? routeInformationProvider;
@@ -542,6 +549,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
     if (_usesRouter) {
       return WidgetsApp.router(
         key: GlobalObjectKey(this),
+        routeInformationCodec: widget.routeInformationCodec,
         routeInformationProvider: widget.routeInformationProvider,
         routeInformationParser: widget.routeInformationParser,
         routerDelegate: widget.routerDelegate,

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart';
@@ -246,7 +247,8 @@ class MaterialApp extends StatefulWidget {
       'This feature was deprecated after v3.7.0-29.0.pre.'
     )
     this.useInheritedMediaQuery = false,
-  }) : routeInformationProvider = null,
+  }) : routeInformationCodec = null,
+       routeInformationProvider = null,
        routeInformationParser = null,
        routerDelegate = null,
        backButtonDispatcher = null,
@@ -258,6 +260,7 @@ class MaterialApp extends StatefulWidget {
   const MaterialApp.router({
     super.key,
     this.scaffoldMessengerKey,
+    this.routeInformationCodec,
     this.routeInformationProvider,
     this.routeInformationParser,
     this.routerDelegate,
@@ -348,6 +351,9 @@ class MaterialApp extends StatefulWidget {
 
   /// {@macro flutter.widgets.widgetsApp.navigatorObservers}
   final List<NavigatorObserver>? navigatorObservers;
+
+  /// {@macro flutter.widgets.widgetsApp.routeInformationCodec}
+  final Codec<RouteInformation?, Object?>? routeInformationCodec;
 
   /// {@macro flutter.widgets.widgetsApp.routeInformationProvider}
   final RouteInformationProvider? routeInformationProvider;
@@ -974,6 +980,7 @@ class _MaterialAppState extends State<MaterialApp> {
     if (_usesRouter) {
       return WidgetsApp.router(
         key: GlobalObjectKey(this),
+        routeInformationCodec: widget.routeInformationCodec,
         routeInformationProvider: widget.routeInformationProvider,
         routeInformationParser: widget.routeInformationParser,
         routerDelegate: widget.routerDelegate,

--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -988,7 +988,6 @@ bool debugIsSerializableForRestoration(Object? object) {
       const StandardMessageCodec().encodeMessage(object);
       result = true;
     } catch (error) {
-      print('trying to encode $object');
       // This is only used in asserts, so reporting the exception isn't
       // particularly useful, since the assert itself will likely fail.
       result = false;

--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -988,6 +988,7 @@ bool debugIsSerializableForRestoration(Object? object) {
       const StandardMessageCodec().encodeMessage(object);
       result = true;
     } catch (error) {
+      print('trying to encode $object');
       // This is only used in asserts, so reporting the exception isn't
       // particularly useful, since the assert itself will likely fail.
       result = false;

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:collection' show HashMap;
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -402,7 +403,8 @@ class WidgetsApp extends StatefulWidget {
        routeInformationParser = null,
        routerDelegate = null,
        backButtonDispatcher = null,
-       routerConfig = null;
+       routerConfig = null,
+       routeInformationCodec = null;
 
   /// Creates a [WidgetsApp] that uses the [Router] instead of a [Navigator].
   ///
@@ -413,6 +415,7 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   WidgetsApp.router({
     super.key,
+    this.routeInformationCodec,
     this.routeInformationProvider,
     this.routeInformationParser,
     this.routerDelegate,
@@ -609,6 +612,22 @@ class WidgetsApp extends StatefulWidget {
   ///    widget builds the [Router].
   /// {@endtemplate}
   final RouteInformationProvider? routeInformationProvider;
+
+  /// {@template flutter.widgets.widgetsApp.routeInformationCodec}
+  /// A codec to convert [RouteInformation] into a serializable form.
+  ///
+  /// This codec is used for encoding and decoding route information during
+  /// router's state restoration.
+  ///
+  /// Consider provide a codec if the [RouteInformation.state] may contain
+  /// complex objects that are not serializable.
+  ///
+  /// See also:
+  ///
+  ///  * [Router.routeInformationCodec], which receives this object when this
+  ///    widget builds the [Router].
+  /// {@endtemplate}
+  final Codec<RouteInformation?, Object?>? routeInformationCodec;
 
   /// {@template flutter.widgets.widgetsApp.routerConfig}
   /// An object to configure the underlying [Router].
@@ -1671,6 +1690,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
       routing = Router<Object>(
         restorationScopeId: 'router',
         routeInformationProvider: _effectiveRouteInformationProvider,
+        routeInformationCodec: widget.routeInformationCodec,
         routeInformationParser: widget.routeInformationParser,
         routerDelegate: widget.routerDelegate!,
         backButtonDispatcher: _effectiveBackButtonDispatcher,

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -292,6 +294,35 @@ void main() {
     expect(find.text('popped'), findsOneWidget);
   });
 
+  testWidgetsWithLeakTracking('MaterialApp.router routeInformationCodec pass to router', (WidgetTester tester) async {
+    final PlatformRouteInformationProvider provider = PlatformRouteInformationProvider(
+      initialRouteInformation: RouteInformation(
+        uri: Uri.parse('initial'),
+      ),
+    );
+    addTearDown(provider.dispose);
+    final SimpleNavigatorRouterDelegate delegate = SimpleNavigatorRouterDelegate(
+      builder: (BuildContext context, RouteInformation information) {
+        return Text(information.uri.toString());
+      },
+      onPopPage: (Route<void> route, void result, SimpleNavigatorRouterDelegate delegate) {
+        delegate.routeInformation = RouteInformation(
+          uri: Uri.parse('popped'),
+        );
+        return route.didPop(result);
+      },
+    );
+    addTearDown(delegate.dispose);
+    await tester.pumpWidget(CupertinoApp.router(
+      routeInformationProvider: provider,
+      routeInformationParser: SimpleRouteInformationParser(),
+      routerDelegate: delegate,
+      routeInformationCodec: const _TestRouteInformationCodec(),
+    ));
+    final Router<Object> router = tester.widget<Router<Object>>(find.byType(Router<Object>));
+    expect(router.routeInformationCodec, const _TestRouteInformationCodec());
+  });
+
   testWidgetsWithLeakTracking('CupertinoApp has correct default ScrollBehavior', (WidgetTester tester) async {
     late BuildContext capturedContext;
     await tester.pumpWidget(
@@ -553,5 +584,31 @@ class SimpleNavigatorRouterDelegate extends RouterDelegate<RouteInformation> wit
         ),
       ],
     );
+  }
+}
+
+class _TestRouteInformationCodec extends Codec<RouteInformation?, Object?> {
+  const _TestRouteInformationCodec();
+  @override
+  Converter<Object?, RouteInformation?> get decoder => const _TestRouteInformationDecoder();
+
+  @override
+  Converter<RouteInformation?, Object?> get encoder => const _TestRouteInformationEncoder();
+
+}
+
+class _TestRouteInformationDecoder extends Converter<Object?, RouteInformation?> {
+  const _TestRouteInformationDecoder();
+  @override
+  RouteInformation? convert(Object? input) {
+    return RouteInformation(uri: Uri.parse('/'));
+  }
+}
+
+class _TestRouteInformationEncoder extends Converter<RouteInformation?, Object?> {
+  const _TestRouteInformationEncoder();
+  @override
+  Object? convert(RouteInformation? input) {
+    return null;
   }
 }

--- a/packages/flutter/test/widgets/router_restoration_test.dart
+++ b/packages/flutter/test/widgets/router_restoration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -75,6 +77,87 @@ void main() {
     expect(find.text('Current config: /foo'), findsOneWidget);
     expect(delegate().newRoutePaths, <String>['/bar']);
     expect(delegate().restoredRoutePaths, <String>['/foo', '/foo']);
+  });
+
+  testWidgets('Router state restoration with serializable state works', (WidgetTester tester) async {
+    final UniqueKey router = UniqueKey();
+    _TestRouteInformationProvider provider() => tester.widget<Router<Object?>>(find.byKey(router)).routeInformationProvider! as _TestRouteInformationProvider;
+    final _TestRouterDelegateWithState delegate = _TestRouterDelegateWithState();
+    addTearDown(() {
+      delegate.dispose();
+    });
+
+    await tester.pumpWidget(
+      _TestWidget(
+        routerKey: router,
+        delegate: delegate,
+        parser: _TestRouteInformationParserWithState(),
+        withInformationProvider: true,
+      ),
+    );
+    expect(delegate.currentConfiguration!.uri.toString(), '/home');
+    expect(delegate.currentConfiguration!.state, null);
+
+    provider().value = RouteInformation(uri: Uri(path: '/foo'), state: 'state');
+    await tester.pumpAndSettle();
+    expect(delegate.currentConfiguration!.uri.toString(), '/foo');
+    expect(delegate.currentConfiguration!.state, 'state');
+
+    await tester.restartAndRestore();
+    expect(delegate.currentConfiguration!.uri.toString(), '/foo');
+    expect(delegate.currentConfiguration!.state, 'state');
+
+    final TestRestorationData restorationData = await tester.getRestorationData();
+
+    provider().value = RouteInformation(uri: Uri.parse('/bar'), state: 'state2');
+    await tester.pumpAndSettle();
+    expect(delegate.currentConfiguration!.uri.toString(), '/bar');
+    expect(delegate.currentConfiguration!.state, 'state2');
+
+    await tester.restoreFrom(restorationData);
+    expect(delegate.currentConfiguration!.uri.toString(), '/foo');
+    expect(delegate.currentConfiguration!.state, 'state');
+  });
+
+  testWidgets('Router state restoration with complex state and custom codec works', (WidgetTester tester) async {
+    final UniqueKey router = UniqueKey();
+    _TestRouteInformationProvider provider() => tester.widget<Router<Object?>>(find.byKey(router)).routeInformationProvider! as _TestRouteInformationProvider;
+    final _TestRouterDelegateWithState delegate = _TestRouterDelegateWithState();
+    addTearDown(() {
+      delegate.dispose();
+    });
+
+    await tester.pumpWidget(
+      _TestWidget(
+        routerKey: router,
+        delegate: delegate,
+        parser: _TestRouteInformationParserWithState(),
+        withInformationProvider: true,
+        codec: const _TestRouteInformationCodec(),
+      ),
+    );
+    expect(delegate.currentConfiguration!.uri.toString(), '/home');
+    expect(delegate.currentConfiguration!.state, null);
+
+    provider().value = RouteInformation(uri: Uri(path: '/foo'), state: const _TestComplexObject(1, 2));
+    await tester.pumpAndSettle();
+    expect(delegate.currentConfiguration!.uri.toString(), '/foo');
+    expect(delegate.currentConfiguration!.state, const _TestComplexObject(1, 2));
+
+    await tester.restartAndRestore();
+    expect(delegate.currentConfiguration!.uri.toString(), '/foo');
+    expect(delegate.currentConfiguration!.state, const _TestComplexObject(1, 2));
+
+    final TestRestorationData restorationData = await tester.getRestorationData();
+
+    provider().value = RouteInformation(uri: Uri.parse('/bar'), state: const _TestComplexObject(3, 4));
+    await tester.pumpAndSettle();
+    expect(delegate.currentConfiguration!.uri.toString(), '/bar');
+    expect(delegate.currentConfiguration!.state, const _TestComplexObject(3, 4));
+
+    await tester.restoreFrom(restorationData);
+    expect(delegate.currentConfiguration!.uri.toString(), '/foo');
+    expect(delegate.currentConfiguration!.state, const _TestComplexObject(1, 2));
   });
 }
 
@@ -154,22 +237,32 @@ class _TestRouteInformationProvider extends RouteInformationProvider with Change
 }
 
 class _TestWidget extends StatefulWidget {
-  const _TestWidget({this.withInformationProvider = false, this.routerKey});
+  const _TestWidget({
+    this.withInformationProvider = false,
+    this.routerKey,
+    this.parser,
+    this.delegate,
+    this.codec,
+  });
 
   final bool withInformationProvider;
   final Key? routerKey;
+  final RouteInformationParser<Object?>? parser;
+  final RouterDelegate<Object?>? delegate;
+  final Codec<RouteInformation?, Object?>? codec;
 
   @override
   State<_TestWidget> createState() => _TestWidgetState();
 }
 
 class _TestWidgetState extends State<_TestWidget> {
-  final _TestRouterDelegate _delegate = _TestRouterDelegate();
+  late final RouterDelegate<Object?> _delegate = widget.delegate ?? (_internalDelegate = _TestRouterDelegate());
+  _TestRouterDelegate? _internalDelegate;
   final _TestRouteInformationProvider _routeInformationProvider = _TestRouteInformationProvider();
 
   @override
   void dispose() {
-    _delegate.dispose();
+    _internalDelegate?.dispose();
     _routeInformationProvider.dispose();
     super.dispose();
   }
@@ -178,13 +271,128 @@ class _TestWidgetState extends State<_TestWidget> {
   Widget build(BuildContext context) {
     return RootRestorationScope(
       restorationId: 'root',
-      child: Router<String>(
+      child: Router<Object?>(
         key: widget.routerKey,
         restorationScopeId: 'router',
         routerDelegate: _delegate,
-        routeInformationParser: _TestRouteInformationParser(),
+        routeInformationCodec: widget.codec,
+        routeInformationParser: widget.parser ?? _TestRouteInformationParser(),
         routeInformationProvider: widget.withInformationProvider ? _routeInformationProvider : null,
       ),
     );
+  }
+}
+
+class _TestRouteInformationParserWithState extends RouteInformationParser<RouteInformation> {
+  @override
+  Future<RouteInformation> parseRouteInformation(RouteInformation routeInformation) {
+    return SynchronousFuture<RouteInformation>(routeInformation);
+  }
+
+  @override
+  RouteInformation? restoreRouteInformation(RouteInformation configuration) {
+    return configuration;
+  }
+}
+
+class _TestRouterDelegateWithState extends RouterDelegate<RouteInformation> with ChangeNotifier {
+  _TestRouterDelegateWithState() {
+    if (kFlutterMemoryAllocationsEnabled) {
+      ChangeNotifier.maybeDispatchObjectCreation(this);
+    }
+  }
+
+  @override
+  RouteInformation? get currentConfiguration => _currentConfiguration;
+  RouteInformation? _currentConfiguration;
+  set currentConfiguration(RouteInformation? value) {
+    if (value == _currentConfiguration) {
+      return;
+    }
+    _currentConfiguration = value;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> setNewRoutePath(RouteInformation configuration) {
+    _currentConfiguration = configuration;
+    return SynchronousFuture<void>(null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('uri: ${currentConfiguration?.uri}, state: ${currentConfiguration?.state}', textDirection: TextDirection.ltr);
+  }
+
+  @override
+  Future<bool> popRoute() async => throw UnimplementedError();
+}
+
+@immutable
+class _TestComplexObject {
+  const _TestComplexObject(this.a, this.b);
+  final int a;
+  final int b;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is _TestComplexObject
+        && a == other.a
+        && b == other.b;
+  }
+
+  @override
+  int get hashCode => Object.hash(a, b);
+}
+
+class _TestRouteInformationCodec extends Codec<RouteInformation?, Object?> {
+  const _TestRouteInformationCodec();
+  @override
+  Converter<Object?, RouteInformation?> get decoder => const _TestRouteInformationDecoder();
+
+  @override
+  Converter<RouteInformation?, Object?> get encoder => const _TestRouteInformationEncoder();
+
+}
+
+class _TestRouteInformationDecoder extends Converter<Object?, RouteInformation?> {
+  const _TestRouteInformationDecoder();
+  @override
+  RouteInformation? convert(Object? input) {
+    if (input == null) {
+      return null;
+    }
+    final List<Object?> castedData = input as List<Object?>;
+    final String? uri = castedData.first as String?;
+    if (uri == null) {
+      return null;
+    }
+    final Object? state;
+    if (castedData.length == 2) {
+      final List<Object?> encodedState = castedData.last! as List<Object?>;
+      state = _TestComplexObject(encodedState[0]! as int, encodedState[1]! as int);
+    } else {
+      state = null;
+    }
+    return RouteInformation(uri: Uri.parse(uri), state: state);
+  }
+}
+
+class _TestRouteInformationEncoder extends Converter<RouteInformation?, Object?> {
+  const _TestRouteInformationEncoder();
+  @override
+  Object? convert(RouteInformation? input) {
+    if (input == null) {
+      return null;
+    }
+    final _TestComplexObject? complexState = input.state as _TestComplexObject?;
+    return <Object?>[
+      input.uri.toString(),
+      if (complexState != null)
+        <int>[complexState.a, complexState.b],
+    ];
   }
 }


### PR DESCRIPTION
The serialization and deserialization was hard coded in _RestorableRouteInformation, which forces the RouteInformation.state to be serializable. This pr add a custom codec parameter to router so that customer can have complex data type as state object as long as they provide a custom codec.


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
