### PR TITLE
Avoid passing a nullable value to potentially non-nullable parameters

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -287,7 +287,7 @@ abstract class SceneBuilderRecorder extends Recorder {
         if (shouldContinue()) {
           PlatformDispatcher.instance.scheduleFrame();
         } else {
-          profileCompleter.complete(_profile);
+          profileCompleter.complete(_profile!);
         }
       } catch (error, stackTrace) {
         profileCompleter.completeError(error, stackTrace);

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2350,6 +2350,9 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
       if (animationController.status != AnimationStatus.dismissed) {
         _dismissedBottomSheets.add(bottomSheet);
       }
+      // TODO(https://github.com/flutter/flutter/issues/137294): Ensure that
+      // this Completer has a nullable type (or more likely, `void`).
+      // ignore: null_argument_to_non_null_type
       completer.complete();
     }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2350,8 +2350,9 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
       if (animationController.status != AnimationStatus.dismissed) {
         _dismissedBottomSheets.add(bottomSheet);
       }
-      // TODO(https://github.com/flutter/flutter/issues/137294): Ensure that
-      // this Completer has a nullable type (or more likely, `void`).
+      // TODO(srawlins): Ensure that this Completer has a nullable type (or more
+      // likely, `void`).
+      // https://github.com/flutter/flutter/issues/137294).
       // ignore: null_argument_to_non_null_type
       completer.complete();
     }


### PR DESCRIPTION
Also ignore one case where it is hard to fix.

The code with out the null assertion is legal as per the type signature, but will throw a runtime exception if the nullable value is null. To make this exception more explicit, the value must be null-checked before completing the completer with the value.

The analyzer will soon enforce such checks. See https://github.com/dart-lang/sdk/issues/53253.

Fixes https://github.com/flutter/flutter/issues/137294

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
