### PR TITLE
Run tests on either macOS 12 or 13

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -79,7 +79,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:2022_to_2023"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       device_type: none
       $flutter/osx_sdk : >-
         {
@@ -91,7 +91,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:2022_to_2023"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       device_type: none
       cpu: arm64
       $flutter/osx_sdk : >-
@@ -106,7 +106,7 @@ platform_properties:
         ]
       device_type: none
       mac_model: "Macmini8,1"
-      os: Mac-12
+      os: Mac-12|Mac-13
       tags: >
         ["devicelab", "hostonly", "mac"]
       $flutter/osx_sdk : >-
@@ -119,7 +119,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:2022_to_2023"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -133,7 +133,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:2022_to_2023"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -148,7 +148,7 @@ platform_properties:
           {"dependency": "chrome_and_driver", "version": "version:119.0.6045.9"},
           {"dependency": "open_jdk", "version": "version:11"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       cpu: x86
       device_type: "msm8952"
   mac_arm64_android:
@@ -158,7 +158,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:33v6"},
           {"dependency": "open_jdk", "version": "version:11"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       cpu: arm64
       device_type: "msm8952"
   mac_ios:
@@ -168,7 +168,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:2022_to_2023"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       cpu: x86
       device_os: iOS-16
       $flutter/osx_sdk : >-
@@ -182,7 +182,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "none"}
         ]
-      os: Mac-12
+      os: Mac-12|Mac-13
       cpu: arm64
       device_os: iOS-16
       $flutter/osx_sdk : >-
@@ -4415,7 +4415,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
       drone_dimensions: >
-        ["device_os=iOS-16","os=Mac-12", "cpu=x86"]
+        ["device_os=iOS-16","os=Mac-12|Mac-13", "cpu=x86"]
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
In preparation for migrating our fleet to macOS 13, we're updating tests to run on either macOS 12 or macOS 13.

I have run all tests on macOS 13: https://docs.google.com/spreadsheets/d/1-KOSOSF7uVA4KuqSMn9xz3IIJW78u8SXLYK2OAfe_Qg/edit?usp=sharing&resourcekey=0-df8Bj5PRS1IPBccPDdvRCQ

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
