### PR TITLE
Revert "Update `DataTable` test when data row is pressed for Material 3 (#137230)"

### DIFF
--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// This file is run as part of a reduced test set in CI on Mac and Windows
-// machines.
-@Tags(<String>['reduced-test-set'])
 @TestOn('!chrome')
 library;
 
@@ -1728,11 +1725,16 @@ void main() {
     ));
 
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Content1')));
-    await tester.pump(); // start the splash animation
-    await tester.pump(const Duration(milliseconds: 100)); // splash is underway
+    await tester.pump(const Duration(milliseconds: 200)); // splash is well underway
+    final RenderBox box = Material.of(tester.element(find.byType(InkWell)))as RenderBox;
     // Material 3 uses the InkSparkle which uses a shader, so we can't capture
-    // the effect with paint methods. Use a golden test instead.
-    await expectLater(find.byType(InkWell), matchesGoldenFile('data_table_test.data_row_pressed.png'));
+    // the effect with paint methods.
+    expect(
+      box,
+      paints
+        ..rect()
+        ..rect(rect: const Rect.fromLTRB(0.0, 56.0, 800.0, 104.0), color: pressedColor.withOpacity(0.0)),
+    );
     await gesture.up();
   });
 
@@ -2031,7 +2033,7 @@ void main() {
     );
 
     // Go without crashes.
-    expect(tester.takeException(), isNull);
+
   });
 
   testWidgetsWithLeakTracking('DataTable clip behavior', (WidgetTester tester) async {


### PR DESCRIPTION


This reverts commit 64f31b2f1a99f394dc4a9f194a93bf8532f35b77.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
