### PR TITLE
BannerPainter should dispatch creation and disposal events. 

### DIFF
--- a/packages/flutter/lib/src/widgets/banner.dart
+++ b/packages/flutter/lib/src/widgets/banner.dart
@@ -23,6 +23,8 @@ const TextStyle _kTextStyle = TextStyle(
   height: 1.0,
 );
 
+const String _flutterWidgetsLibrary = 'package:flutter/widgets.dart';
+
 /// Where to show a [Banner].
 ///
 /// The start and end locations are relative to the ambient [Directionality]
@@ -61,7 +63,17 @@ class BannerPainter extends CustomPainter {
     required this.layoutDirection,
     this.color = _kColor,
     this.textStyle = _kTextStyle,
-  }) : super(repaint: PaintingBinding.instance.systemFonts);
+  }) : super(repaint: PaintingBinding.instance.systemFonts) {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      MemoryAllocations.instance.dispatchObjectCreated(
+        library: _flutterWidgetsLibrary,
+        className: '$BannerPainter',
+        object: this,
+      );
+    }
+  }
 
   /// The message to show in the banner.
   final String message;
@@ -117,6 +129,11 @@ class BannerPainter extends CustomPainter {
   ///
   /// After calling this method, this object is no longer usable.
   void dispose() {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      MemoryAllocations.instance.dispatchObjectDisposed(object: this);
+    }
     _textPainter?.dispose();
     _textPainter = null;
   }

--- a/packages/flutter/test/widgets/banner_test.dart
+++ b/packages/flutter/test/widgets/banner_test.dart
@@ -280,4 +280,19 @@ void main() {
     );
     debugDisableShadows = true;
   });
+
+  test('BannerPainter dispatches memory events', () async {
+    await expectLater(
+      await memoryEvents(
+        () => BannerPainter(
+          message: 'foo',
+          textDirection: TextDirection.rtl,
+          location: BannerLocation.topStart,
+          layoutDirection: TextDirection.ltr,
+        ).dispose(),
+        BannerPainter,
+      ),
+      areCreateAndDispose,
+    );
+  });
 }


### PR DESCRIPTION
### Description
- Adds `BannerPainter` creation and disposal dispatching for memory leak tracking as part of https://github.com/flutter/flutter/issues/137311.

### Tests
- Updates `banner_test.dart` to test `BannerPainter` object creation and disposal dispatching.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
