### PR TITLE
Provide a helpful error message when `ColorScheme.brightness` doesn't match `ThemeData.brightness`

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -388,7 +388,12 @@ class ThemeData with Diagnosticable {
       : InkSplash.splashFactory;
 
     // COLOR
-    assert(colorScheme?.brightness == null || brightness == null || colorScheme!.brightness == brightness);
+    assert(
+      colorScheme?.brightness == null || brightness == null || colorScheme!.brightness == brightness,
+      'ThemeData.brightness does not match ColorScheme.brightness. '
+      'Either override ColorScheme.brightness or ThemeData.brightness to '
+      'match the other.'
+    );
     assert(colorSchemeSeed == null || colorScheme == null);
     assert(colorSchemeSeed == null || primarySwatch == null);
     assert(colorSchemeSeed == null || primaryColor == null);

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -1284,6 +1284,102 @@ void main() {
     // Ensure they are all there.
     expect(propertyNames, expectedPropertyNames);
   });
+
+  testWidgetsWithLeakTracking(
+    'ThemeData.brightness not matching ColorScheme.brightness throws a helpful error message', (WidgetTester tester) async {
+      AssertionError? error;
+
+      // Test `ColorScheme.light()` and `ThemeData.brightness == Brightness.dark`.
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: const ColorScheme.light(),
+              brightness: Brightness.dark,
+            ),
+            home: const Placeholder(),
+          ),
+        );
+      } on AssertionError catch (e) {
+        error = e;
+      } finally {
+        expect(error, isNotNull);
+        expect(error?.message, contains(
+          'ThemeData.brightness does not match ColorScheme.brightness. '
+          'Either override ColorScheme.brightness or ThemeData.brightness to '
+          'match the other.'
+        ));
+      }
+
+      // Test `ColorScheme.dark()` and `ThemeData.brightness == Brightness.light`.
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: const ColorScheme.dark(),
+              brightness: Brightness.light,
+            ),
+            home: const Placeholder(),
+          ),
+        );
+      } on AssertionError catch (e) {
+        error = e;
+      } finally {
+        expect(error, isNotNull);
+        expect(error?.message, contains(
+          'ThemeData.brightness does not match ColorScheme.brightness. '
+          'Either override ColorScheme.brightness or ThemeData.brightness to '
+          'match the other.'
+        ));
+      }
+
+      // Test `ColorScheme.fromSeed()` and `ThemeData.brightness == Brightness.dark`.
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xffff0000)),
+              brightness: Brightness.dark,
+            ),
+            home: const Placeholder(),
+          ),
+        );
+      } on AssertionError catch (e) {
+        error = e;
+      } finally {
+        expect(error, isNotNull);
+        expect(error?.message, contains(
+          'ThemeData.brightness does not match ColorScheme.brightness. '
+          'Either override ColorScheme.brightness or ThemeData.brightness to '
+          'match the other.'
+        ));
+      }
+
+      // Test `ColorScheme.fromSeed()` using `Brightness.dark` and `ThemeData.brightness == Brightness.light`.
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xffff0000),
+                brightness: Brightness.dark,
+              ),
+              brightness: Brightness.light,
+            ),
+            home: const Placeholder(),
+          ),
+        );
+      } on AssertionError catch (e) {
+        error = e;
+      } finally {
+        expect(error, isNotNull);
+        expect(error?.message, contains(
+          'ThemeData.brightness does not match ColorScheme.brightness. '
+          'Either override ColorScheme.brightness or ThemeData.brightness to '
+          'match the other.'
+        ));
+      }
+  });
 }
 
 @immutable


### PR DESCRIPTION
fixes [Unexpected behaviour with ColorScheme.fromSeed and Brightness.dark](https://github.com/flutter/flutter/issues/127523)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
