### PR TITLE
Fix text selection in `SearchAnchor/SearchBar`

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1332,6 +1332,7 @@ class _SearchBarState extends State<SearchBar> {
                         widget.onTap?.call();
                         _focusNode.requestFocus();
                       },
+                      onTapAlwaysCalled: true,
                       focusNode: _focusNode,
                       onChanged: widget.onChanged,
                       onSubmitted: widget.onSubmitted,

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1324,6 +1324,7 @@ class _SearchBarState extends State<SearchBar> {
                 if (leading != null) leading,
                 Expanded(
                   child: IgnorePointer(
+                    ignoring: false,
                     child: Padding(
                       padding: effectivePadding,
                       child: TextField(

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1311,7 +1311,9 @@ class _SearchBarState extends State<SearchBar> {
         child: InkWell(
           onTap: () {
             widget.onTap?.call();
-            _focusNode.requestFocus();
+            if (!_focusNode.hasFocus) {
+              _focusNode.requestFocus();
+            }
           },
           overlayColor: effectiveOverlayColor,
           customBorder: effectiveShape?.copyWith(side: effectiveSide),
@@ -1323,35 +1325,35 @@ class _SearchBarState extends State<SearchBar> {
               children: <Widget>[
                 if (leading != null) leading,
                 Expanded(
-                  child: IgnorePointer(
-                    ignoring: false,
-                    child: Padding(
-                      padding: effectivePadding,
-                      child: TextField(
-                        focusNode: _focusNode,
-                        onChanged: widget.onChanged,
-                        onSubmitted: widget.onSubmitted,
-                        controller: widget.controller,
-                        style: effectiveTextStyle,
-                        decoration: InputDecoration(
-                          hintText: widget.hintText,
-                        ).applyDefaults(InputDecorationTheme(
-                          hintStyle: effectiveHintStyle,
-
-                          // The configuration below is to make sure that the text field
-                          // in `SearchBar` will not be overridden by the overall `InputDecorationTheme`
-                          enabledBorder: InputBorder.none,
-                          border: InputBorder.none,
-                          focusedBorder: InputBorder.none,
-                          contentPadding: EdgeInsets.zero,
-                          // Setting `isDense` to true to allow the text field height to be
-                          // smaller than 48.0
-                          isDense: true,
-                        )),
-                        textCapitalization: effectiveTextCapitalization,
-                      ),
+                  child: Padding(
+                    padding: effectivePadding,
+                    child: TextField(
+                      onTap: () {
+                        widget.onTap?.call();
+                        _focusNode.requestFocus();
+                      },
+                      focusNode: _focusNode,
+                      onChanged: widget.onChanged,
+                      onSubmitted: widget.onSubmitted,
+                      controller: widget.controller,
+                      style: effectiveTextStyle,
+                      decoration: InputDecoration(
+                        hintText: widget.hintText,
+                      ).applyDefaults(InputDecorationTheme(
+                        hintStyle: effectiveHintStyle,
+                        // The configuration below is to make sure that the text field
+                        // in `SearchBar` will not be overridden by the overall `InputDecorationTheme`
+                        enabledBorder: InputBorder.none,
+                        border: InputBorder.none,
+                        focusedBorder: InputBorder.none,
+                        contentPadding: EdgeInsets.zero,
+                        // Setting `isDense` to true to allow the text field height to be
+                        // smaller than 48.0
+                        isDense: true,
+                      )),
+                      textCapitalization: effectiveTextCapitalization,
                     ),
-                  )
+                  ),
                 ),
                 if (trailing != null) ...trailing,
               ],

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -715,10 +715,6 @@ class _ViewContentState extends State<_ViewContent> {
     _viewRect = widget.viewRect;
     _controller = widget.searchController;
     _controller.addListener(updateSuggestions);
-
-    if (!_focusNode.hasFocus) {
-      _focusNode.requestFocus();
-    }
   }
 
   @override
@@ -865,6 +861,7 @@ class _ViewContentState extends State<_ViewContent> {
                           top: false,
                           bottom: false,
                           child: SearchBar(
+                            autoFocus: true,
                             constraints: widget.showFullScreenView ? BoxConstraints(minHeight: _SearchViewDefaultsM3.fullScreenBarHeight) : null,
                             focusNode: _focusNode,
                             leading: widget.viewLeading ?? defaultLeading,
@@ -1091,6 +1088,7 @@ class SearchBar extends StatefulWidget {
     this.textStyle,
     this.hintStyle,
     this.textCapitalization,
+    this.autoFocus = false,
   });
 
   /// Controls the text being edited in the search bar's text field.
@@ -1212,6 +1210,9 @@ class SearchBar extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textCapitalization}
   final TextCapitalization? textCapitalization;
 
+  /// {@macro flutter.widgets.editableText.autoFocus}
+  final bool autoFocus;
+
   @override
   State<SearchBar> createState() => _SearchBarState();
 }
@@ -1328,9 +1329,9 @@ class _SearchBarState extends State<SearchBar> {
                   child: Padding(
                     padding: effectivePadding,
                     child: TextField(
+                      autofocus: widget.autoFocus,
                       onTap: () {
                         widget.onTap?.call();
-                        _focusNode.requestFocus();
                       },
                       onTapAlwaysCalled: true,
                       focusNode: _focusNode,

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -707,7 +707,6 @@ class _ViewContentState extends State<_ViewContent> {
   late Rect _viewRect;
   late final SearchController _controller;
   Iterable<Widget> result = <Widget>[];
-  final FocusNode _focusNode = FocusNode();
 
   @override
   void initState() {
@@ -744,7 +743,6 @@ class _ViewContentState extends State<_ViewContent> {
   @override
   void dispose() {
     _controller.removeListener(updateSuggestions);
-    _focusNode.dispose();
     super.dispose();
   }
 
@@ -863,7 +861,6 @@ class _ViewContentState extends State<_ViewContent> {
                           child: SearchBar(
                             autoFocus: true,
                             constraints: widget.showFullScreenView ? BoxConstraints(minHeight: _SearchViewDefaultsM3.fullScreenBarHeight) : null,
-                            focusNode: _focusNode,
                             leading: widget.viewLeading ?? defaultLeading,
                             trailing: widget.viewTrailing ?? defaultTrailing,
                             hintText: widget.viewHintText,
@@ -1330,9 +1327,7 @@ class _SearchBarState extends State<SearchBar> {
                     padding: effectivePadding,
                     child: TextField(
                       autofocus: widget.autoFocus,
-                      onTap: () {
-                        widget.onTap?.call();
-                      },
+                      onTap: widget.onTap,
                       onTapAlwaysCalled: true,
                       focusNode: _focusNode,
                       onChanged: widget.onChanged,

--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -1210,7 +1210,7 @@ class SearchBar extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.textCapitalization}
   final TextCapitalization? textCapitalization;
 
-  /// {@macro flutter.widgets.editableText.autoFocus}
+  /// {@macro flutter.widgets.editableText.autofocus}
   final bool autoFocus;
 
   @override

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -69,6 +69,14 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
   void onSingleTapUp(TapDragUpDetails details) {
     super.onSingleTapUp(details);
     _state._requestKeyboard();
+    // _state.widget.onTap?.call();// A user might want to run this everytime despite it not being a single tap up.
+  }
+
+  @override
+  bool get onTapAlwaysCalled => _state.widget.onTapAlwaysCalled;
+
+  @override
+  void onUserTap() {
     _state.widget.onTap?.call();
   }
 
@@ -297,6 +305,7 @@ class TextField extends StatefulWidget {
     bool? enableInteractiveSelection,
     this.selectionControls,
     this.onTap,
+    this.onTapAlwaysCalled = false,
     this.onTapOutside,
     this.mouseCursor,
     this.buildCounter,
@@ -656,6 +665,15 @@ class TextField extends StatefulWidget {
   /// text field's internal gesture detector, use a [Listener].
   /// {@endtemplate}
   final GestureTapCallback? onTap;
+
+  /// Whether [onTap] is only called for distinct taps.
+  ///
+  /// When disabled [onTap] is only called for distinct taps.
+  ///
+  /// When enabled [onTap] is called for every tap.
+  ///
+  /// Defaults to false.
+  final bool onTapAlwaysCalled;
 
   /// {@macro flutter.widgets.editableText.onTapOutside}
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -644,7 +644,10 @@ class TextField extends StatefulWidget {
   bool get selectionEnabled => enableInteractiveSelection;
 
   /// {@template flutter.material.textfield.onTap}
-  /// Called for each distinct tap except for every second tap of a double tap.
+  /// Called for the first tap in a series of taps.
+  /// 
+  /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
+  /// taps.
   ///
   /// The text field builds a [GestureDetector] to handle input events like tap,
   /// to trigger focus requests, to move the caret, adjust the selection, etc.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -645,7 +645,7 @@ class TextField extends StatefulWidget {
 
   /// {@template flutter.material.textfield.onTap}
   /// Called for the first tap in a series of taps.
-  /// 
+  ///
   /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
   /// taps.
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -665,13 +665,10 @@ class TextField extends StatefulWidget {
   /// {@endtemplate}
   final GestureTapCallback? onTap;
 
-  /// Whether [onTap] is only called for distinct taps.
+  /// Whether [onTap] should be called for every tap.
   ///
-  /// When disabled [onTap] is only called for distinct taps.
-  ///
-  /// When enabled [onTap] is called for every tap.
-  ///
-  /// Defaults to false.
+  /// Defaults to false, so [onTap] is only called for each distinct tap. When
+  /// enabled, [onTap] is called for every tap including consecutive taps.
   final bool onTapAlwaysCalled;
 
   /// {@macro flutter.widgets.editableText.onTapOutside}

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -69,7 +69,6 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
   void onSingleTapUp(TapDragUpDetails details) {
     super.onSingleTapUp(details);
     _state._requestKeyboard();
-    // _state.widget.onTap?.call();// A user might want to run this everytime despite it not being a single tap up.
   }
 
   @override

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -72,7 +72,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
   }
 
   @override
-  bool get onTapAlwaysCalled => _state.widget.onTapAlwaysCalled;
+  bool get onUserTapAlwaysCalled => _state.widget.onTapAlwaysCalled;
 
   @override
   void onUserTap() {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -646,9 +646,6 @@ class TextField extends StatefulWidget {
   /// {@template flutter.material.textfield.onTap}
   /// Called for the first tap in a series of taps.
   ///
-  /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
-  /// taps.
-  ///
   /// The text field builds a [GestureDetector] to handle input events like tap,
   /// to trigger focus requests, to move the caret, adjust the selection, etc.
   /// Handling some of those events by wrapping the text field with a competing
@@ -666,6 +663,9 @@ class TextField extends StatefulWidget {
   /// To listen to arbitrary pointer events without competing with the
   /// text field's internal gesture detector, use a [Listener].
   /// {@endtemplate}
+  ///
+  /// If [onTapAlwaysCalled] is enabled, this will also be called for consecutive
+  /// taps.
   final GestureTapCallback? onTap;
 
   /// Whether [onTap] should be called for every tap.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2271,7 +2271,7 @@ class TextSelectionGestureDetectorBuilder {
   /// Whether the user provided [onUserTap] callback should be dispatched on every
   /// tap or only non-consecutive taps.
   @protected
-  bool get onTapAlwaysCalled => false;
+  bool get onUserTapAlwaysCalled => false;
 
   /// Handler for [TextSelectionGestureDetector.onUserTap].
   ///
@@ -2279,7 +2279,7 @@ class TextSelectionGestureDetectorBuilder {
   ///
   ///  * [TextSelectionGestureDetector.onUserTap], which triggers this
   ///    callback.
-  ///  * [TextSelectionGestureDetector.onTapAlwaysCalled], which controls
+  ///  * [TextSelectionGestureDetector.onUserTapAlwaysCalled], which controls
   ///     whether this callback is called only on the first tap in a series
   ///     of taps.
   @protected
@@ -3018,7 +3018,7 @@ class TextSelectionGestureDetectorBuilder {
       onDragSelectionStart: onDragSelectionStart,
       onDragSelectionUpdate: onDragSelectionUpdate,
       onDragSelectionEnd: onDragSelectionEnd,
-      onTapAlwaysCalled: onTapAlwaysCalled,
+      onUserTapAlwaysCalled: onUserTapAlwaysCalled,
       behavior: behavior,
       child: child,
     );
@@ -3061,7 +3061,7 @@ class TextSelectionGestureDetector extends StatefulWidget {
     this.onDragSelectionStart,
     this.onDragSelectionUpdate,
     this.onDragSelectionEnd,
-    this.onTapAlwaysCalled = false,
+    this.onUserTapAlwaysCalled = false,
     this.behavior,
     required this.child,
   });
@@ -3104,10 +3104,10 @@ class TextSelectionGestureDetector extends StatefulWidget {
   /// another gesture from the touch is recognized.
   final GestureCancelCallback? onSingleTapCancel;
 
-  /// Called for the first tap in a series of taps when [onTapAlwaysCalled] is
+  /// Called for the first tap in a series of taps when [onUserTapAlwaysCalled] is
   /// disabled.
   ///
-  /// When [onTapAlwaysCalled] is enabled, this will be called for every tap,
+  /// When [onUserTapAlwaysCalled] is enabled, this will be called for every tap,
   /// including consecutive taps.
   final GestureTapCallback? onUserTap;
 
@@ -3145,7 +3145,7 @@ class TextSelectionGestureDetector extends StatefulWidget {
   /// a series of taps.
   ///
   /// When enabled [onUserTap] will be called for consecutive taps.
-  final bool onTapAlwaysCalled;
+  final bool onUserTapAlwaysCalled;
 
   /// How this gesture detector should behave during hit testing.
   ///
@@ -3226,7 +3226,7 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     if (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount) == 1) {
       widget.onSingleTapUp?.call(details);
       widget.onUserTap?.call();
-    } else if (widget.onTapAlwaysCalled) {
+    } else if (widget.onUserTapAlwaysCalled) {
       widget.onUserTap?.call();
     }
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2268,7 +2268,7 @@ class TextSelectionGestureDetectorBuilder {
     }
   }
 
-  /// Whether the user provided onTap callback should be dispatched on every
+  /// Whether the user provided [onUserTap] callback should be dispatched on every
   /// tap or only non-consecutive taps.
   @protected
   bool get onTapAlwaysCalled => false;
@@ -3141,7 +3141,7 @@ class TextSelectionGestureDetector extends StatefulWidget {
 
   /// Whether [onUserTap] should always be called.
   ///
-  /// When disabled [onUserTap] will only be called the first tap in a
+  /// When disabled [onUserTap] will only be called for the first tap in a
   /// a series of taps.
   ///
   /// When enabled [onUserTap] will be called for consecutive taps.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1888,10 +1888,6 @@ abstract class TextSelectionGestureDetectorBuilderDelegate {
 
   /// Whether the user may select text in the text field.
   bool get selectionEnabled;
-
-  // /// Whether the user provided onTap callback should be dispatched on every
-  // /// tap or only non-consecutive taps.
-  // bool get onTapAlwaysCalled => false;
 }
 
 /// Builds a [TextSelectionGestureDetector] to wrap an [EditableText].

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2268,12 +2268,16 @@ class TextSelectionGestureDetectorBuilder {
     }
   }
 
-  /// Whether the user provided [onUserTap] callback should be dispatched on every
+  /// Whether the provided [onUserTap] callback should be dispatched on every
   /// tap or only non-consecutive taps.
+  ///
+  /// Defaults to false.
   @protected
   bool get onUserTapAlwaysCalled => false;
 
   /// Handler for [TextSelectionGestureDetector.onUserTap].
+  ///
+  /// By default, it services as placeholder to enable subclass override.
   ///
   /// See also:
   ///
@@ -2388,7 +2392,7 @@ class TextSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onSingleTapCancel].
   ///
-  /// By default, it services as place holder to enable subclass override.
+  /// By default, it services as placeholder to enable subclass override.
   ///
   /// See also:
   ///
@@ -3105,9 +3109,9 @@ class TextSelectionGestureDetector extends StatefulWidget {
   final GestureCancelCallback? onSingleTapCancel;
 
   /// Called for the first tap in a series of taps when [onUserTapAlwaysCalled] is
-  /// disabled.
+  /// disabled, which is the default behavior.
   ///
-  /// When [onUserTapAlwaysCalled] is enabled, this will be called for every tap,
+  /// When [onUserTapAlwaysCalled] is enabled, this is called for every tap,
   /// including consecutive taps.
   final GestureTapCallback? onUserTap;
 
@@ -3139,12 +3143,9 @@ class TextSelectionGestureDetector extends StatefulWidget {
   /// Called when a mouse that was previously dragging is released.
   final GestureTapDragEndCallback? onDragSelectionEnd;
 
-  /// Whether [onUserTap] should always be called.
+  /// Whether [onUserTap] will be called for all taps including consecutive taps.
   ///
-  /// When disabled [onUserTap] will only be called for the first tap in a
-  /// a series of taps.
-  ///
-  /// When enabled [onUserTap] will be called for consecutive taps.
+  /// Defaults to false, so [onUserTap] is only called for each distinct tap.
   final bool onUserTapAlwaysCalled;
 
   /// How this gesture detector should behave during hit testing.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2277,7 +2277,7 @@ class TextSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onUserTap].
   ///
-  /// By default, it services as placeholder to enable subclass override.
+  /// By default, it serves as placeholder to enable subclass override.
   ///
   /// See also:
   ///
@@ -2392,7 +2392,7 @@ class TextSelectionGestureDetectorBuilder {
 
   /// Handler for [TextSelectionGestureDetector.onSingleTapCancel].
   ///
-  /// By default, it services as placeholder to enable subclass override.
+  /// By default, it serves as placeholder to enable subclass override.
   ///
   /// See also:
   ///

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -11,45 +11,46 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-// Returns the RenderEditable at the given index, or the first if not given.
-RenderEditable findRenderEditable(WidgetTester tester, {int index = 0}) {
-  final RenderObject root = tester.renderObject(find.byType(EditableText).at(index));
-  expect(root, isNotNull);
-
-  late RenderEditable renderEditable;
-  void recursiveFinder(RenderObject child) {
-    if (child is RenderEditable) {
-      renderEditable = child;
-      return;
-    }
-    child.visitChildren(recursiveFinder);
-  }
-  root.visitChildren(recursiveFinder);
-  expect(renderEditable, isNotNull);
-  return renderEditable;
-}
-
-List<TextSelectionPoint> globalize(Iterable<TextSelectionPoint> points, RenderBox box) {
-  return points.map<TextSelectionPoint>((TextSelectionPoint point) {
-    return TextSelectionPoint(
-      box.localToGlobal(point.point),
-      point.direction,
-    );
-  }).toList();
-}
-
-Offset _textOffsetToPosition(WidgetTester tester, int offset, {int index = 0}) {
-  final RenderEditable renderEditable = findRenderEditable(tester, index: index);
-  final List<TextSelectionPoint> endpoints = globalize(
-    renderEditable.getEndpointsForSelection(
-      TextSelection.collapsed(offset: offset),
-    ),
-    renderEditable,
-  );
-  expect(endpoints.length, 1);
-  return endpoints[0].point + const Offset(kIsWeb? 1.0 : 0.0, -2.0);
-}
 void main() {
+  // Returns the RenderEditable at the given index, or the first if not given.
+  RenderEditable findRenderEditable(WidgetTester tester, {int index = 0}) {
+    final RenderObject root = tester.renderObject(find.byType(EditableText).at(index));
+    expect(root, isNotNull);
+
+    late RenderEditable renderEditable;
+    void recursiveFinder(RenderObject child) {
+      if (child is RenderEditable) {
+        renderEditable = child;
+        return;
+      }
+      child.visitChildren(recursiveFinder);
+    }
+    root.visitChildren(recursiveFinder);
+    expect(renderEditable, isNotNull);
+    return renderEditable;
+  }
+
+  List<TextSelectionPoint> globalize(Iterable<TextSelectionPoint> points, RenderBox box) {
+    return points.map<TextSelectionPoint>((TextSelectionPoint point) {
+      return TextSelectionPoint(
+        box.localToGlobal(point.point),
+        point.direction,
+      );
+    }).toList();
+  }
+
+  Offset textOffsetToPosition(WidgetTester tester, int offset, {int index = 0}) {
+    final RenderEditable renderEditable = findRenderEditable(tester, index: index);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(
+        TextSelection.collapsed(offset: offset),
+      ),
+      renderEditable,
+    );
+    expect(endpoints.length, 1);
+    return endpoints[0].point + const Offset(kIsWeb? 1.0 : 0.0, -2.0);
+  }
+
   testWidgetsWithLeakTracking('SearchBar defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     final ColorScheme colorScheme = theme.colorScheme;
@@ -2390,7 +2391,7 @@ void main() {
       expect(find.text(defaultText), findsOneWidget);
 
       final TestGesture gesture = await tester.startGesture(
-        _textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0),
+        textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0),
         kind: PointerDeviceKind.mouse,
         buttons: kSecondaryMouseButton,
       );
@@ -2424,13 +2425,13 @@ void main() {
       expect(find.text(defaultText), findsOneWidget);
 
       final TestGesture gesture = await _pointGestureToSearchBar(tester);
-      await gesture.down(_textOffsetToPosition(tester, 2) + const Offset(0.0, -9.0));
+      await gesture.down(textOffsetToPosition(tester, 2) + const Offset(0.0, -9.0));
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle(kDoubleTapTimeout);
       expect(controller.value.selection, const TextSelection.collapsed(offset: 2));
 
-      await gesture.down(_textOffsetToPosition(tester, 9, index: 1) + const Offset(0.0, -9.0));
+      await gesture.down(textOffsetToPosition(tester, 9, index: 1) + const Offset(0.0, -9.0));
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
@@ -2461,13 +2462,13 @@ void main() {
       expect(find.text(defaultText), findsOneWidget);
 
       final TestGesture gesture = await _pointGestureToSearchBar(tester);
-      final Offset targetPosition = _textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0);
+      final Offset targetPosition = textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0);
       await gesture.down(targetPosition);
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      final Offset targetPositionAfterViewOpened = _textOffsetToPosition(tester, 4, index: 1) + const Offset(0.0, -9.0);
+      final Offset targetPositionAfterViewOpened = textOffsetToPosition(tester, 4, index: 1) + const Offset(0.0, -9.0);
       await gesture.down(targetPositionAfterViewOpened);
       await tester.pumpAndSettle();
       await gesture.up();
@@ -2504,13 +2505,13 @@ void main() {
       expect(find.text(defaultText), findsOneWidget);
 
       final TestGesture gesture = await _pointGestureToSearchBar(tester);
-      final Offset targetPosition = _textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0);
+      final Offset targetPosition = textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0);
       await gesture.down(targetPosition);
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      final Offset targetPositionAfterViewOpened = _textOffsetToPosition(tester, 4, index: 1) + const Offset(0.0, -9.0);
+      final Offset targetPositionAfterViewOpened = textOffsetToPosition(tester, 4, index: 1) + const Offset(0.0, -9.0);
       await gesture.down(targetPositionAfterViewOpened);
       await tester.pump();
       await gesture.up();

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -2424,13 +2424,13 @@ void main() {
       expect(find.text(defaultText), findsOneWidget);
 
       final TestGesture gesture = await _pointGestureToSearchBar(tester);
-      await gesture.down(_textOffsetToPosition(tester, 4) + const Offset(0.0, -9.0));
+      await gesture.down(_textOffsetToPosition(tester, 2) + const Offset(0.0, -9.0));
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle(kDoubleTapTimeout);
-      expect(controller.value.selection, const TextSelection.collapsed(offset: 4));
+      expect(controller.value.selection, const TextSelection.collapsed(offset: 2));
 
-      await gesture.down(_textOffsetToPosition(tester, 9) + Offset(0.0, -9.0));
+      await gesture.down(_textOffsetToPosition(tester, 9, index: 1) + const Offset(0.0, -9.0));
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();
@@ -2467,12 +2467,13 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      await gesture.down(targetPosition);
+      final Offset targetPositionAfterViewOpened = _textOffsetToPosition(tester, 4, index: 1) + const Offset(0.0, -9.0);
+      await gesture.down(targetPositionAfterViewOpened);
       await tester.pumpAndSettle();
       await gesture.up();
       await tester.pump();
   
-      await gesture.down(targetPosition);
+      await gesture.down(targetPositionAfterViewOpened);
       await tester.pump();
       await gesture.up();
       await tester.pump();
@@ -2509,17 +2510,18 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle(kDoubleTapTimeout);
 
-      await gesture.down(targetPosition);
+      final Offset targetPositionAfterViewOpened = _textOffsetToPosition(tester, 4, index: 1) + const Offset(0.0, -9.0);
+      await gesture.down(targetPositionAfterViewOpened);
       await tester.pump();
       await gesture.up();
       await tester.pump();
 
-      await gesture.down(targetPosition);
+      await gesture.down(targetPositionAfterViewOpened);
       await tester.pump();
       await gesture.up();
       await tester.pump();
 
-      await gesture.down(targetPosition);
+      await gesture.down(targetPositionAfterViewOpened);
       await tester.pump();
       await gesture.up();
       await tester.pumpAndSettle();

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -414,20 +414,22 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.elevation, hoveredElevation);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.elevation, pressedElevation);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.elevation, focusedElevation);
@@ -454,20 +456,22 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.color, pressedColor);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.color, focusedColor);
@@ -494,20 +498,22 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shadowColor, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shadowColor, pressedColor);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shadowColor, focusedColor);
@@ -534,20 +540,22 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.surfaceTintColor, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.surfaceTintColor, pressedColor);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.surfaceTintColor, focusedColor);
@@ -574,21 +582,23 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pumpAndSettle();
     expect(inkFeatures, paints..rect(color: hoveredColor.withOpacity(1.0)));
 
     // On pressed.
     await tester.pumpAndSettle();
-    await tester.startGesture(tester.getCenter(find.byType(SearchBar)));
+    await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pumpAndSettle();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect()..rect(color: pressedColor.withOpacity(1.0)));
 
     // On focused.
     await tester.pumpAndSettle();
-    focusNode.requestFocus();
+    await gesture.up();
     await tester.pumpAndSettle();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
+    await tester.pump();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect()..rect(color: focusedColor.withOpacity(1.0)));
   });
@@ -648,20 +658,22 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shape, hoveredShape.copyWith(side: hoveredSide));
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shape, pressedShape.copyWith(side: pressedSide));
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shape, focusedShape.copyWith(side: focusedSide));
@@ -711,19 +723,21 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
     helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, pressedColor);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, focusedColor);
@@ -748,19 +762,21 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     EditableText inputText = tester.widget(find.text('input text'));
     expect(inputText.style.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
     inputText = tester.widget(find.text('input text'));
     expect(inputText.style.color, pressedColor);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     inputText = tester.widget(find.text('input text'));
     expect(inputText.style.color, focusedColor);
@@ -997,19 +1013,21 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
-    addTearDown(gesture.removePointer);
     await tester.pump();
     Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, hoveredColor);
 
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
-    await tester.pump();
+    await tester.pumpAndSettle();
     helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, pressedColor);
 
     // On focused.
-    await tester.tap(find.byType(SearchBar));
+    await gesture.up();
+    await tester.pump();
+    // Remove the pointer so we are no longer hovering.
+    await gesture.removePointer();
     await tester.pump();
     helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, focusedColor);

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -414,6 +414,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.elevation, hoveredElevation);
@@ -421,7 +422,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.elevation, pressedElevation);
@@ -454,6 +454,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.color, hoveredColor);
@@ -461,7 +462,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.color, pressedColor);
@@ -494,6 +494,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shadowColor, hoveredColor);
@@ -501,7 +502,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shadowColor, pressedColor);
@@ -534,6 +534,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.surfaceTintColor, hoveredColor);
@@ -541,7 +542,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.surfaceTintColor, pressedColor);
@@ -574,6 +574,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pumpAndSettle();
     expect(inkFeatures, paints..rect(color: hoveredColor.withOpacity(1.0)));
 
@@ -583,7 +584,6 @@ void main() {
     await tester.pumpAndSettle();
     inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
     expect(inkFeatures, paints..rect()..rect(color: pressedColor.withOpacity(1.0)));
-    await gesture.removePointer();
 
     // On focused.
     await tester.pumpAndSettle();
@@ -648,6 +648,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shape, hoveredShape.copyWith(side: hoveredSide));
@@ -655,7 +656,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
 
     material = tester.widget<Material>(searchBarMaterial);
     expect(material.shape, pressedShape.copyWith(side: pressedSide));
@@ -711,6 +711,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, hoveredColor);
@@ -720,7 +721,6 @@ void main() {
     await tester.pump();
     helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, pressedColor);
-    await gesture.removePointer();
 
     // On focused.
     await tester.tap(find.byType(SearchBar));
@@ -748,6 +748,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     EditableText inputText = tester.widget(find.text('input text'));
     expect(inputText.style.color, hoveredColor);
@@ -755,7 +756,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
     inputText = tester.widget(find.text('input text'));
     expect(inputText.style.color, pressedColor);
 
@@ -997,6 +997,7 @@ void main() {
 
     // On hovered.
     final TestGesture gesture = await _pointGestureToSearchBar(tester);
+    addTearDown(gesture.removePointer);
     await tester.pump();
     Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, hoveredColor);
@@ -1004,7 +1005,6 @@ void main() {
     // On pressed.
     await gesture.down(tester.getCenter(find.byType(SearchBar)));
     await tester.pump();
-    await gesture.removePointer();
     helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, pressedColor);
 
@@ -1922,23 +1922,25 @@ void main() {
     final SearchController controller = SearchController();
     addTearDown(controller.dispose);
 
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: SearchAnchor.bar(
-          searchController: controller,
-          isFullScreen: false,
-          suggestionsBuilder: (BuildContext context, SearchController controller) {
-            return <Widget>[
-              ListTile(
-                title: const Text('item 0'),
-                onTap: () {
-                  controller.closeView('item 0');
-                },
-              )
-            ];
-          },
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SearchAnchor.bar(
+            searchController: controller,
+            isFullScreen: false,
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[
+                ListTile(
+                  title: const Text('item 0'),
+                  onTap: () {
+                    controller.closeView('item 0');
+                  },
+                )
+              ];
+            },
+          ),
         ),
-      ),),
+      ),
     );
 
     expect(controller.isOpen, false);
@@ -1954,51 +1956,13 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('Search view does not go off the screen - LTR', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: Align(
-          // Put the search anchor on the bottom-right corner of the screen to test
-          // if the search view goes off the window.
-          alignment: Alignment.bottomRight,
-          child: SearchAnchor(
-            isFullScreen: false,
-            builder: (BuildContext context, SearchController controller) {
-              return IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  controller.openView();
-                },
-              );
-            },
-            suggestionsBuilder: (BuildContext context, SearchController controller) {
-              return <Widget>[];
-            },
-          ),
-        ),
-      ),),
-    );
-
-    final Finder findIconButton = find.widgetWithIcon(IconButton, Icons.search);
-    final Rect iconButton = tester.getRect(findIconButton);
-    // Icon button has a size of (48.0, 48.0) and the screen size is (800.0, 600.0).
-    expect(iconButton, equals(const Rect.fromLTRB(752.0, 552.0, 800.0, 600.0)));
-
-    await tester.tap(find.byIcon(Icons.search));
-    await tester.pumpAndSettle();
-
-    final Rect searchViewRect = tester.getRect(find.descendant(of: findViewContent(), matching: find.byType(SizedBox)).first);
-    expect(searchViewRect, equals(const Rect.fromLTRB(440.0, 200.0, 800.0, 600.0)));
-  });
-
-  testWidgetsWithLeakTracking('Search view does not go off the screen - RTL', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp(
-      home: Directionality(
-        textDirection: TextDirection.rtl,
-        child: Material(
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
           child: Align(
-            // Put the search anchor on the bottom-left corner of the screen to test
-            // if the search view goes off the window when the text direction is right-to-left.
-            alignment: Alignment.bottomLeft,
+            // Put the search anchor on the bottom-right corner of the screen to test
+            // if the search view goes off the window.
+            alignment: Alignment.bottomRight,
             child: SearchAnchor(
               isFullScreen: false,
               builder: (BuildContext context, SearchController controller) {
@@ -2015,7 +1979,49 @@ void main() {
             ),
           ),
         ),
-      ),),
+      ),
+    );
+
+    final Finder findIconButton = find.widgetWithIcon(IconButton, Icons.search);
+    final Rect iconButton = tester.getRect(findIconButton);
+    // Icon button has a size of (48.0, 48.0) and the screen size is (800.0, 600.0).
+    expect(iconButton, equals(const Rect.fromLTRB(752.0, 552.0, 800.0, 600.0)));
+
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    final Rect searchViewRect = tester.getRect(find.descendant(of: findViewContent(), matching: find.byType(SizedBox)).first);
+    expect(searchViewRect, equals(const Rect.fromLTRB(440.0, 200.0, 800.0, 600.0)));
+  });
+
+  testWidgetsWithLeakTracking('Search view does not go off the screen - RTL', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Material(
+            child: Align(
+              // Put the search anchor on the bottom-left corner of the screen to test
+              // if the search view goes off the window when the text direction is right-to-left.
+              alignment: Alignment.bottomLeft,
+              child: SearchAnchor(
+                isFullScreen: false,
+                builder: (BuildContext context, SearchController controller) {
+                  return IconButton(
+                    icon: const Icon(Icons.search),
+                    onPressed: () {
+                      controller.openView();
+                    },
+                  );
+                },
+                suggestionsBuilder: (BuildContext context, SearchController controller) {
+                  return <Widget>[];
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
     );
 
     final Finder findIconButton = find.widgetWithIcon(IconButton, Icons.search);
@@ -2057,7 +2063,8 @@ void main() {
               },
             ),
           ),
-        ),);
+        ),
+      );
     }
 
     // Test LTR text direction.
@@ -2095,27 +2102,29 @@ void main() {
     tester.view.physicalSize = const Size(500.0, 600.0);
     tester.view.devicePixelRatio = 1.0;
 
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: SearchAnchor(
-          isFullScreen: false,
-          builder: (BuildContext context, SearchController controller) {
-            return Align(
-              alignment: Alignment.bottomRight,
-              child: IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  controller.openView();
-                },
-              ),
-            );
-          },
-          suggestionsBuilder: (BuildContext context, SearchController controller) {
-            return <Widget>[];
-          },
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SearchAnchor(
+            isFullScreen: false,
+            builder: (BuildContext context, SearchController controller) {
+              return Align(
+                alignment: Alignment.bottomRight,
+                child: IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    controller.openView();
+                  },
+                ),
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
         ),
       ),
-    ));
+    );
 
     // Open the search view
     await tester.tap(find.byIcon(Icons.search));
@@ -2134,27 +2143,29 @@ void main() {
     tester.view.physicalSize = const Size(500.0, 600.0);
     tester.view.devicePixelRatio = 1.0;
 
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: SearchAnchor(
-          isFullScreen: true,
-          builder: (BuildContext context, SearchController controller) {
-            return Align(
-              alignment: Alignment.bottomRight,
-              child: IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  controller.openView();
-                },
-              ),
-            );
-          },
-          suggestionsBuilder: (BuildContext context, SearchController controller) {
-            return <Widget>[];
-          },
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SearchAnchor(
+            isFullScreen: true,
+            builder: (BuildContext context, SearchController controller) {
+              return Align(
+                alignment: Alignment.bottomRight,
+                child: IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    controller.openView();
+                  },
+                ),
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
         ),
       ),
-    ));
+    );
 
     // Open a full-screen search view
     await tester.tap(find.byIcon(Icons.search));
@@ -2170,32 +2181,34 @@ void main() {
 
   testWidgetsWithLeakTracking('Search view route does not throw exception during pop animation', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/126590.
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: Center(
-          child: SearchAnchor(
-            builder: (BuildContext context, SearchController controller) {
-              return IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  controller.openView();
-                },
-              );
-            },
-            suggestionsBuilder: (BuildContext context, SearchController controller) {
-              return List<Widget>.generate(5, (int index) {
-                final String item = 'item $index';
-                return ListTile(
-                  leading: const Icon(Icons.history),
-                  title: Text(item),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {},
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SearchAnchor(
+              builder: (BuildContext context, SearchController controller) {
+                return IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    controller.openView();
+                  },
                 );
-              });
-            }),
+              },
+              suggestionsBuilder: (BuildContext context, SearchController controller) {
+                return List<Widget>.generate(5, (int index) {
+                  final String item = 'item $index';
+                  return ListTile(
+                    leading: const Icon(Icons.history),
+                    title: Text(item),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () {},
+                  );
+                });
+              }),
+          ),
         ),
       ),
-    ));
+    );
 
     // Open search view
     await tester.tap(find.byIcon(Icons.search));
@@ -2211,59 +2224,17 @@ void main() {
   testWidgetsWithLeakTracking('Docked search should position itself correctly based on closest navigator', (WidgetTester tester) async {
     const double rootSpacing = 100.0;
 
-    await tester.pumpWidget(MaterialApp(
-      builder: (BuildContext context, Widget? child) {
-        return Scaffold(
-          body: Padding(
-            padding: const EdgeInsets.all(rootSpacing),
-            child: child,
-          ),
-        );
-      },
-      home: Material(
-        child: SearchAnchor(
-          isFullScreen: false,
-          builder: (BuildContext context, SearchController controller) {
-            return IconButton(
-              icon: const Icon(Icons.search),
-              onPressed: () {
-                controller.openView();
-              },
-            );
-          },
-          suggestionsBuilder: (BuildContext context, SearchController controller) {
-            return <Widget>[];
-          },
-        ),
-      ),
-    ));
-
-    await tester.tap(find.byIcon(Icons.search));
-    await tester.pumpAndSettle();
-
-    final Rect searchViewRect = tester.getRect(find.descendant(of: findViewContent(), matching: find.byType(SizedBox)).first);
-    expect(searchViewRect.topLeft, equals(const Offset(rootSpacing, rootSpacing)));
-  });
-
-  testWidgetsWithLeakTracking('Docked search view with nested navigator does not go off the screen', (WidgetTester tester) async {
-    addTearDown(tester.view.reset);
-    tester.view.physicalSize = const Size(400.0, 400.0);
-    tester.view.devicePixelRatio = 1.0;
-
-    const double rootSpacing = 100.0;
-
-    await tester.pumpWidget(MaterialApp(
-      builder: (BuildContext context, Widget? child) {
-        return Scaffold(
-          body: Padding(
-            padding: const EdgeInsets.all(rootSpacing),
-            child: child,
-          ),
-        );
-      },
-      home: Material(
-        child: Align(
-          alignment: Alignment.bottomRight,
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget? child) {
+          return Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(rootSpacing),
+              child: child,
+            ),
+          );
+        },
+        home: Material(
           child: SearchAnchor(
             isFullScreen: false,
             builder: (BuildContext context, SearchController controller) {
@@ -2280,7 +2251,53 @@ void main() {
           ),
         ),
       ),
-    ));
+    );
+
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    final Rect searchViewRect = tester.getRect(find.descendant(of: findViewContent(), matching: find.byType(SizedBox)).first);
+    expect(searchViewRect.topLeft, equals(const Offset(rootSpacing, rootSpacing)));
+  });
+
+  testWidgetsWithLeakTracking('Docked search view with nested navigator does not go off the screen', (WidgetTester tester) async {
+    addTearDown(tester.view.reset);
+    tester.view.physicalSize = const Size(400.0, 400.0);
+    tester.view.devicePixelRatio = 1.0;
+
+    const double rootSpacing = 100.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget? child) {
+          return Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(rootSpacing),
+              child: child,
+            ),
+          );
+        },
+        home: Material(
+          child: Align(
+            alignment: Alignment.bottomRight,
+            child: SearchAnchor(
+              isFullScreen: false,
+              builder: (BuildContext context, SearchController controller) {
+                return IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    controller.openView();
+                  },
+                );
+              },
+              suggestionsBuilder: (BuildContext context, SearchController controller) {
+                return <Widget>[];
+              },
+            ),
+          ),
+        ),
+      ),
+    );
 
     await tester.tap(find.byIcon(Icons.search));
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -2473,7 +2473,7 @@ void main() {
       await tester.pumpAndSettle();
       await gesture.up();
       await tester.pump();
-  
+
       await gesture.down(targetPositionAfterViewOpened);
       await tester.pump();
       await gesture.up();


### PR DESCRIPTION
This changes fixes text selection gestures on the search field when using `SearchAnchor`.

Before this change text selection gestures did not work due to an `IgnorePointer` in the widget tree.

This change:
* Removes the `IgnorePointer` so the underlying `TextField` can receive pointer events.
* Introduces `TextField.onTapAlwaysCalled` and `TextSelectionGestureDetector.onUserTapAlwaysCalled`, so a user provided on tap callback can be called on consecutive taps. This is so that the user provided on tap callback for `SearchAnchor/SearchBar` that was previously only handled by `InkWell` will still work if a tap occurs in the `TextField`s hit box. The `TextField`s default behavior is maintained outside of the context of `SearchAnchor/SearchBar`.

Fixes https://github.com/flutter/flutter/issues/128332 and #134965

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
