### PR TITLE
Change _SelectableFragment to a public naming scheme, SelectableFragment.

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -1312,10 +1312,17 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
 /// Since the selections in [PlaceholderSpan] are handled independently in its
 /// subtree, a selection in [RenderParagraph] can't continue across a
 /// [PlaceholderSpan]. The [RenderParagraph] splits itself on [PlaceholderSpan]
-/// to create multiple `_SelectableFragment`s so that they can be selected
+/// to create multiple `SelectableFragment`s so that they can be selected
 /// separately.
-class _SelectableFragment with Selectable, ChangeNotifier implements TextLayoutMetrics {
-  _SelectableFragment({
+class SelectableFragment
+    with Selectable, ChangeNotifier
+    implements TextLayoutMetrics {
+  /// Creates a new interactive piece of a paragraph.
+  ///
+  /// - [paragraph] : The underlying paragraph object that we're making selectable.
+  /// - [fullText] : The complete text content for context.
+  /// - [range] : The specific section of text that this fragment covers.
+  SelectableFragment({
     required this.paragraph,
     required this.fullText,
     required this.range,

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -349,7 +349,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
       return const <TextSelection>[];
     }
     final List<TextSelection> results = <TextSelection>[];
-    for (final _SelectableFragment fragment in _lastSelectableFragments!) {
+    for (final SelectableFragment fragment in _lastSelectableFragments!) {
       if (fragment._textSelectionStart != null &&
           fragment._textSelectionEnd != null) {
         results.add(
@@ -366,7 +366,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
   // Should be null if selection is not enabled, i.e. _registrar = null. The
   // paragraph splits on [PlaceholderSpan.placeholderCodeUnit], and stores each
   // fragment in this list.
-  List<_SelectableFragment>? _lastSelectableFragments;
+  List<SelectableFragment>? _lastSelectableFragments;
 
   /// The [SelectionRegistrar] this paragraph will be, or is, registered to.
   SelectionRegistrar? get registrar => _registrar;
@@ -399,9 +399,9 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     _lastSelectableFragments!.forEach(_registrar!.remove);
   }
 
-  List<_SelectableFragment> _getSelectableFragments() {
+  List<SelectableFragment> _getSelectableFragments() {
     final String plainText = text.toPlainText(includeSemanticsLabels: false);
-    final List<_SelectableFragment> result = <_SelectableFragment>[];
+    final List<SelectableFragment> result = <SelectableFragment>[];
     int start = 0;
     while (start < plainText.length) {
       int end = plainText.indexOf(_placeholderCharacter, start);
@@ -409,7 +409,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
         if (end == -1) {
           end = plainText.length;
         }
-        result.add(_SelectableFragment(paragraph: this, range: TextRange(start: start, end: end), fullText: plainText));
+        result.add(SelectableFragment(paragraph: this, range: TextRange(start: start, end: end), fullText: plainText));
         start = end;
       }
       start += 1;
@@ -421,7 +421,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     if (_lastSelectableFragments == null) {
       return;
     }
-    for (final _SelectableFragment fragment in _lastSelectableFragments!) {
+    for (final SelectableFragment fragment in _lastSelectableFragments!) {
       fragment.dispose();
     }
     _lastSelectableFragments = null;
@@ -432,7 +432,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
 
   @override
   void markNeedsLayout() {
-    _lastSelectableFragments?.forEach((_SelectableFragment element) => element.didChangeParagraphLayout());
+    _lastSelectableFragments?.forEach((SelectableFragment element) => element.didChangeParagraphLayout());
     super.markNeedsLayout();
   }
 
@@ -614,7 +614,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
       return;
     }
     _selectionColor = value;
-    if (_lastSelectableFragments?.any((_SelectableFragment fragment) => fragment.value.hasSelection) ?? false) {
+    if (_lastSelectableFragments?.any((SelectableFragment fragment) => fragment.value.hasSelection) ?? false) {
       markNeedsPaint();
     }
   }
@@ -899,7 +899,7 @@ class RenderParagraph extends RenderBox with ContainerRenderObjectMixin<RenderBo
     }
 
     if (_lastSelectableFragments != null) {
-      for (final _SelectableFragment fragment in _lastSelectableFragments!) {
+      for (final SelectableFragment fragment in _lastSelectableFragments!) {
         fragment.paint(context, offset);
       }
     }


### PR DESCRIPTION
## Summary
Change _SelectableFragment to a public naming scheme, SelectableFragment.

## Description
This PR modifies the naming scheme of _SelectableFragment to make it public as SelectableFragment. This change allows for casting returned Selectable objects to SelectableFragment within MultiSelectableSelectionContainerDelegate.

## Motivation
Making _SelectableFragment public enables developers to implement specific functionalities (like in the linked issues) outside of the Flutter framework by allowing for the type casting of Selectable to SelectableFragment in an extension of MultiSelectableSelectionContainerDelegate.

## Related Issue
[Flutter Issue #137371](https://github.com/flutter/flutter/issues/137371)
https://github.com/flutter/flutter/issues/110594

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


