### PR TITLE
reset state of CustomSemanticsAction before running tests

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -274,6 +274,17 @@ class CustomSemanticsAction {
   static CustomSemanticsAction? getAction(int id) {
     return _actions[id];
   }
+
+  /// Resets internal state between tests. Does nothing if asserts are disabled.
+  @visibleForTesting
+  static void resetForTests() {
+    assert(() {
+      _actions.clear();
+      _ids.clear();
+      _nextId = 0;
+      return true;
+    }());
+  }
 }
 
 /// A string that carries a list of [StringAttribute]s.

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -251,6 +251,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     if (registerTestTextInput) {
       _testTextInput.register();
     }
+    CustomSemanticsAction.resetForTests(); // ignore: invalid_use_of_visible_for_testing_member
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/137696

This will get the tree green again.

The problem is that `CustomSemanticsAction` has static state in it, and todays test seed order makes things unhappy.