### PR TITLE
Added `transitionDuration` property to `PopupMenuButton` and `PopupMenuThemeData`

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -816,6 +816,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
     this.constraints,
     required this.clipBehavior,
     super.settings,
+    this.menuDuration,
   }) : itemSizes = List<Size?>.filled(items.length, null),
        // Menus always cycle focus through their items irrespective of the
        // focus traversal edge behavior set in the Navigator.
@@ -834,6 +835,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   final CapturedThemes capturedThemes;
   final BoxConstraints? constraints;
   final Clip clipBehavior;
+  final Duration? menuDuration;
 
   @override
   Animation<double> createAnimation() {
@@ -845,7 +847,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   }
 
   @override
-  Duration get transitionDuration => _kMenuDuration;
+  Duration get transitionDuration => menuDuration ?? _kMenuDuration;
 
   @override
   bool get barrierDismissible => true;
@@ -945,6 +947,9 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
 /// menu to the [Navigator] furthest from or nearest to the given `context`. It
 /// is `false` by default.
 ///
+/// The `transitionDuration` argument is used to control the duration of
+/// animation when menu opens/closes.
+///
 /// The `semanticLabel` argument is used by accessibility frameworks to
 /// announce screen transitions when the menu is opened and closed. If this
 /// label is not provided, it will default to
@@ -977,6 +982,7 @@ Future<T?> showMenu<T>({
   BoxConstraints? constraints,
   Clip clipBehavior = Clip.none,
   RouteSettings? routeSettings,
+  Duration? transitionDuration,
 }) {
   assert(items.isNotEmpty);
   assert(debugCheckHasMaterialLocalizations(context));
@@ -1008,6 +1014,7 @@ Future<T?> showMenu<T>({
     constraints: constraints,
     clipBehavior: clipBehavior,
     settings: routeSettings,
+    menuDuration: transitionDuration,
   ));
 }
 
@@ -1128,6 +1135,7 @@ class PopupMenuButton<T> extends StatefulWidget {
     this.constraints,
     this.position,
     this.clipBehavior = Clip.none,
+    this.transitionDuration,
   }) : assert(
          !(child != null && icon != null),
          'You can only pass [child] or [icon], not both.',
@@ -1292,6 +1300,10 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
+  /// The `transitionDuration` argument is used to control the duration of
+  /// animation when menu opens/closes.
+  final Duration? transitionDuration;
+
   @override
   PopupMenuButtonState<T> createState() => PopupMenuButtonState<T>();
 }
@@ -1348,6 +1360,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
         color: widget.color ?? popupMenuTheme.color,
         constraints: widget.constraints,
         clipBehavior: widget.clipBehavior,
+        transitionDuration: widget.transitionDuration ?? popupMenuTheme.transitionDuration,
       )
       .then<void>((T? newValue) {
         if (!mounted) {

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -57,6 +57,7 @@ class PopupMenuThemeData with Diagnosticable {
     this.position,
     this.iconColor,
     this.iconSize,
+    this.transitionDuration,
   });
 
   /// The background color of the popup menu.
@@ -103,6 +104,9 @@ class PopupMenuThemeData with Diagnosticable {
   /// The size of the icon in the popup menu button.
   final double? iconSize;
 
+  /// The duration of animation when menu opens or closes.
+  final Duration? transitionDuration;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   PopupMenuThemeData copyWith({
@@ -118,6 +122,7 @@ class PopupMenuThemeData with Diagnosticable {
     PopupMenuPosition? position,
     Color? iconColor,
     double? iconSize,
+    Duration? transitionDuration,
   }) {
     return PopupMenuThemeData(
       color: color ?? this.color,
@@ -132,6 +137,7 @@ class PopupMenuThemeData with Diagnosticable {
       position: position ?? this.position,
       iconColor: iconColor ?? this.iconColor,
       iconSize: iconSize ?? this.iconSize,
+      transitionDuration: transitionDuration ?? this.transitionDuration,
     );
   }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3809,7 +3809,80 @@ void main() {
     );
     await tester.tap(find.text('button'));
     await tester.pumpAndSettle();
-    expect(tester.widget<PopupMenuButton<String>>(find.byType(PopupMenuButton<String>)).transitionDuration?.inSeconds, 5);
+    // Close the menu.
+    await tester.tapAt(const Offset(20.0, 20.0));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 4));
+    expect(find.text('item1'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 1001));
+    expect(find.text('item1'), findsNothing);
+  });
+
+  testWidgetsWithLeakTracking('PopupMenuButton honors transitionDuration from PopupThemeData', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          popupMenuTheme: const PopupMenuThemeData(
+            transitionDuration: Duration(seconds: 3),
+          ),
+        ),
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              child: const Text('button'),
+              itemBuilder: (BuildContext context) {
+                return <PopupMenuItem<String>>[
+                  const CheckedPopupMenuItem<String>(
+                    value: 'item1',
+                    child: Text('item1'),
+                  ),
+                ];
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('button'));
+    await tester.pumpAndSettle();
+    // Close the menu.
+    await tester.tapAt(const Offset(20.0, 20.0));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    expect(find.text('item1'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 1001));
+    expect(find.text('item1'), findsNothing);
+  });
+
+  testWidgetsWithLeakTracking('PopupMenuButton honors default 300ms transition duration', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              child: const Text('button'),
+              itemBuilder: (BuildContext context) {
+                return <PopupMenuItem<String>>[
+                  const CheckedPopupMenuItem<String>(
+                    value: 'item1',
+                    child: Text('item1'),
+                  ),
+                ];
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('button'));
+    await tester.pumpAndSettle();
+    // Close the menu.
+    await tester.tapAt(const Offset(20.0, 20.0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('item1'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 101));
+    expect(find.text('item1'), findsNothing);
   });
 }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3785,6 +3785,32 @@ void main() {
     await tester.pumpAndSettle();
     expect(count, 1);
   });
+
+  testWidgetsWithLeakTracking('PopupMenuButton honors transitionDuration', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              transitionDuration: const Duration(seconds: 5),
+              child: const Text('button'),
+              itemBuilder: (BuildContext context) {
+                return <PopupMenuItem<String>>[
+                  const CheckedPopupMenuItem<String>(
+                    value: 'item1',
+                    child: Text('item1'),
+                  ),
+                ];
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('button'));
+    await tester.pumpAndSettle();
+    expect(tester.widget<PopupMenuButton<String>>(find.byType(PopupMenuButton<String>)).transitionDuration?.inSeconds, 5);
+  });
 }
 
 class TestApp extends StatelessWidget {


### PR DESCRIPTION
Added `transitionDuration` property to `PopupMenuButton` and `PopupMenuThemeData`.

Fixes #135638 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
