### PR TITLE
Change cast in json parsing

### DIFF
--- a/packages/flutter_tools/lib/src/proxied_devices/file_transfer.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/file_transfer.dart
@@ -51,7 +51,7 @@ class BlockHashes {
       blockSize: obj['blockSize']! as int,
       totalSize: obj['totalSize']! as int,
       adler32: Uint32List.view(base64.decode(obj['adler32']! as String).buffer),
-      md5: (obj['md5']! as List<Object>).cast<String>(),
+      md5: (obj['md5']! as List<Object?>).cast<String>(),
       fileMd5: obj['fileMd5']! as String,
     );
   }

--- a/packages/flutter_tools/test/general.shard/proxied_devices/file_transfer_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/file_transfer_test.dart
@@ -187,4 +187,26 @@ void main() {
       expect(file.readAsStringSync(), content2);
     });
   });
+
+  group('BlockHashes', () {
+    test('json conversion works normally', () {
+      const String json = '''
+{
+  "blockSize":4,
+  "totalSize":18,
+  "adler32":"7ACcAu0AoALuAKQC7wCoApQA+gA=",
+  "md5": [
+    "zB0S8R/fGt05GcI5v8AjIQ==",
+    "uZCZ4i/LUGFYAD+K1ZD0Wg==",
+    "6kbZGS8T1NJl/naWODQcNw==",
+    "kKh/aA2XAhR/r0HdZa3Bxg==",
+    "34eF7Bs/OhfoJ5+sAw0zyw=="
+  ],
+  "fileMd5":"VT/gkSEdctzUEUJCxclxuQ=="
+}
+''';
+      final Map<String, Object?> decodedJson = jsonDecode(json) as Map<String, Object?>;
+      expect(BlockHashes.fromJson(decodedJson).toJson(), decodedJson);
+    });
+  });
 }


### PR DESCRIPTION
`jsonDecode` decodes lists as `List<Object?>`, so the cast to `List<Object>` fails at runtime in sound null safety mode.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
