### PR TITLE
Revert "Add no-shuffle to reorderable_list_test.dart"

### DIFF
--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(dnfield): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/137696
-// Fails with "flutter test --test-randomize-ordering-seed=20231101"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';


### PR DESCRIPTION
Reverts flutter/flutter#137698

Not needed after https://github.com/flutter/flutter/pull/137697

Must not land until after that one