### PR TITLE
Fix mounted checks

### DIFF
--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -175,7 +175,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
 
   Future<void> saveRecordedEvents(ByteData data, BuildContext context) async {
     if (await channel.invokeMethod<bool>('getStoragePermission') ?? false) {
-      if (mounted) {
+      if (context.mounted) {
         showMessage(context, 'External storage permissions are required to save events');
       }
       return;
@@ -185,12 +185,12 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
       // This test only runs on Android so we can assume path separator is '/'.
       final File file = File('${outDir?.path}/$kEventsFileName');
       await file.writeAsBytes(data.buffer.asUint8List(0, data.lengthInBytes), flush: true);
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       showMessage(context, 'Saved original events to ${file.path}');
     } catch (e) {
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       showMessage(context, 'Failed saving $e');

--- a/dev/integration_tests/flutter_gallery/lib/gallery/demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/demo.dart
@@ -80,7 +80,7 @@ class _TabbedComponentDemoScaffoldState extends State<TabbedComponentDemoScaffol
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
-    } else if (mounted) {
+    } else if (context.mounted) {
       showDialog<void>(
         context: context,
         builder: (BuildContext context) {

--- a/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
@@ -157,7 +157,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
 
   Future<void> saveRecordedEvents(ByteData data, BuildContext context) async {
     if (await channel.invokeMethod<bool>('getStoragePermission') != true) {
-      if (mounted) {
+      if (context.mounted) {
         showMessage(context, 'External storage permissions are required to save events');
       }
       return;
@@ -167,12 +167,12 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
       // This test only runs on Android so we can assume path separator is '/'.
       final File file = File('${outDir.path}/$kEventsFileName');
       await file.writeAsBytes(data.buffer.asUint8List(0, data.lengthInBytes), flush: true);
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       showMessage(context, 'Saved original events to ${file.path}');
     } catch (e) {
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       showMessage(context, 'Failed saving $e');


### PR DESCRIPTION
Fixes in preparation for https://dart-review.googlesource.com/c/sdk/+/330561.

The change referenced above tightens the `use_build_context_synchronously` to ensure that `mounted` is checked on the appropriate `BuildContext` or `State`. This change fixes up the flutter/flutter in preparation of this new enforcement.