### PR TITLE
Check sample links for malformed links

### DIFF
--- a/dev/bots/test/check_code_samples_test.dart
+++ b/dev/bots/test/check_code_samples_test.dart
@@ -140,25 +140,30 @@ void main() {
       },
       shouldHaveErrors: true,
     );
+    final bool isWindows = Platform.isWindows;
     final String lines = <String>[
       '╔═╡ERROR╞═══════════════════════════════════════════════════════════════════════',
       '║ The following examples are not linked from any source file API doc comments:',
-      '║   examples/api/lib/animation/curves/curve2_d.0.dart',
-      '║   examples/api/lib/layer/foo_example.0.dart',
-      '║   examples/api/lib/layer/bar_example.0.dart',
+      if (!isWindows) '║   examples/api/lib/animation/curves/curve2_d.0.dart',
+      if (!isWindows) '║   examples/api/lib/layer/foo_example.0.dart',
+      if (!isWindows) '║   examples/api/lib/layer/bar_example.0.dart',
+      if (isWindows) r'║   examples\api\lib\animation\curves\curve2_d.0.dart',
+      if (isWindows) r'║   examples\api\lib\layer\foo_example.0.dart',
+      if (isWindows) r'║   examples\api\lib\layer\bar_example.0.dart',
       '║ Either link them to a source file API doc comment, or remove them.',
       '╚═══════════════════════════════════════════════════════════════════════════════',
       '╔═╡ERROR╞═══════════════════════════════════════════════════════════════════════',
       '║ The following malformed links were found in API doc comments:',
-      '║   /flutter sdk/packages/flutter/lib/src/animation/curves.dart:6: ///* see code in examples/api/lib/animation/curves/curve2_d.0.dart *',
-      '║   /flutter sdk/packages/flutter/lib/src/layer/foo.dart:6: ///*See Code *',
-      '║   /flutter sdk/packages/flutter/lib/src/layer/bar.dart:6: /// ** See code examples/api/lib/layer/bar_example.0.dart **',
+      if (!isWindows) '║   /flutter sdk/packages/flutter/lib/src/animation/curves.dart:6: ///* see code in examples/api/lib/animation/curves/curve2_d.0.dart *',
+      if (!isWindows) '║   /flutter sdk/packages/flutter/lib/src/layer/foo.dart:6: ///*See Code *',
+      if (!isWindows) '║   /flutter sdk/packages/flutter/lib/src/layer/bar.dart:6: /// ** See code examples/api/lib/layer/bar_example.0.dart **',
+      if (isWindows) r'║   C:\flutter sdk\packages\flutter\lib\src\animation\curves.dart:6: ///* see code in examples/api/lib/animation/curves/curve2_d.0.dart *',
+      if (isWindows) r'║   C:\flutter sdk\packages\flutter\lib\src\layer\foo.dart:6: ///*See Code *',
+      if (isWindows) r'║   C:\flutter sdk\packages\flutter\lib\src\layer\bar.dart:6: /// ** See code examples/api/lib/layer/bar_example.0.dart **',
       '║ Correct the formatting of these links so that they match the exact pattern:',
       r"║   r'\*\* See code in (?<path>.+) \*\*'",
       '╚═══════════════════════════════════════════════════════════════════════════════',
-    ].map((String line) {
-      return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
-    }).join('\n');
+    ].join('\n');
     expect(result, equals('$lines\n'));
     expect(success, equals(false));
   });

--- a/dev/bots/test/check_code_samples_test.dart
+++ b/dev/bots/test/check_code_samples_test.dart
@@ -25,7 +25,8 @@ void main() {
     return path.relative(file.absolute.path, from: flutterRoot.absolute.path);
   }
 
-  void writeLink({required File source, required File example}) {
+  void writeLink({required File source, required File example, String? alternateLink}) {
+    final String link = alternateLink ?? ' ** See code in ${getRelativePath(example)} **';
     source
       ..createSync(recursive: true)
       ..writeAsStringSync('''
@@ -34,12 +35,12 @@ void main() {
 /// {@tool dartpad}
 /// Example description
 ///
-/// ** See code in ${getRelativePath(example)} **
+///$link
 /// {@end-tool}
 ''');
   }
 
-  void buildTestFiles({bool missingLinks = false, bool missingTests = false}) {
+  void buildTestFiles({bool missingLinks = false, bool missingTests = false, bool malformedLinks = false}) {
     final Directory examplesLib = examples.childDirectory('lib').childDirectory('layer')..createSync(recursive: true);
     final File fooExample = examplesLib.childFile('foo_example.0.dart')
       ..createSync(recursive: true)
@@ -73,9 +74,15 @@ void main() {
     }
     final Directory flutterPackage = packages.childDirectory('flutter').childDirectory('lib').childDirectory('src')
       ..createSync(recursive: true);
-    writeLink(source: flutterPackage.childDirectory('layer').childFile('foo.dart'), example: fooExample);
-    writeLink(source: flutterPackage.childDirectory('layer').childFile('bar.dart'), example: barExample);
-    writeLink(source: flutterPackage.childDirectory('animation').childFile('curves.dart'), example: curvesExample);
+    if (malformedLinks) {
+      writeLink(source: flutterPackage.childDirectory('layer').childFile('foo.dart'), example: fooExample, alternateLink: '*See Code *');
+      writeLink(source: flutterPackage.childDirectory('layer').childFile('bar.dart'), example: barExample, alternateLink: ' ** See code examples/api/lib/layer/bar_example.0.dart **');
+      writeLink(source: flutterPackage.childDirectory('animation').childFile('curves.dart'), example: curvesExample, alternateLink: '* see code in examples/api/lib/animation/curves/curve2_d.0.dart *');
+    } else {
+      writeLink(source: flutterPackage.childDirectory('layer').childFile('foo.dart'), example: fooExample);
+      writeLink(source: flutterPackage.childDirectory('layer').childFile('bar.dart'), example: barExample);
+      writeLink(source: flutterPackage.childDirectory('animation').childFile('curves.dart'), example: curvesExample);
+    }
   }
 
   setUp(() {
@@ -116,6 +123,38 @@ void main() {
       '║ The following examples are not linked from any source file API doc comments:',
       '║   examples/api/lib/layer/missing_example.0.dart',
       '║ Either link them to a source file API doc comment, or remove them.',
+      '╚═══════════════════════════════════════════════════════════════════════════════',
+    ].map((String line) {
+      return line.replaceAll('/', Platform.isWindows ? r'\' : '/');
+    }).join('\n');
+    expect(result, equals('$lines\n'));
+    expect(success, equals(false));
+  });
+
+  test('check_code_samples.dart - checkCodeSamples catches malformed links', () async {
+    buildTestFiles(malformedLinks: true);
+    bool? success;
+    final String result = await capture(
+      () async {
+        success = checker.checkCodeSamples();
+      },
+      shouldHaveErrors: true,
+    );
+    final String lines = <String>[
+      '╔═╡ERROR╞═══════════════════════════════════════════════════════════════════════',
+      '║ The following examples are not linked from any source file API doc comments:',
+      '║   examples/api/lib/animation/curves/curve2_d.0.dart',
+      '║   examples/api/lib/layer/foo_example.0.dart',
+      '║   examples/api/lib/layer/bar_example.0.dart',
+      '║ Either link them to a source file API doc comment, or remove them.',
+      '╚═══════════════════════════════════════════════════════════════════════════════',
+      '╔═╡ERROR╞═══════════════════════════════════════════════════════════════════════',
+      '║ The following malformed links were found in API doc comments:',
+      '║   /flutter sdk/packages/flutter/lib/src/animation/curves.dart:6: ///* see code in examples/api/lib/animation/curves/curve2_d.0.dart *',
+      '║   /flutter sdk/packages/flutter/lib/src/layer/foo.dart:6: ///*See Code *',
+      '║   /flutter sdk/packages/flutter/lib/src/layer/bar.dart:6: /// ** See code examples/api/lib/layer/bar_example.0.dart **',
+      '║ Correct the formatting of these links so that they match the exact pattern:',
+      r"║   r'\*\* See code in (?<path>.+) \*\*'",
       '╚═══════════════════════════════════════════════════════════════════════════════',
     ].map((String line) {
       return line.replaceAll('/', Platform.isWindows ? r'\' : '/');


### PR DESCRIPTION
## Description

This checks API doc strings for malformed links to examples. It prevents errors in capitalization, spacing, number of asterisks, etc.  It won't catch all errors, because it needs to have a minimally indicative string to know that it even is trying to be a link to an example.  At a minimum, the line needs to look like (literally, not as a regexp) `///*seecode.*` in order to be seen as a link to an example.

Separately, I'm going to add a check to the snippets tool that checks to make sure that an `{@tool}` block includes either a link to a sample file or a dart code block.

## Tests
 - Added a test to make sure it catches some malformed links.