### PR TITLE
HeroController should dispatch creation and disposal events.

### DIFF
--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -156,6 +156,12 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
     }
   }
 
+  @override
+  void dispose() {
+    _heroController.dispose();
+    super.dispose();
+  }
+
   void _updateObservers() {
     _navigatorObservers =
         List<NavigatorObserver>.of(widget.navigatorObservers)

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -784,7 +784,17 @@ class HeroController extends NavigatorObserver {
   ///
   /// The [createRectTween] argument is optional. If null, the controller uses a
   /// linear [Tween<Rect>].
-  HeroController({ this.createRectTween });
+  HeroController({ this.createRectTween }) {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      MemoryAllocations.instance.dispatchObjectCreated(
+        library: 'package:flutter/widgets.dart',
+        className: '$HeroController',
+        object: this,
+      );
+    }
+  }
 
   /// Used to create [RectTween]s that interpolate the position of heroes in flight.
   ///
@@ -1043,6 +1053,12 @@ class HeroController extends NavigatorObserver {
   /// Releases resources.
   @mustCallSuper
   void dispose() {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      MemoryAllocations.instance.dispatchObjectDisposed(object: this);
+    }
+
     for (final _HeroFlight flight in _flights.values) {
       flight.dispose();
     }

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1060,6 +1060,7 @@ void main() {
 
   testWidgetsWithLeakTracking('MaterialApp does create HeroController with the MaterialRectArcTween', (WidgetTester tester) async {
     final HeroController controller = MaterialApp.createMaterialHeroController();
+    addTearDown(controller.dispose);
     final Tween<Rect?> tween = controller.createRectTween!(
       const Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
       const Rect.fromLTRB(0.0, 0.0, 20.0, 20.0),

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -2367,6 +2367,8 @@ void main() {
           ),
         );
       };
+    addTearDown(spy.dispose);
+
     await tester.pumpWidget(
       HeroControllerScope(
         controller: spy,
@@ -2437,6 +2439,8 @@ void main() {
           ),
         );
       };
+    addTearDown(spy.dispose);
+
     await tester.pumpWidget(
       HeroControllerScope(
         controller: spy,
@@ -2506,6 +2510,7 @@ void main() {
           ),
         );
       };
+    addTearDown(spy1.dispose);
     final List<NavigatorObservation> observations2 = <NavigatorObservation>[];
     final HeroControllerSpy spy2 = HeroControllerSpy()
       ..onPushed = (Route<dynamic>? route, Route<dynamic>? previousRoute) {
@@ -2517,6 +2522,8 @@ void main() {
           ),
         );
       };
+    addTearDown(spy2.dispose);
+
     await tester.pumpWidget(
       TestDependencies(
         child: Stack(
@@ -2633,6 +2640,8 @@ void main() {
 
   testWidgetsWithLeakTracking('hero controller subscribes to multiple navigators does throw', (WidgetTester tester) async {
     final HeroControllerSpy spy = HeroControllerSpy();
+    addTearDown(spy.dispose);
+
     await tester.pumpWidget(
       HeroControllerScope(
         controller: spy,
@@ -2671,6 +2680,8 @@ void main() {
 
   testWidgetsWithLeakTracking('hero controller throws has correct error message', (WidgetTester tester) async {
     final HeroControllerSpy spy = HeroControllerSpy();
+    addTearDown(spy.dispose);
+
     await tester.pumpWidget(
       HeroControllerScope(
         controller: spy,


### PR DESCRIPTION
### Description
- Adds `HeroController` creation and disposal events dispatching for memory leak tracking as part of https://github.com/flutter/flutter/issues/137311;
- Fixes leak in `_CupertinoTabViewState`.

### Tests
- Updates `heroes_test.dart` to test `HeroController` object creation and disposal dispatching;
- Adds disposal of `HeroController` in a couple of tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
