### PR TITLE
Send caret rect to embedder on selection update

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4118,7 +4118,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // Sends the current composing rect to the embedder's text input plugin.
   //
   // In cases where the composing rect hasn't been updated in the embedder due
-  // the lag of asynchronous messages over the channel, the position of the
+  // to the lag of asynchronous messages over the channel, the position of the
   // current caret rect is used instead.
   //
   // See: [_updateCaretRectIfNeeded]
@@ -4137,20 +4137,22 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   // Sends the current caret rect to the embedder's text input plugin.
   //
-  // The position of the caret rect is updated on each change such that if the
+  // The position of the caret rect is updated periodically such that if the
   // user initiates composing input, the current cursor rect can be used for
   // the first character until the composing rect can be sent.
   //
   // On selection changes, the start of the selection is used. This ensures
   // that regardless of the direction the selection was created, the cursor is
-  // set to the position where next text input occurs.
+  // set to the position where next text input occurs. This position is used to
+  // position the IME's candidate selection menu.
+  //
+  // See: [_updateComposingRectIfNeeded]
   void _updateCaretRectIfNeeded() {
     final TextSelection? selection = renderEditable.selection;
     if (selection == null || !selection.isValid) {
       return;
     }
-    final int startOffset = math.min(selection.baseOffset, selection.extentOffset);
-    final TextPosition currentTextPosition = TextPosition(offset: startOffset);
+    final TextPosition currentTextPosition = TextPosition(offset: selection.start);
     final Rect caretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
     _textInputConnection!.setCaretRect(caretRect);
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4115,11 +4115,13 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _textInputConnection!.setSelectionRects(rects);
   }
 
-  // Sends the current composing rect to the iOS text input plugin via the text
-  // input channel. We need to keep sending the information even if no text is
-  // currently marked, as the information usually lags behind. The text input
-  // plugin needs to estimate the composing rect based on the latest caret rect,
-  // when the composing rect info didn't arrive in time.
+  // Sends the current composing rect to the embedder's text input plugin.
+  //
+  // In cases where the composing rect hasn't been updated in the embedder due
+  // the lag of asynchronous messages over the channel, the position of the
+  // current caret rect is used instead.
+  //
+  // See: [_updateCaretRectIfNeeded]
   void _updateComposingRectIfNeeded() {
     final TextRange composingRange = _value.composing;
     assert(mounted);
@@ -4133,12 +4135,22 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _textInputConnection!.setComposingRect(composingRect);
   }
 
+  // Sends the current caret rect to the embedder's text input plugin.
+  //
+  // The position of the caret rect is updated on each change such that if the
+  // user initiates composing input, the current cursor rect can be used for
+  // the first character until the composing rect can be sent.
+  //
+  // On selection changes, the start of the selection is used. This ensures
+  // that regardless of the direction the selection was created, the cursor is
+  // set to the position where next text input occurs.
   void _updateCaretRectIfNeeded() {
     final TextSelection? selection = renderEditable.selection;
-    if (selection == null || !selection.isValid || !selection.isCollapsed) {
+    if (selection == null || !selection.isValid) {
       return;
     }
-    final TextPosition currentTextPosition = TextPosition(offset: selection.baseOffset);
+    final int startOffset = math.min(selection.baseOffset, selection.extentOffset);
+    final TextPosition currentTextPosition = TextPosition(offset: startOffset);
     final Rect caretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
     _textInputConnection!.setCaretRect(caretRect);
   }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5875,16 +5875,48 @@ void main() {
     );
 
     testWidgetsWithLeakTracking(
-      'not sent with selection',
+      'set to selection start on forward selection',
       (WidgetTester tester) async {
         controller.value = TextEditingValue(
           text: 'a' * 100,
-          selection: const TextSelection(baseOffset: 0, extentOffset: 10),
+          selection: const TextSelection(baseOffset: 10, extentOffset: 30),
         );
         await tester.pumpWidget(builder());
         await tester.showKeyboard(find.byType(EditableText));
 
-        expect(tester.testTextInput.log, isNot(contains(matchesMethodCall('TextInput.setCaretRect'))));
+        expect(tester.testTextInput.log, contains(
+          matchesMethodCall(
+            'TextInput.setCaretRect',
+            // Now the composing range is not empty.
+            args: allOf(
+              containsPair('x', equals(140)),
+              containsPair('y', equals(0)),
+            ),
+          ),
+        ));
+      },
+    );
+
+    testWidgetsWithLeakTracking(
+      'set to selection start on reversed selection',
+      (WidgetTester tester) async {
+        controller.value = TextEditingValue(
+          text: 'a' * 100,
+          selection: const TextSelection(baseOffset: 30, extentOffset: 10),
+        );
+        await tester.pumpWidget(builder());
+        await tester.showKeyboard(find.byType(EditableText));
+
+        expect(tester.testTextInput.log, contains(
+          matchesMethodCall(
+            'TextInput.setCaretRect',
+            // Now the composing range is not empty.
+            args: allOf(
+              containsPair('x', equals(140)),
+              containsPair('y', equals(0)),
+            ),
+          ),
+        ));
       },
     );
   });


### PR DESCRIPTION
Background: In the framework, the position of the caret rect is updated on each cursor position change such that if the user initiates composing input, the current cursor position can be used for the first character until the composing rect can be sent.

Previously, no update was sent on selection changes, on the assumption that the most recent cursor position will remain the correct position for the duration of the selection. While this is the case for forward selections, it is an incorrect assumption for reversed selections, where selection.base > selection.extent.

We now update the cursor position during selection changes such that the cursor position sent to the embedder is always the position at which next text input would occur. This is the start position of the selection or min(selection.baseOffset, selection.extentOffset).

Issue: https://github.com/flutter/flutter/issues/137677

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
