### PR TITLE
Constrain dimensions passed down in intrinsic protocol within RenderConstrainedBox

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -226,7 +226,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth) {
       return _additionalConstraints.minWidth;
     }
-    final double width = super.computeMinIntrinsicWidth(height);
+    final double width = super.computeMinIntrinsicWidth(
+      _additionalConstraints.constrainHeight(height),
+    );
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth) {
       return _additionalConstraints.constrainWidth(width);
@@ -239,7 +241,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedWidth && _additionalConstraints.hasTightWidth) {
       return _additionalConstraints.minWidth;
     }
-    final double width = super.computeMaxIntrinsicWidth(height);
+    final double width = super.computeMaxIntrinsicWidth(
+      _additionalConstraints.constrainHeight(height),
+    );
     assert(width.isFinite);
     if (!_additionalConstraints.hasInfiniteWidth) {
       return _additionalConstraints.constrainWidth(width);
@@ -252,7 +256,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight) {
       return _additionalConstraints.minHeight;
     }
-    final double height = super.computeMinIntrinsicHeight(width);
+    final double height = super.computeMinIntrinsicHeight(
+      _additionalConstraints.constrainWidth(width),
+    );
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight) {
       return _additionalConstraints.constrainHeight(height);
@@ -265,7 +271,9 @@ class RenderConstrainedBox extends RenderProxyBox {
     if (_additionalConstraints.hasBoundedHeight && _additionalConstraints.hasTightHeight) {
       return _additionalConstraints.minHeight;
     }
-    final double height = super.computeMaxIntrinsicHeight(width);
+    final double height = super.computeMaxIntrinsicHeight(
+      _additionalConstraints.constrainWidth(width),
+    );
     assert(height.isFinite);
     if (!_additionalConstraints.hasInfiniteHeight) {
       return _additionalConstraints.constrainHeight(height);

--- a/packages/flutter/test/widgets/constrained_box_test.dart
+++ b/packages/flutter/test/widgets/constrained_box_test.dart
@@ -133,4 +133,37 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.byType(ConstrainedBox)).getMinIntrinsicHeight(double.infinity), 0.0);
     expect(tester.renderObject<RenderBox>(find.byType(ConstrainedBox)).getMaxIntrinsicHeight(double.infinity), 0.0);
   });
+
+  testWidgets('RenderConstrainedBox returning widget constrains dimension passed to get intrinsic dimension', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/137546
+
+    const Key key = Key('widget');
+
+    await tester.pumpWidget(
+     Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: IntrinsicHeight(
+            key: key,
+            child: SizedBox(
+              width: 100,
+              child: Wrap(
+                children: List<Widget>.filled(5, const SizedBox(width: 50, height: 10)),
+              ),
+            ),
+          ),
+        ),
+     ),
+    );
+
+    final RenderBox renderBox = tester.renderObject<RenderBox>(find.byKey(key));
+
+    // Rectangles 50x10 will fit in a 100x100 square with intrinsic height like that:
+    // +----------+
+    // |<===><===>|
+    // |<===><===>|
+    // |<===>     |
+    // +----------+
+    expect(renderBox.size, const Size(100, 30));
+  });
 }


### PR DESCRIPTION
`RenderConstrainedBox` was ignoring the `additionalConstraints` while calling the child's `get{Min,Max}Intrinsic{Width,Height}`. This was in my understanding wrong. The intrinsic dimensions are often used to make some layout calculations. But these dimensions can't be imaginary. They must be real. If we call for minimum intrinsic height given some width, then the widget should be able to lay itself out within tight constraints for the same width and height. This was not the case for widgets that we wrap in `SizedBox` or `ConstrainedBox`, because they were ignoring the constraints when passing down the known dimension when calling for intrinsic other dimension. This PR fixes that.

Fixes #137546.

Below are screenshots of before and after, given the code from the issue above.

| Before | After |
|-|-|
| <img width="569" alt="image" src="https://github.com/flutter/flutter/assets/4085280/e35f5e2d-9307-4cde-83af-c2582aa00f5e"> | <img width="569" alt="image" src="https://github.com/flutter/flutter/assets/4085280/c111f0bc-4377-4813-84c0-4d07f2471089"> |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
