### PR TITLE
Added DecorationImage params to CircularAvatar to allow better control of image fit and other properties

### DIFF
--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -63,15 +63,29 @@ class CircleAvatar extends StatelessWidget {
     super.key,
     this.child,
     this.backgroundColor,
+    @Deprecated(
+      'Use backgroundDecorationImage instead. '
+      'backgroundDecorationImage was introduced in order to give better control over image fit and alignment. '
+      'This feature was deprecated after v3.17.0-1.0.pre.'
+    )
     this.backgroundImage,
+    @Deprecated(
+      'Use foregroundDecorationImage instead. '
+      'foregroundDecorationImage was introduced in order to give better control over image fit and alignment. '
+      'This feature was deprecated after v3.17.0-1.0.pre.'
+    )
     this.foregroundImage,
     this.onBackgroundImageError,
     this.onForegroundImageError,
+    this.foregroundDecorationImage,
+    this.backgroundDecorationImage,
     this.foregroundColor,
     this.radius,
     this.minRadius,
     this.maxRadius,
   }) : assert(radius == null || (minRadius == null && maxRadius == null)),
+       assert(backgroundDecorationImage == null || backgroundImage== null),
+       assert(foregroundDecorationImage == null || foregroundImage== null),
        assert(backgroundImage != null || onBackgroundImageError == null),
        assert(foregroundImage != null || onForegroundImageError== null);
 
@@ -107,12 +121,35 @@ class CircleAvatar extends StatelessWidget {
   /// Typically used as a fallback image for [foregroundImage].
   ///
   /// If the [CircleAvatar] is to have the user's initials, use [child] instead.
+  @Deprecated(
+    'Use backgroundDecorationImage instead. '
+    'backgroundDecorationImage was introduced in order to give better control over image fit and alignment. '
+    'This feature was deprecated after v3.17.0-1.0.pre.'
+  )
   final ImageProvider? backgroundImage;
 
   /// The foreground image of the circle.
   ///
   /// Typically used as profile image. For fallback use [backgroundImage].
+  @Deprecated(
+    'Use foregroundDecorationImage instead. '
+    'foregroundDecorationImage was introduced in order to give better control over image fit and alignment. '
+    'This feature was deprecated after v3.17.0-1.0.pre.'
+  )
   final ImageProvider? foregroundImage;
+
+  /// The foreground image of the circle.
+  ///
+  /// Typically used as profile image. For fallback use [backgroundDecorationImage].
+  final DecorationImage? foregroundDecorationImage;
+
+  /// The background image of the circle. Changing the background
+  /// image will cause the avatar to animate to the new image.
+  ///
+  /// Typically used as a fallback image for [foregroundImage].
+  ///
+  /// If the [CircleAvatar] is to have the user's initials, use [child] instead.
+  final DecorationImage? backgroundDecorationImage;
 
   /// An optional error callback for errors emitted when loading
   /// [backgroundImage].
@@ -230,8 +267,8 @@ class CircleAvatar extends StatelessWidget {
       duration: kThemeChangeDuration,
       decoration: BoxDecoration(
         color: effectiveBackgroundColor,
-        image: backgroundImage != null
-          ? DecorationImage(
+        image: backgroundImage != null || backgroundDecorationImage != null
+          ? backgroundDecorationImage ?? DecorationImage(
               image: backgroundImage!,
               onError: onBackgroundImageError,
               fit: BoxFit.cover,
@@ -239,9 +276,9 @@ class CircleAvatar extends StatelessWidget {
           : null,
         shape: BoxShape.circle,
       ),
-      foregroundDecoration: foregroundImage != null
+      foregroundDecoration: foregroundImage != null || foregroundDecorationImage != null
           ? BoxDecoration(
-              image: DecorationImage(
+              image: foregroundDecorationImage ?? DecorationImage(
                 image: foregroundImage!,
                 onError: onForegroundImageError,
                 fit: BoxFit.cover,

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -95,6 +95,78 @@ void main() {
     expect(decoration.image!.fit, equals(BoxFit.cover));
   });
 
+
+  testWidgetsWithLeakTracking('CircleAvatar with image foreground decoration', (WidgetTester tester) async {
+    const BoxFit imageFit = BoxFit.contain;
+    await tester.pumpWidget(
+      wrap(
+        child: CircleAvatar(
+          foregroundDecorationImage: DecorationImage(
+              image: MemoryImage(Uint8List.fromList(kBlueRectPng)),
+              fit: imageFit),
+          radius: 50.0,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
+    final BoxDecoration decoration = child.decoration as BoxDecoration;
+    expect(decoration.image!.fit, equals(imageFit));
+  });
+
+
+  testWidgetsWithLeakTracking('CircleAvatar with image background decoration', (WidgetTester tester) async {
+    const BoxFit imageFit = BoxFit.contain;
+    await tester.pumpWidget(
+      wrap(
+        child: CircleAvatar(
+          backgroundDecorationImage: DecorationImage(
+              image: MemoryImage(Uint8List.fromList(kBlueRectPng)),
+              fit: imageFit),
+          radius: 50.0,
+        ),
+      ),
+    );
+
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
+    final BoxDecoration decoration = child.decoration as BoxDecoration;
+    expect(decoration.image!.fit, equals(imageFit));
+  });
+
+
+  testWidgetsWithLeakTracking('CircleAvatar backgroundDecorationImage is used as a fallback for foregroundDecorationImage', (WidgetTester tester) async {
+    const BoxFit imageFit = BoxFit.contain;
+    final ErrorImageProvider errorImage = ErrorImageProvider();
+    bool caughtForegroundImageError = false;
+    await tester.pumpWidget(
+      wrap(
+        child: RepaintBoundary(
+          child: CircleAvatar(
+          foregroundDecorationImage: DecorationImage(image: errorImage, onError:  (_,__) => caughtForegroundImageError = true, fit: imageFit,),
+          backgroundDecorationImage: DecorationImage(image: MemoryImage(Uint8List.fromList(kBlueRectPng)),
+          fit: imageFit),
+          radius: 50.0,
+          ),
+        ),
+      ),
+    );
+
+    expect(caughtForegroundImageError, true);
+    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+    expect(box.size, equals(const Size(100.0, 100.0)));
+    final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
+    final BoxDecoration decoration = child.decoration as BoxDecoration;
+    expect(decoration.image!.fit, equals(imageFit));
+    await expectLater(
+      find.byType(CircleAvatar),
+      matchesGoldenFile('circle_avatar.fallback.png'),
+    );
+  });
+
   testWidgetsWithLeakTracking('CircleAvatar backgroundImage is used as a fallback for foregroundImage', (WidgetTester tester) async {
     final ErrorImageProvider errorImage = ErrorImageProvider();
     bool caughtForegroundImageError = false;


### PR DESCRIPTION
Added DecorationImage params to CircularAvatar to allow better control of image fit and other properties

Fixes #98350 

Based on review of #105729
 


This is a draft PR to get initial feedback on whether this is an acceptable approach or not. If positive, I'll check for required actions for deprecation and write a fix.

In my opinion, adding optional `BoxFit` and `Alignment` params to `CircleAvatar` is sufficient and will allow for avoiding this breaking change. It makes sense for users who want even further control over this widget to write their custom avatar widget at that point. It's just an opinion :) 

It's also worth noting that `CircularAvatar` constructor will look more verbose

```
// Proposed
CircleAvatar(
  foregroundDecorationImage:
      DecorationImage(image: AssetImage('image/path'))),

// Current
CircleAvatar(foregroundImage: AssetImage('image/path')),
```

| Example usecase for `alignment`  | Example usecase for `fit` |
| ------------- | ------------- |
| ![image](https://github.com/flutter/flutter/assets/89970141/fcfc7800-6e02-4aa4-adff-50db963c94a7)  | ![image](https://github.com/flutter/flutter/assets/89970141/4c42e903-b4e9-4f48-8358-29cad0c1cb2c) |


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

