### PR TITLE
[ExpansionTile] expansion animation parameters

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -248,6 +248,8 @@ class ExpansionTile extends StatefulWidget {
     this.clipBehavior,
     this.controlAffinity,
     this.controller,
+    this.expansionDuration,
+    this.expansionTween,
   }) : assert(
        expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
        'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -491,6 +493,14 @@ class ExpansionTile extends StatefulWidget {
   /// than supplying a controller.
   final ExpansionTileController? controller;
 
+  /// If provided will decide the duration it takes to expand or collapse tiles.
+  /// 
+  /// Defaults to [_kExpand].
+  final Duration? expansionDuration;
+
+  /// If provided will be used to drive the expansion animation.
+  final Animatable<double>? expansionTween;
+
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
 }
@@ -519,8 +529,8 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   @override
   void initState() {
     super.initState();
-    _animationController = AnimationController(duration: _kExpand, vsync: this);
-    _heightFactor = _animationController.drive(_easeInTween);
+    _animationController = AnimationController(duration: widget.expansionDuration ?? _kExpand, vsync: this);
+    _heightFactor = _animationController.drive(widget.expansionTween ?? _easeInTween);
     _iconTurns = _animationController.drive(_halfTween.chain(_easeInTween));
     _border = _animationController.drive(_borderTween.chain(_easeOutTween));
     _headerColor = _animationController.drive(_headerColorTween.chain(_easeInTween));

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -1198,4 +1198,42 @@ void main() {
     final ExpansionTileController? controller2 = ExpansionTileController.maybeOf(nonDescendantKey.currentContext!);
     expect(controller2, isNull);
   });
+
+  testWidgetsWithLeakTracking('ExpansionTile custom animation parameters', (WidgetTester tester) async {
+    final ExpansionTileController fastController = ExpansionTileController();
+    final ExpansionTileController slowController = ExpansionTileController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              ExpansionTile(
+                controller: fastController,
+                title: const Text('Title'),
+                subtitle: const Text('Subtitle'),
+                expansionDuration: const Duration(milliseconds: 10),
+                children: const <Widget>[ListTile(title: Text('0'))],
+              ),
+              ExpansionTile(
+                controller: slowController,
+                title: const Text('Title'),
+                subtitle: const Text('Subtitle'),
+                expansionDuration: const Duration(milliseconds: 20),
+                children: const <Widget>[ListTile(title: Text('0'))],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    fastController.expand();
+    final int fastPumps = await tester.pumpAndSettle(const Duration(milliseconds: 10));
+    
+    slowController.expand();
+    final int slowPumps = await tester.pumpAndSettle(const Duration(milliseconds: 10));
+
+    expect(fastPumps < slowPumps, true);
+  });
 }


### PR DESCRIPTION
This PR adds two parameters to the [ExpansionTile] widget to give the user more control over the widget's animation.

* [Issue](https://github.com/flutter/flutter/issues/138047#issue-1982482470)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
