### PR TITLE
[Android] Fix `FlutterTestRunner.java` deprecations

### DIFF
--- a/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/FlutterTestRunner.java
+++ b/packages/integration_test/android/src/main/java/dev/flutter/plugins/integration_test/FlutterTestRunner.java
@@ -7,6 +7,7 @@ package dev.flutter.plugins.integration_test;
 import android.util.Log;
 import androidx.test.rule.ActivityTestRule;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
@@ -20,7 +21,7 @@ public class FlutterTestRunner extends Runner {
 
   private static final String TAG = "FlutterTestRunner";
 
-  final Class testClass;
+  final Class<?> testClass;
   TestRule rule = null;
 
   public FlutterTestRunner(Class<?> testClass) {
@@ -32,11 +33,13 @@ public class FlutterTestRunner extends Runner {
     for (Field field : fields) {
       if (field.isAnnotationPresent(Rule.class)) {
         try {
-          Object instance = testClass.newInstance();
+          Object instance = testClass.getDeclaredConstructor().newInstance();
           if (field.get(instance) instanceof ActivityTestRule) {
             rule = (TestRule) field.get(instance);
             break;
           }
+        } catch (InvocationTargetException | NoSuchMethodException e) {
+          throw new RuntimeException("Unable to contruct " + testClass.getName() + " object for testing");
         } catch (InstantiationException | IllegalAccessException e) {
           // This might occur if the developer did not make the rule public.
           // We could call field.setAccessible(true) but it seems better to throw.


### PR DESCRIPTION
Fixes deprecations causing unexpected standard error integration test failures: https://github.com/flutter/flutter/issues/138061, https://github.com/flutter/flutter/issues/138063, https://github.com/flutter/flutter/issues/138067, https://github.com/flutter/flutter/pull/138077.

Note that the issue this fixes was the same that was the cause for reverting https://github.com/flutter/flutter/pull/137191. I made this same fix in https://github.com/flutter/flutter/pull/137967 and changed `Mac_android run_release_test` to run in presubmit to see a successful run for proof that this fix works.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
