### PR TITLE
prevent tool crash when `IntelliJValidatorOnMac` encounters an installation with a missing `CFBundleIdentifier`

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -53,17 +53,20 @@ abstract class DoctorValidatorsProvider {
   // [FeatureFlags].
   factory DoctorValidatorsProvider.test({
     Platform? platform,
+    Logger? logger,
     required FeatureFlags featureFlags,
   }) {
     return _DefaultDoctorValidatorsProvider(
       featureFlags: featureFlags,
       platform: platform ?? FakePlatform(),
+      logger: logger ?? BufferLogger.test(),
     );
   }
   /// The singleton instance, pulled from the [AppContext].
   static DoctorValidatorsProvider get _instance => context.get<DoctorValidatorsProvider>()!;
 
   static final DoctorValidatorsProvider defaultInstance = _DefaultDoctorValidatorsProvider(
+    logger: globals.logger,
     platform: globals.platform,
     featureFlags: featureFlags,
   );
@@ -76,12 +79,14 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
   _DefaultDoctorValidatorsProvider({
     required this.platform,
     required this.featureFlags,
-  });
+    required Logger logger,
+  }) : _logger = logger;
 
   List<DoctorValidator>? _validators;
   List<Workflow>? _workflows;
   final Platform platform;
   final FeatureFlags featureFlags;
+  final Logger _logger;
 
   late final LinuxWorkflow linuxWorkflow = LinuxWorkflow(
     platform: platform,
@@ -117,6 +122,7 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         userMessages: userMessages,
         plistParser: globals.plistParser,
         processManager: globals.processManager,
+        logger: _logger,
       ),
       ...VsCodeValidator.installedValidators(globals.fs, platform, globals.processManager),
     ];

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
@@ -5,6 +5,7 @@
 import 'package:archive/archive.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -308,6 +309,7 @@ void main() {
         PlistParser.kCFBundleShortVersionStringKey: '2020.10',
         PlistParser.kCFBundleIdentifierKey: 'com.jetbrains.intellij',
       }),
+      logger: BufferLogger.test(),
     ).whereType<IntelliJValidatorOnMac>();
     expect(validators.length, 2);
 
@@ -389,6 +391,7 @@ void main() {
         'CFBundleIdentifier': 'com.jetbrains.toolbox.linkapp',
       }),
       processManager: processManager,
+      logger: BufferLogger.test(),
     );
 
     expect(validators.length, 1);
@@ -431,9 +434,54 @@ void main() {
         'CFBundleIdentifier': 'com.jetbrains.toolbox.linkapp',
       }),
       processManager: processManager,
+      logger: BufferLogger.test(),
     );
 
     expect(installed.length, 0);
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  testWithoutContext('Does not crash when installation is missing its CFBundleIdentifier property', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final String ultimatePath = fileSystem.path.join('/', 'foo', 'bar', 'Applications',
+          'JetBrains Toolbox', 'IntelliJ IDEA Ultimate.app');
+    final String communityEditionPath = fileSystem.path.join('/', 'foo', 'bar', 'Applications',
+          'JetBrains Toolbox', 'IntelliJ IDEA Community Edition.app');
+    final List<String> installPaths = <String>[
+      ultimatePath,
+      communityEditionPath
+    ];
+
+    for (final String installPath in installPaths) {
+      fileSystem.directory(installPath).createSync(recursive: true);
+    }
+
+    final FakeProcessManager processManager =
+    FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(command: const <String>[
+        'mdfind',
+        'kMDItemCFBundleIdentifier="com.jetbrains.intellij.ce"',
+      ], stdout: communityEditionPath),
+      FakeCommand(command: const <String>[
+        'mdfind',
+        'kMDItemCFBundleIdentifier="com.jetbrains.intellij*"',
+      ], stdout: ultimatePath)
+    ]);
+
+    final Iterable<DoctorValidator> installed = IntelliJValidatorOnMac.installed(
+      fileSystem: fileSystem,
+      fileSystemUtils: FileSystemUtils(fileSystem: fileSystem, platform: macPlatform),
+      userMessages: UserMessages(),
+      plistParser: FakePlistParser(<String, String>{
+        'JetBrainsToolboxApp': '/path/to/JetBrainsToolboxApp',
+      }),
+      processManager: processManager,
+      logger: logger,
+    );
+
+    expect(installed.length, 2);
+    expect(logger.traceText, contains('installation at $ultimatePath has a null CFBundleIdentifierKey'));
     expect(processManager, hasNoRemainingExpectations);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138029 (see my comment there for more info)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
