### PR TITLE
Remove physicalGeometry

### DIFF
--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -745,66 +745,11 @@ class TestFlutterView implements FlutterView {
     platformDispatcher.onMetricsChanged?.call();
   }
 
-  /// The physical geometry to use for this test.
-  ///
-  /// Defaults to the value provided by [FlutterView.physicalGeometry]. This
-  /// can only be set in a test environment to emulate different view
-  /// configurations. A standard [FlutterView] is not mutable from the framework.
-  ///
-  /// This property and [physicalSize] are dependent on one another. If both
-  /// properties are set through their test setters, the final result will be
-  /// that [physicalGeometry] determines the location and [physicalSize]
-  /// determines the size of the [physicalGeometry] [Rect]. If only
-  /// [physicalSize] is set, the final result is that the default value of
-  /// [physicalGeometry] determines the location and [physicalSize] determines
-  /// the size of the [physicalGeometry] [Rect]. If only [physicalGeometry]
-  /// is set, it will determine both the location and size of the
-  /// [physicalGeometry] [Rect].
-  ///
-  /// See also:
-  ///
-  ///   * [FlutterView.physicalGeometry] for the standard implementation
-  ///   * [resetPhysicalGeometry] to reset this value specifically
-  ///   * [reset] to reset all test values for this view
-  @override
-  Rect get physicalGeometry {
-    Rect value = _physicalGeometry ?? _view.physicalGeometry;
-    if (_physicalSize != null) {
-      value = value.topLeft & _physicalSize!;
-    }
-    return value;
-  }
-  Rect? _physicalGeometry;
-  set physicalGeometry(Rect value) {
-    _physicalGeometry = value;
-    platformDispatcher.onMetricsChanged?.call();
-  }
-
-  /// Resets [physicalGeometry] to the default value for this view.
-  ///
-  /// This will also reset [physicalSize] as the values are dependent
-  /// on one another.
-  void resetPhysicalGeometry() {
-    _physicalGeometry = null;
-    _physicalSize = null;
-    platformDispatcher.onMetricsChanged?.call();
-  }
-
   /// The physical size to use for this test.
   ///
   /// Defaults to the value provided by [FlutterView.physicalSize]. This
   /// can only be set in a test environment to emulate different view
   /// configurations. A standard [FlutterView] is not mutable from the framework.
-  ///
-  /// This property and [physicalGeometry] are dependent on one another. If both
-  /// properties are set through their test setters, the final result will be
-  /// that [physicalGeometry] determines the location and [physicalSize]
-  /// determines the size of the [physicalGeometry] [Rect]. If only
-  /// [physicalSize] is set, the final result is that the default value of
-  /// [physicalGeometry] determines the location and [physicalSize] determines
-  /// the size of the [physicalGeometry] [Rect]. If only [physicalGeometry]
-  /// is set, it will determine both the location and size of the
-  /// [physicalGeometry] [Rect].
   ///
   /// See also:
   ///
@@ -812,12 +757,7 @@ class TestFlutterView implements FlutterView {
   ///   * [resetPhysicalSize] to reset this value specifically
   ///   * [reset] to reset all test values for this view
   @override
-  Size get physicalSize {
-    // This has to be able to default to `_view.physicalSize` as web_ui handles
-    // `physicalSize` and `physicalGeometry` differently than dart:ui, where
-    // the values are both based off of `physicalGeometry`.
-    return _physicalSize ?? _physicalGeometry?.size ?? _view.physicalSize;
-  }
+  Size get physicalSize => _physicalSize ?? _view.physicalSize;
   Size? _physicalSize;
   set physicalSize(Size value) {
     _physicalSize = value;
@@ -825,11 +765,9 @@ class TestFlutterView implements FlutterView {
   }
 
   /// Resets [physicalSize] to the default value for this view.
-  ///
-  /// This will also reset [physicalGeometry] as the values are dependent
-  /// on one another.
   void resetPhysicalSize() {
-    resetPhysicalGeometry();
+    _physicalSize = null;
+    platformDispatcher.onMetricsChanged?.call();
   }
 
   /// The system gesture insets to use for this test.
@@ -952,7 +890,6 @@ class TestFlutterView implements FlutterView {
   ///   * [resetDevicePixelRatio] to reset [devicePixelRatio] specifically
   ///   * [resetDisplayFeatures]  to reset [displayFeatures] specifically
   ///   * [resetPadding] to reset [padding] specifically
-  ///   * [resetPhysicalGeometry] to reset [physicalGeometry] specifically
   ///   * [resetPhysicalSize] to reset [physicalSize] specifically
   ///   * [resetSystemGestureInsets] to reset [systemGestureInsets] specifically
   ///   * [resetViewInsets] to reset [viewInsets] specifically
@@ -962,8 +899,7 @@ class TestFlutterView implements FlutterView {
     resetDevicePixelRatio();
     resetDisplayFeatures();
     resetPadding();
-    resetPhysicalGeometry();
-    // Skipping resetPhysicalSize because resetPhysicalGeometry resets both values.
+    resetPhysicalSize();
     resetSystemGestureInsets();
     resetViewInsets();
     resetViewPadding();
@@ -1878,14 +1814,6 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   FrameData get frameData => platformDispatcher.frameData;
-
-  @Deprecated(
-    'Use WidgetTester.platformDispatcher.physicalGeometry instead. '
-    'Deprecated to prepare for the upcoming multi-window support. '
-    'This feature was deprecated after v3.9.0-0.1.pre.'
-  )
-  @override
-  Rect get physicalGeometry => _view.physicalGeometry;
 
   @Deprecated(
     'Use WidgetTester.platformDispatcher.systemFontFamily instead. '

--- a/packages/flutter_test/test/view_test.dart
+++ b/packages/flutter_test/test/view_test.dart
@@ -112,39 +112,6 @@ void main() {
       );
     });
 
-    testWidgets('can fake physicalGeometry', (WidgetTester tester) async {
-      verifyPropertyFaked<Rect>(
-        tester: tester,
-        realValue: trueImplicitView().physicalGeometry,
-        fakeValue: const Rect.fromLTWH(0, 0, 550, 850),
-        propertyRetriever: () => boundImplicitView().physicalGeometry,
-        propertyFaker: (_, Rect fakeValue) {
-          tester.view.physicalGeometry = fakeValue;
-        },
-      );
-    });
-
-    testWidgets('can reset physicalGeometry', (WidgetTester tester) async {
-      verifyPropertyReset<Rect>(
-        tester: tester,
-        fakeValue: const Rect.fromLTWH(0, 0, 35, 475),
-        propertyRetriever: () => boundImplicitView().physicalGeometry,
-        propertyResetter: () {
-          tester.view.resetPhysicalGeometry();
-        },
-        propertyFaker: (Rect fakeValue) {
-          tester.view.physicalGeometry = fakeValue;
-        },
-      );
-    });
-
-    testWidgets('updating physicalGeometry also updates physicalSize', (WidgetTester tester) async {
-      const Rect testGeometry = Rect.fromLTWH(0, 0, 450, 575);
-      tester.view.physicalGeometry = testGeometry;
-
-      expect(tester.view.physicalSize, testGeometry.size);
-    });
-
     testWidgets('can fake physicalSize', (WidgetTester tester) async {
       verifyPropertyFaked<Size>(
         tester: tester,
@@ -169,17 +136,6 @@ void main() {
           tester.view.physicalSize = fakeValue;
         },
       );
-    });
-
-    testWidgets('updating physicalSize also updates physicalGeometry', (WidgetTester tester) async {
-      const Rect testGeometry = Rect.fromLTWH(0, 0, 450, 575);
-      const Size testSize = Size(50, 50);
-      const Rect expectedGeometry = Rect.fromLTWH(0, 0, 50, 50);
-
-      tester.view.physicalGeometry = testGeometry;
-      tester.view.physicalSize = testSize;
-
-      expect(tester.view.physicalGeometry, expectedGeometry);
     });
 
     testWidgets('can fake systemGestureInsets', (WidgetTester tester) async {
@@ -272,7 +228,6 @@ void main() {
       tester.view.devicePixelRatio = 7;
       tester.view.displayFeatures = <DisplayFeature>[const DisplayFeature(bounds: Rect.fromLTWH(0, 0, 20, 300), type: DisplayFeatureType.unknown, state: DisplayFeatureState.unknown)];
       tester.view.padding = FakeViewPadding.zero;
-      tester.view.physicalGeometry = const Rect.fromLTWH(0, 0, 505, 805);
       tester.view.systemGestureInsets = FakeViewPadding.zero;
       tester.view.viewInsets = FakeViewPadding.zero;
       tester.view.viewPadding = FakeViewPadding.zero;
@@ -356,9 +311,6 @@ class _FlutterViewSnapshotMatcher extends Matcher {
       paddingMatcher.describeMismatch(actual.padding, mismatchDescription, matchState, verbose);
     }
 
-    if (actual.physicalGeometry != expected.physicalGeometry) {
-      mismatchDescription.add('actual.physicalGeometry (${actual.physicalGeometry}) did not match expected.physicalGeometry (${expected.physicalGeometry})');
-    }
     if (actual.physicalSize != expected.physicalSize) {
       mismatchDescription.add('actual.physicalSize (${actual.physicalSize}) did not match expected.physicalSize (${expected.physicalSize})');
     }
@@ -397,7 +349,6 @@ class _FlutterViewSnapshotMatcher extends Matcher {
       actual.displayFeatures.equals(expected.displayFeatures) &&
       actual.gestureSettings == expected.gestureSettings &&
       matchesViewPadding(expected.padding).matches(actual.padding, matchState) &&
-      actual.physicalGeometry == expected.physicalGeometry &&
       actual.physicalSize == expected.physicalSize &&
       matchesViewPadding(expected.systemGestureInsets).matches(actual.padding, matchState) &&
       actual.viewId == expected.viewId &&
@@ -412,7 +363,6 @@ class FlutterViewSnapshot {
     displayFeatures = <DisplayFeature>[...view.displayFeatures],
     gestureSettings = view.gestureSettings,
     padding = view.padding,
-    physicalGeometry = view.physicalGeometry,
     physicalSize = view.physicalSize,
     systemGestureInsets = view.systemGestureInsets,
     viewId = view.viewId,
@@ -423,7 +373,6 @@ class FlutterViewSnapshot {
   final List<DisplayFeature> displayFeatures;
   final GestureSettings  gestureSettings;
   final ViewPadding  padding;
-  final Rect physicalGeometry;
   final Size physicalSize;
   final ViewPadding systemGestureInsets;
   final Object viewId;


### PR DESCRIPTION
Looks like this was proactively added in https://github.com/flutter/engine/pull/20496, but never wired up to anything on any platform. It is also unused in framework and customer code; we never exposed this on e.g. MediaQuery.

Related engine PR: https://github.com/flutter/engine/pull/47825