### PR TITLE
Prepare the analyze_once test for removal of analysis_options_user support

### DIFF
--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -164,16 +164,10 @@ void main() {
 
   // Analyze in the current directory - no arguments
   testWithoutContext('working directory with errors', () async {
-    // Break the code to produce the "Avoid empty else" hint
-    // that is upgraded to a warning in package:flutter/analysis_options_user.yaml
-    // to assert that we are using the default Flutter analysis options.
+    // Break the code to produce an error and a warning.
     // Also insert a statement that should not trigger a lint here
     // but will trigger a lint later on when an analysis_options.yaml is added.
     String source = await libMain.readAsString();
-    source = source.replaceFirst(
-      'return MaterialApp(',
-      'if (debugPrintRebuildDirtyWidgets) {} else ; return MaterialApp(',
-    );
     source = source.replaceFirst(
       'onPressed: _incrementCounter,',
       '// onPressed: _incrementCounter,',
@@ -189,12 +183,12 @@ void main() {
       arguments: <String>['analyze', '--no-pub'],
       statusTextContains: <String>[
         'Analyzing',
-        'avoid_empty_else',
-        'empty_statements',
         'unused_element',
         'missing_required_param',
       ],
-      exitMessageContains: '4 issues found.',
+      // TODO(srawlins): Assert with `exitMessageContains: '2 issues found.',` after
+      // https://github.com/dart-lang/sdk/commit/c033718da0502ed92609f8c6cee2f6a59ccc058e
+      // rolls into this repo.
       exitCode: 1,
     );
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138227. Work towards https://github.com/flutter/flutter/issues/82948

In https://github.com/dart-lang/sdk/commit/c033718da0502ed92609f8c6cee2f6a59ccc058e, the analyzer's support for `analysis_options_user.yaml` is dropped. So no lint is reported in this test, as expected. This PR changes the test to expect no lint, and also no write the edits that trigger the lint.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
