### PR TITLE
Just use string interpolation for ws url for tests

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -211,8 +211,8 @@ void catchIsolateErrors() {
 }
 
 void main() {
-  String serverPort = Platform.environment['SERVER_PORT'] ?? '';
-  String server = Uri.decodeComponent('$websocketUrl:\$serverPort');
+  final String serverPort = Platform.environment['SERVER_PORT'] ?? '';
+  final String server = '$websocketUrl:\$serverPort';
   StreamChannel<dynamic> testChannel = serializeSuite(() {
     catchIsolateErrors();
 ''');


### PR DESCRIPTION
Follows up on https://github.com/flutter/flutter/pull/137969 - we don't need decodeComponent here

