### PR TITLE
`NestedScrollView`'s outer scrollable jumping with `BouncingScrollPhysics` due to `double` precision errors

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1065,7 +1065,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
           outerDelta = math.max(outerDelta, potentialOuterDelta);
         }
       }
-      if (outerDelta != 0.0) {
+      if (outerDelta.abs() > precisionErrorTolerance) {
         final double innerDelta = _outerPosition!.applyClampedDragUpdate(
           outerDelta,
         );

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1302,8 +1302,8 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
       this,
       delta,
     );
-    if (oldPixels == newPixels) {
-      // Delta must have been so small we dropped it during floating point addition.
+    if ((oldPixels - newPixels).abs() < precisionErrorTolerance) {
+      // Delta is so small we can drop it.
       return 0.0;
     }
     // Check for overscroll:

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -295,7 +295,6 @@ void main() {
     expect(outer.offset, 0.0);
     expect(inner.offset, endPosition + 600);
 
-    // Since there is a difference between scrolling on devices and the web absolute values are not checked...
     double currentOffset = inner.offset;
     int maxNumberOfSteps = 100;
 
@@ -312,6 +311,12 @@ void main() {
     }
 
     // Assert positions returned to/stayed at 0.0
+    expect(outer.offset, 0.0);
+    expect(inner.offset, 0.0);
+
+    await tester.pumpAndSettle();
+
+    // Assert values settle at 0.0
     expect(outer.offset, 0.0);
     expect(inner.offset, 0.0);
   });

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -212,7 +212,8 @@ void main() {
     expect(context.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgets('NestedScrollView always scrolls outer scrollable first, (double precision errors, #136199)', (WidgetTester tester) async {
+  testWidgetsWithLeakTracking('NestedScrollView always scrolls outer scrollable first', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/136199
     final Key innerKey = UniqueKey();
     final Key outerKey = UniqueKey();
 

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -212,6 +212,54 @@ void main() {
     expect(context.clipBehavior, equals(Clip.antiAlias));
   });
 
+  testWidgets('Outer scrollable always scrolls first with BouncingScrollPhysics; fix for (#136199)', (WidgetTester tester) async {
+    final Key inner = UniqueKey();
+    final Key outer = UniqueKey();
+
+    Widget build() {
+      return Scaffold(
+        body: NestedScrollView(
+          key: outer,
+          physics: const BouncingScrollPhysics(),
+          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => [
+            SliverToBoxAdapter(
+              child: Container(color: Colors.green, height: 300),
+            ),
+            SliverOverlapAbsorber(
+              handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+              sliver: SliverToBoxAdapter(
+                child: Container(
+                  color: Colors.blue,
+                  height: 64,
+                ),
+              ),
+            ),
+          ],
+          body: SingleChildScrollView(
+            physics: const BouncingScrollPhysics(),
+            child: Container(
+              key: inner,
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: <ui.Color>[Colors.black, Colors.blue],
+                  stops: <double>[0, 1],
+                ),
+              ),
+              height: 800,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Build the widget.
+    await tester.pumpWidget(build());
+
+    // TODO Write the actual test (fling inner scrollable, outer scrollable should not move)
+  });
+
   testWidgets('NestedScrollView overscroll and release and hold', (WidgetTester tester) async {
     await tester.pumpWidget(buildTest());
     expect(find.text('aaa2'), findsOneWidget);

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -276,6 +276,9 @@ void main() {
 
     await tester.drag(find.byKey(innerKey), const Offset(0, 2000)); // Over-scroll the inner Scrollable to the bottom
 
+    // Using a precise value to make addition/subtraction possible later in the test
+    // Which better conveys the intent of the test
+    // The value is not equal to 2000 due to BouncingScrollPhysics of the inner Scrollable
     const double endPosition = -1974.0862087158384;
     const Duration nextFrame = Duration(microseconds: 16666);
 

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -271,7 +271,7 @@ void main() {
     expect(inner.offset, 0.0);
 
     outerController.addListener(() {
-      assert(false); // We do not want this to be called.
+      fail('Outer controller should not be scrolling'); // This should never be called
     });
 
     await tester.drag(find.byKey(innerKey), const Offset(0, 2000)); // Over-scroll the inner Scrollable to the bottom
@@ -295,77 +295,23 @@ void main() {
     expect(outer.offset, 0.0);
     expect(inner.offset, endPosition + 600);
 
-    const List<double> innerOffsets = <double>[
-      -1316.1176758537506,
-      -1224.8170160990555,
-      -1117.6097877754744,
-      -1005.5574610794743,
-      -895.4550700899018,
-      -791.264234881037,
-      -695.0886336136309,
-      -607.8349614887205,
-      -529.6581107592709,
-      -460.2586681710882,
-      -399.0796463469083,
-      -345.4347308728091,
-      -298.59021847911447,
-      -257.81584759409844,
-      -222.41491428472293,
-      -191.74075533967326,
-      -165.20440317597044,
-      -142.27665417716244,
-      -122.48672155447044,
-      -105.4189127625281,
-      -90.708274096657,
-      -78.03580827323584,
-      -67.12364411096027,
-      -57.73038610588277,
-      -49.64677176594978,
-      -42.69169955726153,
-      -36.708648893466346,
-      -31.56248801311129,
-      -27.13665053483395,
-      -23.33065334544838,
-      -20.057924812356934,
-      -17.243911468327354,
-      -14.824432188827757,
-      -12.744250738073964,
-      -10.955839921578985,
-      -9.418313143813856,
-      -8.096501738510593,
-      -6.960158902040851,
-      -5.983273353819624,
-      -5.143477941386347,
-      -4.421540292214858,
-      -3.800924292777648,
-      -3.2674126588351187,
-      -2.8087821642406303,
-      -2.4145242353912972,
-      -2.075604611777379,
-      -1.7842566363112475,
-      -1.5338034876418676,
-      -1.318505314594382,
-      -1.1334277929606227,
-      -0.9743291084817788,
-      -0.8375627870831994,
-      -0.7199941531058178,
-      -0.6189285061879893,
-      -0.5320493743534278,
-      -0.4573654306400669,
-      -0.39316485836690424,
-      -0.3379761203023452,
-      0.0,
-    ];
+    // Since there is a difference between scrolling on devices and the web absolute values are not checked...
+    double currentOffset = inner.offset;
+    int maxNumberOfSteps = 100;
 
-    for (final double offset in innerOffsets) {
+    while (inner.offset < 0) {
+      maxNumberOfSteps--;
+      if(maxNumberOfSteps <= 0) {
+        fail('Scrolling did not settle in an expected number of steps.');
+      }
       await tester.pump(nextFrame);
-      expect(inner.offset, offset);
+      expect(inner.offset, greaterThanOrEqualTo(currentOffset));
       expect(outer.offset, 0.0);
+
+      currentOffset = inner.offset;
     }
 
-    await tester.pumpAndSettle();
-
-    // Assert positions returned to origin after pumpAndSettle
+    // Assert positions returned to/stayed at 0.0
     expect(outer.offset, 0.0);
     expect(inner.offset, 0.0);
   });

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -221,7 +221,7 @@ void main() {
         body: NestedScrollView(
           key: outer,
           physics: const BouncingScrollPhysics(),
-          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => [
+          headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => <Widget>[
             SliverToBoxAdapter(
               child: Container(color: Colors.green, height: 300),
             ),

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -212,7 +212,7 @@ void main() {
     expect(context.clipBehavior, equals(Clip.antiAlias));
   });
 
-  testWidgetsWithLeakTracking('NestedScrollView always scrolls outer scrollable first', (WidgetTester tester) async {
+  testWidgets('NestedScrollView always scrolls outer scrollable first', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/136199
     final Key innerKey = UniqueKey();
     final GlobalKey<NestedScrollViewState> outerKey = GlobalKey();
@@ -324,7 +324,7 @@ void main() {
     expect(inner.offset, 0.0);
   });
 
-  testWidgetsWithLeakTracking('NestedScrollView overscroll and release and hold', (WidgetTester tester) async {
+  testWidgets('NestedScrollView overscroll and release and hold', (WidgetTester tester) async {
     await tester.pumpWidget(buildTest());
     expect(find.text('aaa2'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 250));

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -301,7 +301,7 @@ void main() {
 
     while (inner.offset < 0) {
       maxNumberOfSteps--;
-      if(maxNumberOfSteps <= 0) {
+      if (maxNumberOfSteps <= 0) {
         fail('Scrolling did not settle in an expected number of steps.');
       }
       await tester.pump(nextFrame);


### PR DESCRIPTION
This PR fixes scrolling issues with `NestedScrollView` using the `BouncingScrollPhysics`. In one of the steps of the calculation, we can reach a state where the position of the inner scrollable is set to a `double` value that falls within `precisionErrorTolerance` of `0` but we were using `==` with `0` rather than checking for a precision. My posts in the linked issue show the current behavior, and how I reached to conclusion (the code in this PR). This PR only addresses the "jumping" of the outer scrollable.  

Fixes #136199

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

I have not finished a test for this since I have never done so and therefore have 0 experience writing tests in Flutter, so any help there would be appreciated. I am also not sure how to test double precision errors in general. I did run all the nested_scroll_view_tests.dart locally and there are no failures.