### PR TITLE
Run all tests in examples/

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -843,7 +843,7 @@ Future<void> _runFrameworkTests() async {
       );
     }
     for (final FileSystemEntity entity in Directory(path.join(flutterRoot, 'examples')).listSync()) {
-      if (entity is! Directory) {
+      if (entity is! Directory || !Directory(path.join(entity.path, 'test')).existsSync()) {
         continue;
       }
       await _runFlutterTest(entity.path);

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -842,9 +842,12 @@ Future<void> _runFrameworkTests() async {
         workingDirectory: path.join(flutterRoot, 'examples', 'api'),
       );
     }
-    await _runFlutterTest(path.join(flutterRoot, 'examples', 'api'));
-    await _runFlutterTest(path.join(flutterRoot, 'examples', 'hello_world'));
-    await _runFlutterTest(path.join(flutterRoot, 'examples', 'layers'));
+    for (final FileSystemEntity entity in Directory(path.join(flutterRoot, 'examples')).listSync()) {
+      if (entity is! Directory) {
+        continue;
+      }
+      await _runFlutterTest(entity.path);
+    }
   }
 
   Future<void> runTracingTests() async {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/138253 demonstrated that the tests for the textures example weren't actually running on CI. This changes the testing script to execute the tests for everything inside the `examples` directory.