### PR TITLE
Migration for `NullSafetyAnalysisEvent` to `package:unified_analytics`

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/unified_analytics.dart
+++ b/packages/flutter_tools/lib/src/reporting/unified_analytics.dart
@@ -85,6 +85,8 @@ Map<String, Object>? getNullSafetyAnalysisInfo({
     if (package.name == currentPackage) {
       languageVersion = packageLanguageVersion;
     }
+    // TODO: (eliasyishak) this logic is copied from "lib/src/reporting/events.dart"
+    //  but is this correct, this would fail if comparing 3.1 to 2.12
     if (packageLanguageVersion != null &&
         packageLanguageVersion.major >= nullSafeVersion.major &&
         packageLanguageVersion.minor >= nullSafeVersion.minor) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1742,6 +1742,22 @@ Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and 
       project.manifest.appName,
       globals.flutterUsage,
     ).send();
+
+    final Map<String, Object>? analysisInfo = getNullSafetyAnalysisInfo(
+      packageConfig: buildInfo.packageConfig,
+      nullSafetyMode: buildInfo.nullSafetyMode,
+      currentPackage: project.manifest.appName,
+    );
+    if (analysisInfo != null) {
+      analytics.send(Event.nullSafetyAnalysisResult(
+        runtimeMode: analysisInfo['runtimeMode']! as String,
+        nullSafeMigratedLibraries: analysisInfo['nullSafeMigratedLibraries']! as int,
+        nullSafeTotalLibraries: analysisInfo['nullSafeTotalLibraries']! as int,
+        languageVersion: analysisInfo.containsKey('languageVersion')
+            ? analysisInfo['languageVersion']! as String
+            : null,
+      ));
+    }
   }
 
   /// The set of development artifacts required for this command.

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -591,9 +591,18 @@ void main() {
           label: '2.12',
         ),
       ]));
+      expect(fakeAnalytics.sentEvents, contains(
+        Event.nullSafetyAnalysisResult(
+              runtimeMode: 'NullSafetyMode.sound',
+              nullSafeMigratedLibraries: 1,
+              nullSafeTotalLibraries: 1,
+              languageVersion: '2.12',
+        )
+      ));
     }, overrides: <Type, Generator>{
       Pub: () => FakePub(),
       Usage: () => usage,
+      Analytics: () => fakeAnalytics,
       FileSystem: () => fileSystem,
       ProcessManager: () => processManager,
     });


### PR DESCRIPTION
Related to tracker issue:
- https://github.com/flutter/flutter/issues/128251

This PR will use the new event from `package:unified_analytics` and will consolidate the 3 separate send events from the legacy analytics system to just sending one

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
