### PR TITLE
Added hover and splash color to NavigationRailDestination

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -455,6 +455,8 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
                             iconTheme: widget.selectedIndex == i ? selectedIconTheme : effectiveUnselectedIconTheme,
                             labelTextStyle: widget.selectedIndex == i ? selectedLabelTextStyle : unselectedLabelTextStyle,
                             padding: widget.destinations[i].padding,
+                            hoverColor: widget.destinations[i].hoverColor,
+                            splashColor: widget.destinations[i].splashColor,
                             useIndicator: useIndicator,
                             indicatorColor: useIndicator ? indicatorColor : null,
                             indicatorShape: useIndicator ? indicatorShape : null,
@@ -544,6 +546,8 @@ class _RailDestination extends StatelessWidget {
     required this.indexLabel,
     this.padding,
     required this.useIndicator,
+    this.hoverColor,
+    this.splashColor,
     this.indicatorColor,
     this.indicatorShape,
     this.disabled = false,
@@ -567,6 +571,8 @@ class _RailDestination extends StatelessWidget {
   final String indexLabel;
   final EdgeInsetsGeometry? padding;
   final bool useIndicator;
+  final Color? hoverColor;
+  final Color? splashColor;
   final Color? indicatorColor;
   final ShapeBorder? indicatorShape;
   final bool disabled;
@@ -800,8 +806,8 @@ class _RailDestination extends StatelessWidget {
               onTap: disabled ? null : onTap,
               borderRadius: BorderRadius.all(Radius.circular(minWidth / 2.0)),
               customBorder: indicatorShape,
-              splashColor: effectiveSplashColor,
-              hoverColor: effectiveHoverColor,
+              splashColor: splashColor ?? effectiveSplashColor,
+              hoverColor: hoverColor ?? effectiveHoverColor,
               useMaterial3: material3,
               indicatorOffset: indicatorOffset,
               applyXOffset: applyXOffset,
@@ -959,6 +965,8 @@ class NavigationRailDestination {
   const NavigationRailDestination({
     required this.icon,
     Widget? selectedIcon,
+    this.hoverColor,
+    this.splashColor,
     this.indicatorColor,
     this.indicatorShape,
     required this.label,
@@ -992,6 +1000,12 @@ class NavigationRailDestination {
   ///  * [NavigationRailDestination.icon], for a description of how to pair
   ///    icons.
   final Widget selectedIcon;
+
+  /// The color when this destination is hovered.
+  final Color? hoverColor;
+
+  /// The color when this destination is splashed.
+  final Color? splashColor;
 
   /// The color of the [indicatorShape] when this destination is selected.
   final Color? indicatorColor;

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -3463,6 +3463,71 @@ void main() {
     expect(_getIndicatorDecoration(tester)?.shape, shape);
   });
 
+  testWidgetsWithLeakTracking('Navigation destination updates hover and splash color', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    const Color hoverColor = Color(0xff0000ff);
+    const Color splashColor = Color(0xff00ffff);
+
+    Widget buildNavigationRail({Color? hoverColor, Color? splashColor}) {
+      return MaterialApp(
+        theme: theme,
+        home: Builder(
+          builder: (BuildContext context) {
+            return Scaffold(
+              body: Row(
+                children: <Widget>[
+                  NavigationRail(
+                    key: const ValueKey<int>(1),
+                    useIndicator: true,
+                    selectedIndex: 0,
+                    destinations: <NavigationRailDestination>[
+                      NavigationRailDestination(
+                        icon: const Icon(Icons.favorite_border),
+                        selectedIcon: const Icon(Icons.favorite),
+                        hoverColor: hoverColor,
+                        splashColor: splashColor,
+                        label: const Text('Abc'),
+                      ),
+                      const NavigationRailDestination(
+                        icon: Icon(Icons.favorite_border),
+                        selectedIcon: Icon(Icons.favorite),
+                        label: Text('Abc'),
+                      ),
+                    ],
+                  ),
+                  const Expanded(
+                    child: Text('body'),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    InkResponse? getInkResponse(WidgetTester tester) {
+      return tester.firstWidget<InkResponse>(
+        find.descendant(
+          of: find.byKey(const ValueKey<int>(1)),
+          matching: find.byWidgetPredicate((Widget widget) => widget is InkResponse),
+        ).first,
+      );
+    }
+
+    await tester.pumpWidget(buildNavigationRail());
+
+    // Test default hover and splash color.
+    expect(getInkResponse(tester)?.hoverColor, theme.colorScheme.primary.withOpacity(0.04));
+    expect(getInkResponse(tester)?.splashColor, theme.colorScheme.primary.withOpacity(0.12));
+
+    await tester.pumpWidget(buildNavigationRail(hoverColor: hoverColor, splashColor: splashColor));
+
+    // Test custom hover and splash color.
+    expect(getInkResponse(tester)?.hoverColor, hoverColor);
+    expect(getInkResponse(tester)?.splashColor, splashColor);
+  });
+
   testWidgetsWithLeakTracking("Destination's respect their disabled state", (WidgetTester tester) async {
     late int selectedIndex;
     await _pumpNavigationRail(


### PR DESCRIPTION
This PR will add the functionality of custom and different hover and splash colors to each NavigationRailDestination. 

The feature of a custom shape (while hovering) of the NavigationRailDestination (as mentioned in #138392) is yet to decide, because there would be the need of a callback and a rebuild if the InkResponse is hovered, because the NavigationRail or even the Destination has no information about the hovering or splashing.

closes #138392 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
