### PR TITLE
Improve UI-thread animation performance on busy screens (~10x reduction depending on your use-case)

### DIFF
--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -91,7 +91,8 @@ mixin AnimationEagerListenerMixin {
 /// and [didUnregisterListener]. Implementations of these methods can be obtained
 /// by mixing in another mixin from this library, such as [AnimationLazyListenerMixin].
 mixin AnimationLocalListenersMixin {
-  final ObserverList<VoidCallback> _listeners = ObserverList<VoidCallback>();
+  final HashedObserverList<VoidCallback> _listeners =
+      HashedObserverList<VoidCallback>();
 
   /// Called immediately before a listener is added via [addListener].
   ///

--- a/packages/flutter/lib/src/foundation/observer_list.dart
+++ b/packages/flutter/lib/src/foundation/observer_list.dart
@@ -43,12 +43,15 @@ class ObserverList<T> extends Iterable<T> {
   ///
   /// Returns whether the item was present in the list.
   bool remove(T item) {
-    _isDirty = true;
-    _set.clear(); // Clear the set so that we don't leak items.
-    return _list.remove(item);
+    final bool removed = _list.remove(item);
+    if (removed) {
+      _isDirty = true;
+      _set.clear(); // Clear the set so that we don't leak items.
+    }
+    return removed;
   }
 
-  /// Removes all items from the list.
+  /// Removes all items from the [ObserverList].
   void clear() {
     _isDirty = false;
     _list.clear();
@@ -78,6 +81,10 @@ class ObserverList<T> extends Iterable<T> {
   @override
   bool get isNotEmpty => _list.isNotEmpty;
 
+  /// Creates a List containing the elements of the [ObserverList].
+  ///
+  /// Overrides the default implementation of the [Iterable] to reduce number
+  /// of allocations.
   @override
   List<T> toList({bool growable = true}) {
     return _list.toList(growable: growable);
@@ -126,6 +133,9 @@ class HashedObserverList<T> extends Iterable<T> {
     return true;
   }
 
+  /// Removes all items from the [HashedObserverList].
+  void clear() => _map.clear();
+
   @override
   bool contains(Object? element) => _map.containsKey(element);
 
@@ -137,4 +147,15 @@ class HashedObserverList<T> extends Iterable<T> {
 
   @override
   bool get isNotEmpty => _map.isNotEmpty;
+
+  /// Creates a List containing the elements of the [HashedObserverList].
+  ///
+  /// Overrides the default implementation of [Iterable] to reduce number of
+  /// allocations.
+  @override
+  List<T> toList({bool growable = true}) {
+    final Iterator<T> iter = _map.keys.iterator;
+    return List<T>.generate(_map.length, (_) => (iter..moveNext()).current,
+        growable: growable);
+  }
 }

--- a/packages/flutter/test/animation/iteration_patterns_test.dart
+++ b/packages/flutter/test/animation/iteration_patterns_test.dart
@@ -40,7 +40,7 @@ void main() {
     log.clear();
 
     controller.value = 0.4;
-    expect(log, <String>['listener2', 'listener4', 'listener4']);
+    expect(log, <String>['listener2', 'listener4']);
     log.clear();
   });
 


### PR DESCRIPTION
This change can be a significant reduction in UI thread load for animations when a controller drives many animations that will come in and go out of existance. 100x are easily possible depending on how many things are popping on and off the screen (e.g. hundreds).

WARNING: This is a somewhat breaking change (as shown by the test-change), due to listeners only being notified once (in first-insertion order) rather than once every registration. I'd be more than happy to make the behavior configurable on the AnimationController, so that folks could opt into the new behavior or construct an AnimationController depending on what their use-case demands.
Tangentially, I'd also be interested in understanding the motivation for the implemented behavior a bit better. Given that listeners can be mutating, preserving the order seems quite intuitive. Whereas multiple registrations may make sense, I just can't think of a good use-case. I can easily think of unintentional gotchas like advancing an animation multiple times per step/frame. (EDIT: it's also surprising that despite its ordering, it's not a stack, i.e. you push new listeners to the end but you remove them from the front,which makes working with multiple registrations conceptually probably hard to work with :woman_shrugging: )

CONTEXT: I'm using a library that draws markers onto a map and then depending on the zoom-level it will cluster (collapse/expand) these markers. This results often in tens or hundreds of markers being animated (position & opacity) with a single AnimationController. After this animation no-longer visible markers will be taken off screen resulting in large numbers of listeners being `removed`. With the implementation at HEAD, my App is spending a majority of its UI-thread time (tens of milliseconds per frame) just deleting listeners. I'd argue that a generic tool like AnimationController should not micro-optimize for the case N=1.

I also did a performance comparison based on N to support the proposal. I tried to model realistic use cases, i.e. add/remove, `notifiyListeners()` w/o any `_set` invalidation, with invalidation, and a cycle of notifylisteners/rm/add. The benchmark code can be found here: https://gist.github.com/ignatz/dba6293d0fef41e3c6e1ed3c51364de6 .

```
2 add/remove                       SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:       -0%   (0:00:01.373926 vs 0:00:01.376916)
2 add/remove                       SAME HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:       -0%   (0:00:02.170364 vs 0:00:02.177635)
2 add/remove                     SLOWER ObserverList vs MyHashedObserverList           takes:      0.6x, saved:      -64%   (0:00:01.375987 vs 0:00:02.254769)

2 notifyListeners                  SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:        1%   (0:00:01.183753 vs 0:00:01.167889)
2 notifyListeners                FASTER HashedObserverList vs MyHashedObserverList     takes:      1.6x, saved:       38%   (0:00:01.703029 vs 0:00:01.054944)
2 notifyListeners                FASTER ObserverList vs MyHashedObserverList           takes:      1.1x, saved:       10%   (0:00:01.173942 vs 0:00:01.061108)

2 notifyListeners self-mod         SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:        1%   (0:00:00.413579 vs 0:00:00.409012)
2 notifyListeners self-mod       FASTER HashedObserverList vs MyHashedObserverList     takes:      1.2x, saved:       16%   (0:00:00.861495 vs 0:00:00.725754)
2 notifyListeners self-mod       SLOWER ObserverList vs MyHashedObserverList           takes:      0.6x, saved:      -79%   (0:00:00.410618 vs 0:00:00.734759)

2 mix nl/rm/add                  SLOWER ObserverList vs MyObserverList                 takes:      1.0x, saved:       -4%   (0:00:00.382266 vs 0:00:00.398285)
2 mix nl/rm/add                  FASTER HashedObserverList vs MyHashedObserverList     takes:      1.3x, saved:       25%   (0:00:00.696625 vs 0:00:00.522181)
2 mix nl/rm/add                  SLOWER ObserverList vs MyHashedObserverList           takes:      0.8x, saved:      -25%   (0:00:00.363710 vs 0:00:00.454669)


4 add/remove                       SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:       -1%   (0:00:03.210935 vs 0:00:03.240136)
4 add/remove                       SAME HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:       -2%   (0:00:04.000753 vs 0:00:04.088699)
4 add/remove                     SLOWER ObserverList vs MyHashedObserverList           takes:      0.9x, saved:      -18%   (0:00:03.457464 vs 0:00:04.062586)

4 notifyListeners                SLOWER ObserverList vs MyObserverList                 takes:      0.8x, saved:      -22%   (0:00:01.857049 vs 0:00:02.266333)
4 notifyListeners                FASTER HashedObserverList vs MyHashedObserverList     takes:      1.3x, saved:       21%   (0:00:03.031229 vs 0:00:02.395746)
4 notifyListeners                FASTER ObserverList vs MyHashedObserverList           takes:      1.2x, saved:       14%   (0:00:03.723434 vs 0:00:03.213373)

4 notifyListeners self-mod       SLOWER ObserverList vs MyObserverList                 takes:      0.8x, saved:      -28%   (0:00:03.809080 vs 0:00:04.857361)
4 notifyListeners self-mod       FASTER HashedObserverList vs MyHashedObserverList     takes:      1.3x, saved:       24%   (0:00:03.694135 vs 0:00:02.797687)
4 notifyListeners self-mod       FASTER ObserverList vs MyHashedObserverList           takes:      1.3x, saved:       23%   (0:00:03.691153 vs 0:00:02.850335)

4 mix nl/rm/add                  SLOWER ObserverList vs MyObserverList                 takes:      0.9x, saved:       -6%   (0:00:01.665852 vs 0:00:01.759793)
4 mix nl/rm/add                    SAME HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:        1%   (0:00:01.430239 vs 0:00:01.422435)
4 mix nl/rm/add                  FASTER ObserverList vs MyHashedObserverList           takes:      2.6x, saved:       62%   (0:00:03.076555 vs 0:00:01.176919)


7 add/remove                     FASTER ObserverList vs MyObserverList                 takes:      1.2x, saved:       16%   (0:00:08.613052 vs 0:00:07.209422)
7 add/remove                       SAME HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:        1%   (0:00:08.334085 vs 0:00:08.291406)
7 add/remove                       SAME ObserverList vs MyHashedObserverList           takes:      1.0x, saved:       -1%   (0:00:07.939038 vs 0:00:07.982456)

7 notifyListeners                FASTER ObserverList vs MyObserverList                 takes:      1.1x, saved:       11%   (0:00:03.537551 vs 0:00:03.162703)
7 notifyListeners                FASTER HashedObserverList vs MyHashedObserverList     takes:      1.2x, saved:       19%   (0:00:04.266710 vs 0:00:03.441823)
7 notifyListeners                  SAME ObserverList vs MyHashedObserverList           takes:      1.0x, saved:        2%   (0:00:03.562112 vs 0:00:03.489668)

7 notifyListeners self-mod       FASTER ObserverList vs MyObserverList                 takes:      1.3x, saved:       20%   (0:00:07.683331 vs 0:00:06.141342)
7 notifyListeners self-mod       FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:        6%   (0:00:02.777192 vs 0:00:02.607791)
7 notifyListeners self-mod       FASTER ObserverList vs MyHashedObserverList           takes:      2.3x, saved:       57%   (0:00:06.138749 vs 0:00:02.623466)

7 mix nl/rm/add                  SLOWER ObserverList vs MyObserverList                 takes:      1.0x, saved:       -4%   (0:00:01.527072 vs 0:00:01.591417)
7 mix nl/rm/add                  FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:       10%   (0:00:01.424173 vs 0:00:01.274727)
7 mix nl/rm/add                  FASTER ObserverList vs MyHashedObserverList           takes:      1.8x, saved:       43%   (0:00:01.718774 vs 0:00:00.972161)


10 add/remove                      SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:        1%   (0:00:06.705254 vs 0:00:06.652850)
10 add/remove                    SLOWER HashedObserverList vs MyHashedObserverList     takes:      0.9x, saved:       -8%   (0:00:06.127039 vs 0:00:06.634606)
10 add/remove                    FASTER ObserverList vs MyHashedObserverList           takes:      1.1x, saved:        6%   (0:00:06.621233 vs 0:00:06.242699)

10 notifyListeners               SLOWER ObserverList vs MyObserverList                 takes:      0.8x, saved:      -21%   (0:00:02.542935 vs 0:00:03.065810)
10 notifyListeners               FASTER HashedObserverList vs MyHashedObserverList     takes:      1.2x, saved:       20%   (0:00:03.038072 vs 0:00:02.441563)
10 notifyListeners               FASTER ObserverList vs MyHashedObserverList           takes:      1.1x, saved:       10%   (0:00:02.708075 vs 0:00:02.429304)

10 notifyListeners self-mod      SLOWER ObserverList vs MyObserverList                 takes:      0.6x, saved:      -63%   (0:00:04.636833 vs 0:00:07.569618)
10 notifyListeners self-mod      SLOWER HashedObserverList vs MyHashedObserverList     takes:      0.7x, saved:      -44%   (0:00:01.926254 vs 0:00:02.768144)
10 notifyListeners self-mod      FASTER ObserverList vs MyHashedObserverList           takes:      3.9x, saved:       75%   (0:00:19.460013 vs 0:00:04.935028)

10 mix nl/rm/add                   SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:       -3%   (0:00:03.122031 vs 0:00:03.207405)
10 mix nl/rm/add                 FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:       12%   (0:00:02.104239 vs 0:00:01.853132)
10 mix nl/rm/add                 FASTER ObserverList vs MyHashedObserverList           takes:      1.7x, saved:       43%   (0:00:03.167834 vs 0:00:01.817996)


100 add/remove                   FASTER ObserverList vs MyObserverList                 takes:      2.1x, saved:       53%   (0:00:29.435696 vs 0:00:13.740486)
100 add/remove                   SLOWER HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:       -4%   (0:00:01.810957 vs 0:00:01.874549)
100 add/remove                   FASTER ObserverList vs MyHashedObserverList           takes:      7.0x, saved:       86%   (0:00:13.562779 vs 0:00:01.932154)

100 notifyListeners              FASTER ObserverList vs MyObserverList                 takes:      1.1x, saved:       11%   (0:00:00.824788 vs 0:00:00.735041)
100 notifyListeners              FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:       10%   (0:00:00.780762 vs 0:00:00.701437)
100 notifyListeners              FASTER ObserverList vs MyHashedObserverList           takes:      1.1x, saved:        8%   (0:00:00.797545 vs 0:00:00.732023)

100 notifyListeners self-mod     FASTER ObserverList vs MyObserverList                 takes:      1.1x, saved:       11%   (0:00:24.091372 vs 0:00:21.355631)
100 notifyListeners self-mod     FASTER HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:        4%   (0:00:00.560706 vs 0:00:00.536952)
100 notifyListeners self-mod     FASTER ObserverList vs MyHashedObserverList           takes:     42.2x, saved:       98%   (0:00:22.614892 vs 0:00:00.536188)

100 mix nl/rm/add                  SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:       -1%   (0:00:00.399696 vs 0:00:00.403067)
100 mix nl/rm/add                FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:       12%   (0:00:00.168415 vs 0:00:00.148730)
100 mix nl/rm/add                FASTER ObserverList vs MyHashedObserverList           takes:      2.7x, saved:       63%   (0:00:00.395535 vs 0:00:00.145706)


1000 add/remove                  SLOWER ObserverList vs MyObserverList                 takes:      1.0x, saved:       -3%   (0:00:43.742194 vs 0:00:45.164800)
1000 add/remove                    SAME HashedObserverList vs MyHashedObserverList     takes:      1.0x, saved:       -0%   (0:00:00.596296 vs 0:00:00.596309)
1000 add/remove                  FASTER ObserverList vs MyHashedObserverList           takes:     74.4x, saved:       99%   (0:00:44.349347 vs 0:00:00.595768)

1000 notifyListeners               SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:       -3%   (0:00:00.281672 vs 0:00:00.289646)
1000 notifyListeners             FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:        7%   (0:00:00.251050 vs 0:00:00.234575)
1000 notifyListeners             FASTER ObserverList vs MyHashedObserverList           takes:      1.2x, saved:       17%   (0:00:00.283716 vs 0:00:00.235989)

1000 notifyListeners self-mod    SLOWER ObserverList vs MyObserverList                 takes:      1.0x, saved:       -3%   (0:01:03.477013 vs 0:01:05.411053)
1000 notifyListeners self-mod    SLOWER HashedObserverList vs MyHashedObserverList     takes:      0.6x, saved:      -78%   (0:00:00.188581 vs 0:00:00.336313)
1000 notifyListeners self-mod    FASTER ObserverList vs MyHashedObserverList           takes:    348.7x, saved:      100%   (0:01:05.049408 vs 0:00:00.186552)

1000 mix nl/rm/add                 SAME ObserverList vs MyObserverList                 takes:      1.0x, saved:       -1%   (0:00:00.123481 vs 0:00:00.124426)
1000 mix nl/rm/add               FASTER HashedObserverList vs MyHashedObserverList     takes:      1.1x, saved:        5%   (0:00:00.050968 vs 0:00:00.048402)
1000 mix nl/rm/add               FASTER ObserverList vs MyHashedObserverList           takes:      2.5x, saved:       60%   (0:00:00.121606 vs 0:00:00.048307)
```

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
