### PR TITLE
Catch error for missing directory in `FontConfigManager`

### DIFF
--- a/packages/flutter_tools/lib/src/test/font_config_manager.dart
+++ b/packages/flutter_tools/lib/src/test/font_config_manager.dart
@@ -34,7 +34,11 @@ class FontConfigManager {
   Future<void> dispose() async {
     if (_fontsDirectory != null) {
       globals.printTrace('Deleting ${_fontsDirectory!.path}...');
-      await _fontsDirectory!.delete(recursive: true);
+      try {
+        await _fontsDirectory!.delete(recursive: true);
+      } on Exception {
+        // Silently exit
+      }
       _fontsDirectory = null;
     }
   }

--- a/packages/flutter_tools/lib/src/test/font_config_manager.dart
+++ b/packages/flutter_tools/lib/src/test/font_config_manager.dart
@@ -36,7 +36,7 @@ class FontConfigManager {
       globals.printTrace('Deleting ${_fontsDirectory!.path}...');
       try {
         await _fontsDirectory!.delete(recursive: true);
-      } on Exception {
+      } on FileSystemException {
         // Silently exit
       }
       _fontsDirectory = null;

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -56,7 +56,7 @@ void main() {
     final Directory fontsDirectory = fileSystem.file(fontConfigManager.fontConfigFile).parent;
     fontsDirectory.deleteSync(recursive: true);
 
-    expect(fontConfigManager.dispose, returnsNormally);
+    await fontConfigManager.dispose();
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -50,6 +50,18 @@ void main() {
       uriConverter: (String input) => '$input/converted',
     );
 
+  testUsingContext('Missing dir error caught for FontConfigManger.dispose', () async {
+    final FontConfigManager fontConfigManager = FontConfigManager();
+
+    final Directory fontsDirectory = fileSystem.file(fontConfigManager.fontConfigFile).parent;
+    fontsDirectory.deleteSync(recursive: true);
+
+    expect(fontConfigManager.dispose, returnsNormally);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
   group('The FLUTTER_TEST environment variable is passed to the test process', () {
     setUp(() {
       processManager = FakeProcessManager.list(<FakeCommand>[]);


### PR DESCRIPTION
Closes:
- https://github.com/flutter/flutter/issues/138434

We will catch any errors while attempting to clear the temp directories that don't exist for the `FontConfigManager` class

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
