### PR TITLE
[web] skip flaky overflow_clipbehavior_none.cupertino.0.png golden check

### DIFF
--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -8411,10 +8411,13 @@ void main() {
     final EditableText editableText = tester.firstWidget(find.byType(EditableText));
     expect(editableText.clipBehavior, Clip.none);
 
-    await expectLater(
-      find.byKey(const ValueKey<int>(1)),
-      matchesGoldenFile('overflow_clipbehavior_none.cupertino.0.png'),
-    );
+    // TODO(harryterkelsen): see https://github.com/flutter/flutter/issues/137669
+    if (!isCanvasKit) {
+      await expectLater(
+        find.byKey(const ValueKey<int>(1)),
+        matchesGoldenFile('overflow_clipbehavior_none.cupertino.0.png'),
+      );
+    }
   });
 
   testWidgetsWithLeakTracking('can shift + tap to select with a keyboard (Apple platforms)', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -8412,7 +8412,7 @@ void main() {
     expect(editableText.clipBehavior, Clip.none);
 
     // TODO(harryterkelsen): see https://github.com/flutter/flutter/issues/137669
-    if (!isCanvasKit) {
+    if (!kIsWeb || !isCanvasKit) {
       await expectLater(
         find.byKey(const ValueKey<int>(1)),
         matchesGoldenFile('overflow_clipbehavior_none.cupertino.0.png'),


### PR DESCRIPTION
Skipping the test due to https://github.com/flutter/flutter/issues/137669. It's not clear which PR started it, so we can't revert anything, and the fix is not yet clear either. However, the flakiness is very high and is disruptive to the Flutter team.