### PR TITLE
Analyze against using Stopwatches in the framework

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -124,6 +124,9 @@ Future<void> run(List<String> arguments) async {
   printProgress('Goldens...');
   await verifyGoldenTags(flutterPackages);
 
+  printProgress('Prevent flakes from Stopwatches...');
+  await verifyNoStopwatches(flutterPackages);
+
   printProgress('Skip test comments...');
   await verifySkipTestComments(flutterRoot);
 
@@ -580,6 +583,48 @@ Future<void> verifyGoldenTags(String workingDirectory, { int minimumMatches = 20
     foundError(<String>[
       ...errors,
       '${bold}See: https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter$reset',
+    ]);
+  }
+}
+
+/// Use of Stopwatches can introduce test flakes as the logical time of a
+/// stopwatch can fall out of sync with the mocked time of FakeAsync in testing.
+/// The Clock object provides a safe stopwatch instead, which is paired with
+/// FakeAsync as part of the test binding.
+final RegExp _findStopwatchPattern = RegExp(r'Stopwatch\(\)');
+const String _ignoreStopwatch = '// flutter_ignore: stopwatch (see analyze.dart)';
+const String _ignoreStopwatchForFile = '// flutter_ignore_for_file: stopwatch (see analyze.dart)';
+
+Future<void> verifyNoStopwatches(String workingDirectory, { int minimumMatches = 2000 }) async {
+  final List<String> errors = <String>[];
+  await for (final File file in _allFiles(workingDirectory, 'dart', minimumMatches: minimumMatches)) {
+    if (file.path.contains('flutter_tool')) {
+      // Skip flutter_tool package.
+      continue;
+    }
+    int lineNumber = 1;
+    final List<String> lines = file.readAsLinesSync();
+    for (final String line in lines) {
+      // If the file is being ignored, skip parsing the rest of the lines.
+      if (line.contains(_ignoreStopwatchForFile)) {
+        break;
+      }
+
+      if (line.contains(_findStopwatchPattern)
+          && !line.contains(_leadingComment)
+          && !line.contains(_ignoreStopwatch)) {
+        // Stopwatch found
+        errors.add('\t${file.path}:$lineNumber');
+      }
+      lineNumber++;
+    }
+  }
+  if (errors.isNotEmpty) {
+    foundError(<String>[
+      'Stopwatch use was found in the following files:',
+      ...errors,
+      '${bold}Stopwatches introduce flakes by falling out of sync with the FakeAsync used in testing.$reset',
+      'A Stopwatch that stays in sync with FakeAsync is available through the Gesture or Test bindings, through samplingClock.'
     ]);
   }
 }

--- a/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_doc.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_doc.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Sample Code
+///
+/// No analysis failures should be found.
+///
+/// {@tool snippet}
+/// Sample invocations of [Stopwatch].
+///
+/// ```dart
+/// Stopwatch();
+/// ```
+/// {@end-tool}
+///
+String? foo;
+// Other comments
+// Stopwatch();
+
+String literal = 'Stopwatch()'; // flutter_ignore: stopwatch (see analyze.dart)

--- a/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_doc.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_doc.dart
@@ -13,7 +13,6 @@
 /// Stopwatch();
 /// ```
 /// {@end-tool}
-///
 String? foo;
 // Other comments
 // Stopwatch();

--- a/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_fail.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_fail.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This should fail analysis.
+
+void main() {
+  Stopwatch();
+
+  // Identify more than one in a file.
+  final Stopwatch
+  myStopwatch = Stopwatch();
+  myStopwatch.reset();
+}

--- a/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_fail.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_fail.dart
@@ -8,7 +8,7 @@ void main() {
   Stopwatch();
 
   // Identify more than one in a file.
-  final Stopwatch
+ Stopwatch myStopwatch;
   myStopwatch = Stopwatch();
   myStopwatch.reset();
 }

--- a/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_ignore.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/stopwatch_ignore.dart
@@ -1,0 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This would fail analysis, but it is ignored
+// flutter_ignore_for_file: stopwatch (see analyze.dart)
+
+void main() {
+  Stopwatch();
+}

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -92,6 +92,24 @@ void main() {
     expect(result[result.length - 1], ''); // trailing newline
   });
 
+  test('analyze.dart - verifyNoStopwatches', () async {
+    final List<String> result = (await capture(() => verifyNoStopwatches(testRootPath, minimumMatches: 6), shouldHaveErrors: true)).split('\n');
+    final List<String> lines = <String>[
+      '║ \ttest/analyze-test-input/root/packages/foo/stopwatch_fail.dart:8',
+      '║ \ttest/analyze-test-input/root/packages/foo/stopwatch_fail.dart:12',
+    ]
+        .map((String line) => line.replaceAll('/', Platform.isWindows ? r'\' : '/'))
+        .toList();
+    expect(result.length, 6 + lines.length, reason: 'output had unexpected number of lines:\n${result.join('\n')}');
+    expect(result[0], '╔═╡ERROR╞═══════════════════════════════════════════════════════════════════════');
+    expect(result[1], '║ Stopwatch use was found in the following files:');
+    expect(result.getRange(2, result.length - 4).toSet(), lines.toSet());
+    expect(result[result.length - 4], '║ Stopwatches introduce flakes by falling out of sync with the FakeAsync used in testing.');
+    expect(result[result.length - 3], '║ A Stopwatch that stays in sync with FakeAsync is available through the Gesture or Test bindings, through samplingClock.');
+    expect(result[result.length - 2], '╚═══════════════════════════════════════════════════════════════════════════════');
+    expect(result[result.length - 1], ''); // trailing newline
+  });
+
   test('analyze.dart - verifyNoMissingLicense', () async {
     final String result = await capture(() => verifyNoMissingLicense(testRootPath, checkMinimums: false), shouldHaveErrors: true);
     final String file = 'test/analyze-test-input/root/packages/foo/foo.dart'

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -75,7 +75,7 @@ Future<T> debugInstrumentAction<T>(String description, Future<T> Function() acti
     return true;
   }());
   if (instrument) {
-    final Stopwatch stopwatch = Stopwatch()..start();
+    final Stopwatch stopwatch = Stopwatch()..start(); // flutter_ignore: stopwatch (see analyze.dart)
     try {
       return await action();
     } finally {

--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -76,6 +76,7 @@ Future<T> debugInstrumentAction<T>(String description, Future<T> Function() acti
   }());
   if (instrument) {
     final Stopwatch stopwatch = Stopwatch()..start(); // flutter_ignore: stopwatch (see analyze.dart)
+    // Ignore context: The framework does not use this function internally so it will not cause flakes.
     try {
       return await action();
     } finally {

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -66,7 +66,7 @@ int _debugPrintedCharacters = 0;
 const int _kDebugPrintCapacity = 12 * 1024;
 const Duration _kDebugPrintPauseTime = Duration(seconds: 1);
 final Queue<String> _debugPrintBuffer = Queue<String>();
-final Stopwatch _debugPrintStopwatch = Stopwatch();
+final Stopwatch _debugPrintStopwatch = Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
 Completer<void>? _debugPrintCompleter;
 bool _debugPrintScheduled = false;
 void _debugPrintTask() {

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -67,6 +67,7 @@ const int _kDebugPrintCapacity = 12 * 1024;
 const Duration _kDebugPrintPauseTime = Duration(seconds: 1);
 final Queue<String> _debugPrintBuffer = Queue<String>();
 final Stopwatch _debugPrintStopwatch = Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
+// Ignore context: This is not used in tests, only for throttled logging.
 Completer<void>? _debugPrintCompleter;
 bool _debugPrintScheduled = false;
 void _debugPrintTask() {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -36,7 +36,12 @@ class SamplingClock {
   DateTime now() => DateTime.now();
 
   /// Returns a new stopwatch that uses the current time as reported by `this`.
-  Stopwatch stopwatch() => Stopwatch();
+  ///
+  /// See also:
+  ///
+  ///   * [GestureBinding.debugSamplingClock], which is used in tests and
+  ///     debug builds to observe [FakeAsync].
+  Stopwatch stopwatch() => Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
 }
 
 // Class that handles resampling of touch events for multiple pointer
@@ -59,7 +64,7 @@ class _Resampler {
   Duration _frameTime = Duration.zero;
 
   // Time since `_frameTime` was updated.
-  Stopwatch _frameTimeAge = Stopwatch();
+  Stopwatch _frameTimeAge = Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
 
   // Last sample time and time stamp of last event.
   //

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -42,6 +42,7 @@ class SamplingClock {
   ///   * [GestureBinding.debugSamplingClock], which is used in tests and
   ///     debug builds to observe [FakeAsync].
   Stopwatch stopwatch() => Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
+  // Ignore context: This is replaced by debugSampling clock in the test binding.
 }
 
 // Class that handles resampling of touch events for multiple pointer
@@ -65,6 +66,7 @@ class _Resampler {
 
   // Time since `_frameTime` was updated.
   Stopwatch _frameTimeAge = Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
+  // Ignore context: This is tested safely outside of FakeAsync.
 
   // Last sample time and time stamp of last event.
   //

--- a/packages/flutter/test/foundation/timeline_test.dart
+++ b/packages/flutter/test/foundation/timeline_test.dart
@@ -72,7 +72,7 @@ void main() {
     // a bit inconsistent with Stopwatch.
     final int start = FlutterTimeline.now - 1;
     FlutterTimeline.timeSync('TEST', () {
-      final Stopwatch watch = Stopwatch()..start();
+      final Stopwatch watch = Stopwatch()..start(); // flutter_ignore: stopwatch (see analyze.dart)
       while (watch.elapsedMilliseconds < 5) {}
       watch.stop();
     });

--- a/packages/flutter/test/foundation/timeline_test.dart
+++ b/packages/flutter/test/foundation/timeline_test.dart
@@ -73,6 +73,7 @@ void main() {
     final int start = FlutterTimeline.now - 1;
     FlutterTimeline.timeSync('TEST', () {
       final Stopwatch watch = Stopwatch()..start(); // flutter_ignore: stopwatch (see analyze.dart)
+      // Ignore context: Used safely for benchmarking.
       while (watch.elapsedMilliseconds < 5) {}
       watch.stop();
     });

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -297,7 +297,7 @@ class _Reporter {
   final bool _printPath;
 
   /// A stopwatch that tracks the duration of the full run.
-  final Stopwatch _stopwatch = Stopwatch();
+  final Stopwatch _stopwatch = Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
 
   /// The size of `_engine.passed` last time a progress notification was
   /// printed.

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -298,6 +298,7 @@ class _Reporter {
 
   /// A stopwatch that tracks the duration of the full run.
   final Stopwatch _stopwatch = Stopwatch(); // flutter_ignore: stopwatch (see analyze.dart)
+  // Ignore context: Used for logging of actual test runs, outside of FakeAsync.
 
   /// The size of `_engine.passed` last time a progress notification was
   /// printed.


### PR DESCRIPTION
Adds analysis to prevent Stopwatches from being reintroduced to the framework.

Fixes https://github.com/flutter/flutter/issues/137804
This is a follow up to https://github.com/flutter/flutter/pull/137381
It will prevent issues like https://github.com/flutter/flutter/issues/135728, where adding a stopwatch introduced a high number of flakes in the framework when it fell out of sync with the clock. This particular case affected every call to fling something in testing, which meant over 300 tests were suddenly very flaky. 😱

Original PR was botched in a rebase
- https://github.com/flutter/flutter/pull/137805

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
