### PR TITLE
Enable the silent flag for invalid string exceptions when building a TextSpan

### DIFF
--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -285,6 +285,7 @@ class TextSpan extends InlineSpan implements HitTestTarget, MouseTrackerAnnotati
           stack: stack,
           library: 'painting library',
           context: ErrorDescription('while building a TextSpan'),
+          silent: true,
         ));
         // Use a Unicode replacement character as a substitute for invalid text.
         builder.addText('\uFFFD');

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1193,9 +1193,9 @@ void main() {
   }, skip: isBrowser && !isCanvasKit); // https://github.com/flutter/flutter/issues/87543
 
   test('TextPainter handles invalid UTF-16', () {
-    Object? exception;
+    FlutterErrorDetails? error;
     FlutterError.onError = (FlutterErrorDetails details) {
-      exception = details.exception;
+      error = details;
     };
 
     final TextPainter painter = TextPainter()
@@ -1207,7 +1207,8 @@ void main() {
     painter.layout();
     // The layout should include one replacement character.
     expect(painter.width, equals(fontSize));
-    expect(exception, isNotNull);
+    expect(error!.exception, isNotNull);
+    expect(error!.silent, isTrue);
     painter.dispose();
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/87544
 


### PR DESCRIPTION
This error can occur in a release app (for example, if the text comes from user input that is not valid UTF-16).  In that case, TextSpan will replace the invalid text with a placeholder character.