### PR TITLE
`AnimationStyle.noAnimation` replaces `AnimatedTheme` with just `Theme` in `MaterialApp.themeAnimationStyle`

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -955,8 +955,11 @@ class _MaterialAppState extends State<MaterialApp> {
     final Color effectiveSelectionColor = theme.textSelectionTheme.selectionColor ?? theme.colorScheme.primary.withOpacity(0.40);
     final Color effectiveCursorColor = theme.textSelectionTheme.cursorColor ?? theme.colorScheme.primary;
 
-    Widget childWidget = widget.builder != null
-      ? Builder(
+    Widget childWidget = child ?? const SizedBox.shrink();
+
+    if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
+      if (widget.builder != null) {
+        childWidget = Builder(
           builder: (BuildContext context) {
             // Why are we surrounding a builder with a builder?
             //
@@ -971,14 +974,17 @@ class _MaterialAppState extends State<MaterialApp> {
             // resolves to the theme we passed to AnimatedTheme.
             return widget.builder!(context, child);
           },
-        )
-      : child ?? const SizedBox.shrink();
-
-    if (widget.themeAnimationStyle != AnimationStyle.noAnimation) {
+        );
+      }
       childWidget = AnimatedTheme(
         data: theme,
         duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
         curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
+        child: childWidget,
+      );
+    } else {
+      childWidget = Theme(
+        data: theme,
         child: childWidget,
       );
     }
@@ -988,12 +994,7 @@ class _MaterialAppState extends State<MaterialApp> {
       child: DefaultSelectionStyle(
         selectionColor: effectiveSelectionColor,
         cursorColor: effectiveCursorColor,
-        child: AnimatedTheme(
-          data: theme,
-          duration: widget.themeAnimationStyle?.duration ?? widget.themeAnimationDuration,
-          curve: widget.themeAnimationStyle?.curve ?? widget.themeAnimationCurve,
-          child: childWidget,
-        ),
+        child: childWidget,
       ),
     );
   }

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1590,6 +1590,18 @@ void main() {
     expect(tester.widget<Material>(find.byType(Material)).color, isNot(const Color(0xff1c1b1f)));
     expect(tester.widget<Material>(find.byType(Material)).color, const Color(0xfffffbfe));
   });
+
+  testWidgetsWithLeakTracking('AnimationStyle.noAnimation removes AnimatedTheme from the tree', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(themeAnimationStyle: AnimationStyle()));
+
+    expect(find.byType(AnimatedTheme), findsOneWidget);
+    expect(find.byType(Theme), findsOneWidget);
+
+    await tester.pumpWidget(MaterialApp(themeAnimationStyle: AnimationStyle.noAnimation));
+
+    expect(find.byType(AnimatedTheme), findsNothing);
+    expect(find.byType(Theme), findsOneWidget);
+  });
 }
 
 class MockScrollBehavior extends ScrollBehavior {


### PR DESCRIPTION
fixes [`AnimationStyle.noAnimation` needs to replace `AnimatedTheme` with just `Theme` in the `MaterialApp`](https://github.com/flutter/flutter/issues/138618)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
