### PR TITLE
Do not send frames to engine in automated tests

### DIFF
--- a/packages/flutter/test/animation/live_binding_test.dart
+++ b/packages/flutter/test/animation/live_binding_test.dart
@@ -138,4 +138,9 @@ void main() {
   },
     skip: isBrowser, // [intended] https://github.com/flutter/flutter/issues/56001
   );
+
+  testWidgetsWithLeakTracking('LiveTestWidgetsFlutterBinding does render into FlutterViews', (WidgetTester tester) async {
+    expect(tester.binding, isA<LiveTestWidgetsFlutterBinding>());
+    expect(tester.binding.platformDispatcher.renderIntoFlutterView, isTrue);
+  });
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -192,9 +192,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   ///
   /// This constructor overrides the [debugPrint] global hook to point to
   /// [debugPrintOverride], which can be overridden by subclasses.
-  TestWidgetsFlutterBinding() : platformDispatcher = TestPlatformDispatcher(
-    platformDispatcher: PlatformDispatcher.instance,
-  ) {
+  TestWidgetsFlutterBinding() {
     debugPrint = debugPrintOverride;
     debugDisableShadows = disableShadows;
   }
@@ -229,7 +227,13 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   late final TestWindow window;
 
   @override
-  final TestPlatformDispatcher platformDispatcher;
+  TestPlatformDispatcher get platformDispatcher => _platformDispatcher;
+  late final TestPlatformDispatcher _platformDispatcher = TestPlatformDispatcher(
+    platformDispatcher: PlatformDispatcher.instance,
+    renderIntoFlutterView: _renderIntoFlutterView,
+  );
+
+  bool get _renderIntoFlutterView => false;
 
   @override
   TestRestorationManager get restorationManager {
@@ -1690,6 +1694,9 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     }
     return LiveTestWidgetsFlutterBinding.instance;
   }
+
+  @override
+  bool get _renderIntoFlutterView => true;
 
   @override
   bool get inTest => _inTest;

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -152,6 +152,7 @@ class TestPlatformDispatcher implements PlatformDispatcher {
   /// [PlatformDispatcher] unless explicitly overridden for test purposes.
   TestPlatformDispatcher({
     required PlatformDispatcher platformDispatcher,
+    this.renderIntoFlutterView = false,
   }) : _platformDispatcher = platformDispatcher {
     _updateViewsAndDisplays();
     _platformDispatcher.onMetricsChanged = _handleMetricsChanged;
@@ -159,6 +160,15 @@ class TestPlatformDispatcher implements PlatformDispatcher {
 
   /// The [PlatformDispatcher] that is wrapped by this [TestPlatformDispatcher].
   final PlatformDispatcher _platformDispatcher;
+
+  /// Whether the [views] managed by this platform dispatcher will send frames
+  /// to the engine when [FlutterView.render] is called.
+  ///
+  /// When this [TestPlatformDispatcher] is used in an environment that manually
+  /// drives the frame pipeline (e.g. [AutomatedTestWidgetsFlutterBinding])
+  /// frames shouldn't be sent to the engine as the engine may not be ready
+  /// to process them.
+  final bool renderIntoFlutterView;
 
   @override
   TestFlutterView? get implicitView {
@@ -875,7 +885,9 @@ class TestFlutterView implements FlutterView {
 
   @override
   void render(Scene scene) {
-    _view.render(scene);
+    if (platformDispatcher.renderIntoFlutterView) {
+      _view.render(scene);
+    }
   }
 
   @override
@@ -1636,7 +1648,9 @@ class TestWindow implements SingletonFlutterWindow {
   )
   @override
   void render(Scene scene) {
-    _view.render(scene);
+    if (platformDispatcher.renderIntoFlutterView) {
+      _view.render(scene);
+    }
   }
 
   @Deprecated(

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -111,4 +111,9 @@ void main() {
     });
     expect(responded, true);
   });
+
+  test('AutomatedTestWidgetsFlutterBinding does not render into FlutterViews', () {
+    expect(binding, isA<AutomatedTestWidgetsFlutterBinding>());
+    expect(binding.platformDispatcher.renderIntoFlutterView, isFalse);
+  });
 }

--- a/packages/flutter_test/test/view_test.dart
+++ b/packages/flutter_test/test/view_test.dart
@@ -243,21 +243,6 @@ void main() {
       expect(initial, matchesSnapshot(reset));
     });
 
-    testWidgets('render is passed through to backing FlutterView', (WidgetTester tester) async {
-      final Scene expectedScene = SceneBuilder().build();
-      final _FakeFlutterView backingView = _FakeFlutterView();
-      final TestFlutterView view = TestFlutterView(
-        view: backingView,
-        platformDispatcher: tester.binding.platformDispatcher,
-        display: _FakeDisplay(),
-      );
-
-      view.render(expectedScene);
-
-      expect(backingView.lastRenderedScene, isNotNull);
-      expect(backingView.lastRenderedScene, expectedScene);
-    });
-
     testWidgets('updateSemantics is passed through to backing FlutterView', (WidgetTester tester) async {
       final SemanticsUpdate expectedUpdate = SemanticsUpdateBuilder().build();
       final _FakeFlutterView backingView = _FakeFlutterView();
@@ -271,6 +256,41 @@ void main() {
 
       expect(backingView.lastSemanticsUpdate, isNotNull);
       expect(backingView.lastSemanticsUpdate, expectedUpdate);
+    });
+
+    testWidgets('does not call render if renderIntoFlutterView is false', (WidgetTester tester) async {
+      final TestPlatformDispatcher nonRenderingDispatcher = TestPlatformDispatcher(
+        platformDispatcher: tester.binding.platformDispatcher,
+        renderIntoFlutterView: false,
+      );
+      final _FakeFlutterView flutterView = _FakeFlutterView();
+      final TestFlutterView testFlutterView = TestFlutterView(
+        view: flutterView,
+        platformDispatcher: nonRenderingDispatcher,
+        display: _FakeDisplay(),
+      );
+
+      expect(flutterView.lastRenderedScene, isNull);
+      final Scene scene = SceneBuilder().build();
+      testFlutterView.render(scene);
+      expect(flutterView.lastRenderedScene, isNull);
+    });
+
+    testWidgets('does call render if renderIntoFlutterView is true', (WidgetTester tester) async {
+      final TestPlatformDispatcher nonRenderingDispatcher = TestPlatformDispatcher(
+        platformDispatcher: tester.binding.platformDispatcher,
+      );
+      final _FakeFlutterView flutterView = _FakeFlutterView();
+      final TestFlutterView testFlutterView = TestFlutterView(
+        view: flutterView,
+        platformDispatcher: nonRenderingDispatcher,
+        display: _FakeDisplay(),
+      );
+
+      expect(flutterView.lastRenderedScene, isNull);
+      final Scene scene = SceneBuilder().build();
+      testFlutterView.render(scene);
+      expect(flutterView.lastRenderedScene, isNotNull);
     });
   });
 }

--- a/packages/flutter_test/test/view_test.dart
+++ b/packages/flutter_test/test/view_test.dart
@@ -258,10 +258,9 @@ void main() {
       expect(backingView.lastSemanticsUpdate, expectedUpdate);
     });
 
-    testWidgets('does not call render if renderIntoFlutterView is false', (WidgetTester tester) async {
+    testWidgets('does not call render if renderIntoFlutterView is false (default)', (WidgetTester tester) async {
       final TestPlatformDispatcher nonRenderingDispatcher = TestPlatformDispatcher(
         platformDispatcher: tester.binding.platformDispatcher,
-        renderIntoFlutterView: false,
       );
       final _FakeFlutterView flutterView = _FakeFlutterView();
       final TestFlutterView testFlutterView = TestFlutterView(
@@ -279,6 +278,7 @@ void main() {
     testWidgets('does call render if renderIntoFlutterView is true', (WidgetTester tester) async {
       final TestPlatformDispatcher nonRenderingDispatcher = TestPlatformDispatcher(
         platformDispatcher: tester.binding.platformDispatcher,
+        renderIntoFlutterView: true,
       );
       final _FakeFlutterView flutterView = _FakeFlutterView();
       final TestFlutterView testFlutterView = TestFlutterView(


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/134501.

In automated tests we manually drive the frame pipeline in the testing framework without the engine's participation. This means (prior to this change), frames were sent to the engine outside of the onBeginFrame / onDrawFrame callbacks, which the engine doesn't expect; the engine just drops those frames on the floor (see [1]). This change modifies the test framework to not even send those frames to the engine in the first place. In the future, this will allow us to make some stronger assertions in the engine about how and when frames are send to the engine (see [2]).

[1] https://github.com/flutter/engine/blob/06d5adb099466b22058a34130924fd5ae3ba4d01/lib/ui/window.dart#L339
[2] https://github.com/flutter/engine/pull/48090