### PR TITLE
Adds `includeSeparatorForLastItem` argument for `ListView.separated` factory

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1390,6 +1390,8 @@ class ListView extends BoxScrollView {
   /// `addSemanticIndexes` argument corresponds to the
   /// [SliverChildBuilderDelegate.addSemanticIndexes] property. None may be
   /// null.
+  /// The `includeSeperatorForLastItem` argument determines whether to add
+  /// a seperator after the last item or not. Defaults to `False`.
   ListView.separated({
     super.key,
     super.scrollDirection,
@@ -1411,6 +1413,7 @@ class ListView extends BoxScrollView {
     super.keyboardDismissBehavior,
     super.restorationId,
     super.clipBehavior,
+    bool includeSeperatorForLastItem = false,
   }) : assert(itemCount >= 0),
        itemExtent = null,
        itemExtentBuilder = null,
@@ -1424,7 +1427,7 @@ class ListView extends BoxScrollView {
            return separatorBuilder(context, itemIndex);
          },
          findChildIndexCallback: findChildIndexCallback,
-         childCount: _computeActualChildCount(itemCount),
+         childCount: _computeActualChildCount(itemCount, includeSeperatorForLastItem),
          addAutomaticKeepAlives: addAutomaticKeepAlives,
          addRepaintBoundaries: addRepaintBoundaries,
          addSemanticIndexes: addSemanticIndexes,
@@ -1578,7 +1581,10 @@ class ListView extends BoxScrollView {
   }
 
   // Helper method to compute the actual child count for the separated constructor.
-  static int _computeActualChildCount(int itemCount) {
+  static int _computeActualChildCount(int itemCount, bool includeSeperatorForLastItem) {
+    if (includeSeperatorForLastItem) {
+      return math.max(0, itemCount * 2);
+    }
     return math.max(0, itemCount * 2 - 1);
   }
 }

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1390,8 +1390,8 @@ class ListView extends BoxScrollView {
   /// `addSemanticIndexes` argument corresponds to the
   /// [SliverChildBuilderDelegate.addSemanticIndexes] property. None may be
   /// null.
-  /// The `includeSeperatorForLastItem` argument determines whether to add
-  /// a seperator after the last item or not. Defaults to `False`.
+  /// The `includeSeparatorForLastItem` argument determines whether to add
+  /// a separator after the last item or not. Defaults to `False`.
   ListView.separated({
     super.key,
     super.scrollDirection,
@@ -1413,7 +1413,7 @@ class ListView extends BoxScrollView {
     super.keyboardDismissBehavior,
     super.restorationId,
     super.clipBehavior,
-    bool includeSeperatorForLastItem = false,
+    bool includeSeparatorForLastItem = false,
   }) : assert(itemCount >= 0),
        itemExtent = null,
        itemExtentBuilder = null,
@@ -1427,7 +1427,7 @@ class ListView extends BoxScrollView {
            return separatorBuilder(context, itemIndex);
          },
          findChildIndexCallback: findChildIndexCallback,
-         childCount: _computeActualChildCount(itemCount, includeSeperatorForLastItem),
+         childCount: _computeActualChildCount(itemCount, includeSeparatorForLastItem),
          addAutomaticKeepAlives: addAutomaticKeepAlives,
          addRepaintBoundaries: addRepaintBoundaries,
          addSemanticIndexes: addSemanticIndexes,
@@ -1581,8 +1581,8 @@ class ListView extends BoxScrollView {
   }
 
   // Helper method to compute the actual child count for the separated constructor.
-  static int _computeActualChildCount(int itemCount, bool includeSeperatorForLastItem) {
-    if (includeSeperatorForLastItem) {
+  static int _computeActualChildCount(int itemCount, bool includeSeparatorForLastItem) {
+    if (includeSeparatorForLastItem) {
       return math.max(0, itemCount * 2);
     }
     return math.max(0, itemCount * 2 - 1);

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1391,7 +1391,7 @@ class ListView extends BoxScrollView {
   /// [SliverChildBuilderDelegate.addSemanticIndexes] property. None may be
   /// null.
   /// The `includeSeparatorForLastItem` argument determines whether to add
-  /// a separator after the last item or not. Defaults to `false`.
+  /// a separator after the last item or not. Defaults to false.
   ListView.separated({
     super.key,
     super.scrollDirection,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1391,7 +1391,7 @@ class ListView extends BoxScrollView {
   /// [SliverChildBuilderDelegate.addSemanticIndexes] property. None may be
   /// null.
   /// The `includeSeparatorForLastItem` argument determines whether to add
-  /// a separator after the last item or not. Defaults to `False`.
+  /// a separator after the last item or not. Defaults to `false`.
   ListView.separated({
     super.key,
     super.scrollDirection,

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -1759,12 +1759,12 @@ void main() {
     expect(item2Height, 30.0);
   });
 
-  testWidgetsWithLeakTracking('ListView.separated honors includeSeperatorForLastItem', (WidgetTester tester) async {
-    Widget buildFrame({bool includeSeperatorForLastItem = false}) {
+  testWidgetsWithLeakTracking('ListView.separated honors includeSeparatorForLastItem', (WidgetTester tester) async {
+    Widget buildFrame({bool includeSeparatorForLastItem = false}) {
       return MaterialApp(
         home: Material(
           child: ListView.separated(
-            includeSeperatorForLastItem: includeSeperatorForLastItem,
+            includeSeparatorForLastItem: includeSeparatorForLastItem,
             itemCount: 10,
             separatorBuilder: (BuildContext context, int index) {
               return const Text('separator-widget');

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -1781,7 +1781,7 @@ void main() {
     expect(find.text('item-widget'), findsNWidgets(10));
     expect(find.text('separator-widget'), findsNWidgets(9));
 
-    await tester.pumpWidget(buildFrame(includeSeperatorForLastItem: true));
+    await tester.pumpWidget(buildFrame(includeSeparatorForLastItem: true));
     expect(find.text('item-widget'), findsNWidgets(10));
     expect(find.text('separator-widget'), findsNWidgets(10));
   });

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -1758,4 +1758,31 @@ void main() {
     expect(item1Height, 30.0);
     expect(item2Height, 30.0);
   });
+
+  testWidgetsWithLeakTracking('ListView.separated honors includeSeperatorForLastItem', (WidgetTester tester) async {
+    Widget buildFrame({bool includeSeperatorForLastItem = false}) {
+      return MaterialApp(
+        home: Material(
+          child: ListView.separated(
+            includeSeperatorForLastItem: includeSeperatorForLastItem,
+            itemCount: 10,
+            separatorBuilder: (BuildContext context, int index) {
+              return const Text('separator-widget');
+            },
+            itemBuilder: (BuildContext context, int index) {
+              return const Text('item-widget');
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    expect(find.text('item-widget'), findsNWidgets(10));
+    expect(find.text('separator-widget'), findsNWidgets(9));
+
+    await tester.pumpWidget(buildFrame(includeSeperatorForLastItem: true));
+    expect(find.text('item-widget'), findsNWidgets(10));
+    expect(find.text('separator-widget'), findsNWidgets(10));
+  });
 }


### PR DESCRIPTION
Adds `includeSeparatorForLastItem` argument for `ListView.separated` factory.

Fixes #134272

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
