### PR TITLE
Add `undoStackModifier` to `UndoHistory`

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4824,6 +4824,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                 return oldValue.text != newValue.text || oldValue.composing != newValue.composing;
               },
               undoStackModifier: (TextEditingValue value) {
+                // On Android we should discard the composing region when pushing
+                // a new entry to the undo stack. This is matches the native
+                // behavior and prevents the TextInputPlugin from resetting the
+                // composing region on every undo/redo.
                 return defaultTargetPlatform == TargetPlatform.android ? value.copyWith(composing: TextRange.empty) : value;
               },
               focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4823,7 +4823,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
                 return oldValue.text != newValue.text || oldValue.composing != newValue.composing;
               },
-              historyModifier: (TextEditingValue value) {
+              undoStackModifier: (TextEditingValue value) {
                 return defaultTargetPlatform == TargetPlatform.android ? value.copyWith(composing: TextRange.empty) : value;
               },
               focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4823,6 +4823,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
                 return oldValue.text != newValue.text || oldValue.composing != newValue.composing;
               },
+              historyModifier: (TextEditingValue value) {
+                return defaultTargetPlatform == TargetPlatform.android ? value.copyWith(composing: TextRange.empty) : value;
+              },
               focusNode: widget.focusNode,
               controller: widget.undoController,
               child: Focus(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4825,10 +4825,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               },
               undoStackModifier: (TextEditingValue value) {
                 // On Android we should discard the composing region when pushing
-                // a new entry to the undo stack. This matches the native
-                // behavior and prevents the TextInputPlugin from resetting the
-                // composing region on every undo/redo when the composing region
-                // is changed by the framework.
+                // a new entry to the undo stack. This prevents the TextInputPlugin
+                // from restarting the input on every undo/redo when the composing
+                // region is changed by the framework.
                 return defaultTargetPlatform == TargetPlatform.android ? value.copyWith(composing: TextRange.empty) : value;
               },
               focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4825,9 +4825,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
               },
               undoStackModifier: (TextEditingValue value) {
                 // On Android we should discard the composing region when pushing
-                // a new entry to the undo stack. This is matches the native
+                // a new entry to the undo stack. This matches the native
                 // behavior and prevents the TextInputPlugin from resetting the
-                // composing region on every undo/redo.
+                // composing region on every undo/redo when the composing region
+                // is changed by the framework.
                 return defaultTargetPlatform == TargetPlatform.android ? value.copyWith(composing: TextRange.empty) : value;
               },
               focusNode: widget.focusNode,

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -32,6 +32,7 @@ class UndoHistory<T> extends StatefulWidget {
     required this.value,
     required this.onTriggered,
     required this.focusNode,
+    this.historyModifier,
     this.controller,
     required this.child,
   });
@@ -42,6 +43,12 @@ class UndoHistory<T> extends StatefulWidget {
   /// Called when checking whether a value change should be pushed onto
   /// the undo stack.
   final bool Function(T? oldValue, T newValue)? shouldChangeUndoStack;
+
+  /// Called right before a history entry is pushed to the undo stack.
+  ///
+  /// The value returned from this method will be pushed to the stack instead
+  /// of the original value.
+  final T Function(T value)? historyModifier;
 
   /// Called when an undo or redo causes a state change.
   ///
@@ -178,9 +185,9 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
       return;
     }
 
-    _lastValue = widget.value.value;
+    _lastValue = widget.historyModifier?.call(widget.value.value) ?? widget.value.value;
 
-    _throttleTimer = _throttledPush(widget.value.value);
+    _throttleTimer = _throttledPush(_lastValue!);
   }
 
   void _handleFocus() {

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -192,7 +192,7 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
       return;
     }
 
-    _lastValue = widget.undoStackModifier?.call(widget.value.value) ?? widget.value.value;
+    _lastValue = nextValue;
 
     _throttleTimer = _throttledPush(nextValue);
   }

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -32,7 +32,7 @@ class UndoHistory<T> extends StatefulWidget {
     required this.value,
     required this.onTriggered,
     required this.focusNode,
-    this.historyModifier,
+    this.undoStackModifier,
     this.controller,
     required this.child,
   });
@@ -44,11 +44,13 @@ class UndoHistory<T> extends StatefulWidget {
   /// the undo stack.
   final bool Function(T? oldValue, T newValue)? shouldChangeUndoStack;
 
-  /// Called right before a history entry is pushed to the undo stack.
+  /// Called right before a new entry is pushed to the undo stack.
   ///
   /// The value returned from this method will be pushed to the stack instead
   /// of the original value.
-  final T Function(T value)? historyModifier;
+  ///
+  /// If null then the original value will always be pushed to the stack.
+  final T Function(T value)? undoStackModifier;
 
   /// Called when an undo or redo causes a state change.
   ///
@@ -185,7 +187,7 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
       return;
     }
 
-    _lastValue = widget.historyModifier?.call(widget.value.value) ?? widget.value.value;
+    _lastValue = widget.undoStackModifier?.call(widget.value.value) ?? widget.value.value;
 
     _throttleTimer = _throttledPush(_lastValue as T);
   }

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -187,7 +187,7 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
 
     _lastValue = widget.historyModifier?.call(widget.value.value) ?? widget.value.value;
 
-    _throttleTimer = _throttledPush(_lastValue!);
+    _throttleTimer = _throttledPush(_lastValue as T);
   }
 
   void _handleFocus() {

--- a/packages/flutter/lib/src/widgets/undo_history.dart
+++ b/packages/flutter/lib/src/widgets/undo_history.dart
@@ -187,9 +187,14 @@ class UndoHistoryState<T> extends State<UndoHistory<T>> with UndoManagerClient {
       return;
     }
 
+    final T nextValue = widget.undoStackModifier?.call(widget.value.value) ?? widget.value.value;
+    if (nextValue == _lastValue) {
+      return;
+    }
+
     _lastValue = widget.undoStackModifier?.call(widget.value.value) ?? widget.value.value;
 
-    _throttleTimer = _throttledPush(_lastValue as T);
+    _throttleTimer = _throttledPush(nextValue);
   }
 
   void _handleFocus() {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13906,7 +13906,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -13916,7 +13915,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -13934,7 +13932,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -13943,7 +13940,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -13969,7 +13965,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -13978,7 +13973,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -14018,7 +14012,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -14027,7 +14020,6 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13127,6 +13127,13 @@ void main() {
     Future<void> sendUndo(WidgetTester tester) => sendUndoRedo(tester);
     Future<void> sendRedo(WidgetTester tester) => sendUndoRedo(tester, true);
 
+    TextEditingValue emptyComposingOnAndroid(TextEditingValue value) {
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        return value.copyWith(composing: TextRange.empty);
+      }
+      return value;
+    }
+
     Widget boilerplate() {
       return MaterialApp(
         home: EditableText(
@@ -13330,14 +13337,14 @@ void main() {
 
       // Undo first insertion.
       await sendUndo(tester);
-      expect(controller.value, composingStep2);
+      expect(controller.value, emptyComposingOnAndroid(composingStep2));
 
       // Waiting for the throttling between undos should have no effect.
       await tester.pump(const Duration(milliseconds: 500));
 
       // Undo second insertion.
       await sendUndo(tester);
-      expect(controller.value, composingStep1);
+      expect(controller.value, emptyComposingOnAndroid(composingStep1));
 
     // On web, these keyboard shortcuts are handled by the browser.
     }, variant: TargetPlatformVariant.only(TargetPlatform.android), skip: kIsWeb); // [intended]
@@ -13899,7 +13906,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange(start: 2, end: 7),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -13909,7 +13916,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange(start: 2, end: 4),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -13927,7 +13934,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange(start: 2, end: 4),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -13936,7 +13943,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange(start: 2, end: 7),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -13962,7 +13969,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange(start: 2, end: 7),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -13971,7 +13978,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange(start: 2, end: 4),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -14011,7 +14018,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 ni',
-          composing: TextRange(start: 2, end: 4),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 4),
         ),
       );
@@ -14020,7 +14027,7 @@ void main() {
         controller.value,
         const TextEditingValue(
           text: '1 nihao',
-          composing: TextRange(start: 2, end: 7),
+          composing: TextRange.empty,
           selection: TextSelection.collapsed(offset: 7),
         ),
       );
@@ -14138,10 +14145,12 @@ void main() {
         case TargetPlatform.android:
           expect(
             controller.value,
-            const TextEditingValue(
-              text: '1 2 ni',
-              composing: TextRange(start: 4, end: 6),
-              selection: TextSelection.collapsed(offset: 6),
+            emptyComposingOnAndroid(
+              const TextEditingValue(
+                text: '1 2 ni',
+                composing: TextRange(start: 4, end: 6),
+                selection: TextSelection.collapsed(offset: 6),
+              ),
             ),
           );
         // Composing changes are ignored on all other platforms.
@@ -14195,10 +14204,12 @@ void main() {
         case TargetPlatform.android:
           expect(
             controller.value,
-            const TextEditingValue(
-              text: '1 2 ni',
-              composing: TextRange(start: 4, end: 6),
-              selection: TextSelection.collapsed(offset: 6),
+            emptyComposingOnAndroid(
+              const TextEditingValue(
+                text: '1 2 ni',
+                composing: TextRange(start: 4, end: 6),
+                selection: TextSelection.collapsed(offset: 6),
+              ),
             ),
           );
         // Composing changes are ignored on all other platforms.


### PR DESCRIPTION
This change adds a feature to `UndoHistory` that allows the user to modify the value being pushed onto the undo stack.

This is used by the framework to ignore the composing region when pushing history entries to the Undo stack on Android. This is so an undo does not trigger an input connection restart by the Android TextInputPlugin, which occurs when the framework changes the composing region. This is also the native platform behavior observed in Google Keep app on Android, where doing an undo during composing reverts to the previous state but with composing inactive and a subsequent redo does not bring back the composing region.

Fixes #130881
Partial fix for #134398

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.