### PR TITLE
Fix turbulence seed for all tests with ink sparkles

### DIFF
--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -202,7 +202,7 @@ class InkSparkle extends InteractiveInkFeature {
     // Creates an element of randomness so that ink emanating from the same
     // pixel have slightly different rings and sparkles.
     assert((){
-      // In tests builds, randomness can cause flakes. So if a seed has not
+      // In tests, randomness can cause flakes. So if a seed has not
       // already been specified (i.e. for the purpose of the test), set it to
       // the constant turbulence seed.
       turbulenceSeed ??= _InkSparkleFactory.constantSeed;

--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -202,7 +202,7 @@ class InkSparkle extends InteractiveInkFeature {
     // Creates an element of randomness so that ink emanating from the same
     // pixel have slightly different rings and sparkles.
     assert((){
-      // In debug builds, randomness can cause flakes. So if a seed has not
+      // In tests builds, randomness can cause flakes. So if a seed has not
       // already been specified (i.e. for the purpose of the test), set it to
       // the constant turbulence seed.
       turbulenceSeed ??= _InkSparkleFactory.constantSeed;

--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -201,6 +201,13 @@ class InkSparkle extends InteractiveInkFeature {
 
     // Creates an element of randomness so that ink emanating from the same
     // pixel have slightly different rings and sparkles.
+    assert((){
+      // In debug builds, randomness can cause flakes. So if a seed has not
+      // already been specified (i.e. for the purpose of the test), set it to
+      // the constant turbulence seed.
+      turbulenceSeed ??= _InkSparkleFactory.constantSeed;
+      return true;
+    }());
     _turbulenceSeed = turbulenceSeed ?? math.Random().nextDouble() * 1000.0;
   }
 
@@ -429,7 +436,9 @@ class InkSparkle extends InteractiveInkFeature {
 class _InkSparkleFactory extends InteractiveInkFeatureFactory {
   const _InkSparkleFactory() : turbulenceSeed = null;
 
-  const _InkSparkleFactory.constantTurbulenceSeed() : turbulenceSeed = 1337.0;
+  const _InkSparkleFactory.constantTurbulenceSeed() : turbulenceSeed = _InkSparkleFactory.constantSeed;
+
+  static const double constantSeed = 1337.0;
 
   static void initializeShader() {
     if (!_initCalled) {

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -140,7 +140,7 @@ Future<void> _runTest(WidgetTester tester, String positionName, double distanceF
           key: repaintKey,
           child: ElevatedButton(
             key: buttonKey,
-            style: ElevatedButton.styleFrom(splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory),
+            style: ElevatedButton.styleFrom(),
             child: const Text('Sparkle!'),
             onPressed: () { },
           ),

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -140,7 +140,7 @@ Future<void> _runTest(WidgetTester tester, String positionName, double distanceF
           key: repaintKey,
           child: ElevatedButton(
             key: buttonKey,
-            style: ElevatedButton.styleFrom(),
+            style: ElevatedButton.styleFrom(splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory),
             child: const Text('Sparkle!'),
             onPressed: () { },
           ),
@@ -179,7 +179,7 @@ Future<void> _runM3Test(WidgetTester tester, String positionName, double distanc
           key: repaintKey,
           child: ElevatedButton(
             key: buttonKey,
-            style: ElevatedButton.styleFrom(splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory),
+            style: ElevatedButton.styleFrom(),
             child: const Text('Sparkle!'),
             onPressed: () { },
           ),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138753

This makes sure that InkSparkles are always fixed for testing rather than random.  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
