### PR TITLE
Implement Specific Fixes for Multi-Touch Scrolling Across Platforms

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -538,13 +538,19 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     Offset? localPosition,
   }) {
     if (onUpdate != null) {
+      // Calculate the average motion
+      final int numPointers = _velocityTrackers.length;
+      final Offset averageDelta = delta / numPointers.toDouble();
+
+      // Use the average delta in the details
       final DragUpdateDetails details = DragUpdateDetails(
         sourceTimeStamp: sourceTimeStamp,
-        delta: delta,
-        primaryDelta: primaryDelta,
+        delta: averageDelta,
+        primaryDelta: _getPrimaryValueFromOffset(averageDelta),
         globalPosition: globalPosition,
         localPosition: localPosition,
       );
+
       invokeCallback<void>('onUpdate', () => onUpdate!(details));
     }
   }

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -48,6 +48,72 @@ enum DragStartBehavior {
   start,
 }
 
+/// Configuration of drag behavior on multitouch devices.
+/// This only takes effect when receiving input from multiple pointers simultaneously.
+enum MultiTouchDragBehavior {
+  /// This will choose the best behavior based on the platform.
+  ///
+  /// On iOS, this will use [MultiTouchDragBehavior.average].
+  /// On Android, this will use [MultiTouchDragBehavior.last].
+  ///
+  /// Other platforms will use [MultiTouchDragBehavior.average].
+  ///
+  /// This is the default behavior.
+  platformDefault,
+
+  /// Each pointer's delta is averaged out, so the effective point tracked by the
+  /// recognizer is the centerpoint of all active pointers.
+  ///
+  /// E.g. if two pointers are pressed, with the first moving +10 pixels and the
+  /// second moving -10 pixels, the recognizer will report a delta of 0.
+  ///
+  /// But if two pointers are pressed, with the first moving +10 pixels and the
+  /// second moving +10 pixels, the recognizer will report a delta of +10.
+  ///
+  /// Furthermore, if two pointers are pressed, with the first moving +10 pixels
+  /// and the second moving +20 pixels, the recognizer will report a delta of +15.
+  ///
+  /// This matches the behavior of iOS, iPadOS, macOS, and other Apple platforms.
+  average,
+
+  /// The recognizer only tracks the first pointer that was added, ignoring
+  /// all other pointers until that first pointer is released.
+  ///
+  /// Upon release, the earliest of the remaining active pointers will continue
+  /// to be tracked.
+  ///
+  /// E.g. if two pointers are pressed, with the first moving +10 pixels and the
+  /// second moving -10 pixels, the recognizer will report a delta of +10.
+  ///
+  /// This is not used by iOS or Android, but is included for completeness.
+  first,
+
+  /// The recognizer only tracks the last pointer that was added, ignoring
+  /// all other pointers until that last pointer is released.
+  ///
+  /// Upon release, the latest of the remaining active pointers will continue to
+  /// be tracked.
+  ///
+  /// E.g. if two pointers are pressed, with the first moving +10 pixels and the
+  /// second moving -10 pixels, the recognizer will report a delta of -10.
+  ///
+  /// This matches Android's behavior.
+  last,
+
+  /// The recognizer sums the deltas of all active pointers, so the effective
+  /// point tracked by the recognizer is the sum of all active pointers.
+  ///
+  /// E.g. if two pointers are pressed, with the first moving +10 pixels and the
+  /// second moving -10 pixels, the recognizer will report a delta of 0.
+  ///
+  /// But if two pointers are pressed, with the first moving +10 pixels and the
+  /// second moving +10 pixels, the recognizer will report a delta of +20.
+  ///
+  /// This is the legacy behavior of Flutter's gesture system.
+  sum,
+}
+
+
 /// Signature for `allowedButtonsFilter` in [GestureRecognizer].
 /// Used to filter the input buttons of incoming pointer events.
 /// The parameter `buttons` comes from [PointerEvent.buttons].

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -62,7 +62,8 @@ enum MultiTouchDragBehavior {
   platformDefault,
 
   /// Each pointer's delta is averaged out, so the effective point tracked by the
-  /// recognizer is the centerpoint of all active pointers.
+  /// recognizer is the centerpoint of all active pointers, where each pointer's
+  /// estimated motion is above the [kMinFlingVelocity] threshold.
   ///
   /// E.g. if two pointers are pressed, with the first moving +10 pixels and the
   /// second moving -10 pixels, the recognizer will report a delta of 0.
@@ -72,6 +73,10 @@ enum MultiTouchDragBehavior {
   ///
   /// Furthermore, if two pointers are pressed, with the first moving +10 pixels
   /// and the second moving +20 pixels, the recognizer will report a delta of +15.
+  ///
+  /// Finally, if two pointers are pressed, with the first moving +10 pixels and
+  /// the second with negligible motion (below [kMinFlingVelocity]), the recognizer
+  /// will report a delta of +10.
   ///
   /// This matches the behavior of iOS, iPadOS, macOS, and other Apple platforms.
   average,

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -77,6 +77,7 @@ class ScrollBehavior {
     bool? scrollbars,
     bool? overscroll,
     Set<PointerDeviceKind>? dragDevices,
+    MultiTouchDragBehavior? multiTouchDragBehavior,
     Set<LogicalKeyboardKey>? pointerAxisModifiers,
     ScrollPhysics? physics,
     TargetPlatform? platform,
@@ -86,6 +87,7 @@ class ScrollBehavior {
       scrollbars: scrollbars ?? true,
       overscroll: overscroll ?? true,
       dragDevices: dragDevices,
+      multiTouchDragBehavior: multiTouchDragBehavior,
       pointerAxisModifiers: pointerAxisModifiers,
       physics: physics,
       platform: platform,
@@ -104,6 +106,14 @@ class ScrollBehavior {
   /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
   /// impossible to select text in scrollable containers and is not recommended.
   Set<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
+
+  /// {@macro flutter.gestures.monodrag.DragGestureRecognizer.multiTouchDragBehavior}
+  ///
+  /// Defaults to [MultiTouchDragBehavior.platformDefault], which is
+  /// [MultiTouchDragBehavior.last] on Android, and [MultiTouchDragBehavior.average]
+  /// elsewhere.
+  ///
+  MultiTouchDragBehavior get multiTouchDragBehavior => MultiTouchDragBehavior.platformDefault;
 
   /// A set of [LogicalKeyboardKey]s that, when any or all are pressed in
   /// combination with a [PointerDeviceKind.mouse] pointer scroll event, will
@@ -245,10 +255,12 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.scrollbars = true,
     this.overscroll = true,
     Set<PointerDeviceKind>? dragDevices,
+    MultiTouchDragBehavior? multiTouchDragBehavior,
     Set<LogicalKeyboardKey>? pointerAxisModifiers,
     this.physics,
     this.platform,
   }) : _dragDevices = dragDevices,
+        _multiTouchDragBehavior = multiTouchDragBehavior,
        _pointerAxisModifiers = pointerAxisModifiers;
 
   final ScrollBehavior delegate;
@@ -257,10 +269,14 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
   final Set<PointerDeviceKind>? _dragDevices;
+  final MultiTouchDragBehavior? _multiTouchDragBehavior;
   final Set<LogicalKeyboardKey>? _pointerAxisModifiers;
 
   @override
   Set<PointerDeviceKind> get dragDevices => _dragDevices ?? delegate.dragDevices;
+
+  @override
+  MultiTouchDragBehavior get multiTouchDragBehavior => _multiTouchDragBehavior ?? delegate.multiTouchDragBehavior;
 
   @override
   Set<LogicalKeyboardKey> get pointerAxisModifiers => _pointerAxisModifiers ?? delegate.pointerAxisModifiers;
@@ -286,6 +302,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     bool? scrollbars,
     bool? overscroll,
     Set<PointerDeviceKind>? dragDevices,
+    MultiTouchDragBehavior? multiTouchDragBehavior,
     Set<LogicalKeyboardKey>? pointerAxisModifiers,
     ScrollPhysics? physics,
     TargetPlatform? platform,

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -762,6 +762,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
                   ..dragStartBehavior = widget.dragStartBehavior
+                  ..multiTouchDragBehavior = _configuration.multiTouchDragBehavior
                   ..gestureSettings = _mediaQueryGestureSettings
                   ..supportedDevices = _configuration.dragDevices;
               },
@@ -783,6 +784,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
                   ..dragStartBehavior = widget.dragStartBehavior
+                  ..multiTouchDragBehavior = _configuration.multiTouchDragBehavior
                   ..gestureSettings = _mediaQueryGestureSettings
                   ..supportedDevices = _configuration.dragDevices;
               },


### PR DESCRIPTION
Currently, when scrolling in Flutter with multiple fingers, the target platform's conventions are not respected. See #11884 and its discussion for an overview of the situation, as well as #38926 for further details.

This PR implements a solution as discussed [here](https://github.com/flutter/flutter/issues/11884#issuecomment-1813084591) and [here](https://github.com/flutter/flutter/issues/11884#issuecomment-1819814066).

In short, it adds a new enum `MultiTouchDragBehavior` which allows customization of the way multiple finger inputs are treated during scrolling.

It includes `.average`, which implements iOS-style behavior, `.last` for Android-style behavior, `.sum` for legacy behavior, as well as a `.first` in case anyone _really_ wants theirs to behave that way for some reason. It also includes a special `.platformDefault`, which lets Flutter decide which behavior is appropriate for the current platform.

Most of the modifications are in `monodrag.dart`.

Finally, this solution includes @xu-baolin's work on #136708 to support Android-style last-touch scroll behavior, albeit with slight modifications to play nice with more scrolling behaviors, such as the iOS-style `.average`, which is where most of my own effort here went.

Fixes #11884.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
