### PR TITLE
Textformfield controller

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -30,10 +30,10 @@ class _MainWidget extends StatelessWidget {
       ),
       body: ListView(
         children: <Widget>[
-          const TextField(
-            key: Key('enabled text field'),
+          TextField(
+            key: const Key('enabled text field'),
             autofocus: true,
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               labelText: 'Email',
               suffixText: '@gmail.com',
               hintText: 'Enter your email',

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -29,19 +29,19 @@ class _MainWidget extends StatelessWidget {
         title: const Text('TextField password'),
       ),
       body: ListView(
-        children: const <Widget>[
+        children: <Widget>[
           TextField(
-            key: Key('enabled password'),
+            key: const Key('enabled password'),
             autofocus: true,
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               labelText: 'Password',
               hintText: 'Enter your password',
             ),
             obscureText: true,
           ),
           TextField(
-            key: Key('disabled password'),
-            decoration: InputDecoration(
+            key: const Key('disabled password'),
+            decoration: const InputDecoration(
               labelText: 'Password',
               hintText: 'Enter your password',
             ),

--- a/dev/benchmarks/macrobenchmarks/lib/src/text.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/text.dart
@@ -9,7 +9,7 @@ class TextPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Material(
+    return Material(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
@@ -17,7 +17,7 @@ class TextPage extends StatelessWidget {
             width: 200,
             height: 100,
             child: TextField(
-              key: Key('basic-textfield'),
+              key: const Key('basic-textfield'),
             ),
           ),
         ],

--- a/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
@@ -341,15 +341,15 @@ class _CreateCompanySheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Column(
+    return Column(
       children: <Widget>[
         TextField(
           autofocus: true,
-          decoration: InputDecoration(
+          decoration: const InputDecoration(
             hintText: 'Company Name',
           ),
         ),
-        Text('(This demo is not yet complete.)'),
+        const Text('(This demo is not yet complete.)'),
         // For example, we could add a button that actually updates the list
         // and then contacts the server, etc.
       ],

--- a/dev/integration_tests/ui/lib/driver.dart
+++ b/dev/integration_tests/ui/lib/driver.dart
@@ -81,8 +81,8 @@ class DriverTestAppState extends State<DriverTestApp> {
                 ),
               ],
             ),
-            const TextField(
-              key: ValueKey<String>('enter-text-field'),
+            TextField(
+              key: const ValueKey<String>('enter-text-field'),
             ),
           ],
         ),

--- a/dev/integration_tests/ui/lib/keyboard_textfield.dart
+++ b/dev/integration_tests/ui/lib/keyboard_textfield.dart
@@ -74,8 +74,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 Container(
                   height: MediaQuery.of(context).size.height,
                 ),
-                const TextField(
-                  key: ValueKey<String>(keys.kDefaultTextField),
+                TextField(
+                  key: const ValueKey<String>(keys.kDefaultTextField),
                 ),
               ],
             ),

--- a/dev/integration_tests/web_e2e_tests/lib/text_editing_main.dart
+++ b/dev/integration_tests/web_e2e_tests/lib/text_editing_main.dart
@@ -90,6 +90,19 @@ class _MyHomePageState extends State<MyHomePage> {
                 setState(() => infoText = 'enter pressed');
               },
             ),
+            TextFormField(
+              key: const Key('input3'),
+              enabled: true,
+							initialValue: 'Text3',
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(10.0),
+                labelText: 'Text Input Field 2:',
+              ),
+              onFieldSubmitted: (String str) {
+                print('event received');
+                setState(() => infoText = 'enter pressed');
+              },
+            ),
             Text(
               infoText,
               key: const Key('text'),

--- a/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
@@ -34,7 +34,7 @@ void main() {
 
     // Change the value of the TextFormField.
     final TextFormField textFormField = tester.widget(finder);
-    textFormField.controller?.text = 'New Value';
+    textFormField.controller.text = 'New Value';
     // DOM element's value also changes.
     expect(input.value, 'New Value');
   }, semanticsEnabled: false);
@@ -58,7 +58,7 @@ void main() {
 
     // Change the value of the TextFormField.
     final TextFormField textFormField = tester.widget(finder);
-    textFormField.controller?.text = 'New Value';
+    textFormField.controller.text = 'New Value';
     // DOM element's value also changes.
     expect(input.value, 'New Value');
   }, semanticsEnabled: false);
@@ -82,7 +82,7 @@ void main() {
 
     // Change the value of the TextFormField.
     final TextFormField textFormField = tester.widget(finder);
-    textFormField.controller?.text = 'New Value';
+    textFormField.controller.text = 'New Value';
     // DOM element's value also changes.
     expect(input.value, 'New Value');
   }, semanticsEnabled: false);

--- a/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
@@ -63,6 +63,30 @@ void main() {
     expect(input.value, 'New Value');
   }, semanticsEnabled: false);
 
+  testWidgets('Input field with no controller but has initial value works',
+      (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // Focus on a TextFormField.
+    final Finder finder = find.byKey(const Key('input3'));
+    expect(finder, findsOneWidget);
+    await tester.tap(find.byKey(const Key('input3')));
+
+    // A native input element will be appended to the DOM.
+    final List<Node> nodeList = findElements('input');
+    expect(nodeList.length, equals(1));
+    final InputElement input = nodeList[0] as InputElement;
+    // The element's value will be the same as the textFormField's value.
+    expect(input.value, 'Text3');
+
+    // Change the value of the TextFormField.
+    final TextFormField textFormField = tester.widget(finder);
+    textFormField.controller?.text = 'New Value';
+    // DOM element's value also changes.
+    expect(input.value, 'New Value');
+  }, semanticsEnabled: false);
+
   testWidgets('Pressing enter on the text field triggers submit',
       (WidgetTester tester) async {
     app.main();

--- a/dev/manual_tests/lib/focus.dart
+++ b/dev/manual_tests/lib/focus.dart
@@ -181,16 +181,16 @@ class _FocusDemoState extends State<FocusDemo> {
                       ],
                     ),
                     OutlinedButton(onPressed: () => print('pressed'), child: const Text('PRESS ME')),
-                    const Padding(
-                      padding: EdgeInsets.all(8.0),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
                       child: TextField(
-                        decoration: InputDecoration(labelText: 'Enter Text', filled: true),
+                        decoration: const InputDecoration(labelText: 'Enter Text', filled: true),
                       ),
                     ),
-                    const Padding(
-                      padding: EdgeInsets.all(8.0),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
                       child: TextField(
-                        decoration: InputDecoration(
+                        decoration: const InputDecoration(
                           border: OutlineInputBorder(),
                           labelText: 'Enter Text',
                           filled: false,

--- a/dev/manual_tests/lib/hover.dart
+++ b/dev/manual_tests/lib/hover.dart
@@ -62,16 +62,16 @@ class _HoverDemoState extends State<HoverDemo> {
                     ),
                   ],
                 ),
-                const Padding(
-                  padding: EdgeInsets.all(8.0),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
                   child: TextField(
-                    decoration: InputDecoration(labelText: 'Enter Text', filled: true),
+                    decoration: const InputDecoration(labelText: 'Enter Text', filled: true),
                   ),
                 ),
-                const Padding(
-                  padding: EdgeInsets.all(8.0),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
                   child: TextField(
-                    decoration: InputDecoration(
+                    decoration: const InputDecoration(
                       border: OutlineInputBorder(),
                       labelText: 'Enter Text',
                       filled: false,

--- a/examples/api/lib/material/input_decorator/input_decoration.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.0.dart
@@ -28,7 +28,7 @@ class InputDecorationExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
+    return TextField(
       decoration: InputDecoration(
         icon: Icon(Icons.send),
         hintText: 'Hint Text',

--- a/examples/api/lib/material/input_decorator/input_decoration.1.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.1.dart
@@ -28,7 +28,7 @@ class InputDecorationExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
+    return TextField(
       decoration: InputDecoration.collapsed(
         hintText: 'Hint Text',
         border: OutlineInputBorder(),

--- a/examples/api/lib/material/input_decorator/input_decoration.2.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.2.dart
@@ -28,8 +28,8 @@ class InputDecorationExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
-      decoration: InputDecoration(
+    return TextField(
+      decoration: const InputDecoration(
         hintText: 'Hint Text',
         errorText: 'Error Text',
         border: OutlineInputBorder(),

--- a/examples/api/lib/material/input_decorator/input_decoration.label.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.label.0.dart
@@ -28,9 +28,9 @@ class LabelExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: TextField(
-        decoration: InputDecoration(
+        decoration: const InputDecoration(
           label: Text.rich(
             TextSpan(
               children: <InlineSpan>[

--- a/examples/api/lib/material/input_decorator/input_decoration.prefix_icon.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.prefix_icon.0.dart
@@ -25,7 +25,7 @@ class InputDecoratorExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
+    return TextField(
       decoration: InputDecoration(
         border: OutlineInputBorder(),
         labelText: 'Enter name',

--- a/examples/api/lib/material/input_decorator/input_decoration.prefix_icon_constraints.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.prefix_icon_constraints.0.dart
@@ -28,20 +28,20 @@ class PrefixIconConstraintsExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.symmetric(horizontal: 8.0),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           TextField(
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               hintText: 'Normal Icon Constraints',
               prefixIcon: Icon(Icons.search),
             ),
           ),
-          SizedBox(height: 10),
+          const SizedBox(height: 10),
           TextField(
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               isDense: true,
               hintText: 'Smaller Icon Constraints',
               prefixIcon: Icon(Icons.search),

--- a/examples/api/lib/material/input_decorator/input_decoration.suffix_icon.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.suffix_icon.0.dart
@@ -25,7 +25,7 @@ class InputDecoratorExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
+    return TextField(
       decoration: InputDecoration(
         border: OutlineInputBorder(),
         labelText: 'Enter password',

--- a/examples/api/lib/material/input_decorator/input_decoration.suffix_icon_constraints.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.suffix_icon_constraints.0.dart
@@ -28,20 +28,20 @@ class SuffixIconConstraintsExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.symmetric(horizontal: 8.0),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           TextField(
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               hintText: 'Normal Icon Constraints',
               suffixIcon: Icon(Icons.search),
             ),
           ),
-          SizedBox(height: 10),
+          const SizedBox(height: 10),
           TextField(
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               isDense: true,
               hintText: 'Smaller Icon Constraints',
               suffixIcon: Icon(Icons.search),

--- a/examples/api/lib/material/text_field/text_field.0.dart
+++ b/examples/api/lib/material/text_field/text_field.0.dart
@@ -11,11 +11,11 @@ class ObscuredTextFieldSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox(
+    return SizedBox(
       width: 250,
       child: TextField(
         obscureText: true,
-        decoration: InputDecoration(
+        decoration: const InputDecoration(
           border: OutlineInputBorder(),
           labelText: 'Password',
         ),

--- a/examples/api/lib/material/text_field/text_field.2.dart
+++ b/examples/api/lib/material/text_field/text_field.2.dart
@@ -41,7 +41,7 @@ class FilledTextFieldExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
+    return TextField(
       decoration: InputDecoration(
         prefixIcon: Icon(Icons.search),
         suffixIcon: Icon(Icons.clear),
@@ -63,7 +63,7 @@ class OutlinedTextFieldExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const TextField(
+    return TextField(
       decoration: InputDecoration(
         prefixIcon: Icon(Icons.search),
         suffixIcon: Icon(Icons.clear),

--- a/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
@@ -39,12 +39,12 @@ class _UnfocusExampleState extends State<UnfocusExample> {
           children: <Widget>[
             Wrap(
               children: List<Widget>.generate(4, (int index) {
-                return const SizedBox(
+                return SizedBox(
                   width: 200,
                   child: Padding(
-                    padding: EdgeInsets.all(8.0),
+                    padding: const EdgeInsets.all(8.0),
                     child: TextField(
-                      decoration: InputDecoration(border: OutlineInputBorder()),
+                      decoration: const InputDecoration(border: OutlineInputBorder()),
                     ),
                   ),
                 );

--- a/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
+++ b/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
@@ -56,12 +56,12 @@ class FallbackDemoState extends State<FallbackDemo> {
             const Text('This area handles key presses that are unhandled by any shortcuts, by '
                 'displaying them below. Try text shortcuts such as Ctrl-A!'),
             Text(_capture == null ? '' : '$_capture is not handled by shortcuts.'),
-            const TextField(decoration: InputDecoration(label: Text('Text field 1'))),
+            TextField(decoration: InputDecoration(label: Text('Text field 1'))),
             Shortcuts(
               shortcuts: <ShortcutActivator, Intent>{
                 const SingleActivator(LogicalKeyboardKey.keyQ): VoidCallbackIntent(() {}),
               },
-              child: const TextField(
+              child: TextField(
                 decoration: InputDecoration(
                   label: Text('This field also considers key Q as a shortcut (that does nothing).'),
                 ),

--- a/examples/api/test/widgets/tap_region/text_field_tap_region.0_test.dart
+++ b/examples/api/test/widgets/tap_region/text_field_tap_region.0_test.dart
@@ -96,5 +96,5 @@ void main() {
 }
 
 TextEditingValue getFieldValue(WidgetTester tester) {
-  return (tester.widget(find.byType(TextField)) as TextField).controller!.value;
+  return (tester.widget(find.byType(TextField)) as TextField).controller.value;
 }

--- a/examples/api/test/widgets/text_magnifier/text_magnifier.0_test.dart
+++ b/examples/api/test/widgets/text_magnifier/text_magnifier.0_test.dart
@@ -61,7 +61,7 @@ void main() {
 
     final TextSelection selection = tester
         .firstWidget<TextField>(find.byType(TextField))
-        .controller!
+        .controller
         .selection;
 
     final RenderEditable renderEditable = _findRenderEditable(tester);

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -200,7 +200,7 @@ class TextFormField extends FormField<String> {
              bucket: field.bucket,
              child: TextField(
                restorationId: restorationId,
-               controller: state._effectiveController,
+               controller: state._controller,
                focusNode: focusNode,
                decoration: effectiveDecoration.copyWith(errorText: field.errorText),
                keyboardType: keyboardType,
@@ -272,7 +272,7 @@ class TextFormField extends FormField<String> {
   ///
   /// If null, this widget will create its own [TextEditingController] and
   /// initialize its [TextEditingController.text] with [initialValue].
-  late final TextEditingController? controller;
+  late final TextEditingController controller;
 
   /// {@template flutter.material.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's
@@ -291,74 +291,38 @@ class TextFormField extends FormField<String> {
 }
 
 class _TextFormFieldState extends FormFieldState<String> {
-  RestorableTextEditingController? _controller;
-
-  TextEditingController get _effectiveController => _textFormField.controller ?? _controller!.value;
+  TextEditingController get _controller => _textFormField.controller ;
 
   TextFormField get _textFormField => super.widget as TextFormField;
 
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
     super.restoreState(oldBucket, initialRestore);
-    if (_controller != null) {
-      _registerController();
-    }
     // Make sure to update the internal [FormFieldState] value to sync up with
     // text editing controller value.
-    setValue(_effectiveController.text);
-  }
-
-  void _registerController() {
-    assert(_controller != null);
-    registerForRestoration(_controller!, 'controller');
-  }
-
-  void _createLocalController([TextEditingValue? value]) {
-    assert(_controller == null);
-    _controller = value == null
-        ? RestorableTextEditingController()
-        : RestorableTextEditingController.fromValue(value);
-    if (!restorePending) {
-      _registerController();
-    }
+    setValue(_controller.text);
   }
 
   @override
   void initState() {
     super.initState();
-    if (_textFormField.controller == null) {
-      _createLocalController(widget.initialValue != null ? TextEditingValue(text: widget.initialValue!) : null);
-    } else {
-      _textFormField.controller!.addListener(_handleControllerChanged);
-    }
+      _textFormField.controller.addListener(_handleControllerChanged);
   }
 
   @override
   void didUpdateWidget(TextFormField oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (_textFormField.controller != oldWidget.controller) {
-      oldWidget.controller?.removeListener(_handleControllerChanged);
-      _textFormField.controller?.addListener(_handleControllerChanged);
+      oldWidget.controller.removeListener(_handleControllerChanged);
+      _textFormField.controller.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && _textFormField.controller == null) {
-        _createLocalController(oldWidget.controller!.value);
-      }
-
-      if (_textFormField.controller != null) {
-        setValue(_textFormField.controller!.text);
-        if (oldWidget.controller == null) {
-          unregisterFromRestoration(_controller!);
-          _controller!.dispose();
-          _controller = null;
-        }
-      }
+			setValue(_textFormField.controller.text);
     }
   }
 
   @override
   void dispose() {
-    _textFormField.controller?.removeListener(_handleControllerChanged);
-    _controller?.dispose();
+    _textFormField.controller.removeListener(_handleControllerChanged);
     super.dispose();
   }
 
@@ -366,8 +330,8 @@ class _TextFormFieldState extends FormFieldState<String> {
   void didChange(String? value) {
     super.didChange(value);
 
-    if (_effectiveController.text != value) {
-      _effectiveController.text = value ?? '';
+    if (_controller.text != value) {
+      _controller.text = value ?? '';
     }
   }
 
@@ -375,9 +339,9 @@ class _TextFormFieldState extends FormFieldState<String> {
   void reset() {
     // Set the controller value before calling super.reset() to let
     // _handleControllerChanged suppress the change.
-    _effectiveController.text = widget.initialValue ?? '';
+    _controller.text = widget.initialValue ?? '';
     super.reset();
-    _textFormField.onChanged?.call(_effectiveController.text);
+    _textFormField.onChanged?.call(_controller.text);
   }
 
   void _handleControllerChanged() {
@@ -388,8 +352,8 @@ class _TextFormFieldState extends FormFieldState<String> {
     // notifications for changes originating from within this class -- for
     // example, the reset() method. In such cases, the FormField value will
     // already have been set.
-    if (_effectiveController.text != value) {
-      didChange(_effectiveController.text);
+    if (_controller.text != value) {
+      didChange(_controller.text);
     }
   }
 }

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -100,7 +100,7 @@ class TextFormField extends FormField<String> {
   /// and [TextField.new], the constructor.
   TextFormField({
     super.key,
-    this.controller,
+    TextEditingController? controller,
     String? initialValue,
     FocusNode? focusNode,
     InputDecoration? decoration = const InputDecoration(),
@@ -264,13 +264,15 @@ class TextFormField extends FormField<String> {
              ),
            );
          },
-       );
+       ) {
+				this.controller = controller ?? TextEditingController(text: initialValue);
+			 }
 
   /// Controls the text being edited.
   ///
   /// If null, this widget will create its own [TextEditingController] and
   /// initialize its [TextEditingController.text] with [initialValue].
-  final TextEditingController? controller;
+  late final TextEditingController? controller;
 
   /// {@template flutter.material.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's

--- a/packages/flutter/lib/src/painting/inline_span.dart
+++ b/packages/flutter/lib/src/painting/inline_span.dart
@@ -175,7 +175,7 @@ List<InlineSpanSemanticsInformation> combineSemanticsInfo(List<InlineSpanSemanti
 ///         baseline: TextBaseline.alphabetic,
 ///         child: ConstrainedBox(
 ///           constraints: const BoxConstraints(maxWidth: 100),
-///           child: const TextField(),
+///           child: TextField(),
 ///         )
 ///       ),
 ///       const TextSpan(

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -128,7 +128,7 @@ import 'text_editing_intents.dart';
 ///                     },
 ///                   ),
 ///                 },
-///                 child: const TextField(
+///                 child: TextField(
 ///                   maxLines: 2,
 ///                   decoration: InputDecoration(
 ///                     hintText: 'Up/down increment/decrement here.',
@@ -136,7 +136,7 @@ import 'text_editing_intents.dart';
 ///                 ),
 ///               ),
 ///             ),
-///             const TextField(
+///             TextField(
 ///               maxLines: 2,
 ///               decoration: InputDecoration(
 ///                 hintText: 'Up/down behave normally here.',

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1123,26 +1123,26 @@ class EditableText extends StatefulWidget {
   ///
   /// Input that occupies a single line and scrolls horizontally as needed.
   /// ```dart
-  /// const TextField()
+  /// TextField()
   /// ```
   ///
   /// Input whose height grows from one line up to as many lines as needed for
   /// the text that was entered. If a height limit is imposed by its parent, it
   /// will scroll vertically when its height reaches that limit.
   /// ```dart
-  /// const TextField(maxLines: null)
+  /// TextField(maxLines: null)
   /// ```
   ///
   /// The input's height is large enough for the given number of lines. If
   /// additional lines are entered the input scrolls vertically.
   /// ```dart
-  /// const TextField(maxLines: 2)
+  /// TextField(maxLines: 2)
   /// ```
   ///
   /// Input whose height grows with content between a min and max. An infinite
   /// max is possible with `maxLines: null`.
   /// ```dart
-  /// const TextField(minLines: 2, maxLines: 4)
+  /// TextField(minLines: 2, maxLines: 4)
   /// ```
   ///
   /// See also:
@@ -1186,7 +1186,7 @@ class EditableText extends StatefulWidget {
   /// point the height limit is reached. If additional lines are entered it will
   /// scroll vertically.
   /// ```dart
-  /// const TextField(minLines:2, maxLines: 4)
+  /// TextField(minLines:2, maxLines: 4)
   /// ```
   ///
   /// Defaults to null.

--- a/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/material/tab_scaffold_test.dart
@@ -249,7 +249,7 @@ void main() {
             child: CupertinoTabScaffold(
               tabBar: _buildTabBar(),
               tabBuilder: (BuildContext context, int index) {
-                return const TextField();
+                return TextField();
               },
             ),
           ),
@@ -271,7 +271,7 @@ void main() {
             child: CupertinoTabScaffold(
               tabBar: _buildTabBar(),
               tabBuilder: (BuildContext context, int index) {
-                return const TextField();
+                return TextField();
               },
             ),
           ),

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -92,7 +92,7 @@ void main() {
     expect(find.byType(TextFormField), findsOneWidget);
     expect(find.byType(ListView), findsNothing);
     final TextFormField field = find.byType(TextFormField).evaluate().first.widget as TextFormField;
-    expect(field.controller!.text, 'chameleon');
+    expect(field.controller.text, 'chameleon');
     expect(lastSelection, 'chameleon');
 
     // Modify the field text. The options appear again and are filtered.
@@ -148,7 +148,7 @@ void main() {
     expect(find.byType(TextFormField), findsOneWidget);
     expect(find.byType(ListView), findsNothing);
     final TextFormField field = find.byType(TextFormField).evaluate().first.widget as TextFormField;
-    expect(field.controller!.text, 'Alice, alice@example.com');
+    expect(field.controller.text, 'Alice, alice@example.com');
 
     // Modify the field text. The options appear again and are filtered.
     await tester.enterText(find.byType(TextFormField), 'B');
@@ -200,7 +200,7 @@ void main() {
     expect(find.byType(TextFormField), findsOneWidget);
     expect(find.byType(ListView), findsNothing);
     final TextFormField field = find.byType(TextFormField).evaluate().first.widget as TextFormField;
-    expect(field.controller!.text, kOptionsUsers.first.name);
+    expect(field.controller.text, kOptionsUsers.first.name);
   });
 
   testWidgetsWithLeakTracking('can build a custom field', (WidgetTester tester) async {
@@ -314,7 +314,7 @@ void main() {
       final Finder listFinder = find.byType(ListView);
       final Finder inputFinder = find.byType(TextFormField);
       final TextFormField field = inputFinder.evaluate().first.widget as TextFormField;
-      field.controller!.clear();
+      field.controller.clear();
       await tester.tap(inputFinder);
       await tester.enterText(inputFinder, enteredText);
       await tester.pump();
@@ -378,7 +378,7 @@ void main() {
     expect(find.byType(TextFormField), findsOneWidget);
     expect(find.byType(ListView), findsNothing);
     expect(
-      tester.widget<TextFormField>(find.byType(TextFormField)).controller!.text,
+      tester.widget<TextFormField>(find.byType(TextFormField)).controller.text,
       'lem',
     );
 
@@ -397,7 +397,7 @@ void main() {
     expect(find.byType(TextFormField), findsOneWidget);
     expect(find.byType(ListView), findsNothing);
     final TextFormField field = find.byType(TextFormField).evaluate().first.widget as TextFormField;
-    expect(field.controller!.text, 'lemur');
+    expect(field.controller.text, 'lemur');
     expect(lastSelection, 'lemur');
   });
 

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1373,7 +1373,7 @@ void main() {
     testWidgetsWithLeakTracking('Toggle to calendar mode keeps selected date', (WidgetTester tester) async {
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
-        field.controller!.clear();
+        field.controller.clear();
 
         await tester.enterText(find.byType(TextField), '12/25/2016');
         await tester.tap(find.byIcon(Icons.calendar_today));
@@ -1386,7 +1386,7 @@ void main() {
     testWidgetsWithLeakTracking('Entered text returns date', (WidgetTester tester) async {
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
-        field.controller!.clear();
+        field.controller.clear();
 
         await tester.enterText(find.byType(TextField), '12/25/2016');
         await tester.tap(find.text('OK'));
@@ -1398,7 +1398,7 @@ void main() {
       errorFormatText = 'oops';
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
-        field.controller!.clear();
+        field.controller.clear();
 
         await tester.pumpAndSettle();
         await tester.enterText(find.byType(TextField), '1225');
@@ -1414,7 +1414,7 @@ void main() {
       errorFormatText = 'oops';
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
-        field.controller!.clear();
+        field.controller.clear();
 
         await tester.pumpAndSettle();
         await tester.enterText(find.byType(TextField), '20 days, 3 months, 2003');
@@ -1431,7 +1431,7 @@ void main() {
       errorInvalidText = 'oops';
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
-        field.controller!.clear();
+        field.controller.clear();
 
         await tester.pumpAndSettle();
         await tester.enterText(find.byType(TextField), '08/10/1969');
@@ -1447,7 +1447,7 @@ void main() {
       // This is a regression test for https://github.com/flutter/flutter/issues/126397.
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
-        field.controller!.clear();
+        field.controller.clear();
 
         // Enter some text to trigger autovalidate.
         await tester.enterText(find.byType(TextField), 'xyz');
@@ -1458,7 +1458,7 @@ void main() {
         expect(find.text('Invalid format.'), findsOneWidget);
 
         // Clear the text.
-        field.controller!.clear();
+        field.controller.clear();
 
         // Enter an invalid date that is too long while autovalidate is still on.
         await tester.enterText(find.byType(TextField), '10/05/2023666777889');

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -85,7 +85,7 @@ void main() {
   }
 
   TextEditingController textFieldController(WidgetTester tester) {
-    return textField(tester).controller!;
+    return textField(tester).controller;
   }
 
   double textOpacity(WidgetTester tester, String textValue) {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2088,10 +2088,10 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgetsWithLeakTracking('InputDecorator iconColor/prefixIconColor/suffixIconColor', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               icon: Icon(Icons.cabin),
               prefixIcon: Icon(Icons.sailing),
               suffixIcon: Icon(Icons.close),
@@ -5882,13 +5882,13 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
     const Key key = Key('textField');
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Directionality(
             textDirection: TextDirection.ltr,
             child: TextField(
               key: key,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 fillColor: Colors.white,
                 filled: true,
                 border: UnderlineInputBorder(
@@ -6573,14 +6573,14 @@ testWidgetsWithLeakTracking('OutlineInputBorder with BorderRadius.zero should dr
 
   testWidgetsWithLeakTracking('min intrinsic height for TextField with no content padding', (WidgetTester tester) async {
     // Regression test for: https://github.com/flutter/flutter/issues/75509
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: Material(
         child: Center(
           child: IntrinsicHeight(
             child: Column(
               children: <Widget>[
                 TextField(
-                  decoration: InputDecoration(
+                  decoration: const InputDecoration(
                     labelText: 'Label Text',
                     helperText: 'Helper Text',
                     contentPadding: EdgeInsets.zero,

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -40,7 +40,7 @@ void main() {
     final TextField textField = tester.widget<TextField>(find.byType(TextField));
 
     expect(
-      textField.controller!.selection,
+      textField.controller.selection,
       TextSelection(
         baseOffset: delegate.query.length,
         extentOffset: delegate.query.length,
@@ -1101,7 +1101,7 @@ void main() {
 
     final Finder textFieldFinder = find.byType(TextField);
     final TextField textField = tester.widget<TextField>(textFieldFinder);
-    expect(textField.controller!.text.length, 0);
+    expect(textField.controller.text.length, 0);
 
     mockClipboard.handleMethodCall(const MethodCall(
       'Clipboard.setData',
@@ -1117,7 +1117,7 @@ void main() {
 
     await tester.tap(find.text('Paste'));
     await tester.pump();
-    expect(textField.controller!.text.length, 15);
+    expect(textField.controller.text.length, 15);
   }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 }
 

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -104,7 +104,7 @@ void main() {
     expect(tester.testTextInput.isVisible, isFalse);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(
@@ -126,7 +126,7 @@ void main() {
     expect(tester.testTextInput.isVisible, isFalse);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(),
@@ -242,7 +242,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/16880
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(
@@ -514,8 +514,8 @@ void main() {
         home: Material(
           child: ListView(
             children: <Widget>[
-              const TextField(),
-              const TextField(),
+              TextField(),
+              TextField(),
               TextField(
                 focusNode: focusNodeA,
               ),
@@ -572,7 +572,7 @@ class _APage extends Page<void> {
   @override
   Route<void> createRoute(BuildContext context) => PageRouteBuilder<void>(
     settings: this,
-    pageBuilder: (_, __, ___) => const TextField(autofocus: true),
+    pageBuilder: (_, __, ___) => TextField(autofocus: true),
   );
 }
 

--- a/packages/flutter/test/material/text_field_helper_text_test.dart
+++ b/packages/flutter/test/material/text_field_helper_text_test.dart
@@ -8,11 +8,11 @@ import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   testWidgetsWithLeakTracking('TextField works correctly when changing helperText', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: Material(child: TextField(decoration: InputDecoration(helperText: 'Awesome')))));
+    await tester.pumpWidget(MaterialApp(home: Material(child: TextField(decoration: const InputDecoration(helperText: 'Awesome')))));
     expect(find.text('Awesome'), findsNWidgets(1));
     await tester.pump(const Duration(milliseconds: 100));
     expect(find.text('Awesome'), findsNWidgets(1));
-    await tester.pumpWidget(const MaterialApp(home: Material(child: TextField(decoration: InputDecoration(errorText: 'Awesome')))));
+    await tester.pumpWidget(MaterialApp(home: Material(child: TextField(decoration: const InputDecoration(errorText: 'Awesome')))));
     expect(find.text('Awesome'), findsNWidgets(2));
   });
 }

--- a/packages/flutter/test/material/text_field_splash_test.dart
+++ b/packages/flutter/test/material/text_field_splash_test.dart
@@ -144,12 +144,12 @@ void main() {
           child: Material(
             child: ListView(
               children: <Widget>[
-                const TextField(
+                TextField(
                   decoration: InputDecoration(
                     labelText: 'label1',
                   ),
                 ),
-                const TextField(
+                TextField(
                   decoration: InputDecoration(
                     labelText: 'label2',
                   ),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -261,14 +261,14 @@ void main() {
 
   testWidgetsWithLeakTracking('text field selection toolbar should hide when the user starts typing', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: Center(
             child: SizedBox(
               width: 100,
               height: 100,
               child: TextField(
-                decoration: InputDecoration(hintText: 'Placeholder'),
+                decoration: const InputDecoration(hintText: 'Placeholder'),
               ),
             ),
           ),
@@ -771,7 +771,7 @@ void main() {
     const Color cursorColor = Colors.red;
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: DefaultSelectionStyle(
             selectionColor: selectionColor,
@@ -789,11 +789,11 @@ void main() {
 
   testWidgetsWithLeakTracking('Use error cursor color when an InputDecoration with an errorText or error widget is provided', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(
             autofocus: true,
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               error: Text('error'),
               errorStyle: TextStyle(color: Colors.teal),
             ),
@@ -806,11 +806,11 @@ void main() {
     expect(state.widget.cursorColor, Colors.teal);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(
             autofocus: true,
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               errorText: 'error',
               errorStyle: TextStyle(color: Colors.teal),
             ),
@@ -828,7 +828,7 @@ void main() {
     // True
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(autofocus: true, cursorOpacityAnimates: true),
         ),
@@ -841,7 +841,7 @@ void main() {
     // False
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(autofocus: true, cursorOpacityAnimates: false),
         ),
@@ -976,8 +976,8 @@ void main() {
   testWidgetsWithLeakTracking('Cursor blinks', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(
-          decoration: InputDecoration(
+        child: TextField(
+          decoration: const InputDecoration(
             hintText: 'Placeholder',
           ),
         ),
@@ -1044,7 +1044,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Cursor radius is 2.0', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(),
         ),
@@ -1060,7 +1060,7 @@ void main() {
   testWidgetsWithLeakTracking('cursor has expected defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(),
+        child: TextField(),
       ),
     );
 
@@ -1073,8 +1073,8 @@ void main() {
   testWidgetsWithLeakTracking('cursor has expected radius value', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(
-          cursorRadius: Radius.circular(3.0),
+        child: TextField(
+          cursorRadius: const Radius.circular(3.0),
         ),
       ),
     );
@@ -1087,7 +1087,7 @@ void main() {
   testWidgetsWithLeakTracking('clipBehavior has expected defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(),
+        child: TextField(),
       ),
     );
 
@@ -1138,12 +1138,12 @@ void main() {
     final Widget widget = Theme(
       data: ThemeData(useMaterial3: false),
       child: overlay(
-        child: const RepaintBoundary(
-          key: ValueKey<int>(1),
+        child: RepaintBoundary(
+          key: const ValueKey<int>(1),
           child: TextField(
             cursorColor: Colors.blue,
             cursorWidth: 15,
-            cursorRadius: Radius.circular(3.0),
+            cursorRadius: const Radius.circular(3.0),
           ),
         ),
       ),
@@ -1167,12 +1167,12 @@ void main() {
     final Widget widget = Theme(
       data: ThemeData(useMaterial3: false),
       child: overlay(
-        child: const RepaintBoundary(
-          key: ValueKey<int>(1),
+        child: RepaintBoundary(
+          key: const ValueKey<int>(1),
           child: TextField(
             cursorColor: Colors.blue,
             cursorWidth: 15,
-            cursorRadius: Radius.circular(3.0),
+            cursorRadius: const Radius.circular(3.0),
           ),
         ),
       ),
@@ -1239,7 +1239,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
-        home: const Scaffold(
+        home: Scaffold(
           body: Center(
             child: SizedBox(
               width: 100,
@@ -1247,7 +1247,7 @@ void main() {
               child: Opacity(
                 opacity: 0.5,
                 child: TextField(
-                  decoration: InputDecoration(hintText: 'Placeholder'),
+                  decoration: const InputDecoration(hintText: 'Placeholder'),
                 ),
               ),
             ),
@@ -1669,7 +1669,7 @@ void main() {
   testWidgetsWithLeakTracking('Overflowing a line with spaces stops the cursor at the end (rtl direction)', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(
+        child: TextField(
           textDirection: TextDirection.rtl,
           maxLines: null,
         ),
@@ -1696,9 +1696,9 @@ void main() {
   testWidgetsWithLeakTracking('mobile obscureText control test', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(
+        child: TextField(
           obscureText: true,
-          decoration: InputDecoration(
+          decoration: const InputDecoration(
             hintText: 'Placeholder',
           ),
         ),
@@ -1736,9 +1736,9 @@ void main() {
   testWidgetsWithLeakTracking('desktop obscureText control test', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(
+        child: TextField(
           obscureText: true,
-          decoration: InputDecoration(
+          decoration: const InputDecoration(
             hintText: 'Placeholder',
           ),
         ),
@@ -2081,7 +2081,7 @@ void main() {
 
   testWidgetsWithLeakTracking('does not paint toolbar when no options available', (WidgetTester tester) async {
     await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Material(
             child: TextField(
               readOnly: true,
@@ -2102,7 +2102,7 @@ void main() {
 
   testWidgetsWithLeakTracking('text field build empty toolbar when no options available', (WidgetTester tester) async {
     await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Material(
             child: TextField(
               readOnly: true,
@@ -4479,7 +4479,7 @@ void main() {
             ),
           ],
         ),
-        body: const TextField(),
+        body: TextField(),
       ),
     );
 
@@ -5167,8 +5167,8 @@ void main() {
       Theme(
         data: ThemeData(useMaterial3: false),
         child: overlay(
-          child: const TextField(
-            decoration: InputDecoration(
+          child: TextField(
+            decoration: const InputDecoration(
               errorText: 'error text',
               helperText: 'helper text',
             ),
@@ -5186,8 +5186,8 @@ void main() {
       overlay(
         child: Theme(
           data: themeData,
-          child: const TextField(
-            decoration: InputDecoration(
+          child: TextField(
+            decoration: const InputDecoration(
               helperText: 'helper text',
             ),
           ),
@@ -5362,8 +5362,8 @@ void main() {
       overlay(
         child: Column(
           children: <Widget>[
-            const TextField(
-              decoration: InputDecoration(
+            TextField(
+              decoration: const InputDecoration(
                 labelText: 'First',
               ),
             ),
@@ -5410,8 +5410,8 @@ void main() {
       overlay(
         child: Column(
           children: <Widget>[
-            const TextField(
-              decoration: InputDecoration(
+            TextField(
+              decoration: const InputDecoration(
                 labelText: 'First',
               ),
             ),
@@ -5473,8 +5473,8 @@ void main() {
       overlay(
         child: Column(
           children: <Widget>[
-            const TextField(
-              decoration: InputDecoration(
+            TextField(
+              decoration: const InputDecoration(
                 labelText: 'First',
               ),
             ),
@@ -5528,8 +5528,8 @@ void main() {
       overlay(
         child: Column(
           children: <Widget>[
-            const TextField(
-              decoration: InputDecoration(
+            TextField(
+              decoration: const InputDecoration(
                 labelText: 'First',
               ),
             ),
@@ -5565,8 +5565,8 @@ void main() {
   testWidgetsWithLeakTracking('Icon is separated from input/label by 16+12', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const TextField(
-          decoration: InputDecoration(
+        child: TextField(
+          decoration: const InputDecoration(
             icon: Icon(Icons.phone),
             labelText: 'label',
             filled: true,
@@ -5588,8 +5588,8 @@ void main() {
       Theme(
         data: ThemeData(useMaterial3: false),
         child: overlay(
-          child: const TextField(
-            decoration: InputDecoration.collapsed(
+          child: TextField(
+            decoration: const InputDecoration.collapsed(
               hintText: 'hint',
             ),
             strutStyle: StrutStyle.disabled,
@@ -5604,7 +5604,7 @@ void main() {
   testWidgetsWithLeakTracking('Can align to center', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const SizedBox(
+        child: SizedBox(
           width: 300.0,
           child: TextField(
             textAlign: TextAlign.center,
@@ -5639,7 +5639,7 @@ void main() {
   testWidgetsWithLeakTracking('Can align to center within center', (WidgetTester tester) async {
     await tester.pumpWidget(
       overlay(
-        child: const SizedBox(
+        child: SizedBox(
           width: 300.0,
           child: Center(
             child: TextField(
@@ -6544,7 +6544,7 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('setting maxLength shows counter', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: Material(
         child: Center(
             child: TextField(
@@ -6564,7 +6564,7 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('maxLength counter measures surrogate pairs as one character', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: Material(
         child: Center(
             child: TextField(
@@ -6585,7 +6585,7 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('maxLength counter measures grapheme clusters as one character', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: Material(
         child: Center(
             child: TextField(
@@ -6606,7 +6606,7 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('setting maxLength to TextField.noMaxLength shows only entered length', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: Material(
         child: Center(
             child: TextField(
@@ -6652,7 +6652,7 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
               child: TextField(
@@ -6671,7 +6671,7 @@ void main() {
   testWidgetsWithLeakTracking('Disabled text field does not have tap action', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(
@@ -6712,7 +6712,7 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(
@@ -6902,7 +6902,7 @@ void main() {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(
@@ -8485,7 +8485,7 @@ void main() {
   }, skip: isBrowser); // [intended] see above.
 
   testWidgetsWithLeakTracking('TextField throws when not descended from a Material widget', (WidgetTester tester) async {
-    const Widget textField = TextField();
+    final Widget textField = TextField();
     await tester.pumpWidget(textField);
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
@@ -8564,7 +8564,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
-        home: const Material(
+        home: Material(
           child: TextField(
             textDirection: TextDirection.rtl,
           ),
@@ -8585,7 +8585,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: false),
-        home: const Material(
+        home: Material(
           child: TextField(
             textDirection: TextDirection.ltr,
           ),
@@ -13342,7 +13342,7 @@ void main() {
   testWidgetsWithLeakTracking('default TextField debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
-    const TextField().debugFillProperties(builder);
+    TextField().debugFillProperties(builder);
 
     final List<String> description = builder.properties
       .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
@@ -13355,11 +13355,11 @@ void main() {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
     // Not checking controller, inputFormatters, focusNode
-    const TextField(
-      decoration: InputDecoration(labelText: 'foo'),
+    TextField(
+      decoration: const InputDecoration(labelText: 'foo'),
       keyboardType: TextInputType.text,
       textInputAction: TextInputAction.done,
-      style: TextStyle(color: Color(0xff00ff00)),
+      style: const TextStyle(color: Color(0xff00ff00)),
       textAlign: TextAlign.end,
       textDirection: TextDirection.ltr,
       autofocus: true,
@@ -13373,10 +13373,10 @@ void main() {
       cursorWidth: 1.0,
       cursorHeight: 1.0,
       cursorRadius: Radius.zero,
-      cursorColor: Color(0xff00ff00),
+      cursorColor: const Color(0xff00ff00),
       keyboardAppearance: Brightness.dark,
       scrollPadding: EdgeInsets.zero,
-      scrollPhysics: ClampingScrollPhysics(),
+      scrollPhysics: const ClampingScrollPhysics(),
       enableInteractiveSelection: false,
     ).debugFillProperties(builder);
 
@@ -13415,7 +13415,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(),
             ),
@@ -13440,10 +13440,10 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
-                style: TextStyle(fontSize: 20),
+                style: const TextStyle(fontSize: 20),
               ),
             ),
           ),
@@ -13460,10 +13460,10 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
-                style: TextStyle(fontSize: 20),
+                style: const TextStyle(fontSize: 20),
                 strutStyle: StrutStyle.disabled,
               ),
             ),
@@ -13485,7 +13485,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
                 maxLines: 6,
@@ -13509,11 +13509,11 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
                 maxLines: 6,
-                strutStyle: StrutStyle(
+                strutStyle: const StrutStyle(
                   // The small strut is overtaken by the larger
                   // TextStyle fontSize.
                   fontSize: 5,
@@ -13540,11 +13540,11 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
                 maxLines: 6,
-                strutStyle: StrutStyle(
+                strutStyle: const StrutStyle(
                   fontSize: 25,
                 ),
               ),
@@ -13569,11 +13569,11 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
                 maxLines: 3,
-                strutStyle: StrutStyle(
+                strutStyle: const StrutStyle(
                   fontSize: 8,
                   forceStrutHeight: true,
                 ),
@@ -13598,12 +13598,12 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: TargetPlatform.android, useMaterial3: false),
-          home: const Material(
+          home: Material(
             child: Center(
               child: TextField(
                 maxLines: 3,
-                style: TextStyle(fontSize: 10),
-                strutStyle: StrutStyle(
+                style: const TextStyle(fontSize: 10),
+                strutStyle: const StrutStyle(
                   fontSize: 18,
                   forceStrutHeight: true,
                 ),
@@ -13628,7 +13628,7 @@ void main() {
       overlay(
         child: Theme(
           data: ThemeData(useMaterial3: false),
-          child: const SizedBox(
+          child: SizedBox(
             width: 300.0,
             child: TextField(
               textAlign: TextAlign.center,
@@ -13671,7 +13671,7 @@ void main() {
       overlay(
         child: Theme(
           data: ThemeData(useMaterial3: false),
-          child: const SizedBox(
+          child: SizedBox(
             width: 300.0,
             child: TextField(
               textAlign: TextAlign.center,
@@ -14148,7 +14148,7 @@ void main() {
             controller: scrollController,
             children: <Widget>[
               Container(height: 579), // Push field almost off screen.
-              const TextField(),
+              TextField(),
               Container(height: 1000),
             ],
           ),
@@ -14216,7 +14216,7 @@ void main() {
     testWidgetsWithLeakTracking('By default, TextField is at least kMinInteractiveDimension high', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(),
-        home: const Scaffold(
+        home: Scaffold(
           body: Center(
             child: TextField(),
           ),
@@ -14230,10 +14230,10 @@ void main() {
     testWidgetsWithLeakTracking("When text is very small, TextField still doesn't go below kMinInteractiveDimension height", (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(),
-        home: const Scaffold(
+        home: Scaffold(
           body: Center(
             child: TextField(
-              style: TextStyle(fontSize: 2.0),
+              style: const TextStyle(fontSize: 2.0),
             ),
           ),
         ),
@@ -14246,10 +14246,10 @@ void main() {
     testWidgetsWithLeakTracking('When isDense, TextField can go below kMinInteractiveDimension height', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(),
-        home: const Scaffold(
+        home: Scaffold(
           body: Center(
             child: TextField(
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 isDense: true,
               ),
             ),
@@ -14413,10 +14413,10 @@ void main() {
           },
           child: Material(
             child: ListView(
-              children: const <Widget>[
-                Padding(padding: EdgeInsets.symmetric(vertical: 200)),
+              children: <Widget>[
+                const Padding(padding: EdgeInsets.symmetric(vertical: 200)),
                 TextField(),
-                Padding(padding: EdgeInsets.symmetric(vertical: 800)),
+                const Padding(padding: EdgeInsets.symmetric(vertical: 800)),
               ],
             ),
           ),
@@ -14560,13 +14560,13 @@ void main() {
 
   testWidgetsWithLeakTracking('TextField changes mouse cursor when hovered', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: MouseRegion(
             cursor: SystemMouseCursors.forbidden,
             child: TextField(
               mouseCursor: SystemMouseCursors.grab,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 // Add an icon so that the left edge is not the text area
                 icon: Icon(Icons.person),
               ),
@@ -14590,12 +14590,12 @@ void main() {
 
     // Test default cursor
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: MouseRegion(
             cursor: SystemMouseCursors.forbidden,
             child: TextField(
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 icon: Icon(Icons.person),
               ),
             ),
@@ -14611,13 +14611,13 @@ void main() {
 
     // Test default cursor when disabled
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: MouseRegion(
             cursor: SystemMouseCursors.forbidden,
             child: TextField(
               enabled: false,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 icon: Icon(Icons.person),
               ),
             ),
@@ -14635,12 +14635,12 @@ void main() {
     testWidgetsWithLeakTracking('TextField icons change mouse cursor when hovered', (WidgetTester tester) async {
     // Test default cursor in icons area.
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: MouseRegion(
             cursor: SystemMouseCursors.forbidden,
             child: TextField(
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 icon: Icon(Icons.label),
                 prefixIcon: Icon(Icons.cabin),
                 suffixIcon: Icon(Icons.person),
@@ -15135,11 +15135,11 @@ void main() {
 
   testWidgetsWithLeakTracking('autofill info has hint text', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: TextField(
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 hintText: 'placeholder text'
               ),
             ),
@@ -15158,7 +15158,7 @@ void main() {
 
   testWidgetsWithLeakTracking('TextField at rest does not push any layers with alwaysNeedsAddToScene', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home:  Material(
           child: Center(
             child: TextField(),
@@ -16327,7 +16327,7 @@ void main() {
 
     group('defaults', () {
       testWidgetsWithLeakTracking('should build Magnifier on Android', (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(
+        await tester.pumpWidget(MaterialApp(
           home: Scaffold(body: TextField()))
         );
 
@@ -16347,7 +16347,7 @@ void main() {
 
       testWidgetsWithLeakTracking('should build CupertinoMagnifier on iOS',
           (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(
+        await tester.pumpWidget(MaterialApp(
           home: Scaffold(body: TextField()))
         );
 
@@ -16367,7 +16367,7 @@ void main() {
 
       testWidgetsWithLeakTracking('should build nothing on Android and iOS',
           (WidgetTester tester) async {
-        await tester.pumpWidget(const MaterialApp(
+        await tester.pumpWidget(MaterialApp(
           home: Scaffold(body: TextField()))
         );
 
@@ -16907,9 +16907,9 @@ void main() {
             child: Builder(
               builder: (BuildContext context) {
                 builderContext = context;
-                return const TextField(
+                return TextField(
                   autofocus: true,
-                  spellCheckConfiguration: SpellCheckConfiguration(),
+                  spellCheckConfiguration: const SpellCheckConfiguration(),
                 );
               },
             ),
@@ -16973,12 +16973,12 @@ void main() {
         );
     }
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: Center(
             child: TextField(
               autofocus: true,
-              spellCheckConfiguration: SpellCheckConfiguration(),
+              spellCheckConfiguration: const SpellCheckConfiguration(),
             ),
           ),
         ),

--- a/packages/flutter/test/material/text_selection_theme_test.dart
+++ b/packages/flutter/test/material/text_selection_theme_test.dart
@@ -72,7 +72,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextField(autofocus: true),
         ),
       ),
@@ -121,7 +121,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextField(autofocus: true),
         ),
       ),
@@ -175,7 +175,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextField(autofocus: true),
         ),
       ),
@@ -232,7 +232,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextSelectionTheme(
             data: widgetTextSelectionTheme,
             child: TextField(autofocus: true),
@@ -289,7 +289,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextSelectionTheme(
             data: widgetTextSelectionTheme,
             child: TextField(cursorColor: cursorColor),

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -502,7 +502,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/23666
     Widget materialAppWithViewInsets(double viewInsetsHeight) {
       final Widget scaffold = Scaffold(
-        body: const TextField(),
+        body: TextField(),
         floatingActionButton: FloatingActionButton(
           tooltip: tooltipText,
           onPressed: () { /* do nothing */ },

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -58,7 +58,7 @@ class SampleForm extends StatelessWidget {
             willPopCount += 1;
             return callback();
           },
-          child: const TextField(),
+          child: TextField(),
         ),
       ),
     );

--- a/packages/flutter/test/widgets/autofill_group_test.dart
+++ b/packages/flutter/test/widgets/autofill_group_test.dart
@@ -14,11 +14,11 @@ void main() {
     const Key outerKey = Key('outer');
     const Key innerKey = Key('inner');
 
-    const TextField client1 = TextField(autofillHints: <String>['1']);
-    const TextField client2 = TextField(autofillHints: <String>['2']);
+    final TextField client1 = TextField(autofillHints: const <String>['1']);
+    final TextField client2 = TextField(autofillHints: const <String>['2']);
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: AutofillGroup(
             key: outerKey,
@@ -48,8 +48,8 @@ void main() {
   testWidgetsWithLeakTracking('new clients can be added & removed to a scope', (WidgetTester tester) async {
     const Key scopeKey = Key('scope');
 
-    const TextField client1 = TextField(autofillHints: <String>['1']);
-    TextField client2 = const TextField(autofillHints: null);
+    final TextField client1 = TextField(autofillHints: const <String>['1']);
+    TextField client2 = TextField(autofillHints: null);
 
     late StateSetter setState;
 
@@ -77,7 +77,7 @@ void main() {
     expect(scopeState.autofillClients.toList(), <State<TextField>>[clientState1]);
 
     // Add to scope.
-    setState(() { client2 = const TextField(autofillHints: <String>['2']); });
+    setState(() { client2 = TextField(autofillHints: const <String>['2']); });
 
     await tester.pump();
 
@@ -86,7 +86,7 @@ void main() {
     expect(scopeState.autofillClients.length, 2);
 
     // Remove from scope again.
-    setState(() { client2 = const TextField(autofillHints: null); });
+    setState(() { client2 = TextField(autofillHints: null); });
 
     await tester.pump();
 
@@ -98,8 +98,8 @@ void main() {
     const Key innerKey = Key('inner');
     final GlobalKey keyClient3 = GlobalKey();
 
-    const TextField client1 = TextField(autofillHints: <String>['1']);
-    const TextField client2 = TextField(autofillHints: <String>['2']);
+    final TextField client1 = TextField(autofillHints: const <String>['1']);
+    final TextField client2 = TextField(autofillHints: const <String>['2']);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -136,7 +136,7 @@ void main() {
             child: Column(children: <Widget>[
               client1,
               TextField(key: keyClient3, autofillHints: const <String>['3']),
-              const AutofillGroup(
+              AutofillGroup(
                 key: innerKey,
                 child: Column(children: <Widget>[client2]),
               ),
@@ -157,9 +157,9 @@ void main() {
     const Key group1 = Key('group1');
     const Key group2 = Key('group2');
     const Key group3 = Key('group3');
-    const TextField placeholder = TextField(autofillHints: <String>[AutofillHints.name]);
+    final TextField placeholder = TextField(autofillHints: const <String>[AutofillHints.name]);
 
-    List<Widget> children = const <Widget> [
+    List<Widget> children = <Widget> [
       AutofillGroup(
         key: group1,
         child: AutofillGroup(child: placeholder),
@@ -193,7 +193,7 @@ void main() {
 
     // Remove the first topmost group group1. Should commit.
     setState(() {
-      children = const <Widget> [
+      children = <Widget> [
         AutofillGroup(key: group2, onDisposeAction: AutofillContextAction.cancel, child: placeholder),
         AutofillGroup(
           key: group3,
@@ -213,7 +213,7 @@ void main() {
 
     // Remove the topmost group group2. Should cancel.
     setState(() {
-      children = const <Widget> [
+      children = <Widget> [
         AutofillGroup(
           key: group3,
           child: AutofillGroup(child: placeholder),
@@ -232,7 +232,7 @@ void main() {
 
     // Remove the inner group within group3. No action.
     setState(() {
-      children = const <Widget> [
+      children = <Widget> [
         AutofillGroup(
           key: group3,
           child: placeholder,

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -181,7 +181,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Cursor animates on iOS', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(),
         ),
@@ -232,7 +232,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Cursor does not animate on non-iOS platforms', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(child: TextField(maxLines: 3)),
       ),
     );
@@ -251,7 +251,7 @@ void main() {
 
   testWidgetsWithLeakTracking('Cursor does not animate on Android', (WidgetTester tester) async {
     final Color defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
-    const Widget widget = MaterialApp(
+    final Widget widget = MaterialApp(
       home: Material(
         child: TextField(
           maxLines: 3,
@@ -292,7 +292,7 @@ void main() {
   testWidgetsWithLeakTracking('Cursor does not animates when debugDeterministicCursor is set', (WidgetTester tester) async {
     EditableText.debugDeterministicCursor = true;
     final Color defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
-    const Widget widget = MaterialApp(
+    final Widget widget = MaterialApp(
       home: Material(
         child: TextField(
           maxLines: 3,
@@ -332,7 +332,7 @@ void main() {
   testWidgetsWithLeakTracking('Cursor does not animate on Android when debugDeterministicCursor is set', (WidgetTester tester) async {
     final Color defaultCursorColor = Color(ThemeData.fallback().colorScheme.primary.value);
     EditableText.debugDeterministicCursor = true;
-    const Widget widget = MaterialApp(
+    final Widget widget = MaterialApp(
       home: Material(
         child: TextField(
           maxLines: 3,
@@ -449,7 +449,7 @@ void main() {
   );
 
   testWidgetsWithLeakTracking('Cursor does not show when showCursor set to false', (WidgetTester tester) async {
-    const Widget widget = MaterialApp(
+    final Widget widget = MaterialApp(
       home: Material(
         child: TextField(
           showCursor: false,
@@ -507,7 +507,7 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('Cursor radius is 2.0', (WidgetTester tester) async {
-    const Widget widget = MaterialApp(
+    final Widget widget = MaterialApp(
       home: Material(
         child: TextField(
           maxLines: 3,

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1797,7 +1797,7 @@ void main() {
       // Pushes one page.
       navigatorKey.currentState!.push<void>(
         MaterialPageRoute<void>(
-          builder: (BuildContext context) => const Material(child: TextField()),
+          builder: (BuildContext context) => Material(child: TextField()),
         ),
       );
       await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1219,10 +1219,10 @@ void main() {
       home: Scaffold(
         body: ListView(
           key: key,
-          children: const <Widget>[
+          children: <Widget>[
             TextField(
               autofocus: true,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 prefixText: 'prefix',
               ),
             ),

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -629,17 +629,17 @@ void main() {
                 ),
                 child: ConstrainedBox(
                   constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                  child: const Text.rich(
+                  child: Text.rich(
                     TextSpan(
                       text: 'My name is: ',
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontSize: 20,
                       ),
                       children: <InlineSpan>[
                         WidgetSpan(
                           child: SizedBox(width: 70, height: 25, child: TextField()),
                         ),
-                        TextSpan(text: ', and my favorite city is: ', style: TextStyle(fontSize: 20)),
+                        const TextSpan(text: ', and my favorite city is: ', style: TextStyle(fontSize: 20)),
                         WidgetSpan(
                           child: SizedBox(width: 70, height: 25, child: TextField()),
                         ),
@@ -676,14 +676,14 @@ void main() {
                 ),
                 child: ConstrainedBox(
                   constraints: const BoxConstraints(maxWidth: 200, maxHeight: 100),
-                  child: const Text.rich(
+                  child: Text.rich(
                     TextSpan(
                       text: 'outer',
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontSize: 20,
                       ),
                       children: <InlineSpan>[
-                        WidgetSpan(
+                        const WidgetSpan(
                           child: Text.rich(
                             TextSpan(
                               text: 'inner',
@@ -747,11 +747,11 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'outer', style: TextStyle(fontSize: 20)),
+                        const TextSpan(text: 'outer', style: TextStyle(fontSize: 20)),
                         WidgetSpan(
                           child: SizedBox(width: 70, height: 25, child: TextField()),
                         ),
-                        WidgetSpan(
+                        const WidgetSpan(
                           child: SizedBox(
                             width: 50.0,
                             height: 55.0,

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -422,7 +422,7 @@ mixin CommandHandlerFactory {
     } else if (widget.runtimeType == TextField) {
       text = (widget as TextField).controller?.text;
     } else if (widget.runtimeType == TextFormField) {
-      text = (widget as TextFormField).controller?.text;
+      text = (widget as TextFormField).controller.text;
     } else if (widget.runtimeType == EditableText) {
       text = (widget as EditableText).controller.text;
     }

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -420,7 +420,7 @@ mixin CommandHandlerFactory {
         includePlaceholders: false,
       );
     } else if (widget.runtimeType == TextField) {
-      text = (widget as TextField).controller?.text;
+      text = (widget as TextField).controller.text;
     } else if (widget.runtimeType == TextFormField) {
       text = (widget as TextFormField).controller.text;
     } else if (widget.runtimeType == EditableText) {

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -904,11 +904,11 @@ void main() {
       return result;
     }
 
-    const Widget testWidget = MaterialApp(
+    final Widget testWidget = MaterialApp(
       home: Material(
         child: Center(
           child: TextField(
-            key: ValueKey<String>('foo'),
+            key: const ValueKey<String>('foo'),
             autofocus: true,
           ),
         ),

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -941,7 +941,7 @@ void main() {
 
     testWidgets('Passes if text field does not have label', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(_boilerplate(const TextField()));
+      await tester.pumpWidget(_boilerplate(TextField()));
       final Evaluation result = await labeledTapTargetGuideline.evaluate(tester);
       expect(result.passed, true);
       handle.dispose();

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -1494,7 +1494,7 @@ class _SemanticsTestWidget extends StatelessWidget {
       body: SingleChildScrollView(
         child: Column(
           children: <Widget>[
-            const _SemanticsTestCard(
+             _SemanticsTestCard(
               label: 'TextField',
               widget: TextField(),
             ),

--- a/packages/flutter_test/test/test_text_input_test.dart
+++ b/packages/flutter_test/test/test_text_input_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('enterText works', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: TextField(),
         ),
@@ -35,7 +35,7 @@ void main() {
 
   testWidgets('receiveAction() forwards exception when exception occurs during action processing', (WidgetTester tester) async {
     // Setup a widget that can receive focus so that we can open the keyboard.
-    const Widget widget = MaterialApp(
+    final Widget widget = MaterialApp(
       home: Material(
         child: TextField(),
       ),


### PR DESCRIPTION
This PR modifies TextFormField to ensure that its 'controller' field is never null. The docs state that if you do not pass a TextEditingController then it will create its own, which it does, but that controller instance only exists in the State and is not accessible from the widget. But the docs imply that the controller would be accessible, and there some pieces of code that assume that is the case.

For example in 'packages\flutter_driver\lib\src\common\handler_factory.dart' the _getText method finds the TextFormField widget and attempts to return its text value (text = (widget as TextFormField).controller?.text;). If the widget was constructed without passing a TextEdititngController then the null check on the controller field will fail and it won't get the text value. This causes _getText to throw an (incorrect) exception that "Type TextFormField is currently not supported by getText". This is the problem I encountered that lead me to dive in and fix this code.

I found several other instances in the code, including in the tests, that assume that controller will never be null (by accessing it with 'widget.controller!'). The tests pass because they all construct the widgets by passing a TextEditingController. I added a new test to cover the case where the widget is constructed with an initialValue but not a TextEditingController.

After fixing this I noticed that TextField has the same issue, so I fixed that too. I also added the 'initialValue' parameter to TextField to make it consistent with other widgets (like TextFormField). Unfortunetly this required removing the "const" from the TextField constructor which resulted in many changes across many files (basically anything that constructed a TextField).
This leads to an (easily fixed) breaking change.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
https://github.com/flutter/flutter/issues/95652 (this issue was closed without being properly resolved because they got distracted by fuschia issues)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
