### PR TITLE
Do not build native assets when building a bundle on darwin

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -967,6 +967,10 @@ const String kSdkRoot = 'SdkRoot';
 /// Whether to enable Dart obfuscation and where to save the symbol map.
 const String kDartObfuscation = 'DartObfuscation';
 
+/// Whether to enable Native Assets for the Darwin target platform.
+/// Used for hotfix https://github.com/flutter/flutter/issues/138519
+const String kDarwinNativeAssets = 'DarwinNativeAssets';
+
 /// An output directory where one or more code-size measurements may be written.
 const String kCodeSizeDirectory = 'CodeSizeDirectory';
 

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -64,146 +64,146 @@ class NativeAssets extends Target {
       await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
     }
     else {
-      final File packagesFile = fileSystem
-          .directory(projectUri)
-          .childDirectory('.dart_tool')
-          .childFile('package_config.json');
-      final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-        packagesFile,
-        logger: environment.logger,
-      );
-      final NativeAssetsBuildRunner buildRunner = _buildRunner ??
-          NativeAssetsBuildRunnerImpl(
-            projectUri,
-            packageConfig,
-            fileSystem,
-            environment.logger,
-          );
+    final File packagesFile = fileSystem
+        .directory(projectUri)
+        .childDirectory('.dart_tool')
+        .childFile('package_config.json');
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+      packagesFile,
+      logger: environment.logger,
+    );
+    final NativeAssetsBuildRunner buildRunner = _buildRunner ??
+        NativeAssetsBuildRunnerImpl(
+          projectUri,
+          packageConfig,
+          fileSystem,
+          environment.logger,
+        );
 
-      switch (targetPlatform) {
-        case TargetPlatform.ios:
-          final String? iosArchsEnvironment = environment.defines[kIosArchs];
-          if (iosArchsEnvironment == null) {
-            throw MissingDefineException(kIosArchs, name);
-          }
-          final List<DarwinArch> iosArchs = iosArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
-          final String? environmentBuildMode = environment.defines[kBuildMode];
-          if (environmentBuildMode == null) {
-            throw MissingDefineException(kBuildMode, name);
-          }
-          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
-          final String? sdkRoot = environment.defines[kSdkRoot];
-          if (sdkRoot == null) {
-            throw MissingDefineException(kSdkRoot, name);
-          }
-          final EnvironmentType environmentType = environmentTypeFromSdkroot(sdkRoot, environment.fileSystem)!;
-          dependencies = await buildNativeAssetsIOS(
-            environmentType: environmentType,
-            darwinArchs: iosArchs,
-            buildMode: buildMode,
-            projectUri: projectUri,
-            codesignIdentity: environment.defines[kCodesignIdentity],
-            fileSystem: fileSystem,
-            buildRunner: buildRunner,
-            yamlParentDirectory: environment.buildDir.uri,
-          );
-        case TargetPlatform.darwin:
-          final String? darwinArchsEnvironment = environment.defines[kDarwinArchs];
-          if (darwinArchsEnvironment == null) {
-            throw MissingDefineException(kDarwinArchs, name);
-          }
-          final List<DarwinArch> darwinArchs = darwinArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
-          final String? environmentBuildMode = environment.defines[kBuildMode];
-          if (environmentBuildMode == null) {
-            throw MissingDefineException(kBuildMode, name);
-          }
-          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+    switch (targetPlatform) {
+      case TargetPlatform.ios:
+        final String? iosArchsEnvironment = environment.defines[kIosArchs];
+        if (iosArchsEnvironment == null) {
+          throw MissingDefineException(kIosArchs, name);
+        }
+        final List<DarwinArch> iosArchs = iosArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
+        final String? environmentBuildMode = environment.defines[kBuildMode];
+        if (environmentBuildMode == null) {
+          throw MissingDefineException(kBuildMode, name);
+        }
+        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+        final String? sdkRoot = environment.defines[kSdkRoot];
+        if (sdkRoot == null) {
+          throw MissingDefineException(kSdkRoot, name);
+        }
+        final EnvironmentType environmentType = environmentTypeFromSdkroot(sdkRoot, environment.fileSystem)!;
+        dependencies = await buildNativeAssetsIOS(
+          environmentType: environmentType,
+          darwinArchs: iosArchs,
+          buildMode: buildMode,
+          projectUri: projectUri,
+          codesignIdentity: environment.defines[kCodesignIdentity],
+          fileSystem: fileSystem,
+          buildRunner: buildRunner,
+          yamlParentDirectory: environment.buildDir.uri,
+        );
+      case TargetPlatform.darwin:
+        final String? darwinArchsEnvironment = environment.defines[kDarwinArchs];
+        if (darwinArchsEnvironment == null) {
+          throw MissingDefineException(kDarwinArchs, name);
+        }
+        final List<DarwinArch> darwinArchs = darwinArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
+        final String? environmentBuildMode = environment.defines[kBuildMode];
+        if (environmentBuildMode == null) {
+          throw MissingDefineException(kBuildMode, name);
+        }
+        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+        (_, dependencies) = await buildNativeAssetsMacOS(
+          darwinArchs: darwinArchs,
+          buildMode: buildMode,
+          projectUri: projectUri,
+          codesignIdentity: environment.defines[kCodesignIdentity],
+          yamlParentDirectory: environment.buildDir.uri,
+          fileSystem: fileSystem,
+          buildRunner: buildRunner,
+        );
+      case TargetPlatform.linux_arm64:
+      case TargetPlatform.linux_x64:
+        final String? environmentBuildMode = environment.defines[kBuildMode];
+        if (environmentBuildMode == null) {
+          throw MissingDefineException(kBuildMode, name);
+        }
+        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+        (_, dependencies) = await buildNativeAssetsLinux(
+          targetPlatform: targetPlatform,
+          buildMode: buildMode,
+          projectUri: projectUri,
+          yamlParentDirectory: environment.buildDir.uri,
+          fileSystem: fileSystem,
+          buildRunner: buildRunner,
+        );
+      case TargetPlatform.windows_x64:
+        final String? environmentBuildMode = environment.defines[kBuildMode];
+        if (environmentBuildMode == null) {
+          throw MissingDefineException(kBuildMode, name);
+        }
+        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+        (_, dependencies) = await buildNativeAssetsWindows(
+          targetPlatform: targetPlatform,
+          buildMode: buildMode,
+          projectUri: projectUri,
+          yamlParentDirectory: environment.buildDir.uri,
+          fileSystem: fileSystem,
+          buildRunner: buildRunner,
+        );
+      case TargetPlatform.tester:
+        if (const LocalPlatform().isMacOS) {
           (_, dependencies) = await buildNativeAssetsMacOS(
-            darwinArchs: darwinArchs,
-            buildMode: buildMode,
+            buildMode: BuildMode.debug,
             projectUri: projectUri,
             codesignIdentity: environment.defines[kCodesignIdentity],
             yamlParentDirectory: environment.buildDir.uri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
+            flutterTester: true,
           );
-        case TargetPlatform.linux_arm64:
-        case TargetPlatform.linux_x64:
-          final String? environmentBuildMode = environment.defines[kBuildMode];
-          if (environmentBuildMode == null) {
-            throw MissingDefineException(kBuildMode, name);
-          }
-          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+        } else if (const LocalPlatform().isLinux) {
           (_, dependencies) = await buildNativeAssetsLinux(
-            targetPlatform: targetPlatform,
-            buildMode: buildMode,
+            buildMode: BuildMode.debug,
             projectUri: projectUri,
             yamlParentDirectory: environment.buildDir.uri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
+            flutterTester: true,
           );
-        case TargetPlatform.windows_x64:
-          final String? environmentBuildMode = environment.defines[kBuildMode];
-          if (environmentBuildMode == null) {
-            throw MissingDefineException(kBuildMode, name);
-          }
-          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+        } else if (const LocalPlatform().isWindows) {
           (_, dependencies) = await buildNativeAssetsWindows(
-            targetPlatform: targetPlatform,
-            buildMode: buildMode,
+            buildMode: BuildMode.debug,
             projectUri: projectUri,
             yamlParentDirectory: environment.buildDir.uri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
+            flutterTester: true,
           );
-        case TargetPlatform.tester:
-          if (const LocalPlatform().isMacOS) {
-            (_, dependencies) = await buildNativeAssetsMacOS(
-              buildMode: BuildMode.debug,
-              projectUri: projectUri,
-              codesignIdentity: environment.defines[kCodesignIdentity],
-              yamlParentDirectory: environment.buildDir.uri,
-              fileSystem: fileSystem,
-              buildRunner: buildRunner,
-              flutterTester: true,
-            );
-          } else if (const LocalPlatform().isLinux) {
-            (_, dependencies) = await buildNativeAssetsLinux(
-              buildMode: BuildMode.debug,
-              projectUri: projectUri,
-              yamlParentDirectory: environment.buildDir.uri,
-              fileSystem: fileSystem,
-              buildRunner: buildRunner,
-              flutterTester: true,
-            );
-          } else if (const LocalPlatform().isWindows) {
-            (_, dependencies) = await buildNativeAssetsWindows(
-              buildMode: BuildMode.debug,
-              projectUri: projectUri,
-              yamlParentDirectory: environment.buildDir.uri,
-              fileSystem: fileSystem,
-              buildRunner: buildRunner,
-              flutterTester: true,
-            );
-          } else {
-            // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
-            // Write the file we claim to have in the [outputs].
-            await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
-            dependencies = <Uri>[];
-          }
-        case TargetPlatform.android_arm:
-        case TargetPlatform.android_arm64:
-        case TargetPlatform.android_x64:
-        case TargetPlatform.android_x86:
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia_arm64:
-        case TargetPlatform.fuchsia_x64:
-        case TargetPlatform.web_javascript:
+        } else {
           // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
           // Write the file we claim to have in the [outputs].
           await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
           dependencies = <Uri>[];
-      }
+        }
+      case TargetPlatform.android_arm:
+      case TargetPlatform.android_arm64:
+      case TargetPlatform.android_x64:
+      case TargetPlatform.android_x86:
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia_arm64:
+      case TargetPlatform.fuchsia_x64:
+      case TargetPlatform.web_javascript:
+        // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
+        // Write the file we claim to have in the [outputs].
+        await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
+        dependencies = <Uri>[];
+    }
     }
 
     final File nativeAssetsFile = environment.buildDir.childFile('native_assets.yaml');

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -56,146 +56,154 @@ class NativeAssets extends Target {
 
     final Uri projectUri = environment.projectDir.uri;
     final FileSystem fileSystem = environment.fileSystem;
-    final File packagesFile = fileSystem
-        .directory(projectUri)
-        .childDirectory('.dart_tool')
-        .childFile('package_config.json');
-    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-      packagesFile,
-      logger: environment.logger,
-    );
-    final NativeAssetsBuildRunner buildRunner = _buildRunner ??
-        NativeAssetsBuildRunnerImpl(
-          projectUri,
-          packageConfig,
-          fileSystem,
-          environment.logger,
-        );
 
     final List<Uri> dependencies;
-    switch (targetPlatform) {
-      case TargetPlatform.ios:
-        final String? iosArchsEnvironment = environment.defines[kIosArchs];
-        if (iosArchsEnvironment == null) {
-          throw MissingDefineException(kIosArchs, name);
-        }
-        final List<DarwinArch> iosArchs = iosArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
-        final String? environmentBuildMode = environment.defines[kBuildMode];
-        if (environmentBuildMode == null) {
-          throw MissingDefineException(kBuildMode, name);
-        }
-        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
-        final String? sdkRoot = environment.defines[kSdkRoot];
-        if (sdkRoot == null) {
-          throw MissingDefineException(kSdkRoot, name);
-        }
-        final EnvironmentType environmentType = environmentTypeFromSdkroot(sdkRoot, environment.fileSystem)!;
-        dependencies = await buildNativeAssetsIOS(
-          environmentType: environmentType,
-          darwinArchs: iosArchs,
-          buildMode: buildMode,
-          projectUri: projectUri,
-          codesignIdentity: environment.defines[kCodesignIdentity],
-          fileSystem: fileSystem,
-          buildRunner: buildRunner,
-          yamlParentDirectory: environment.buildDir.uri,
-        );
-      case TargetPlatform.darwin:
-        final String? darwinArchsEnvironment = environment.defines[kDarwinArchs];
-        if (darwinArchsEnvironment == null) {
-          throw MissingDefineException(kDarwinArchs, name);
-        }
-        final List<DarwinArch> darwinArchs = darwinArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
-        final String? environmentBuildMode = environment.defines[kBuildMode];
-        if (environmentBuildMode == null) {
-          throw MissingDefineException(kBuildMode, name);
-        }
-        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
-        (_, dependencies) = await buildNativeAssetsMacOS(
-          darwinArchs: darwinArchs,
-          buildMode: buildMode,
-          projectUri: projectUri,
-          codesignIdentity: environment.defines[kCodesignIdentity],
-          yamlParentDirectory: environment.buildDir.uri,
-          fileSystem: fileSystem,
-          buildRunner: buildRunner,
-        );
-      case TargetPlatform.linux_arm64:
-      case TargetPlatform.linux_x64:
-        final String? environmentBuildMode = environment.defines[kBuildMode];
-        if (environmentBuildMode == null) {
-          throw MissingDefineException(kBuildMode, name);
-        }
-        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
-        (_, dependencies) = await buildNativeAssetsLinux(
-          targetPlatform: targetPlatform,
-          buildMode: buildMode,
-          projectUri: projectUri,
-          yamlParentDirectory: environment.buildDir.uri,
-          fileSystem: fileSystem,
-          buildRunner: buildRunner,
-        );
-      case TargetPlatform.windows_x64:
-        final String? environmentBuildMode = environment.defines[kBuildMode];
-        if (environmentBuildMode == null) {
-          throw MissingDefineException(kBuildMode, name);
-        }
-        final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
-        (_, dependencies) = await buildNativeAssetsWindows(
-          targetPlatform: targetPlatform,
-          buildMode: buildMode,
-          projectUri: projectUri,
-          yamlParentDirectory: environment.buildDir.uri,
-          fileSystem: fileSystem,
-          buildRunner: buildRunner,
-        );
-      case TargetPlatform.tester:
-        if (const LocalPlatform().isMacOS) {
+
+    if (targetPlatform == TargetPlatform.darwin && environment.defines[kDarwinNativeAssets] == 'false') {
+      dependencies = <Uri>[];
+      await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
+    }
+    else {
+      final File packagesFile = fileSystem
+          .directory(projectUri)
+          .childDirectory('.dart_tool')
+          .childFile('package_config.json');
+      final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+        packagesFile,
+        logger: environment.logger,
+      );
+      final NativeAssetsBuildRunner buildRunner = _buildRunner ??
+          NativeAssetsBuildRunnerImpl(
+            projectUri,
+            packageConfig,
+            fileSystem,
+            environment.logger,
+          );
+
+      switch (targetPlatform) {
+        case TargetPlatform.ios:
+          final String? iosArchsEnvironment = environment.defines[kIosArchs];
+          if (iosArchsEnvironment == null) {
+            throw MissingDefineException(kIosArchs, name);
+          }
+          final List<DarwinArch> iosArchs = iosArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
+          final String? environmentBuildMode = environment.defines[kBuildMode];
+          if (environmentBuildMode == null) {
+            throw MissingDefineException(kBuildMode, name);
+          }
+          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
+          final String? sdkRoot = environment.defines[kSdkRoot];
+          if (sdkRoot == null) {
+            throw MissingDefineException(kSdkRoot, name);
+          }
+          final EnvironmentType environmentType = environmentTypeFromSdkroot(sdkRoot, environment.fileSystem)!;
+          dependencies = await buildNativeAssetsIOS(
+            environmentType: environmentType,
+            darwinArchs: iosArchs,
+            buildMode: buildMode,
+            projectUri: projectUri,
+            codesignIdentity: environment.defines[kCodesignIdentity],
+            fileSystem: fileSystem,
+            buildRunner: buildRunner,
+            yamlParentDirectory: environment.buildDir.uri,
+          );
+        case TargetPlatform.darwin:
+          final String? darwinArchsEnvironment = environment.defines[kDarwinArchs];
+          if (darwinArchsEnvironment == null) {
+            throw MissingDefineException(kDarwinArchs, name);
+          }
+          final List<DarwinArch> darwinArchs = darwinArchsEnvironment.split(' ').map(getDarwinArchForName).toList();
+          final String? environmentBuildMode = environment.defines[kBuildMode];
+          if (environmentBuildMode == null) {
+            throw MissingDefineException(kBuildMode, name);
+          }
+          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
           (_, dependencies) = await buildNativeAssetsMacOS(
-            buildMode: BuildMode.debug,
+            darwinArchs: darwinArchs,
+            buildMode: buildMode,
             projectUri: projectUri,
             codesignIdentity: environment.defines[kCodesignIdentity],
             yamlParentDirectory: environment.buildDir.uri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
-            flutterTester: true,
           );
-        } else if (const LocalPlatform().isLinux) {
+        case TargetPlatform.linux_arm64:
+        case TargetPlatform.linux_x64:
+          final String? environmentBuildMode = environment.defines[kBuildMode];
+          if (environmentBuildMode == null) {
+            throw MissingDefineException(kBuildMode, name);
+          }
+          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
           (_, dependencies) = await buildNativeAssetsLinux(
-            buildMode: BuildMode.debug,
+            targetPlatform: targetPlatform,
+            buildMode: buildMode,
             projectUri: projectUri,
             yamlParentDirectory: environment.buildDir.uri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
-            flutterTester: true,
           );
-        } else if (const LocalPlatform().isWindows) {
+        case TargetPlatform.windows_x64:
+          final String? environmentBuildMode = environment.defines[kBuildMode];
+          if (environmentBuildMode == null) {
+            throw MissingDefineException(kBuildMode, name);
+          }
+          final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
           (_, dependencies) = await buildNativeAssetsWindows(
-            buildMode: BuildMode.debug,
+            targetPlatform: targetPlatform,
+            buildMode: buildMode,
             projectUri: projectUri,
             yamlParentDirectory: environment.buildDir.uri,
             fileSystem: fileSystem,
             buildRunner: buildRunner,
-            flutterTester: true,
           );
-        } else {
+        case TargetPlatform.tester:
+          if (const LocalPlatform().isMacOS) {
+            (_, dependencies) = await buildNativeAssetsMacOS(
+              buildMode: BuildMode.debug,
+              projectUri: projectUri,
+              codesignIdentity: environment.defines[kCodesignIdentity],
+              yamlParentDirectory: environment.buildDir.uri,
+              fileSystem: fileSystem,
+              buildRunner: buildRunner,
+              flutterTester: true,
+            );
+          } else if (const LocalPlatform().isLinux) {
+            (_, dependencies) = await buildNativeAssetsLinux(
+              buildMode: BuildMode.debug,
+              projectUri: projectUri,
+              yamlParentDirectory: environment.buildDir.uri,
+              fileSystem: fileSystem,
+              buildRunner: buildRunner,
+              flutterTester: true,
+            );
+          } else if (const LocalPlatform().isWindows) {
+            (_, dependencies) = await buildNativeAssetsWindows(
+              buildMode: BuildMode.debug,
+              projectUri: projectUri,
+              yamlParentDirectory: environment.buildDir.uri,
+              fileSystem: fileSystem,
+              buildRunner: buildRunner,
+              flutterTester: true,
+            );
+          } else {
+            // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
+            // Write the file we claim to have in the [outputs].
+            await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
+            dependencies = <Uri>[];
+          }
+        case TargetPlatform.android_arm:
+        case TargetPlatform.android_arm64:
+        case TargetPlatform.android_x64:
+        case TargetPlatform.android_x86:
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia_arm64:
+        case TargetPlatform.fuchsia_x64:
+        case TargetPlatform.web_javascript:
           // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
           // Write the file we claim to have in the [outputs].
           await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
           dependencies = <Uri>[];
-        }
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.android_x86:
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.web_javascript:
-        // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
-        // Write the file we claim to have in the [outputs].
-        await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
-        dependencies = <Uri>[];
+      }
     }
 
     final File nativeAssetsFile = environment.buildDir.childFile('native_assets.yaml');

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -60,6 +60,7 @@ class BundleBuilder {
         kTargetFile: mainPath,
         kDeferredComponents: 'false',
         ...buildInfo.toBuildSystemEnvironment(),
+        if (platform == TargetPlatform.darwin) kDarwinNativeAssets: 'false',
       },
       artifacts: globals.artifacts!,
       fileSystem: globals.fs,


### PR DESCRIPTION
The command `build bundle` fails when the target platform is darwin due to changes in the native assets code that are part of this release.

This hotfix narrows down the fix already in master and beta (#136547).

Cherry pick issue: #138519

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

