### PR TITLE
make FakeView not send Scene and semantics to the engine

### DIFF
--- a/packages/flutter/test/widgets/multi_view_testing.dart
+++ b/packages/flutter/test/widgets/multi_view_testing.dart
@@ -1,0 +1,33 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeView extends TestFlutterView {
+  FakeView(FlutterView view, { this.viewId = 100 }) : super(
+    view: view,
+    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
+    display: view.display as TestDisplay,
+  );
+
+  @override
+  final int viewId;
+
+  @override
+  void render(Scene scene) {
+    // Do not render the scene in the engine. The engine only observes one
+    // instance of FlutterView (the _view), and it is generally expected that
+    // the framework will render no more than one `Scene` per frame.
+  }
+
+  @override
+  void updateSemantics(SemanticsUpdate update) {
+    // Do not send the update to the engine. The engine only observes one
+    // instance of FlutterView (the _view). Sending semantic updates meant for
+    // different views to the same engine view does not work as the updates do
+    // not produce consistent semantics trees.
+  }
+}

--- a/packages/flutter/test/widgets/multi_view_tree_updates_test.dart
+++ b/packages/flutter/test/widgets/multi_view_tree_updates_test.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+
+import 'multi_view_testing.dart';
 
 void main() {
   testWidgetsWithLeakTracking('Widgets in view update as expected', (WidgetTester tester) async {
@@ -208,15 +208,4 @@ Future<void> pumpWidgetWithoutViewWrapper({required WidgetTester tester, require
   tester.binding.attachRootWidget(widget);
   tester.binding.scheduleFrame();
   return tester.binding.pump();
-}
-
-class FakeView extends TestFlutterView{
-  FakeView(FlutterView view, { this.viewId = 100 }) : super(
-    view: view,
-    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
-    display: view.display as TestDisplay,
-  );
-
-  @override
-  final int viewId;
 }

--- a/packages/flutter/test/widgets/tree_shape_test.dart
+++ b/packages/flutter/test/widgets/tree_shape_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'multi_view_testing.dart';
+
 void main() {
   testWidgetsWithLeakTracking('Providing a RenderObjectWidget directly to the RootWidget fails', (WidgetTester tester) async {
     // No render tree exists to attach the RenderObjectWidget to.
@@ -1148,15 +1150,4 @@ Future<void> pumpWidgetWithoutViewWrapper({required WidgetTester tester, require
   tester.binding.attachRootWidget(widget);
   tester.binding.scheduleFrame();
   return tester.binding.pump();
-}
-
-class FakeView extends TestFlutterView{
-  FakeView(FlutterView view, { this.viewId = 100 }) : super(
-    view: view,
-    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
-    display: view.display as TestDisplay,
-  );
-
-  @override
-  final int viewId;
 }

--- a/packages/flutter/test/widgets/view_test.dart
+++ b/packages/flutter/test/widgets/view_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
+import 'multi_view_testing.dart';
+
 void main() {
   testWidgetsWithLeakTracking('Widgets running with runApp can find View', (WidgetTester tester) async {
     FlutterView? viewOf;
@@ -454,17 +456,6 @@ Future<void> pumpWidgetWithoutViewWrapper({required WidgetTester tester, require
   tester.binding.attachRootWidget(widget);
   tester.binding.scheduleFrame();
   return tester.binding.pump();
-}
-
-class FakeView extends TestFlutterView{
-  FakeView(FlutterView view, { this.viewId = 100 }) : super(
-    view: view,
-    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
-    display: view.display as TestDisplay,
-  );
-
-  @override
-  final int viewId;
 }
 
 class SpyRenderWidget extends SizedBox {

--- a/packages/flutter_test/test/multi_view_accessibility_test.dart
+++ b/packages/flutter_test/test/multi_view_accessibility_test.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'multi_view_testing.dart';
 
 void main() {
   testWidgets('Detects tap targets in all views', (WidgetTester tester) async {
@@ -121,15 +122,4 @@ Future<void> pumpViews({required WidgetTester tester, required  List<Widget> vie
   );
   tester.binding.scheduleFrame();
   return tester.binding.pump();
-}
-
-class FakeView extends TestFlutterView{
-  FakeView(FlutterView view, { this.viewId = 100 }) : super(
-    view: view,
-    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
-    display: view.display as TestDisplay,
-  );
-
-  @override
-  final int viewId;
 }

--- a/packages/flutter_test/test/multi_view_controller_test.dart
+++ b/packages/flutter_test/test/multi_view_controller_test.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import 'multi_view_testing.dart';
 
 void main() {
   testWidgets('simulatedAccessibilityTraversal - start and end in same view', (WidgetTester tester) async {
@@ -218,15 +218,4 @@ Future<void> pumpViews({required WidgetTester tester}) {
   );
   tester.binding.scheduleFrame();
   return tester.binding.pump();
-}
-
-class FakeView extends TestFlutterView{
-  FakeView(FlutterView view, { this.viewId = 100 }) : super(
-    view: view,
-    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
-    display: view.display as TestDisplay,
-  );
-
-  @override
-  final int viewId;
 }

--- a/packages/flutter_test/test/multi_view_testing.dart
+++ b/packages/flutter_test/test/multi_view_testing.dart
@@ -1,0 +1,33 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeView extends TestFlutterView {
+  FakeView(FlutterView view, { this.viewId = 100 }) : super(
+    view: view,
+    platformDispatcher: view.platformDispatcher as TestPlatformDispatcher,
+    display: view.display as TestDisplay,
+  );
+
+  @override
+  final int viewId;
+
+  @override
+  void render(Scene scene) {
+    // Do not render the scene in the engine. The engine only observes one
+    // instance of FlutterView (the _view), and it is generally expected that
+    // the framework will render no more than one `Scene` per frame.
+  }
+
+  @override
+  void updateSemantics(SemanticsUpdate update) {
+    // Do not send the update to the engine. The engine only observes one
+    // instance of FlutterView (the _view). Sending semantic updates meant for
+    // different views to the same engine view does not work as the updates do
+    // not produce consistent semantics trees.
+  }
+}


### PR DESCRIPTION
`FakeView` wraps the same underlying `FlutterView`. Sending semantics updates and Scene objects from multiple fake views into the same engine `FlutterView` violates contracts with the engine. This PR stubs out `render` and `updateSemantics` methods in `FakeView` classes to prevent that.

This unblocks https://github.com/flutter/engine/pull/48251, which implements multi-view semantics for web.