### PR TITLE
[l10n] Update Material shareButtonLabel

### DIFF
--- a/packages/flutter/lib/src/material/material_localizations.dart
+++ b/packages/flutter/lib/src/material/material_localizations.dart
@@ -1195,7 +1195,7 @@ class DefaultMaterialLocalizations implements MaterialLocalizations {
   String get searchWebButtonLabel => 'Search Web';
 
   @override
-  String get shareButtonLabel => 'Share...';
+  String get shareButtonLabel => 'Share';
 
   @override
   String get viewLicensesButtonLabel => 'View licenses';

--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -7879,7 +7879,7 @@ class MaterialLocalizationEn extends GlobalMaterialLocalizations {
   String? get selectedRowCountTitleZero => 'No items selected';
 
   @override
-  String get shareButtonLabel => 'Share...';
+  String get shareButtonLabel => 'Share';
 
   @override
   String get showAccountsLabel => 'Show accounts';
@@ -7941,6 +7941,9 @@ class MaterialLocalizationEnAu extends MaterialLocalizationEn {
     required super.decimalFormat,
     required super.twoDigitZeroPaddedFormat,
   });
+
+  @override
+  String get shareButtonLabel => 'Share...';
 
   @override
   String get lookUpButtonLabel => 'Look up';
@@ -8149,6 +8152,9 @@ class MaterialLocalizationEnGb extends MaterialLocalizationEn {
   });
 
   @override
+  String get shareButtonLabel => 'Share...';
+
+  @override
   String get lookUpButtonLabel => 'Look up';
 
   @override
@@ -8247,6 +8253,9 @@ class MaterialLocalizationEnIe extends MaterialLocalizationEn {
     required super.decimalFormat,
     required super.twoDigitZeroPaddedFormat,
   });
+
+  @override
+  String get shareButtonLabel => 'Share...';
 
   @override
   String get lookUpButtonLabel => 'Look up';
@@ -8349,6 +8358,9 @@ class MaterialLocalizationEnIn extends MaterialLocalizationEn {
   });
 
   @override
+  String get shareButtonLabel => 'Share...';
+
+  @override
   String get lookUpButtonLabel => 'Look up';
 
   @override
@@ -8444,6 +8456,9 @@ class MaterialLocalizationEnNz extends MaterialLocalizationEn {
     required super.decimalFormat,
     required super.twoDigitZeroPaddedFormat,
   });
+
+  @override
+  String get shareButtonLabel => 'Share...';
 
   @override
   String get lookUpButtonLabel => 'Look up';
@@ -8543,6 +8558,9 @@ class MaterialLocalizationEnSg extends MaterialLocalizationEn {
   });
 
   @override
+  String get shareButtonLabel => 'Share...';
+
+  @override
   String get lookUpButtonLabel => 'Look up';
 
   @override
@@ -8638,6 +8656,9 @@ class MaterialLocalizationEnZa extends MaterialLocalizationEn {
     required super.decimalFormat,
     required super.twoDigitZeroPaddedFormat,
   });
+
+  @override
+  String get shareButtonLabel => 'Share...';
 
   @override
   String get lookUpButtonLabel => 'Look up';

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -207,7 +207,7 @@
     "description": "The label for the Search Web button and menu items on iOS."
   },
 
-  "shareButtonLabel": "Share...",
+  "shareButtonLabel": "Share",
   "@shareButtonLabel": {
     "description": "The label for the Share button and menu items on iOS."
   },

--- a/packages/flutter_localizations/lib/src/l10n/material_en.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_en.arb
@@ -199,17 +199,17 @@
 
   "lookUpButtonLabel": "Look Up",
   "@lookUpButtonLabel": {
-    "description": "The label for the Look Up button and menu items on iOS."
+    "description": "The label for the Look Up button and menu items."
   },
 
   "searchWebButtonLabel": "Search Web",
   "@searchWebButtonLabel": {
-    "description": "The label for the Search Web button and menu items on iOS."
+    "description": "The label for the Search Web button and menu items."
   },
 
   "shareButtonLabel": "Share",
   "@shareButtonLabel": {
-    "description": "The label for the Share button and menu items on iOS."
+    "description": "The label for the Share button and menu items."
   },
 
   "okButtonLabel": "OK",

--- a/packages/flutter_localizations/test/material/translations_test.dart
+++ b/packages/flutter_localizations/test/material/translations_test.dart
@@ -535,9 +535,18 @@ void main() {
   // Regression test for https://github.com/flutter/flutter/issues/110451.
   testWidgets('Finnish translation for tab label', (WidgetTester tester) async {
     const Locale locale = Locale('fi');
-    expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);
+    expect(GlobalMaterialLocalizations.delegate.isSupported(locale), isTrue);
     final MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(locale);
     expect(localizations, isA<MaterialLocalizationFi>());
     expect(localizations.tabLabel(tabIndex: 1, tabCount: 2), 'Välilehti 1 kautta 2');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/138728.
+  testWidgets('Share button label on Material', (WidgetTester tester) async {
+    const Locale locale = Locale('en');
+    expect(GlobalMaterialLocalizations.delegate.isSupported(locale), isTrue);
+    final MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(locale);
+    expect(localizations, isA<MaterialLocalizationEn>());
+    expect(localizations.shareButtonLabel, 'Share');
   });
 }


### PR DESCRIPTION
## Description

This PR updates the Material label for the share option, currently it is "**Share...**" (the expected label on iOS), on Android it should be "**Share**".

Native Android TextField screenshot:

![Capture d’écran du 2023-11-20 17-19-02](https://github.com/flutter/flutter/assets/840911/6004b900-0ba4-441e-a814-4afd0c0e2fe2)

## Related Issue

Step 2 for https://github.com/flutter/flutter/issues/138728

## Tests

Adds 1 test.