### PR TITLE
Fix SliverGrid garbage collection issue

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -596,14 +596,9 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
     final int firstIndex = layout.getMinChildIndexForScrollOffset(scrollOffset);
     final int? targetLastIndex = targetEndScrollOffset.isFinite ?
       layout.getMaxChildIndexForScrollOffset(targetEndScrollOffset) : null;
-
     if (firstChild != null) {
-      final int oldFirstIndex = indexOf(firstChild!);
-      final int oldLastIndex = indexOf(lastChild!);
-      final int leadingGarbage = (firstIndex - oldFirstIndex).clamp(0, childCount); // ignore_clamp_double_lint
-      final int trailingGarbage = targetLastIndex == null
-        ? 0
-        : (oldLastIndex - targetLastIndex).clamp(0, childCount); // ignore_clamp_double_lint
+      final int leadingGarbage = _calculateLeadingGarbage(firstIndex);
+      final int trailingGarbage = targetLastIndex != null ? _calculateTrailingGarbage(targetLastIndex) : 0;
       collectGarbage(leadingGarbage, trailingGarbage);
     } else {
       collectGarbage(0, 0);
@@ -712,5 +707,25 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       childManager.setDidUnderflow(true);
     }
     childManager.didFinishLayout();
+  }
+
+  int _calculateLeadingGarbage(int firstIndex) {
+    RenderBox? walker = firstChild;
+    int leadingGarbage = 0;
+    while (walker != null && indexOf(walker) < firstIndex) {
+      leadingGarbage += 1;
+      walker = childAfter(walker);
+    }
+    return leadingGarbage;
+  }
+
+  int _calculateTrailingGarbage(int targetLastIndex) {
+    RenderBox? walker = lastChild;
+    int trailingGarbage = 0;
+    while (walker != null && indexOf(walker) > targetLastIndex) {
+      trailingGarbage += 1;
+      walker = childBefore(walker);
+    }
+    return trailingGarbage;
   }
 }

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -1597,10 +1597,11 @@ class TestGridLayout implements SliverGridLayout {
   @override
   SliverGridGeometry getGeometryForChildIndex(int index) {
     return SliverGridGeometry(
-        crossAxisOffset: 20.0 + 20 * index,
-        crossAxisExtent: 20,
-        mainAxisExtent: 20,
-        scrollOffset: 0);
+      crossAxisOffset: 20.0 + 20 * index,
+      crossAxisExtent: 20,
+      mainAxisExtent: 20,
+      scrollOffset: 0,
+    );
   }
 
   @override

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -232,6 +232,69 @@ void main() {
     expect(find.text('BOTTOM'), findsOneWidget);
   });
 
+  testWidgetsWithLeakTracking('Sliver grid can replace intermediate items', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/138749.
+    // The bug happens when items in between first and last item changed while
+    // the sliver layout only display a item in the middle of the list.
+    final List<int> items = <int>[0, 1, 2, 3, 4, 5];
+    final List<int> replacedItems = <int>[0, 2, 9, 10, 11, 12, 5];
+    Future<void> pumpSliverGrid(bool replace) async {
+      await tester.pumpWidget(
+        Center(
+          child: SizedBox(
+            width: 200,
+            height: 200,
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  SliverGrid(
+                    gridDelegate: TestGridDelegate(replace),
+                    delegate: SliverChildBuilderDelegate(
+                          (BuildContext context, int index) {
+                        final int item = replace
+                            ? replacedItems[index]
+                            : items[index];
+                        return Container(
+                          key: ValueKey<int>(item),
+                          alignment: Alignment.center,
+                          child: Text('item $item'),
+                        );
+                      },
+                      childCount: replace ? 7 : 6,
+                      findChildIndexCallback: (Key key) {
+                        final int item = (key as ValueKey<int>).value;
+                        final int index = replace
+                            ? replacedItems.indexOf(item)
+                            : items.indexOf(item);
+                        return index >= 0 ? index : null;
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await pumpSliverGrid(false);
+    expect(find.text('item 0'), findsOneWidget);
+    expect(find.text('item 1'), findsOneWidget);
+    expect(find.text('item 2'), findsOneWidget);
+    expect(find.text('item 3'), findsOneWidget);
+    expect(find.text('item 4'), findsOneWidget);
+
+    await pumpSliverGrid(true);
+    // The TestGridDelegate only show child at index 1 when not expand.
+    expect(find.text('item 0'), findsNothing);
+    expect(find.text('item 1'), findsNothing);
+    expect(find.text('item 2'), findsOneWidget);
+    expect(find.text('item 3'), findsNothing);
+    expect(find.text('item 4'), findsNothing);
+  });
+
   testWidgetsWithLeakTracking('SliverFixedExtentList correctly clears garbage', (WidgetTester tester) async {
     final List<String> items = <String>['1', '2', '3', '4', '5', '6'];
     await testSliverFixedExtentList(tester, items);
@@ -1503,4 +1566,56 @@ class KeepAliveState extends State<KeepAlive> with AutomaticKeepAliveClientMixin
 class _NullBuildContext implements BuildContext {
   @override
   dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestGridDelegate implements SliverGridDelegate {
+  TestGridDelegate(this.replace);
+
+  final bool replace;
+
+  @override
+  SliverGridLayout getLayout(SliverConstraints constraints) {
+    return TestGridLayout(replace);
+  }
+
+  @override
+  bool shouldRelayout(covariant TestGridDelegate oldDelegate) {
+    return true;
+  }
+}
+
+class TestGridLayout implements SliverGridLayout {
+  TestGridLayout(this.replace);
+
+  final bool replace;
+
+  @override
+  double computeMaxScrollOffset(int childCount) {
+    return 200;
+  }
+
+  @override
+  SliverGridGeometry getGeometryForChildIndex(int index) {
+    return SliverGridGeometry(
+        crossAxisOffset: 20.0 + 20 * index,
+        crossAxisExtent: 20,
+        mainAxisExtent: 20,
+        scrollOffset: 0);
+  }
+
+  @override
+  int getMaxChildIndexForScrollOffset(double scrollOffset) {
+    if (replace) {
+      return 1;
+    }
+    return 5;
+  }
+
+  @override
+  int getMinChildIndexForScrollOffset(double scrollOffset) {
+    if (replace) {
+      return 1;
+    }
+    return 0;
+  }
 }


### PR DESCRIPTION
The code doesn't consider indices of children may not be continuous after rebuild.

fixes https://github.com/flutter/flutter/issues/138749

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
