### PR TITLE
Fix team-infra label in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       - "yusuf-goog"
     labels:
       - "team"
-      - "team: infra"
+      - "team-infra"
       - "autosubmit"
   - package-ecosystem: "docker"
     directory: "/dev/ci/docker_linux"
@@ -26,7 +26,7 @@ updates:
       - "christopherfujino"
     labels:
       - "team"
-      - "team: infra"
+      - "team-infra"
       - "autosubmit"
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -36,5 +36,5 @@ updates:
       - "godofredoc"
     labels:
       - "team"
-      - "team: infra"
+      - "team-infra"
       - "autosubmit"


### PR DESCRIPTION
As part of the new triage process (https://flutter.dev/go/triage-2023-rfc) the "team: infra" label was replaced by "team-infra"