### PR TITLE
Update Android app project template to apply Kotlin Gradle plugin declaratively

### DIFF
--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
@@ -21,8 +21,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
@@ -8,6 +8,8 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '{{kotlinVersion}}'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        // AGP version is set in settings.gradle.
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/src/main/kotlin/androidIdentifier/MainActivity.kt.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/src/main/kotlin/androidIdentifier/MainActivity.kt.tmpl
@@ -2,5 +2,4 @@ package {{androidIdentifier}}
 
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity: FlutterActivity() {
-}
+class MainActivity: FlutterActivity()

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
@@ -21,8 +21,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
@@ -8,6 +8,8 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '{{kotlinVersion}}'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        // AGP version is set in settings.gradle.
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/settings.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/settings.gradle.tmpl
@@ -20,6 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "{{agpVersion}}" apply false
+    id "org.jetbrains.kotlin.android" version "{{kotlinVersion}}" apply false
 }
 
 include ":app"


### PR DESCRIPTION
This PR updates the app templates generated by `flutter create` to use declarative `plugins {}` syntax for applying the Kotlin Gradle Plugin.

I realized this is missing while writing [#9857.](https://github.com/flutter/website/pull/9857)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.