### PR TITLE
Add armedColor to RefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -599,13 +599,19 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                       semanticsLabel: widget.semanticsLabel ?? MaterialLocalizations.of(context).refreshIndicatorSemanticLabel,
                       semanticsValue: widget.semanticsValue,
                       value: showIndeterminateIndicator ? null : _value.value,
-                      valueColor: widget.armedColor ?? _valueColor,
+                      valueColor:
+                        (_mode == _RefreshIndicatorMode.armed
+                          ? widget.armedColor
+                          : null) ?? _valueColor,
                       backgroundColor: widget.backgroundColor,
                       strokeWidth: widget.strokeWidth,
                     );
 
                     final Widget cupertinoIndicator = CupertinoActivityIndicator(
-                      color: widget.armedColor ?? widget.color,
+                      color:
+                        (_mode == _RefreshIndicatorMode.armed
+                          ? widget.armedColor
+                          : null) ?? widget.color,
                     );
 
                     switch (widget._indicatorType) {

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -166,6 +166,7 @@ class RefreshIndicator extends StatefulWidget {
     this.edgeOffset = 0.0,
     required this.onRefresh,
     this.color,
+    this.armedColor,
     this.backgroundColor,
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.semanticsLabel,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -600,9 +600,10 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                       semanticsValue: widget.semanticsValue,
                       value: showIndeterminateIndicator ? null : _value.value,
                       valueColor:
-                        (_mode == _RefreshIndicatorMode.armed
-                          ? widget.armedColor
-                          : null) ?? _valueColor,
+                        _mode == _RefreshIndicatorMode.armed
+                            && widget.armedColor != null
+                          ? AlwaysStoppedAnimation<Color>(widget.armedColor!)
+                          : _valueColor,
                       backgroundColor: widget.backgroundColor,
                       strokeWidth: widget.strokeWidth,
                     );

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -134,6 +134,7 @@ class RefreshIndicator extends StatefulWidget {
     this.edgeOffset = 0.0,
     required this.onRefresh,
     this.color,
+    this.armedColor,
     this.backgroundColor,
     this.notificationPredicate = defaultScrollNotificationPredicate,
     this.semanticsLabel,
@@ -214,6 +215,10 @@ class RefreshIndicator extends StatefulWidget {
   /// The progress indicator's foreground color. The current theme's
   /// [ColorScheme.primary] by default.
   final Color? color;
+
+  /// The progress indicator's foreground color, when armed for refresh.
+  /// Uses [color] or the current theme's [ColorScheme.primary] by default.
+  final Color? armedColor;
 
   /// The progress indicator's background color. The current theme's
   /// [ThemeData.canvasColor] by default.
@@ -594,13 +599,13 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
                       semanticsLabel: widget.semanticsLabel ?? MaterialLocalizations.of(context).refreshIndicatorSemanticLabel,
                       semanticsValue: widget.semanticsValue,
                       value: showIndeterminateIndicator ? null : _value.value,
-                      valueColor: _valueColor,
+                      valueColor: widget.armedColor ?? _valueColor,
                       backgroundColor: widget.backgroundColor,
                       strokeWidth: widget.strokeWidth,
                     );
 
                     final Widget cupertinoIndicator = CupertinoActivityIndicator(
-                      color: widget.color,
+                      color: widget.armedColor ?? widget.color,
                     );
 
                     switch (widget._indicatorType) {


### PR DESCRIPTION
Adds a separate `armedColor` parameter to `RefreshIndicator`. This allows Flutter to show the user when a refresh action is armed. Right now the only indication is that the refresh indicator stops animating, which doesn't seem to be sufficient (there really needs to be a separate indication of armed state).

I didn't add any animation between `color` and `armedColor` when the state changes from `drag` to `armed`, but I think this minimal change is sufficient.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
