### PR TITLE
Prepare for dynamically sized views - pt. 2

### DIFF
--- a/packages/flutter/test/widgets/multi_view_testing.dart
+++ b/packages/flutter/test/widgets/multi_view_testing.dart
@@ -17,7 +17,7 @@ class FakeView extends TestFlutterView {
   final int viewId;
 
   @override
-  void render(Scene scene) {
+  void render(Scene scene, {Size? size}) {
     // Do not render the scene in the engine. The engine only observes one
     // instance of FlutterView (the _view), and it is generally expected that
     // the framework will render no more than one `Scene` per frame.

--- a/packages/flutter_test/test/multi_view_testing.dart
+++ b/packages/flutter_test/test/multi_view_testing.dart
@@ -17,7 +17,7 @@ class FakeView extends TestFlutterView {
   final int viewId;
 
   @override
-  void render(Scene scene) {
+  void render(Scene scene, {Size? size}) {
     // Do not render the scene in the engine. The engine only observes one
     // instance of FlutterView (the _view), and it is generally expected that
     // the framework will render no more than one `Scene` per frame.


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/134501.

Required to roll https://github.com/flutter/engine/pull/48090 into the framework.

Two new subclasses of FlutterView were added recently for testing (in https://github.com/flutter/flutter/pull/138849) that I missed in my previous PR (https://github.com/flutter/flutter/pull/138565).