### PR TITLE
Run platform_channels_benchmarks on Pixel 7 Pro

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2584,6 +2584,16 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: platform_channels_benchmarks
 
+  - name: Linux_pixel_7pro platform_channels_benchmarks
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "pixel", "7pro"]
+      task_name: platform_channels_benchmarks
+
   - name: Linux_android platform_channel_sample_test
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/138689 for 64-bit coverage for Dart VM changes in this area

cc @aam 