### PR TITLE
Improve documentation of CardTheme.shape

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -164,7 +164,8 @@ class Card extends StatelessWidget {
   ///
   /// If this property is null then [CardTheme.shape] of [ThemeData.cardTheme]
   /// is used. If that's null then the shape will be a [RoundedRectangleBorder]
-  /// with a circular corner radius of 4.0.
+  /// with a circular corner radius of 12.0 and if [ThemeData.useMaterial3] is
+  /// false, then the circular corner radius will be 4.0.
   final ShapeBorder? shape;
 
   /// Whether to paint the [shape] border in front of the [child].

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -78,7 +78,8 @@ class CardTheme with Diagnosticable {
   /// Overrides the default value for [Card.shape].
   ///
   /// If null, [Card] then uses a [RoundedRectangleBorder] with a circular
-  /// corner radius of 4.0 for Material 2 and 12.0 for Material 3.
+  /// corner radius of 12.0 and if [ThemeData.useMaterial3] is false,
+  /// then the circular corner radius will be 4.0.
   final ShapeBorder? shape;
 
   /// Creates a copy of this object with the given fields replaced with the

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -78,7 +78,7 @@ class CardTheme with Diagnosticable {
   /// Overrides the default value for [Card.shape].
   ///
   /// If null, [Card] then uses a [RoundedRectangleBorder] with a circular
-  /// corner radius of 4.0.
+  /// corner radius of 4.0 for Material 2 and 12.0 for Material 3.
   final ShapeBorder? shape;
 
   /// Creates a copy of this object with the given fields replaced with the


### PR DESCRIPTION
The previous documentation did not point out the difference between the default corner radius for Material 2 and Material 3.

Fixes: https://github.com/flutter/flutter/issues/139093

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
