### PR TITLE
Add send_text_input_action case to deserialization_factory to allow sendTextInputAction usages through flutter_driver.

### DIFF
--- a/packages/flutter_driver/lib/src/common/deserialization_factory.dart
+++ b/packages/flutter_driver/lib/src/common/deserialization_factory.dart
@@ -15,6 +15,7 @@ import 'render_tree.dart';
 import 'request_data.dart';
 import 'semantics.dart';
 import 'text.dart';
+import 'text_input_action.dart';
 import 'wait.dart';
 
 /// A factory for deserializing [Finder]s.
@@ -46,6 +47,7 @@ mixin DeserializeCommandFactory {
       case 'get_layer_tree': return GetLayerTree.deserialize(params);
       case 'get_render_tree': return GetRenderTree.deserialize(params);
       case 'enter_text': return EnterText.deserialize(params);
+      case 'send_text_input_action': return SendTextInputAction.deserialize(params);
       case 'get_text': return GetText.deserialize(params, finderFactory);
       case 'request_data': return RequestData.deserialize(params);
       case 'scroll': return Scroll.deserialize(params, finderFactory);


### PR DESCRIPTION
**As a follow up to https://github.com/flutter/flutter/pull/131776.**

**Summary:**
Previously in https://github.com/flutter/flutter/pull/106561, SendTextInputAction was added to Flutter Driver.
But it still cannot be used from flutter_driver tests. This PR intends to resolve that issue.

**Issue:**
An `DriverError: Unsupported command kind send_text_input_action` would be thrown from `flutter_driver/lib/src/common/deserialization_factory.dart` when a call to `driver.sendTextInputAction(TextInputAction.done);` was made despite the method `sendTextInputAction` is available for use since https://github.com/flutter/flutter/pull/106561.

Previous works has been done in https://github.com/flutter/flutter/pull/131776, I merely added tests.

Best regards.