### PR TITLE
Migrate fuchsia_precache to shard tests.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -681,8 +681,7 @@ targets:
     recipe: flutter/flutter
     timeout: 60
     properties:
-      validation: fuchsia_precache
-      validation_name: Fuchsia precache
+      shard: fuchsia_precache
       tags: >
         ["framework", "hostonly", "shard", "linux"]
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1618,18 +1618,8 @@ Future<void> _runFuchsiaPrecache() async {
     'flutter',
     <String>[
       'precache',
-      '--fuchsia',
-      '--no-android',
-      '--no-ios',
-      '--force',
-    ],
-    workingDirectory: flutterRoot,
-  );
-  await runCommand(
-    'flutter',
-    <String>[
-      'precache',
       '--flutter_runner',
+      '--fuchsia',
       '--no-android',
       '--no-ios',
       '--force',

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -265,6 +265,7 @@ Future<void> main(List<String> args) async {
       'realm_checker': _runRealmCheckerTest,
       'customer_testing': _runCustomerTesting,
       'analyze': _runAnalyze,
+      'fuchsia_precache': _runFuchsiaPrecache,
       kTestHarnessShardName: _runTestHarnessTests, // Used for testing this script; also run as part of SHARD=framework_tests, SUBSHARD=misc.
     });
   } catch (error, stackTrace) {
@@ -1597,6 +1598,41 @@ Future<void> _runAnalyze() async {
     <String>[
       '--enable-asserts',
       path.join(flutterRoot, 'dev', 'bots', 'analyze.dart'),
+    ],
+    workingDirectory: flutterRoot,
+  );
+}
+
+// Runs flutter_precache.
+Future<void> _runFuchsiaPrecache() async {
+  printProgress('${green}Running flutter precache tests$reset');
+  await runCommand(
+    'flutter',
+    <String>[
+      'config',
+      '--enable-fuchsia',
+    ],
+    workingDirectory: flutterRoot,
+  );
+  await runCommand(
+    'flutter',
+    <String>[
+      'precache',
+      '--fuchsia',
+      '--no-android',
+      '--no-ios',
+      '--force',
+    ],
+    workingDirectory: flutterRoot,
+  );
+  await runCommand(
+    'flutter',
+    <String>[
+      'precache',
+      '--flutter_runner',
+      '--no-android',
+      '--no-ios',
+      '--force',
     ],
     workingDirectory: flutterRoot,
   );


### PR DESCRIPTION
Adhoc tests are being deprecated and existing tests are being migrated to shard tests.

Bug: https://github.com/flutter/flutter/issues/139153

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
