### PR TITLE
Added flag to disable build name validation on ios

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -47,6 +47,7 @@ class BuildInfo {
     this.initializeFromDill,
     this.assumeInitializeFromDillUpToDate = false,
     this.buildNativeAssets = true,
+    this.validateBuildName = true,
   }) : extraFrontEndOptions = extraFrontEndOptions ?? const <String>[],
        extraGenSnapshotOptions = extraGenSnapshotOptions ?? const <String>[],
        fileSystemRoots = fileSystemRoots ?? const <String>[],
@@ -179,6 +180,10 @@ class BuildInfo {
 
   /// If set, builds native assets with `build.dart` from all packages.
   final bool buildNativeAssets;
+
+  /// Whether to run validation on the build name.
+  /// On iOS, this will remove all non-digit characters to ensure a format of x.y.z
+  final bool validateBuildName;
 
   static const BuildInfo debug = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
   static const BuildInfo profile = BuildInfo(BuildMode.profile, null, treeShakeIcons: kIconTreeShakerEnabledDefault);

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -586,6 +586,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     usesAnalyzeSizeFlag();
+    usesValidateBuildNameFlag();
     argParser.addFlag('codesign',
       defaultsTo: true,
       help: 'Codesign the application bundle (only available on device builds).',

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -111,6 +111,10 @@ String? parsedBuildName({
   BuildInfo? buildInfo,
 }) {
   final String? buildNameToParse = buildInfo?.buildName ?? manifest.buildName;
+  final bool shouldValidate = buildInfo?.validateBuildName ?? true;
+  if (!shouldValidate) {
+    return buildNameToParse;
+  }
   return validatedBuildNameForPlatform(TargetPlatform.ios, buildNameToParse, globals.logger);
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1161,7 +1161,7 @@ abstract class FlutterCommand extends Command<void> {
       FlutterOptions.kValidateBuildName,
       defaultsTo: true,
       help: 'Validate the build name. On iOS, this will remove all non-digit '
-          'characters to ensure a valid format of x.y.z',
+          'characters to ensure a valid format of "x.y.z".',
     );
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -156,6 +156,7 @@ abstract final class FlutterOptions {
   static const String kWebRendererFlag = 'web-renderer';
   static const String kWebResourcesCdnFlag = 'web-resources-cdn';
   static const String kWebWasmFlag = 'wasm';
+  static const String kValidateBuildName = 'validate-build-name';
 }
 
 /// flutter command categories for usage.
@@ -1155,6 +1156,15 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
+  void usesValidateBuildNameFlag() {
+    argParser.addFlag(
+      FlutterOptions.kValidateBuildName,
+      defaultsTo: true,
+      help: 'Validate the build name. On iOS, this will remove all non-digit '
+          'characters to ensure a valid format of x.y.z',
+    );
+  }
+
   /// Compute the [BuildInfo] for the current flutter command.
   /// Commands that build multiple build modes can pass in a [forcedBuildMode]
   /// to be used instead of parsing flags.
@@ -1268,6 +1278,9 @@ abstract class FlutterCommand extends Command<void> {
       ? stringArg(FlutterOptions.kPerformanceMeasurementFile)
       : null;
 
+    final bool validateBuildName = argParser.options.containsKey(FlutterOptions.kValidateBuildName)
+        && boolArg(FlutterOptions.kValidateBuildName);
+
     final Map<String, Object?> defineConfigJsonMap = extractDartDefineConfigJsonMap();
     List<String> dartDefines = extractDartDefines(defineConfigJsonMap: defineConfigJsonMap);
 
@@ -1336,6 +1349,7 @@ abstract class FlutterCommand extends Command<void> {
           : null,
       assumeInitializeFromDillUpToDate: argParser.options.containsKey(FlutterOptions.kAssumeInitializeFromDillUpToDate)
           && boolArg(FlutterOptions.kAssumeInitializeFromDillUpToDate),
+      validateBuildName: validateBuildName,
     );
   }
 

--- a/packages/flutter_tools/test/general.shard/ios/xcode_build_settings_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcode_build_settings_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';

--- a/packages/flutter_tools/test/general.shard/ios/xcode_build_settings_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcode_build_settings_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/ios/xcode_build_settings.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main() {
+  late BufferLogger logger;
+  setUp(() {
+    logger = BufferLogger.test();
+  });
+
+  group('parsedBuildName', () {
+    testUsingContext('validation enabled', () async {
+      final FlutterManifest manifest = FlutterManifest.empty(logger: logger);
+
+      String? buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: 'xyz'),
+      );
+      expect(buildName, null);
+
+      buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: '0.0.1'),
+      );
+      expect(buildName, '0.0.1');
+
+      buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: '1.0.0-beta'),
+      );
+      expect(buildName, '1.0.0');
+
+      buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: '123.xyz'),
+      );
+      expect(buildName, '123.0.0');
+    });
+
+    testUsingContext('validation disabled', () async {
+      final FlutterManifest manifest = FlutterManifest.empty(logger: logger);
+
+      String? buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: 'xyz', validateBuildName: false),
+      );
+      expect(buildName, 'xyz');
+
+      buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: '0.0.1', validateBuildName: false),
+      );
+      expect(buildName, '0.0.1');
+
+      buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: '1.0.0-beta', validateBuildName: false),
+      );
+      expect(buildName, '1.0.0-beta');
+
+      buildName = parsedBuildName(
+        manifest: manifest,
+        buildInfo: const BuildInfo(BuildMode.debug, null, treeShakeIcons: true, buildName: '123.xyz', validateBuildName: false),
+      );
+      expect(buildName, '123.xyz');
+    });
+  });
+}


### PR DESCRIPTION
Added --validate-build-name flag to the flutter build ios/ipa commands.
Version names with pre-release suffixes such as 1.0.0-beta or 1.2.3-alpha were previously being truncated to 1.0.0 and 1.2.3, in accordance with Apple's [documentation on CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).
This flag allows the developer to bypass this validation.

Fixes #63768 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
