### PR TITLE
Remove WidgetInspectorService setPubRootDirectories deprecations

### DIFF
--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -35,7 +35,7 @@ transforms:
         newName: 'addPubRootDirectories'
 
   # Changes made in TBD
-  - title: "Use WidgetServicesExtensions.addPubRootDirectories"
+  - title: "Use WidgetServiceExtensions.addPubRootDirectories"
     date: 2023-11-29
     element:
       uris: ['widgets.dart', 'material.dart', 'cupertino.dart']

--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -23,6 +23,28 @@
 #     * ListWheelScrollView: fix_list_wheel_scroll_view.yaml
 version: 1
 transforms:
+  # Changes made in TBD
+  - title: "Migrate to addPubRootDirectories"
+    date: 2023-11-29
+    element:
+      uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
+      method: 'setPubRootDirectories'
+      inMixin: 'WidgetInspectorService'
+    changes:
+      - kind: 'rename'
+        newName: 'addPubRootDirectories'
+
+  # Changes made in TBD
+  - title: "Use WidgetServicesExtensions.addPubRootDirectories"
+    date: 2023-11-29
+    element:
+      uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
+      enum: 'setPubRootDirectories'
+      inEnum: 'WidgetInspectorServiceExtensions'
+    changes:
+    - kind: 'rename'
+      newName: 'addPubRootDirectories'
+
   # Changes made in https://github.com/flutter/flutter/pull/138509
   - title: "Migrate to 'PlatformMenuBar.child'"
     date: 2023-11-15
@@ -33,6 +55,7 @@ transforms:
     changes:
       - kind: 'rename'
         newName: 'child'
+
   - title: "Migrate PlatformMenuBar(body:) to PlatformMenuBar(child:)"
     date: 2023-11-15
     element:

--- a/packages/flutter/lib/src/widgets/service_extensions.dart
+++ b/packages/flutter/lib/src/widgets/service_extensions.dart
@@ -202,24 +202,6 @@ enum WidgetInspectorServiceExtensions {
   ///   extension is registered.
   disposeId,
 
-  /// Name of service extension that, when called, will set the list of
-  /// directories that should be considered part of the local project for the
-  /// Widget inspector summary tree.
-  ///
-  /// See also:
-  ///
-  /// * [WidgetInspectorService.addPubRootDirectories], which should be used in
-  ///   place of this method to add directories.
-  /// * [WidgetInspectorService.removePubRootDirectories], which should be used
-  ///   in place of this method to remove directories.
-  /// * [WidgetInspectorService.initServiceExtensions], where the service
-  ///   extension is registered.
-  @Deprecated(
-    'Use addPubRootDirectories instead. '
-    'This feature was deprecated after v3.1.0-9.0.pre.',
-  )
-  setPubRootDirectories,
-
   /// Name of service extension that, when called, will add a list of
   /// directories that should be considered part of the local project for the
   /// Widget inspector summary tree.

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1170,9 +1170,9 @@ mixin WidgetInspectorService {
       registerExtension: registerExtension,
     );
     _registerServiceExtensionVarArgs(
-      name: WidgetInspectorServiceExtensions.setPubRootDirectories.name,
+      name: WidgetInspectorServiceExtensions.addPubRootDirectories.name,
       callback: (List<String> args) async {
-        setPubRootDirectories(args);
+        addPubRootDirectories(args);
         return null;
       },
       registerExtension: registerExtension,
@@ -1475,21 +1475,6 @@ mixin WidgetInspectorService {
       throw FlutterError.fromParts(<DiagnosticsNode>[ErrorSummary('Id is not in group')]);
     }
     _decrementReferenceCount(referenceData);
-  }
-
-  /// Set the list of directories that should be considered part of the local
-  /// project.
-  ///
-  /// The local project directories are used to distinguish widgets created by
-  /// the local project from widgets created from inside the framework
-  /// or other packages.
-  @protected
-  @Deprecated(
-    'Use addPubRootDirectories instead. '
-    'This feature was deprecated after v3.1.0-9.0.pre.',
-  )
-  void setPubRootDirectories(List<String> pubRootDirectories) {
-    addPubRootDirectories(pubRootDirectories);
   }
 
   /// Resets the list of directories, that should be considered part of the

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1786,7 +1786,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               );
 
               service
-                  .setPubRootDirectories(<String>[pubRootFramework, pubRootTest]);
+                  .addPubRootDirectories(<String>[pubRootFramework, pubRootTest]);
               service.setSelection(elementA, 'my-group');
               expect(
                 json.decode(service.getSelectedWidget(null, 'my-group')),
@@ -2947,7 +2947,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                 .evaluate()
                 .first;
             service.setSelection(richText, 'my-group');
-            service.setPubRootDirectories(<String>[pubRootTest]);
+            service.addPubRootDirectories(<String>[pubRootTest]);
             final Map<String, Object?> jsonObject =
                 json.decode(service.getSelectedWidget(null, 'my-group'))
                     as Map<String, Object?>;

--- a/packages/flutter/test_fixes/cupertino/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino/cupertino.dart
@@ -248,4 +248,12 @@ void main() {
 
   final PlatformMenuBar platformMenuBar = PlatformMenuBar(menus: <PlatformMenuItem>[], body: const SizedBox());
   final Widget bodyValue = platformMenuBar.body;
+
+  // Changes made in TBD
+  class Test with WidgetInspectorService {
+  Test();
+  }
+  final Test test = Test();
+  test.setPubRootDirectories([]);
+  WidgetInspectorServiceExtensions.setPubRootDirectories
 }

--- a/packages/flutter/test_fixes/cupertino/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino/cupertino.dart
@@ -255,5 +255,5 @@ void main() {
   }
   final Test test = Test();
   test.setPubRootDirectories([]);
-  WidgetInspectorServiceExtensions.setPubRootDirectories
+  WidgetInspectorServiceExtensions.setPubRootDirectories;
 }

--- a/packages/flutter/test_fixes/cupertino/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino/cupertino.dart.expect
@@ -255,5 +255,5 @@ void main() {
   }
   final Test test = Test();
   test.addPubRootDirectories([]);
-  WidgetInspectorServiceExtensions.addPubRootDirectories
+  WidgetInspectorServiceExtensions.addPubRootDirectories;
 }

--- a/packages/flutter/test_fixes/cupertino/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino/cupertino.dart.expect
@@ -248,4 +248,12 @@ void main() {
 
   final PlatformMenuBar platformMenuBar = PlatformMenuBar(menus: <PlatformMenuItem>[], child: const SizedBox());
   final Widget bodyValue = platformMenuBar.child;
+
+  // Changes made in TBD
+  class Test with WidgetInspectorService {
+    Test();
+  }
+  final Test test = Test();
+  test.addPubRootDirectories([]);
+  WidgetInspectorServiceExtensions.addPubRootDirectories
 }

--- a/packages/flutter/test_fixes/material/material.dart
+++ b/packages/flutter/test_fixes/material/material.dart
@@ -333,5 +333,5 @@ void main() {
   }
   final Test test = Test();
   test.setPubRootDirectories([]);
-  WidgetInspectorServiceExtensions.setPubRootDirectories
+  WidgetInspectorServiceExtensions.setPubRootDirectories;
 }

--- a/packages/flutter/test_fixes/material/material.dart
+++ b/packages/flutter/test_fixes/material/material.dart
@@ -326,4 +326,12 @@ void main() {
 
   final PlatformMenuBar platformMenuBar = PlatformMenuBar(menus: <PlatformMenuItem>[], body: const SizedBox());
   final Widget bodyValue = platformMenuBar.body;
+
+  // Changes made in TBD
+  class Test with WidgetInspectorService {
+  Test();
+  }
+  final Test test = Test();
+  test.setPubRootDirectories([]);
+  WidgetInspectorServiceExtensions.setPubRootDirectories
 }

--- a/packages/flutter/test_fixes/material/material.dart.expect
+++ b/packages/flutter/test_fixes/material/material.dart.expect
@@ -322,4 +322,12 @@ void main() {
 
   final PlatformMenuBar platformMenuBar = PlatformMenuBar(menus: <PlatformMenuItem>[], child: const SizedBox());
   final Widget bodyValue = platformMenuBar.child;
+
+  // Changes made in TBD
+  class Test with WidgetInspectorService {
+    Test();
+  }
+  final Test test = Test();
+  test.addPubRootDirectories([]);
+  WidgetInspectorServiceExtensions.addPubRootDirectories
 }

--- a/packages/flutter/test_fixes/material/material.dart.expect
+++ b/packages/flutter/test_fixes/material/material.dart.expect
@@ -329,5 +329,5 @@ void main() {
   }
   final Test test = Test();
   test.addPubRootDirectories([]);
-  WidgetInspectorServiceExtensions.addPubRootDirectories
+  WidgetInspectorServiceExtensions.addPubRootDirectories;
 }

--- a/packages/flutter/test_fixes/widgets/widgets.dart
+++ b/packages/flutter/test_fixes/widgets/widgets.dart
@@ -173,4 +173,12 @@ void main() {
 
   final PlatformMenuBar platformMenuBar = PlatformMenuBar(menus: <PlatformMenuItem>[], body: const SizedBox());
   final Widget bodyValue = platformMenuBar.body;
+
+  // Changes made in TBD
+  class Test with WidgetInspectorService {
+    Test();
+  }
+  final Test test = Test();
+  test.setPubRootDirectories([]);
+  WidgetInspectorServiceExtensions.setPubRootDirectories
 }

--- a/packages/flutter/test_fixes/widgets/widgets.dart
+++ b/packages/flutter/test_fixes/widgets/widgets.dart
@@ -180,5 +180,5 @@ void main() {
   }
   final Test test = Test();
   test.setPubRootDirectories([]);
-  WidgetInspectorServiceExtensions.setPubRootDirectories
+  WidgetInspectorServiceExtensions.setPubRootDirectories;
 }

--- a/packages/flutter/test_fixes/widgets/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets/widgets.dart.expect
@@ -180,5 +180,5 @@ void main() {
   }
   final Test test = Test();
   test.addPubRootDirectories([]);
-  WidgetInspectorServiceExtensions.addPubRootDirectories
+  WidgetInspectorServiceExtensions.addPubRootDirectories;
 }

--- a/packages/flutter/test_fixes/widgets/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets/widgets.dart.expect
@@ -173,4 +173,12 @@ void main() {
 
   final PlatformMenuBar platformMenuBar = PlatformMenuBar(menus: <PlatformMenuItem>[], child: const SizedBox());
   final Widget bodyValue = platformMenuBar.child;
+
+  // Changes made in TBD
+  class Test with WidgetInspectorService {
+    Test();
+  }
+  final Test test = Test();
+  test.addPubRootDirectories([]);
+  WidgetInspectorServiceExtensions.addPubRootDirectories
 }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/139243

setPubRootDirectories is replaced by the addPubRootDirectories method.
Deprecated in https://github.com/flutter/flutter/pull/106567


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
