### PR TITLE
Fix DropdownMenu throwing TextEditingController disposed error on select (#139266)

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -518,14 +518,17 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         leadingIcon: entry.leadingIcon,
         trailingIcon: entry.trailingIcon,
         onPressed: entry.enabled
-          ? () {
-              textEditingController.text = entry.label;
-              textEditingController.selection =
-                TextSelection.collapsed(offset: textEditingController.text.length);
-              currentHighlight = widget.enableSearch ? i : null;
-              widget.onSelected?.call(entry.value);
-            }
-          : null,
+            ? () {
+                // The textEditingController may have been disposed if the DropdownMenu closes in response to a selection.
+                if (textEditingController.hasListeners) {
+                  textEditingController.text = entry.label;
+                  textEditingController.selection =
+                      TextSelection.collapsed(offset: textEditingController.text.length);
+                }
+                currentHighlight = widget.enableSearch ? i : null;
+                widget.onSelected?.call(entry.value);
+              }
+            : null,
         requestFocusOnHover: false,
         child: label,
       );

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1180,7 +1180,7 @@ void main() {
     }
   }, variant: TargetPlatformVariant.all());
 
-  testWidgetsWithLeakTracking('The onSelected gets called only when a selection is made in a nested menu',
+  testWidgetsWithLeakTracking('onSelected gets called when a selection is made in a nested menu',
       (WidgetTester tester) async {
     int selectionCount = 0;
 
@@ -1224,12 +1224,63 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    // Disabled item doesn't trigger onSelected callback.
     final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 0').last;
     await tester.tap(item1);
     await tester.pumpAndSettle();
 
     expect(selectionCount, 1);
+  });
+
+  testWidgetsWithLeakTracking('When onSelected is called and menu is closed, no textEditingController exception is thrown',
+      (WidgetTester tester) async {
+    int selectionCount = 0;
+
+    final ThemeData themeData = ThemeData();
+    final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      theme: themeData,
+      home: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+        return Scaffold(
+          body: MenuAnchor(
+            menuChildren: <Widget>[
+              DropdownMenu<TestMenu>(
+                dropdownMenuEntries: menuWithDisabledItems,
+                onSelected: (_) {
+                  setState(() {
+                    selectionCount++;
+                  });
+                },
+              ),
+            ],
+            builder: (BuildContext context, MenuController controller, Widget? widget) {
+              return IconButton(
+                icon: const Icon(Icons.smartphone_rounded),
+                onPressed: () {
+                  controller.open();
+                },
+              );
+            },
+          ),
+        );
+      }),
+    ));
+
+    // Open the first menu
+    await tester.tap(find.byType(IconButton));
+    await tester.pump();
+    // Open the dropdown menu
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+
+    final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 0').last;
+    await tester.tap(item1);
+    await tester.pumpAndSettle();
+
+    expect(selectionCount, 1);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgetsWithLeakTracking('The selectedValue gives an initial text and highlights the according item', (WidgetTester tester) async {


### PR DESCRIPTION
When a DropdownMenu exists within another menu and a MenuItem is selected, the TextEditingController of the DropdownMenu is used after it has been disposed.

This PR checks whether the controller has been disposed before using it in the onPressed callback.

Note I'm not sure whether the `hasListeners` method is the correct way to check if the textEditingController is disposed.


Fixes #139266
*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].