### PR TITLE
Move Impeller tests on Pixel 7 Pro from staging to prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1774,58 +1774,50 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: backdrop_filter_perf__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro draw_atlas_perf_opengles__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-     # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: draw_atlas_perf_opengles__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro draw_atlas_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: draw_atlas_perf__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro dynamic_path_tessellation_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: dynamic_path_tessellation_perf__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro static_path_tessellation_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: static_path_tessellation_perf__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro hello_world_impeller
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
     timeout: 60
     properties:
       tags: >
@@ -2482,10 +2474,8 @@ targets:
   - name: Linux_android new_gallery_impeller__transition_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux"]
       task_name: new_gallery_impeller__transition_perf
@@ -2493,7 +2483,6 @@ targets:
   # Pixel 7 Pro, Impeller (Vulkan)
   - name: Linux_pixel_7pro new_gallery_impeller_old_zoom__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2504,7 +2493,6 @@ targets:
   # Pixel 7 Pro, Impeller (Vulkan)
   - name: Linux_pixel_7pro new_gallery_impeller__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2514,24 +2502,20 @@ targets:
 
   # Samsung A02, Impeller (OpenGL)
   - name: Linux_samsung_a02 new_gallery_impeller__transition_perf
-    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "samsung", "a02"]
       task_name: new_gallery_impeller__transition_perf
 
   # Pixel 7 Pro, Impeller (OpenGL)
   - name: Linux_pixel_7pro new_gallery_opengles_impeller__transition_perf
-    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: new_gallery_opengles_impeller__transition_perf
@@ -2584,7 +2568,6 @@ targets:
   - name: Linux_pixel_7pro platform_channels_benchmarks
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -2639,12 +2622,10 @@ targets:
       task_name: platform_views_scroll_perf_impeller__timeline_summary
 
   - name: Linux_pixel_7pro platform_views_scroll_perf_impeller__timeline_summary
-    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: platform_views_scroll_perf_impeller__timeline_summary
@@ -2826,35 +2807,31 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: animated_blur_backdrop_filter_perf__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro animated_blur_backdrop_filter_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: animated_blur_backdrop_filter_perf__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro animated_advanced_blend_perf_opengles__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: animated_advanced_blend_perf_opengles__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro animated_advanced_blend_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
+    bringup: true # https://github.com/flutter/flutter/issues/138385
     timeout: 60
     properties:
       ignore_flakiness: "true"
@@ -2871,38 +2848,32 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: animated_advanced_blend_perf_ios__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro animated_blur_backdrop_filter_perf_opengles__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: animated_blur_backdrop_filter_perf_opengles__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro draw_vertices_perf_opengles__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: draw_vertices_perf_opengles__timeline_summary
 
+  # Uses Impeller.
   - name: Linux_pixel_7pro draw_vertices_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    # Uses Impeller.
-    bringup: true
     timeout: 60
     properties:
-      ignore_flakiness: "true"
       tags: >
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: draw_vertices_perf__timeline_summary


### PR DESCRIPTION
These tests are now expected to be reasonably stable, and increases in flakiness should be reported as part of the regular flaky test triage process.