### PR TITLE
TabPageSelector wrapped by GestureDetector which navigates to view

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -2110,6 +2110,7 @@ class TabPageSelector extends StatelessWidget {
     this.color,
     this.selectedColor,
     this.borderStyle,
+    this.clickableDots = false,
   }) : assert(indicatorSize > 0.0);
 
   /// This widget's selection and animation state.
@@ -2137,6 +2138,11 @@ class TabPageSelector extends StatelessWidget {
   ///
   /// Defaults to [BorderStyle.solid] if value is not specified.
   final BorderStyle? borderStyle;
+
+  /// Allows the user to click on the dots to change tabs.
+  ///
+  /// Defaults to false.
+  final bool clickableDots;
 
   Widget _buildTabIndicator(
     int tabIndex,
@@ -2169,11 +2175,19 @@ class TabPageSelector extends StatelessWidget {
         background = selectedColorTween.begin!;
       }
     }
-    return TabPageSelectorIndicator(
-      backgroundColor: background,
-      borderColor: selectedColorTween.end!,
-      size: indicatorSize,
-      borderStyle: borderStyle ?? BorderStyle.solid,
+
+    return GestureDetector(
+      onTap: clickableDots ? () => tabController.animateTo(tabIndex) : null,
+      child: MouseRegion(
+        cursor:
+            clickableDots ? SystemMouseCursors.click : SystemMouseCursors.basic,
+        child: TabPageSelectorIndicator(
+          backgroundColor: background,
+          borderColor: selectedColorTween.end!,
+          size: indicatorSize,
+          borderStyle: borderStyle ?? BorderStyle.solid,
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
An UX/Developer experience improvement for the development of apps, which will be used on the web platform. 

The `TabPageSelector` widget only allows navigating between when swiping - which is only usable on the mobile phone/touchpad. If a user encounters TabPageSelector with mouse only he has no way of navigating between these views. 

The current implementation of `TabPageSelector` does not allow this, so I decided to contribute by wrapping the `TabPageSelector` with `GestureDetector` that navigates to the view, coresponding to the `TabPageSelectorIndicator `'s index.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
