### PR TITLE
Use ImageFilter.compose on all platforms now that it is supported

### DIFF
--- a/packages/flutter/lib/src/cupertino/desktop_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection_toolbar.dart
@@ -104,14 +104,7 @@ class CupertinoDesktopTextSelectionToolbar extends StatelessWidget {
         borderRadius: BorderRadius.all(_kToolbarBorderRadius),
       ),
       child: BackdropFilter(
-        // Flutter web doesn't support ImageFilter.compose on CanvasKit yet
-        // (https://github.com/flutter/flutter/issues/120123).
-        filter: kIsWeb
-            ? ImageFilter.blur(
-                sigmaX: _kToolbarBlurSigma,
-                sigmaY: _kToolbarBlurSigma,
-              )
-            : ImageFilter.compose(
+        filter: ImageFilter.compose(
                 outer: ColorFilter.matrix(
                   _matrixWithSaturation(_kToolbarSaturationBoost),
                 ),


### PR DESCRIPTION
Follow-up to https://github.com/flutter/engine/pull/48546

Once the above PR lands then https://github.com/flutter/flutter/issues/120123 will be fixed, which means we no longer need this workaround for Flutter Web in the framework.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
