### PR TITLE
fix reorderable_list drop animation

### DIFF
--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -1473,8 +1473,8 @@ void main() {
       (3, 1),
       (3, 3),
       (3, 5),
-      (1, 5),
-      (5, 1),
+      (0, 5),
+      (5, 0),
     ];
     for (final (int, int) element in testCases) {
       await testMove(element.$1, element.$2);

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -1408,6 +1408,7 @@ void main() {
   );
 
   testWidgetsWithLeakTracking('Tests the correctness of the drop animation in various scenarios', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/138994
     late Size screenSize;
     final List<double> itemSizes = <double>[20, 50, 30, 80, 100, 30];
     Future<void> pumpFor(bool reverse, Axis scrollDirection) async {

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -1405,6 +1406,83 @@ void main() {
       await tester.pumpAndSettle();
     },
   );
+
+  testWidgetsWithLeakTracking('Tests the correctness of the drop animation in various scenarios', (WidgetTester tester) async {
+    late Size screenSize;
+    final List<double> itemSizes = <double>[20, 50, 30, 80, 100, 30];
+    Future<void> pumpFor(bool reverse, Axis scrollDirection) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              screenSize = MediaQuery.sizeOf(context);
+              return Scaffold(
+                body: CustomScrollView(
+                  reverse: reverse,
+                  scrollDirection: scrollDirection,
+                  slivers: <Widget>[
+                    SliverReorderableList(
+                      itemBuilder: (BuildContext context, int index) {
+                        return ReorderableDragStartListener(
+                          key: ValueKey<int>(index),
+                          index: index,
+                          child: Builder(
+                            builder: (BuildContext context) {
+                              return SizedBox(
+                                height: scrollDirection == Axis.vertical ? itemSizes[index] : double.infinity,
+                                width: scrollDirection == Axis.horizontal ? itemSizes[index] : double.infinity,
+                                child: Text('$index'),
+                              );
+                            },
+                          ),
+                        );
+                      },
+                      itemCount: itemSizes.length,
+                      onReorder: (int fromIndex, int toIndex) {},
+                    ),
+                  ],
+                ),
+              );
+            }
+          ),
+        ),
+      );
+    }
+
+    Future<void> testMove(int from, int to, {bool reverse = false, Axis scrollDirection = Axis.vertical}) async {
+      await pumpFor(reverse, scrollDirection);
+      final double targetOffset = (List<double>.of(itemSizes)..removeAt(from)).sublist(0, to).sum;
+      final Offset targetPosition = reverse
+        ? (scrollDirection == Axis.vertical
+            ? Offset(0, screenSize.height - targetOffset - itemSizes[from])
+            : Offset(screenSize.width - targetOffset - itemSizes[from], 0))
+        : (scrollDirection == Axis.vertical ? Offset(0, targetOffset) : Offset(targetOffset, 0));
+      final Offset moveOffset = targetPosition - tester.getTopLeft(find.text('$from'));
+      await tester.timedDrag(find.text('$from'), moveOffset, const Duration(seconds: 1));
+      // Before the drop animation starts
+      final Offset animationBeginOffset = tester.getTopLeft(find.text('$from'));
+      // Halfway through the animation
+      await tester.pump(const Duration(milliseconds: 125));
+      expect(tester.getTopLeft(find.text('$from')), Offset.lerp(animationBeginOffset, targetPosition, 0.5));
+      // Animation ends
+      await tester.pump(const Duration(milliseconds: 125));
+      expect(tester.getTopLeft(find.text('$from')), targetPosition);
+      await tester.pumpAndSettle();
+    }
+    final List<(int,int)> testCases = <(int,int)>[
+      (3, 1),
+      (3, 3),
+      (3, 5),
+      (1, 5),
+      (5, 1),
+    ];
+    for (final (int, int) element in testCases) {
+      await testMove(element.$1, element.$2);
+      await testMove(element.$1, element.$2, reverse: true);
+      await testMove(element.$1, element.$2, scrollDirection: Axis.horizontal);
+      await testMove(element.$1, element.$2, reverse: true, scrollDirection: Axis.horizontal);
+    }
+  });
 }
 
 class TestList extends StatelessWidget {


### PR DESCRIPTION
This PR fixes reorderable_list drop animation.

Fixes #138994 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
