### PR TITLE
Typo fix in dartdoc in tool test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -337,7 +337,7 @@ extension DapTestClientExtension on DapTestClient {
   /// console, stdout and stderr.
   ///
   /// Only one of [start] or [launch] may be provided. Use [start] to customise
-  /// the whole start of the session (including initialise) or [launch] to only
+  /// the whole start of the session (including initialize) or [launch] to only
   /// customise the [launchRequest].
   Future<List<OutputEventBody>> collectAllOutput({
     String? program,


### PR DESCRIPTION
The tree is red due a non-hermetic customer test from `macos_ui`. The test was disabled in https://github.com/flutter/tests/pull/317 and an issue was filed at https://github.com/macosui/macos_ui/issues/499.

We need this empty commit in order to re-run CI with the latest https://github.com/flutter/tests.