### PR TITLE
Add WidgetStateOutlinedBorder.resolveWith

### DIFF
--- a/examples/api/lib/material/material_state/material_state_outlined_border.0.dart
+++ b/examples/api/lib/material/material_state/material_state_outlined_border.0.dart
@@ -19,18 +19,6 @@ class MaterialStateOutlinedBorderExampleApp extends StatelessWidget {
   }
 }
 
-class SelectedBorder extends RoundedRectangleBorder implements MaterialStateOutlinedBorder {
-  const SelectedBorder();
-
-  @override
-  OutlinedBorder? resolve(Set<MaterialState> states) {
-    if (states.contains(MaterialState.selected)) {
-      return const RoundedRectangleBorder();
-    }
-    return null; // Defer to default value on the theme or widget.
-  }
-}
-
 class MaterialStateOutlinedBorderExample extends StatefulWidget {
   const MaterialStateOutlinedBorderExample({super.key});
 
@@ -52,7 +40,14 @@ class _MaterialStateOutlinedBorderExampleState extends State<MaterialStateOutlin
             isSelected = value;
           });
         },
-        shape: const SelectedBorder(),
+        shape: WidgetStateOutlinedBorder.resolveWith(
+              (Set<WidgetState> states) {
+            if (states.contains(WidgetState.selected)) {
+              return const RoundedRectangleBorder();
+            }
+            return null; // Defer to default value on the theme or widget.
+          },
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -444,13 +444,6 @@ abstract class WidgetStateOutlinedBorder extends LinearBorder implements WidgetS
       _WidgetStateOutlinedBorder(callback);
 }
 
-/// A [WidgetStateOutlinedBorder] created from a [WidgetPropertyResolver<OutlinedBorder>]
-/// callback alone.
-///
-/// If used as a regular [OutlinedBorder], the shape resolved in the default state will
-/// be used.
-///
-/// Used by [MaterialStateOutlinedBorder.resolveWith].
 class _WidgetStateOutlinedBorder extends WidgetStateOutlinedBorder {
   const _WidgetStateOutlinedBorder(this._resolve);
 

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -424,7 +424,7 @@ class _WidgetStateBorderSide extends WidgetStateBorderSide {
 ///  * [ShapeBorder] the base class for shape outlines.
 ///  * [MaterialStateOutlinedBorder], the Material specific version of
 ///    `WidgetStateOutlinedBorder`.
-abstract class WidgetStateOutlinedBorder extends OutlinedBorder implements WidgetStateProperty<OutlinedBorder?> {
+abstract class WidgetStateOutlinedBorder extends LinearBorder implements WidgetStateProperty<OutlinedBorder?> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const WidgetStateOutlinedBorder();
@@ -434,6 +434,32 @@ abstract class WidgetStateOutlinedBorder extends OutlinedBorder implements Widge
   /// or theme.
   @override
   OutlinedBorder? resolve(Set<WidgetState> states);
+
+  /// Creates a [WidgetStateOutlinedBorder] from a [WidgetPropertyResolver<OutlinedBorder?>]
+  /// callback function.
+  ///
+  /// If used as a regular [OutlinedBorder], the border resolved in the default state (the
+  /// empty set of states) will be used.
+  static WidgetStateOutlinedBorder resolveWith(WidgetPropertyResolver<OutlinedBorder?> callback) =>
+      _WidgetStateOutlinedBorder(callback);
+}
+
+/// A [WidgetStateOutlinedBorder] created from a [WidgetPropertyResolver<OutlinedBorder>]
+/// callback alone.
+///
+/// If used as a regular [OutlinedBorder], the shape resolved in the default state will
+/// be used.
+///
+/// Used by [MaterialStateOutlinedBorder.resolveWith].
+class _WidgetStateOutlinedBorder extends WidgetStateOutlinedBorder {
+  const _WidgetStateOutlinedBorder(this._resolve);
+
+  final WidgetPropertyResolver<OutlinedBorder?> _resolve;
+
+  @override
+  OutlinedBorder? resolve(Set<WidgetState> states) {
+    return _resolve(states);
+  }
 }
 
 /// Defines a [TextStyle] that is also a [WidgetStateProperty].

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -3748,7 +3748,7 @@ void main() {
               label: const Text('Chip'),
               selected: selected,
               onSelected: enabled ? (_) {} : null,
-              side: _MaterialStateBorderSide(getBorderSide),
+              side: MaterialStateBorderSide.resolveWith(getBorderSide),
             ),
           ),
         ),
@@ -3826,7 +3826,7 @@ void main() {
               label: const Text('Chip'),
               selected: selected,
               onSelected: enabled ? (_) {} : null,
-              side: _MaterialStateBorderSide(getBorderSide),
+              side: MaterialStateBorderSide.resolveWith(getBorderSide),
             ),
           ),
         ),
@@ -4228,7 +4228,7 @@ void main() {
             child: ChoiceChip(
               selected: selected,
               label: const Text('Chip'),
-              shape: _MaterialStateOutlinedBorder(getShape),
+              shape: MaterialStateOutlinedBorder.resolveWith(getShape),
               onSelected: enabled ? (_) {} : null,
             ),
           ),
@@ -4298,7 +4298,7 @@ void main() {
             child: ChoiceChip(
               selected: selected,
               label: const Text('Chip'),
-              shape: _MaterialStateOutlinedBorder(getShape),
+              shape: WidgetStateOutlinedBorder.resolveWith(getShape),
               onSelected: enabled ? (_) {} : null,
             ),
           ),
@@ -4374,8 +4374,8 @@ void main() {
           body: ChoiceChip(
             selected: selected,
             label: const Text('Chip'),
-            shape: _MaterialStateOutlinedBorder(getShape),
-            side: _MaterialStateBorderSide(getBorderSide),
+            shape: WidgetStateOutlinedBorder.resolveWith(getShape),
+            side: MaterialStateBorderSide.resolveWith(getBorderSide),
             onSelected: enabled ? (_) {} : null,
           ),
         ),
@@ -4425,8 +4425,8 @@ void main() {
           body: ChoiceChip(
             selected: selected,
             label: const Text('Chip'),
-            shape: _MaterialStateOutlinedBorder(getShape),
-            side: _MaterialStateBorderSide(getBorderSide),
+            shape: WidgetStateOutlinedBorder.resolveWith(getShape),
+            side: MaterialStateBorderSide.resolveWith(getBorderSide),
             onSelected: enabled ? (_) {} : null,
           ),
         ),
@@ -6105,24 +6105,6 @@ void main() {
 
     expect(tester.widget<RawChip>(find.byType(RawChip)).chipAnimationStyle, chipAnimationStyle);
   });
-}
-
-class _MaterialStateOutlinedBorder extends StadiumBorder implements MaterialStateOutlinedBorder {
-  const _MaterialStateOutlinedBorder(this.resolver);
-
-  final MaterialPropertyResolver<OutlinedBorder?> resolver;
-
-  @override
-  OutlinedBorder? resolve(Set<MaterialState> states) => resolver(states);
-}
-
-class _MaterialStateBorderSide extends MaterialStateBorderSide {
-  const _MaterialStateBorderSide(this.resolver);
-
-  final MaterialPropertyResolver<BorderSide?> resolver;
-
-  @override
-  BorderSide? resolve(Set<MaterialState> states) => resolver(states);
 }
 
 class RenderLayoutCount extends RenderBox {

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -941,7 +941,7 @@ void main() {
       secondaryColor: Colors.blue,
       labelStyle: const TextStyle(),
     ).copyWith(
-      side: _MaterialStateBorderSide(getBorderSide),
+      side: MaterialStateBorderSide.resolveWith(getBorderSide),
     );
 
     Widget chipWidget({ bool selected = false }) {
@@ -979,7 +979,7 @@ void main() {
     }
 
     final ChipThemeData chipTheme = ChipThemeData(
-      side: _MaterialStateBorderSide(getBorderSide),
+      side: MaterialStateBorderSide.resolveWith(getBorderSide),
     );
 
     Widget chipWidget({ bool selected = false }) {
@@ -1017,7 +1017,7 @@ void main() {
       secondaryColor: Colors.blue,
       labelStyle: const TextStyle(),
     ).copyWith(
-      shape: _MaterialStateOutlinedBorder(getShape),
+      shape: MaterialStateOutlinedBorder.resolveWith(getShape),
     );
 
     Widget chipWidget({ bool selected = false }) {
@@ -1051,8 +1051,7 @@ void main() {
     }
 
     final ChipThemeData chipTheme = ChipThemeData(
-      shape: _MaterialStateOutlinedBorder(getShape),
-
+      shape: MaterialStateOutlinedBorder.resolveWith(getShape),
     );
 
     Widget chipWidget({ bool selected = false }) {
@@ -1521,22 +1520,4 @@ void main() {
 
     expect(getChipRenderBox(), paints..drrect(color: colorScheme.primary));
   });
-}
-
-class _MaterialStateOutlinedBorder extends StadiumBorder implements MaterialStateOutlinedBorder {
-  const _MaterialStateOutlinedBorder(this.resolver);
-
-  final MaterialPropertyResolver<OutlinedBorder?> resolver;
-
-  @override
-  OutlinedBorder? resolve(Set<MaterialState> states) => resolver(states);
-}
-
-class _MaterialStateBorderSide extends MaterialStateBorderSide {
-  const _MaterialStateBorderSide(this.resolver);
-
-  final MaterialPropertyResolver<BorderSide?> resolver;
-
-  @override
-  BorderSide? resolve(Set<MaterialState> states) => resolver(states);
 }


### PR DESCRIPTION
Adds `WidgetStateOutlinedBorder.resolveWith(myCallback)` static method to make `WidgetStateOutlinedBorder` easier to use.

Resolves #139430

Example:
```dart
Chip(
  label: const Text('Transceiver'),
  shape: WidgetStateOutlinedBorder.resolveWith((Set<WidgetState> states) {
    if (states.contains(WidgetState.selected)) {
      return const StadiumBorder(
        side: BorderSide(color: Colors.transparent),
      );
    }
    return null;  // Defer to default value on the theme or widget.
  }),
),
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
