### PR TITLE
Fix: On the Web, cannot support multiline inputting when registering customized TextInputControl

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -197,7 +197,7 @@ class TextInputType {
   static const TextInputType streetAddress = TextInputType._(9);
 
   /// Prevent the OS from showing the on-screen virtual keyboard.
-  static const TextInputType none = TextInputType.noneWithOptions(forceMultiline: false);
+  static const TextInputType none = TextInputType.noneWithOptions();
 
   /// All possible enum values.
   static const List<TextInputType> values = <TextInputType>[

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -89,7 +89,8 @@ enum SmartQuotesType {
 class TextInputType {
   const TextInputType._(this.index)
     : signed = null,
-      decimal = null;
+      decimal = null,
+      forceMultiline = null;
 
   /// Optimize for numerical information.
   ///
@@ -98,7 +99,15 @@ class TextInputType {
   const TextInputType.numberWithOptions({
     this.signed = false,
     this.decimal = false,
-  }) : index = 2;
+  }) : index = 2, forceMultiline = null;
+
+  /// Optimize for none information.
+  /// 
+  /// Requests a none keyboard with additional settings.
+  /// The [forceMultiline] parameter is optional.
+  const TextInputType.noneWithOptions({
+    this.forceMultiline = false,
+  }) : index = 10, signed = null, decimal = null;
 
   /// Enum value index, corresponds to one of the [values].
   final int index;
@@ -114,6 +123,12 @@ class TextInputType {
   /// This flag is only used for the [number] input type, otherwise `null`.
   /// Use `const TextInputType.numberWithOptions(decimal: true)` to set this.
   final bool? decimal;
+
+  /// The none is force multiline, allowing a multiline text input.
+  /// 
+  /// This flag is only used for the [none] input type, otherwise `null`.
+  /// Use `const TextInputType.noneWithOptions(forceMultiline: true)` to set this.
+  final bool? forceMultiline;
 
   /// Optimize for textual information.
   ///
@@ -182,7 +197,7 @@ class TextInputType {
   static const TextInputType streetAddress = TextInputType._(9);
 
   /// Prevent the OS from showing the on-screen virtual keyboard.
-  static const TextInputType none = TextInputType._(10);
+  static const TextInputType none = TextInputType.noneWithOptions(forceMultiline: false);
 
   /// All possible enum values.
   static const List<TextInputType> values = <TextInputType>[
@@ -203,6 +218,7 @@ class TextInputType {
       'name': _name,
       'signed': signed,
       'decimal': decimal,
+      'forceMultiline': forceMultiline,
     };
   }
 
@@ -211,7 +227,8 @@ class TextInputType {
     return '${objectRuntimeType(this, 'TextInputType')}('
         'name: $_name, '
         'signed: $signed, '
-        'decimal: $decimal)';
+        'decimal: $decimal, '
+        'forceMultiline: $forceMultiline)';
   }
 
   @override
@@ -219,11 +236,12 @@ class TextInputType {
     return other is TextInputType
         && other.index == index
         && other.signed == signed
-        && other.decimal == decimal;
+        && other.decimal == decimal
+        && other.forceMultiline == forceMultiline;
   }
 
   @override
-  int get hashCode => Object.hash(index, signed, decimal);
+  int get hashCode => Object.hash(index, signed, decimal, forceMultiline);
 }
 
 /// An action the user has requested the text input control to perform.
@@ -2226,7 +2244,9 @@ class _PlatformTextInputControl with TextInputControl {
   Map<String, dynamic> _configurationToJson(TextInputConfiguration configuration) {
     final Map<String, dynamic> json = configuration.toJson();
     if (TextInput._instance._currentControl != _PlatformTextInputControl.instance) {
-      json['inputType'] = TextInputType.none.toJson();
+      json['inputType'] = TextInputType.noneWithOptions(
+        forceMultiline: configuration.inputType == TextInputType.multiline,
+      );
     }
     return json;
   }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -102,7 +102,7 @@ class TextInputType {
   }) : index = 2, forceMultiline = null;
 
   /// Optimize for none information.
-  /// 
+  ///
   /// Requests a none keyboard with additional settings.
   /// The [forceMultiline] parameter is optional.
   const TextInputType.noneWithOptions({
@@ -125,7 +125,7 @@ class TextInputType {
   final bool? decimal;
 
   /// The none is force multiline, allowing a multiline text input.
-  /// 
+  ///
   /// This flag is only used for the [none] input type, otherwise `null`.
   /// Use `const TextInputType.noneWithOptions(forceMultiline: true)` to set this.
   final bool? forceMultiline;

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -298,6 +298,7 @@ void main() {
         'name': 'TextInputType.text',
         'signed': null,
         'decimal': null,
+        'forceMultiline': null,
       });
       expect(json['readOnly'], true);
       expect(json['obscureText'], true);
@@ -317,6 +318,27 @@ void main() {
         'name': 'TextInputType.number',
         'signed': false,
         'decimal': true,
+        'forceMultiline': null,
+      });
+      expect(json['readOnly'], false);
+      expect(json['obscureText'], true);
+      expect(json['autocorrect'], false);
+      expect(json['actionLabel'], 'xyzzy');
+    });
+
+    test('none serializes to JSON', () async {
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        inputType: TextInputType.noneWithOptions(forceMultiline: true),
+        obscureText: true,
+        autocorrect: false,
+        actionLabel: 'xyzzy',
+      );
+      final Map<String, dynamic> json = configuration.toJson();
+      expect(json['inputType'], <String, dynamic>{
+        'name': 'TextInputType.none',
+        'signed': null,
+        'decimal': null,
+        'forceMultiline': true,
       });
       expect(json['readOnly'], false);
       expect(json['obscureText'], true);
@@ -333,21 +355,26 @@ void main() {
       const TextInputType decimal = TextInputType.numberWithOptions(decimal: true);
       const TextInputType signedDecimal =
         TextInputType.numberWithOptions(signed: true, decimal: true);
+      const TextInputType none = TextInputType.none;
+      const TextInputType none2 = TextInputType.none;
+      const TextInputType multilineNone = TextInputType.noneWithOptions(forceMultiline: true);
+      const TextInputType multilineNone2 = TextInputType.noneWithOptions(forceMultiline: true);
 
-      expect(text.toString(), 'TextInputType(name: TextInputType.text, signed: null, decimal: null)');
-      expect(number.toString(), 'TextInputType(name: TextInputType.number, signed: false, decimal: false)');
-      expect(signed.toString(), 'TextInputType(name: TextInputType.number, signed: true, decimal: false)');
-      expect(decimal.toString(), 'TextInputType(name: TextInputType.number, signed: false, decimal: true)');
-      expect(signedDecimal.toString(), 'TextInputType(name: TextInputType.number, signed: true, decimal: true)');
-      expect(TextInputType.multiline.toString(), 'TextInputType(name: TextInputType.multiline, signed: null, decimal: null)');
-      expect(TextInputType.phone.toString(), 'TextInputType(name: TextInputType.phone, signed: null, decimal: null)');
-      expect(TextInputType.datetime.toString(), 'TextInputType(name: TextInputType.datetime, signed: null, decimal: null)');
-      expect(TextInputType.emailAddress.toString(), 'TextInputType(name: TextInputType.emailAddress, signed: null, decimal: null)');
-      expect(TextInputType.url.toString(), 'TextInputType(name: TextInputType.url, signed: null, decimal: null)');
-      expect(TextInputType.visiblePassword.toString(), 'TextInputType(name: TextInputType.visiblePassword, signed: null, decimal: null)');
-      expect(TextInputType.name.toString(), 'TextInputType(name: TextInputType.name, signed: null, decimal: null)');
-      expect(TextInputType.streetAddress.toString(), 'TextInputType(name: TextInputType.address, signed: null, decimal: null)');
-      expect(TextInputType.none.toString(), 'TextInputType(name: TextInputType.none, signed: null, decimal: null)');
+      expect(text.toString(), 'TextInputType(name: TextInputType.text, signed: null, decimal: null, forceMultiline: null)');
+      expect(number.toString(), 'TextInputType(name: TextInputType.number, signed: false, decimal: false, forceMultiline: null)');
+      expect(signed.toString(), 'TextInputType(name: TextInputType.number, signed: true, decimal: false, forceMultiline: null)');
+      expect(decimal.toString(), 'TextInputType(name: TextInputType.number, signed: false, decimal: true, forceMultiline: null)');
+      expect(signedDecimal.toString(), 'TextInputType(name: TextInputType.number, signed: true, decimal: true, forceMultiline: null)');
+      expect(none.toString(), 'TextInputType(name: TextInputType.none, signed: null, decimal: null, forceMultiline: false)');
+      expect(multilineNone.toString(), 'TextInputType(name: TextInputType.none, signed: null, decimal: null, forceMultiline: true)');
+      expect(TextInputType.multiline.toString(), 'TextInputType(name: TextInputType.multiline, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.phone.toString(), 'TextInputType(name: TextInputType.phone, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.datetime.toString(), 'TextInputType(name: TextInputType.datetime, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.emailAddress.toString(), 'TextInputType(name: TextInputType.emailAddress, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.url.toString(), 'TextInputType(name: TextInputType.url, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.visiblePassword.toString(), 'TextInputType(name: TextInputType.visiblePassword, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.name.toString(), 'TextInputType(name: TextInputType.name, signed: null, decimal: null, forceMultiline: null)');
+      expect(TextInputType.streetAddress.toString(), 'TextInputType(name: TextInputType.address, signed: null, decimal: null, forceMultiline: null)');
 
       expect(text == number, false);
       expect(number == number2, true);
@@ -357,6 +384,11 @@ void main() {
       expect(signed == signedDecimal, false);
       expect(decimal == signedDecimal, false);
 
+      expect(text == none2, false);
+      expect(none == none2, true);
+      expect(none == multilineNone, false);
+      expect(multilineNone == multilineNone2, true);
+
       expect(text.hashCode == number.hashCode, false);
       expect(number.hashCode == number2.hashCode, true);
       expect(number.hashCode == signed.hashCode, false);
@@ -364,6 +396,11 @@ void main() {
       expect(signed.hashCode == decimal.hashCode, false);
       expect(signed.hashCode == signedDecimal.hashCode, false);
       expect(decimal.hashCode == signedDecimal.hashCode, false);
+
+      expect(text.hashCode == none2.hashCode, false);
+      expect(none.hashCode == none2.hashCode, true);
+      expect(none.hashCode == multilineNone.hashCode, false);
+      expect(multilineNone.hashCode == multilineNone2.hashCode, true);
 
       expect(TextInputType.text.index, 0);
       expect(TextInputType.multiline.index, 1);


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/125875 and https://github.com/flutter/engine/pull/45522

According to this [discussion](https://github.com/flutter/engine/pull/45522#discussion_r1408482478), I have added `forceMultiline` to `TextInputType.none`. 
When we customize `TextInputControl`, `_PlatformTextInputControl` will send `TextInputType.none` with `forceMultiline` flag to the engine.
