### PR TITLE
Allowing CheckboxListTile, RadioListTile, SwitchListTile to have only one focus on Tab

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -517,12 +517,18 @@ class CheckboxListTile extends StatelessWidget {
     Widget? leading, trailing;
     switch (controlAffinity) {
       case ListTileControlAffinity.leading:
-        leading = control;
+        leading = Focus(
+            descendantsAreFocusable: false,
+            canRequestFocus: false,
+            child: control);
         trailing = secondary;
       case ListTileControlAffinity.trailing:
       case ListTileControlAffinity.platform:
         leading = secondary;
-        trailing = control;
+        trailing = Focus(
+            descendantsAreFocusable: false,
+            canRequestFocus: false,
+            child: control);
     }
     final ThemeData theme = Theme.of(context);
     final CheckboxThemeData checkboxTheme = CheckboxTheme.of(context);

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -488,11 +488,17 @@ class RadioListTile<T> extends StatelessWidget {
     switch (controlAffinity) {
       case ListTileControlAffinity.leading:
       case ListTileControlAffinity.platform:
-        leading = control;
+        leading = Focus(
+            descendantsAreFocusable: false,
+            canRequestFocus: false,
+            child: control);
         trailing = secondary;
       case ListTileControlAffinity.trailing:
         leading = secondary;
-        trailing = control;
+        trailing = Focus(
+            descendantsAreFocusable: false,
+            canRequestFocus: false,
+            child: control);
     }
     final ThemeData theme = Theme.of(context);
     final RadioThemeData radioThemeData = RadioTheme.of(context);

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -565,12 +565,18 @@ class SwitchListTile extends StatelessWidget {
     Widget? leading, trailing;
     switch (controlAffinity) {
       case ListTileControlAffinity.leading:
-        leading = control;
+        leading = Focus(
+            descendantsAreFocusable: false,
+            canRequestFocus: false,
+            child: control);
         trailing = secondary;
       case ListTileControlAffinity.trailing:
       case ListTileControlAffinity.platform:
         leading = secondary;
-        trailing = control;
+        trailing = Focus(
+            descendantsAreFocusable: false,
+            canRequestFocus: false,
+            child: control);
     }
 
     final ThemeData theme = Theme.of(context);


### PR DESCRIPTION
This PR should fix #77470 and allow only the ListTile to be focused but not the checkbox/Radio/Switch (has `control` as its variable name) which might be trailing or leading. This was fixed by wrapping `control` with Focus and disabling focus to it and its descendants. Thus allowing only one widget to focus on a single tab.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

I did not add any documentation since all I did was wrap a focus widget. Also I did not know how to make tests so I did not do any as mentioned in the guide. But I made the above changes locally in my system it works fine for windows, android and web (did not test for macos, linux, ios). (checked against official examples for [CheckboxListTile](https://api.flutter.dev/flutter/material/CheckboxListTile-class.html), [RadioListTile](https://api.flutter.dev/flutter/material/RadioListTile-class.html) and [SwitchListTile](https://api.flutter.dev/flutter/material/SwitchListTile-class.html))

https://github.com/flutter/flutter/assets/82655889/24ed24b4-cc21-4eac-825f-05cc39e72b3d

## Additional Comment

I did wonder whether I should disable the ListTile's focus or `control`'s focus. I thought these being subset of ListTile, they should have the focus rather than `control` widget. 

Also if anyone needs focus on `control` widget rather than ListTile, the following code can easily be written (Since ListTile's focus should be disabled without onTap or onLongPress parameters).

```
ListTile(
    title: const Text('Headline'),
    subtitle: const Text('Supporting text'),
    trailing: Switch(
        value: switchValue1,
        onChanged: (bool? value) {
            setState(() => switchValue1 = value!;);
            },
        ),
    ),
```
On the contrary, to make ListTile focusable with ListTile widget, it takes more lines of code as seen below and has redundant code which gets complicated with checkbox and radio (below code works as the same when the PR changes are made).

```
ListTile(
    title: const Text('Headline'),
    subtitle: const Text('Supporting text'),
    onTap: () {
        setState(() => switchValue1 = !switchValue1);
    },
    trailing: Focus(
        descendantsAreFocusable: false,
        canRequestFocus: false,
        child: Switch(
            value: switchValue1,
            onChanged: (bool? value) {
              setState(() => switchValue1 = value!);
            },
          ),
    )),
```