### PR TITLE
Remove InkSparkle.constantTurbulenceSeedSplashFactory usage

### DIFF
--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -2339,12 +2339,9 @@ void main() {
     // Regression test for: https://github.com/flutter/flutter/issues/22226
     Widget runTest() {
       int currentIndex = 0;
-      const bool useInkSparkle = !kIsWeb;
 
       return MaterialApp(
-        // Because this test relies on golden, fo a constant seed for the ink sparkle animation.
-        theme: ThemeData(splashFactory: useInkSparkle ? InkSparkle.constantTurbulenceSeedSplashFactory : null),
-          home: StatefulBuilder(
+        home: StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(
               bottomNavigationBar: RepaintBoundary(


### PR DESCRIPTION
This PR removes the call to `InkSparkle.constantTurbulenceSeedSplashFactory` which was introduced in https://github.com/flutter/flutter/pull/137998.

This is now obsolete since https://github.com/flutter/flutter/pull/138757 was merged and InkSparkle randomness is no more active in tests.