### PR TITLE
Overlay supports unconstrained environments

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -142,19 +142,20 @@ class OverlayEntry implements Listenable {
   /// Whether the content of this [OverlayEntry] can be used to size the
   /// [Overlay].
   ///
-  /// In most situations the Overlay sizes itself based on its incoming
+  /// In most situations the overlay sizes itself based on its incoming
   /// constraints to be as large as possible. However, if that would result in
   /// an infinite size, it has to rely on one of its children to size itself. In
-  /// this situation, the Overlay will consult the topmost [OverlayEntry] that
-  /// has this property set to true, lay it out with unconstrained
-  /// [BoxConstraints], and force all other OverlayEntries to have the same
-  /// size.
+  /// this situation, the overlay will consult the topmost non-[Positioned]
+  /// overlay entry that has this property set to true, lay it out with the
+  /// incoming [BoxConstraints] of the overlay, and force all other
+  /// non-[Positioned] overlay entries to have the same size. The [Positioned]
+  /// entries are laid out as usual based on the calculated size of the overlay.
   ///
-  /// OverlayEntries that set this to true must be able to handle unconstrained
+  /// Overlay entries that set this to true must be able to handle unconstrained
   /// [BoxConstraints].
   ///
-  /// Setting this to true has no effect if the OverlayEntry uses a [Positioned]
-  /// widget to position itself in the Overlay.
+  /// Setting this to true has no effect if the overlay entry uses a [Positioned]
+  /// widget to position itself in the overlay.
   final bool canSizeOverlay;
 
   /// Whether the [OverlayEntry] is currently mounted in the widget tree.
@@ -1297,10 +1298,13 @@ class _RenderTheater extends RenderBox with ContainerRenderObjectMixin<RenderBox
       ErrorDescription(
         'The constraints given to the overlay ($constraints) would result in an illegal '
         'infinite size (${constraints.biggest}). To avoid that, the Overlay tried to size '
-        'itself to one of its children, but no suitable non-positioned child that has '
-        'OverlayEntry.canSizeOverlay set to true could be found.',
+        'itself to one of its children, but no suitable non-positioned child that belongs to an '
+        'OverlayEntry with canSizeOverlay set to true could be found.',
       ),
-      ErrorHint('Try wrapping the Overlay in a SizedBox to give it a finite size.'),
+      ErrorHint(
+        'Try wrapping the Overlay in a SizedBox to give it a finite size or '
+        'use an OverlayEntry with canSizeOverlay set to true.',
+      ),
     ]);
   }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -849,6 +849,7 @@ class _WrappingOverlay extends StatefulWidget {
 
 class _WrappingOverlayState extends State<_WrappingOverlay> {
   late final OverlayEntry _entry = OverlayEntry(
+    canSizeOverlay: true,
     opaque: true,
     builder: (BuildContext context) {
       return widget.child;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -1247,7 +1247,7 @@ class _RenderTheater extends RenderBox with ContainerRenderObjectMixin<RenderBox
     if (constraints.biggest.isFinite) {
       size = constraints.biggest;
     } else {
-      RenderBox? child = _lastOnstageChild;
+      RenderBox? child = _firstOnstageChild;
       while (child != null) {
         final _TheaterParentData childParentData = child.parentData! as _TheaterParentData;
         // Only children that were not created by an OverlayPortal (overlayEntry != null)
@@ -1258,7 +1258,7 @@ class _RenderTheater extends RenderBox with ContainerRenderObjectMixin<RenderBox
           size = child.size;
           break;
         }
-        child = childParentData.previousSibling;
+        child = childParentData.nextSibling;
       }
       // TODO(goderbauer): Provide better error message if we cannot find a size-determining child.
       assert(sizeDeterminingChild != null);

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1847,7 +1847,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   Iterable<OverlayEntry> createOverlayEntries() {
     return <OverlayEntry>[
       _modalBarrier = OverlayEntry(builder: _buildModalBarrier),
-      _modalScope = OverlayEntry(builder: _buildModalScope, maintainState: maintainState),
+      _modalScope = OverlayEntry(builder: _buildModalScope, maintainState: maintainState, canSizeOverlay: opaque),
     ];
   }
 

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1603,9 +1603,8 @@ void main() {
     expect(find.byType(Theme), findsOneWidget);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/137875.
   testWidgets('MaterialApp works in an unconstrained environment', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/137875.
-
     await tester.pumpWidget(
       const UnconstrainedBox(
         child: MaterialApp(

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1602,6 +1602,20 @@ void main() {
     expect(find.byType(AnimatedTheme), findsNothing);
     expect(find.byType(Theme), findsOneWidget);
   });
+
+  testWidgets('MaterialApp works in an unconstrained environment', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/137875.
+
+    await tester.pumpWidget(
+      const UnconstrainedBox(
+        child: MaterialApp(
+          home: SizedBox(width: 123, height: 456),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(MaterialApp)), const Size(123, 456));
+  });
 }
 
 class MockScrollBehavior extends ScrollBehavior {

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1594,7 +1594,7 @@ void main() {
     expect(tester.state(find.byType(Overlay)), same(overlayState));
   });
 
-  testWidgets('Overlay.wrap works in an unconstrained environment', (WidgetTester tester) async {
+  testWidgets('Overlay.wrap is sized by child in an unconstrained environment', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -1614,7 +1614,7 @@ void main() {
     expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
   });
 
-  testWidgets('Overlay works in an unconstrained environment', (WidgetTester tester) async {
+  testWidgets('Overlay is sized by child in an unconstrained environment', (WidgetTester tester) async {
     final OverlayEntry initialEntry = OverlayEntry(
       opaque: true,
       canSizeOverlay: true,
@@ -1682,7 +1682,7 @@ void main() {
     expect(find.text('World'), findsNothing);
   });
 
-  testWidgets('Overlay throws if unconstrained and no child', (WidgetTester tester) async {
+  testWidgets('Overlay throws if unconstrained and has no child', (WidgetTester tester) async {
     final List<FlutterErrorDetails> errors = <FlutterErrorDetails>[];
     final FlutterExceptionHandler? oldHandler = FlutterError.onError;
     FlutterError.onError = errors.add;

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1593,6 +1593,177 @@ void main() {
     expect(find.text('Bye, bye'), findsOneWidget);
     expect(tester.state(find.byType(Overlay)), same(overlayState));
   });
+
+  testWidgets('Overlay.wrap works in an unconstrained environment', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: Overlay.wrap(
+            child: const Center(
+              child: SizedBox(
+                width: 123,
+                height: 456,
+              )
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
+  });
+
+  testWidgets('Overlay works in an unconstrained environment', (WidgetTester tester) async {
+    final OverlayEntry initialEntry = OverlayEntry(
+      opaque: true,
+      canSizeOverlay: true,
+      builder: (BuildContext context) {
+        return const SizedBox(width: 123, height: 456);
+      }
+    );
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: Overlay(
+            initialEntries: <OverlayEntry>[initialEntry]
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
+    
+    final OverlayState overlay = tester.state<OverlayState>(find.byType(Overlay));
+
+    final OverlayEntry nonSizingEntry = OverlayEntry(
+      builder: (BuildContext context) {
+        return const SizedBox(
+          width: 600,
+          height: 600,
+          child: Center(child: Text('Hello')),
+        );
+      },
+    );
+
+    overlay.insert(nonSizingEntry);
+    await tester.pump();
+    expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
+    expect(find.text('Hello'), findsOneWidget);
+
+    final OverlayEntry sizingEntry = OverlayEntry(
+      canSizeOverlay: true,
+      builder: (BuildContext context) {
+        return const SizedBox(
+          width: 222,
+          height: 111,
+          child: Center(child: Text('World')),
+        );
+      },
+    );
+
+    overlay.insert(sizingEntry);
+    await tester.pump();
+    expect(tester.getSize(find.byType(Overlay)), const Size(222, 111));
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.text('World'), findsOneWidget);
+
+    nonSizingEntry.remove();
+    await tester.pump();
+    expect(tester.getSize(find.byType(Overlay)), const Size(222, 111));
+    expect(find.text('Hello'), findsNothing);
+    expect(find.text('World'), findsOneWidget);
+
+    sizingEntry.remove();
+    await tester.pump();
+    expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
+    expect(find.text('Hello'), findsNothing);
+    expect(find.text('World'), findsNothing);
+  });
+
+  testWidgets('Overlay throws if unconstrained and no child', (WidgetTester tester) async {
+    final List<FlutterErrorDetails> errors = <FlutterErrorDetails>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = errors.add;
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: Overlay(),
+        ),
+      ),
+    );
+    FlutterError.onError = oldHandler;
+
+    expect(
+      errors.first.toString().replaceAll('\n', ' '),
+      contains('Overlay was given infinite constraints and cannot be sized by a suitable child.'),
+    );
+  });
+
+  testWidgets('Overlay throws if unconstrained and only positioned child', (WidgetTester tester) async {
+    final List<FlutterErrorDetails> errors = <FlutterErrorDetails>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = errors.add;
+
+    final OverlayEntry entry = OverlayEntry(
+      canSizeOverlay: true,
+      builder: (BuildContext context) {
+        return const Positioned(
+          top: 100,
+          child: SizedBox(width: 600, height: 600),
+        );
+      },
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: Overlay(
+            initialEntries: <OverlayEntry>[entry],
+          ),
+        ),
+      ),
+    );
+    FlutterError.onError = oldHandler;
+
+    expect(
+      errors.first.toString().replaceAll('\n', ' '),
+      contains('Overlay was given infinite constraints and cannot be sized by a suitable child.'),
+    );
+  });
+
+  testWidgets('Overlay throws if unconstrained and no canSizeOverlay child', (WidgetTester tester) async {
+    final List<FlutterErrorDetails> errors = <FlutterErrorDetails>[];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = errors.add;
+
+    final OverlayEntry entry = OverlayEntry(
+      builder: (BuildContext context) {
+        return const SizedBox(width: 600, height: 600);
+      },
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: UnconstrainedBox(
+          child: Overlay(
+            initialEntries: <OverlayEntry>[entry],
+          ),
+        ),
+      ),
+    );
+    FlutterError.onError = oldHandler;
+
+    expect(
+      errors.first.toString().replaceAll('\n', ' '),
+      contains('Overlay was given infinite constraints and cannot be sized by a suitable child.'),
+    );
+  });
 }
 
 class StatefulTestWidget extends StatefulWidget {

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1634,7 +1634,7 @@ void main() {
     );
 
     expect(tester.getSize(find.byType(Overlay)), const Size(123, 456));
-    
+
     final OverlayState overlay = tester.state<OverlayState>(find.byType(Overlay));
 
     final OverlayEntry nonSizingEntry = OverlayEntry(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/137875.

Unfortunately, we cannot auto-detect which OverlayEntry should be sizing the Overlay in unconstrained environment. So, this PR adds a special flag to annotate the Overlay Entry that should be used.