### PR TITLE
Add linked dart doc for Display on media query.

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -290,7 +290,8 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  /// * [FlutterView.physicalSize], which returns the size in physical pixels.
+  /// * [FlutterView.physicalSize], which returns the size of the view in physical pixels.
+  /// * [FlutterView.display], which returns reports display information like size, and refresh rate. 
   /// * [MediaQuery.sizeOf], a method to find and depend on the size defined for
   ///   a [BuildContext].
   final Size size;

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -291,7 +291,7 @@ class MediaQueryData {
   /// See also:
   ///
   /// * [FlutterView.physicalSize], which returns the size of the view in physical pixels.
-  /// * [FlutterView.display], which returns reports display information like size, and refresh rate. 
+  /// * [FlutterView.display], which returns reports display information like size, and refresh rate.
   /// * [MediaQuery.sizeOf], a method to find and depend on the size defined for
   ///   a [BuildContext].
   final Size size;


### PR DESCRIPTION
FlutterView.display.size tells you the resolution of the display on supported platforms. FlutterView.physicalSize tells you the view size, which may be different from the display. This can help you tell if you are being letterboxed on android. 

https://medium.com/flutter/developing-flutter-apps-for-large-screens-53b7b0e17f10

Related to [flutter/website/9896](https://github.com/flutter/website/issues/9896)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
