### PR TITLE
re-enable windows build_tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4584,7 +4584,6 @@ targets:
       - .ci.yaml
 
   - name: Windows build_tests_1_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4603,7 +4602,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_2_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4622,7 +4620,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_3_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4641,7 +4638,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_4_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4660,7 +4656,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_5_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4679,7 +4674,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_6_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4698,7 +4692,6 @@ targets:
         ["framework", "hostonly", "shard", "windows"]
 
   - name: Windows build_tests_7_7
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
These have all passed since being introduced >20 commits ago:

![Screenshot from 2023-12-05 14-37-41](https://github.com/flutter/flutter/assets/7856010/997f39a1-377c-4e85-a7a1-02bb7e687506)
