### PR TITLE
Be less verbose in CI for customer_testing, and revert old timeout hack

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3,6 +3,12 @@
 # Flutter infra uses this file to generate a checklist of tasks to be performed
 # for every commit.
 #
+# The recipes mentioned below refer to those in this repo:
+#   https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/
+#
+# The "flutter_drone" recipe just defers to dev/bots/test.dart in this repo,
+# with the shard set according to the "shard" key in this file.
+#
 # More information at:
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
 enabled_branches:
@@ -420,6 +426,9 @@ targets:
       - .ci.yaml
 
   - name: Linux customer_testing
+    # This really just runs dev/bots/customer_testing/ci.sh,
+    # but it does so indirectly via the flutter_drone recipe
+    # calling the dev/bots/test.dart script.
     enabled_branches:
       - master
     recipe: flutter/flutter_drone
@@ -432,7 +441,7 @@ targets:
   - name: Linux docs_publish
     recipe: flutter/docs
     presubmit: false
-    timeout: 90 # https://github.com/flutter/flutter/issues/120901
+    timeout: 60
     dimensions:
       os: "Linux"
     properties:

--- a/dev/customer_testing/ci.sh
+++ b/dev/customer_testing/ci.sh
@@ -34,4 +34,4 @@ git clone https://github.com/flutter/tests.git ../../bin/cache/pkg/tests
 git -C ../../bin/cache/pkg/tests checkout `dart --enable-asserts ../tools/bin/find_commit.dart . master ../../bin/cache/pkg/tests main`
 
 # Finally, run the tests.
-dart --enable-asserts run_tests.dart --verbose --skip-on-fetch-failure --skip-template ../../bin/cache/pkg/tests/registry/*.test
+dart --enable-asserts run_tests.dart --skip-on-fetch-failure --skip-template ../../bin/cache/pkg/tests/registry/*.test


### PR DESCRIPTION
This PR does two things. First, it reduces the verbosity in the customer_testing shard. We want to be less verbose because it's nigh on impossible to find anything when there's a failure in the verbose logs. Also, some additional comments are added to make following the breadcrumbs easier for the next person.

Second, it reverts a timeout that had been set to 90 minutes a while ago. It's no longer needed.

Fixes https://github.com/flutter/flutter/issues/120901.
