### PR TITLE
Add key to BottomNavigationBarItem

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -449,6 +449,7 @@ class _BottomNavigationTile extends StatelessWidget {
     this.item,
     this.animation,
     this.iconSize, {
+    super.key,
     this.onTap,
     this.labelColorTween,
     this.iconColorTween,
@@ -1101,6 +1102,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         widget.items[i],
         _animations[i],
         widget.iconSize,
+        key: widget.items[i].key,
         selectedIconTheme: widget.useLegacyColorScheme ? widget.selectedIconTheme ?? bottomTheme.selectedIconTheme : effectiveSelectedIconTheme,
         unselectedIconTheme: widget.useLegacyColorScheme ? widget.unselectedIconTheme ?? bottomTheme.unselectedIconTheme : effectiveUnselectedIconTheme,
         selectedLabelStyle: effectiveSelectedLabelStyle,

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -23,12 +23,16 @@ class BottomNavigationBarItem {
   ///
   /// The argument [icon] should not be null and the argument [label] should not be null when used in a Material Design's [BottomNavigationBar].
   const BottomNavigationBarItem({
+    this.key,
     required this.icon,
     this.label,
     Widget? activeIcon,
     this.backgroundColor,
     this.tooltip,
   }) : activeIcon = activeIcon ?? icon;
+
+  /// A key to be passed through to the _BottomNavigationTile widget
+  final Key? key;
 
   /// The icon of the item.
   ///

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -31,7 +31,13 @@ class BottomNavigationBarItem {
     this.tooltip,
   }) : activeIcon = activeIcon ?? icon;
 
-  /// A key to be passed through to the _BottomNavigationTile widget
+  /// A key to be passed through to the resultant widget
+  ///
+  /// This allows the identification of different [BottomNavigationBarItem]s
+  /// This is useful for testing purposes
+  ///
+  /// When changing the number of bar items in response to a bar item being tapped, giving
+  /// each item a key will allow the inkwell / splash animation to be correctly positioned
   final Key? key;
 
   /// The icon of the item.

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -31,7 +31,7 @@ class BottomNavigationBarItem {
     this.tooltip,
   }) : activeIcon = activeIcon ?? icon;
 
-  /// A key to be passed through to the resultant widget
+  /// A key to be passed through to the resultant widget.
   ///
   /// This allows the identification of different [BottomNavigationBarItem]s through their keys.
   ///

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -33,11 +33,10 @@ class BottomNavigationBarItem {
 
   /// A key to be passed through to the resultant widget
   ///
-  /// This allows the identification of different [BottomNavigationBarItem]s
-  /// This is useful for testing purposes
+  /// This allows the identification of different [BottomNavigationBarItem]s through their keys.
   ///
   /// When changing the number of bar items in response to a bar item being tapped, giving
-  /// each item a key will allow the inkwell / splash animation to be correctly positioned
+  /// each item a key will allow the inkwell / splash animation to be correctly positioned.
   final Key? key;
 
   /// The icon of the item.

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -3174,6 +3174,36 @@ void main() {
 
     addTearDown(tester.view.resetPhysicalSize);
   });
+
+  testWidgets('BottomNavigationBar keys passed through', (WidgetTester tester) async {
+    const Key key1 = Key('key1');
+    const Key key2 = Key('key2');
+    int selectedItem = 0;
+
+    await tester.pumpWidget(
+      boilerplate(
+        textDirection: TextDirection.ltr,
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: selectedItem,
+          items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+              key: key1,
+              icon: Icon(Icons.favorite_border),
+              label: 'Favorite',
+            ),
+            BottomNavigationBarItem(
+              key: key2,
+              icon: Icon(Icons.access_alarm),
+              label: 'Alarm',
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.byKey(key1), findsOneWidget);
+    expect(find.byKey(key2), findsOneWidget);
+  });
 }
 
 Widget boilerplate({ Widget? bottomNavigationBar, required TextDirection textDirection, bool? useMaterial3 }) {

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -3178,13 +3178,11 @@ void main() {
   testWidgets('BottomNavigationBar keys passed through', (WidgetTester tester) async {
     const Key key1 = Key('key1');
     const Key key2 = Key('key2');
-    int selectedItem = 0;
 
     await tester.pumpWidget(
       boilerplate(
         textDirection: TextDirection.ltr,
         bottomNavigationBar: BottomNavigationBar(
-          currentIndex: selectedItem,
           items: const <BottomNavigationBarItem>[
             BottomNavigationBarItem(
               key: key1,


### PR DESCRIPTION
Pass key into _BottomNavigationTile

Adding a optional key parameter to BottomNavigationBarItem to be passed through to _BottomNavigationTile.
This will allow easier testing in some scenarios, and fix the splash appearing on the wrong tile.

https://github.com/flutter/flutter/issues/139615
https://github.com/flutter/flutter/issues/34833