### PR TITLE
[github] Remove commit hash from CP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/7_cherry_pick.yml
+++ b/.github/ISSUE_TEMPLATE/7_cherry_pick.yml
@@ -10,13 +10,6 @@ body:
       description: What is the link to the issue this cherry-pick is addressing?
     validations:
       required: true
-  - type: input
-    id: commit_hash
-    attributes:
-      label: Commit Hash
-      description: What is the shortened commit hash that has been merged to master/main?
-    validations:
-      required: true
   - type: dropdown
     id: Target
     attributes:
@@ -41,7 +34,7 @@ body:
     attributes:
       label: Changelog Description
       description: >-
-        Explain this CP in one line that is accessible to most Flutter developers
+        Explain this CP in less than 80 characters that is accessible to most Flutter developers
         See https://github.com/flutter/flutter/wiki/Hotfix-Documentation-Best-Practices for examples
     validations:
       required: true


### PR DESCRIPTION
* This seems to be unnecessary as users will open a CP PR with the original commit linked in it.
* Add note on changelog description to be less than 80 chars

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
