### PR TITLE
Implement `SubmenuButton.onFocusChange`

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1951,6 +1951,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
             child: TextButton(
               style: mergedStyle,
               focusNode: _buttonFocusNode,
+              onFocusChange: _enabled ? widget.onFocusChange : null,
               onHover: _enabled ? (bool hovering) => handleHover(hovering, context) : null,
               onPressed: _enabled ? () => toggleShowMenu(context) : null,
               isSemanticButton: null,

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3519,6 +3519,43 @@ void main() {
     expect(material.textStyle?.wordSpacing, menuTextStyle.wordSpacing);
     expect(material.textStyle?.decoration, menuTextStyle.decoration);
   });
+
+  testWidgetsWithLeakTracking('SubmenuButton.onFocusChange is respected', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    int onFocusChangeCalled = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return SubmenuButton(
+                focusNode: focusNode,
+                onFocusChange: (bool value) {
+                  setState(() {
+                    onFocusChangeCalled += 1;
+                  });
+                },
+                menuChildren: const <Widget>[
+                  MenuItemButton(child: Text('item 0'))
+                ],
+                child: const Text('Submenu 0'),
+              );
+            }
+          ),
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, true);
+    expect(onFocusChangeCalled, 1);
+
+    focusNode.unfocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, false);
+    expect(onFocusChangeCalled, 2);
+  });
 }
 
 List<Widget> createTestMenus({


### PR DESCRIPTION
Fixes #139409

`SubmenuButton.onFocusChange` is not implemented. This PR is just add one line fix to assign this property to `TextButton.onFocusChange` which is used in `SubmenuButton`:)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
