### PR TITLE
Warn when Gradle plugins are applied using the legacy "apply script method" way

### DIFF
--- a/packages/flutter_tools/gradle/app_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/app_plugin_loader.gradle
@@ -5,5 +5,11 @@
 // This file exists solely for the compatibility with projects that have
 // not migrated to the declarative apply of the Flutter App Plugin Loader Gradle Plugin.
 
+logger.error("You are applying Flutter's app_plugin_loader Gradle plugin \
+imperatively using the apply script method, which is deprecated and will be \
+removed in a future release. Migrate to applying Gradle plugins with the \
+declarative plugins block: https://flutter.dev/go/flutter-gradle-plugin-apply\n\
+")
+
 def pathToThisDirectory = buildscript.sourceFile.parentFile
 apply from: "$pathToThisDirectory/src/main/groovy/app_plugin_loader.groovy"

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -5,5 +5,10 @@
 // This file exists solely for the compatibility with projects that have
 // not migrated to the declarative apply of the Flutter Gradle Plugin.
 
+logger.error("You are applying Flutter's main Gradle plugin imperatively using \
+the apply script method, which is deprecated and will be removed in a future \
+release. Migrate to applying Gradle plugins with the declarative plugins \
+block: https://flutter.dev/go/flutter-gradle-plugin-apply\n")
+
 def pathToThisDirectory = buildscript.sourceFile.parentFile
 apply from: "$pathToThisDirectory/src/main/groovy/flutter.groovy"

--- a/packages/flutter_tools/test/integration.shard/android_gradle_deprecated_plugin_apply_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_deprecated_plugin_apply_test.dart
@@ -1,0 +1,195 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext(
+      'gradle prints warning when Flutter\'s Gradle plugins are applied using deprecated "apply plugin" way', () async {
+    // Create a new flutter project.
+    final String flutterBin =
+    fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+    ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      'create',
+      tempDir.path,
+      '--project-name=testapp',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+    // Ensure that gradle files exists from templates.
+    result = await processManager.run(<String>[
+      flutterBin,
+      'build',
+      'apk',
+      '--config-only',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+
+    // Change build files to use deprecated "apply plugin:" way.
+    // Contents are taken from https://github.com/flutter/flutter/issues/135392 (for Flutter 3.10)
+    final File settings = tempDir.childDirectory('android').childFile('settings.gradle');
+    final File buildGradle = tempDir.childDirectory('android').childFile('build.gradle');
+    final File appBuildGradle = tempDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
+    settings.writeAsStringSync(r'''
+include ':app'
+
+def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
+def properties = new Properties()
+
+assert localPropertiesFile.exists()
+localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+
+def flutterSdkPath = properties.getProperty("flutter.sdk")
+assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+'''
+    );
+  buildGradle.writeAsStringSync(r'''
+buildscript {
+    ext.kotlin_version = '1.7.10'
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+subprojects {
+    project.evaluationDependsOn(':app')
+}
+
+tasks.register("clean", Delete) {
+    delete rootProject.buildDir
+}
+''');
+  appBuildGradle.writeAsStringSync(r'''
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
+def flutterRoot = localProperties.getProperty('flutter.sdk')
+if (flutterRoot == null) {
+    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+}
+
+def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+if (flutterVersionCode == null) {
+    flutterVersionCode = '1'
+}
+
+def flutterVersionName = localProperties.getProperty('flutter.versionName')
+if (flutterVersionName == null) {
+    flutterVersionName = '1.0'
+}
+
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+
+android {
+    compileSdkVersion flutter.compileSdkVersion
+    ndkVersion flutter.ndkVersion
+    namespace "com.example.testapp"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
+    defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId "com.example.testapp"
+        // You can update the following values to match your application needs.
+        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
+        versionCode flutterVersionCode.toInteger()
+        versionName flutterVersionName
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            // TODO: Add your own signing config for the release build.
+            // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig signingConfigs.debug
+        }
+    }
+}
+
+flutter {
+    source '../..'
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+''');
+
+    result = await processManager.run(<String>[
+      flutterBin,
+      'build',
+      'apk',
+      '--debug',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+    // Verify that stderr output contains deprecation warnings.
+    final List<String> actualLines = LineSplitter.split(result.stderr.toString()).toList();
+    expect(
+      actualLines.any((String msg) => msg.contains(
+        "You are applying Flutter's main Gradle plugin imperatively"),
+      ),
+      isTrue,
+    );
+    expect(
+      actualLines.any((String msg) => msg.contains(
+        "You are applying Flutter's app_plugin_loader Gradle plugin imperatively"),
+      ),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
This PR adds a deprecation message when Android build is using the legacy "apply script method" way of applying Flutter's Gradle plugins (that is: [`flutter.gradle`](https://github.com/flutter/flutter/blob/3.16.0/packages/flutter_tools/gradle/flutter.gradle) and [`app_plugin_loader.gradle`](https://github.com/flutter/flutter/blob/3.16.0/packages/flutter_tools/gradle/app_plugin_loader.gradle)).

See also:
- #121541
  - in particular https://github.com/flutter/flutter/issues/121541#issuecomment-1836947311
- #135392
  - and PR that add the migration guide: [#9857](https://github.com/flutter/website/pull/9857)

- I think either `logger.error` or `logger.quiet` must be used, because all other error levels are not shown during `flutter build apk` (and that's what most people use).


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.