### PR TITLE
Don't send images to Gold on release branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7,7 +7,7 @@
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
 enabled_branches:
   - master
-  - flutter-\d+\.\d+-candidate\.\d+ # If this changes, update flutter_goldens.dart
+  - flutter-\d+\.\d+-candidate\.\d+
 
 platform_properties:
   staging_build_linux:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7,7 +7,7 @@
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
 enabled_branches:
   - master
-  - flutter-\d+\.\d+-candidate\.\d+
+  - flutter-\d+\.\d+-candidate\.\d+ # If this changes, update flutter_goldens.dart
 
 platform_properties:
   staging_build_linux:

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -19,6 +19,7 @@ export 'package:flutter_goldens_client/skia_client.dart';
 // https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package%3Aflutter
 
 const String _kFlutterRootKey = 'FLUTTER_ROOT';
+final RegExp _kReleaseBranch = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
 
 /// Main method that can be used in a `flutter_test_config.dart` file to set
 /// [goldenFileComparator] to an instance of [FlutterGoldenFileComparator] that
@@ -259,7 +260,9 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
     final bool luciPostSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')
       // Luci tryjob environments contain this value to inform the [FlutterPreSubmitComparator].
-      && !platform.environment.containsKey('GOLD_TRYJOB');
+      && !platform.environment.containsKey('GOLD_TRYJOB')
+      // Do not run on release branches
+      && !(platform.environment['GIT_BRANCH'] ?? '').contains(_kReleaseBranch);
 
     return luciPostSubmit;
   }
@@ -346,7 +349,9 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
   static bool isAvailableForEnvironment(Platform platform) {
     final bool luciPreSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')
-      && platform.environment.containsKey('GOLD_TRYJOB');
+      && platform.environment.containsKey('GOLD_TRYJOB')
+      // Do not run on release branches
+      && !(platform.environment['GIT_BRANCH'] ?? '').contains(_kReleaseBranch);
     return luciPreSubmit;
   }
 }
@@ -415,7 +420,9 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
   static bool isAvailableForEnvironment(Platform platform) {
     return platform.environment.containsKey('SWARMING_TASK_ID')
       // Some builds are still being run on Cirrus, we should skip these.
-      || platform.environment.containsKey('CIRRUS_CI');
+      || platform.environment.containsKey('CIRRUS_CI')
+      // Absolutely run on release branches
+      || (platform.environment['GIT_BRANCH'] ?? '').contains(_kReleaseBranch);
   }
 }
 

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -19,7 +19,7 @@ export 'package:flutter_goldens_client/skia_client.dart';
 // https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package%3Aflutter
 
 const String _kFlutterRootKey = 'FLUTTER_ROOT';
-final RegExp _kReleaseBranch = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
+final RegExp _kMainBranch = RegExp(r'master|main');
 
 /// Main method that can be used in a `flutter_test_config.dart` file to set
 /// [goldenFileComparator] to an instance of [FlutterGoldenFileComparator] that
@@ -261,8 +261,8 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
       && platform.environment.containsKey('GOLDCTL')
       // Luci tryjob environments contain this value to inform the [FlutterPreSubmitComparator].
       && !platform.environment.containsKey('GOLD_TRYJOB')
-      // Do not run on release branches
-      && !(platform.environment['GIT_BRANCH'] ?? '').contains(_kReleaseBranch);
+      // Only run on main branch.
+      && _kMainBranch.hasMatch(platform.environment['GIT_BRANCH'] ?? '');
 
     return luciPostSubmit;
   }
@@ -350,8 +350,8 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
     final bool luciPreSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')
       && platform.environment.containsKey('GOLD_TRYJOB')
-      // Do not run on release branches
-      && !(platform.environment['GIT_BRANCH'] ?? '').contains(_kReleaseBranch);
+      // Only run on the main branch
+      && _kMainBranch.hasMatch(platform.environment['GIT_BRANCH'] ?? '');
     return luciPreSubmit;
   }
 }
@@ -418,11 +418,11 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
   /// If we are in a CI environment, LUCI or Cirrus, but are not using the other
   /// comparators, we skip.
   static bool isAvailableForEnvironment(Platform platform) {
-    return platform.environment.containsKey('SWARMING_TASK_ID')
+    return (platform.environment.containsKey('SWARMING_TASK_ID')
       // Some builds are still being run on Cirrus, we should skip these.
-      || platform.environment.containsKey('CIRRUS_CI')
-      // Absolutely run on release branches
-      || (platform.environment['GIT_BRANCH'] ?? '').contains(_kReleaseBranch);
+      || platform.environment.containsKey('CIRRUS_CI'))
+      // If we are in CI, skip on branches that are not main.
+      && !_kMainBranch.hasMatch(platform.environment['GIT_BRANCH'] ?? '');
   }
 }
 

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -716,6 +716,7 @@ void main() {
               'FLUTTER_ROOT': _kFlutterRoot,
               'SWARMING_TASK_ID' : '12345678990',
               'GOLDCTL' : 'goldctl',
+              'GIT_BRANCH' : 'master',
             },
             operatingSystem: 'macos',
           );
@@ -738,6 +739,38 @@ void main() {
           expect(
             FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
             isFalse,
+          );
+        });
+
+        test('returns true on master branch in postsubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GIT_BRANCH' : 'master',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            isTrue,
+          );
+        });
+
+        test('returns true on main branch in postsubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GIT_BRANCH' : 'main',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            isTrue,
           );
         });
 
@@ -861,6 +894,40 @@ void main() {
           );
         });
 
+        test('returns true on master branch in presubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GOLD_TRYJOB' : 'true',
+              'GIT_BRANCH' : 'master',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            isTrue,
+          );
+        });
+
+        test('returns true on main branch in presubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GOLD_TRYJOB' : 'true',
+              'GIT_BRANCH' : 'main',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            isTrue,
+          );
+        });
+
         test('returns true for Luci', () {
           platform = FakePlatform(
             environment: <String, String>{
@@ -868,6 +935,7 @@ void main() {
               'SWARMING_TASK_ID' : '12345678990',
               'GOLDCTL' : 'goldctl',
               'GOLD_TRYJOB' : 'git/ref/12345/head',
+              'GIT_BRANCH' : 'master',
             },
             operatingSystem: 'macos',
           );
@@ -1002,7 +1070,7 @@ void main() {
           );
         });
 
-        test('returns false - no CI', () {
+        test('returns false - not in CI', () {
           platform = FakePlatform(
             environment: <String, String>{
               'FLUTTER_ROOT': _kFlutterRoot,
@@ -1010,8 +1078,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterSkippingFileComparator.isAvailableForEnvironment(
-              platform),
+            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
             isFalse,
           );
         });

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -725,6 +725,22 @@ void main() {
           );
         });
 
+        test('returns false on release branches in postsubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GIT_BRANCH' : 'flutter-3.16-candidate.0',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            isFalse,
+          );
+        });
+
         test('returns false - GOLDCTL not present', () {
           platform = FakePlatform(
             environment: <String, String>{
@@ -828,6 +844,23 @@ void main() {
       });
 
       group('correctly determines testing environment', () {
+        test('returns false on release branches in presubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GOLD_TRYJOB' : 'true',
+              'GIT_BRANCH' : 'flutter-3.16-candidate.0',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            isFalse,
+          );
+        });
+
         test('returns true for Luci', () {
           platform = FakePlatform(
             environment: <String, String>{
@@ -908,6 +941,39 @@ void main() {
 
     group('Skipping', () {
       group('correctly determines testing environment', () {
+        test('returns true on release branches in presubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GOLD_TRYJOB' : 'true',
+              'GIT_BRANCH' : 'flutter-3.16-candidate.0',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            isTrue,
+          );
+        });
+
+        test('returns true on release branches in postsubmit', () {
+          platform = FakePlatform(
+            environment: <String, String>{
+              'FLUTTER_ROOT': _kFlutterRoot,
+              'SWARMING_TASK_ID' : 'sweet task ID',
+              'GOLDCTL' : 'some/path',
+              'GIT_BRANCH' : 'flutter-3.16-candidate.0',
+            },
+            operatingSystem: 'macos',
+          );
+          expect(
+            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            isTrue,
+          );
+        });
+
         test('returns true on Cirrus builds', () {
           platform = FakePlatform(
             environment: <String, String>{


### PR DESCRIPTION
Part of fixing https://github.com/flutter/flutter/issues/139673, it will need to be cherry picked into the stable branch to fully resolve.

Originally I tried to come at this from `ci.yaml`, but the syntax does not exist to either conditionally include a dependency based on the branch we are on, or to disable a shard for a given branch (as opposed to enabling it which is supported). I could double every CI shard that uses Gold to try to serve my purpose, but it is already a very large and cumbersome file to keep up to date. Doubling it does not feel like the best solution. Using a RegEx is not my favorite, but I am using the same one we use in our CI, and left a note there to update it if it should ever change. Since there is already a whole infra built around it, I feel it is pretty safe so we can fix the stable tree.

We already had mitigated Gold affecting release branches in the past through flutter/cocoon (https://github.com/flutter/flutter/issues/58814), but https://github.com/flutter/flutter/issues/139673 exposed a rather rare edge case. A change was CP'd into the stable branch that introduced golden file image changes. Typically this would not cause an issue since any change that has landed on the master branch has golden files accounted for. In this case, the CP'd change on master has generated a different image on canvaskit due to another change that was not on stable. So when the CP landed, it generated a new image Gold had never seen before. Gold only tracks the master branch, so we cannot approve the image, and so cannot fix the stable tree.

This would disable the failing check on release branches and fix the tree.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
