### PR TITLE
[CP] Catch error for missing directory in `FontConfigManager` (#138496)

### DIFF
--- a/packages/flutter_tools/lib/src/test/font_config_manager.dart
+++ b/packages/flutter_tools/lib/src/test/font_config_manager.dart
@@ -34,7 +34,11 @@ class FontConfigManager {
   Future<void> dispose() async {
     if (_fontsDirectory != null) {
       globals.printTrace('Deleting ${_fontsDirectory!.path}...');
-      await _fontsDirectory!.delete(recursive: true);
+      try {
+        await _fontsDirectory!.delete(recursive: true);
+      } on FileSystemException {
+        // Silently exit
+      }
       _fontsDirectory = null;
     }
   }

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -50,6 +50,18 @@ void main() {
       uriConverter: (String input) => '$input/converted',
     );
 
+  testUsingContext('Missing dir error caught for FontConfigManger.dispose', () async {
+    final FontConfigManager fontConfigManager = FontConfigManager();
+
+    final Directory fontsDirectory = fileSystem.file(fontConfigManager.fontConfigFile).parent;
+    fontsDirectory.deleteSync(recursive: true);
+
+    await fontConfigManager.dispose();
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
   group('The FLUTTER_TEST environment variable is passed to the test process', () {
     setUp(() {
       processManager = FakeProcessManager.list(<FakeCommand>[]);


### PR DESCRIPTION
Closes:
- https://github.com/flutter/flutter/issues/138434

We will catch any errors while attempting to clear the temp directories that don't exist for the `FontConfigManager` class