### PR TITLE
If one method of finding Dart VM fails for CoreDevice, wait for the other method

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -680,6 +680,14 @@ class IOSDevice extends Device {
           localUri = await Future.any(
             <Future<Uri?>>[vmUrlFromMDns, vmUrlFromLogs]
           );
+
+          // If the first future to return is null, wait for the other to complete.
+          if (localUri == null) {
+            final List<Uri?> vmUrls = await Future.wait(
+              <Future<Uri?>>[vmUrlFromMDns, vmUrlFromLogs]
+            );
+            localUri = vmUrls.where((Uri? vmUrl) => vmUrl != null).firstOrNull;
+          }
         } else {
           localUri = await vmServiceDiscovery?.uri;
           // If the `ios-deploy` debugger loses connection before it finds the

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -904,6 +904,68 @@ void main() {
       }, overrides: <Type, Generator>{
         MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery(),
       });
+
+      group('IOSDevice.startApp attaches in debug mode via device logging', () {
+        late FakeMDnsVmServiceDiscovery mdnsDiscovery;
+        setUp(() {
+          mdnsDiscovery = FakeMDnsVmServiceDiscovery(returnsNull: true);
+        });
+
+        testUsingContext('when mDNS fails', () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final FakeProcessManager processManager = FakeProcessManager.empty();
+
+          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory.childDirectory('flutter_empty_xcode.rand0');
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+            xcodeDebug: FakeXcodeDebug(
+              expectedProject: XcodeDebugProject(
+                scheme: 'Runner',
+                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
+                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
+                hostAppProjectName: 'Runner',
+              ),
+              expectedDeviceId: '123',
+              expectedLaunchArguments: <String>['--enable-dart-profiling'],
+              expectedBundlePath: bundleLocation.path,
+            )
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final FakeDeviceLogReader deviceLogReader = FakeDeviceLogReader();
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          unawaited(mdnsDiscovery.completer.future.whenComplete(() {
+            // Start writing messages to the log reader.
+            Timer.run(() {
+              deviceLogReader.addLine('Foo');
+              deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+            });
+          }));
+
+          final LaunchResult launchResult = await device.startApp(iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(launchResult.hasVmService, true);
+          expect(await device.stopApp(iosApp), true);
+        }, overrides: <Type, Generator>{
+          MDnsVmServiceDiscovery: () => mdnsDiscovery,
+        });
+      });
     });
   });
 }
@@ -974,6 +1036,10 @@ class FakeDevicePortForwarder extends Fake implements DevicePortForwarder {
 }
 
 class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery {
+  FakeMDnsVmServiceDiscovery({this.returnsNull = false});
+  bool returnsNull;
+
+  Completer<void> completer = Completer<void>();
   @override
   Future<Uri?> getVMServiceUriForLaunch(
     String applicationId,
@@ -984,6 +1050,11 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
     bool useDeviceIPAsHost = false,
     Duration timeout = Duration.zero,
   }) async {
+    completer.complete();
+    if (returnsNull) {
+      return null;
+    }
+
     return Uri.tryParse('http://0.0.0.0:1234');
   }
 }


### PR DESCRIPTION
For CoreDevices we use a combination of mDNS and device logs to find the Dart VM url. If mDNS fails first, it will cause the launch to fail even though the device logs may be able to find the url. So if one of the methods fails, wait for the other method before failing the launch.

Fixes https://github.com/flutter/flutter/issues/139685.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
