### PR TITLE
[flutter_tools] catch SocketException writing to ios-deploy stdin

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -233,6 +233,22 @@ abstract class ProcessUtils {
     List<String> cli, {
     Map<String, String>? environment,
   });
+
+  static Future<void> writelnToStdin({
+    required IOSink stdin,
+    required String line,
+    void Function(Object, StackTrace)? onError,
+  }) async {
+    final Completer<void> completer = Completer<void>();
+    runZonedGuarded(
+      () {
+        stdin.writeln(line);
+        stdin.flush().whenComplete(() => completer.complete());
+      },
+      onError ?? (Object _, StackTrace __) {},
+    );
+    return completer.future;
+  }
 }
 
 class _DefaultProcessUtils implements ProcessUtils {

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -240,13 +240,17 @@ abstract class ProcessUtils {
     void Function(Object, StackTrace)? onError,
   }) async {
     final Completer<void> completer = Completer<void>();
-    runZonedGuarded(
-      () {
-        stdin.writeln(line);
-        stdin.flush().whenComplete(() => completer.complete());
-      },
-      onError ?? (Object _, StackTrace __) {},
-    );
+
+    void writeFlushAndComplete() {
+      stdin.writeln(line);
+      stdin.flush().whenComplete(() => completer.complete());
+    }
+
+    if (onError == null) {
+      runZoned(writeFlushAndComplete);
+    } else {
+      runZonedGuarded(writeFlushAndComplete, onError);
+    }
     return completer.future;
   }
 }

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -271,10 +271,10 @@ abstract class ProcessUtils {
     runZonedGuarded(
       writeFlushAndComplete,
       (Object error, StackTrace stackTrace) {
+        onError(error, stackTrace);
         if (!completer.isCompleted) {
           completer.complete();
         }
-        onError(error, stackTrace);
       },
     );
     return completer.future;

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -261,10 +261,22 @@ abstract class ProcessUtils {
 
     void writeFlushAndComplete() {
       stdin.writeln(line);
-      stdin.flush().whenComplete(() => completer.complete());
+      stdin.flush().whenComplete(() {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      });
     }
 
-    runZonedGuarded(writeFlushAndComplete, onError);
+    runZonedGuarded(
+      writeFlushAndComplete,
+      (Object error, StackTrace stackTrace) {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+        onError(error, stackTrace);
+      },
+    );
     return completer.future;
   }
 }

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -614,13 +614,20 @@ class IOSDeployDebugger {
       return;
     }
 
-    try {
+    runZonedGuarded(() async {
       // Detach lldb from the app process.
       _iosDeployProcess?.stdin.writeln('process detach');
-    } on SocketException catch (error) {
-      // Best effort, try to detach, but maybe the app already exited or already detached.
-      _logger.printTrace('Could not detach from debugger: $error');
-    }
+      await _iosDeployProcess?.stdin.flush();
+    }, (Object error, StackTrace stackTrace) {
+      throw Exception('foo');
+    });
+    //try {
+    //  // Detach lldb from the app process.
+    //  _iosDeployProcess?.stdin.writeln('process detach');
+    //} on SocketException catch (error) {
+    //  // Best effort, try to detach, but maybe the app already exited or already detached.
+    //  _logger.printTrace('Could not detach from debugger: $error');
+    //}
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -625,7 +625,6 @@ class IOSDeployDebugger {
       runZonedGuarded(
         () {
           process.stdin.writeln(line);
-          //process.stdin.flush().then<void>((_) => completer.complete());
           process.stdin.flush().whenComplete(() => completer.complete());
         },
         (Object error, StackTrace trace) {
@@ -641,14 +640,16 @@ class IOSDeployDebugger {
     } else {
       _stdinWriteFuture = writeln();
     }
+
+    return _stdinWriteFuture;
   }
 
-  void detach() {
+  Future<void> detach() async {
     if (!debuggerAttached) {
       return;
     }
 
-    stdinWriteln('process detach');
+    await stdinWriteln('process detach');
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -614,7 +614,7 @@ class IOSDeployDebugger {
   /// The flush of any previous writes have completed, because calling
   /// [IOSink.flush()] before a previous flush has completed will throw a
   /// [StateError].
-  Future<void> stdinWriteln(String line) async {
+  Future<void> stdinWriteln(String line, {void Function(Object, StackTrace)? onError}) async {
     final Process? process = _iosDeployProcess;
     if (process == null) {
       return;
@@ -624,10 +624,7 @@ class IOSDeployDebugger {
       return ProcessUtils.writelnToStdin(
         stdin: process.stdin,
         line: line,
-        onError: (Object error, StackTrace trace) {
-          // Best effort, try to detach, but maybe the app already exited or already detached.
-          _logger.printTrace('Could not detach from debugger: $error');
-        },
+        onError: onError,
       );
     }
 
@@ -645,7 +642,13 @@ class IOSDeployDebugger {
       return;
     }
 
-    await stdinWriteln('process detach');
+    await stdinWriteln(
+      'process detach',
+      onError: (Object error, _) {
+        // Best effort, try to detach, but maybe the app already exited or already detached.
+        _logger.printTrace('Could not detach from debugger: $error');
+      }
+    );
   }
 }
 

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -621,18 +621,14 @@ class IOSDeployDebugger {
     }
 
     Future<void> writeln() {
-      final Completer<void> completer = Completer<void>();
-      runZonedGuarded(
-        () {
-          process.stdin.writeln(line);
-          process.stdin.flush().whenComplete(() => completer.complete());
-        },
-        (Object error, StackTrace trace) {
+      return ProcessUtils.writelnToStdin(
+        stdin: process.stdin,
+        line: line,
+        onError: (Object error, StackTrace trace) {
           // Best effort, try to detach, but maybe the app already exited or already detached.
           _logger.printTrace('Could not detach from debugger: $error');
-        }
+        },
       );
-      return completer.future;
     }
 
     if (_stdinWriteFuture != null) {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -1001,7 +1001,7 @@ class FakeIOSDeployDebugger extends Fake implements IOSDeployDebugger {
   Stream<String> logLines = const Stream<String>.empty();
 
   @override
-  void detach() {
+  Future<void> detach() async {
     detached = true;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/139709

This adds a static helper method `ProcessUtils.writelnToStdinGuarded()`, which will asynchronously write to a sub-process's STDIN `IOSink` and catch errors.

In talking with Brian, it sounds like this is the best and most reliable way to catch `SocketException`s during these writes *to sub-process file descriptors* specifically (with a "real" hard drive file, the future returned by `.flush()` should complete with the write error).

Also, as I note in the dartdoc to `writelnToStdinGuarded()`, the behavior seems to be different between macOS and linux.

Moving forward, in any place where we want to catch exceptions writing to STDIN, we will want to use this new helper.