### PR TITLE
[CP (beta)] have Java.version return null if `java --version` fails or cannot be run

### DIFF
--- a/packages/flutter_tools/lib/src/android/java.dart
+++ b/packages/flutter_tools/lib/src/android/java.dart
@@ -135,6 +135,10 @@ class Java {
   /// Returns the version of java in the format \d(.\d)+(.\d)+
   /// Returns null if version could not be determined.
   late final Version? version = (() {
+    if (!canRun()) {
+      return null;
+    }
+
     final RunResult result = _processUtils.runSync(
       <String>[binaryPath, '--version'],
       environment: environment,
@@ -142,6 +146,7 @@ class Java {
     if (result.exitCode != 0) {
       _logger.printTrace('java --version failed: exitCode: ${result.exitCode}'
         ' stdout: ${result.stdout} stderr: ${result.stderr}');
+      return null;
     }
     final String rawVersionOutput = result.stdout;
     final List<String> versionLines = rawVersionOutput.split('\n');

--- a/packages/flutter_tools/test/general.shard/android/java_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/java_test.dart
@@ -183,7 +183,7 @@ OpenJDK 64-Bit Server VM Zulu19.32+15-CA (build 19.0.2+7, mixed mode, sharing)
       });
     });
 
-    group('getVersionString', () {
+    group('version', () {
       late Java java;
 
       setUp(() {
@@ -207,6 +207,23 @@ OpenJDK 64-Bit Server VM Zulu19.32+15-CA (build 19.0.2+7, mixed mode, sharing)
           ),
         );
       }
+
+      testWithoutContext('is null when java binary cannot be run', () async {
+        addJavaVersionCommand('');
+        processManager.excludedExecutables.add('java');
+
+        expect(java.version, null);
+      });
+
+      testWithoutContext('is null when java --version returns a non-zero exit code', () async {
+        processManager.addCommand(
+          FakeCommand(
+            command: <String>[java.binaryPath, '--version'],
+            exitCode: 1,
+          ),
+        );
+        expect(java.version, null);
+      });
 
       testWithoutContext('parses jdk 8', () {
         addJavaVersionCommand('''


### PR DESCRIPTION
cherry-picks changes from https://github.com/flutter/flutter/pull/139614 onto the beta channel

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
