### PR TITLE
Select simulator runtime for tests based on Xcode's preferred runtime build

### DIFF
--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -56,8 +56,6 @@ Future<void> testWithNewIOSSimulator(
   SimulatorFunction testFunction, {
   String deviceTypeId = 'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
 }) async {
-  // Xcode 11.4 simctl create makes the runtime argument optional, and defaults to latest.
-  // TODO(jmagman): Remove runtime parsing when devicelab upgrades to Xcode 11.4 https://github.com/flutter/flutter/issues/54889
   final String availableRuntimes = await eval(
     'xcrun',
     <String>[
@@ -68,11 +66,43 @@ Future<void> testWithNewIOSSimulator(
     workingDirectory: flutterDirectory.path,
   );
 
+  // Get the runtime build identifier for the default runtime Xcode would use.
+  final String runtimesForSelectedXcode = await eval(
+    'xcrun',
+    <String>[
+      'simctl',
+      'runtime',
+      'match',
+      'list',
+      '--json'
+    ],
+    workingDirectory: flutterDirectory.path,
+  );
+
+  final Map<String, Object?> decodeResult = json.decode(runtimesForSelectedXcode) as Map<String, Object?>;
+  final String? iosKey = decodeResult.keys.where((String key) => key.contains('iphoneos')).firstOrNull;
+  final Object? iosDetails = decodeResult[iosKey];
+  String? runtimeBuildForSelectedXcode;
+  if (iosDetails != null && iosDetails is Map<String, Object?>) {
+    final Object? runtimeBuildObj = iosDetails['preferredBuild'];
+    if (runtimeBuildObj is String) {
+      runtimeBuildForSelectedXcode = runtimeBuildObj;
+    }
+  }
+
   String? iOSSimRuntime;
 
   final RegExp iOSRuntimePattern = RegExp(r'iOS .*\) - (.*)');
 
+  // [availableRuntimes] may include runtime versions greater than the selected
+  // Xcode's greatest supported version. Use [runtimeBuildForSelectedXcode] when
+  // possible to pick which runtime to use.
+  // For example, iOS 17 (released with Xcode 15) may be available even if the
+  // selected Xcode version is 14.
   for (final String runtime in LineSplitter.split(availableRuntimes)) {
+    if (runtimeBuildForSelectedXcode != null && !runtime.contains(runtimeBuildForSelectedXcode)) {
+      continue;
+    }
     // These seem to be in order, so allow matching multiple lines so it grabs
     // the last (hopefully latest) one.
     final RegExpMatch? iOSRuntimeMatch = iOSRuntimePattern.firstMatch(runtime);
@@ -82,7 +112,11 @@ Future<void> testWithNewIOSSimulator(
     }
   }
   if (iOSSimRuntime == null) {
-    throw 'No iOS simulator runtime found. Available runtimes:\n$availableRuntimes';
+    if (runtimeBuildForSelectedXcode != null) {
+      throw 'iOS simulator runtime $runtimeBuildForSelectedXcode not found. Available runtimes:\n$availableRuntimes';
+    } else {
+      throw 'No iOS simulator runtime found. Available runtimes:\n$availableRuntimes';
+    }
   }
 
   final String deviceId = await eval(

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -66,7 +66,6 @@ Future<void> testWithNewIOSSimulator(
     workingDirectory: flutterDirectory.path,
   );
 
-  // Get the runtime build identifier for the default runtime Xcode would use.
   final String runtimesForSelectedXcode = await eval(
     'xcrun',
     <String>[
@@ -74,19 +73,24 @@ Future<void> testWithNewIOSSimulator(
       'runtime',
       'match',
       'list',
-      '--json'
+      '--json',
     ],
     workingDirectory: flutterDirectory.path,
   );
 
+  // Get the preferred runtime build for the selected Xcode version. Preferred
+  // means the runtime was either bundled with Xcode, exactly matched your SDK
+  // version, or it's indicated a better match for your SDK.
   final Map<String, Object?> decodeResult = json.decode(runtimesForSelectedXcode) as Map<String, Object?>;
-  final String? iosKey = decodeResult.keys.where((String key) => key.contains('iphoneos')).firstOrNull;
+  final String? iosKey = decodeResult.keys
+      .where((String key) => key.contains('iphoneos'))
+      .firstOrNull;
   final Object? iosDetails = decodeResult[iosKey];
   String? runtimeBuildForSelectedXcode;
   if (iosDetails != null && iosDetails is Map<String, Object?>) {
-    final Object? runtimeBuildObj = iosDetails['preferredBuild'];
-    if (runtimeBuildObj is String) {
-      runtimeBuildForSelectedXcode = runtimeBuildObj;
+    final Object? preferredBuild = iosDetails['preferredBuild'];
+    if (preferredBuild is String) {
+      runtimeBuildForSelectedXcode = preferredBuild;
     }
   }
 
@@ -100,7 +104,8 @@ Future<void> testWithNewIOSSimulator(
   // For example, iOS 17 (released with Xcode 15) may be available even if the
   // selected Xcode version is 14.
   for (final String runtime in LineSplitter.split(availableRuntimes)) {
-    if (runtimeBuildForSelectedXcode != null && !runtime.contains(runtimeBuildForSelectedXcode)) {
+    if (runtimeBuildForSelectedXcode != null &&
+        !runtime.contains(runtimeBuildForSelectedXcode)) {
       continue;
     }
     // These seem to be in order, so allow matching multiple lines so it grabs


### PR DESCRIPTION
When creating a simulator for a test, select the runtime based on the selected Xcode's preferred build. This is to prevent it from using a runtime greater than its greatest supported version.

Fixes https://github.com/flutter/flutter/issues/139917.

Example test with both iOS 16 and 17 available: https://chromium-swarm.appspot.com/task?id=6672aca184395a10

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
