### PR TITLE
fix typo of 'not' instead of 'now' for `useInheritedMediaQuery` 

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1171,7 +1171,7 @@ class WidgetsApp extends StatefulWidget {
   final String? restorationScopeId;
 
   /// {@template flutter.widgets.widgetsApp.useInheritedMediaQuery}
-  /// Deprecated. This setting is not ignored.
+  /// Deprecated. This setting is now ignored.
   ///
   /// The widget never introduces its own [MediaQuery]; the [View] widget takes
   /// care of that.


### PR DESCRIPTION
The doc comment for `useInheritedMediaQuery` has a typo of 'not' instead of 'now' and it is confusing at the `@Deprecated()` message clearly states it is *now* ignored.
(and indeed checking the code you can verify that it *is* indeed ignored)

existing code before PR:
```dart
/// {@template flutter.widgets.widgetsApp.useInheritedMediaQuery}
/// Deprecated. This setting is not ignored.
///                             ^^^
/// The widget never introduces its own [MediaQuery]; the [View] widget takes
/// care of that.
/// {@endtemplate}
@Deprecated(
  'This setting is now ignored. '
  'WidgetsApp never introduces its own MediaQuery; the View widget takes care of that. '
  'This feature was deprecated after v3.7.0-29.0.pre.'
)
final bool useInheritedMediaQuery;
```


## Pre-launch Checklist

- [X ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
