### PR TITLE
Use `SemanticsUpdateBuilder` again, remove all references to temporary `SemanticsUpdateBuilderNew`

### DIFF
--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // ignore: deprecated_member_use
-import 'dart:ui' as ui show AccessibilityFeatures, SemanticsActionEvent, SemanticsUpdateBuilderNew;
+import 'dart:ui' as ui show AccessibilityFeatures, SemanticsActionEvent, SemanticsUpdateBuilder;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -11,7 +11,7 @@ import 'package:flutter/services.dart';
 import 'debug.dart';
 
 // ignore: deprecated_member_use
-export 'dart:ui' show AccessibilityFeatures, SemanticsActionEvent, SemanticsUpdateBuilderNew;
+export 'dart:ui' show AccessibilityFeatures, SemanticsActionEvent, SemanticsUpdateBuilder;
 
 /// The glue between the semantics layer and the Flutter engine.
 mixin SemanticsBinding on BindingBase {
@@ -162,10 +162,8 @@ mixin SemanticsBinding on BindingBase {
   ///
   /// This method is used by the [SemanticsOwner] to create builder for all its
   /// semantics updates.
-  // ignore: deprecated_member_use
-  ui.SemanticsUpdateBuilderNew createSemanticsUpdateBuilder() {
-    // ignore: deprecated_member_use
-    return ui.SemanticsUpdateBuilderNew();
+  ui.SemanticsUpdateBuilder createSemanticsUpdateBuilder() {
+    return ui.SemanticsUpdateBuilder();
   }
 
   /// The platform is requesting that animations be disabled or simplified.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -4,7 +4,7 @@
 
 import 'dart:math' as math;
 // ignore: deprecated_member_use
-import 'dart:ui' show Offset, Rect, SemanticsAction, SemanticsFlag, SemanticsUpdate, SemanticsUpdateBuilderNew, StringAttribute, TextDirection;
+import 'dart:ui' show Offset, Rect, SemanticsAction, SemanticsFlag, SemanticsUpdate, SemanticsUpdateBuilder, StringAttribute, TextDirection;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -2750,8 +2750,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   static final Int32List _kEmptyCustomSemanticsActionsList = Int32List(0);
   static final Float64List _kIdentityTransform = _initIdentityTransform();
 
-  // ignore: deprecated_member_use
-  void _addToUpdate(SemanticsUpdateBuilderNew builder, Set<int> customSemanticsActionIdsUpdate) {
+  void _addToUpdate(SemanticsUpdateBuilder builder, Set<int> customSemanticsActionIdsUpdate) {
     assert(_dirty);
     final SemanticsData data = getSemanticsData();
     final Int32List childrenInTraversalOrder;
@@ -3444,8 +3443,7 @@ class SemanticsOwner extends ChangeNotifier {
       }
     }
     visitedNodes.sort((SemanticsNode a, SemanticsNode b) => a.depth - b.depth);
-    // ignore: deprecated_member_use
-    final SemanticsUpdateBuilderNew builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
+    final SemanticsUpdateBuilder builder = SemanticsBinding.instance.createSemanticsUpdateBuilder();
     for (final SemanticsNode node in visitedNodes) {
       assert(node.parent?._dirty != true); // could be null (no parent) or false (not dirty)
       // The _serialize() method marks the node as not dirty, and

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -171,16 +171,13 @@ void main() {
 
 class SemanticsUpdateTestBinding extends AutomatedTestWidgetsFlutterBinding {
   @override
-  // ignore: deprecated_member_use
-  ui.SemanticsUpdateBuilderNew createSemanticsUpdateBuilder() {
+  ui.SemanticsUpdateBuilder createSemanticsUpdateBuilder() {
     return SemanticsUpdateBuilderSpy();
   }
 }
 
-// ignore: deprecated_member_use
-class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilderNew {
-  // ignore: deprecated_member_use
-  final SemanticsUpdateBuilderNew _builder = ui.SemanticsUpdateBuilderNew();
+class SemanticsUpdateBuilderSpy extends Fake implements ui.SemanticsUpdateBuilder {
+  final SemanticsUpdateBuilder _builder = ui.SemanticsUpdateBuilder();
 
   static Map<int, SemanticsNodeUpdateObservation> observations = <int, SemanticsNodeUpdateObservation>{};
 

--- a/packages/flutter_test/test/view_test.dart
+++ b/packages/flutter_test/test/view_test.dart
@@ -259,8 +259,7 @@ void main() {
     });
 
     testWidgets('updateSemantics is passed through to backing FlutterView', (WidgetTester tester) async {
-      // ignore: deprecated_member_use
-      final SemanticsUpdate expectedUpdate = SemanticsUpdateBuilderNew().build();
+      final SemanticsUpdate expectedUpdate = SemanticsUpdateBuilder().build();
       final _FakeFlutterView backingView = _FakeFlutterView();
       final TestFlutterView view = TestFlutterView(
         view: backingView,


### PR DESCRIPTION
This PR removes all usages of the temporary `SemanticsUpdateBuilderNew` API in favor of `SemanticsUpdateBuilder`. These two APIs are the same as of now.

This is mainly targeted at https://github.com/flutter/flutter/issues/17988

Steps:
part 1: [engine] add `SemanticsUpdateBuilderNew` https://github.com/flutter/engine/pull/47961
part 2: [flutter] use `SemanticsUpdateBuilderNew` https://github.com/flutter/flutter/pull/138331
part 3: [engine] update `SemanticsUpdateBuilder` to be the same as `SemanticsUpdateBuilderNew` https://github.com/flutter/engine/pull/48882
**part 4: [flutter] use (now updated) `SemanticsUpdateBuilder` again** <-- we are here
part 5: [engine] remove `SemanticsBuilderNew` https://github.com/flutter/engine/pull/49139

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.