### PR TITLE
Optimize file transfer when using proxied devices.

### DIFF
--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -41,9 +41,11 @@ class ProxiedDevices extends PollingDeviceDiscovery {
     bool deltaFileTransfer = true,
     bool enableDdsProxy = false,
     required Logger logger,
+    FileTransfer fileTransfer = const FileTransfer(),
   }) : _deltaFileTransfer = deltaFileTransfer,
        _enableDdsProxy = enableDdsProxy,
        _logger = logger,
+       _fileTransfer = fileTransfer,
        super('Proxied devices');
 
   /// [DaemonConnection] used to communicate with the daemon.
@@ -54,6 +56,8 @@ class ProxiedDevices extends PollingDeviceDiscovery {
   final bool _deltaFileTransfer;
 
   final bool _enableDdsProxy;
+
+  final FileTransfer _fileTransfer;
 
   @override
   bool get supportsPlatform => true;
@@ -117,6 +121,7 @@ class ProxiedDevices extends PollingDeviceDiscovery {
       supportsFastStart: _cast<bool>(capabilities['fastStart']),
       supportsHardwareRendering: _cast<bool>(capabilities['hardwareRendering']),
       logger: _logger,
+      fileTransfer: _fileTransfer,
     );
   }
 }
@@ -149,6 +154,7 @@ class ProxiedDevice extends Device {
     required this.supportsFastStart,
     required bool supportsHardwareRendering,
     required Logger logger,
+    FileTransfer fileTransfer = const FileTransfer(),
   }): _deltaFileTransfer = deltaFileTransfer,
       _enableDdsProxy = enableDdsProxy,
       _isLocalEmulator = isLocalEmulator,
@@ -157,6 +163,7 @@ class ProxiedDevice extends Device {
       _supportsHardwareRendering = supportsHardwareRendering,
       _targetPlatform = targetPlatform,
       _logger = logger,
+      _fileTransfer = fileTransfer,
       super(id,
         category: category,
         platformType: platformType,
@@ -170,6 +177,8 @@ class ProxiedDevice extends Device {
   final bool _deltaFileTransfer;
 
   final bool _enableDdsProxy;
+  
+  final FileTransfer _fileTransfer;
 
   @override
   final String name;
@@ -359,7 +368,7 @@ class ProxiedDevice extends Device {
 
     Map<String, Object?>? rollingHashResultJson;
     if (_deltaFileTransfer) {
-     rollingHashResultJson = _cast<Map<String, Object?>?>(await connection.sendRequest('proxy.calculateFileHashes', args));
+      rollingHashResultJson = _cast<Map<String, Object?>?>(await connection.sendRequest('proxy.calculateFileHashes', args));
     }
 
     if (rollingHashResultJson == null) {
@@ -371,18 +380,31 @@ class ProxiedDevice extends Device {
       await connection.sendRequest('proxy.writeTempFile', args, await binary.readAsBytes());
     } else {
       final BlockHashes rollingHashResult = BlockHashes.fromJson(rollingHashResultJson);
-      final List<FileDeltaBlock> delta = await FileTransfer().computeDelta(binary, rollingHashResult);
+      final List<FileDeltaBlock> delta = await _fileTransfer.computeDelta(binary, rollingHashResult);
 
       // Delta is empty if the file does not need to be updated
       if (delta.isNotEmpty) {
         final List<Map<String, Object>> deltaJson = delta.map((FileDeltaBlock block) => block.toJson()).toList();
-        final Uint8List buffer = await FileTransfer().binaryForRebuilding(binary, delta);
+        final Uint8List buffer = await _fileTransfer.binaryForRebuilding(binary, delta);
 
         await connection.sendRequest('proxy.updateFile', <String, Object>{
           'path': fileName,
           'delta': deltaJson,
         }, buffer);
       }
+    }
+
+    if (_deltaFileTransfer) {
+      // Ask the daemon to precache the hash content for subsequent runs.
+      // Wait for several seconds for the app to be launched, to not interfere
+      // with whatever the daemon is doing.
+      unawaited(() async {
+        await Future<void>.delayed(const Duration(seconds: 60));
+        await connection.sendRequest('proxy.calculateFileHashes', <String, Object>{
+          'path': fileName,
+          'cacheResult': true,
+        });
+      }());
     }
 
     final String id = _cast<String>(await connection.sendRequest('device.uploadApplicationPackage', <String, Object>{

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -177,7 +177,7 @@ class ProxiedDevice extends Device {
   final bool _deltaFileTransfer;
 
   final bool _enableDdsProxy;
-  
+
   final FileTransfer _fileTransfer;
 
   @override

--- a/packages/flutter_tools/lib/src/proxied_devices/file_transfer.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/file_transfer.dart
@@ -104,7 +104,7 @@ const int _adler32Prime = 65521;
 
 /// Helper function to calculate Adler32 hash of a binary.
 @visibleForTesting
-int adler32Hash(List<int> binary) {
+int adler32Hash(Uint8List binary) {
   // The maximum integer that can be stored in the `int` data type.
   const int maxInt = 0x1fffffffffffff;
   // maxChunkSize is the maximum number of bytes we can sum without
@@ -119,8 +119,8 @@ int adler32Hash(List<int> binary) {
   final int length = binary.length;
   for (int i = 0; i < length; i += maxChunkSize) {
     final int end = i + maxChunkSize < length ? i + maxChunkSize : length;
-    for (final int c in binary.getRange(i, end)) {
-      a += c;
+    for (int j = i; j < end; j++) {
+      a += binary[j];
       b += a;
     }
     a %= _adler32Prime;
@@ -220,19 +220,22 @@ class RollingAdler32 {
 /// On the receiving end, it will build a copy of the source file from the
 /// given instructions.
 class FileTransfer {
+  const FileTransfer();
+
   /// Calculate hashes of blocks in the file.
   Future<BlockHashes> calculateBlockHashesOfFile(File file, { int? blockSize }) async {
     final int totalSize = await file.length();
     blockSize ??= max(sqrt(totalSize).ceil(), 2560);
 
-    final Stream<Uint8List> fileContentStream = file.openRead().map((List<int> chunk) => Uint8List.fromList(chunk));
+    final Stream<Uint8List> fileContentStream = file.openRead().map((List<int> chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk));
 
     final List<int> adler32Results = <int>[];
     final List<String> md5Results = <String>[];
-    await for (final Uint8List chunk in convertToChunks(fileContentStream, blockSize)) {
+
+    await convertToChunks(fileContentStream, blockSize).forEach((Uint8List chunk) {
       adler32Results.add(adler32Hash(chunk));
       md5Results.add(base64.encode(md5.convert(chunk).bytes));
-    }
+    });
 
     // Handle whole file md5 separately. Md5Hash requires the chunk size to be a multiple of 64.
     final String fileMd5 = await _md5OfFile(file);
@@ -276,8 +279,9 @@ class FileTransfer {
 
     final List<FileDeltaBlock> blocks = <FileDeltaBlock>[];
 
-    await for (final List<int> chunk in fileContentStream) {
-      for (final int c in chunk) {
+    await fileContentStream.forEach((List<int> chunk) {
+      for (int i = 0; i < chunk.length; i++) {
+        final int c = chunk[i];
         final int hash = adler32.push(c);
         size++;
 
@@ -326,7 +330,7 @@ class FileTransfer {
           break;
         }
       }
-    }
+    });
 
     // For the remaining content that is not matched, copy from the source.
     if (start < size) {
@@ -401,7 +405,7 @@ class FileTransfer {
 
   Future<String> _md5OfFile(File file) async {
     final Md5Hash fileMd5Hash = Md5Hash();
-    await file.openRead().forEach((List<int> chunk) => fileMd5Hash.addChunk(Uint8List.fromList(chunk)));
+    await file.openRead().forEach((List<int> chunk) => fileMd5Hash.addChunk(chunk is Uint8List ? chunk : Uint8List.fromList(chunk)));
     return base64.encode(fileMd5Hash.finalize().buffer.asUint8List());
   }
 }

--- a/packages/flutter_tools/test/general.shard/proxied_devices/file_transfer_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/file_transfer_test.dart
@@ -63,7 +63,7 @@ void main() {
 
   group('adler32Hash', () {
     test('works correctly', () {
-      final int hash = adler32Hash(utf8.encode('abcdefg'));
+      final int hash = adler32Hash(Uint8List.fromList(utf8.encode('abcdefg')));
       expect(hash, 0x0adb02bd);
     });
   });
@@ -72,19 +72,19 @@ void main() {
     test('works correctly without rolling', () {
       final RollingAdler32 adler32 = RollingAdler32(7);
       utf8.encode('abcdefg').forEach(adler32.push);
-      expect(adler32.hash, adler32Hash(utf8.encode('abcdefg')));
+      expect(adler32.hash, adler32Hash(Uint8List.fromList(utf8.encode('abcdefg'))));
     });
 
     test('works correctly after rolling once', () {
       final RollingAdler32 adler32 = RollingAdler32(7);
       utf8.encode('12abcdefg').forEach(adler32.push);
-      expect(adler32.hash, adler32Hash(utf8.encode('abcdefg')));
+      expect(adler32.hash, adler32Hash(Uint8List.fromList(utf8.encode('abcdefg'))));
     });
 
     test('works correctly after rolling multiple cycles', () {
       final RollingAdler32 adler32 = RollingAdler32(7);
       utf8.encode('1234567890123456789abcdefg').forEach(adler32.push);
-      expect(adler32.hash, adler32Hash(utf8.encode('abcdefg')));
+      expect(adler32.hash, adler32Hash(Uint8List.fromList(utf8.encode('abcdefg'))));
     });
 
     test('works correctly after reset', () {
@@ -92,7 +92,7 @@ void main() {
       utf8.encode('1234567890123456789abcdefg').forEach(adler32.push);
       adler32.reset();
       utf8.encode('abcdefg').forEach(adler32.push);
-      expect(adler32.hash, adler32Hash(utf8.encode('abcdefg')));
+      expect(adler32.hash, adler32Hash(Uint8List.fromList(utf8.encode('abcdefg'))));
     });
 
     test('currentBlock returns the correct entry when read less than one block', () {
@@ -133,7 +133,7 @@ void main() {
     test('calculateBlockHashesOfFile works normally', () async {
       final File file = fileSystem.file('test')..writeAsStringSync(content1);
 
-      final BlockHashes hashes = await FileTransfer().calculateBlockHashesOfFile(file, blockSize: 4);
+      final BlockHashes hashes = await const FileTransfer().calculateBlockHashesOfFile(file, blockSize: 4);
       expect(hashes.blockSize, 4);
       expect(hashes.totalSize, content1.length);
       expect(hashes.adler32, hasLength(5));
@@ -159,8 +159,8 @@ void main() {
       final File file1 = fileSystem.file('file1')..writeAsStringSync(content1);
       final File file2 = fileSystem.file('file1')..writeAsStringSync(content1);
 
-      final BlockHashes hashes = await FileTransfer().calculateBlockHashesOfFile(file1, blockSize: 4);
-      final List<FileDeltaBlock> delta = await FileTransfer().computeDelta(file2, hashes);
+      final BlockHashes hashes = await const FileTransfer().calculateBlockHashesOfFile(file1, blockSize: 4);
+      final List<FileDeltaBlock> delta = await const FileTransfer().computeDelta(file2, hashes);
 
       expect(delta, isEmpty);
     });
@@ -169,21 +169,21 @@ void main() {
       final File file1 = fileSystem.file('file1')..writeAsStringSync(content1);
       final File file2 = fileSystem.file('file2')..writeAsStringSync(content2);
 
-      final BlockHashes hashes = await FileTransfer().calculateBlockHashesOfFile(file1, blockSize: 4);
-      final List<FileDeltaBlock> delta = await FileTransfer().computeDelta(file2, hashes);
+      final BlockHashes hashes = await const FileTransfer().calculateBlockHashesOfFile(file1, blockSize: 4);
+      final List<FileDeltaBlock> delta = await const FileTransfer().computeDelta(file2, hashes);
 
       expect(delta, expectedDelta);
     });
 
     test('binaryForRebuilding returns the correct binary', () async {
       final File file = fileSystem.file('file')..writeAsStringSync(content2);
-      final List<int> binaryForRebuilding = await FileTransfer().binaryForRebuilding(file, expectedDelta);
+      final List<int> binaryForRebuilding = await const FileTransfer().binaryForRebuilding(file, expectedDelta);
       expect(binaryForRebuilding, utf8.encode(expectedBinaryForRebuilding));
     });
 
     test('rebuildFile can rebuild the correct file', () async {
       final File file = fileSystem.file('file')..writeAsStringSync(content1);
-      await FileTransfer().rebuildFile(file, expectedDelta, Stream<List<int>>.fromIterable(<List<int>>[utf8.encode(expectedBinaryForRebuilding)]));
+      await const FileTransfer().rebuildFile(file, expectedDelta, Stream<List<int>>.fromIterable(<List<int>>[utf8.encode(expectedBinaryForRebuilding)]));
       expect(file.readAsStringSync(), content2);
     });
   });

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -354,7 +354,7 @@ void main() {
         final ProxiedDevice device = proxiedDevices.deviceFromDaemonResult(fakeDevice);
 
         final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands.asBroadcastStream();
-        
+
         final Future<String> resultFuture = device.applicationPackageId(applicationPackage);
 
         // Send proxy.writeTempFile.
@@ -392,7 +392,7 @@ void main() {
         final ProxiedDevice device = proxiedDevices.deviceFromDaemonResult(fakeDevice);
 
         final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands.asBroadcastStream();
-        
+
         final Future<String> resultFuture = device.applicationPackageId(applicationPackage);
 
         // Send proxy.calculateFileHashes.
@@ -453,7 +453,7 @@ void main() {
         final ProxiedDevice device = proxiedDevices.deviceFromDaemonResult(fakeDevice);
 
         final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands.asBroadcastStream();
-        
+
         final Future<String> resultFuture = device.applicationPackageId(applicationPackage);
 
         // Send proxy.calculateFileHashes.

--- a/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/proxied_devices/proxied_devices_test.dart
@@ -6,12 +6,16 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/dds.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/daemon.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/proxied_devices/devices.dart';
+import 'package:flutter_tools/src/proxied_devices/file_transfer.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -327,6 +331,167 @@ void main() {
       expect(message.data['id'], isNotNull);
       expect(message.data['method'], 'device.stopApp');
       expect(message.data['params'], <String, Object?>{'deviceId': 'device-id', 'userIdentifier': 'user-id'});
+    });
+
+    group('when launching an app with PrebuiltApplicationPackage', () {
+      late MemoryFileSystem fileSystem;
+      late FakePrebuiltApplicationPackage applicationPackage;
+      const List<int> fileContent = <int>[100, 120, 140];
+      setUp(() {
+        fileSystem = MemoryFileSystem.test()
+          ..directory('dir').createSync()
+          ..file('dir/foo').writeAsBytesSync(fileContent);
+        applicationPackage = FakePrebuiltApplicationPackage(fileSystem.file('dir/foo'));
+      });
+
+      testWithoutContext('transfers file to the daemon', () async {
+        bufferLogger = BufferLogger.test();
+        final ProxiedDevices proxiedDevices = ProxiedDevices(
+          clientDaemonConnection,
+          logger: bufferLogger,
+          deltaFileTransfer: false,
+        );
+        final ProxiedDevice device = proxiedDevices.deviceFromDaemonResult(fakeDevice);
+
+        final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands.asBroadcastStream();
+        
+        final Future<String> resultFuture = device.applicationPackageId(applicationPackage);
+
+        // Send proxy.writeTempFile.
+        final DaemonMessage writeTempFileMessage = await broadcastOutput.first;
+        expect(writeTempFileMessage.data['id'], isNotNull);
+        expect(writeTempFileMessage.data['method'], 'proxy.writeTempFile');
+        expect(writeTempFileMessage.data['params'], <String, Object?>{
+          'path': 'foo',
+        });
+        expect(await writeTempFileMessage.binary?.first, fileContent);
+
+        serverDaemonConnection.sendResponse(writeTempFileMessage.data['id']!);
+
+        // Send device.uploadApplicationPackage.
+        final DaemonMessage uploadApplicationPackageMessage = await broadcastOutput.first;
+        expect(uploadApplicationPackageMessage.data['id'], isNotNull);
+        expect(uploadApplicationPackageMessage.data['method'], 'device.uploadApplicationPackage');
+        expect(uploadApplicationPackageMessage.data['params'], <String, Object?>{
+          'targetPlatform': 'android-arm',
+          'applicationBinary': 'foo',
+        });
+
+        serverDaemonConnection.sendResponse(uploadApplicationPackageMessage.data['id']!, 'test_id');
+        expect(await resultFuture, 'test_id');
+      });
+
+      testWithoutContext('transfers file to the daemon with delta turned on, file not exist on remote', () async {
+        bufferLogger = BufferLogger.test();
+        final FakeFileTransfer fileTransfer = FakeFileTransfer();
+        final ProxiedDevices proxiedDevices = ProxiedDevices(
+          clientDaemonConnection,
+          logger: bufferLogger,
+          fileTransfer: fileTransfer,
+        );
+        final ProxiedDevice device = proxiedDevices.deviceFromDaemonResult(fakeDevice);
+
+        final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands.asBroadcastStream();
+        
+        final Future<String> resultFuture = device.applicationPackageId(applicationPackage);
+
+        // Send proxy.calculateFileHashes.
+        final DaemonMessage calculateFileHashesMessage = await broadcastOutput.first;
+        expect(calculateFileHashesMessage.data['id'], isNotNull);
+        expect(calculateFileHashesMessage.data['method'], 'proxy.calculateFileHashes');
+        expect(calculateFileHashesMessage.data['params'], <String, Object?>{
+          'path': 'foo',
+        });
+        serverDaemonConnection.sendResponse(calculateFileHashesMessage.data['id']!);
+
+        // Send proxy.writeTempFile.
+        final DaemonMessage writeTempFileMessage = await broadcastOutput.first;
+        expect(writeTempFileMessage.data['id'], isNotNull);
+        expect(writeTempFileMessage.data['method'], 'proxy.writeTempFile');
+        expect(writeTempFileMessage.data['params'], <String, Object?>{
+          'path': 'foo',
+        });
+        expect(await writeTempFileMessage.binary?.first, fileContent);
+
+        serverDaemonConnection.sendResponse(writeTempFileMessage.data['id']!);
+
+        // Send device.uploadApplicationPackage.
+        final DaemonMessage uploadApplicationPackageMessage = await broadcastOutput.first;
+        expect(uploadApplicationPackageMessage.data['id'], isNotNull);
+        expect(uploadApplicationPackageMessage.data['method'], 'device.uploadApplicationPackage');
+        expect(uploadApplicationPackageMessage.data['params'], <String, Object?>{
+          'targetPlatform': 'android-arm',
+          'applicationBinary': 'foo',
+        });
+
+        serverDaemonConnection.sendResponse(uploadApplicationPackageMessage.data['id']!, 'test_id');
+        expect(await resultFuture, 'test_id');
+      });
+
+      testWithoutContext('transfers file to the daemon with delta turned on, file exists on remote', () async {
+        bufferLogger = BufferLogger.test();
+        final FakeFileTransfer fileTransfer = FakeFileTransfer();
+        final BlockHashes blockHashes = BlockHashes(
+          blockSize: 10,
+          totalSize: 30,
+          adler32: <int>[1, 2, 3],
+          md5: <String>['a', 'b', 'c'],
+          fileMd5: 'abc',
+        );
+        const List<FileDeltaBlock> deltaBlocks = <FileDeltaBlock>[
+          FileDeltaBlock.fromSource(start: 10, size: 10),
+          FileDeltaBlock.fromDestination(start: 30, size: 40),
+        ];
+        fileTransfer.binary = Uint8List.fromList(<int>[11, 12, 13]);
+        fileTransfer.delta = deltaBlocks;
+
+        final ProxiedDevices proxiedDevices = ProxiedDevices(
+          clientDaemonConnection,
+          logger: bufferLogger,
+          fileTransfer: fileTransfer,
+        );
+        final ProxiedDevice device = proxiedDevices.deviceFromDaemonResult(fakeDevice);
+
+        final Stream<DaemonMessage> broadcastOutput = serverDaemonConnection.incomingCommands.asBroadcastStream();
+        
+        final Future<String> resultFuture = device.applicationPackageId(applicationPackage);
+
+        // Send proxy.calculateFileHashes.
+        final DaemonMessage calculateFileHashesMessage = await broadcastOutput.first;
+        expect(calculateFileHashesMessage.data['id'], isNotNull);
+        expect(calculateFileHashesMessage.data['method'], 'proxy.calculateFileHashes');
+        expect(calculateFileHashesMessage.data['params'], <String, Object?>{
+          'path': 'foo',
+        });
+        serverDaemonConnection.sendResponse(calculateFileHashesMessage.data['id']!, blockHashes.toJson());
+
+        // Send proxy.updateFile.
+        final DaemonMessage updateFileMessage = await broadcastOutput.first;
+        expect(updateFileMessage.data['id'], isNotNull);
+        expect(updateFileMessage.data['method'], 'proxy.updateFile');
+        expect(updateFileMessage.data['params'], <String, Object?>{
+          'path': 'foo',
+          'delta': <Map<String, Object>>[
+            <String, Object>{'size': 10},
+            <String, Object>{'start': 30, 'size': 40},
+          ],
+        });
+        expect(await updateFileMessage.binary?.first, <int>[11, 12, 13]);
+
+        serverDaemonConnection.sendResponse(updateFileMessage.data['id']!);
+
+        // Send device.uploadApplicationPackage.
+        final DaemonMessage uploadApplicationPackageMessage = await broadcastOutput.first;
+        expect(uploadApplicationPackageMessage.data['id'], isNotNull);
+        expect(uploadApplicationPackageMessage.data['method'], 'device.uploadApplicationPackage');
+        expect(uploadApplicationPackageMessage.data['params'], <String, Object?>{
+          'targetPlatform': 'android-arm',
+          'applicationBinary': 'foo',
+        });
+
+        serverDaemonConnection.sendResponse(uploadApplicationPackageMessage.data['id']!, 'test_id');
+        expect(await resultFuture, 'test_id');
+      });
     });
   });
 
@@ -713,4 +878,20 @@ class FakeDartDevelopmentService extends Fake implements DartDevelopmentService 
 
   @override
   Future<void> shutdown() async => shutdownCalled = true;
+}
+
+class FakePrebuiltApplicationPackage extends Fake implements PrebuiltApplicationPackage {
+  FakePrebuiltApplicationPackage(this.applicationPackage);
+  @override
+  final FileSystemEntity applicationPackage;
+}
+
+class FakeFileTransfer extends Fake implements FileTransfer {
+  List<FileDeltaBlock>? delta;
+  Uint8List? binary;
+  @override
+  Future<List<FileDeltaBlock>> computeDelta(File file, BlockHashes hashes) async => delta!;
+
+  @override
+  Future<Uint8List> binaryForRebuilding(File file, List<FileDeltaBlock> delta) async => binary!;
 }


### PR DESCRIPTION
List of changes:
1. Optimizations in FileTransfer. a. Use `stream.forEach` instead of `await for`. b. Type cast `List<int>` to `Uint8List` instead of using `Uint8List.fromList` results in (presumably) fewer copy and faster execution. c. Iterate through `Uint8List` with regular for loop instead of for-in loop.
2. Precache the block hashes of a file, and reuse it on subsequent runs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
