### PR TITLE
[docs] Add document content related to chip shape

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -123,7 +123,9 @@ abstract interface class ChipAttributes {
   /// Otherwise, [StadiumBorder] is used.
   ///
   /// This shape is combined with [side] to create a shape decorated with an
-  /// outline. To omit the outline entirely, pass [BorderSide.none] to [side].
+  /// outline. If the value of [side] is not null or the value of
+  /// [shape.side] is [BorderSide.none], the value of [shape.side] is ignored.
+  /// To omit the outline entirely, pass [BorderSide.none] to [side].
   ///
   /// If it is a [MaterialStateOutlinedBorder], [MaterialStateProperty.resolve]
   /// is used for the following [MaterialState]s:

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -123,9 +123,9 @@ abstract interface class ChipAttributes {
   /// Otherwise, [StadiumBorder] is used.
   ///
   /// This shape is combined with [side] to create a shape decorated with an
-  /// outline. If the value of [side] is not null or the value of
-  /// [shape.side] is [BorderSide.none], the value of [shape.side] is ignored.
-  /// To omit the outline entirely, pass [BorderSide.none] to [side].
+  /// outline. If [side] is not null or side of [shape] is [BorderSide.none],
+  /// side of [shape] is ignored. To omit the outline entirely,
+  /// pass [BorderSide.none] to [side].
   ///
   /// If it is a [MaterialStateOutlinedBorder], [MaterialStateProperty.resolve]
   /// is used for the following [MaterialState]s:


### PR DESCRIPTION
(#139572)  I would like to request an update to the document to resolve confusion.
I actually modified the code by applying priority as in the comment in [#139572](https://github.com/flutter/flutter/issues/139572) as shown below, but I thought that if 'OutlinedBorder' was used for 'shape', the default value of side for 'OutlinedBorder' was also the developer's intention.

```
OutlinedBorder _getShape(ThemeData theme, ChipThemeData chipTheme, ChipThemeData chipDefaults) {
  final BorderSide? resolvedSide =
      MaterialStateProperty.resolveAs<BorderSide?>(widget.side, materialStates)
          ?? MaterialStateProperty.resolveAs<BorderSide?>(chipTheme.side, materialStates);
  final BorderSide? resolvedShapeSide =
      MaterialStateProperty.resolveAs<BorderSide?>(widget.shape?.side, materialStates)
          ?? MaterialStateProperty.resolveAs<BorderSide?>(chipTheme.shape?.side, materialStates);
  final OutlinedBorder resolvedShape =
      MaterialStateProperty.resolveAs<OutlinedBorder?>(widget.shape, materialStates)
          ?? MaterialStateProperty.resolveAs<OutlinedBorder?>( chipTheme.shape, materialStates)
          ?? MaterialStateProperty.resolveAs<OutlinedBorder?>(chipDefaults.shape, materialStates)
          // TODO(tahatesser): Remove this fallback when Material 2 is deprecated.
          ?? const StadiumBorder();
  // If the side is provided, shape uses the provided side.

  if (resolvedSide != null) {
    return resolvedShape.copyWith(side: resolvedSide);
  }
  if (resolvedShapeSide != null) {
    return resolvedShape.copyWith(side: resolvedShapeSide);
  }
  // If the side is not provided
  // then the shape's side is used. Otherwise, the default side is used.
  return resolvedShape.copyWith(side: chipDefaults.side);
}
```
(in `chip.dart`)

However, (#133856)  PR seems to be intended to ignore this and use the aspect of `chipDefault.side` even if the developer specifies `shape.side` as [Border.none] without explicitly applying `side` .
This is probably because the default value of OutlinedBorder is [Border.none].
I think this is an area that can cause enough confusion, but there are a lot of things that need to be modified to reduce confusion through code changes, and the impact on existing code is likely to be significant.
I also confirmed that this is not accurately explained in the API Docs.
So rather than modifying the code, I decided to add additional explanation to the `shape` comment.
If the results are different from what you intended or the updated content is strange, please review. 🙏

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
