### PR TITLE
Add commonly used parameter names

### DIFF
--- a/packages/flutter/lib/src/animation/tween.dart
+++ b/packages/flutter/lib/src/animation/tween.dart
@@ -19,7 +19,7 @@ export 'curves.dart' show Curve;
 
 /// A typedef used by [Animatable.fromCallback] to create an [Animatable]
 /// from a callback.
-typedef AnimatableCallback<T> = T Function(double);
+typedef AnimatableCallback<T> = T Function(double value);
 
 /// An object that can produce a value of type `T` given an [Animation<double>]
 /// as input.

--- a/packages/flutter/lib/src/foundation/memory_allocations.dart
+++ b/packages/flutter/lib/src/foundation/memory_allocations.dart
@@ -52,7 +52,7 @@ abstract class ObjectEvent{
 }
 
 /// A listener of [ObjectEvent].
-typedef ObjectEventListener = void Function(ObjectEvent);
+typedef ObjectEventListener = void Function(ObjectEvent event);
 
 /// An event that describes creation of an object.
 class ObjectCreated extends ObjectEvent {

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -428,7 +428,7 @@ class _BottomSheetState extends State<BottomSheet> {
 
 // See scaffold.dart
 
-typedef _SizeChangeCallback<Size> = void Function(Size);
+typedef _SizeChangeCallback<Size> = void Function(Size size);
 
 class _DragHandle extends StatelessWidget {
   const _DragHandle({

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -2112,7 +2112,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
 }
 
 /// Signature for when the time picker entry mode is changed.
-typedef EntryModeChangeCallback = void Function(TimePickerEntryMode);
+typedef EntryModeChangeCallback = void Function(TimePickerEntryMode mode);
 
 /// A Material Design time picker designed to appear inside a popup dialog.
 ///

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -41,7 +41,7 @@ HttpClientProvider? debugNetworkImageHttpClientProvider;
 /// output size.
 ///
 /// See: [debugOnPaintImage].
-typedef PaintImageCallback = void Function(ImageSizeInfo);
+typedef PaintImageCallback = void Function(ImageSizeInfo info);
 
 /// Tracks the bytes used by a [dart:ui.Image] compared to the bytes needed to
 /// paint that image without scaling it.
@@ -199,14 +199,14 @@ bool debugAssertAllPaintingVarsUnset(String reason, { bool debugDisableShadowsOv
 /// Used by tests to run assertions on the [Picture] created by
 /// [ShaderWarmUp.execute]. The return value indicates whether the assertions
 /// pass or not.
-typedef ShaderWarmUpPictureCallback = bool Function(Picture);
+typedef ShaderWarmUpPictureCallback = bool Function(Picture picture);
 
 /// The signature of [debugCaptureShaderWarmUpImage].
 ///
 /// Used by tests to run assertions on the [Image] created by
 /// [ShaderWarmUp.execute]. The return value indicates whether the assertions
 /// pass or not.
-typedef ShaderWarmUpImageCallback = bool Function(Image);
+typedef ShaderWarmUpImageCallback = bool Function(Image image);
 
 /// Called by [ShaderWarmUp.execute] immediately after it creates a [Picture].
 ///

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1077,7 +1077,7 @@ class PerformanceOverlayLayer extends Layer {
 }
 
 /// The signature of the callback added in [Layer.addCompositionCallback].
-typedef CompositionCallback = void Function(Layer);
+typedef CompositionCallback = void Function(Layer layer);
 
 /// A composited layer that has a list of children.
 ///

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -19,7 +19,7 @@ import 'stack.dart' show RelativeRect;
 /// Used by [RenderConstraintsTransformBox] and [ConstraintsTransformBox].
 /// Typically the caller requires the returned [BoxConstraints] to be
 /// [BoxConstraints.isNormalized].
-typedef BoxConstraintsTransform = BoxConstraints Function(BoxConstraints);
+typedef BoxConstraintsTransform = BoxConstraints Function(BoxConstraints constraints);
 
 /// Abstract class for one-child-layout render boxes that provide control over
 /// the child's position.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -59,7 +59,7 @@ export 'package:flutter/services.dart' show KeyboardInsertedContent, SelectionCh
 typedef SelectionChangedCallback = void Function(TextSelection selection, SelectionChangedCause? cause);
 
 /// Signature for the callback that reports the app private command results.
-typedef AppPrivateCommandCallback = void Function(String, Map<String, dynamic>);
+typedef AppPrivateCommandCallback = void Function(String action, Map<String, dynamic> data);
 
 /// Signature for a widget builder that builds a context menu for the given
 /// [EditableTextState].

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -54,7 +54,7 @@ export 'package:flutter/rendering.dart' show AxisDirection;
 ///  * [WidgetBuilder], which is similar but only takes a [BuildContext].
 ///  * [NullableIndexedWidgetBuilder], which is similar but may return null.
 ///  * [IndexedWidgetBuilder], which is similar but not nullable.
-typedef TwoDimensionalIndexedWidgetBuilder = Widget? Function(BuildContext, ChildVicinity vicinity);
+typedef TwoDimensionalIndexedWidgetBuilder = Widget? Function(BuildContext context, ChildVicinity vicinity);
 
 /// A widget through which a portion of larger content can be viewed, typically
 /// in combination with a [TwoDimensionalScrollable].

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -490,7 +490,7 @@ class MockScrollBehavior extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) => const NeverScrollableScrollPhysics();
 }
 
-typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);
+typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext context, RouteInformation information);
 typedef SimpleNavigatorRouterDelegatePopPage<T> = bool Function(Route<T> route, T result, SimpleNavigatorRouterDelegate delegate);
 
 class SimpleRouteInformationParser extends RouteInformationParser<RouteInformation> {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1611,7 +1611,7 @@ class MockScrollBehavior extends ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) => const NeverScrollableScrollPhysics();
 }
 
-typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);
+typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext context, RouteInformation information);
 typedef SimpleNavigatorRouterDelegatePopPage<T> = bool Function(Route<T> route, T result, SimpleNavigatorRouterDelegate delegate);
 
 class SimpleRouteInformationParser extends RouteInformationParser<RouteInformation> {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -17131,7 +17131,7 @@ class _ObscureTextTestWidgetState extends State<_ObscureTextTestWidget> {
 }
 
 
-typedef FormatEditUpdateCallback = void Function(TextEditingValue, TextEditingValue);
+typedef FormatEditUpdateCallback = void Function(TextEditingValue oldValue, TextEditingValue newValue);
 
 // On web, key events in text fields are handled by the browser.
 const bool areKeyEventsHandledByPlatform = isBrowser;

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1425,7 +1425,7 @@ void main() {
   });
 
   testWidgetsWithLeakTracking('Passes onAppPrivateCommand to onAppPrivateCommand TextField', (WidgetTester tester) async {
-    void onAppPrivateCommand(String p0, Map<String, dynamic> p1) {}
+    void onAppPrivateCommand(String action, Map<String, dynamic> data) {}
 
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -784,7 +784,7 @@ void main() {
   });
 }
 
-typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);
+typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext context, RouteInformation information);
 typedef SimpleNavigatorRouterDelegatePopPage<T> = bool Function(Route<T> route, T result, SimpleNavigatorRouterDelegate delegate);
 
 class SelectAllSpy extends Action<SelectAllTextIntent> {

--- a/packages/flutter/test/widgets/build_context_test.dart
+++ b/packages/flutter/test/widgets/build_context_test.dart
@@ -32,7 +32,7 @@ void main() {
   });
 }
 
-typedef BuildCallback = void Function(BuildContext);
+typedef BuildCallback = void Function(BuildContext context);
 
 class TestStatelessWidget extends StatelessWidget {
   const TestStatelessWidget({super.key, required this.onBuild});

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -319,7 +319,7 @@ void main() {
   });
 }
 
-typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);
+typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext context, RouteInformation information);
 typedef SimpleRouterDelegatePopRoute = Future<bool> Function();
 
 class SimpleRouteInformationParser extends RouteInformationParser<RouteInformation> {

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -1708,11 +1708,11 @@ Widget buildBoilerPlate(Widget child) {
   );
 }
 
-typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation?);
+typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext context, RouteInformation? information);
 typedef SimpleRouterDelegatePopRoute = Future<bool> Function();
 typedef SimpleNavigatorRouterDelegatePopPage<T> = bool Function(Route<T> route, T result);
-typedef RouterReportRouterInformation = void Function(RouteInformation, RouteInformationReportingType);
-typedef CustomRouteInformationParserCallback = RouteInformation Function(RouteInformation, BuildContext);
+typedef RouterReportRouterInformation = void Function(RouteInformation information, RouteInformationReportingType type);
+typedef CustomRouteInformationParserCallback = RouteInformation Function(RouteInformation information, BuildContext context);
 
 class SimpleRouteInformationParser extends RouteInformationParser<RouteInformation> {
   SimpleRouteInformationParser();


### PR DESCRIPTION
## Description

Similar to #119877, but with more cases that I could find in `packages/flutter`. 

Although there is already a [proposal](https://github.com/dart-lang/sdk/issues/59047), it is uncertain how long it will take to be implemented.

![[image-20200711205959042](https://user-images.githubusercontent.com/72788825/216486897-b56453d2-b309-47ea-885b-b0ec6ed1b648.png)](https://user-images.githubusercontent.com/72788825/216486897-b56453d2-b309-47ea-885b-b0ec6ed1b648.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
