### PR TITLE
Only run dart files as a test in the Android preview tools test shard

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -482,7 +482,7 @@ Future<void> _runAndroidPreviewIntegrationToolTests() async {
   final List<String> allTests = Directory(path.join(_toolsPath, 'test', 'android_preview_integration.shard'))
       .listSync(recursive: true).whereType<File>()
       .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
-      .where((String testPath) => path.basename(testPath).endsWith('.dart')).toList();
+      .where((String testPath) => path.basename(testPath).endsWith('_test.dart')).toList();
 
   await _runDartTest(
     _toolsPath,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -482,7 +482,7 @@ Future<void> _runAndroidPreviewIntegrationToolTests() async {
   final List<String> allTests = Directory(path.join(_toolsPath, 'test', 'android_preview_integration.shard'))
       .listSync(recursive: true).whereType<File>()
       .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: _toolsPath))
-      .toList();
+      .where((String testPath) => path.basename(testPath).endsWith('.dart')).toList();
 
   await _runDartTest(
     _toolsPath,


### PR DESCRIPTION
I added a README at the end of https://github.com/flutter/flutter/pull/131901 and did not realize that it was being run as a test, [leading to test failures (of course)](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8761789207346423409/+/u/run_test.dart_for_android_preview_tool_integration_tests_shard_and_subshard_None/test_stdout). This makes it so we only run dart files as dart tests. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
