### PR TITLE
Evaluate variables in associated domains in iOS analyze

### DIFF
--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -147,10 +147,12 @@ class BuildableIOSApp extends IOSApp {
   String get archiveBundleOutputPath =>
       globals.fs.path.setExtension(archiveBundlePath, '.xcarchive');
 
-  String get builtInfoPlistPathAfterArchive => globals.fs.path.join(archiveBundleOutputPath,
+  String get builtAppBundlePathAfterArchive => globals.fs.path.join(archiveBundleOutputPath,
       'Products',
       'Applications',
-      _hostAppBundleName ?? 'Runner.app',
+      _hostAppBundleName ?? 'Runner.app');
+
+  String get builtInfoPlistPathAfterArchive => globals.fs.path.join(builtAppBundlePathAfterArchive,
       'Info.plist');
 
   String get projectAppIconDirName => _projectImageAssetDirName(_appIconAsset);

--- a/packages/flutter_tools/lib/src/ios/plist_parser.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_parser.dart
@@ -177,4 +177,16 @@ class PlistParser {
     final Map<String, dynamic> parsed = parseFile(plistFilePath);
     return parsed[key] as T?;
   }
+
+  /// Parses the xml Plist content located at [plistFilePath] and returns the value
+  /// that's associated with the specified [key] within the property list.
+  ///
+  /// If [plistFilePath] points to a non-existent file or a file that's not a
+  /// valid property list file, this will return null.
+  ///
+  /// If [key] is not found in the property list, this will return null.
+  T? getValueFromXml<T>(String xmlContent, String key) {
+    final Map<String, dynamic> parsed = _parseXml(xmlContent);
+    return parsed[key] as T?;
+  }
 }

--- a/packages/flutter_tools/lib/src/ios/plist_parser.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_parser.dart
@@ -178,11 +178,8 @@ class PlistParser {
     return parsed[key] as T?;
   }
 
-  /// Parses the xml Plist content located at [plistFilePath] and returns the value
-  /// that's associated with the specified [key] within the property list.
-  ///
-  /// If [plistFilePath] points to a non-existent file or a file that's not a
-  /// valid property list file, this will return null.
+  /// Parses the xml Plist content and returns the value that's associated with
+  /// the specified [key] within the property list.
   ///
   /// If [key] is not found in the property list, this will return null.
   T? getValueFromXml<T>(String xmlContent, String key) {

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -367,6 +367,7 @@ class IosProject extends XcodeBasedProject {
       configuration: buildContext.configuration,
     );
     final BuildableIOSApp app = BuildableIOSApp(this, bundleIdentifier, hostAppBundleName);
+    // Archiving app bundle will evaluate the variables in entitlements.
     final XcodeBuildResult result = await buildXcodeProject(
       app: app,
       buildInfo: _generateBuildInfoFrom(buildContext),

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -888,6 +888,7 @@ apply plugin: 'kotlin-android'
       group('product bundle identifier', () {
         testWithMocks('null, if no build settings or plist entries', () async {
           final FlutterProject project = await someProject();
+          xcodeProjectInterpreter.xcodeProjectInfo = XcodeProjectInfo(<String>[], <String>[], <String>['Runner'], logger);
           expect(await project.ios.productBundleIdentifier(null), isNull);
         });
 
@@ -918,6 +919,7 @@ apply plugin: 'kotlin-android'
           final FlutterProject project = await someProject();
           project.ios.defaultHostInfoPlist.createSync(recursive: true);
           testPlistUtils.setProperty('CFBundleIdentifier', 'io.flutter.someProject');
+          xcodeProjectInterpreter.xcodeProjectInfo = XcodeProjectInfo(<String>[], <String>[], <String>['Runner'], logger);
           expect(await project.ios.productBundleIdentifier(null), 'io.flutter.someProject');
         });
 
@@ -1035,6 +1037,7 @@ apply plugin: 'kotlin-android'
 
       testUsingContext('app product name defaults to Runner.app', () async {
         final FlutterProject project = await someProject();
+        mockXcodeProjectInterpreter.xcodeProjectInfo = XcodeProjectInfo(<String>[], <String>[], <String>['Runner'], logger);
         expect(await project.ios.hostAppBundleName(null), 'Runner.app');
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
@@ -1149,6 +1152,7 @@ apply plugin: 'kotlin-android'
     testUsingContext('cannot find bundle identifier', () async {
       final FlutterProject project = await someProject();
       final XcodeProjectInfo projectInfo = XcodeProjectInfo(<String>['WatchTarget'], <String>[], <String>[], logger);
+      mockXcodeProjectInterpreter.xcodeProjectInfo = XcodeProjectInfo(<String>[], <String>[], <String>['Runner'], logger);
       expect(
         await project.ios.containsWatchCompanion(
           projectInfo: projectInfo,
@@ -1383,7 +1387,8 @@ Future<FlutterProject> someProject({
     ..createSync(recursive: true)
     ..writeAsStringSync(validPubspec);
   }
-  directory.childDirectory('ios').createSync(recursive: true);
+  directory.childDirectory('ios').childDirectory('Runner.xcodeproj').childFile('project.pbxproj').createSync(recursive: true);
+
   final Directory androidDirectory = directory
       .childDirectory('android')
       ..createSync(recursive: true);
@@ -1713,6 +1718,12 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   Future<XcodeProjectInfo> getInfo(String projectPath, {String? projectFilename}) async {
     return xcodeProjectInfo;
   }
+
+  @override
+  Version? get version => Version(1, 0, 0);
+
+  @override
+  String? get versionText => '1.0.0';
 
   @override
   bool get isInstalled => true;

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -316,6 +316,11 @@ class FakePlistParser implements PlistParser {
   }
 
   @override
+  T? getValueFromXml<T>(String xmlContent, String key) {
+    return _underlyingValues[key] as T?;
+  }
+
+  @override
   bool replaceKey(String plistFilePath, {required String key, String? value}) {
     if (value == null) {
       _underlyingValues.remove(key);


### PR DESCRIPTION
Change the logic to archiving the app and use codesign cli to pull the entitlement. if any of it fails, fallback to original behavior. The original behavior may contain variable still, my current plan is to handle that in devtool deeplink validation tool. Probably to show a prompt to ask for user input, or just display error.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
