### PR TITLE
[flutter_tools] add custom tool analysis to analyze.dart, lint Future.catchError

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -91,95 +91,90 @@ Future<void> run(List<String> arguments) async {
     foundError(<String>['The analyze.dart script must be run with --enable-asserts.']);
   }
 
-  //printProgress('TargetPlatform tool/framework consistency');
-  //await verifyTargetPlatform(flutterRoot);
+  printProgress('TargetPlatform tool/framework consistency');
+  await verifyTargetPlatform(flutterRoot);
 
-  //printProgress('All tool test files end in _test.dart...');
-  //await verifyToolTestsEndInTestDart(flutterRoot);
+  printProgress('All tool test files end in _test.dart...');
+  await verifyToolTestsEndInTestDart(flutterRoot);
 
-  //printProgress('No sync*/async*');
-  //await verifyNoSyncAsyncStar(flutterPackages);
-  //await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
+  printProgress('No sync*/async*');
+  await verifyNoSyncAsyncStar(flutterPackages);
+  await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
 
-  //printProgress('No runtimeType in toString...');
-  //await verifyNoRuntimeTypeInToString(flutterRoot);
+  printProgress('No runtimeType in toString...');
+  await verifyNoRuntimeTypeInToString(flutterRoot);
 
-  //printProgress('Debug mode instead of checked mode...');
-  //await verifyNoCheckedMode(flutterRoot);
+  printProgress('Debug mode instead of checked mode...');
+  await verifyNoCheckedMode(flutterRoot);
 
-  //printProgress('Links for creating GitHub issues');
-  //await verifyIssueLinks(flutterRoot);
+  printProgress('Links for creating GitHub issues');
+  await verifyIssueLinks(flutterRoot);
 
-  //printProgress('Unexpected binaries...');
-  //await verifyNoBinaries(flutterRoot);
+  printProgress('Unexpected binaries...');
+  await verifyNoBinaries(flutterRoot);
 
-  //printProgress('Trailing spaces...');
-  //await verifyNoTrailingSpaces(flutterRoot); // assumes no unexpected binaries, so should be after verifyNoBinaries
+  printProgress('Trailing spaces...');
+  await verifyNoTrailingSpaces(flutterRoot); // assumes no unexpected binaries, so should be after verifyNoBinaries
 
-  //printProgress('Spaces after flow control statements...');
-  //await verifySpacesAfterFlowControlStatements(flutterRoot);
+  printProgress('Spaces after flow control statements...');
+  await verifySpacesAfterFlowControlStatements(flutterRoot);
 
-  //printProgress('Deprecations...');
-  //await verifyDeprecations(flutterRoot);
+  printProgress('Deprecations...');
+  await verifyDeprecations(flutterRoot);
 
-  //printProgress('Goldens...');
-  //await verifyGoldenTags(flutterPackages);
+  printProgress('Goldens...');
+  await verifyGoldenTags(flutterPackages);
 
-  //printProgress('Prevent flakes from Stopwatches...');
-  //await verifyNoStopwatches(flutterPackages);
+  printProgress('Skip test comments...');
+  await verifySkipTestComments(flutterRoot);
 
-  //printProgress('Skip test comments...');
-  //await verifySkipTestComments(flutterRoot);
+  printProgress('Licenses...');
+  await verifyNoMissingLicense(flutterRoot);
 
-  //printProgress('Licenses...');
-  //await verifyNoMissingLicense(flutterRoot);
+  printProgress('Test imports...');
+  await verifyNoTestImports(flutterRoot);
 
-  //printProgress('Test imports...');
-  //await verifyNoTestImports(flutterRoot);
+  printProgress('Bad imports (framework)...');
+  await verifyNoBadImportsInFlutter(flutterRoot);
 
-  //printProgress('Bad imports (framework)...');
-  //await verifyNoBadImportsInFlutter(flutterRoot);
+  printProgress('Bad imports (tools)...');
+  await verifyNoBadImportsInFlutterTools(flutterRoot);
 
-  //printProgress('Bad imports (tools)...');
-  //await verifyNoBadImportsInFlutterTools(flutterRoot);
+  printProgress('Internationalization...');
+  await verifyInternationalizations(flutterRoot, dart);
 
-  //printProgress('Internationalization...');
-  //await verifyInternationalizations(flutterRoot, dart);
+  printProgress('Integration test timeouts...');
+  await verifyIntegrationTestTimeouts(flutterRoot);
 
-  //printProgress('Integration test timeouts...');
-  //await verifyIntegrationTestTimeouts(flutterRoot);
+  printProgress('null initialized debug fields...');
+  await verifyNullInitializedDebugExpensiveFields(flutterRoot);
 
-  //printProgress('null initialized debug fields...');
-  //await verifyNullInitializedDebugExpensiveFields(flutterRoot);
+  printProgress('Taboo words...');
+  await verifyTabooDocumentation(flutterRoot);
 
-  //printProgress('Taboo words...');
-  //await verifyTabooDocumentation(flutterRoot);
+  // Ensure that all package dependencies are in sync.
+  printProgress('Package dependencies...');
+  await runCommand(flutter, <String>['update-packages', '--verify-only'],
+    workingDirectory: flutterRoot,
+  );
 
-  //// Ensure that all package dependencies are in sync.
-  //printProgress('Package dependencies...');
-  //await runCommand(flutter, <String>['update-packages', '--verify-only'],
-  //  workingDirectory: flutterRoot,
-  //);
+  /// Ensure that no new dependencies have been accidentally
+  /// added to core packages.
+  printProgress('Package Allowlist...');
+  await _checkConsumerDependencies();
 
-  ///// Ensure that no new dependencies have been accidentally
-  ///// added to core packages.
-  //printProgress('Package Allowlist...');
-  //await _checkConsumerDependencies();
-
-  //// Analyze all the Dart code in the repo.
-  //printProgress('Dart analysis...');
-  //final CommandResult dartAnalyzeResult = await _runFlutterAnalyze(flutterRoot, options: <String>[
-  //  '--flutter-repo',
-  //  ...arguments,
-  //]);
-
-  final CommandResult dartAnalyzeResult = CommandResult(0, Duration.zero, '', '');
+  // Analyze all the Dart code in the repo.
+  printProgress('Dart analysis...');
+  final CommandResult dartAnalyzeResult = await _runFlutterAnalyze(flutterRoot, options: <String>[
+    '--flutter-repo',
+    ...arguments,
+  ]);
 
   if (dartAnalyzeResult.exitCode == 0) {
     // Only run the private lints when the code is free of type errors. The
     // lints are easier to write when they can assume, for example, there is no
     // inheritance cycles.
-    final List<AnalyzeRule> rules = <AnalyzeRule>[noDoubleClamp, noStopwatches, AvoidFutureCatchError()];
+    final List<AnalyzeRule> rules = <AnalyzeRule>[noDoubleClamp, noStopwatches];
     final String ruleNames = rules.map((AnalyzeRule rule) => '\n * $rule').join();
     printProgress('Analyzing code in the framework with the following rules:$ruleNames');
     await analyzeWithRules(flutterRoot, rules,
@@ -200,62 +195,62 @@ Future<void> run(List<String> arguments) async {
     printProgress('Skipped performing further analysis in the framework because "flutter analyze" finished with a non-zero exit code.');
   }
 
-  //printProgress('Executable allowlist...');
-  //await _checkForNewExecutables();
+  printProgress('Executable allowlist...');
+  await _checkForNewExecutables();
 
-  //// Try with the --watch analyzer, to make sure it returns success also.
-  //// The --benchmark argument exits after one run.
-  //// We specify a failureMessage so that the actual output is muted in the case where _runFlutterAnalyze above already failed.
-  //printProgress('Dart analysis (with --watch)...');
-  //await _runFlutterAnalyze(flutterRoot, failureMessage: 'Dart analyzer failed when --watch was used.', options: <String>[
-  //  '--flutter-repo',
-  //  '--watch',
-  //  '--benchmark',
-  //  ...arguments,
-  //]);
+  // Try with the --watch analyzer, to make sure it returns success also.
+  // The --benchmark argument exits after one run.
+  // We specify a failureMessage so that the actual output is muted in the case where _runFlutterAnalyze above already failed.
+  printProgress('Dart analysis (with --watch)...');
+  await _runFlutterAnalyze(flutterRoot, failureMessage: 'Dart analyzer failed when --watch was used.', options: <String>[
+    '--flutter-repo',
+    '--watch',
+    '--benchmark',
+    ...arguments,
+  ]);
 
-  //// Analyze the code in `{@tool snippet}` sections in the repo.
-  //printProgress('Snippet code...');
-  //await runCommand(dart,
-  //  <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'), '--verbose'],
-  //  workingDirectory: flutterRoot,
-  //);
+  // Analyze the code in `{@tool snippet}` sections in the repo.
+  printProgress('Snippet code...');
+  await runCommand(dart,
+    <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'), '--verbose'],
+    workingDirectory: flutterRoot,
+  );
 
-  //// Make sure that all of the existing samples are linked from at least one API doc comment.
-  //printProgress('Code sample link validation...');
-  //await runCommand(dart,
-  //  <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart')],
-  //  workingDirectory: flutterRoot,
-  //);
+  // Make sure that all of the existing samples are linked from at least one API doc comment.
+  printProgress('Code sample link validation...');
+  await runCommand(dart,
+    <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart')],
+    workingDirectory: flutterRoot,
+  );
 
-  //// Try analysis against a big version of the gallery; generate into a temporary directory.
-  //printProgress('Dart analysis (mega gallery)...');
-  //final Directory outDir = Directory.systemTemp.createTempSync('flutter_mega_gallery.');
-  //try {
-  //  await runCommand(dart,
-  //    <String>[
-  //      path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
-  //      '--out',
-  //      outDir.path,
-  //    ],
-  //    workingDirectory: flutterRoot,
-  //  );
-  //  await _runFlutterAnalyze(outDir.path, failureMessage: 'Dart analyzer failed on mega_gallery benchmark.', options: <String>[
-  //    '--watch',
-  //    '--benchmark',
-  //    ...arguments,
-  //  ]);
-  //} finally {
-  //  outDir.deleteSync(recursive: true);
-  //}
+  // Try analysis against a big version of the gallery; generate into a temporary directory.
+  printProgress('Dart analysis (mega gallery)...');
+  final Directory outDir = Directory.systemTemp.createTempSync('flutter_mega_gallery.');
+  try {
+    await runCommand(dart,
+      <String>[
+        path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
+        '--out',
+        outDir.path,
+      ],
+      workingDirectory: flutterRoot,
+    );
+    await _runFlutterAnalyze(outDir.path, failureMessage: 'Dart analyzer failed on mega_gallery benchmark.', options: <String>[
+      '--watch',
+      '--benchmark',
+      ...arguments,
+    ]);
+  } finally {
+    outDir.deleteSync(recursive: true);
+  }
 
-  //// Ensure gen_default links the correct files
-  //printProgress('Correct file names in gen_defaults.dart...');
-  //await verifyTokenTemplatesUpdateCorrectFiles(flutterRoot);
+  // Ensure gen_default links the correct files
+  printProgress('Correct file names in gen_defaults.dart...');
+  await verifyTokenTemplatesUpdateCorrectFiles(flutterRoot);
 
-  //// Ensure integration test files are up-to-date with the app template.
-  //printProgress('Up to date integration test template files...');
-  //await verifyIntegrationTestTemplateFiles(flutterRoot);
+  // Ensure integration test files are up-to-date with the app template.
+  printProgress('Up to date integration test template files...');
+  await verifyIntegrationTestTemplateFiles(flutterRoot);
 }
 
 

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -18,6 +18,7 @@ import 'package:path/path.dart' as path;
 
 import 'allowlist.dart';
 import 'custom_rules/analyze.dart';
+import 'custom_rules/avoid_future_catcherror.dart';
 import 'custom_rules/no_double_clamp.dart';
 import 'custom_rules/no_stop_watches.dart';
 import 'run_command.dart';
@@ -90,90 +91,95 @@ Future<void> run(List<String> arguments) async {
     foundError(<String>['The analyze.dart script must be run with --enable-asserts.']);
   }
 
-  printProgress('TargetPlatform tool/framework consistency');
-  await verifyTargetPlatform(flutterRoot);
+  //printProgress('TargetPlatform tool/framework consistency');
+  //await verifyTargetPlatform(flutterRoot);
 
-  printProgress('All tool test files end in _test.dart...');
-  await verifyToolTestsEndInTestDart(flutterRoot);
+  //printProgress('All tool test files end in _test.dart...');
+  //await verifyToolTestsEndInTestDart(flutterRoot);
 
-  printProgress('No sync*/async*');
-  await verifyNoSyncAsyncStar(flutterPackages);
-  await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
+  //printProgress('No sync*/async*');
+  //await verifyNoSyncAsyncStar(flutterPackages);
+  //await verifyNoSyncAsyncStar(flutterExamples, minimumMatches: 200);
 
-  printProgress('No runtimeType in toString...');
-  await verifyNoRuntimeTypeInToString(flutterRoot);
+  //printProgress('No runtimeType in toString...');
+  //await verifyNoRuntimeTypeInToString(flutterRoot);
 
-  printProgress('Debug mode instead of checked mode...');
-  await verifyNoCheckedMode(flutterRoot);
+  //printProgress('Debug mode instead of checked mode...');
+  //await verifyNoCheckedMode(flutterRoot);
 
-  printProgress('Links for creating GitHub issues');
-  await verifyIssueLinks(flutterRoot);
+  //printProgress('Links for creating GitHub issues');
+  //await verifyIssueLinks(flutterRoot);
 
-  printProgress('Unexpected binaries...');
-  await verifyNoBinaries(flutterRoot);
+  //printProgress('Unexpected binaries...');
+  //await verifyNoBinaries(flutterRoot);
 
-  printProgress('Trailing spaces...');
-  await verifyNoTrailingSpaces(flutterRoot); // assumes no unexpected binaries, so should be after verifyNoBinaries
+  //printProgress('Trailing spaces...');
+  //await verifyNoTrailingSpaces(flutterRoot); // assumes no unexpected binaries, so should be after verifyNoBinaries
 
-  printProgress('Spaces after flow control statements...');
-  await verifySpacesAfterFlowControlStatements(flutterRoot);
+  //printProgress('Spaces after flow control statements...');
+  //await verifySpacesAfterFlowControlStatements(flutterRoot);
 
-  printProgress('Deprecations...');
-  await verifyDeprecations(flutterRoot);
+  //printProgress('Deprecations...');
+  //await verifyDeprecations(flutterRoot);
 
-  printProgress('Goldens...');
-  await verifyGoldenTags(flutterPackages);
+  //printProgress('Goldens...');
+  //await verifyGoldenTags(flutterPackages);
 
-  printProgress('Skip test comments...');
-  await verifySkipTestComments(flutterRoot);
+  //printProgress('Prevent flakes from Stopwatches...');
+  //await verifyNoStopwatches(flutterPackages);
 
-  printProgress('Licenses...');
-  await verifyNoMissingLicense(flutterRoot);
+  //printProgress('Skip test comments...');
+  //await verifySkipTestComments(flutterRoot);
 
-  printProgress('Test imports...');
-  await verifyNoTestImports(flutterRoot);
+  //printProgress('Licenses...');
+  //await verifyNoMissingLicense(flutterRoot);
 
-  printProgress('Bad imports (framework)...');
-  await verifyNoBadImportsInFlutter(flutterRoot);
+  //printProgress('Test imports...');
+  //await verifyNoTestImports(flutterRoot);
 
-  printProgress('Bad imports (tools)...');
-  await verifyNoBadImportsInFlutterTools(flutterRoot);
+  //printProgress('Bad imports (framework)...');
+  //await verifyNoBadImportsInFlutter(flutterRoot);
 
-  printProgress('Internationalization...');
-  await verifyInternationalizations(flutterRoot, dart);
+  //printProgress('Bad imports (tools)...');
+  //await verifyNoBadImportsInFlutterTools(flutterRoot);
 
-  printProgress('Integration test timeouts...');
-  await verifyIntegrationTestTimeouts(flutterRoot);
+  //printProgress('Internationalization...');
+  //await verifyInternationalizations(flutterRoot, dart);
 
-  printProgress('null initialized debug fields...');
-  await verifyNullInitializedDebugExpensiveFields(flutterRoot);
+  //printProgress('Integration test timeouts...');
+  //await verifyIntegrationTestTimeouts(flutterRoot);
 
-  printProgress('Taboo words...');
-  await verifyTabooDocumentation(flutterRoot);
+  //printProgress('null initialized debug fields...');
+  //await verifyNullInitializedDebugExpensiveFields(flutterRoot);
 
-  // Ensure that all package dependencies are in sync.
-  printProgress('Package dependencies...');
-  await runCommand(flutter, <String>['update-packages', '--verify-only'],
-    workingDirectory: flutterRoot,
-  );
+  //printProgress('Taboo words...');
+  //await verifyTabooDocumentation(flutterRoot);
 
-  /// Ensure that no new dependencies have been accidentally
-  /// added to core packages.
-  printProgress('Package Allowlist...');
-  await _checkConsumerDependencies();
+  //// Ensure that all package dependencies are in sync.
+  //printProgress('Package dependencies...');
+  //await runCommand(flutter, <String>['update-packages', '--verify-only'],
+  //  workingDirectory: flutterRoot,
+  //);
 
-  // Analyze all the Dart code in the repo.
-  printProgress('Dart analysis...');
-  final CommandResult dartAnalyzeResult = await _runFlutterAnalyze(flutterRoot, options: <String>[
-    '--flutter-repo',
-    ...arguments,
-  ]);
+  ///// Ensure that no new dependencies have been accidentally
+  ///// added to core packages.
+  //printProgress('Package Allowlist...');
+  //await _checkConsumerDependencies();
+
+  //// Analyze all the Dart code in the repo.
+  //printProgress('Dart analysis...');
+  //final CommandResult dartAnalyzeResult = await _runFlutterAnalyze(flutterRoot, options: <String>[
+  //  '--flutter-repo',
+  //  ...arguments,
+  //]);
+
+  final CommandResult dartAnalyzeResult = CommandResult(0, Duration.zero, '', '');
 
   if (dartAnalyzeResult.exitCode == 0) {
     // Only run the private lints when the code is free of type errors. The
     // lints are easier to write when they can assume, for example, there is no
     // inheritance cycles.
-    final List<AnalyzeRule> rules = <AnalyzeRule>[noDoubleClamp, noStopwatches];
+    final List<AnalyzeRule> rules = <AnalyzeRule>[noDoubleClamp, noStopwatches, AvoidFutureCatchError()];
     final String ruleNames = rules.map((AnalyzeRule rule) => '\n * $rule').join();
     printProgress('Analyzing code in the framework with the following rules:$ruleNames');
     await analyzeWithRules(flutterRoot, rules,
@@ -186,66 +192,70 @@ Future<void> run(List<String> arguments) async {
     await analyzeWithRules(flutterRoot, testRules,
       includePaths: <String>['packages/flutter/test'],
     );
+    final List<AnalyzeRule> toolRules = <AnalyzeRule>[AvoidFutureCatchError()];
+    final String toolRuleNames = toolRules.map((AnalyzeRule rule) => '\n * $rule').join();
+    printProgress('Analyzing code in the tool with the following rules:$toolRuleNames');
+    await analyzeToolWithRules(flutterRoot, toolRules);
   } else {
     printProgress('Skipped performing further analysis in the framework because "flutter analyze" finished with a non-zero exit code.');
   }
 
-  printProgress('Executable allowlist...');
-  await _checkForNewExecutables();
+  //printProgress('Executable allowlist...');
+  //await _checkForNewExecutables();
 
-  // Try with the --watch analyzer, to make sure it returns success also.
-  // The --benchmark argument exits after one run.
-  // We specify a failureMessage so that the actual output is muted in the case where _runFlutterAnalyze above already failed.
-  printProgress('Dart analysis (with --watch)...');
-  await _runFlutterAnalyze(flutterRoot, failureMessage: 'Dart analyzer failed when --watch was used.', options: <String>[
-    '--flutter-repo',
-    '--watch',
-    '--benchmark',
-    ...arguments,
-  ]);
+  //// Try with the --watch analyzer, to make sure it returns success also.
+  //// The --benchmark argument exits after one run.
+  //// We specify a failureMessage so that the actual output is muted in the case where _runFlutterAnalyze above already failed.
+  //printProgress('Dart analysis (with --watch)...');
+  //await _runFlutterAnalyze(flutterRoot, failureMessage: 'Dart analyzer failed when --watch was used.', options: <String>[
+  //  '--flutter-repo',
+  //  '--watch',
+  //  '--benchmark',
+  //  ...arguments,
+  //]);
 
-  // Analyze the code in `{@tool snippet}` sections in the repo.
-  printProgress('Snippet code...');
-  await runCommand(dart,
-    <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'), '--verbose'],
-    workingDirectory: flutterRoot,
-  );
+  //// Analyze the code in `{@tool snippet}` sections in the repo.
+  //printProgress('Snippet code...');
+  //await runCommand(dart,
+  //  <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'analyze_snippet_code.dart'), '--verbose'],
+  //  workingDirectory: flutterRoot,
+  //);
 
-  // Make sure that all of the existing samples are linked from at least one API doc comment.
-  printProgress('Code sample link validation...');
-  await runCommand(dart,
-    <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart')],
-    workingDirectory: flutterRoot,
-  );
+  //// Make sure that all of the existing samples are linked from at least one API doc comment.
+  //printProgress('Code sample link validation...');
+  //await runCommand(dart,
+  //  <String>['--enable-asserts', path.join(flutterRoot, 'dev', 'bots', 'check_code_samples.dart')],
+  //  workingDirectory: flutterRoot,
+  //);
 
-  // Try analysis against a big version of the gallery; generate into a temporary directory.
-  printProgress('Dart analysis (mega gallery)...');
-  final Directory outDir = Directory.systemTemp.createTempSync('flutter_mega_gallery.');
-  try {
-    await runCommand(dart,
-      <String>[
-        path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
-        '--out',
-        outDir.path,
-      ],
-      workingDirectory: flutterRoot,
-    );
-    await _runFlutterAnalyze(outDir.path, failureMessage: 'Dart analyzer failed on mega_gallery benchmark.', options: <String>[
-      '--watch',
-      '--benchmark',
-      ...arguments,
-    ]);
-  } finally {
-    outDir.deleteSync(recursive: true);
-  }
+  //// Try analysis against a big version of the gallery; generate into a temporary directory.
+  //printProgress('Dart analysis (mega gallery)...');
+  //final Directory outDir = Directory.systemTemp.createTempSync('flutter_mega_gallery.');
+  //try {
+  //  await runCommand(dart,
+  //    <String>[
+  //      path.join(flutterRoot, 'dev', 'tools', 'mega_gallery.dart'),
+  //      '--out',
+  //      outDir.path,
+  //    ],
+  //    workingDirectory: flutterRoot,
+  //  );
+  //  await _runFlutterAnalyze(outDir.path, failureMessage: 'Dart analyzer failed on mega_gallery benchmark.', options: <String>[
+  //    '--watch',
+  //    '--benchmark',
+  //    ...arguments,
+  //  ]);
+  //} finally {
+  //  outDir.deleteSync(recursive: true);
+  //}
 
-  // Ensure gen_default links the correct files
-  printProgress('Correct file names in gen_defaults.dart...');
-  await verifyTokenTemplatesUpdateCorrectFiles(flutterRoot);
+  //// Ensure gen_default links the correct files
+  //printProgress('Correct file names in gen_defaults.dart...');
+  //await verifyTokenTemplatesUpdateCorrectFiles(flutterRoot);
 
-  // Ensure integration test files are up-to-date with the app template.
-  printProgress('Up to date integration test template files...');
-  await verifyIntegrationTestTemplateFiles(flutterRoot);
+  //// Ensure integration test files are up-to-date with the app template.
+  //printProgress('Up to date integration test template files...');
+  //await verifyIntegrationTestTemplateFiles(flutterRoot);
 }
 
 

--- a/dev/bots/custom_rules/avoid_future_catcherror.dart
+++ b/dev/bots/custom_rules/avoid_future_catcherror.dart
@@ -10,7 +10,7 @@ import 'package:analyzer/dart/element/type.dart';
 import '../utils.dart';
 import 'analyze.dart';
 
-/// Don't use Future.catchError.
+/// Don't use Future.catchError or Future.onError.
 ///
 /// See https://github.com/flutter/flutter/pull/130662 for more context.
 ///
@@ -67,7 +67,7 @@ class AvoidFutureCatchError extends AnalyzeRule {
   }
 
   @override
-  String toString() => 'Avoid "Future.catchError"';
+  String toString() => 'Avoid "Future.catchError" and "Future.onError"';
 }
 
 class _Visitor extends RecursiveAstVisitor<void> {

--- a/dev/bots/custom_rules/avoid_future_catcherror.dart
+++ b/dev/bots/custom_rules/avoid_future_catcherror.dart
@@ -4,43 +4,42 @@
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 import '../utils.dart';
 import 'analyze.dart';
 
-const String _desc = r"Don't use Future.catchError.";
-
-const String _details = r'''
-**DON'T** call Future.catchError.
-
-TODO explain.
-
-**BAD:**
-
-```dart
-Future<Object?> doSomething() {
-  return doSomethingAsync().catchError((_) => null);
-}
-Future<Object?> doSomethingAsync() => Future<Object?>.value(1);
-```
-
-**GOOD:**
-
-```dart
-Future<Object?> doSomething() {
-  return doSomethingAsync().then(
-    (Object? obj) => obj,
-    onError: (_) => null,
-  );
-}
-Future<Object?> doSomethingAsync() => Future<Object?>.value(1);
-```
-''';
-
-
+/// Don't use Future.catchError.
+///
+/// See https://github.com/flutter/flutter/pull/130662 for more context.
+///
+/// **BAD:**
+///
+/// ```dart
+/// Future<Object?> doSomething() {
+///   return doSomethingAsync().catchError((_) => null);
+/// }
+///
+/// Future<Object?> doSomethingAsync() {
+///   return Future<Object>.error(Exception('error'));
+/// }
+/// ```
+///
+/// **GOOD:**
+///
+/// ```dart
+/// Future<Object?> doSomething() {
+///   return doSomethingAsync().then(
+///     (Object? obj) => obj,
+///     onError: (_) => null,
+///   );
+/// }
+///
+/// Future<Object?> doSomethingAsync() {
+///   return Future<Object>.error(Exception('error'));
+/// }
+/// ```
 class AvoidFutureCatchError extends AnalyzeRule {
   final Map<ResolvedUnitResult, List<AstNode>> _errors = <ResolvedUnitResult, List<AstNode>>{};
 

--- a/dev/bots/custom_rules/avoid_future_catcherror.dart
+++ b/dev/bots/custom_rules/avoid_future_catcherror.dart
@@ -1,0 +1,90 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import '../utils.dart';
+import 'analyze.dart';
+
+const String _desc = r"Don't use Future.catchError.";
+
+const String _details = r'''
+**DON'T** call Future.catchError.
+
+TODO explain.
+
+**BAD:**
+
+```dart
+Future<Object?> doSomething() {
+  return doSomethingAsync().catchError((_) => null);
+}
+Future<Object?> doSomethingAsync() => Future<Object?>.value(1);
+```
+
+**GOOD:**
+
+```dart
+Future<Object?> doSomething() {
+  return doSomethingAsync().then(
+    (Object? obj) => obj,
+    onError: (_) => null,
+  );
+}
+Future<Object?> doSomethingAsync() => Future<Object?>.value(1);
+```
+''';
+
+
+class AvoidFutureCatchError extends AnalyzeRule {
+  final Map<ResolvedUnitResult, List<AstNode>> _errors = <ResolvedUnitResult, List<AstNode>>{};
+
+  @override
+  void applyTo(ResolvedUnitResult unit) {
+    final _Visitor visitor = _Visitor();
+    unit.unit.visitChildren(visitor);
+    if (visitor._offendingNodes.isNotEmpty) {
+      _errors.putIfAbsent(unit, () => <AstNode>[]).addAll(visitor._offendingNodes);
+    }
+  }
+
+  @override
+  void reportViolations(String workingDirectory) {
+    if (_errors.isEmpty) {
+      return;
+    }
+
+    foundError(<String>[
+      for (final MapEntry<ResolvedUnitResult, List<AstNode>> entry in _errors.entries)
+        for (final AstNode node in entry.value)
+          '${locationInFile(entry.key, node, workingDirectory)}: ${node.parent}',
+      '\n${bold}Future.catchError and Future.onError are not type safe--instead use Future.then: https://github.com/dart-lang/sdk/issues/51248$reset',
+    ]);
+  }
+
+  @override
+  String toString() => 'Avoid "Future.catchError"';
+}
+
+class _Visitor extends RecursiveAstVisitor<void> {
+  _Visitor();
+
+  final List<AstNode> _offendingNodes = <AstNode>[];
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name != 'onError') {
+      return;
+    }
+    final DartType? targetType = node.realTarget?.staticType;
+    if (targetType == null || !targetType.isDartAsyncFuture) {
+      return;
+    }
+    _offendingNodes.add(node);
+  }
+}

--- a/dev/bots/custom_rules/avoid_future_catcherror.dart
+++ b/dev/bots/custom_rules/avoid_future_catcherror.dart
@@ -77,7 +77,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    if (node.methodName.name != 'onError') {
+    if (node.methodName.name != 'onError' && node.methodName.name != 'catchError') {
       return;
     }
     final DartType? targetType = node.realTarget?.staticType;

--- a/dev/bots/custom_rules/no_double_clamp.dart
+++ b/dev/bots/custom_rules/no_double_clamp.dart
@@ -7,7 +7,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:path/path.dart' as path;
 
 import '../utils.dart';
 import 'analyze.dart';
@@ -39,14 +38,10 @@ class _NoDoubleClamp implements AnalyzeRule {
       return;
     }
 
-    String locationInFile(ResolvedUnitResult unit, AstNode node) {
-      return '${path.relative(path.relative(unit.path, from: workingDirectory))}:${unit.lineInfo.getLocation(node.offset).lineNumber}';
-    }
-
     foundError(<String>[
       for (final MapEntry<ResolvedUnitResult, List<AstNode>> entry in _errors.entries)
         for (final AstNode node in entry.value)
-          '${locationInFile(entry.key, node)}: ${node.parent}',
+          '${locationInFile(entry.key, node, workingDirectory)}: ${node.parent}',
       '\n${bold}For performance reasons, we use a custom "clampDouble" function instead of using "double.clamp".$reset',
     ]);
   }

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -58,6 +58,7 @@ class Command {
 /// The result of running a command using [startCommand] and [runCommand];
 class CommandResult {
   CommandResult._(this.exitCode, this.elapsedTime, this.flattenedStdout, this.flattenedStderr);
+  CommandResult(this.exitCode, this.elapsedTime, this.flattenedStdout, this.flattenedStderr); // TODO delete
 
   /// The exit code of the process.
   final int exitCode;

--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -58,7 +58,6 @@ class Command {
 /// The result of running a command using [startCommand] and [runCommand];
 class CommandResult {
   CommandResult._(this.exitCode, this.elapsedTime, this.flattenedStdout, this.flattenedStderr);
-  CommandResult(this.exitCode, this.elapsedTime, this.flattenedStdout, this.flattenedStderr); // TODO delete
 
   /// The exit code of the process.
   final int exitCode;

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -8,7 +8,10 @@ import 'dart:io' as system show exit;
 import 'dart:io' hide exit;
 import 'dart:math' as math;
 
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
 
 const Duration _quietTimeout = Duration(minutes: 10); // how long the output should be hidden between calls to printProgress before just being verbose
 
@@ -252,4 +255,8 @@ Future<bool> _isPortAvailable(int port) async {
   } on SocketException {
     return true;
   }
+}
+
+String locationInFile(ResolvedUnitResult unit, AstNode node, String workingDirectory) {
+  return '${path.relative(path.relative(unit.path, from: workingDirectory))}:${unit.lineInfo.getLocation(node.offset).lineNumber}';
 }

--- a/packages/flutter_tools/lib/src/daemon.dart
+++ b/packages/flutter_tools/lib/src/daemon.dart
@@ -190,10 +190,10 @@ class DaemonStreams {
     final Future<Socket> socketFuture = Socket.connect(host, port);
     final StreamController<List<int>> inputStreamController = StreamController<List<int>>();
     final StreamController<List<int>> outputStreamController = StreamController<List<int>>();
-    socketFuture.then((Socket socket) {
+    socketFuture.then<void>((Socket socket) {
       inputStreamController.addStream(socket);
       socket.addStream(outputStreamController.stream);
-    }).onError((Object error, StackTrace stackTrace) {
+    }, onError: (Object error, StackTrace stackTrace) {
       logger.printError('Socket error: $error');
       logger.printTrace('$stackTrace');
       // Propagate the error to the streams.


### PR DESCRIPTION
Ensure tool code does not use Future.catchError or Future.onError, because it is not statically safe: https://github.com/dart-lang/sdk/issues/51248.

This was proposed upstream in dart-lang/linter in https://github.com/dart-lang/sdk/issues/59040 and https://github.com/dart-lang/linter/pull/4068, but not accepted.