### PR TITLE
add support for specifying item extent inside DropdownButton

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -204,6 +204,9 @@ class _DropdownMenu<T> extends StatefulWidget {
     required this.route,
     required this.buttonRect,
     required this.constraints,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
     this.dropdownColor,
     required this.enableFeedback,
     this.borderRadius,
@@ -214,6 +217,9 @@ class _DropdownMenu<T> extends StatefulWidget {
   final EdgeInsets? padding;
   final Rect buttonRect;
   final BoxConstraints constraints;
+  final double? itemExtent;
+  final ItemExtentBuilder? itemExtentBuilder;
+  final Widget? prototypeItem;
   final Color? dropdownColor;
   final bool enableFeedback;
   final BorderRadius? borderRadius;
@@ -317,6 +323,9 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
                       primary: true,
                       padding: kMaterialListPadding,
                       shrinkWrap: true,
+                      itemExtent: widget.itemExtent,
+                      itemExtentBuilder: widget.itemExtentBuilder,
+                      prototypeItem: widget.prototypeItem,
                       children: children,
                     ),
                   ),
@@ -432,6 +441,9 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     required this.style,
     this.barrierLabel,
     this.itemHeight,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
     this.dropdownColor,
     this.menuMaxHeight,
     required this.enableFeedback,
@@ -446,6 +458,9 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   final CapturedThemes capturedThemes;
   final TextStyle style;
   final double? itemHeight;
+  final double? itemExtent;
+  final ItemExtentBuilder? itemExtentBuilder;
+  final Widget? prototypeItem;
   final Color? dropdownColor;
   final double? menuMaxHeight;
   final bool enableFeedback;
@@ -479,6 +494,9 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
           elevation: elevation,
           capturedThemes: capturedThemes,
           style: style,
+          itemExtent: itemExtent,
+          itemExtentBuilder: itemExtentBuilder,
+          prototypeItem: prototypeItem,
           dropdownColor: dropdownColor,
           enableFeedback: enableFeedback,
           borderRadius: borderRadius,
@@ -588,6 +606,9 @@ class _DropdownRoutePage<T> extends StatefulWidget {
     this.elevation = 8,
     required this.capturedThemes,
     this.style,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
     required this.dropdownColor,
     required this.enableFeedback,
     this.borderRadius,
@@ -602,6 +623,9 @@ class _DropdownRoutePage<T> extends StatefulWidget {
   final int elevation;
   final CapturedThemes capturedThemes;
   final TextStyle? style;
+  final double? itemExtent;
+  final ItemExtentBuilder? itemExtentBuilder;
+  final Widget? prototypeItem;
   final Color? dropdownColor;
   final bool enableFeedback;
   final BorderRadius? borderRadius;
@@ -638,6 +662,9 @@ class _DropdownRoutePageState<T> extends State<_DropdownRoutePage<T>> {
       padding: widget.padding.resolve(textDirection),
       buttonRect: widget.buttonRect,
       constraints: widget.constraints,
+      itemExtent: widget.itemExtent,
+      itemExtentBuilder: widget.itemExtentBuilder,
+      prototypeItem: widget.prototypeItem,
       dropdownColor: widget.dropdownColor,
       enableFeedback: widget.enableFeedback,
       borderRadius: widget.borderRadius,
@@ -934,6 +961,9 @@ class DropdownButton<T> extends StatefulWidget {
     this.isDense = false,
     this.isExpanded = false,
     this.itemHeight = kMinInteractiveDimension,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
     this.focusColor,
     this.focusNode,
     this.autofocus = false,
@@ -978,6 +1008,9 @@ class DropdownButton<T> extends StatefulWidget {
     this.isDense = false,
     this.isExpanded = false,
     this.itemHeight = kMinInteractiveDimension,
+    this.itemExtent,
+    this.itemExtentBuilder,
+    this.prototypeItem,
     this.focusColor,
     this.focusNode,
     this.autofocus = false,
@@ -1157,6 +1190,15 @@ class DropdownButton<T> extends StatefulWidget {
   /// offset is computed as if all of the menu item heights were
   /// [kMinInteractiveDimension].
   final double? itemHeight;
+
+  /// {@macro flutter.widgets.list_view.itemExtent}
+  final double? itemExtent;
+
+  /// {@macro flutter.widgets.list_view.itemExtentBuilder}
+  final ItemExtentBuilder? itemExtentBuilder;
+
+  /// {@macro flutter.widgets.list_view.prototypeItem}
+  final Widget? prototypeItem;
 
   /// The color for the button's [Material] when it has the input focus.
   final Color? focusColor;
@@ -1349,6 +1391,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       style: _textStyle!,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       itemHeight: widget.itemHeight,
+      itemExtent: widget.itemExtent,
+      itemExtentBuilder: widget.itemExtentBuilder,
+      prototypeItem: widget.prototypeItem,
       dropdownColor: widget.dropdownColor,
       menuMaxHeight: widget.menuMaxHeight,
       enableFeedback: widget.enableFeedback ?? true,
@@ -1604,6 +1649,9 @@ class DropdownButtonFormField<T> extends FormField<T> {
     Color? focusColor,
     FocusNode? focusNode,
     bool autofocus = false,
+    double? itemExtent,
+    ItemExtentBuilder? itemExtentBuilder,
+    Widget? prototypeItem,
     Color? dropdownColor,
     InputDecoration? decoration,
     super.onSaved,
@@ -1700,6 +1748,9 @@ class DropdownButtonFormField<T> extends FormField<T> {
                    isDense: isDense,
                    isExpanded: isExpanded,
                    itemHeight: itemHeight,
+                   itemExtent: itemExtent,
+                   itemExtentBuilder: itemExtentBuilder,
+                   prototypeItem: prototypeItem,
                    focusColor: focusColor,
                    focusNode: focusNode,
                    autofocus: autofocus,


### PR DESCRIPTION
This PR adds support for specifying `itemExtent`, `itemExtentBuilder` or `protypeItem` inside `DropdownButton` and `DropdownButtonFormField` by passing these parameters to the underlying `ListView`. This fixes scroll animation jank for long dropdowns.

Fixes #140054 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
