### PR TITLE
Fix text selection edge scrolling when inside a horizontal scrollable

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -102,7 +102,6 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
     if (!delegate.selectionEnabled) {
       return;
     }
-    debugPrint('long press start');
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
     Feedback.forLongPress(_state.context);
     _dragStartViewportOffset = renderEditable.offset.pixels;

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -102,6 +102,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
     if (!delegate.selectionEnabled) {
       return;
     }
+    debugPrint('long press start');
     renderEditable.selectWord(cause: SelectionChangedCause.longPress);
     Feedback.forLongPress(_state.context);
     _dragStartViewportOffset = renderEditable.offset.pixels;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2131,6 +2131,14 @@ class TextSelectionGestureDetectorBuilder {
         : scrollableState.position.pixels;
   }
 
+  AxisDirection? get _scrollDirection {
+    final ScrollableState? scrollableState =
+        delegate.editableTextKey.currentContext == null
+            ? null
+            : Scrollable.maybeOf(delegate.editableTextKey.currentContext!);
+    return scrollableState?.axisDirection;
+  }
+
   // For a shift + tap + drag gesture, the TextSelection at the point of the
   // tap. Mac uses this value to reset to the original selection when an
   // inversion of the base and offset happens.
@@ -2498,9 +2506,11 @@ class TextSelectionGestureDetectorBuilder {
       final Offset editableOffset = renderEditable.maxLines == 1
           ? Offset(renderEditable.offset.pixels - _dragStartViewportOffset, 0.0)
           : Offset(0.0, renderEditable.offset.pixels - _dragStartViewportOffset);
+      final double effectiveScrollPosition = _scrollPosition - _dragStartScrollOffset;
+      final bool scrollingOnVerticalAxis = _scrollDirection == AxisDirection.up || _scrollDirection == AxisDirection.down;
       final Offset scrollableOffset = Offset(
-        0.0,
-        _scrollPosition - _dragStartScrollOffset,
+        !scrollingOnVerticalAxis ? effectiveScrollPosition : 0.0,
+        scrollingOnVerticalAxis ? effectiveScrollPosition : 0.0,
       );
       switch (defaultTargetPlatform) {
         case TargetPlatform.iOS:
@@ -2839,9 +2849,11 @@ class TextSelectionGestureDetectorBuilder {
       final Offset editableOffset = renderEditable.maxLines == 1
           ? Offset(renderEditable.offset.pixels - _dragStartViewportOffset, 0.0)
           : Offset(0.0, renderEditable.offset.pixels - _dragStartViewportOffset);
+      final double effectiveScrollPosition = _scrollPosition - _dragStartScrollOffset;
+      final bool scrollingOnVerticalAxis = _scrollDirection == AxisDirection.up || _scrollDirection == AxisDirection.down;
       final Offset scrollableOffset = Offset(
-        0.0,
-        _scrollPosition - _dragStartScrollOffset,
+        !scrollingOnVerticalAxis ? effectiveScrollPosition : 0.0,
+        scrollingOnVerticalAxis ? effectiveScrollPosition : 0.0,
       );
       final Offset dragStartGlobalPosition = details.globalPosition - details.offsetFromOrigin;
 

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3879,12 +3879,11 @@ void main() {
       ),
     );
     // The toolbar shows up.
-    // expect(find.byType(CupertinoButton), findsNWidgets(1));
-    // if (defaultTargetPlatform == TargetPlatform.iOS) {
-    //   expectCupertinoSelectionToolbar();
-    // } else {
-    //   expectMaterialSelectionToolbar();
-    // }
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      expectCupertinoSelectionToolbar();
+    } else {
+      expectMaterialSelectionToolbar();
+    }
 
     // Find the selection handle fade transition after the start handle has been
     // hidden because it is out of view.

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3690,6 +3690,7 @@ void main() {
   );
 
   testWidgetsWithLeakTracking('long press drag can edge scroll when inside a scrollable', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/129590.
     await tester.pumpWidget(
       MaterialApp(
         home: Material(

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3689,13 +3689,122 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }),
   );
 
-  testWidgets('long press drag can edge scroll', (WidgetTester tester) async {
+  // testWidgetsWithLeakTracking('long press drag can edge scroll when inside a scrollable', (WidgetTester tester) async {
+  //   // This is a regression test for https://github.com/flutter/flutter/issues/129590.
+  //   await tester.pumpWidget(
+  //     const MaterialApp(
+  //       home: Material(
+  //         child: Center(
+  //           child: SizedBox(
+  //             width: 300.0,
+  //             child: SingleChildScrollView(
+  //               scrollDirection: Axis.horizontal,
+  //               child: SelectableText(
+  //                 'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+  //               ),
+  //             ),
+  //           ),
+  //         ),
+  //       ),
+  //     ),
+  //   );
+
+  //   final RenderEditable renderEditable = findRenderEditable(tester);
+
+  //   List<TextSelectionPoint> lastCharEndpoint = renderEditable.getEndpointsForSelection(
+  //     const TextSelection.collapsed(offset: 66), // Last character's position.
+  //   );
+
+  //   expect(lastCharEndpoint.length, 1);
+  //   // Just testing the test and making sure that the last character is off
+  //   // the right side of the screen.
+  //   expect(lastCharEndpoint[0].point.dx, 940.5);
+
+  //   final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
+
+  //   final TestGesture gesture =
+  //       await tester.startGesture(const Offset(300, 5));
+  //   await tester.pump(const Duration(milliseconds: 500));
+
+  //   final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
+  //   final TextEditingController controller = editableTextWidget.controller;
+
+  //   expect(
+  //     controller.selection,
+  //     const TextSelection(baseOffset: 13, extentOffset: 23),
+  //   );
+  //   expect(find.byType(CupertinoButton), findsNothing);
+
+  //   await gesture.moveBy(const Offset(600, 0));
+  //   // To the edge of the screen basically.
+  //   await tester.pump();
+  //   expect(
+  //     controller.selection,
+  //     const TextSelection(
+  //       baseOffset: 13,
+  //       extentOffset: 66,
+  //     ),
+  //   );
+  //   // Keep moving out.
+  //   await gesture.moveBy(const Offset(1, 0));
+  //   await tester.pump();
+  //   expect(
+  //     controller.selection,
+  //     const TextSelection(
+  //       baseOffset: 13,
+  //       extentOffset: 66,
+  //     ),
+  //   );
+  //   await gesture.moveBy(const Offset(1, 0));
+  //   await tester.pump();
+  //   expect(
+  //     controller.selection,
+  //     const TextSelection(
+  //       baseOffset: 13,
+  //       extentOffset: 66,
+  //     ),
+  //   );
+  //   expect(find.byType(CupertinoButton), findsNothing);
+
+  //   await gesture.up();
+  //   await tester.pump();
+
+  //   // The selection isn't affected by the gesture lift.
+  //   expect(
+  //     controller.selection,
+  //     const TextSelection(
+  //       baseOffset: 13,
+  //       extentOffset: 66,
+  //     ),
+  //   );
+  //   // The toolbar shows up with one button (copy).
+  //   expect(find.byType(CupertinoButton), findsNWidgets(1));
+
+  //   lastCharEndpoint = renderEditable.getEndpointsForSelection(
+  //     const TextSelection.collapsed(offset: 66), // Last character's position.
+  //   );
+
+  //   expect(lastCharEndpoint.length, 1);
+  //   // The last character is now on screen near the right edge.
+  //   expect(lastCharEndpoint[0].point.dx, moreOrLessEquals(798, epsilon: 1));
+
+  //   final List<TextSelectionPoint> firstCharEndpoint = renderEditable.getEndpointsForSelection(
+  //     const TextSelection.collapsed(offset: 0), // First character's position.
+  //   );
+  //   expect(firstCharEndpoint.length, 1);
+  //   // The first character is now offscreen to the left.
+  //   expect(firstCharEndpoint[0].point.dx, moreOrLessEquals(-125, epsilon: 1));
+  // },
+  //   variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.android }),
+  // );
+
+  testWidgetsWithLeakTracking('long press drag can edge scroll', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
           child: Center(
             child: SelectableText(
-              'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges',
+              'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges ' * 2,
               maxLines: 1,
             ),
           ),
@@ -3704,16 +3813,6 @@ void main() {
     );
 
     final RenderEditable renderEditable = findRenderEditable(tester);
-
-    List<TextSelectionPoint> lastCharEndpoint = renderEditable.getEndpointsForSelection(
-      const TextSelection.collapsed(offset: 66), // Last character's position.
-    );
-
-    expect(lastCharEndpoint.length, 1);
-    // Just testing the test and making sure that the last character is off
-    // the right side of the screen.
-    expect(lastCharEndpoint[0].point.dx, 924.0);
-
     final Offset selectableTextStart = tester.getTopLeft(find.byType(SelectableText));
 
     final TestGesture gesture =
@@ -3727,20 +3826,19 @@ void main() {
       controller.selection,
       const TextSelection(baseOffset: 13, extentOffset: 23),
     );
-    expect(find.byType(CupertinoButton), findsNothing);
 
-    await gesture.moveBy(const Offset(600, 0));
+    await gesture.moveBy(const Offset(300, 0));
     // To the edge of the screen basically.
     await tester.pump();
     expect(
       controller.selection,
       const TextSelection(
         baseOffset: 13,
-        extentOffset: 66,
+        extentOffset: 45,
       ),
     );
     // Keep moving out.
-    await gesture.moveBy(const Offset(1, 0));
+    await gesture.moveBy(const Offset(300, 0));
     await tester.pump();
     expect(
       controller.selection,
@@ -3749,48 +3847,61 @@ void main() {
         extentOffset: 66,
       ),
     );
-    await gesture.moveBy(const Offset(1, 0));
+    await gesture.moveBy(const Offset(400, 0));
     await tester.pump();
     expect(
       controller.selection,
       const TextSelection(
         baseOffset: 13,
-        extentOffset: 66,
+        extentOffset: 102,
       ),
     );
-    expect(find.byType(CupertinoButton), findsNothing);
+
+    await gesture.moveBy(const Offset(700, 0));
+    await tester.pump();
+    expect(
+      controller.selection,
+      const TextSelection(
+        baseOffset: 13,
+        extentOffset: 134,
+      ),
+    );
 
     await gesture.up();
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     // The selection isn't affected by the gesture lift.
     expect(
       controller.selection,
       const TextSelection(
         baseOffset: 13,
-        extentOffset: 66,
+        extentOffset: 134,
       ),
     );
-    // The toolbar shows up with one button (copy).
-    expect(find.byType(CupertinoButton), findsNWidgets(1));
+    // The toolbar shows up.
+    // expect(find.byType(CupertinoButton), findsNWidgets(1));
+    // if (defaultTargetPlatform == TargetPlatform.iOS) {
+    //   expectCupertinoSelectionToolbar();
+    // } else {
+    //   expectMaterialSelectionToolbar();
+    // }
 
-    lastCharEndpoint = renderEditable.getEndpointsForSelection(
-      const TextSelection.collapsed(offset: 66), // Last character's position.
-    );
+    // Find the selection handle fade transition after the start handle has been
+    // hidden because it is out of view.
+    final List<FadeTransition> transitionsAfter = find.descendant(
+      of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay'),
+      matching: find.byType(FadeTransition),
+    ).evaluate().map((Element e) => e.widget).cast<FadeTransition>().toList();
 
-    expect(lastCharEndpoint.length, 1);
-    // The last character is now on screen near the right edge.
-    expect(lastCharEndpoint[0].point.dx, moreOrLessEquals(798, epsilon: 1));
+    expect(transitionsAfter.length, 2);
 
-    final List<TextSelectionPoint> firstCharEndpoint = renderEditable.getEndpointsForSelection(
-      const TextSelection.collapsed(offset: 0), // First character's position.
-    );
-    expect(firstCharEndpoint.length, 1);
-    // The first character is now offscreen to the left.
-    expect(firstCharEndpoint[0].point.dx, moreOrLessEquals(-125, epsilon: 1));
+    final FadeTransition startHandleAfter = transitionsAfter[0];
+    final FadeTransition endHandleAfter = transitionsAfter[1];
+
+    expect(startHandleAfter.opacity.value, 0.0);
+    expect(endHandleAfter.opacity.value, 1.0);
   },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
-    skip: true, // https://github.com/flutter/flutter/issues/64059
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.android }),
   );
 
   testWidgets(

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3701,6 +3701,7 @@ void main() {
                 scrollDirection: Axis.horizontal,
                 child: SelectableText(
                   'Atwater Peel Sherbrooke Bonaventure Angrignon Peel Côte-des-Neiges ' * 2,
+                  maxLines: 1,
                 ),
               ),
             ),
@@ -3743,13 +3744,13 @@ void main() {
         extentOffset: 35,
       ),
     );
-    await gesture.moveBy(const Offset(1300, 0));
+    await gesture.moveBy(const Offset(1600, 0));
     await tester.pump();
     expect(
       controller.selection,
       const TextSelection(
         baseOffset: 13,
-        extentOffset: 122,
+        extentOffset: 134,
       ),
     );
 
@@ -3761,7 +3762,7 @@ void main() {
       controller.selection,
       const TextSelection(
         baseOffset: 13,
-        extentOffset: 122,
+        extentOffset: 134,
       ),
     );
     // The toolbar shows up.

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3689,7 +3689,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }),
   );
 
-  testWidgetsWithLeakTracking('long press drag can edge scroll when inside a scrollable', (WidgetTester tester) async {
+  testWidgets('long press drag can edge scroll when inside a scrollable', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/129590.
     await tester.pumpWidget(
       MaterialApp(
@@ -3785,7 +3785,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.android }),
   );
 
-  testWidgetsWithLeakTracking('long press drag can edge scroll', (WidgetTester tester) async {
+  testWidgets('long press drag can edge scroll', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Material(

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3714,7 +3714,7 @@ void main() {
 
     final TestGesture gesture =
         await tester.startGesture(selectableTextStart + const Offset(200.0, 0.0));
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(kLongPressTimeout);
 
     final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
     final TextEditingController controller = editableTextWidget.controller;
@@ -3890,7 +3890,7 @@ void main() {
 
     final TestGesture gesture =
         await tester.startGesture(selectableTextStart + const Offset(300, 5));
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(kLongPressTimeout);
 
     final EditableText editableTextWidget = tester.widget(find.byType(EditableText).first);
     final TextEditingController controller = editableTextWidget.controller;

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3782,6 +3782,8 @@ void main() {
     expect(endpoints[0].point.dx, isNegative);
     expect(endpoints[1].point.dx, isPositive);
   },
+    // TODO(Renzo-Olivares): Add in TargetPlatform.android in the line below when
+    // we fix edge scrolling in a Scrollable https://github.com/flutter/flutter/issues/64059.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3787,7 +3787,7 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
-  testWidgets('Desktop long press drag can edge scroll when inside a scrollable', (WidgetTester tester) async {
+  testWidgets('Desktop mouse drag can edge scroll when inside a horizontal scrollable', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/129590.
     await tester.pumpWidget(
       MaterialApp(
@@ -3858,22 +3858,16 @@ void main() {
         extentOffset: 134,
       ),
     );
-    // // The toolbar shows up.
-    // if (defaultTargetPlatform == TargetPlatform.iOS) {
-    //   expectCupertinoSelectionToolbar();
-    // } else {
-    //   expectMaterialSelectionToolbar();
-    // }
 
-    // final RenderEditable renderEditable = findRenderEditable(tester);
-    // final List<TextSelectionPoint> endpoints = globalize(
-    //   renderEditable.getEndpointsForSelection(controller.selection),
-    //   renderEditable,
-    // );
-    // expect(endpoints.isNotEmpty, isTrue);
-    // expect(endpoints.length, 2);
-    // expect(endpoints[0].point.dx, isNegative);
-    // expect(endpoints[1].point.dx, isPositive);
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(controller.selection),
+      renderEditable,
+    );
+    expect(endpoints.isNotEmpty, isTrue);
+    expect(endpoints.length, 2);
+    expect(endpoints[0].point.dx, isNegative);
+    expect(endpoints[1].point.dx, isPositive);
   },
     variant: TargetPlatformVariant.desktop(),
   );

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -3782,7 +3782,7 @@ void main() {
     expect(endpoints[0].point.dx, isNegative);
     expect(endpoints[1].point.dx, isPositive);
   },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.android }),
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
   testWidgets('long press drag can edge scroll', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes #129590

* Consider `AxisDirection` when calculating scroll offset used in determining TextSelection during a drag/long press drag. Previously it seems that we were assuming the direction was always vertical https://github.com/flutter/flutter/blob/30cc83198544582b858e48c7bb9d761ecdb3d944/packages/flutter/lib/src/widgets/text_selection.dart#L2842-L2844 .
* SelectableText now considers RenderEditable offset changes and Scrollable offset changes when calculating the TextSelection during a long press drag.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.