### PR TITLE
Prevent full rebuilds when rerunning `flutter test`.

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -503,7 +503,7 @@ class FlutterPlatform extends PlatformPlugin {
       } else if (precompiledDillFiles != null) {
         mainDart = precompiledDillFiles![testPath];
       } else {
-        mainDart = _createListenerDart(finalizers, ourTestCount, testPath);
+        mainDart = createListenerDart(testPath);
 
         // Integration test device takes care of the compilation.
         if (integrationTestDevice == null) {
@@ -615,20 +615,16 @@ class FlutterPlatform extends PlatformPlugin {
     return outOfBandError;
   }
 
-  String _createListenerDart(
-    List<Finalizer> finalizers,
-    int ourTestCount,
+  @visibleForTesting
+  String createListenerDart(
     String testPath,
   ) {
-    // Prepare a temporary directory to store the Dart file that will talk to us.
-    final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_test_listener.');
-    finalizers.add(() async {
-      globals.printTrace('test $ourTestCount: deleting temporary directory');
-      tempDir.deleteSync(recursive: true);
-    });
+    // Prepare a directory to store the Dart file that will talk to us.
+    final Directory? flutterTestListenerDirectory = flutterProject?.buildDirectory.childDirectory('flutter_test_listener');
+    flutterTestListenerDirectory?.createSync();
 
     // Prepare the Dart file that will talk to us and start the test.
-    final File listenerFile = globals.fs.file('${tempDir.path}/listener.dart');
+    final File listenerFile = globals.fs.file('${flutterTestListenerDirectory?.path}/listener.dart');
     listenerFile.createSync();
     listenerFile.writeAsStringSync(_generateTestMain(
       testUrl: globals.fs.path.toUri(globals.fs.path.absolute(testPath)),

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -194,7 +194,15 @@ class TestCompiler {
         if (shouldCopyDillFile) {
           final String path = request.mainUri.toFilePath(windows: globals.platform.isWindows);
           final File outputFile = globals.fs.file(outputPath);
-          final File kernelReadyToRun = await outputFile.copy('$path.dill');
+
+          final File kernelReadyToRun;
+
+          if (globals.fs.file('$path.dill').existsSync()) {
+            kernelReadyToRun = globals.fs.file('$path.dill');
+          } else {
+            kernelReadyToRun = await outputFile.copy('$path.dill');
+          }
+
           final File testCache = globals.fs.file(testFilePath);
           if (firstCompile || !testCache.existsSync() || (testCache.lengthSync() < outputFile.lengthSync())) {
             // The idea is to keep the cache file up-to-date and include as

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -194,15 +194,13 @@ class TestCompiler {
         if (shouldCopyDillFile) {
           final String path = request.mainUri.toFilePath(windows: globals.platform.isWindows);
           final File outputFile = globals.fs.file(outputPath);
-
-          final File kernelReadyToRun;
-
-          if (globals.fs.file('$path.dill').existsSync()) {
-            kernelReadyToRun = globals.fs.file('$path.dill');
-          } else {
-            kernelReadyToRun = await outputFile.copy('$path.dill');
-          }
-
+          final File kernelReadyToRun = await outputFile.copy(
+            globals.fsUtils.getUniqueFile(
+              globals.fs.file(path).parent,
+              globals.fs.file(path).basename,
+              'dill'
+            ).path
+          );
           final File testCache = globals.fs.file(testFilePath);
           if (firstCompile || !testCache.existsSync() || (testCache.lengthSync() < outputFile.lengthSync())) {
             // The idea is to keep the cache file up-to-date and include as

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -163,8 +163,7 @@ void main() {
           'test.dart',
         );
 
-        const String expectedListenerFilePath =
-            '/build/068070b05f23393259df743349b63e04/listener.dart';
+        const String expectedListenerFilePath = '/build/068070b05f23393259df743349b63e04/listener.dart';
 
         expect(listenerFilePath, expectedListenerFilePath);
         expect(fileSystem.file(expectedListenerFilePath).existsSync(), isTrue);

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -155,71 +155,99 @@ void main() {
       );
 
       testUsingContext(
-          'creates listener.dart in the build directory of the FlutterProject',
+          'creates listener.dart in the correct directory within the build directory of the FlutterProject',
           () async {
         final String listenerFilePath = flutterPlatform.createListenerDart(
+          <Finalizer>[],
+          0,
           'test.dart',
         );
 
         const String expectedListenerFilePath =
-            '/build/flutter_test_listener/listener.dart';
+            '/build/068070b05f23393259df743349b63e04/listener.dart';
 
         expect(listenerFilePath, expectedListenerFilePath);
-
         expect(fileSystem.file(expectedListenerFilePath).existsSync(), isTrue);
       }, overrides: overrides);
 
       testUsingContext(
-          'does not create a new listener.dart file if called more '
-          'than once with the same test path', () async {
+          'creates a new listener.dart file at the same path each time if called '
+          'more than once with the same test file path', () async {
         final String listenerFilePath1 = flutterPlatform.createListenerDart(
+          <Finalizer>[],
+          0,
           'test.dart',
         );
 
         final File listenerFile1 = fileSystem.file(listenerFilePath1);
 
+        expect(listenerFile1.existsSync(), isTrue);
+
+        final FileStat file1Stat = listenerFile1.statSync();
+
         final String listenerFilePath2 = flutterPlatform.createListenerDart(
+          <Finalizer>[],
+          0,
           'test.dart',
         );
 
         final File listenerFile2 = fileSystem.file(listenerFilePath2);
 
-        expect(listenerFilePath1, listenerFilePath2);
-
-        expect(listenerFile1.existsSync(), isTrue);
         expect(listenerFile2.existsSync(), isTrue);
 
-        expect(
-            listenerFile1.lastModifiedSync(), listenerFile2.lastModifiedSync());
-        expect(
-            listenerFile1.readAsBytesSync(), listenerFile2.readAsBytesSync());
+        final FileStat file2Stat = listenerFile2.statSync();
+
+        expect(listenerFilePath1, listenerFilePath2);
+        expect(file2Stat.modified.isAfter(file1Stat.modified), isTrue);
       }, overrides: overrides);
 
       testUsingContext(
-          'does not create a new listener.dart file if called more '
-          'than once with different test paths', () async {
+          'creates different listener.dart files at different paths if called '
+          'multiple times with different test file paths', () async {
         final String listenerFilePath1 = flutterPlatform.createListenerDart(
+          <Finalizer>[],
+          0,
           'test1.dart',
         );
 
         final File listenerFile1 = fileSystem.file(listenerFilePath1);
 
+        expect(listenerFile1.existsSync(), isTrue);
+
         final String listenerFilePath2 = flutterPlatform.createListenerDart(
+          <Finalizer>[],
+          0,
           'test2.dart',
         );
 
         final File listenerFile2 = fileSystem.file(listenerFilePath2);
 
-        expect(listenerFilePath1, listenerFilePath2);
-
-        expect(listenerFile1.existsSync(), isTrue);
         expect(listenerFile2.existsSync(), isTrue);
 
-        expect(
-            listenerFile1.lastModifiedSync(), listenerFile2.lastModifiedSync());
-        expect(
-            listenerFile1.readAsBytesSync(), listenerFile2.readAsBytesSync());
-      }, overrides: overrides);
+        expect(listenerFile1, isNot(listenerFile2));
+
+        expect(listenerFilePath1, isNot(listenerFilePath2));
+          }, overrides: overrides);
+
+      testUsingContext(
+          'adds a cleanup function to the finalizers list', () async {
+        final List<Finalizer> finalizers = <Finalizer>[];
+
+        final String listenerFilepath = flutterPlatform.createListenerDart(
+          finalizers,
+          0,
+          'test.dart',
+        );
+        expect(finalizers, hasLength(1));
+
+        final File listenerFile = fileSystem.file(listenerFilepath);
+        expect(listenerFile.existsSync(), isTrue);
+
+        final Finalizer finalizer = finalizers.last;
+        await finalizer();
+
+        expect(listenerFile.existsSync(), isFalse);
+        }, overrides: overrides);
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -144,6 +144,7 @@ void main() {
                 BuildMode.debug,
                 null,
                 treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
               ),
             ),
             enableVmService: false,

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -55,7 +55,7 @@ void main() {
       residentCompiler,
     );
 
-    expect(await testCompiler.compile(Uri.parse('test/foo.dart')), 'test/foo.dart.dill');
+    expect(await testCompiler.compile(Uri.parse('test/foo.dart')), 'test/foo.dart_01.dill');
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     Platform: () => linuxPlatform,
@@ -107,7 +107,7 @@ void main() {
       residentCompiler,
       testTimeRecorder: testTimeRecorder,
     );
-    expect(await testCompiler.compile(Uri.parse('test/foo.dart')), 'test/foo.dart.dill');
+    expect(await testCompiler.compile(Uri.parse('test/foo.dart')), 'test/foo.dart_01.dill');
     testTimeRecorder.print();
 
     // Expect one message for each phase.

--- a/packages/flutter_tools/test/integration.shard/test_test.dart
+++ b/packages/flutter_tools/test/integration.shard/test_test.dart
@@ -295,7 +295,7 @@ void main() {
     final String stdout = (result.stdout as String).replaceAll('\r', '\n');
     expect(stdout, contains(RegExp(r'\+\d+: All tests passed\!')));
     expect(stdout, contains('test 0: Starting flutter_tester process with command'));
-    expect(stdout, contains('test 0: deleting temporary directory'));
+    expect(stdout, contains('test 0: deleting directory'));
     expect(stdout, contains('test 0: finished'));
     expect(stdout, contains('test package returned with exit code 0'));
     if ((result.stderr as String).isNotEmpty) {
@@ -341,7 +341,7 @@ void main() {
     );
     expect(stdout, contains(RegExp(r'\+\d+: All tests passed\!')));
     expect(stdout, contains('test 0: Starting flutter_tester process with command'));
-    expect(stdout, contains('test 0: deleting temporary directory'));
+    expect(stdout, contains('test 0: deleting directory'));
     expect(stdout, contains('test 0: finished'));
     expect(stdout, contains('test package returned with exit code 0'));
     if ((result.stderr as String).isNotEmpty) {
@@ -379,7 +379,7 @@ void main() {
     final String stdout = (result.stdout as String).replaceAll('\r', '\n');
     expect(result.stdout, contains(RegExp(r'\+\d+: All tests passed\!')));
     expect(stdout, contains('test 0: Starting flutter_tester process with command'));
-    expect(stdout, contains('test 0: deleting temporary directory'));
+    expect(stdout, contains('test 0: deleting directory'));
     expect(stdout, contains('test 0: finished'));
     expect(stdout, contains('test package returned with exit code 0'));
     if ((result.stderr as String).isNotEmpty) {


### PR DESCRIPTION
This PR updates `FlutterPlatform` to prevent a rebuild of the assemble targets when rerunning 'flutter test'.

This update changes the directory where the `listener.dart` file is created from the system temp folder to a location based on the test file hash: `build/{fileHash}` folder.  

Since the location of the `listener.dart` file is now [stable](https://github.com/flutter/flutter/issues/108400#issuecomment-1196104701), the build system no longer creates a different temp directory on every run.  

This means the file store hash for the `listener.dart` file [stays the same](https://github.com/victoreronmosele/flutter/blob/bec1d139454d871b5bdd3eba8f8901ca3eee47b2/packages/flutter_tools/lib/src/build_system/build_system.dart#L1090-L1101), and rebuilds are [skipped](https://github.com/victoreronmosele/flutter/blob/bec1d139454d871b5bdd3eba8f8901ca3eee47b2/packages/flutter_tools/lib/src/build_system/build_system.dart#L839).

Fixes #108400 

## Test Results

Rerunning this command for an integration test on an iOS simulator 

```dart
flutter --no-color test --machine  --plain-name testGetVisibleRegion  -v integration_test/main_test.dart
```                                 
gave me these results below:

- _After Update:_ 

  <details>
  <summary>flutter assemble" took 1,114ms. Skipped all targets.</summary>

  #### Details:

  ```bash
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/flutter --verbose assemble
  --no-version-check
  --output=/Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/ios/Debug-iphonesimulator/
  -dTargetPlatform=ios
  -dTargetFile=/Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/flutter_test_listener/listener.dart
  -dBuildMode=debug -dIosArchs=arm64
  -dSdkRoot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator16.4.sdk
  -dSplitDebugInfo= -dTreeShakeIcons=false -dTrackWidgetCreation=true -dDartObfuscation=false -dAction=build
  -dFrontendServerStarterPath= --ExtraGenSnapshotOptions=
  --DartDefines=RkxVVFRFUl9XRUJfQVVUT19ERVRFQ1Q9dHJ1ZQ==,SU5URUdSQVRJT05fVEVTVF9TSE9VTERfUkVQT1JUX1JFU1VMVFNfVE9fTkFUSVZFPWZhbHNl
  --ExtraFrontEndOptions= -dCodesignIdentity=- debug_ios_bundle_flutter_assets
  Resolving dependencies...
  Got dependencies.
  [   +1 ms] Could not interpret results of "git describe": 3.18.0-2.0.pre.1
  [  +16 ms] executing: sysctl hw.optional.arm64
  [   +3 ms] Exit code 0 from: sysctl hw.optional.arm64
  [        ] hw.optional.arm64: 1
  [  +18 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
  [        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
  [   +1 ms] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
  [  +47 ms] Artifact Instance of 'MaterialFonts' is not required, skipping update.
  [        ] Artifact Instance of 'GradleWrapper' is not required, skipping update.
  [        ] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
  [        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterSdk' is not required, skipping update.
  [        ] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FontSubsetArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'PubDependencies' is not required, skipping update.
  [  +10 ms] Initializing file store
  [   +5 ms] Done initializing file store
  [ +289 ms] Skipping target: debug_unpack_ios
  [   +2 ms] Skipping target: native_assets
  [        ] Skipping target: gen_localizations
  [        ] Skipping target: gen_dart_plugin_registrant
  [ +439 ms] Skipping target: kernel_snapshot
  [   +2 ms] Skipping target: debug_universal_framework
  [ +295 ms] Skipping target: debug_ios_bundle_flutter_assets
  [        ] Persisting file store
  [   +5 ms] Done persisting file store
  [   +4 ms] build succeeded.
  [   +3 ms] "flutter assemble" took 1,114ms.
  ```

  </details>



- _Before Update:_ 

  <details>
  <summary>flutter assemble" took 5,583ms. Didn't skip all targets.</summary>

  #### Details:

  ```bash
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/flutter --verbose assemble
  --no-version-check
  --output=/Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/ios/Debug-iphonesimulator/
  -dTargetPlatform=ios
  -dTargetFile=/var/folders/8n/qpsf1kw9371gl1_vvgt4_05r0000gn/T/flutter_tools.NjiIAc/flutter_test_listener.cQySHc/listener.dart
  -dBuildMode=debug -dIosArchs=arm64
  -dSdkRoot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator16.4.sdk
  -dSplitDebugInfo= -dTreeShakeIcons=false -dTrackWidgetCreation=true -dDartObfuscation=false -dAction=build
  -dFrontendServerStarterPath= --ExtraGenSnapshotOptions=
  --DartDefines=RkxVVFRFUl9XRUJfQVVUT19ERVRFQ1Q9dHJ1ZQ==,SU5URUdSQVRJT05fVEVTVF9TSE9VTERfUkVQT1JUX1JFU1VMVFNfVE9fTkFUSVZFPWZhbHNl
  --ExtraFrontEndOptions= -dCodesignIdentity=- debug_ios_bundle_flutter_assets
  [   +2 ms] Could not interpret results of "git describe": 3.18.0-2.0.pre.1
  [  +11 ms] executing: sysctl hw.optional.arm64
  [   +3 ms] Exit code 0 from: sysctl hw.optional.arm64
  [        ] hw.optional.arm64: 1
  [  +10 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
  [        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
  [        ] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
  [  +45 ms] Artifact Instance of 'MaterialFonts' is not required, skipping update.
  [        ] Artifact Instance of 'GradleWrapper' is not required, skipping update.
  [        ] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
  [        ] Artifact Instance of 'LegacyCanvasKitRemover' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterSdk' is not required, skipping update.
  [        ] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'FontSubsetArtifacts' is not required, skipping update.
  [        ] Artifact Instance of 'PubDependencies' is not required, skipping update.
  [  +11 ms] Initializing file store
  [  +12 ms] debug_unpack_ios: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated contents:
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/packages/flutter_tools/lib/src/bu
  ild_system/targets/ios.dart,/Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/i
  nternal/engine.version}
  [   +3 ms] native_assets: Starting due to {}
  [        ] Skipping target: gen_localizations
  [   +1 ms] gen_dart_plugin_registrant: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated
  contents: /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/package_config_subset}
  Directory: '/Users/victoreronmosele/development/mobile_projects/flutter_projects/demo'
  does file exist? true
  uri is file:///Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/package_config.json
  uri path is /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/package_config.json
  uri path segments are [Users, victoreronmosele, development, mobile_projects, flutter_projects, demo, .dart_tool,
  package_config.json]
  uri path without using fromUri exists? true
  uri path completed wtih current path directory exist? false
  [  +32 ms] Writing native_assets.yaml.
  [   +7 ms] Writing
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  native_assets.yaml done.
  [   +1 ms] native_assets: Complete
  [  +25 ms] Found plugin integration_test at
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/packages/integration_test/
  [   +4 ms] gen_dart_plugin_registrant: Complete
  [        ] kernel_snapshot: Starting due to {}
  [        ] Embedding native assets mapping
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  native_assets.yaml in kernel.
  [   +2 ms]
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/cache/dart-sdk/bin/dartaotrun
  time --disable-dart-dev
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/cache/dart-sdk/bin/snapshots/
  frontend_server_aot.dart.snapshot --sdk-root
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/cache/artifacts/engine/common
  /flutter_patched_sdk/ --target=flutter --no-print-incremental-dependencies -DFLUTTER_WEB_AUTO_DETECT=true
  -DINTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false -Ddart.vm.profile=false -Ddart.vm.product=false --enable-asserts
  --track-widget-creation --no-link-platform --packages
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/package_config.json --output-dill
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  app.dill --depfile
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  kernel_snapshot.d --incremental --initialize-from-dill
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  app.dill --native-assets
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  native_assets.yaml --verbosity=error
  file:///var/folders/8n/qpsf1kw9371gl1_vvgt4_05r0000gn/T/flutter_tools.NjiIAc/flutter_test_listener.cQySHc/listener.dart
  [ +879 ms] executing: xattr -r -d com.apple.FinderInfo
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/ios/Debug-iphonesimulator/Flutter.framework/Flutter
  [ +230 ms] debug_unpack_ios: Complete
  [+2674 ms] kernel_snapshot: Complete
  [ +369 ms] debug_universal_framework: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated
  contents:
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/packages/flutter_tools/lib/src/bu
  ild_system/targets/ios.dart}
  [   +7 ms] executing: sysctl hw.optional.arm64
  [   +4 ms] Exit code 0 from: sysctl hw.optional.arm64
  [        ] hw.optional.arm64: 1
  [        ] executing: /usr/bin/arch -arm64e xcrun clang -x c -arch arm64
  /var/folders/8n/qpsf1kw9371gl1_vvgt4_05r0000gn/T/flutter_tools.91jToJ/flutter_tools_stub_source.uWBMT9/debug_app.cc -dynamiclib
  -miphonesimulator-version-min=11.0 -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker
  @loader_path/Frameworks -fapplication-extension -install_name @rpath/App.framework/App -isysroot
  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator16.4.sdk -o
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  App.framework/App
  [ +108 ms] executing: xattr -r -d com.apple.FinderInfo
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/.dart_tool/flutter_build/92e76f94a27f20a6898bdaebc3fbe32b/
  App.framework/App
  [  +15 ms] debug_universal_framework: Complete
  [   +2 ms] debug_ios_bundle_flutter_assets: Starting due to {}
  [ +153 ms] shaderc command:
  [/Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/cache/artifacts/engine/darwi
  n-x64/impellerc, --runtime-stage-metal, --iplr,
  --sl=/Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/ios/Debug-iphonesimulator/App.framework/flutter
  _assets/shaders/ink_sparkle.frag,
  --spirv=/Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/ios/Debug-iphonesimulator/App.framework/flut
  ter_assets/shaders/ink_sparkle.frag.spirv,
  --input=/Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/packages/flutter/lib/src/
  material/shaders/ink_sparkle.frag, --input-type=frag,
  --include=/Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/packages/flutter/lib/sr
  c/material/shaders,
  --include=/Users/victoreronmosele/development/mobile_projects/flutter_projects/flutter_contributions/flutter/bin/cache/artifacts/eng
  ine/darwin-x64/shader_lib]
  [ +159 ms] executing: xattr -r -d com.apple.FinderInfo
  /Users/victoreronmosele/development/mobile_projects/flutter_projects/demo/build/ios/Debug-iphonesimulator/App.framework/App
  [ +315 ms] debug_ios_bundle_flutter_assets: Complete
  [ +491 ms] Persisting file store
  [   +6 ms] Done persisting file store
  [   +5 ms] build succeeded.
  [   +5 ms] "flutter assemble" took 5,583ms.
  ```
  </details>

<details>
<summary>Integration Test</summary>

#### Details:

```dart
import 'package:flutter/material.dart';
import 'package:flutter_test/flutter_test.dart';
import 'package:integration_test/integration_test.dart';
import 'package:demo/main.dart' as app;

void main() {
  IntegrationTestWidgetsFlutterBinding.ensureInitialized();

  testWidgets('Verify counter increments when FAB is pressed', (WidgetTester tester) async {
    app.main();

    await tester.pumpAndSettle();

    expect(find.text('0'), findsOneWidget);

    await tester.tap(find.byType(FloatingActionButton));
    await tester.pumpAndSettle();

    expect(find.text('1'), findsOneWidget);
  });
}
```

</details>

<details>
<summary>App's Entrypoint (main.dart)</summary>

#### Details:

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
        useMaterial3: true,
      ),
      home: const MyHomePage(title: 'Flutter Demo Home Page'),
    );
  }
}

class MyHomePage extends StatefulWidget {
  const MyHomePage({super.key, required this.title});

  final String title;

  @override
  State<MyHomePage> createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {
  int _counter = 0;

  void _incrementCounter() {
    setState(() {
      _counter++;
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
        title: Text(widget.title),
      ),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            const Text(
              'You have pushed the button this many times:',
            ),
            Text(
              '$_counter',
              style: Theme.of(context).textTheme.headlineMedium,
            ),
          ],
        ),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: _incrementCounter,
        tooltip: 'Increment',
        child: const Icon(Icons.add),
      ), 
    );
  }
}
```

</details>



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
