### PR TITLE
Add `Spacer.fixed` constructor for a fixed sized spacer

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -1146,6 +1146,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
 /// will be thrown in runtime.
 ///
 /// See also:
+///
 /// * [Spacer.fixed], the widget equivalent.
 final class RenderFixedLengthSpacer extends RenderBox {
   /// Creates a render box that provides a fixed space in a render flex.
@@ -1194,10 +1195,11 @@ final class RenderFixedLengthSpacer extends RenderBox {
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    assert(parent is RenderFlex);
+    assert(this.parent is RenderFlex);
+    final RenderObject? parent = this.parent;
 
-    if (parent case RenderFlex(:final Axis direction)) {
-      final Size size = switch (direction) {
+    if (parent is RenderFlex) {
+      final Size size = switch (parent.direction) {
         Axis.horizontal => Size(length, 0.0),
         Axis.vertical => Size(0.0, length),
       };

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -1140,6 +1140,94 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   }
 }
 
+/// A space with a fixed length in the main axis of a [RenderFlex].
+///
+/// This render must be a direct child of a [RenderFlex], or else an error
+/// will be thrown in runtime.
+///
+/// See also:
+/// * [Spacer.fixed], the widget equivalent.
+final class RenderFixedLengthSpacer extends RenderBox {
+  /// Creates a render box that provides a fixed space in a render flex.
+  RenderFixedLengthSpacer({
+    required double length,
+  })  : _length = length;
+
+  /// The size of the space in the [parent]'s main axis.
+  double get length => _length;
+  double _length;
+  set length(double value) {
+    if (_length != value) {
+      _length = value;
+      markNeedsLayout();
+    }
+  }
+
+  @override
+  bool get sizedByParent => true;
+
+  @override
+  double computeMinIntrinsicWidth(double height) => 0.0;
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    assert(parent is RenderFlex);
+
+    return switch ((parent! as RenderFlex).direction) {
+      Axis.horizontal => length,
+      Axis.vertical => 0.0,
+    };
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) => 0.0;
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    assert(parent is RenderFlex);
+
+    return switch ((parent! as RenderFlex).direction) {
+      Axis.horizontal => 0.0,
+      Axis.vertical => length,
+    };
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    assert(parent is RenderFlex);
+
+    if (parent case RenderFlex(:final Axis direction)) {
+      final Size size = switch (direction) {
+        Axis.horizontal => Size(length, 0.0),
+        Axis.vertical => Size(0.0, length),
+      };
+
+      return constraints.constrain(size);
+    } else {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('Incorrect use of RenderFixedLengthSpacer.'),
+        ErrorDescription(
+          'RenderFixedLengthSpacer should be a direct child of a '
+              'RenderFlex.',
+        ),
+        ErrorHint(
+            'Usually, this indicates that a Spacer.fixed was used in as a '
+                'child to any widget that is not a Flexible, Column or Row.'
+        ),
+        ErrorDescription(
+          'The parent for the RenderFixedLengthSpacer was:\n$parent',
+        ),
+      ]);
+    }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('length', length));
+  }
+}
+
 class _LayoutSizes {
   const _LayoutSizes({
     required this.mainSize,

--- a/packages/flutter/lib/src/widgets/spacer.dart
+++ b/packages/flutter/lib/src/widgets/spacer.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../../rendering.dart';
+import 'package:flutter/rendering.dart';
+
 import 'basic.dart';
 import 'framework.dart';
 
@@ -11,14 +12,15 @@ import 'framework.dart';
 ///
 /// The [Spacer] widget will take space in a dynamic or fixed way, depending
 /// on which constructor is used:
-/// * The default unnamed constructor [Spacer] will take up any available
-/// space, so setting the [Flex.mainAxisAlignment] on a flex container that
-/// contains a [Spacer] to [MainAxisAlignment.spaceAround],
-/// [MainAxisAlignment.spaceBetween], or [MainAxisAlignment.spaceEvenly] will
-/// not have any visible effect: the [Spacer] has taken up all of the
-/// additional space, therefore there is none left to redistribute.
-/// * The [Spacer.fixed] constructor will take an absolute amount of space in
-/// the main axis.
+///
+///  * The default unnamed constructor [Spacer] will take up any available
+///    space, so setting the [Flex.mainAxisAlignment] on a flex container that
+///    contains a [Spacer] to [MainAxisAlignment.spaceAround],
+///    [MainAxisAlignment.spaceBetween], or [MainAxisAlignment.spaceEvenly]
+///    will not have any visible effect: the [Spacer] has taken up all of the
+///    additional space, therefore there is none left to redistribute.
+///  * The [Spacer.fixed] constructor will take an absolute amount of space in
+///    the main axis.
 ///
 /// {@tool snippet}
 ///
@@ -52,7 +54,7 @@ class Spacer extends StatelessWidget {
   const Spacer({super.key, int this.flex = 1})
       : length = null, assert(flex > 0);
 
-  /// Creates a space with fixed length to insert into a [Flexible] widget.
+  /// Creates a space with fixed length to insert into a [Flex] widget.
   ///
   /// The [length] parameter must be equal or greater than zero.
   const Spacer.fixed({super.key, double this.length = 0.0}) : flex = null, assert(length >= 0.0);

--- a/packages/flutter/test/widgets/spacer_test.dart
+++ b/packages/flutter/test/widgets/spacer_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,22 +10,14 @@ void main() {
   testWidgets('Spacer takes up space.', (WidgetTester tester) async {
     await tester.pumpWidget(const Column(
       children: <Widget>[
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
         Spacer(),
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
       ],
     ));
-    final Rect topFixedSpacerRect = tester.getRect(find.byType(Spacer).at(0));
-    expect(topFixedSpacerRect.size, const Size(0.0, 10.0));
-    expect(topFixedSpacerRect.topLeft, const Offset(400.0, 0.0));
-
-    final Rect flexibleSpacerRect = tester.getRect(find.byType(Spacer).at(1));
-    expect(flexibleSpacerRect.size, const Size(0.0, 580.0));
-    expect(flexibleSpacerRect.topLeft, const Offset(400.0, 10.0));
-
-    final Rect bottomFixedSpacerRect = tester.getRect(find.byType(Spacer).at(2));
-    expect(bottomFixedSpacerRect.size, const Size(0.0, 10.0));
-    expect(bottomFixedSpacerRect.topLeft, const Offset(400.0, 590.0));
+    final Rect spacerRect = tester.getRect(find.byType(Spacer));
+    expect(spacerRect.size, const Size(0.0, 580.0));
+    expect(spacerRect.topLeft, const Offset(400.0, 10.0));
   });
 
   testWidgets('Spacer takes up space proportional to flex.', (WidgetTester tester) async {
@@ -35,22 +28,21 @@ void main() {
     await tester.pumpWidget(const Row(
       textDirection: TextDirection.rtl,
       children: <Widget>[
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
         spacer1,
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
         spacer2,
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
         spacer3,
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
         spacer4,
-        Spacer.fixed(length: 10.0),
+        SizedBox(width: 10.0, height: 10.0),
       ],
     ));
-
-    final Rect spacer1Rect = tester.getRect(find.byType(Spacer).at(1));
-    final Rect spacer2Rect = tester.getRect(find.byType(Spacer).at(3));
-    final Rect spacer3Rect = tester.getRect(find.byType(Spacer).at(5));
-    final Rect spacer4Rect = tester.getRect(find.byType(Spacer).at(7));
+    final Rect spacer1Rect = tester.getRect(find.byType(Spacer).at(0));
+    final Rect spacer2Rect = tester.getRect(find.byType(Spacer).at(1));
+    final Rect spacer3Rect = tester.getRect(find.byType(Spacer).at(2));
+    final Rect spacer4Rect = tester.getRect(find.byType(Spacer).at(3));
     expect(spacer1Rect.size.height, 0.0);
     expect(spacer1Rect.size.width, moreOrLessEquals(93.8, epsilon: 0.1));
     expect(spacer1Rect.left, moreOrLessEquals(696.3, epsilon: 0.1));
@@ -67,25 +59,57 @@ void main() {
       constrainedAxis: Axis.vertical,
       child: Column(
         children: <Widget>[
-          Spacer.fixed(length: 10.0),
+          SizedBox(width: 20.0, height: 10.0),
           Spacer(),
-          Spacer.fixed(length: 10.0),
+          SizedBox(width: 10.0, height: 10.0),
         ],
       ),
     ));
+    final Rect spacerRect = tester.getRect(find.byType(Spacer));
     final Rect flexRect = tester.getRect(find.byType(Column));
-    expect(flexRect, const Rect.fromLTWH(400.0, 0.0, 0.0, 600.0));
+    expect(spacerRect.size, const Size(0.0, 580.0));
+    expect(spacerRect.topLeft, const Offset(400.0, 10.0));
+    expect(flexRect, const Rect.fromLTWH(390.0, 0.0, 20.0, 600.0));
+  });
 
-    final Rect topFixedSpacerRect = tester.getRect(find.byType(Spacer).at(0));
-    expect(topFixedSpacerRect.size, const Size(0.0, 10.0));
-    expect(topFixedSpacerRect.topLeft, const Offset(400.0, 0.0));
+  testWidgets('Spacer.fixed takes up space.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Row(
+          children: <Widget>[
+            Spacer.fixed(length: 100.0),
+            SizedBox.square(dimension: 10.0),
+            Spacer.fixed(length: 200.0),
+          ],
+        ),
+      ),
+    );
 
-    final Rect flexibleSpacerRect = tester.getRect(find.byType(Spacer).at(1));
-    expect(flexibleSpacerRect.size, const Size(0.0, 580.0));
-    expect(flexibleSpacerRect.topLeft, const Offset(400.0, 10.0));
+    final Rect horizontalSpacerRect1 = tester.getRect(find.byType(Spacer).at(0));
+    expect(horizontalSpacerRect1.size, const Size(100.0, 0.0));
+    expect(horizontalSpacerRect1.left, 0.0);
 
-    final Rect bottomFixedSpacerRect = tester.getRect(find.byType(Spacer).at(2));
-    expect(bottomFixedSpacerRect.size, const Size(0.0, 10.0));
-    expect(bottomFixedSpacerRect.topLeft, const Offset(400.0, 590.0));
+    final Rect horizontalSpacerRect2 = tester.getRect(find.byType(Spacer).at(1));
+    expect(horizontalSpacerRect2.size, const Size(200.0, 0.0));
+    expect(horizontalSpacerRect2.left, 110.0);
+
+    await tester.pumpWidget(
+      const Column(
+        children: <Widget>[
+          Spacer.fixed(length: 100.0),
+          SizedBox.square(dimension: 10.0),
+          Spacer.fixed(length: 200.0),
+        ],
+      ),
+    );
+
+    final Rect verticalSpacerRect1 = tester.getRect(find.byType(Spacer).at(0));
+    expect(verticalSpacerRect1.size, const Size(0.0, 100.0));
+    expect(verticalSpacerRect1.top, 0.0);
+
+    final Rect verticalSpacerRect2 = tester.getRect(find.byType(Spacer).at(1));
+    expect(verticalSpacerRect2.size, const Size(0.0, 200.0));
+    expect(verticalSpacerRect2.top, 110.0);
   });
 }

--- a/packages/flutter/test/widgets/spacer_test.dart
+++ b/packages/flutter/test/widgets/spacer_test.dart
@@ -9,14 +9,22 @@ void main() {
   testWidgets('Spacer takes up space.', (WidgetTester tester) async {
     await tester.pumpWidget(const Column(
       children: <Widget>[
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
         Spacer(),
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
       ],
     ));
-    final Rect spacerRect = tester.getRect(find.byType(Spacer));
-    expect(spacerRect.size, const Size(0.0, 580.0));
-    expect(spacerRect.topLeft, const Offset(400.0, 10.0));
+    final Rect topFixedSpacerRect = tester.getRect(find.byType(Spacer).at(0));
+    expect(topFixedSpacerRect.size, const Size(0.0, 10.0));
+    expect(topFixedSpacerRect.topLeft, const Offset(400.0, 0.0));
+
+    final Rect flexibleSpacerRect = tester.getRect(find.byType(Spacer).at(1));
+    expect(flexibleSpacerRect.size, const Size(0.0, 580.0));
+    expect(flexibleSpacerRect.topLeft, const Offset(400.0, 10.0));
+
+    final Rect bottomFixedSpacerRect = tester.getRect(find.byType(Spacer).at(2));
+    expect(bottomFixedSpacerRect.size, const Size(0.0, 10.0));
+    expect(bottomFixedSpacerRect.topLeft, const Offset(400.0, 590.0));
   });
 
   testWidgets('Spacer takes up space proportional to flex.', (WidgetTester tester) async {
@@ -27,21 +35,22 @@ void main() {
     await tester.pumpWidget(const Row(
       textDirection: TextDirection.rtl,
       children: <Widget>[
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
         spacer1,
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
         spacer2,
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
         spacer3,
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
         spacer4,
-        SizedBox(width: 10.0, height: 10.0),
+        Spacer.fixed(length: 10.0),
       ],
     ));
-    final Rect spacer1Rect = tester.getRect(find.byType(Spacer).at(0));
-    final Rect spacer2Rect = tester.getRect(find.byType(Spacer).at(1));
-    final Rect spacer3Rect = tester.getRect(find.byType(Spacer).at(2));
-    final Rect spacer4Rect = tester.getRect(find.byType(Spacer).at(3));
+
+    final Rect spacer1Rect = tester.getRect(find.byType(Spacer).at(1));
+    final Rect spacer2Rect = tester.getRect(find.byType(Spacer).at(3));
+    final Rect spacer3Rect = tester.getRect(find.byType(Spacer).at(5));
+    final Rect spacer4Rect = tester.getRect(find.byType(Spacer).at(7));
     expect(spacer1Rect.size.height, 0.0);
     expect(spacer1Rect.size.width, moreOrLessEquals(93.8, epsilon: 0.1));
     expect(spacer1Rect.left, moreOrLessEquals(696.3, epsilon: 0.1));
@@ -58,16 +67,25 @@ void main() {
       constrainedAxis: Axis.vertical,
       child: Column(
         children: <Widget>[
-          SizedBox(width: 20.0, height: 10.0),
+          Spacer.fixed(length: 10.0),
           Spacer(),
-          SizedBox(width: 10.0, height: 10.0),
+          Spacer.fixed(length: 10.0),
         ],
       ),
     ));
-    final Rect spacerRect = tester.getRect(find.byType(Spacer));
     final Rect flexRect = tester.getRect(find.byType(Column));
-    expect(spacerRect.size, const Size(0.0, 580.0));
-    expect(spacerRect.topLeft, const Offset(400.0, 10.0));
-    expect(flexRect, const Rect.fromLTWH(390.0, 0.0, 20.0, 600.0));
+    expect(flexRect, const Rect.fromLTWH(400.0, 0.0, 0.0, 600.0));
+
+    final Rect topFixedSpacerRect = tester.getRect(find.byType(Spacer).at(0));
+    expect(topFixedSpacerRect.size, const Size(0.0, 10.0));
+    expect(topFixedSpacerRect.topLeft, const Offset(400.0, 0.0));
+
+    final Rect flexibleSpacerRect = tester.getRect(find.byType(Spacer).at(1));
+    expect(flexibleSpacerRect.size, const Size(0.0, 580.0));
+    expect(flexibleSpacerRect.topLeft, const Offset(400.0, 10.0));
+
+    final Rect bottomFixedSpacerRect = tester.getRect(find.byType(Spacer).at(2));
+    expect(bottomFixedSpacerRect.size, const Size(0.0, 10.0));
+    expect(bottomFixedSpacerRect.topLeft, const Offset(400.0, 590.0));
   });
 }


### PR DESCRIPTION
Adds a new named constructor `Spacer.fixed` to `Spacer` that describes a absolute spacing.

Fixes #138257.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.