### PR TITLE
don’t warn about running as root within Podman and Kubernets container

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -211,7 +211,7 @@ function shared::execute() {
   esac
 
   # Test if running as superuser – but don't warn if running within Docker or CI.
-  if [[ "$EUID" == "0" && ! -f /.dockerenv && "$CI" != "true" && "$BOT" != "true" && "$CONTINUOUS_INTEGRATION" != "true" ]]; then
+  if [[ "$EUID" == "0" && ! -f /.dockerenv && ! -f /run/.containerenv && "$CI" != "true" && "$BOT" != "true" && "$CONTINUOUS_INTEGRATION" != "true" ]]; then
     >&2 echo "   Woah! You appear to be trying to run flutter as root."
     >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."
     >&2 echo "  /"

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -211,7 +211,7 @@ function shared::execute() {
   esac
 
   # Test if running as superuser – but don't warn if running within Docker or CI.
-  if [[ "$EUID" == "0" && ! -f /.dockerenv && ! -f /run/.containerenv && "$CI" != "true" && "$BOT" != "true" && "$CONTINUOUS_INTEGRATION" != "true" ]]; then
+  if [[ "$EUID" == "0" && ! -f /.dockerenv && ! -f /run/.containerenv && "$CI" != "true" && "$BOT" != "true" && "$CONTINUOUS_INTEGRATION" != "true" && ! -n $KUBERNETES_SERVICE_HOST ]]; then
     >&2 echo "   Woah! You appear to be trying to run flutter as root."
     >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."
     >&2 echo "  /"

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -210,7 +210,7 @@ function shared::execute() {
       ;;
   esac
 
-  # Test if running as superuser – but don't warn if running within Docker or CI.
+  # Test if running as superuser – but don't warn if running within Docker, Podman, Kubernets or CI.
   if [[ "$EUID" == "0" && ! -f /.dockerenv && ! -f /run/.containerenv && "$CI" != "true" && "$BOT" != "true" && "$CONTINUOUS_INTEGRATION" != "true" && ! -n $KUBERNETES_SERVICE_HOST ]]; then
     >&2 echo "   Woah! You appear to be trying to run flutter as root."
     >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."


### PR DESCRIPTION
It's a small improvement to ignore warnings in **Kubernets** and **Podman**.

It doesn't seem so elegant to me to have so many conditions inside an `if` but I just followed the existing pattern.

If you instruct me, I can reimplement anything in another way.

closes #140330

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
