### PR TITLE
Fix spell check throws when text contains regex reserved characters

### DIFF
--- a/packages/flutter/lib/src/widgets/spell_check.dart
+++ b/packages/flutter/lib/src/widgets/spell_check.dart
@@ -134,7 +134,8 @@ List<SuggestionSpan> _correctSpellCheckResults(
     final int spanLength = currentSpan.range.end - currentSpan.range.start;
 
     // Try finding SuggestionSpan from resultsText in new text.
-    final RegExp currentSpanTextRegexp = RegExp('\\b$currentSpanText\\b');
+    final String escapedText = RegExp.escape(currentSpanText);
+    final RegExp currentSpanTextRegexp = RegExp('\\b$escapedText\\b');
     final int foundIndex = newText.substring(searchStart).indexOf(currentSpanTextRegexp);
 
     // Check whether word was found exactly where expected or elsewhere in the newText.

--- a/packages/flutter/test/widgets/spell_check_test.dart
+++ b/packages/flutter/test/widgets/spell_check_test.dart
@@ -369,7 +369,10 @@ void main() {
         ],
       );
 
-      buildTextSpanWithSpellCheckSuggestions(
+      const TextSpan expectedTextSpanTree = TextSpan(children: <TextSpan>[
+        TextSpan(text: 'Hello, *ãresaa'),
+      ]);
+      final TextSpan textSpanTree = buildTextSpanWithSpellCheckSuggestions(
         value,
         composingRegionOutOfRange,
         null,
@@ -378,6 +381,7 @@ void main() {
       );
 
       expect(tester.takeException(), null);
+      expect(textSpanTree, equals(expectedTextSpanTree));
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
   );
 }

--- a/packages/flutter/test/widgets/spell_check_test.dart
+++ b/packages/flutter/test/widgets/spell_check_test.dart
@@ -353,4 +353,31 @@ void main() {
 
     expect(textSpanTree, equals(expectedTextSpanTree));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }));
+
+  testWidgets(
+    'buildTextSpanWithSpellCheckSuggestions does not throw when text contains regex reserved characters',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/136032.
+      const String text = 'Hello, *ãresaa';
+      const String resultsText = 'Hello, *ãresa';
+      const TextEditingValue value = TextEditingValue(text: text);
+      const bool composingRegionOutOfRange = false;
+      const SpellCheckResults spellCheckResults = SpellCheckResults(
+        resultsText,
+        <SuggestionSpan>[
+          SuggestionSpan(TextRange(start: 7, end: 12), <String>['*rangesa']),
+        ],
+      );
+
+      buildTextSpanWithSpellCheckSuggestions(
+        value,
+        composingRegionOutOfRange,
+        null,
+        misspelledTextStyle,
+        spellCheckResults,
+      );
+
+      expect(tester.takeException(), null);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
+  );
 }


### PR DESCRIPTION
## Description

This PR fixes an issue related to the spell check implementation usage of Regex (searched text should be escaped).

## Related Issue

Fixes https://github.com/flutter/flutter/issues/136032.

## Tests

Adds 1 test.