### PR TITLE
[flutter_tools] handle FileSystemException trying to delete temp directory from core_devices.dart

### DIFF
--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
+import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -101,7 +102,7 @@ class IOSCoreDeviceControl {
       _logger.printError('Error executing devicectl: $err');
       return <Object?>[];
     } finally {
-      tempDirectory.deleteSync(recursive: true);
+      ErrorHandlingFileSystem.deleteIfExists(tempDirectory, recursive: true);
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -111,7 +111,7 @@ void main() {
       exceptionHandler = FileExceptionHandler();
     });
 
-    testWithoutContext('bypasses error handling when withAllowedFailure is used', () {
+    testWithoutContext('bypasses error handling when noExitOnFailure is used', () {
       final ErrorHandlingFileSystem fileSystem = ErrorHandlingFileSystem(
         delegate: MemoryFileSystem.test(opHandle: exceptionHandler.opHandle),
         platform: windowsPlatform,
@@ -123,9 +123,9 @@ void main() {
         FileSystemOp.write,
         FileSystemException('', file.path, const OSError('', kUserPermissionDenied)),
       );
-
+      final Matcher throwsNonToolExit = throwsA(isNot(isA<ToolExit>()));
       expect(() => ErrorHandlingFileSystem.noExitOnFailure(
-        () => file.writeAsStringSync('')), throwsException);
+        () => file.writeAsStringSync('')), throwsNonToolExit);
 
       // nesting does not unconditionally re-enable errors.
       expect(() {
@@ -133,7 +133,7 @@ void main() {
           ErrorHandlingFileSystem.noExitOnFailure(() { });
           file.writeAsStringSync('');
         });
-      }, throwsException);
+      }, throwsNonToolExit);
 
       // Check that state does not leak.
       expect(() => file.writeAsStringSync(''), throwsToolExit());


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/140416, the top crasher on stable/3.16.4