### PR TITLE
[github actions] change minimal example workflow to be manually dispatched

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -5,9 +5,7 @@
 name: Minimal workflow to test github action token
 
 on:
-  pull_request:
-    branches: master
-    types: [labeled]
+  workflow_dispatch
 
 permissions: write-all
 
@@ -15,9 +13,6 @@ jobs:
   minimal_token_test:
     name: minimal_token_test
     runs-on: ubuntu-latest
-    if: |
-      (github.event.label.name == format('cp{0} beta', ':') || github.event.label.name == format('cp{0} stable', ':')) &&
-      (github.event.pull_request.merged == true)
     steps:
       - name: Checkout Flutter Repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
This would allow easier testing of the minimal example.

Might need Github Admin power to trigger the manual dispatches.