### PR TITLE
Run mac staging tests with Xcode 15

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -81,7 +81,6 @@ platform_properties:
         ]
       os: Mac-12|Mac-13
       device_type: none
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -95,7 +94,6 @@ platform_properties:
       os: Mac-12|Mac-13
       device_type: none
       cpu: arm64
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -111,7 +109,6 @@ platform_properties:
       os: Mac-12|Mac-13
       tags: >
         ["devicelab", "hostonly", "mac"]
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -125,7 +122,6 @@ platform_properties:
       os: Mac-12|Mac-13
       device_type: none
       cpu: x86
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -140,7 +136,6 @@ platform_properties:
       os: Mac-12|Mac-13
       device_type: none
       cpu: x86
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -176,7 +171,6 @@ platform_properties:
       os: Mac-12|Mac-13
       cpu: x86
       device_os: iOS-16
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -191,7 +185,6 @@ platform_properties:
       os: Mac-12|Mac-13
       cpu: arm64
       device_os: iOS-16
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -4016,11 +4009,11 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flavors_test_ios_xcode_debug
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14c18"
+          "sdk_version": "15a240d"
         }
+      os: Mac-13
     bringup: true
 
   # TODO(vashworth): Stop running in presubmit after macOS 13 upgrade is complete (https://github.com/flutter/flutter/issues/134737)
@@ -4058,11 +4051,11 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__start_up_xcode_debug
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14c18"
+          "sdk_version": "15a240d"
         }
+      os: Mac-13
     bringup: true
 
   - name: Mac_ios flutter_view_ios__start_up
@@ -4149,11 +4142,11 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_driver_xcode_debug
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14c18"
+          "sdk_version": "15a240d"
         }
+      os: Mac-13
     bringup: true
 
   - name: Mac_ios integration_ui_ios_frame_number
@@ -4298,11 +4291,11 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios_xcode_debug
-      # TODO(vashworth): Remove specific toolchain_ver once https://github.com/flutter/flutter/issues/138109 is resolved.
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14c18"
+          "sdk_version": "15a240d"
         }
+      os: Mac-13
     bringup: true
 
   - name: Mac native_assets_ios_simulator
@@ -4495,7 +4488,6 @@ targets:
 
   - name: Mac_build_test flutter_gallery__transition_perf_e2e_ios
     recipe: devicelab/devicelab_drone_build_test
-    # TODO(vashworth): Take out of bringup once https://github.com/flutter/flutter/issues/138194 is resolved.
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Run macOS staging tests with Xcode 15 and macOS 13. Also, cleanup some comments.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
