### PR TITLE
Enable gesture immediately on the underlying page when swiping back

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -780,6 +780,8 @@ class _CupertinoBackGestureController<T> {
     }
 
     if (controller.isAnimating) {
+      navigator.popGestureStarted = true;
+
       // Keep the userGestureInProgress in true state so we don't change the
       // curve of the page transition mid-flight since CupertinoPageTransition
       // depends on userGestureInProgress.

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3516,6 +3516,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
 
   bool get _usingPagesAPI => widget.pages != const <Page<dynamic>>[];
 
+  /// Whether the route was started popping by user gesture.
+  bool popGestureStarted = false;
+
   void _handleHistoryChanged() {
     final bool navigatorCanPop = canPop();
     late final bool routeBlocksPop;
@@ -5475,6 +5478,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   void didStopUserGesture() {
     assert(_userGesturesInProgress > 0);
     _userGesturesInProgress -= 1;
+    popGestureStarted = false;
     if (_userGesturesInProgress == 0) {
       for (final NavigatorObserver observer in _effectiveObservers) {
         observer.didStopUserGesture();

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -957,8 +957,9 @@ class _ModalScopeState<T> extends State<_ModalScope<T>> {
                                 builder: (BuildContext context, Widget? child) {
                                   final bool ignoreEvents = _shouldIgnoreFocusRequest;
                                   focusScopeNode.canRequestFocus = !ignoreEvents;
+                                  final bool popGestureStarted = widget.route.navigator?.popGestureStarted ?? false;
                                   return IgnorePointer(
-                                    ignoring: ignoreEvents,
+                                    ignoring: !popGestureStarted && ignoreEvents,
                                     child: child,
                                   );
                                 },

--- a/packages/flutter/test/cupertino/page_transition_test.dart
+++ b/packages/flutter/test/cupertino/page_transition_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+@immutable
+class _Home extends StatelessWidget {
+  const _Home({
+    required this.buttonKey,
+    required this.onButtonPressed,
+  });
+
+  final Key buttonKey;
+  final VoidCallback onButtonPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(),
+      child: Center(
+        child: CupertinoButton.filled(
+          key: buttonKey,
+          padding: const EdgeInsets.symmetric(horizontal: 200),
+          onPressed: onButtonPressed,
+          child: const Text('Button'),
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class _Next extends StatelessWidget {
+  const _Next();
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(),
+      child: SizedBox.shrink(),
+    );
+  }
+}
+
+void main() {
+  testWidgets(
+      'Can tap widget on underlying page during back animation by back button',
+      (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 600));
+    final GlobalKey buttonKey = GlobalKey();
+    int pressCount = 0;
+
+    final Widget app = CupertinoApp(
+      home: _Home(
+        buttonKey: buttonKey,
+        onButtonPressed: () => pressCount += 1,
+      ),
+    );
+    await tester.pumpWidget(app);
+
+    await tester.tap(find.byKey(buttonKey));
+    await tester.pump();
+    expect(pressCount, 1);
+
+    final NavigatorState navigator = tester.state(find.byType(Navigator));
+    navigator.push(
+      CupertinoPageRoute<void>(
+        builder: (BuildContext context) => const _Next(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(CupertinoNavigationBarBackButton));
+    await tester.pumpFrames(app, const Duration(milliseconds: 100));
+    await tester.tap(find.byKey(buttonKey));
+    await tester.pumpAndSettle();
+    expect(pressCount, 2);
+  });
+
+  testWidgets(
+      'Can tap widget on underlying page during back animation by fling',
+      (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 600));
+
+    final GlobalKey buttonKey = GlobalKey();
+    int pressCount = 0;
+
+    final Widget app = CupertinoApp(
+      home: _Home(
+        buttonKey: buttonKey,
+        onButtonPressed: () => pressCount += 1,
+      ),
+    );
+    await tester.pumpWidget(app);
+
+    await tester.tap(find.byKey(buttonKey));
+    await tester.pump();
+    expect(pressCount, 1);
+
+    final NavigatorState navigator = tester.state(find.byType(Navigator));
+    navigator.push(
+      CupertinoPageRoute<void>(
+        builder: (BuildContext context) => const _Next(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.flingFrom(
+      const Offset(0, 300),
+      const Offset(100, 0),
+      10000,
+    );
+    await tester.pumpFrames(app, const Duration(milliseconds: 100));
+    await tester.tap(find.byKey(buttonKey));
+    await tester.pumpAndSettle();
+    expect(pressCount, 2);
+  });
+}


### PR DESCRIPTION
* Introduce Navigator.popGestureStarted.
* Enable gesture immediately on the underlying page when swiping back using CupertinoRouteTransitionMixin.
* Add cupertino/page_transition_test.dart.

Fixes https://github.com/flutter/flutter/issues/48225.

The behavior fixed in this pull request will probably not be completely identical to iOS native, but it will improve the user experience over the current state.  
(See also: https://github.com/flutter/flutter/issues/48225#issuecomment-1140398792)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
