### PR TITLE
Detect VS Code IDE on Arch Linux

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -237,6 +237,10 @@ class VsCode {
   }
 
   // Linux:
+  //   Arch Linux:
+  //     /usr/lib/code
+  //     /opt/visual-studio-code
+  //     /opt/visual-studio-code-insiders
   //   Deb:
   //     /usr/share/code/bin/code
   //     /usr/share/code-insiders/bin/code-insiders
@@ -246,6 +250,9 @@ class VsCode {
   //     /var/lib/flatpak/app/com.visualstudio.code/x86_64/stable/active/files/extra/vscode
   //     /var/lib/flatpak/app/com.visualstudio.code.insiders/x86_64/beta/active/files/extra/vscode-insiders
   // Linux Extensions:
+  //   Arch Linux:
+  //     $HOME/.vscode/extensions
+  //     $HOME/.vscode-insiders/extensions
   //   Deb:
   //     $HOME/.vscode/extensions
   //   Snap:
@@ -273,6 +280,9 @@ class VsCode {
         '/var/lib/flatpak/app/com.visualstudio.code.insiders/x86_64/beta/active/files/extra/vscode-insiders',
         '.var/app/com.visualstudio.code.insiders/data/vscode-insiders',
       ),
+      const VsCodeInstallLocation('/usr/lib/code', '.vscode'),
+      const VsCodeInstallLocation('/opt/visual-studio-code', '.vscode'),
+      const VsCodeInstallLocation('/opt/visual-studio-code-insiders', '.vscode-insiders'),
     ], fileSystem, platform);
   }
 


### PR DESCRIPTION
Add support for detecting the Visual Studio Code IDE when installed from the following packages on Arch Linux:
- [code](https://archlinux.org/packages/extra/x86_64/code/)
- [visual-studio-code-bin](https://aur.archlinux.org/packages/visual-studio-code-bin)
- [visual-studio-code-insiders-bin](https://aur.archlinux.org/packages/visual-studio-code-insiders-bin)

It looks like `flutter doctor` is unable to detect the version for `code`, due to the way it's packaged (e.g.: `package.json` is stored at `/usr/lib/code/package.json` while the [current logic](https://github.com/flutter/flutter/blob/3df4e735d5d0bd2db7930098eba1b3e620d77aa0/packages/flutter_tools/lib/src/vscode/vscode.dart#L67) is looking for it at `/usr/lib/code/resources/app/package.json`).

However, this only affects the official `code` package, so the `visual-studio-code-bin` and `visual-studio-code-insiders-bin` packages are unaffected:

```sh
$ flutter doctor -v
...
[✓] VS Code (version unknown)
    • VS Code at /usr/lib/code
    • Flutter extension version 3.78.0
    ✗ Unable to determine VS Code version.

[✓] VS Code (version 1.86.0-insider)
    • VS Code at /opt/visual-studio-code-insiders
    • Flutter extension version 3.78.0
...
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
