### PR TITLE
[web] Fix and unskip a few more CanvasKit tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -163,7 +163,6 @@ const Map<String, List<String>> kWebTestFileKnownFailures = <String, List<String
     'test/painting/decoration_test.dart',
     'test/painting/text_style_test.dart',
     'test/material/text_field_test.dart',
-    'test/widgets/app_overrides_test.dart',
     'test/widgets/performance_overlay_test.dart',
     'test/widgets/html_element_view_test.dart',
     'test/cupertino/scaffold_test.dart',

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -161,7 +161,6 @@ const Map<String, List<String>> kWebTestFileKnownFailures = <String, List<String
     // These tests are broken and need to be fixed.
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/71604
     'test/painting/decoration_test.dart',
-    'test/rendering/layers_test.dart',
     'test/painting/text_style_test.dart',
     'test/material/text_field_test.dart',
     'test/widgets/app_overrides_test.dart',

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -160,7 +160,6 @@ const Map<String, List<String>> kWebTestFileKnownFailures = <String, List<String
 
     // These tests are broken and need to be fixed.
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/71604
-    'test/painting/decoration_test.dart',
     'test/painting/text_style_test.dart',
     'test/material/text_field_test.dart',
     'test/widgets/performance_overlay_test.dart',

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -330,7 +330,7 @@ void main() {
     expect(paint.filterQuality, FilterQuality.high);
     expect(paint.isAntiAlias, true);
     // TODO(craiglabenz): change to true when https://github.com/flutter/flutter/issues/88909 is fixed
-    expect(paint.invertColors, isCanvasKit || !kIsWeb);
+    expect(paint.invertColors, !kIsWeb || isCanvasKit);
   });
 
   test('DecorationImage.toString', () async {

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -330,7 +330,7 @@ void main() {
     expect(paint.filterQuality, FilterQuality.high);
     expect(paint.isAntiAlias, true);
     // TODO(craiglabenz): change to true when https://github.com/flutter/flutter/issues/88909 is fixed
-    expect(paint.invertColors, !kIsWeb);
+    expect(paint.invertColors, isCanvasKit || !kIsWeb);
   });
 
   test('DecorationImage.toString', () async {

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -369,7 +369,14 @@ void main() {
     final ImageFilter filter = ImageFilter.blur(sigmaX: 1.0, sigmaY: 1.0, tileMode: TileMode.repeated);
     final BackdropFilterLayer layer = BackdropFilterLayer(filter: filter, blendMode: BlendMode.clear);
     final List<String> info = getDebugInfo(layer);
-    expect(info, contains(isBrowser ? 'filter: ImageFilter.blur(1, 1, TileMode.repeated)' : 'filter: ImageFilter.blur(1.0, 1.0, repeated)'));
+    expect(
+      info,
+      contains(
+        isBrowser && !isCanvasKit
+          ? 'filter: ImageFilter.blur(1, 1, TileMode.repeated)'
+          : 'filter: ImageFilter.blur(${1.0}, ${1.0}, repeated)'
+      ),
+    );
     expect(info, contains('blendMode: clear'));
   });
 
@@ -528,7 +535,7 @@ void main() {
     // Ensure we can render the same scene again after rendering an interior
     // layer.
     parent.buildScene(SceneBuilder());
-  }, skip: isBrowser); // TODO(yjbanov): `toImage` doesn't work on the Web: https://github.com/flutter/flutter/issues/49857
+  }, skip: isBrowser && !isCanvasKit); // TODO(yjbanov): `toImage` doesn't work in HTML: https://github.com/flutter/flutter/issues/49857
 
   test('ContainerLayer.toImageSync can render interior layer', () {
     final OffsetLayer parent = OffsetLayer();
@@ -546,7 +553,7 @@ void main() {
     // Ensure we can render the same scene again after rendering an interior
     // layer.
     parent.buildScene(SceneBuilder());
-  }, skip: isBrowser); // TODO(yjbanov): `toImage` doesn't work on the Web: https://github.com/flutter/flutter/issues/49857
+  }, skip: isBrowser && !isCanvasKit); // TODO(yjbanov): `toImage` doesn't work in HTML: https://github.com/flutter/flutter/issues/49857
 
   test('PictureLayer does not let you call dispose unless refcount is 0', () {
     PictureLayer layer = PictureLayer(Rect.zero);

--- a/packages/flutter/test/widgets/app_overrides_test.dart
+++ b/packages/flutter/test/widgets/app_overrides_test.dart
@@ -57,7 +57,7 @@ void main() {
     expect(find.byType(PerformanceOverlay), findsOneWidget);
     expect(find.byType(CheckedModeBanner), findsOneWidget);
     WidgetsApp.showPerformanceOverlayOverride = false;
-  });
+  }, skip: isBrowser); // TODO(yjbanov): https://github.com/flutter/flutter/issues/52258
 
   testWidgets('showPerformanceOverlayOverride false', (WidgetTester tester) async {
     WidgetsApp.showPerformanceOverlayOverride = true;


### PR DESCRIPTION
Fix and unskip the following CanvasKit tests:

- `test/painting/decoration_test.dart`
- `test/rendering/layers_test.dart`
- `test/widgets/app_overrides_test.dart`
