### PR TITLE
Fix setup race in asset bundle tests

### DIFF
--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -356,14 +356,14 @@ flutter:
         return bundle;
       }
 
-      late final String? previousCacheFlutterRootValue;
+      late String? previousCacheFlutterRootValue;
 
-      setUpAll(() {
+      setUp(() {
         previousCacheFlutterRootValue = Cache.flutterRoot;
         Cache.flutterRoot = Cache.defaultFlutterRoot(platform: platform, fileSystem: testFileSystem, userMessages: UserMessages());
       });
 
-      tearDownAll(() => Cache.flutterRoot = previousCacheFlutterRootValue);
+      tearDown(() => Cache.flutterRoot = previousCacheFlutterRootValue);
 
       testWithoutContext('correctly bundles assets given a simple asset manifest with flavors', () async {
         testFileSystem.file('.packages').createSync();

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(andrewkolos): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/140665
-// Fails with "flutter test --test-randomize-ordering-seed=20231227"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'dart:convert';
 import 'dart:typed_data';
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/140665 by replacing use of `setUpAll` and `teardownAll` with `setUp` and `teardown` respectively.

My theory has to how this issue happened (and how this PR fixes it) is that `setUpAll` is not guaranteed to run after any `setUp` in any parent test groups. However, `setUp` is guaranteed to run after any set-up callbacks in parent groups. From the [documentation](https://api.flutter.dev/flutter/flutter_test/setUp.html): 

> If this is called within a test group, it applies only to tests in that group. The body will be run after any set-up callbacks in parent groups or at the top level.

Meanwhile, [`setUpAll`](https://api.flutter.dev/flutter/flutter_test/setUpAll.html) has a weaker documented guarantee that applies only to other `setUpAll` calls:

> If this is called within a test group, The body will run before all tests in that group. It will be run after any [setUpAll](https://api.flutter.dev/flutter/flutter_test/setUpAll.html) callbacks in parent groups or at the top level. It won't be run if none of the tests in the group are run.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
