### PR TITLE
[flutter_tools] add support for --enable-impeller to test device.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -74,6 +74,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     usesWebRendererOption();
     usesDeviceUserOption();
     usesFlavorOption();
+    addEnableImpellerFlag(verboseHelp: verboseHelp);
 
     argParser
       ..addMultiOption('name',
@@ -436,6 +437,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       enableDds: enableDds,
       nullAssertions: boolArg(FlutterOptions.kNullAssertions),
       usingCISystem: usingCISystem,
+      enableImpeller: ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?),
     );
 
     Device? integrationTestDevice;

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -109,8 +109,13 @@ class FlutterTesterTestDevice extends TestDevice {
       if (icudtlPath != null) '--icu-data-file-path=$icudtlPath',
       '--enable-checked-mode',
       '--verify-entry-points',
-      '--enable-software-rendering',
-      '--skia-deterministic-rendering',
+      if (debuggingOptions.enableImpeller == ImpellerStatus.enabled)
+        '--enable-impeller'
+      else
+        ...<String>[
+          '--enable-software-rendering',
+          '--skia-deterministic-rendering',
+        ],
       if (debuggingOptions.enableDartProfiling)
         '--enable-dart-profiling',
       '--non-interactive',

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -996,6 +996,23 @@ dev_dependencies:
       FileSystem: () => fs,
       ProcessManager: () => FakeProcessManager.any(),
     });
+
+    testUsingContext('Enables Impeller', () async {
+      final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+      final TestCommand testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+        '--enable-impeller',
+      ]);
+      expect(testRunner.lastDebuggingOptionsValue.enableImpeller, ImpellerStatus.enabled);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
   });
 }
 


### PR DESCRIPTION
This allows unit tests to use the impeller backend, which can be useful for Scubas/golden tests.
