### PR TITLE
Remove deprecated bitcode stripping from tooling

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -296,9 +296,6 @@ abstract class UnpackIOS extends Target {
       throw Exception('Binary $frameworkBinaryPath does not exist, cannot thin');
     }
     await _thinFramework(environment, frameworkBinaryPath, archs);
-    if (buildMode == BuildMode.release) {
-      await _bitcodeStripFramework(environment, frameworkBinaryPath);
-    }
     await _signFramework(environment, frameworkBinary, buildMode);
   }
 
@@ -374,26 +371,6 @@ abstract class UnpackIOS extends Target {
 
     if (extractResult.exitCode != 0) {
       throw Exception('Failed to extract $archs for $frameworkBinaryPath.\n${extractResult.stderr}\nRunning lipo -info:\n$lipoInfo');
-    }
-  }
-
-  /// Destructively strip bitcode from the framework. This can be removed
-  /// when the framework is no longer built with bitcode.
-  Future<void> _bitcodeStripFramework(
-    Environment environment,
-    String frameworkBinaryPath,
-  ) async {
-    final ProcessResult stripResult = await environment.processManager.run(<String>[
-      'xcrun',
-      'bitcode_strip',
-      frameworkBinaryPath,
-      '-r', // Delete the bitcode segment.
-      '-o',
-      frameworkBinaryPath,
-    ]);
-
-    if (stripResult.exitCode != 0) {
-      throw Exception('Failed to strip bitcode for $frameworkBinaryPath.\n${stripResult.stderr}');
     }
   }
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -813,56 +813,6 @@ void main() {
       expect(processManager, hasNoRemainingExpectations);
     });
 
-    testWithoutContext('fails when bitcode strip fails', () async {
-      binary.createSync(recursive: true);
-
-      final Environment environment = Environment.test(
-        fileSystem.currentDirectory,
-        processManager: processManager,
-        artifacts: artifacts,
-        logger: logger,
-        fileSystem: fileSystem,
-        outputDir: outputDir,
-        defines: <String, String>{
-          kIosArchs: 'arm64',
-          kSdkRoot: 'path/to/iPhoneOS.sdk',
-        },
-      );
-
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(command: <String>[
-          'rsync',
-          '-av',
-          '--delete',
-          '--filter',
-          '- .DS_Store/',
-          'Artifact.flutterFramework.TargetPlatform.ios.release.EnvironmentType.physical',
-          outputDir.path,
-        ]),
-        lipoCommandNonFatResult,
-        lipoVerifyArm64Command,
-        FakeCommand(command: <String>[
-          'xcrun',
-          'bitcode_strip',
-          binary.path,
-          '-r',
-          '-o',
-          binary.path,
-        ], exitCode: 1, stderr: 'bitcode_strip error'),
-      ]);
-
-      await expectLater(
-        const ReleaseUnpackIOS().build(environment),
-        throwsA(isException.having(
-          (Exception exception) => exception.toString(),
-          'description',
-          contains('Failed to strip bitcode for output/Flutter.framework/Flutter.\nbitcode_strip error'),
-        )),
-      );
-
-      expect(processManager, hasNoRemainingExpectations);
-    });
-
     testWithoutContext('strips framework', () async {
       binary.createSync(recursive: true);
 

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -157,9 +157,6 @@ void main() {
           ));
 
           expect(vmSnapshot.existsSync(), buildMode == BuildMode.debug);
-
-          // Builds should not contain deprecated bitcode.
-          expect(_containsBitcode(outputFlutterFrameworkBinary.path, processManager), isFalse);
         });
 
         testWithoutContext('Info.plist dart VM Service Bonjour service', () {
@@ -362,47 +359,4 @@ void main() {
   }, skip: !platform.isMacOS, // [intended] only makes sense for macos platform.
      timeout: const Timeout(Duration(minutes: 7))
   );
-}
-
-bool _containsBitcode(String pathToBinary, ProcessManager processManager) {
-  // See: https://stackoverflow.com/questions/32755775/how-to-check-a-static-library-is-built-contain-bitcode
-  final ProcessResult result = processManager.runSync(<String>[
-    'otool',
-    '-l',
-    '-arch',
-    'arm64',
-    pathToBinary,
-  ]);
-  final String loadCommands = result.stdout as String;
-  if (!loadCommands.contains('__LLVM')) {
-    return false;
-  }
-  // Presence of the section may mean a bitcode marker was embedded (size=1), but there is no content.
-  if (!loadCommands.contains('size 0x0000000000000001')) {
-    return true;
-  }
-  // Check the false positives: size=1 wasn't referencing the __LLVM section.
-
-  bool emptyBitcodeMarkerFound = false;
-  //  Section
-  //  sectname __bundle
-  //  segname __LLVM
-  //  addr 0x003c4000
-  //  size 0x0042b633
-  //  offset 3932160
-  //  ...
-  final List<String> lines = LineSplitter.split(loadCommands).toList();
-  lines.asMap().forEach((int index, String line) {
-    if (line.contains('segname __LLVM') && lines.length - index - 1 > 3) {
-      final bool bitcodeMarkerFound = lines
-          .skip(index - 1)
-          .take(4)
-          .any((String line) => line.contains(' size 0x0000000000000001'));
-      if (bitcodeMarkerFound) {
-        emptyBitcodeMarkerFound = true;
-        return;
-      }
-    }
-  });
-  return !emptyBitcodeMarkerFound;
 }

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -7,11 +7,9 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/convert.dart';
 
 import '../integration.shard/test_utils.dart';
 import '../src/common.dart';
-import '../src/fake_process_manager.dart';
 
 void main() {
   group('iOS app validation', () {


### PR DESCRIPTION
Bitcode has been removed https://github.com/flutter/flutter/issues/107887, clean up the leftover commands.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
