### PR TITLE
Run half of iOS devicelab tests with Xcode 15

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2896,6 +2896,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animated_advanced_blend_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   # Uses Impeller.
   - name: Linux_pixel_7pro animated_blur_backdrop_filter_perf_opengles__timeline_summary
@@ -2962,6 +2968,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: dynamic_path_tessellation_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Staging_build_linux analyze
     presubmit: false
@@ -3414,6 +3426,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: module_test_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -3896,6 +3914,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3914,6 +3938,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: basic_material_app_ios__compile
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios channels_integration_test_ios
     recipe: devicelab/devicelab_drone
@@ -3923,6 +3953,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: channels_integration_test_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios complex_layout_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -3941,6 +3977,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: complex_layout_scroll_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios complex_layout_scroll_perf_bad_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3959,6 +4001,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: color_filter_and_fade_perf_ios__e2e_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios imagefiltered_transform_animation_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3968,6 +4016,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: imagefiltered_transform_animation_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios external_ui_integration_test_ios
     recipe: devicelab/devicelab_drone
@@ -3987,6 +4041,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: route_test_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios flavors_test_ios
     recipe: devicelab/devicelab_drone
@@ -4005,6 +4065,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flavors_test_ios_xcode_debug
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -4047,6 +4108,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__start_up_xcode_debug
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -4062,6 +4124,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_view_ios__start_up
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
@@ -4080,6 +4148,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: hello_world_ios__compile
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_x64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
@@ -4120,6 +4194,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_test_test_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios integration_ui_ios_driver
     recipe: devicelab/devicelab_drone
@@ -4138,6 +4218,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_driver_xcode_debug
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -4162,6 +4243,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_keyboard_resize
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios integration_ui_ios_textfield
     recipe: devicelab/devicelab_drone
@@ -4206,6 +4293,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_content_validation_test
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_arm64_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
@@ -4224,6 +4317,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_defines_test
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios ios_platform_view_tests
     recipe: devicelab/devicelab_drone
@@ -4233,6 +4332,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_platform_view_tests
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios large_image_changer_perf_ios
     recipe: devicelab/devicelab_drone
@@ -4242,6 +4347,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: large_image_changer_perf_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_x64 macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
@@ -4287,6 +4398,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios_xcode_debug
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -4315,6 +4427,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: native_assets_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios native_platform_view_ui_tests_ios
     recipe: devicelab/devicelab_drone
@@ -4333,6 +4451,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: new_gallery_ios__transition_perf
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios new_gallery_skia_ios__transition_perf
     recipe: devicelab/devicelab_drone
@@ -4360,6 +4484,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channel_sample_test_swift
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios platform_channels_benchmarks_ios
     recipe: devicelab/devicelab_drone
@@ -4369,6 +4499,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channels_benchmarks_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios platform_interaction_test_ios
     recipe: devicelab/devicelab_drone
@@ -4378,6 +4514,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_interaction_test_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios platform_view_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -4432,6 +4574,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: wide_gamut_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
@@ -4441,6 +4589,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_x64 hot_mode_dev_cycle_ios_simulator
     recipe: devicelab/devicelab_drone
@@ -4481,6 +4635,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_build_test flutter_gallery__transition_perf_e2e_ios
     recipe: devicelab/devicelab_drone_build_test
@@ -4500,6 +4660,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animated_blur_backdrop_filter_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios draw_points_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4509,6 +4675,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: draw_points_perf_ios__timeline_summary
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac_ios spell_check_test
     recipe: devicelab/devicelab_drone
@@ -4518,6 +4690,12 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: spell_check_test_ios
+      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
+      os: Mac-13
 
   - name: Mac native_ui_tests_macos
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Since 50% of devicelab bots are on macOS 13, we can upgrade 50% of devicelab tests to Xcode 15.

There are 52 Mac_ios non-bringup tests, this PR updates 26 of them.

There are 4 Mac_arm64_ios non-bringup tests, this PR updates 2 of them.

Part of https://github.com/flutter/flutter/issues/140975

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
