### PR TITLE
Temporarily remove env variable for leak tracking bots.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4974,10 +4974,6 @@ targets:
       subshard: libraries
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      env_variables: >-
-        {
-          "LEAK_TRACKING": "true"
-        }
     runIf:
       - dev/**
       - packages/flutter/**
@@ -5036,10 +5032,6 @@ targets:
       subshard: misc
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      env_variables: >-
-        {
-          "LEAK_TRACKING": "true"
-        }
     runIf:
       - dev/**
       - examples/api/**
@@ -5092,10 +5084,6 @@ targets:
       subshard: widgets
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-      env_variables: >-
-        {
-          "LEAK_TRACKING": "true"
-        }
     runIf:
       - dev/**
       - packages/flutter/**


### PR DESCRIPTION
For some reasons there are [failures](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8759809744202981089/+/u/run_test.dart_for_framework_tests_shard_and_subshard_misc/test_stdout) in leak tracking bots, that do not relate to leak tracking. 

There are two differences between leak tracking bots and 'normal' windows framework bots: 

1. The flag "LEAK_TRACKING": "true". First failures happened before consumption of the flag "LEAK_TRACKING": "true" by testWidgets. Hypothesis: the failures may be caused by mechanisms that sets the env variable. This mechanism is used only by leak tracking bots.
2. bringup: true. 

This PR removes the leak tracking env variable to isolate the first difference and verify if the bots will start passing.  