### PR TITLE
Add RadioListItem use-case to a11y_assessments

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -41,12 +41,23 @@ class _MainWidget extends StatelessWidget {
                   children: <Widget>[
                     const Text('This is a typical dialog.'),
                     const SizedBox(height: 15),
-                    TextButton(
-                      autofocus: true,
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                      child: const Text('Close'),
+                    Row(
+                      children: <Widget>[
+                        TextButton(
+                          autofocus: true,
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          child: const Text('OK'),
+                        ),
+                        TextButton(
+                          autofocus: true,
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          child: const Text('Cancel'),
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -1,0 +1,59 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'use_cases.dart';
+
+class RadioListTileUseCase extends UseCase {
+
+  @override
+  String get name => 'RadioListTile';
+
+  @override
+  String get route => '/radio-list-tile';
+
+  @override
+  Widget build(BuildContext context) => _MainWidget();
+}
+
+class _MainWidget extends StatefulWidget {
+  @override
+  State<_MainWidget> createState() => _MainWidgetState();
+}
+
+enum SingingCharacter { lafayette, jefferson }
+
+class _MainWidgetState extends State<_MainWidget> {
+  SingingCharacter _value = SingingCharacter.lafayette;
+
+  void _onChanged(SingingCharacter? value) {
+    setState(() {
+      _value = value!;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Radio button')),
+      body: ListView(
+        children: <Widget>[
+          RadioListTile<SingingCharacter>(
+            title: const Text('Lafayette'),
+            value: SingingCharacter.lafayette,
+            groupValue: _value,
+            onChanged: _onChanged,
+          ),
+          RadioListTile<SingingCharacter>(
+            title: const Text('Jefferson'),
+            value: SingingCharacter.jefferson,
+            groupValue: _value,
+            onChanged: _onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/dev/a11y_assessments/lib/use_cases/use_cases.dart
+++ b/dev/a11y_assessments/lib/use_cases/use_cases.dart
@@ -11,6 +11,7 @@ import 'date_picker.dart';
 import 'dialog.dart';
 import 'material_banner.dart';
 import 'navigation_bar.dart';
+import 'radio_list_tile.dart';
 import 'slider.dart';
 import 'text_button.dart';
 import 'text_field.dart';
@@ -34,4 +35,5 @@ final List<UseCase> useCases = <UseCase>[
   MaterialBannerUseCase(),
   NavigationBarUseCase(),
   TextButtonUseCase(),
+  RadioListTileUseCase(),
 ];

--- a/dev/a11y_assessments/test/check_box_list_tile_test.dart
+++ b/dev/a11y_assessments/test/check_box_list_tile_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:a11y_assessments/use_cases/check_box_list_tile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  testWidgets('check box list tile use-case renders check boxes', (WidgetTester tester) async {
+    await pumpsUseCase(tester, CheckBoxListTile());
+    expect(find.text('a check box list title'), findsOneWidget);
+    expect(find.text('a disabled check box list title'), findsOneWidget);
+  });
+}

--- a/dev/a11y_assessments/test/dialog_test.dart
+++ b/dev/a11y_assessments/test/dialog_test.dart
@@ -12,12 +12,20 @@ void main() {
     await pumpsUseCase(tester, DialogUseCase());
     expect(find.text('Show Dialog'), findsOneWidget);
 
-    await tester.tap(find.text('Show Dialog'));
-    await tester.pumpAndSettle();
-    expect(find.text('This is a typical dialog.'), findsOneWidget);
+    Future<void> invokeDialog() async {
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+      expect(find.text('This is a typical dialog.'), findsOneWidget);
+    }
 
-    await tester.tap(find.text('Close'));
+    await invokeDialog();
+    await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
-    expect(find.text('Show Dialog'), findsOneWidget);
+    expect(find.text('This is a typical dialog.'), findsNothing);
+
+    await invokeDialog();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(find.text('This is a typical dialog.'), findsNothing);
   });
 }

--- a/dev/a11y_assessments/test/radio_list_tile_test.dart
+++ b/dev/a11y_assessments/test/radio_list_tile_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:a11y_assessments/use_cases/radio_list_tile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  testWidgets('radio list tile use-case renders radio buttons', (WidgetTester tester) async {
+    await pumpsUseCase(tester, RadioListTileUseCase());
+    expect(find.text('Lafayette'), findsOneWidget);
+    expect(find.text('Jefferson'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Adds a use-case screen for `RadioListTile`, similar to the `CheckBoxListTile`. This screen can help test scenarios such as the one reported in https://github.com/flutter/flutter/issues/126805.