### PR TITLE
Mark defaultTargetPlatform as constant for non-debug non-web builds.

### DIFF
--- a/packages/flutter/lib/src/foundation/_platform_io.dart
+++ b/packages/flutter/lib/src/foundation/_platform_io.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 import 'assertions.dart';
+import 'constants.dart';
 import 'platform.dart' as platform;
 
 export 'platform.dart' show TargetPlatform;

--- a/packages/flutter/lib/src/foundation/_platform_io.dart
+++ b/packages/flutter/lib/src/foundation/_platform_io.dart
@@ -10,7 +10,7 @@ import 'platform.dart' as platform;
 export 'platform.dart' show TargetPlatform;
 
 /// The dart:io implementation of [platform.defaultTargetPlatform].
-@pragma("vm:platform-const-if", !kDebugMode)
+@pragma('vm:platform-const-if', !kDebugMode)
 platform.TargetPlatform get defaultTargetPlatform {
   platform.TargetPlatform? result;
   if (Platform.isAndroid) {

--- a/packages/flutter/lib/src/foundation/_platform_io.dart
+++ b/packages/flutter/lib/src/foundation/_platform_io.dart
@@ -9,6 +9,7 @@ import 'platform.dart' as platform;
 export 'platform.dart' show TargetPlatform;
 
 /// The dart:io implementation of [platform.defaultTargetPlatform].
+@pragma("vm:platform-const-if", !kDebugMode)
 platform.TargetPlatform get defaultTargetPlatform {
   platform.TargetPlatform? result;
   if (Platform.isAndroid) {
@@ -30,7 +31,7 @@ platform.TargetPlatform get defaultTargetPlatform {
     }
     return true;
   }());
-  if (platform.debugDefaultTargetPlatformOverride != null) {
+  if (kDebugMode && platform.debugDefaultTargetPlatformOverride != null) {
     result = platform.debugDefaultTargetPlatformOverride;
   }
   if (result == null) {

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -4,6 +4,7 @@
 
 import '_platform_io.dart'
   if (dart.library.js_util) '_platform_web.dart' as platform;
+import 'assertions.dart';
 import 'constants.dart';
 
 /// The [TargetPlatform] that matches the platform on which the framework is
@@ -96,5 +97,17 @@ enum TargetPlatform {
 /// certainly widgets to work assuming the presence of a system-wide back
 /// button, which will make those widgets unusable since iOS has no such button.
 ///
-/// Therefore this property can only override the platform in debug builds.
-TargetPlatform? debugDefaultTargetPlatformOverride;
+/// Attempting to override this property in non-debug builds causes an error.
+TargetPlatform? get debugDefaultTargetPlatformOverride =>
+    _debugDefaultTargetPlatformOverride;
+
+set debugDefaultTargetPlatformOverride(TargetPlatform? value) {
+  if (!kDebugMode) {
+    throw FlutterError(
+      'Cannot modify debugDefaultTargetPlatformOverride in non-debug builds.\n'
+    );
+  }
+  _debugDefaultTargetPlatformOverride = value;
+}
+
+TargetPlatform? _debugDefaultTargetPlatformOverride;

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -22,7 +22,7 @@ import '_platform_io.dart'
 /// originally written assuming Android-like behavior, and we added platform
 /// adaptations for iOS later). Tests can check iOS behavior by using the
 /// platform override APIs (such as [ThemeData.platform] in the material
-/// library) or by setting [debugDefaultTargetPlatformOverride].
+/// library) or by setting [debugDefaultTargetPlatformOverride] in debug builds.
 ///
 /// Tests can also create specific platform tests by and adding a `variant:`
 /// argument to the test and using a [TargetPlatformVariant].
@@ -42,6 +42,7 @@ import '_platform_io.dart'
 // that would mean we'd be stuck with that platform forever emulating the other,
 // and we'd never be able to introduce dedicated behavior for that platform
 // (since doing so would be a big breaking change).
+@pragma("vm:platform-const-if", !kDebugMode)
 TargetPlatform get defaultTargetPlatform => platform.defaultTargetPlatform;
 
 /// The platform that user interaction should adapt to target.
@@ -76,7 +77,7 @@ enum TargetPlatform {
   windows,
 }
 
-/// Override the [defaultTargetPlatform].
+/// Override the [defaultTargetPlatform] in debug builds.
 ///
 /// Setting this to null returns the [defaultTargetPlatform] to its original
 /// value (based on the actual current platform).
@@ -94,5 +95,5 @@ enum TargetPlatform {
 /// certainly widgets to work assuming the presence of a system-wide back
 /// button, which will make those widgets unusable since iOS has no such button.
 ///
-/// In general, therefore, this property should not be used in release builds.
+/// Therefore this property can only override the platform in debug builds.
 TargetPlatform? debugDefaultTargetPlatformOverride;

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -43,7 +43,7 @@ import 'constants.dart';
 // that would mean we'd be stuck with that platform forever emulating the other,
 // and we'd never be able to introduce dedicated behavior for that platform
 // (since doing so would be a big breaking change).
-@pragma("vm:platform-const-if", !kDebugMode)
+@pragma('vm:platform-const-if', !kDebugMode)
 TargetPlatform get defaultTargetPlatform => platform.defaultTargetPlatform;
 
 /// The platform that user interaction should adapt to target.

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -4,6 +4,7 @@
 
 import '_platform_io.dart'
   if (dart.library.js_util) '_platform_web.dart' as platform;
+import 'constants.dart';
 
 /// The [TargetPlatform] that matches the platform on which the framework is
 /// currently executing.

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -104,8 +104,7 @@ TargetPlatform? get debugDefaultTargetPlatformOverride =>
 set debugDefaultTargetPlatformOverride(TargetPlatform? value) {
   if (!kDebugMode) {
     throw FlutterError(
-      'Cannot modify debugDefaultTargetPlatformOverride in non-debug builds.\n'
-    );
+      'Cannot modify debugDefaultTargetPlatformOverride in non-debug builds.');
   }
   _debugDefaultTargetPlatformOverride = value;
 }


### PR DESCRIPTION
This PR adds the Dart VM `vm:platform-const-if` pragma introduced in https://github.com/dart-lang/sdk/commit/57a1168875 to the `defaultTargetPlatform` property, allowing it to be computed as if it was a constant field in non-debug AOT builds. In particular, this means that platform-specific code executed conditionally based on this property can be tree-shaken in release builds. Note that this PR changes `defaultTargetPlatform` to only allow overriding via `debugDefaultTargetPlatformOverride` in debug builds, and makes it so that compilation throws an error if code assigns to`debugDefaultTargetPlatformOverride` in other build modes.

Related issue: #14233

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
