### PR TITLE
Disable test shuffling in widget_tester_leaks_test.dart

### DIFF
--- a/packages/flutter_test/test/widget_tester_leaks_test.dart
+++ b/packages/flutter_test/test/widget_tester_leaks_test.dart
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(polina-c): Remove this tag once this test's state leaks/test
+// dependencies have been fixed.
+// https://github.com/flutter/flutter/issues/85160
+// Fails with "flutter test --test-randomize-ordering-seed=20240108"
+@Tags(<String>['no-shuffle'])
+library;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Fails with `flutter test --test-randomize-ordering-seed=20240108`

https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20framework_tests_misc/15044/overview

cc @polina-c 