### PR TITLE
TextStyle: In copyWith, stop ignoring debugLabel when receiver has none

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -893,8 +893,10 @@ class TextStyle with Diagnosticable {
     assert(backgroundColor == null || background == null, _kColorBackgroundWarning);
     String? newDebugLabel;
     assert(() {
-      if (this.debugLabel != null) {
-        newDebugLabel = debugLabel ?? '(${this.debugLabel}).copyWith';
+      if (debugLabel != null) {
+        newDebugLabel = debugLabel;
+      } else if (this.debugLabel != null) {
+        newDebugLabel = '(${this.debugLabel}).copyWith';
       }
       return true;
     }());

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -374,6 +374,7 @@ void main() {
     expect(unknown.debugLabel, null);
     expect(unknown.toString(), 'TextStyle(<all styles inherited>)');
     expect(unknown.copyWith().debugLabel, null);
+    expect(unknown.copyWith(debugLabel: '123').debugLabel, '123');
     expect(unknown.apply().debugLabel, null);
 
     expect(foo.debugLabel, 'foo');


### PR DESCRIPTION
Fixes #141140.

This ensures that if you call `.copyWith` and pass a `debugLabel`, the `debugLabel` won't be ignored, even if the receiver (the TextStyle you're calling `.copyWith` on) doesn't have a `debugLabel`.

The debugLabel field was added in #12552. I skimmed the discussion there and didn't find anything indicating that the param was being ignored on purpose.

I added a test case that passes with the new code and fails with the old code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
