### PR TITLE
Fix #141061: Add 'color' property to `DrawerButton` and `EndDrawerButton`

### DIFF
--- a/packages/flutter/lib/src/material/action_buttons.dart
+++ b/packages/flutter/lib/src/material/action_buttons.dart
@@ -337,6 +337,7 @@ class DrawerButton extends _ActionButton {
   /// Creates a Material Design drawer icon button.
   const DrawerButton({
     super.key,
+    super.color,
     super.style,
     super.onPressed,
   }) : super(icon: const DrawerButtonIcon());
@@ -402,6 +403,7 @@ class EndDrawerButton extends _ActionButton {
   /// Creates a Material Design end drawer icon button.
   const EndDrawerButton({
     super.key,
+    super.color,
     super.style,
     super.onPressed,
   }) : super(icon: const EndDrawerButtonIcon());

--- a/packages/flutter/test/material/drawer_button_test.dart
+++ b/packages/flutter/test/material/drawer_button_test.dart
@@ -113,6 +113,24 @@ void main() {
 
   testWidgets('DrawerButton color', (WidgetTester tester) async {
     await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: DrawerButton(
+            color: Colors.red,
+          ),
+        ),
+      ),
+    );
+
+    final RichText iconText = tester.firstWidget(find.descendant(
+      of: find.byType(DrawerButton),
+      matching: find.byType(RichText),
+    ));
+    expect(iconText.text.style!.color, Colors.red);
+  });
+
+  testWidgets('DrawerButton color with ButtonStyle', (WidgetTester tester) async {
+    await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: true),
         home: const Material(
@@ -227,6 +245,25 @@ void main() {
   }, variant: TargetPlatformVariant.all());
 
   testWidgets('EndDrawerButton color', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: EndDrawerButton(
+            color: Colors.red,
+          ),
+        ),
+      ),
+    );
+
+    final RichText iconText = tester.firstWidget(find.descendant(
+      of: find.byType(EndDrawerButton),
+      matching: find.byType(RichText),
+    ));
+    expect(iconText.text.style!.color, Colors.red);
+  });
+
+
+  testWidgets('EndDrawerButton color with ButtonStyle', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(useMaterial3: true),

--- a/packages/flutter/test/material/drawer_button_test.dart
+++ b/packages/flutter/test/material/drawer_button_test.dart
@@ -262,7 +262,6 @@ void main() {
     expect(iconText.text.style!.color, Colors.red);
   });
 
-
   testWidgets('EndDrawerButton color with ButtonStyle', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Description

This PR addresses issue #141061, which requested the addition of a 'color' property to buttons extending _ActionButton. The 'color' property has been introduced to enhance customization options for these buttons.

## Issues Fixed

- Fixes #141061 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
