### PR TITLE
Update `RouteObserver` example and fix an error thrown

### DIFF
--- a/examples/api/lib/widgets/routes/route_observer.0.dart
+++ b/examples/api/lib/widgets/routes/route_observer.0.dart
@@ -1,0 +1,120 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [RouteObserver].
+
+final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
+
+void main() {
+  runApp(const RouteObserverApp());
+}
+
+class RouteObserverApp extends StatelessWidget {
+  const RouteObserverApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      navigatorObservers: <NavigatorObserver>[ routeObserver ],
+      home: const RouteObserverExample(),
+    );
+  }
+}
+
+class RouteObserverExample extends StatefulWidget {
+  const RouteObserverExample({super.key});
+
+  @override
+  State<RouteObserverExample> createState() => _RouteObserverExampleState();
+}
+
+class _RouteObserverExampleState extends State<RouteObserverExample> with RouteAware {
+  List<String> log = <String>[];
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void dispose() {
+    routeObserver.unsubscribe(this);
+    super.dispose();
+  }
+
+  @override
+  void didPush() {
+    // Route was pushed onto navigator and is now the topmost route.
+    log.add('didPush');
+  }
+
+  @override
+  void didPopNext() {
+    // Covering route was popped off the navigator.
+    log.add('didPopNext');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              'RouteObserver log:',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 300.0),
+              child: ListView.builder(
+                itemCount: log.length,
+                itemBuilder: (BuildContext context, int index) {
+                  if (log.isEmpty) {
+                    return const SizedBox.shrink();
+                  }
+                  return Text(
+                    log[index],
+                    textAlign: TextAlign.center,
+                  );
+                },
+              ),
+            ),
+            OutlinedButton(
+              onPressed: () {
+                Navigator.of(context).push<void>(
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) => const NextPage(),
+                  ),
+                );
+              },
+              child: const Text('Go to next page'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class NextPage extends StatelessWidget {
+  const NextPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: FilledButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('Go back to RouteAware page'),
+        )
+      ),
+    );
+  }
+}

--- a/examples/api/test/widgets/routes/route_observer.0_test.dart
+++ b/examples/api/test/widgets/routes/route_observer.0_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_api_samples/widgets/routes/route_observer.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('RouteObserver notifies RouteAware widget', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.RouteObserverApp(),
+    );
+
+    // Check the initial RouteObserver logs.
+    expect(find.text('didPush'), findsOneWidget);
+
+    // Tap on the button to push a new route.
+    await tester.tap(find.text('Go to next page'));
+    await tester.pumpAndSettle();
+
+    // Tap on the button to go back to the previous route.
+    await tester.tap(find.text('Go back to RouteAware page'));
+    await tester.pumpAndSettle();
+
+    // Check the RouteObserver logs after the route is popped.
+    expect(find.text('didPush'), findsOneWidget);
+    expect(find.text('didPopNext'), findsOneWidget);
+
+    // Tap on the button to push a new route again.
+    await tester.tap(find.text('Go to next page'));
+    await tester.pumpAndSettle();
+
+    // Tap on the button to go back to the previous route again.
+    await tester.tap(find.text('Go back to RouteAware page'));
+    await tester.pumpAndSettle();
+
+    // Check the RouteObserver logs after the route is popped again.
+    expect(find.text('didPush'), findsOneWidget);
+    expect(find.text('didPopNext'), findsNWidgets(2));
+  });
+}

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1910,60 +1910,16 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
 /// than only specific subtypes. For example, to watch for all [ModalRoute]
 /// variants, the `RouteObserver<ModalRoute<dynamic>>` type may be used.
 ///
-/// {@tool snippet}
+/// {@tool dartpad}
+/// This example demonstrates how to implement a [RouteObserver] that notifies
+/// [RouteAware] widget of changes to the state of their [Route].
 ///
-/// To make a [StatefulWidget] aware of its current [Route] state, implement
-/// [RouteAware] in its [State] and subscribe it to a [RouteObserver]:
-///
-/// ```dart
-/// // Register the RouteObserver as a navigation observer.
-/// final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
-///
-/// void main() {
-///   runApp(MaterialApp(
-///     home: Container(),
-///     navigatorObservers: <RouteObserver<ModalRoute<void>>>[ routeObserver ],
-///   ));
-/// }
-///
-/// class RouteAwareWidget extends StatefulWidget {
-///   const RouteAwareWidget({super.key});
-///
-///   @override
-///   State<RouteAwareWidget> createState() => RouteAwareWidgetState();
-/// }
-///
-/// // Implement RouteAware in a widget's state and subscribe it to the RouteObserver.
-/// class RouteAwareWidgetState extends State<RouteAwareWidget> with RouteAware {
-///
-///   @override
-///   void didChangeDependencies() {
-///     super.didChangeDependencies();
-///     routeObserver.subscribe(this, ModalRoute.of(context)!);
-///   }
-///
-///   @override
-///   void dispose() {
-///     routeObserver.unsubscribe(this);
-///     super.dispose();
-///   }
-///
-///   @override
-///   void didPush() {
-///     // Route was pushed onto navigator and is now topmost route.
-///   }
-///
-///   @override
-///   void didPopNext() {
-///     // Covering route was popped off the navigator.
-///   }
-///
-///   @override
-///   Widget build(BuildContext context) => Container();
-///
-/// }
-/// ```
+/// ** See code in examples/api/lib/widgets/routes/route_observer.0.dart **
 /// {@end-tool}
+///
+/// See also:
+///  * [RouteAware], this is used with [RouteObserver] to make a widget aware
+///   of changes to the [Navigator]'s session history.
 class RouteObserver<R extends Route<dynamic>> extends NavigatorObserver {
   final Map<R, Set<RouteAware>> _listeners = <R, Set<RouteAware>>{};
 


### PR DESCRIPTION
fixes [`RouteObserver` example throws an error](https://github.com/flutter/flutter/issues/141078)

### Description
This updates the `RouteObserver` example from snippet to Dartpad example and fixes the error when running the code snippet 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
