### PR TITLE
Replace deprecated `exists` in podhelper.rb

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -327,7 +327,7 @@ end
 
 def flutter_parse_xcconfig_file(file)
   file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
+  if !File.exist? file_abs_path
     return [];
   end
   entries = Hash.new
@@ -346,7 +346,7 @@ end
 
 def flutter_get_local_engine_dir(xcconfig_file)
   file_abs_path = File.expand_path(xcconfig_file)
-  if !File.exists? file_abs_path
+  if !File.exist? file_abs_path
     return nil
   end
   config = flutter_parse_xcconfig_file(xcconfig_file)


### PR DESCRIPTION
The recently landed https://github.com/flutter/flutter/pull/140222 accidentally used the deprecated `exists?` instead of the non-deprecated `exist?` (which other code in this file is already, correctly, using).

Fixes https://github.com/flutter/flutter/issues/141167

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
