### PR TITLE
Catch UnsupportedError thrown when user provides an asset directory path containing invalid characters

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -918,7 +918,7 @@ class ManifestAssetBundle implements AssetBundle {
           .join(assetBase, assetUri.toFilePath(windows: _platform.isWindows));
       } on UnsupportedError catch (e) {
         throwToolExit(
-          'Unable to search for asset files in directory path "${Uri.decodeFull(assetUri.path)}". '
+          'Unable to search for asset files in directory path "${assetUri.path}". '
           'Please ensure that this is valid URI that points to a directory '
           'that is available on the local file system.\nError details:\n$e');
       }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -912,8 +912,17 @@ class ManifestAssetBundle implements AssetBundle {
     Package? attributedPackage,
     List<String>? flavors,
   }) {
-    final String directoryPath = _fileSystem.path.join(
-        assetBase, assetUri.toFilePath(windows: _platform.isWindows));
+    final String directoryPath = (() {
+      try {
+        return _fileSystem.path
+          .join(assetBase, assetUri.toFilePath(windows: _platform.isWindows));
+      } on UnsupportedError catch (e) {
+        throwToolExit(
+          'Unable to search for asset files in directory path "${Uri.decodeFull(assetUri.path)}". '
+          'Please ensure that this is valid URI that points to a directory '
+          'that is available on the local file system.\nError details:\n$e');
+      }
+    })();
 
     if (!_fileSystem.directory(directoryPath).existsSync()) {
       _logger.printError('Error: unable to find directory entry in pubspec.yaml: $directoryPath');
@@ -1251,7 +1260,7 @@ class _AssetDirectoryCache {
   List<String> variantsFor(String assetPath) {
     final String directory = _fileSystem.path.dirname(assetPath);
 
-    if (!_fileSystem.directory(directory).existsSync()) {
+    if (!_fileSystem.directory(directory).existsSync()) { // HERE
       return const <String>[];
     }
 

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -912,17 +912,16 @@ class ManifestAssetBundle implements AssetBundle {
     Package? attributedPackage,
     List<String>? flavors,
   }) {
-    final String directoryPath = (() {
-      try {
-        return _fileSystem.path
-          .join(assetBase, assetUri.toFilePath(windows: _platform.isWindows));
-      } on UnsupportedError catch (e) {
-        throwToolExit(
-          'Unable to search for asset files in directory path "${assetUri.path}". '
-          'Please ensure that this is valid URI that points to a directory '
-          'that is available on the local file system.\nError details:\n$e');
-      }
-    })();
+    final String directoryPath;
+    try {
+      directoryPath = _fileSystem.path
+        .join(assetBase, assetUri.toFilePath(windows: _platform.isWindows));
+    } on UnsupportedError catch (e) {
+      throwToolExit(
+        'Unable to search for asset files in directory path "${assetUri.path}". '
+        'Please ensure that this is valid URI that points to a directory '
+        'that is available on the local file system.\nError details:\n$e');
+    }
 
     if (!_fileSystem.directory(directoryPath).existsSync()) {
       _logger.printError('Error: unable to find directory entry in pubspec.yaml: $directoryPath');

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1260,7 +1260,7 @@ class _AssetDirectoryCache {
   List<String> variantsFor(String assetPath) {
     final String directory = _fileSystem.path.dirname(assetPath);
 
-    if (!_fileSystem.directory(directory).existsSync()) { // HERE
+    if (!_fileSystem.directory(directory).existsSync()) {
       return const <String>[];
     }
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -171,14 +171,9 @@ flutter:
         'Unsupported operation: Illegal character in path: https:',
       ));
     }, overrides: <Type, Generator>{
-      FileSystem: () {
-        final FileSystem result = MemoryFileSystem(
-          style: FileSystemStyle.windows,
-        );
-        result.currentDirectory = result.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
-        return result;
-      },
+      FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      Platform: () => FakePlatform(operatingSystem: 'windows'),
     });
 
     testUsingContext('handle removal of wildcard directories', () async {

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -153,8 +153,8 @@ flutter:
     });
 
     testUsingContext('throws ToolExit when directory entry contains invalid characters', () async {
-      globals.fs.file('.packages').createSync();
-      globals.fs.file('pubspec.yaml')
+      testFileSystem.file('.packages').createSync();
+      testFileSystem.file('pubspec.yaml')
         ..createSync()
         ..writeAsStringSync(r'''
 name: example

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -163,7 +163,7 @@ flutter:
     - https://mywebsite.com/images/
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-      expect (() => bundle.build(packagesPath: '.packages'), throwsToolExit(
+      expect(() => bundle.build(packagesPath: '.packages'), throwsToolExit(
         message: 'Unable to search for asset files in directory path "https://mywebsite.com/images/". '
         'Please ensure that this is valid URI that points to a directory that is '
         'available on the local file system.\n'
@@ -171,7 +171,13 @@ flutter:
         'Unsupported operation: Illegal character in path: https:',
       ));
     }, overrides: <Type, Generator>{
-      FileSystem: () => testFileSystem,
+      FileSystem: () {
+        final FileSystem result = MemoryFileSystem(
+          style: FileSystemStyle.windows,
+        );
+        result.currentDirectory = result.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+        return result;
+      },
       ProcessManager: () => FakeProcessManager.any(),
     });
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -152,6 +152,29 @@ flutter:
       ProcessManager: () => FakeProcessManager.any(),
     });
 
+    testUsingContext('throws ToolExit when directory entry contains invalid characters', () async {
+      globals.fs.file('.packages').createSync();
+      globals.fs.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync(r'''
+name: example
+flutter:
+  assets:
+    - https://mywebsite.com/images/
+''');
+      final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+      expect (() => bundle.build(packagesPath: '.packages'), throwsToolExit(
+        message: 'Unable to search for asset files in directory path "https://mywebsite.com/images/". '
+        'Please ensure that this is valid URI that points to a directory that is '
+        'available on the local file system.\n'
+        'Error details:\n'
+        'Unsupported operation: Illegal character in path: https:',
+      ));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => testFileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
     testUsingContext('handle removal of wildcard directories', () async {
       globals.fs.file(globals.fs.path.join('assets', 'foo', 'bar.txt')).createSync(recursive: true);
       final File pubspec = globals.fs.file('pubspec.yaml')

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -164,7 +164,7 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       expect(() => bundle.build(packagesPath: '.packages'), throwsToolExit(
-        message: 'Unable to search for asset files in directory path "https://mywebsite.com/images/". '
+        message: 'Unable to search for asset files in directory path "https%3A//mywebsite.com/images/". '
         'Please ensure that this is valid URI that points to a directory that is '
         'available on the local file system.\n'
         'Error details:\n'


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/140092

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
