### PR TITLE
Fix: TextField can inherit `errorStyle` from `InputDecorationTheme`.

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1000,7 +1000,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
 
   bool get _hasError => widget.decoration?.errorText != null || widget.decoration?.error != null || _hasIntrinsicError;
 
-  Color get _errorColor => widget.cursorErrorColor ?? widget.decoration?.errorStyle?.color ?? Theme.of(context).colorScheme.error;
+  Color get _errorColor => widget.cursorErrorColor ?? _getEffectiveDecoration().errorStyle?.color ?? Theme.of(context).colorScheme.error;
 
   InputDecoration _getEffectiveDecoration() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -14961,7 +14961,7 @@ void main() {
     expect(tester.getTopLeft(find.text('Label')).dy, 12.0);
   });
 
-  // Regressing test for https://github.com/flutter/flutter/issues/140607.
+  // Regression test for https://github.com/flutter/flutter/issues/140607.
   testWidgets('TextFields can inherit errorStyle color from InputDecorationTheme.', (WidgetTester tester) async {
     Widget textFieldBuilder() {
       return MaterialApp(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -14967,7 +14967,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           inputDecorationTheme: const InputDecorationTheme(
-            errorStyle: TextStyle(color: Colors.green), 
+            errorStyle: TextStyle(color: Colors.green),
           ),
         ),
         home: const Scaffold(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -14961,6 +14961,31 @@ void main() {
     expect(tester.getTopLeft(find.text('Label')).dy, 12.0);
   });
 
+  // Regressing test for https://github.com/flutter/flutter/issues/140607.
+  testWidgets('TextFields can inherit errorStyle color from InputDecorationTheme.', (WidgetTester tester) async {
+    Widget textFieldBuilder() {
+      return MaterialApp(
+        theme: ThemeData(
+          inputDecorationTheme: InputDecorationTheme(
+            errorStyle: TextStyle(color: Colors.green), 
+          ),
+        ),
+        home: Scaffold(
+          body: TextField(
+            decoration: const InputDecoration(
+              errorText: 'error',
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(textFieldBuilder());
+    await tester.pumpAndSettle();
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    expect(state.widget.cursorColor, Colors.green);
+  });
+
   group('MaxLengthEnforcement', () {
     const int maxLength = 5;
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -14966,13 +14966,13 @@ void main() {
     Widget textFieldBuilder() {
       return MaterialApp(
         theme: ThemeData(
-          inputDecorationTheme: InputDecorationTheme(
+          inputDecorationTheme: const InputDecorationTheme(
             errorStyle: TextStyle(color: Colors.green), 
           ),
         ),
-        home: Scaffold(
+        home: const Scaffold(
           body: TextField(
-            decoration: const InputDecoration(
+            decoration: InputDecoration(
               errorText: 'error',
             ),
           ),


### PR DESCRIPTION
Previously `TextField`s error `cursorColor` was being derived without taking into account any `InputDecorationTheme` defaults. This change respects `InputDecorationTheme` defaults when deriving the error `cursorColor`.

Fixes #140607

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.