### PR TITLE
Collapse pubspec.lock by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/9_first_party_packages.yml
+++ b/.github/ISSUE_TEMPLATE/9_first_party_packages.yml
@@ -113,7 +113,7 @@ body:
         Note: Please do not upload screenshots of text. Instead, use code blocks
         or the above mentioned ways to upload this.
       value: |
-        <details open><summary>pubspec.lock</summary>
+        <details><summary>pubspec.lock</summary>
 
         ```lock
         [Paste file content here]


### PR DESCRIPTION
We recently added `open` to this as part of changing all the templates, but the lock file is often quite large, and is often ancillary to the important issues details (unlike cases like code or screenshots), so it's better to leave this one collapsed by default.