### PR TITLE
Fix menu item overflow

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -640,9 +640,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
       effectiveMenuStyle = effectiveMenuStyle.copyWith(minimumSize: MaterialStatePropertyAll<Size?>(Size(anchorWidth, 0.0)));
     }
 
-    if (widget.menuHeight != null) {
-      effectiveMenuStyle = effectiveMenuStyle.copyWith(maximumSize: MaterialStatePropertyAll<Size>(Size(double.infinity, widget.menuHeight!)));
-    }
+    effectiveMenuStyle = effectiveMenuStyle.copyWith(
+      maximumSize: MaterialStatePropertyAll<Size>(Size(widget.width ?? anchorWidth ?? double.infinity, widget.menuHeight ?? double.infinity))
+    );
     final InputDecorationTheme effectiveInputDecorationTheme = widget.inputDecorationTheme
       ?? theme.inputDecorationTheme
       ?? defaults.inputDecorationTheme!;

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -9,7 +9,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 
 import 'button_style.dart';
 import 'button_style_button.dart';

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -925,6 +925,7 @@ class MenuItemButton extends StatefulWidget {
   /// {@endtemplate}
   final bool closeOnActivate;
 
+  ///
   final Axis menuDirection;
 
   /// The widget displayed in the center of this button.
@@ -1680,6 +1681,7 @@ class SubmenuButton extends StatefulWidget {
   /// An optional icon to display after the [child].
   final Widget? trailingIcon;
 
+  ///
   final Axis menuDirection;
 
   /// The list of widgets that appear in the menu when it is opened.

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -3100,15 +3101,23 @@ class _MenuItemLabel extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: <Widget>[
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            if (leadingIcon != null) leadingIcon!,
-            Padding(
-              padding: leadingIcon != null ? EdgeInsetsDirectional.only(start: horizontalPadding) : EdgeInsets.zero,
-              child: child,
+        Expanded(
+          child: ClipRect(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                if (leadingIcon != null) leadingIcon!,
+                Expanded(
+                  child: ClipRect(
+                    child: Padding(
+                      padding: leadingIcon != null ? EdgeInsetsDirectional.only(start: horizontalPadding) : EdgeInsets.zero,
+                      child: child,
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
         if (trailingIcon != null)
           Padding(

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -855,6 +855,7 @@ class MenuItemButton extends StatefulWidget {
     this.leadingIcon,
     this.trailingIcon,
     this.closeOnActivate = true,
+    this.menuDirection = Axis.vertical,
     required this.child,
   });
 
@@ -923,6 +924,8 @@ class MenuItemButton extends StatefulWidget {
   /// Defaults to true.
   /// {@endtemplate}
   final bool closeOnActivate;
+
+  final Axis menuDirection;
 
   /// The widget displayed in the center of this button.
   ///
@@ -1111,6 +1114,7 @@ class _MenuItemButtonState extends State<MenuItemButton> {
         shortcut: widget.shortcut,
         trailingIcon: widget.trailingIcon,
         hasSubmenu: false,
+        menuDirection: widget.menuDirection,
         child: widget.child!,
       ),
     );
@@ -1608,6 +1612,7 @@ class SubmenuButton extends StatefulWidget {
     this.statesController,
     this.leadingIcon,
     this.trailingIcon,
+    this.menuDirection = Axis.vertical,
     required this.menuChildren,
     required this.child,
   });
@@ -1674,6 +1679,8 @@ class SubmenuButton extends StatefulWidget {
 
   /// An optional icon to display after the [child].
   final Widget? trailingIcon;
+
+  final Axis menuDirection;
 
   /// The list of widgets that appear in the menu when it is opened.
   ///
@@ -1961,6 +1968,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
                 trailingIcon: widget.trailingIcon,
                 hasSubmenu: true,
                 showDecoration: (controller._anchor!._parent?._orientation ?? Axis.horizontal) == Axis.vertical,
+                menuDirection: controller._anchor!._parent?._orientation ?? widget.menuDirection,
                 child: child ?? const SizedBox(),
               ),
             ),
@@ -3064,6 +3072,7 @@ class _MenuItemLabel extends StatelessWidget {
     this.leadingIcon,
     this.trailingIcon,
     this.shortcut,
+    this.menuDirection = Axis.vertical,
     required this.child,
   });
 
@@ -3087,6 +3096,8 @@ class _MenuItemLabel extends StatelessWidget {
   /// the shortcut.
   final MenuSerializableShortcut? shortcut;
 
+  final Axis menuDirection;
+
   /// The required label child widget.
   final Widget child;
 
@@ -3097,27 +3108,43 @@ class _MenuItemLabel extends StatelessWidget {
       _kLabelItemMinSpacing,
       _kLabelItemDefaultSpacing + density.horizontal * 2,
     );
+
+    Widget leadings;
+    if (menuDirection == Axis.vertical) {
+      leadings = Expanded(
+        child: ClipRect(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (leadingIcon != null) leadingIcon!,
+              Expanded(
+                child: ClipRect(
+                  child: Padding(
+                    padding: leadingIcon != null ? EdgeInsetsDirectional.only(start: horizontalPadding) : EdgeInsets.zero,
+                    child: child,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      leadings = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (leadingIcon != null) leadingIcon!,
+          Padding(
+            padding: leadingIcon != null ? EdgeInsetsDirectional.only(start: horizontalPadding) : EdgeInsets.zero,
+            child: child,
+          ),
+        ],
+      );
+    }
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: <Widget>[
-        Expanded(
-          child: ClipRect(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                if (leadingIcon != null) leadingIcon!,
-                Expanded(
-                  child: ClipRect(
-                    child: Padding(
-                      padding: leadingIcon != null ? EdgeInsetsDirectional.only(start: horizontalPadding) : EdgeInsets.zero,
-                      child: child,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+        leadings,
         if (trailingIcon != null)
           Padding(
             padding: EdgeInsetsDirectional.only(start: horizontalPadding),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1932,6 +1932,38 @@ void main() {
 
     expect(find.byType(Scrollbar), findsOneWidget);
   }, variant: TargetPlatformVariant.all());
+
+  testWidgets('Long text item does not overflow', (WidgetTester tester) async {
+    const String longText =
+      'is a color that sings of hope, A hue that shines like gold. It is the color of dreams, A shade that never grows old.';
+    final List<DropdownMenuEntry<int>> menuItems = <DropdownMenuEntry<int>>[
+      const DropdownMenuEntry<int>(
+        value: 0,
+        label: longText,
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            DropdownMenu<int>(
+              expandedInsets: EdgeInsets.zero,
+              dropdownMenuEntries: menuItems,
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    await tester.pump();
+    await tester.tap(find.byType(DropdownMenu<int>));
+    await tester.pumpAndSettle();
+
+    // No exception should be thrown.
+    expect(tester.takeException(), isNull);
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta_meta.dart';
 
 import '../widgets/semantics_tester.dart';
 
@@ -2436,6 +2437,25 @@ void main() {
       await tester.tap(find.text('Button 1'));
       await tester.pump();
       expect(find.byType(MenuItemButton), findsNWidgets(1));
+    });
+
+    testWidgets('MenuItemButton does not overflow when child is long', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 200,
+            child: MenuItemButton(
+              onPressed: () {},
+              child: const Text('MenuItem Button does not overflow when child is long'),
+            ),
+          ),
+        ),
+      ));
+
+      await tester.pumpAndSettle();
+
+      // No exception should be thrown.
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta_meta.dart';
 
 import '../widgets/semantics_tester.dart';
 

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -662,7 +662,7 @@ void main() {
       expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTRB(0, 0, 800, 48)));
       expect(
         tester.getRect(find.text(TestMenu.subMenu10.label)),
-        equals(const Rect.fromLTRB(124.0, 73.0, 278.0, 87.0)),
+        equals(const Rect.fromLTRB(124.0, 73.0, 314.0, 87.0)),
       );
       expect(
         tester.getRect(
@@ -730,7 +730,7 @@ void main() {
       expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTRB(0, 0, 800, 48)));
       expect(
         tester.getRect(find.text(TestMenu.subMenu10.label)),
-        equals(const Rect.fromLTRB(522.0, 73.0, 676.0, 87.0)),
+        equals(const Rect.fromLTRB(486.0, 73.0, 676.0, 87.0)),
       );
       expect(
         tester.getRect(
@@ -941,7 +941,7 @@ void main() {
       expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTRB(22.0, 22.0, 778.0, 70.0)));
       expect(
         tester.getRect(find.text(TestMenu.subMenu10.label)),
-        equals(const Rect.fromLTRB(146.0, 95.0, 300.0, 109.0)),
+        equals(const Rect.fromLTRB(146.0, 95.0, 336.0, 109.0)),
       );
       expect(
         tester.getRect(find.ancestor(of: find.text(TestMenu.subMenu10.label), matching: find.byType(Material)).at(1)),
@@ -997,7 +997,7 @@ void main() {
       expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTRB(22.0, 22.0, 778.0, 70.0)));
       expect(
         tester.getRect(find.text(TestMenu.subMenu10.label)),
-        equals(const Rect.fromLTRB(500.0, 95.0, 654.0, 109.0)),
+        equals(const Rect.fromLTRB(464.0, 95.0, 654.0, 109.0)),
       );
       expect(
         tester.getRect(find.ancestor(of: find.text(TestMenu.subMenu10.label), matching: find.byType(Material)).at(1)),
@@ -1261,6 +1261,7 @@ void main() {
 
     testWidgets('diagnostics', (WidgetTester tester) async {
       const MenuItemButton item = MenuItemButton(
+        menuDirection: Axis.horizontal,
         shortcut: SingleActivator(LogicalKeyboardKey.keyA),
         child: Text('label2'),
       );

--- a/packages/flutter/test/material/menu_style_test.dart
+++ b/packages/flutter/test/material/menu_style_test.dart
@@ -281,7 +281,7 @@ void main() {
       expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTRB(228.0, 0.0, 572.0, 48.0)));
       expect(
         tester.getRect(find.text(TestMenu.subMenu10.label)),
-        equals(const Rect.fromLTRB(366.0, 68.0, 520.0, 82.0)),
+        equals(const Rect.fromLTRB(366.0, 68.0, 559.0, 82.0)),
       );
       expect(
         tester.getRect(find.ancestor(of: find.text(TestMenu.subMenu10.label), matching: find.byType(Material)).at(1)),


### PR DESCRIPTION
Fixes #129439 and #140596

This PR is to fix the overflow issue when the menu item contains long content in `MenuItemButton` and `DropdownMenu`.

Before:
<img src="https://github.com/flutter/flutter/assets/36861262/c70afd95-5e57-43dc-81ec-9237d92980d9" width="300">

After:
<img src="https://github.com/flutter/flutter/assets/36861262/f66f6467-2787-4bc3-a9db-8487c5b74ee7" width="300">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
