### PR TITLE
Add covariants to reduce subclass casts in 2D APIs

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_delegate.dart
+++ b/packages/flutter/lib/src/widgets/scroll_delegate.dart
@@ -895,7 +895,7 @@ abstract class TwoDimensionalChildDelegate extends ChangeNotifier {
   /// widgets have changed, a new delegate must be provided, and the new
   /// delegate's [shouldRebuild] method must return true. Alternatively,
   /// calling [notifyListeners] will allow the same delegate to be used.
-  Widget? build(BuildContext context, ChildVicinity vicinity);
+  Widget? build(BuildContext context, covariant ChildVicinity vicinity);
 
   /// Called whenever a new instance of the child delegate class is
   /// provided.

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -793,7 +793,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   ///
   /// Returns null if there is no active child for the given [ChildVicinity].
   @protected
-  RenderBox? getChildFor(ChildVicinity vicinity) => _children[vicinity];
+  RenderBox? getChildFor(covariant ChildVicinity vicinity) => _children[vicinity];
 
   @override
   void attach(PipelineOwner owner) {

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2714,6 +2714,38 @@ void main() {
   });
 }
 
+class _TestVicinity extends ChildVicinity {
+  const _TestVicinity({required super.xIndex, required super.yIndex});
+}
+
+class _TestBaseDelegate extends TwoDimensionalChildDelegate { //ignore: unused_element
+  // Would fail analysis without covariant
+  @override
+  Widget? build(BuildContext context, _TestVicinity vicinity) => null;
+
+  @override
+  bool shouldRebuild(covariant TwoDimensionalChildDelegate oldDelegate) => false;
+
+}
+
+class _TestBuilderDelegate extends TwoDimensionalChildBuilderDelegate { //ignore: unused_element
+  _TestBuilderDelegate({required super.builder});
+  // Would fail analysis without covariant
+  @override
+  Widget? build(BuildContext context, _TestVicinity vicinity) {
+    return super.build(context, vicinity);
+  }
+}
+
+class _TestListDelegate extends TwoDimensionalChildListDelegate { //ignore: unused_element
+  _TestListDelegate({required super.children});
+  // Would fail analysis without covariant
+  @override
+  Widget? build(BuildContext context, _TestVicinity vicinity) {
+    return super.build(context, vicinity);
+  }
+}
+
 RenderTwoDimensionalViewport getViewport(WidgetTester tester, Key childKey) {
   return RenderAbstractViewport.of(
     tester.renderObject(find.byKey(childKey))
@@ -2777,6 +2809,11 @@ class _SomeRenderTwoDimensionalViewport extends RenderTwoDimensionalViewport { /
   @override
   set delegate(_SomeDelegateMixin value) { // Analysis would fail without covariant
     super.delegate = value;
+  }
+
+  @override
+  RenderBox? getChildFor(_TestVicinity vicinity) { // Analysis would fail without covariant
+    return super.getChildFor(vicinity);
   }
 
   @override


### PR DESCRIPTION
While working in https://pub.dev/packages/two_dimensional_scrollables, I found I could eliminate some casts if we added covariants here in the framework.
Much of the 2D aPI in the framework is abstract, so I think it make sense to add these and make it easier/cleaner for subclasses using the APIs.
I made a similar change in https://github.com/flutter/flutter/pull/131358, this would cover all of the cases I could find so its nice and accommodating now.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
