### PR TITLE
[cp] Replace deprecated `exists` in podhelper.rb

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -327,7 +327,7 @@ end
 
 def flutter_parse_xcconfig_file(file)
   file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
+  if !File.exist? file_abs_path
     return [];
   end
   entries = Hash.new
@@ -346,7 +346,7 @@ end
 
 def flutter_get_local_engine_dir(xcconfig_file)
   file_abs_path = File.expand_path(xcconfig_file)
-  if !File.exists? file_abs_path
+  if !File.exist? file_abs_path
     return nil
   end
   config = flutter_parse_xcconfig_file(xcconfig_file)


### PR DESCRIPTION
Cherry picks https://github.com/flutter/flutter/pull/141169 to beta

The recently landed https://github.com/flutter/flutter/pull/140222 accidentally used the deprecated `exists?` instead of the non-deprecated `exist?` (which other code in this file is already, correctly, using).

See https://github.com/flutter/flutter/issues/141167