### PR TITLE
FlutterExtension: make fields non-static

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -41,10 +41,10 @@ import org.gradle.internal.os.OperatingSystem
 */
 class FlutterExtension {
     /** Sets the compileSdkVersion used by default in Flutter app projects. */
-    static int compileSdkVersion = 34
+    final int compileSdkVersion = 34
 
     /** Sets the minSdkVersion used by default in Flutter app projects. */
-    static int minSdkVersion = 19
+    final int minSdkVersion = 19
 
     /**
      * Sets the targetSdkVersion used by default in Flutter app projects.
@@ -52,14 +52,14 @@ class FlutterExtension {
      *
      * See https://developer.android.com/guide/topics/manifest/uses-sdk-element.
      */
-    static int targetSdkVersion = 33
+    final int targetSdkVersion = 33
 
     /**
      * Sets the ndkVersion used by default in Flutter app projects.
      * Chosen as default version of the AGP version below as found in
      * https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp.
      */
-    static String ndkVersion = "23.1.7779620"
+    final String ndkVersion = "23.1.7779620"
 
     /**
      * Specifies the relative directory to the Flutter project directory.


### PR DESCRIPTION
There's no issue for this PR. I can create one if requested.

## Summary

This PR makes public fields of `FlutterExtension` non-static. The aim is to make migrating from Gradle Groovy DSL to Gradle Kotlin DSL easier for Flutter developers, because...

### Without this PR

**android/app/build.gradle.kts**

```kotlin
plugins {
    id "com.android.application"
    id "dev.flutter.flutter-gradle-plugin"
}

android {
    namespace = "io.flutter.examples.hello_world"
    compileSdk = FlutterExtension.compileSdkVersion

    defaultConfig {
        applicationId = "io.flutter.examples.hello_world"
        minSdk = FlutterExtension.minSdkVersion
        targetSdk = FlutterExtension.targetSdkVersion
        // ...
    }
}
// ...
```

Groovy and Java allow accessing static fields of a class through its instance, but Kotlin is being more "correct" and disallows that.

### With this PR

Thanks to this PR, the user won't have to replace `flutter` with FlutterExtension in some places, thus decreasing possible confusion.

```kotlin
plugins {
    id "com.android.application"
    id "dev.flutter.flutter-gradle-plugin"
}

android {
    namespace = "io.flutter.examples.hello_world"
    compileSdk = flutter.compileSdkVersion

    defaultConfig {
        applicationId = "io.flutter.examples.hello_world"
        minSdk = flutter.minSdkVersion
        targetSdk = flutter.targetSdkVersion
        // ...
    }
}
// ...
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
