### PR TITLE
Sort Swift imports in templates

### DIFF
--- a/dev/a11y_assessments/ios/Runner/AppDelegate.swift
+++ b/dev/a11y_assessments/ios/Runner/AppDelegate.swift
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import UIKit
 import Flutter
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/dev/a11y_assessments/macos/RunnerTests/RunnerTests.swift
+++ b/dev/a11y_assessments/macos/RunnerTests/RunnerTests.swift
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import FlutterMacOS
 import Cocoa
+import FlutterMacOS
 import XCTest
 
 class RunnerTests: XCTestCase {

--- a/dev/benchmarks/complex_layout/ios/Runner/AppDelegate.swift
+++ b/dev/benchmarks/complex_layout/ios/Runner/AppDelegate.swift
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import UIKit
 import Flutter
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/dev/integration_tests/ios_app_with_extensions/ios/Runner/AppDelegate.swift
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Runner/AppDelegate.swift
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import UIKit
 import Flutter
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/dev/integration_tests/ios_app_with_extensions/ios/watch Extension/HostingController.swift
+++ b/dev/integration_tests/ios_app_with_extensions/ios/watch Extension/HostingController.swift
@@ -9,9 +9,9 @@
 //  Created by Georg Wechslberger on 08.04.20.
 //
 
-import WatchKit
 import Foundation
 import SwiftUI
+import WatchKit
 
 class HostingController: WKHostingController<ContentView> {
     override var body: ContentView {

--- a/dev/integration_tests/non_nullable/ios/Runner/AppDelegate.swift
+++ b/dev/integration_tests/non_nullable/ios/Runner/AppDelegate.swift
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import UIKit
 import Flutter
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/dev/manual_tests/ios/Runner/AppDelegate.swift
+++ b/dev/manual_tests/ios/Runner/AppDelegate.swift
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import UIKit
 import Flutter
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/packages/flutter_tools/templates/app_shared/ios-swift.tmpl/Runner/AppDelegate.swift
+++ b/packages/flutter_tools/templates/app_shared/ios-swift.tmpl/Runner/AppDelegate.swift
@@ -1,5 +1,5 @@
-import UIKit
 import Flutter
+import UIKit
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/RunnerTests/RunnerTests.swift.tmpl
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/RunnerTests/RunnerTests.swift.tmpl
@@ -1,5 +1,5 @@
-import FlutterMacOS
 import Cocoa
+import FlutterMacOS
 import XCTest
 {{#withPlatformChannelPluginHook}}
 


### PR DESCRIPTION
`swift-format` alphabetizes imports.  Alphabetize them in swift template files and integration tests.

I found this as part of https://github.com/flutter/flutter/issues/41129 running `swift-import` on packages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
