### PR TITLE
Fix assertion failure when reordering two dimensional children

### DIFF
--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -779,6 +779,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   /// Children must have a [ParentData] of type
   /// [TwoDimensionalViewportParentData], or a subclass thereof.
   @protected
+  @mustCallSuper
   TwoDimensionalViewportParentData parentDataOf(RenderBox child) {
     assert(_children.containsValue(child) ||
         _keepAliveBucket.containsValue(child) ||

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -780,7 +780,9 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   /// [TwoDimensionalViewportParentData], or a subclass thereof.
   @protected
   TwoDimensionalViewportParentData parentDataOf(RenderBox child) {
-    assert(_children.containsValue(child));
+    assert(_children.containsValue(child) ||
+        _keepAliveBucket.containsValue(child) ||
+        _debugOrphans!.contains(child));
     return child.parentData! as TwoDimensionalViewportParentData;
   }
 

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -195,7 +195,7 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
 
   @override
   TestExtendedParentData parentDataOf(RenderBox child) {
-    return child.parentData! as TestExtendedParentData;
+    return super.parentDataOf(child) as TestExtendedParentData;
   }
 
   @override

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2711,6 +2711,54 @@ void main() {
         );
       });
     });
+
+    testWidgets('correctly reorders children and wont throw assertion failure',
+        (WidgetTester tester) async {
+      final TwoDimensionalChildBuilderDelegate delegate1 =
+          TwoDimensionalChildBuilderDelegate(
+              maxXIndex: 5,
+              maxYIndex: 5,
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              builder: (BuildContext context, ChildVicinity vicinity) {
+                ValueKey<int>? key;
+                if (vicinity == const ChildVicinity(xIndex: 1, yIndex: 1)) {
+                  key = const ValueKey<int>(1);
+                } else if (vicinity ==
+                    const ChildVicinity(xIndex: 1, yIndex: 2)) {
+                  key = const ValueKey<int>(2);
+                }
+                return SizedBox.square(key: key, dimension: 200);
+              });
+      final TwoDimensionalChildBuilderDelegate delegate2 =
+          TwoDimensionalChildBuilderDelegate(
+              maxXIndex: 5,
+              maxYIndex: 5,
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              builder: (BuildContext context, ChildVicinity vicinity) {
+                ValueKey<int>? key;
+                if (vicinity == const ChildVicinity(xIndex: 0, yIndex: 0)) {
+                  key = const ValueKey<int>(1);
+                } else if (vicinity ==
+                    const ChildVicinity(xIndex: 1, yIndex: 1)) {
+                  key = const ValueKey<int>(2);
+                }
+                return SizedBox.square(key: key, dimension: 200);
+              });
+      addTearDown(delegate1.dispose);
+      addTearDown(delegate2.dispose);
+
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
+      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
+          const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate2));
+      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
+          const Rect.fromLTWH(0.0, 0.0, 200.0, 200.0));
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
+      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
+          const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
+    }, variant: TargetPlatformVariant.all());
   });
 }
 


### PR DESCRIPTION
It fixes assertion failure due to unstable state of children list during reordering in `RenderTwoDimensionalViewport.parentDataOf`. This changes the assertion to check debug orphan list and `keepAlive` bucket in addition to children list to determine whether child belongs to this render object or not.

- Fixes #141101 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
