### PR TITLE
Delete redundant `settings.ext.flutterSdkPath`

### DIFF
--- a/packages/flutter_tools/templates/app_shared/android.tmpl/settings.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/settings.gradle.tmpl
@@ -5,10 +5,9 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
     repositories {
         google()


### PR DESCRIPTION
This line is a leftover. Removing it is a no-op.