### PR TITLE
Adjust the position of require File.expand_path

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -310,8 +310,38 @@ end
           },
         );
 
-        final File hostPodfileLockFile = File(path.join(objectiveCHostApp.path, 'Podfile.lock'));
-        final String hostPodfileLockOutput = hostPodfileLockFile.readAsStringSync();
+        File hostPodfileLockFile = File(path.join(objectiveCHostApp.path, 'Podfile.lock'));
+        String hostPodfileLockOutput = hostPodfileLockFile.readAsStringSync();
+        if (!hostPodfileLockOutput.contains(':path: "../hello/.ios/Flutter"')
+            || !hostPodfileLockOutput.contains(':path: "../hello/.ios/Flutter/FlutterPluginRegistrant"')
+            || !hostPodfileLockOutput.contains(':path: "../hello/.ios/.symlinks/plugins/url_launcher_ios/ios"')
+            || hostPodfileLockOutput.contains('android_alarm_manager')
+            || hostPodfileLockOutput.contains(dartPluginName)) {
+          print(hostPodfileLockOutput);
+          throw TaskResult.failure('Building host app Podfile.lock does not contain expected pods');
+        }
+
+        section('Validate install_flutter_[engine_pod|plugin_pods|application_pod] methods in the Podfile can be executed normally');
+
+        podfileContent = podfileContent.replaceFirst('''
+  install_all_flutter_pods flutter_application_path
+''', '''
+  install_flutter_engine_pod(flutter_application_path)
+  install_flutter_plugin_pods(flutter_application_path)
+  install_flutter_application_pod(flutter_application_path)
+''');
+        await podfile.writeAsString(podfileContent, flush: true);
+
+        await exec(
+          'pod',
+          <String>['install'],
+          environment: <String, String>{
+            'LANG': 'en_US.UTF-8',
+          },
+        );
+
+        hostPodfileLockFile = File(path.join(objectiveCHostApp.path, 'Podfile.lock'));
+        hostPodfileLockOutput = hostPodfileLockFile.readAsStringSync();
         if (!hostPodfileLockOutput.contains(':path: "../hello/.ios/Flutter"')
             || !hostPodfileLockOutput.contains(':path: "../hello/.ios/Flutter/FlutterPluginRegistrant"')
             || !hostPodfileLockOutput.contains(':path: "../hello/.ios/.symlinks/plugins/url_launcher_ios/ios"')

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -28,8 +28,6 @@ POSTINSTALL
     raise 'Missing `flutter_post_install(installer)` in Podfile `post_install` block'
   end
 
-  require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
-
   flutter_application_path ||= File.join('..', '..')
   install_flutter_engine_pod(flutter_application_path)
   install_flutter_plugin_pods(flutter_application_path)
@@ -111,6 +109,8 @@ def flutter_root
   # This should never happen...
   raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
 # Run the post-install script to set build settings on Flutter plugins.
 #


### PR DESCRIPTION






On `Podfile`:

```ruby
flutter_application_path = '../flutter_module'
load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')

target 'OCProject' do
  # Comment the next line if you don't want to use dynamic frameworks
  use_frameworks!

  # Pods for OCProject
  # install_all_flutter_pods(flutter_application_path)
  # install_flutter_engine_pod(flutter_application_path)
  # install_flutter_application_pod(flutter_application_path)
  install_flutter_plugin_pods(flutter_application_path)

end

post_install do |installer|
  flutter_post_install(installer)
end
```
Encountering the following error after executing `pod install`:

```shell
pod install

[!] Invalid `Podfile` file: undefined method `flutter_relative_path_from_podfile' for #<Pod::Podfile:0x000000010e74c520 @defined_in_file=#<Pathname:/Users/lxf/gitHub/flutter_hybrid_bug/OCProject/Podfile>, @internal_hash={}, @root_target_definitions=[#<Pod::Podfile::TargetDefinition label=Pods>], @current_target_definition=#<Pod::Podfile::TargetDefinition label=Pods>>

  relative = flutter_relative_path_from_podfile(export_script_directory)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^.

 #  from /Users/lxf/gitHub/flutter_hybrid_bug/OCProject/Podfile:17
 #  -------------------------------------------
 #    # install_flutter_plugin_pods(flutter_application_path)
 >    install_flutter_application_pod(flutter_application_path)
 #
 #  -------------------------------------------
```

The `flutter_relative_path_from_podfile` method is in `flutter_tools/bin/podhelper.rb`, but now `flutter_tools/bin/podhelper.rb` is only required in `install_all_flutter_pods` in `podhelper.rb.tmpl`.

Sometimes we only need to use the `install_flutter_plugin_pods` method in podhelper.rb. For example, using `Shorebird` in an iOS hybird app scenario, we need to build `Flutter.xcframework` and `App.xcframework` and embed them into the iOS native project. In order to avoid unnecessary conflicts, use `install_flutter_plugin_pods` method to install Flutter plugin pods.

[Shorebird - Code Push In Hybrid Apps](https://docs.shorebird.dev/guides/hybrid-app/ios)

So I adjust the position of `require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
