### PR TITLE
Reland "BoxPainter should dispatch creation and disposal events."

### DIFF
--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -198,9 +198,18 @@ abstract class Decoration with Diagnosticable {
 /// happens, the [onChanged] callback will be invoked. To stop this callback
 /// from being called after the painter has been discarded, call [dispose].
 abstract class BoxPainter {
-  /// Abstract const constructor. This constructor enables subclasses to provide
-  /// const constructors so that they can be used in const expressions.
-  const BoxPainter([this.onChanged]);
+  /// Default abstract constructor for box painters.
+  BoxPainter([this.onChanged]) {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      FlutterMemoryAllocations.instance.dispatchObjectCreated(
+        library: 'package:flutter/painting.dart',
+        className: '$BoxPainter',
+        object: this,
+      );
+    }
+  }
 
   /// Paints the [Decoration] for which this object was created on the
   /// given canvas using the given configuration.
@@ -243,5 +252,9 @@ abstract class BoxPainter {
   /// The [onChanged] callback will not be invoked after this method has been
   /// called.
   @mustCallSuper
-  void dispose() { }
+  void dispose() {
+    if (kFlutterMemoryAllocationsEnabled) {
+      FlutterMemoryAllocations.instance.dispatchObjectDisposed(object: this);
+    }
+  }
 }

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -9,6 +9,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../image_data.dart';
 import '../painting/mocks_for_image_cache.dart';
@@ -813,4 +814,16 @@ void main() {
 
     info.dispose();
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/87442
+
+  test('$BoxPainter dispatches memory events', () async {
+    await expectLater(
+      await memoryEvents(() => _BoxPainter().dispose(), _BoxPainter),
+      areCreateAndDispose,
+    );
+  });
+}
+
+class _BoxPainter extends BoxPainter {
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {}
 }


### PR DESCRIPTION
This PR relands https://github.com/flutter/flutter/pull/141526, which was reverted in https://github.com/flutter/flutter/pull/141545

### Description
- Adds `BoxPainter` creation and disposal events dispatching for memory leak tracking as part of https://github.com/flutter/flutter/issues/141198

### Tests
- Updates `decoration_test.dart` to test `BoxPainter` object creation and disposal events dispatching.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

