### PR TITLE
Re-adding size: view.physicalSize / devicePixelRatio, because the printing dependency in version 5.11.1 was making the build impossible!

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -26,6 +26,7 @@ class ViewConfiguration {
   /// [ViewConfiguration.fromView] is a more convenient way for deriving a
   /// [ViewConfiguration] from a given [FlutterView].
   const ViewConfiguration({
+    size: view.physicalSize / devicePixelRatio,
     this.physicalConstraints = const BoxConstraints(maxWidth: 0, maxHeight: 0),
     this.logicalConstraints = const BoxConstraints(maxWidth: 0, maxHeight: 0),
     this.devicePixelRatio = 1.0,

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -26,9 +26,9 @@ class ViewConfiguration {
   /// [ViewConfiguration.fromView] is a more convenient way for deriving a
   /// [ViewConfiguration] from a given [FlutterView].
   const ViewConfiguration({
-    size: devicePixelRatio,
     this.physicalConstraints = const BoxConstraints(maxWidth: 0, maxHeight: 0),
     this.logicalConstraints = const BoxConstraints(maxWidth: 0, maxHeight: 0),
+    size = const BoxConstraints(maxWidth: 0, maxHeight: 0),
     this.devicePixelRatio = 1.0,
   });
 

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -26,7 +26,7 @@ class ViewConfiguration {
   /// [ViewConfiguration.fromView] is a more convenient way for deriving a
   /// [ViewConfiguration] from a given [FlutterView].
   const ViewConfiguration({
-    size: view.physicalSize / devicePixelRatio,
+    size: devicePixelRatio,
     this.physicalConstraints = const BoxConstraints(maxWidth: 0, maxHeight: 0),
     this.logicalConstraints = const BoxConstraints(maxWidth: 0, maxHeight: 0),
     this.devicePixelRatio = 1.0,


### PR DESCRIPTION
Re-adding size: view.physicalSize / devicePixelRatio, because the printing dependency in version 5.11.1 was making the build impossible!