### PR TITLE
Add documentation which explains that `debugPrint` also logs in release mode

### DIFF
--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -31,11 +31,11 @@ typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
 /// Prints a message to the console, which you can access using the "flutter"
 /// tool's "logs" command ("flutter logs").
 ///
-/// `debugPrint` logs to console even in [release mode](https://docs.flutter.dev/testing/build-modes#release).
-/// To disable logging from [debugPrint] in release mode, set it to a no-op:
+/// The [debugPrint] function logs to console even in [release mode](https://docs.flutter.dev/testing/build-modes#release).
+/// As per convention, calls to [debugPrint] should be within a debug mode check or an assert:
 /// ```dart
-/// if(kReleaseMode) {
-///   debugPrint = (_, {int? wrapWidth}) {};
+/// if (kDebugMode) {
+///   debugPrint('A useful message');
 /// }
 /// ```
 ///

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -31,6 +31,14 @@ typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
 /// Prints a message to the console, which you can access using the "flutter"
 /// tool's "logs" command ("flutter logs").
 ///
+/// `debugPrint` logs to console even in [release mode](https://docs.flutter.dev/testing/build-modes#release).
+/// To disable logging from [debugPrint] in release mode, set it to a no-op:
+/// ```dart
+/// if(kReleaseMode) {
+///   debugPrint = (_, {int? wrapWidth}) {};
+/// }
+/// ```
+///
 /// See also:
 ///
 ///   * [DebugPrintCallback], for function parameters and usage details.


### PR DESCRIPTION
It's confusing that `debugPrint` also prints in release mode, given that a lot (most?) other things prefixed with `debug` don't do anything in release mode. Therefore, this adds some documentation that this is indeed logging in release mode and adds an example how to disable this.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
