### PR TITLE
handle rc versions of gradle in version compare 

### DIFF
--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -450,5 +450,6 @@ Future<void> main() async {
   await task(combine(<TaskFunction>[
     // ignore: avoid_redundant_argument_values
     ModuleTest('module-gradle-7.6', gradleVersion: '7.6.3').call,
+    ModuleTest('module-gradle-7.6', gradleVersion: '7.6-rc-2').call,
   ]));
 }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1423,7 +1423,7 @@ class FlutterPlugin implements Plugin<Project> {
 
     // compareTo implementation of version strings in the format of ints and periods
     // Requires non null objects.
-    // Will not crash on RC canndiate strings but considers all rc candidates the same version.
+    // Will not crash on RC candidate strings but considers all RC candidates the same version.
     static int compareVersionStrings(String firstString, String secondString) {
         List firstVersion = firstString.tokenize(".")
         List secondVersion = secondString.tokenize(".")

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1436,14 +1436,20 @@ class FlutterPlugin implements Plugin<Project> {
             int firstInt = 0;
             int secondInt = 0
             try {
-                // Strip any chars after "-". For example "8.6-rc-2"
-                firstInt = firstAtIndex.substring(0, firstAtIndex.indexOf('-').toInteger())
+                if (firstAtIndex.contains("-")) {
+                    // Strip any chars after "-". For example "8.6-rc-2"
+                    firstAtIndex = firstAtIndex.substring(0, firstAtIndex.indexOf('-'))
+                }
+                firstInt = firstAtIndex.toInteger()
             } catch (NumberFormatException nfe) {
                 println(nfe)
             }
             try {
-                // Strip any chars after "-". For example "8.6-rc-2"
-                secondInt = secondAtIndex.substring(0, secondAtIndex.indexOf('-').toInteger())
+                if (firstAtIndex.contains("-")) {
+                    // Strip any chars after "-". For example "8.6-rc-2"
+                    secondAtIndex = secondAtIndex.substring(0, secondAtIndex.indexOf('-'))
+                }
+                secondInt = secondAtIndex.toInteger()
             } catch (NumberFormatException nfe) {
                 println(nfe)
             }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1423,6 +1423,7 @@ class FlutterPlugin implements Plugin<Project> {
 
     // compareTo implementation of version strings in the format of ints and periods
     // Requires non null objects.
+    // Will not crash on RC canndiate strings but considers all rc candidates the same version.
     static int compareVersionStrings(String firstString, String secondString) {
         List firstVersion = firstString.tokenize(".")
         List secondVersion = secondString.tokenize(".")
@@ -1430,12 +1431,26 @@ class FlutterPlugin implements Plugin<Project> {
         def commonIndices = Math.min(firstVersion.size(), secondVersion.size())
 
         for (int i = 0; i < commonIndices; i++) {
-            def firstAtIndex = firstVersion[i].toInteger()
-            def secondAtIndex = secondVersion[i].toInteger()
+            String firstAtIndex = firstVersion[i]
+            String secondAtIndex = secondVersion[i]
+            int firstInt = 0;
+            int secondInt = 0
+            try {
+                // Strip any chars after "-". For example "8.6-rc-2"
+                firstInt = firstAtIndex.substring(0, firstAtIndex.indexOf('-').toInteger())
+            } catch (NumberFormatException nfe) {
+                println(nfe)
+            }
+            try {
+                // Strip any chars after "-". For example "8.6-rc-2"
+                secondInt = secondAtIndex.substring(0, secondAtIndex.indexOf('-').toInteger())
+            } catch (NumberFormatException nfe) {
+                println(nfe)
+            }
 
-            if (firstAtIndex != secondAtIndex) {
+            if (firstInt != secondInt) {
                 // <=> in groovy delegates to compareTo
-                return firstAtIndex <=> secondAtIndex
+                return firstInt <=> secondInt
             }
         }
 


### PR DESCRIPTION
- handle number format exceptions and strip rc information from version compare
- add test that handles rc format

part 2/n https://github.com/flutter/flutter/issues/138523

Helpfully pointed out by [asaarnak](https://github.com/asaarnak) https://github.com/flutter/flutter/pull/139325#issuecomment-1892554584

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

