### PR TITLE
Fix the --empty flag to not try working with non-app templates

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -772,8 +772,8 @@ Your $application code is in $relativeAppMain.
     final List<FileSystemEntity> files = testDir.listSync(recursive: true);
     try {
       testDir.deleteSync(recursive: true);
-    } on FileSystemException {
-      return 0;
+    } on FileSystemException catch (exception) {
+      throwToolExit('Failed to delete test directory: $exception');
     }
     return -files.length;
   }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -208,17 +208,19 @@ class CreateCommand extends CreateBase {
     String? sampleCode;
     final String? sampleArgument = stringArg('sample');
     final bool emptyArgument = boolArg('empty');
+    final FlutterProjectType template = _getProjectType(projectDir);
     if (sampleArgument != null) {
-      final String? templateArgument = stringArg('template');
-      if (templateArgument != null && FlutterProjectType.fromCliName(templateArgument) != FlutterProjectType.app) {
+      if (template != FlutterProjectType.app) {
         throwToolExit('Cannot specify --sample with a project type other than '
           '"${FlutterProjectType.app.cliName}"');
       }
       // Fetch the sample from the server.
       sampleCode = await _fetchSampleFromServer(sampleArgument);
     }
+    if (emptyArgument && template != FlutterProjectType.app) {
+      throwToolExit('The --empty flag is only supported for the app template.');
+    }
 
-    final FlutterProjectType template = _getProjectType(projectDir);
     final bool generateModule = template == FlutterProjectType.module;
     final bool generateMethodChannelsPlugin = template == FlutterProjectType.plugin;
     final bool generateFfiPackage = template == FlutterProjectType.packageFfi;
@@ -764,8 +766,15 @@ Your $application code is in $relativeAppMain.
 
   int _removeTestDir(Directory directory) {
     final Directory testDir = directory.childDirectory('test');
+    if (!testDir.existsSync()) {
+      return 0;
+    }
     final List<FileSystemEntity> files = testDir.listSync(recursive: true);
-    testDir.deleteSync(recursive: true);
+    try {
+      testDir.deleteSync(recursive: true);
+    } on FileSystemException {
+      return 0;
+    }
     return -files.length;
   }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2038,6 +2038,26 @@ void main() {
       isNot(contains('Getting Started')));
   });
 
+
+  testUsingContext("can't create an empty non-application project", () async {
+    final String outputDir = globals.fs.path.join(tempDir.path, 'test_project');
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+    final List<String> args = <String>[
+      'create',
+      '--no-pub',
+      '--empty',
+      '--template=plugin',
+      outputDir,
+    ];
+
+    await expectLater(
+      runner.run(args),
+      throwsToolExit(
+        message: 'The --empty flag is only supported for the app template.',
+    ));
+  });
+
   testUsingContext('can create a sample-based project', () async {
     await _createAndAnalyzeProject(
       projectDir,


### PR DESCRIPTION
## Description

This adds a check to make sure that the `--empty` flag isn't applied to non-app templates.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/141592

## Tests
 - Added a test.