### PR TITLE
Label "flutter_localizations" PRs with "framework"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -107,6 +107,7 @@ framework:
       - packages/flutter_driver/**/*
       - packages/flutter_goldens/**/*
       - packages/flutter_goldens_client/**/*
+      - packages/flutter_localizations/**/*
       - packages/flutter_test/**/*
       - packages/integration_test/**/*
       - examples/api/**/*


### PR DESCRIPTION
Make sure that these PRs don't slip through the cracks and only get caught during the stale PR review in critical triage.