### PR TITLE
Make test file systems/platforms used in asset_bundle_test.dart less dependent on the host platform

### DIFF
--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -36,7 +36,7 @@ void main() {
       testFileSystem = MemoryFileSystem();
       testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
       logger = BufferLogger.test();
-      platform = FakePlatform(operatingSystem: globals.platform.operatingSystem);
+      platform = FakePlatform();
     });
 
     testUsingContext('nonempty', () async {
@@ -45,6 +45,7 @@ void main() {
       expect(ab.entries.length, greaterThan(0));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -71,6 +72,7 @@ void main() {
 
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -116,6 +118,7 @@ flutter:
       ]));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -146,6 +149,7 @@ flutter:
           'assets/foo/fizz.txt']));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -188,6 +192,7 @@ name: example''')
         'AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z', 'assets/foo/bar.txt']));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -213,6 +218,7 @@ flutter:
       expect(bundle.needsBuild(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -248,6 +254,7 @@ flutter:
       expect(bundle.needsBuild(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -278,6 +285,7 @@ flutter:
       expect(bundle.needsBuild(), false);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -326,6 +334,7 @@ flutter:
       expect(bundle.deferredComponentsEntries['component1']!.length, 3);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => platform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -511,10 +520,12 @@ flutter:
 
   group('AssetBundle.build (web builds)', () {
     late FileSystem testFileSystem;
+    late Platform testPlatform;
 
     setUp(() async {
       testFileSystem = MemoryFileSystem();
       testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+      testPlatform = FakePlatform();
     });
 
     testUsingContext('empty pubspec', () async {
@@ -542,6 +553,7 @@ flutter:
       );
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => testPlatform,
       ProcessManager: () => FakeProcessManager.any(),
     });
 
@@ -597,6 +609,7 @@ flutter:
         reason: 'JSON-encoded binary content should be identical to BIN file.');
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
+      Platform: () => testPlatform,
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
@@ -649,6 +662,7 @@ assets:
     expect(license, bundle.entries['NOTICES']);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
+    Platform: () => FakePlatform(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -670,6 +684,7 @@ flutter:
     expect(bundle.additionalDependencies.single.path, contains('DOES_NOT_EXIST_RERUN_FOR_WILDCARD'));
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
+    Platform: () => FakePlatform(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -691,6 +706,7 @@ flutter:
     expect(bundle.additionalDependencies, isEmpty);
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
+    Platform: () => FakePlatform(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -33,11 +33,7 @@ void main() {
     late Platform platform;
 
     setUp(() async {
-      testFileSystem = MemoryFileSystem(
-        style: globals.platform.isWindows
-          ? FileSystemStyle.windows
-          : FileSystemStyle.posix,
-      );
+      testFileSystem = MemoryFileSystem();
       testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
       logger = BufferLogger.test();
       platform = FakePlatform(operatingSystem: globals.platform.operatingSystem);
@@ -517,11 +513,7 @@ flutter:
     late FileSystem testFileSystem;
 
     setUp(() async {
-      testFileSystem = MemoryFileSystem(
-        style: globals.platform.isWindows
-          ? FileSystemStyle.windows
-          : FileSystemStyle.posix,
-      );
+      testFileSystem = MemoryFileSystem();
       testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
     });
 


### PR DESCRIPTION
Part of work on https://github.com/flutter/flutter/pull/141214. See [this discussion](https://github.com/flutter/flutter/pull/141214#discussion_r1446727495) for the inspiration for this PR.

## Issue
Many tests in [packages/flutter_tools/test/general.shard/asset_bundle_test.dart](https://github.com/flutter/flutter/blob/4cd0a3252d2b45e243714b3ce93c5b2313bce671/packages/flutter_tools/test/general.shard/asset_bundle_test.dart) aren't hermetic. When setting up fake `FileSystem` and `Platform` objects, the host OS is referenced:

https://github.com/flutter/flutter/blob/f2745e97d53c6a29c7d40003dfaa4fc4c688cdd2/packages/flutter_tools/test/general.shard/asset_bundle_test.dart#L35-L40

https://github.com/flutter/flutter/blob/f2745e97d53c6a29c7d40003dfaa4fc4c688cdd2/packages/flutter_tools/test/general.shard/asset_bundle_test.dart#L43

To improve hermeticity here, we could instead run each once _per_ valid combination of file system style and platform. However, it is unclear if these tests even depend on the file system style (integration tests should catch most cases where this might matter). As a result, I think it's sufficient to improve hermeticity by always assuming a Linux environment, which is generally our default (as `MemoryFileSystem` does, and most of our fakes of `Platform` do by default).

In general, if a test needs to run other kinds of environments, it should make this clear, ideally through the test name.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
