### PR TITLE
Native assets: roll deps

### DIFF
--- a/packages/flutter_tools/lib/src/android/native_assets.dart
+++ b/packages/flutter_tools/lib/src/android/native_assets.dart
@@ -4,8 +4,10 @@
 
 import 'package:native_assets_builder/native_assets_builder.dart'
     show BuildResult, DryRunResult;
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 
 import '../base/common.dart';
 import '../base/file_system.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' show Asset;
+import 'package:native_assets_cli/native_assets_cli_internal.dart' show Asset;
 import 'package:package_config/package_config_types.dart';
 
 import '../../android/gradle_utils.dart';

--- a/packages/flutter_tools/lib/src/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/ios/native_assets.dart
@@ -4,8 +4,10 @@
 
 import 'package:native_assets_builder/native_assets_builder.dart'
     show BuildResult, DryRunResult;
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 
 import '../base/file_system.dart';
 import '../build_info.dart';

--- a/packages/flutter_tools/lib/src/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/linux/native_assets.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode;
 
 import '../base/common.dart';
 import '../base/file_system.dart';

--- a/packages/flutter_tools/lib/src/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/macos/native_assets.dart
@@ -4,8 +4,10 @@
 
 import 'package:native_assets_builder/native_assets_builder.dart'
     show BuildResult, DryRunResult;
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 
 import '../base/file_system.dart';
 import '../build_info.dart';

--- a/packages/flutter_tools/lib/src/macos/native_assets_host.dart
+++ b/packages/flutter_tools/lib/src/macos/native_assets_host.dart
@@ -4,7 +4,8 @@
 
 // Shared logic between iOS and macOS implementations of native assets.
 
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode;
 
 import '../base/common.dart';
 import '../base/file_system.dart';

--- a/packages/flutter_tools/lib/src/native_assets.dart
+++ b/packages/flutter_tools/lib/src/native_assets.dart
@@ -7,7 +7,7 @@
 import 'package:logging/logging.dart' as logging;
 import 'package:native_assets_builder/native_assets_builder.dart' hide NativeAssetsBuildRunner;
 import 'package:native_assets_builder/native_assets_builder.dart' as native_assets_builder show NativeAssetsBuildRunner;
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:package_config/package_config_types.dart';
 
 import 'android/native_assets.dart';

--- a/packages/flutter_tools/lib/src/windows/native_assets.dart
+++ b/packages/flutter_tools/lib/src/windows/native_assets.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode;
 
 import '../base/file_system.dart';
 import '../build_info.dart';

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -55,8 +55,8 @@ dependencies:
 
   cli_config: 0.1.2
   graphs: 2.3.1
-  native_assets_builder: 0.3.0
-  native_assets_cli: 0.3.2
+  native_assets_builder: 0.3.1
+  native_assets_cli: 0.4.1
 
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
 
   cli_config: 0.1.2
   graphs: 2.3.1
-  native_assets_builder: 0.3.1
+  native_assets_builder: 0.3.2
   native_assets_cli: 0.4.1
 
   # We depend on very specific internal implementation details of the
@@ -118,4 +118,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: eb68
+# PUBSPEC CHECKSUM: ba6a

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -9,8 +9,8 @@ environment:
 dependencies:
   cli_config: ^0.1.2
   logging: ^1.2.0
-  native_assets_cli: ^0.3.2
-  native_toolchain_c: ^0.3.2
+  native_assets_cli: ^0.4.1
+  native_toolchain_c: ^0.3.4+1
 
 dev_dependencies:
   ffi: ^2.1.0

--- a/packages/flutter_tools/test/general.shard/android/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/native_assets_test.dart
@@ -15,8 +15,10 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode, Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode, Target;
 import 'package:package_config/package_config_types.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/native_assets_test.dart
@@ -13,7 +13,8 @@ import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/native_assets.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config.dart' show Package;
 
 import '../../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/fake_native_assets_build_runner.dart
+++ b/packages/flutter_tools/test/general.shard/fake_native_assets_build_runner.dart
@@ -5,7 +5,7 @@
 import 'package:flutter_tools/src/native_assets.dart';
 import 'package:native_assets_builder/native_assets_builder.dart'
     as native_assets_builder;
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 import 'package:package_config/package_config_types.dart';
 
 /// Mocks all logic instead of using `package:native_assets_builder`, which

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -21,8 +21,10 @@ import 'package:flutter_tools/src/resident_devtools_handler.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/vmservice.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode, Target;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode, Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart';

--- a/packages/flutter_tools/test/general.shard/ios/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/native_assets_test.dart
@@ -14,8 +14,10 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/native_assets.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode, Target;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode, Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config_types.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/linux/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/native_assets_test.dart
@@ -17,8 +17,10 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/linux/native_assets.dart';
 import 'package:flutter_tools/src/native_assets.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode, Target;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode, Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config_types.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/macos/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/native_assets_test.dart
@@ -15,8 +15,10 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/macos/native_assets.dart';
 import 'package:flutter_tools/src/native_assets.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode, Target;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode, Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config_types.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -36,9 +36,10 @@ import 'package:flutter_tools/src/run_cold.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
-import 'package:native_assets_cli/native_assets_cli.dart'
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
     hide BuildMode, Target;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/src/enums.dart';

--- a/packages/flutter_tools/test/general.shard/windows/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/native_assets_test.dart
@@ -16,8 +16,10 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/native_assets.dart';
 import 'package:flutter_tools/src/windows/native_assets.dart';
-import 'package:native_assets_cli/native_assets_cli.dart' hide BuildMode, Target;
-import 'package:native_assets_cli/native_assets_cli.dart' as native_assets_cli;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    hide BuildMode, Target;
+import 'package:native_assets_cli/native_assets_cli_internal.dart'
+    as native_assets_cli;
 import 'package:package_config/package_config_types.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/integration.shard/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/native_assets_test.dart
@@ -19,7 +19,7 @@ import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
-import 'package:native_assets_cli/native_assets_cli.dart';
+import 'package:native_assets_cli/native_assets_cli_internal.dart';
 
 import '../src/common.dart';
 import 'test_utils.dart' show ProcessResultMatcher, fileSystem, platform;
@@ -230,7 +230,7 @@ void main() {
         // Overrides the build to output static libraries.
         final String buildDotDartContentsNew = buildDotDartContents.replaceFirst(
           'final buildConfig = await BuildConfig.fromArgs(args);',
-          r'''
+          '''
   final buildConfig = await BuildConfig.fromArgs([
     '-D${LinkModePreference.configKey}=${LinkModePreference.static}',
     ...args,


### PR DESCRIPTION
Rolls the packages from https://github.com/dart-lang/native in the native assets implementation.

Most notable we're refactoring `package:native_assets_cli` for `build.dart` use.
Therefore, all imports to that package for Flutter/Dart should be to the implementation internals that are no longer visible for `build.dart` writers. Hence all the import updates.

No behavior in Flutter apps should change.

This PR also updates the template to use the latests version of `package:native_assets_cli` which no longer exposes all the implementation details.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
