### PR TITLE
Use 24-hour validation if 24-hour dials are used (#141610)

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1662,7 +1662,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     registerForRestoration(minuteHasError, 'minute_has_error');
   }
 
-  int? _parseHour(String? value) {
+  int? _parseHour(String? value, bool use24HourFormat) {
     if (value == null) {
       return null;
     }
@@ -1672,7 +1672,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    if (MediaQuery.alwaysUse24HourFormatOf(context)) {
+    if (use24HourFormat) {
       if (newHour >= 0 && newHour < 24) {
         return newHour;
       }
@@ -1704,8 +1704,8 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     return null;
   }
 
-  void _handleHourSavedSubmitted(String? value) {
-    final int? newHour = _parseHour(value);
+  void _handleHourSavedSubmitted(String? value, bool use24HourFormat) {
+    final int? newHour = _parseHour(value, use24HourFormat);
     if (newHour != null) {
       _selectedTime.value = TimeOfDay(hour: newHour, minute: _selectedTime.value.minute);
       _TimePickerModel.setSelectedTime(context, _selectedTime.value);
@@ -1713,8 +1713,8 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     }
   }
 
-  void _handleHourChanged(String value) {
-    final int? newHour = _parseHour(value);
+  void _handleHourChanged(String value, bool use24HourFormat) {
+    final int? newHour = _parseHour(value, use24HourFormat);
     if (newHour != null && value.length == 2) {
       // If a valid hour is typed, move focus to the minute TextField.
       FocusScope.of(context).nextFocus();
@@ -1735,8 +1735,8 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     _TimePickerModel.setSelectedTime(context, _selectedTime.value);
   }
 
-  String? _validateHour(String? value) {
-    final int? newHour = _parseHour(value);
+  String? _validateHour(String? value, bool use24HourFormat) {
+    final int? newHour = _parseHour(value, use24HourFormat);
     setState(() {
       hourHasError.value = newHour == null;
     });
@@ -1805,9 +1805,9 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                               style: hourMinuteStyle,
                               autofocus: widget.autofocusHour,
                               inputAction: TextInputAction.next,
-                              validator: _validateHour,
-                              onSavedSubmitted: _handleHourSavedSubmitted,
-                              onChanged: _handleHourChanged,
+                              validator: (String? value) => _validateHour(value, use24HourDials),
+                              onSavedSubmitted: (String? value) => _handleHourSavedSubmitted(value, use24HourDials),
+                              onChanged: (String value) => _handleHourChanged(value, use24HourDials),
                               hourLabelText: widget.hourLabelText,
                             ),
                           ),


### PR DESCRIPTION
Replace `MediaQuery.alwaysUse24HourFormatOf(context)` with `use24HourDials` boolean.
If system clock uses 12-hour and Flutter locale uses 24-hours time picker would show 24-hour dials but use 12-hours clock to parse hours. Valid time eg. 20:00 would not pass input validation.
Testing requires intl support and mocking MediaQuery#alwaysUse24HourFormat result. `time_picker_test.dart` didn't seem to allow this easily. Actual fix was simple but I'm unable to write unit test for it.
Change was manually tested

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

https://github.com/flutter/flutter/issues/141610

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

Non breaking change

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
