### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,8 +34,8 @@
     - any-glob-to-any-file:
       - packages/flutter_driver/**/*
       - packages/flutter_goldens/**/*
-      - packages/flutter_goldens_client/**/*
       - packages/flutter_test/**/*
+      - packages/integration_test/**/*
 
 'a: text input':
   - changed-files:
@@ -106,7 +106,6 @@ framework:
       - packages/flutter/**/*
       - packages/flutter_driver/**/*
       - packages/flutter_goldens/**/*
-      - packages/flutter_goldens_client/**/*
       - packages/flutter_localizations/**/*
       - packages/flutter_test/**/*
       - packages/integration_test/**/*
@@ -121,6 +120,11 @@ platform-ios:
   - changed-files:
     - any-glob-to-any-file:
       - packages/flutter_tools/lib/src/ios/**/*
+
+platform-web:
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/flutter_web_plugins/**/*
 
 'customer: gallery':
   - changed-files:


### PR DESCRIPTION
* `flutter_web_plugins` didn't have a label that would make PRs show up for team triage, now they are assigned to the web team so they don't fall through the cracks
* `flutter_goldens_client` doesn't exist anymore, deleted
* `integration_test` PRs should be treated like `flutter_test` or `flutter_driver` PRs and get the `a: tests` label.