### PR TITLE
[web] prepare for https://github.com/flutter/engine/pull/49786

### DIFF
--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -329,8 +329,10 @@ void main() {
     expect(paint.color, const Color(0x7F000000)); // 0.5 opacity
     expect(paint.filterQuality, FilterQuality.high);
     expect(paint.isAntiAlias, true);
-    // TODO(craiglabenz): change to true when https://github.com/flutter/flutter/issues/88909 is fixed
-    expect(paint.invertColors, !kIsWeb || isCanvasKit);
+    // TODO(yjbanov): remove kIsWeb when https://github.com/flutter/engine/pull/49786 rolls in
+    if (!kIsWeb) {
+      expect(paint.invertColors, isTrue);
+    }
   });
 
   test('DecorationImage.toString', () async {

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -30,8 +30,7 @@ class _DartUiTextStyleToStringMatcher extends Matcher {
     _propertyToString('letterSpacing', textStyle.letterSpacing),
     _propertyToString('wordSpacing', textStyle.wordSpacing),
     _propertyToString('height', textStyle.height),
-    // TODO(LongCatIsLooong): web support for
-    // https://github.com/flutter/flutter/issues/72521
+    // TODO(yjbanov): remove kIsWeb when https://github.com/flutter/engine/pull/49786 rolls in
     if (!kIsWeb) _propertyToString('leadingDistribution', textStyle.leadingDistribution),
     _propertyToString('locale', textStyle.locale),
     _propertyToString('background', textStyle.background),
@@ -74,12 +73,15 @@ class _DartUiTextStyleToStringMatcher extends Matcher {
   @override
   Description describeMismatch(dynamic item, Description mismatchDescription, Map<dynamic, dynamic> matchState, bool verbose) {
     final Description description = super.describeMismatch(item, mismatchDescription, matchState, verbose);
+    final String itemAsString = item.toString();
     final String? property = matchState['missingProperty'] as String?;
     if (property != null) {
       description.add("expect property: '$property'");
       final int propertyIndex = propertiesInOrder.indexOf(property);
       if (propertyIndex > 0) {
-        description.add(" after: '${propertiesInOrder[propertyIndex - 1]}'");
+        final String lastProperty = propertiesInOrder[propertyIndex - 1];
+        description.add(" after: '$lastProperty'\n");
+        description.add('but found: ${itemAsString.substring(itemAsString.indexOf(lastProperty))}');
       }
       description.add('\n');
     }


### PR DESCRIPTION
Skip incorrect expectations in preparation for https://github.com/flutter/engine/pull/49786.

Bonus: improved error message when text style test fails