### PR TITLE
[web] prepare layers_test.dart for https://github.com/flutter/engine/pull/49786

### DIFF
--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -371,14 +371,14 @@ void main() {
     final ImageFilter filter = ImageFilter.blur(sigmaX: 1.0, sigmaY: 1.0, tileMode: TileMode.repeated);
     final BackdropFilterLayer layer = BackdropFilterLayer(filter: filter, blendMode: BlendMode.clear);
     final List<String> info = getDebugInfo(layer);
-    expect(
-      info,
-      contains(
-        isBrowser && !isCanvasKit
-          ? 'filter: ImageFilter.blur(1, 1, TileMode.repeated)'
-          : 'filter: ImageFilter.blur(${1.0}, ${1.0}, repeated)'
-      ),
-    );
+
+    // TODO(yjbanov): remove kIsWeb when https://github.com/flutter/engine/pull/49786 rolls in
+    if (!kIsWeb) {
+      expect(
+        info,
+        contains('filter: ImageFilter.blur(${1.0}, ${1.0}, repeated)'),
+      );
+    }
     expect(info, contains('blendMode: clear'));
   });
 


### PR DESCRIPTION
This disables the expectation for `TileMode` stringification because https://github.com/flutter/engine/pull/49786 is about to fix it (as in, the test would fail when the engine fix lands).