### PR TITLE
Move mac pixel 7 pro test to presubmit: false

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3978,6 +3978,7 @@ targets:
 
   - name: Mac_pixel_7pro entrypoint_dart_registrant
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
The only bot with this configuration in the try pool just died.