### PR TITLE
`SearchAnchor` search view clear button only shows up when text input is not empty

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -816,7 +816,7 @@ class _ViewContentState extends State<_ViewContent> {
     );
 
     final List<Widget> defaultTrailing = <Widget>[
-      IconButton(
+      if (_controller.text.isNotEmpty) IconButton(
         icon: const Icon(Icons.close),
         onPressed: () {
           _controller.clear();

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -1140,10 +1140,6 @@ void main() {
     // Default search view has a leading back button on the start of the header.
     expect(find.widgetWithIcon(IconButton, Icons.arrow_back), findsOneWidget);
 
-    // Default search view has a trailing close button on the end of the header.
-    // It is used to clear the input in the text field.
-    expect(find.widgetWithIcon(IconButton, Icons.close), findsOneWidget);
-
     final Text helperText = tester.widget(find.text('hint text'));
     expect(helperText.style?.color, colorScheme.onSurfaceVariant);
     expect(helperText.style?.fontSize, 16.0);
@@ -1443,7 +1439,9 @@ void main() {
     await tester.pumpWidget(buildAnchor());
     await tester.tap(find.widgetWithIcon(IconButton, Icons.search));
     await tester.pumpAndSettle();
-    // Default is a icon button with close icon.
+    // Default is a icon button with close icon when input is not empty.
+    await tester.enterText(findTextField(), 'a');
+    await tester.pump();
     expect(find.widgetWithIcon(IconButton, Icons.close), findsOneWidget);
 
     await tester.pumpWidget(Container());
@@ -3061,6 +3059,35 @@ void main() {
     final Finder findHeader = find.descendant(of: findViewContent(), matching: find.byType(SearchBar));
     final RenderBox box = tester.renderObject(findHeader);
     expect(box.size.height, 32);
+  });
+
+  testWidgets('The default clear button only shows when text input is not empty '
+      'on the search view', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Center(
+        child: Material(
+          child: SearchAnchor(
+            builder: (BuildContext context, SearchController controller) {
+              return const Icon(Icons.search);
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.search)); // Open search view.
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithIcon(IconButton, Icons.close), findsNothing);
+    await tester.enterText(findTextField(), 'a');
+    await tester.pump();
+    expect(find.widgetWithIcon(IconButton, Icons.close), findsOneWidget);
+    await tester.enterText(findTextField(), '');
+    await tester.pump();
+    expect(find.widgetWithIcon(IconButton, Icons.close), findsNothing);
   });
 }
 


### PR DESCRIPTION
Fixes #141346
This PR is to update the default clear button on the search view to match the native app behavior. The default trailing button shows up only if the text input is not empty.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
