### PR TITLE
enable more tests in web mode

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -160,7 +160,6 @@ const Map<String, List<String>> kWebTestFileKnownFailures = <String, List<String
 
     // These tests are broken and need to be fixed.
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/71604
-    'test/painting/text_style_test.dart',
     'test/material/text_field_test.dart',
     'test/widgets/performance_overlay_test.dart',
     'test/widgets/html_element_view_test.dart',

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -329,10 +329,7 @@ void main() {
     expect(paint.color, const Color(0x7F000000)); // 0.5 opacity
     expect(paint.filterQuality, FilterQuality.high);
     expect(paint.isAntiAlias, true);
-    // TODO(yjbanov): remove kIsWeb when https://github.com/flutter/engine/pull/49786 rolls in
-    if (!kIsWeb) {
-      expect(paint.invertColors, isTrue);
-    }
+    expect(paint.invertColors, isTrue);
   });
 
   test('DecorationImage.toString', () async {

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui' as ui show FontFeature, FontVariation, ParagraphStyle, Shadow, TextStyle;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -30,8 +30,7 @@ class _DartUiTextStyleToStringMatcher extends Matcher {
     _propertyToString('letterSpacing', textStyle.letterSpacing),
     _propertyToString('wordSpacing', textStyle.wordSpacing),
     _propertyToString('height', textStyle.height),
-    // TODO(yjbanov): remove kIsWeb when https://github.com/flutter/engine/pull/49786 rolls in
-    if (!kIsWeb) _propertyToString('leadingDistribution', textStyle.leadingDistribution),
+    _propertyToString('leadingDistribution', textStyle.leadingDistribution),
     _propertyToString('locale', textStyle.locale),
     _propertyToString('background', textStyle.background),
     _propertyToString('foreground', textStyle.foreground),

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -372,13 +372,10 @@ void main() {
     final BackdropFilterLayer layer = BackdropFilterLayer(filter: filter, blendMode: BlendMode.clear);
     final List<String> info = getDebugInfo(layer);
 
-    // TODO(yjbanov): remove kIsWeb when https://github.com/flutter/engine/pull/49786 rolls in
-    if (!kIsWeb) {
-      expect(
-        info,
-        contains('filter: ImageFilter.blur(${1.0}, ${1.0}, repeated)'),
-      );
-    }
+    expect(
+      info,
+      contains('filter: ImageFilter.blur(${1.0}, ${1.0}, repeated)'),
+    );
     expect(info, contains('blendMode: clear'));
   });
 


### PR DESCRIPTION
- Unskip `text_style_test` for CanvasKit.
- Remove no longer necessary `kIsWeb` checks in a few tests.

This PR depends on https://github.com/flutter/engine/pull/49786, which rolled into the framework. If the engine PR needs to be reverted, this PR will need to be reverted too.