### PR TITLE
Run `flutter_gallery_ios__start_up` test on Mac-14 in staging

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4273,6 +4273,17 @@ targets:
       task_name: flutter_gallery_ios__start_up_xcode_debug
     bringup: true
 
+  - name: Mac_arm64_ios flutter_gallery_ios__start_up
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: flutter_gallery_ios__start_up
+      os: Mac-14
+    bringup: true
+
   - name: Mac_ios flutter_view_ios__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4273,6 +4273,7 @@ targets:
       task_name: flutter_gallery_ios__start_up_xcode_debug
     bringup: true
 
+  # TODO(vashworth): Remove after https://github.com/flutter/flutter/issues/141383 is fixed.
   - name: Mac_arm64_ios flutter_gallery_ios__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
Attempting to debug https://github.com/flutter/flutter/issues/141383.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
