### PR TITLE
Added ButtonStyle.foregroundBuilder and ButtonStyle.backgroundBuilder

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -374,7 +374,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/checkbox/checkbox.1_test.dart',
   'examples/api/test/material/checkbox/checkbox.0_test.dart',
   'examples/api/test/material/navigation_rail/navigation_rail.extended_animation.0_test.dart',
-  'examples/api/test/material/text_button/text_button.0_test.dart',
   'examples/api/test/rendering/growth_direction/growth_direction.0_test.dart',
   'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart',
   'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1_test.dart',

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -69,14 +69,15 @@ class _TextButtonExampleState extends State<TextButtonExample> {
     final Color color1;
     final Color color2;
     final Color color3;
-    if (colorScheme.brightness == Brightness.light) {
-      color1 = Colors.blue.withOpacity(0.5);
-      color2 = Colors.orange.withOpacity(0.5);
-      color3 = Colors.yellow.withOpacity(0.5);
-    } else {
-      color1 = Colors.purple.withOpacity(0.5);
-      color2 = Colors.cyan.withOpacity(0.5);
-      color3 = Colors.yellow.withOpacity(0.5);
+    switch (colorScheme.brightness) {
+      case Brightness.light:
+        color1 = Colors.blue.withOpacity(0.5);
+        color2 = Colors.orange.withOpacity(0.5);
+        color3 = Colors.yellow.withOpacity(0.5);
+      case Brightness.dark:
+        color1 = Colors.purple.withOpacity(0.5);
+        color2 = Colors.cyan.withOpacity(0.5);
+        color3 = Colors.yellow.withOpacity(0.5);
     }
 
     // This gradient's appearance reflects the button's state.
@@ -148,8 +149,7 @@ class _TextButtonExampleState extends State<TextButtonExample> {
 
         // This theme defines default property overrides for all of the buttons
         // that follow.
-        TextButtonTheme
-        (
+        TextButtonTheme(
           data: TextButtonThemeData(
             style: TextButton.styleFrom(
               visualDensity: visualDensity,
@@ -204,7 +204,7 @@ class _TextButtonExampleState extends State<TextButtonExample> {
                       ),
                       verticalSpacer,
 
-                      // Override button's shape its border.
+                      // Override the button's shape and its border.
                       //
                       // In this case we've specified a shape that has border - the
                       // RoundedRectangleBorder's side parameter. If the styleFrom
@@ -371,13 +371,14 @@ class _TextButtonExampleState extends State<TextButtonExample> {
                       // Override the foregroundBuilder to specify images for the button's pressed
                       // hovered and inactive states.
                       //
-                      // This is an example of completely change the default appearance of a button
+                      // This is an example of completely changing the default appearance of a button
                       // by specifying images for each state and by turning off the overlays by
                       // overlayColor: Colors.transparent. AnimatedContainer takes care of the
                       // fade in and out segues between images.
                       //
-                      // The foregroundBuilder its child parameter. Unfortunately TextButton's child
-                      // parameter is required, so we still have to provide one.
+                      // This foregroundBuilder function ignores its child parameter. Unfortunately
+                      // TextButton's child parameter is required, so we still have
+                      // to provide one.
                       TextButton(
                         onPressed: () {},
                         style: TextButton.styleFrom(

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -104,6 +104,256 @@ class _TextButtonExampleState extends State<TextButtonExample> {
       );
     }
 
+    // To make this method a little easier to read, the buttons that
+    // appear in the two columns to the right of the demo switches
+    // Card are broken out below.
+
+    final List<Widget> columnOneButtons = <Widget>[
+      TextButton(
+        onPressed: () {},
+        child: const Text('Enabled'),
+      ),
+      verticalSpacer,
+
+      const TextButton(
+        onPressed: null,
+        child: Text('Disabled'),
+      ),
+      verticalSpacer,
+
+      TextButton.icon(
+        onPressed: () {},
+        icon: const Icon(Icons.access_alarm),
+        label: const Text('TextButton.icon #1'),
+      ),
+      verticalSpacer,
+
+      // Override the foreground and background colors.
+      //
+      // In this example, and most of the ones that follow, we're using
+      // the TextButton.styleFrom() convenience method to create a ButtonStyle.
+      // The styleFrom method is a little easier because it creates
+      // ButtonStyle MaterialStateProperty parameters for you.
+      // In this case, Specifying foregroundColor overrides the text,
+      // icon and overlay (splash and highlight) colors a little differently
+      // depending on the button's state. BackgroundColor is just the background
+      // color for all states.
+      TextButton.icon(
+        style: TextButton.styleFrom(
+          foregroundColor: colorScheme.onError,
+          backgroundColor: colorScheme.error,
+        ),
+        onPressed: () { },
+        icon: const Icon(Icons.access_alarm),
+        label: const Text('TextButton.icon #2'),
+      ),
+      verticalSpacer,
+
+      // Override the button's shape and its border.
+      //
+      // In this case we've specified a shape that has border - the
+      // RoundedRectangleBorder's side parameter. If the styleFrom
+      // side parameter was also specified, or if the TextButtonTheme
+      // defined above included a side parameter, then that would
+      // override the RoundedRectangleBorder's side.
+      TextButton(
+        style: TextButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: const BorderRadius.all(Radius.circular(8)),
+            side: BorderSide(
+              color: colorScheme.primary,
+              width: 5,
+            ),
+          ),
+        ),
+        onPressed: () { },
+        child: const Text('TextButton #3'),
+      ),
+      verticalSpacer,
+
+      // Override overlay: the ink splash and highlight colors.
+      //
+      // The styleFrom method turns the specified overlayColor
+      // into a value MaterialStyleProperty<Color> ButtonStyle.overlay
+      // value that uses opacities depending on the button's state.
+      // If the overlayColor was Colors.transparent, no splash
+      // or highlights would be shown.
+      TextButton(
+        style: TextButton.styleFrom(
+          overlayColor: Colors.yellow,
+        ),
+        onPressed: () { },
+        child: const Text('TextButton #4'),
+      ),
+    ];
+
+
+    final List<Widget> columnTwoButtons = <Widget>[
+      // Override the foregroundBuilder: apply a ShaderMask.
+      //
+      // Apply a ShaderMask to the button's child. This kind of thing
+      // can be applied to one button easily enough by just wrapping the
+      // button's child directly. However to affect all buttons in this
+      // way you can specify a similar foregroundBuilder in a TextButton
+      // theme or the MaterialApp theme's ThemeData.textButtonTheme.
+      TextButton(
+        style: TextButton.styleFrom(
+          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+            return ShaderMask(
+              shaderCallback: (Rect bounds) {
+                return LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: <Color>[
+                    colorScheme.primary,
+                    colorScheme.onPrimary,
+                  ],
+                ).createShader(bounds);
+              },
+              blendMode: BlendMode.srcATop,
+              child: child,
+            );
+          },
+        ),
+        onPressed: () { },
+        child: const Text('TextButton #5'),
+      ),
+      verticalSpacer,
+
+      // Override the foregroundBuilder: add an underline.
+      //
+      // Add a border around button's child. In this case the
+      // border only appears when the button is hovered or pressed
+      // (if it's pressed it's always hovered too). Not that this
+      // border is different than the one specified with the styleFrom
+      // side parameter (or the ButtonStyle.side property). The foregroundBuilder
+      // is applied to a widget that contains the child and has already
+      // included the button's padding. It is unaffected by the button's shape.
+      // The styleFrom side parameter controls the button's outermost border and it
+      // outlines the button's shape.
+      TextButton(
+        style: TextButton.styleFrom(
+          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+            return DecoratedBox(
+              decoration: BoxDecoration(
+                border: states.contains(MaterialState.hovered)
+                  ? Border(bottom: BorderSide(color: colorScheme.primary))
+                  : const Border(), // essentially "no border"
+              ),
+              child: child,
+            );
+          },
+        ),
+        onPressed: () { },
+        child: const Text('TextButton #6'),
+      ),
+      verticalSpacer,
+
+      // Override the backgroundBuilder to add a state specific gradient background
+      // and add an outline that only appears when the button is hovered or pressed.
+      //
+      // The gradient background decoration is computed by the statesToDecoration()
+      // method. The gradient flips horizontally when the button is hovered (watch
+      // closely). Because we want the outline to only appear when the button is hovered
+      // we can't use the styleFrom() side parameter, because that creates the same
+      // outline for all states. The ButtonStyle.copyWith() method is used to add
+      // a MaterialState<BorderSide?> property that does the right thing.
+      //
+      // The gradient background is translucent - all of the colors have opacity 0.5 -
+      // so the overlay's splash and highlight colors are visible even though they're
+      // drawn on the Material widget that's effectively behind the background. The
+      // border is also translucent, so if you look carefully, you'll see that the
+      // background - which is part of the button's Material but is drawn on top of the
+      // the background gradient - shows through the border.
+      TextButton(
+        onPressed: () {},
+        style: TextButton.styleFrom(
+          overlayColor: color2,
+          backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 500),
+              decoration: statesToDecoration(states),
+              child: child,
+            );
+          },
+        ).copyWith(
+          side: MaterialStateProperty.resolveWith<BorderSide?>((Set<MaterialState> states) {
+            if (states.contains(MaterialState.hovered)) {
+              return BorderSide(width: 3, color: color3);
+            }
+            return null; // defer to the default
+          }),
+        ),
+        child: const Text('TextButton #7'),
+      ),
+      verticalSpacer,
+
+      // Override the backgroundBuilder to add a burlap image background.
+      //
+      // The image is clipped to the button's shape. We've included an Ink widget
+      // because the background image is opaque and would otherwise obscure the splash
+      // and highlight overlays that are painted on the button's Material widget
+      // by default. They're drawn on the Ink widget instead. The foreground color
+      // was overridden as well because black shows up a little better on the mottled
+      // brown background.
+      TextButton(
+        onPressed: () {},
+        style: TextButton.styleFrom(
+          foregroundColor: Colors.black,
+          backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+            return Ink(
+              decoration: const BoxDecoration(
+                image: DecorationImage(
+                  image: NetworkImage(burlapUrl),
+                  fit: BoxFit.cover,
+                ),
+              ),
+              child: child,
+            );
+          },
+        ),
+        child: const Text('TextButton #8'),
+      ),
+      verticalSpacer,
+
+      // Override the foregroundBuilder to specify images for the button's pressed
+      // hovered and inactive states.
+      //
+      // This is an example of completely changing the default appearance of a button
+      // by specifying images for each state and by turning off the overlays by
+      // overlayColor: Colors.transparent. AnimatedContainer takes care of the
+      // fade in and out segues between images.
+      //
+      // This foregroundBuilder function ignores its child parameter. Unfortunately
+      // TextButton's child parameter is required, so we still have
+      // to provide one.
+      TextButton(
+        onPressed: () {},
+        style: TextButton.styleFrom(
+          overlayColor: Colors.transparent,
+          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+            String url = states.contains(MaterialState.hovered) ? smiley3Url : smiley1Url;
+            if (states.contains(MaterialState.pressed)) {
+              url = smiley2Url;
+            }
+            return AnimatedContainer(
+              width: 64,
+              height: 64,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.fastOutSlowIn,
+              decoration: BoxDecoration(
+                image: DecorationImage(
+                  image: NetworkImage(url),
+                  fit: BoxFit.contain,
+                ),
+              ),
+            );
+          },
+        ),
+        child: const Text('This child is not used'),
+      ),
+    ];
+
     return Row(
       children: <Widget> [
         // The dark/light and LTR/RTL switches. We use the updateDarkMode function
@@ -111,43 +361,15 @@ class _TextButtonExampleState extends State<TextButtonExample> {
         // in the appropriate dark/light ThemeMdoe. The directionality of the rest
         // of the UI is controlled by the Directionality widget below, and the
         // textDirection local state variable.
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: IntrinsicWidth(
-              child: Column(
-                children: <Widget>[
-                  Row(
-                    children: <Widget>[
-                      const Expanded(child: Text('Dark Mode')),
-                      const SizedBox(width: 4),
-                      Switch(
-                        value: widget.darkMode,
-                        onChanged: (bool value) {
-                          widget.updateDarkMode(value);
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Row(
-                    children: <Widget>[
-                      const Expanded(child: Text('RTL Text')),
-                      const SizedBox(width: 4),
-                      Switch(
-                        value: textDirection == TextDirection.rtl,
-                        onChanged: (bool value) {
-                          setState(() {
-                            textDirection = value ? TextDirection.rtl : TextDirection.ltr;
-                          });
-                        },
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ),
+        TextButtonExampleSwitches(
+          darkMode: widget.darkMode,
+          updateDarkMode: widget.updateDarkMode,
+          textDirection: textDirection,
+          updateRTL: (bool value) {
+            setState(() {
+              textDirection = value ? TextDirection.rtl : TextDirection.ltr;
+            });
+          },
         ),
         horizontalSpacer,
 
@@ -176,84 +398,7 @@ class _TextButtonExampleState extends State<TextButtonExample> {
                     Directionality(
                       textDirection: textDirection,
                       child: Column(
-                        children: <Widget>[
-                          TextButton(
-                            onPressed: () {},
-                            child: const Text('Enabled'),
-                          ),
-                          verticalSpacer,
-
-                          const TextButton(
-                            onPressed: null,
-                            child: Text('Disabled'),
-                          ),
-                          verticalSpacer,
-
-                          TextButton.icon(
-                            onPressed: () {},
-                            icon: const Icon(Icons.access_alarm),
-                            label: const Text('TextButton.icon #1'),
-                          ),
-                          verticalSpacer,
-
-                          // Override the foreground and background colors.
-                          //
-                          // In this example, and most of the ones that follow, we're using
-                          // the TextButton.styleFrom() convenience method to create a ButtonStyle.
-                          // The styleFrom method is a little easier because it creates
-                          // ButtonStyle MaterialStateProperty parameters for you.
-                          // In this case, Specifying foregroundColor overrides the text,
-                          // icon and overlay (splash and highlight) colors a little differently
-                          // depending on the button's state. BackgroundColor is just the background
-                          // color for all states.
-                          TextButton.icon(
-                            style: TextButton.styleFrom(
-                              foregroundColor: colorScheme.onError,
-                              backgroundColor: colorScheme.error,
-                            ),
-                            onPressed: () { },
-                            icon: const Icon(Icons.access_alarm),
-                            label: const Text('TextButton.icon #2'),
-                          ),
-                          verticalSpacer,
-
-                          // Override the button's shape and its border.
-                          //
-                          // In this case we've specified a shape that has border - the
-                          // RoundedRectangleBorder's side parameter. If the styleFrom
-                          // side parameter was also specified, or if the TextButtonTheme
-                          // defined above included a side parameter, then that would
-                          // override the RoundedRectangleBorder's side.
-                          TextButton(
-                            style: TextButton.styleFrom(
-                              shape: RoundedRectangleBorder(
-                                borderRadius: const BorderRadius.all(Radius.circular(8)),
-                                side: BorderSide(
-                                  color: colorScheme.primary,
-                                  width: 5,
-                                ),
-                              ),
-                            ),
-                            onPressed: () { },
-                            child: const Text('TextButton #3'),
-                          ),
-                          verticalSpacer,
-
-                          // Override overlay: the ink splash and highlight colors.
-                          //
-                          // The styleFrom method turns the specified overlayColor
-                          // into a value MaterialStyleProperty<Color> ButtonStyle.overlay
-                          // value that uses opacities depending on the button's state.
-                          // If the overlayColor was Colors.transparent, no splash
-                          // or highlights would be shown.
-                          TextButton(
-                            style: TextButton.styleFrom(
-                              overlayColor: Colors.yellow,
-                            ),
-                            onPressed: () { },
-                            child: const Text('TextButton #4'),
-                          ),
-                        ],
+                        children: columnOneButtons,
                       ),
                     ),
                     horizontalSpacer,
@@ -261,171 +406,7 @@ class _TextButtonExampleState extends State<TextButtonExample> {
                     Directionality(
                       textDirection: textDirection,
                       child: Column(
-                        children: <Widget>[
-                          // Override the foregroundBuilder: apply a ShaderMask.
-                          //
-                          // Apply a ShaderMask to the button's child. This kind of thing
-                          // can be applied to one button easily enough by just wrapping the
-                          // button's child directly. However to affect all buttons in this
-                          // way you can specify a similar foregroundBuilder in a TextButton
-                          // theme or the MaterialApp theme's ThemeData.textButtonTheme.
-                          TextButton(
-                            style: TextButton.styleFrom(
-                              foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                                return ShaderMask(
-                                  shaderCallback: (Rect bounds) {
-                                    return LinearGradient(
-                                      begin: Alignment.bottomCenter,
-                                      end: Alignment.topCenter,
-                                      colors: <Color>[
-                                        colorScheme.primary,
-                                        colorScheme.onPrimary,
-                                      ],
-                                    ).createShader(bounds);
-                                  },
-                                  blendMode: BlendMode.srcATop,
-                                  child: child,
-                                );
-                              },
-                            ),
-                            onPressed: () { },
-                            child: const Text('TextButton #5'),
-                          ),
-                          verticalSpacer,
-
-                          // Override the foregroundBuilder: add an underline.
-                          //
-                          // Add a border around button's child. In this case the
-                          // border only appears when the button is hovered or pressed
-                          // (if it's pressed it's always hovered too). Not that this
-                          // border is different than the one specified with the styleFrom
-                          // side parameter (or the ButtonStyle.side property). The foregroundBuilder
-                          // is applied to a widget that contains the child and has already
-                          // included the button's padding. It is unaffected by the button's shape.
-                          // The styleFrom side parameter controls the button's outermost border and it
-                          // outlines the button's shape.
-                          TextButton(
-                            style: TextButton.styleFrom(
-                              foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                                return DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    border: states.contains(MaterialState.hovered)
-                                      ? Border(bottom: BorderSide(color: colorScheme.primary))
-                                      : const Border(), // essentially "no border"
-                                  ),
-                                  child: child,
-                                );
-                              },
-                            ),
-                            onPressed: () { },
-                            child: const Text('TextButton #6'),
-                          ),
-                          verticalSpacer,
-
-                          // Override the backgroundBuilder to add a state specific gradient background
-                          // and add an outline that only appears when the button is hovered or pressed.
-                          //
-                          // The gradient background decoration is computed by the statesToDecoration()
-                          // method. The gradient flips horizontally when the button is hovered (watch
-                          // closely). Because we want the outline to only appear when the button is hovered
-                          // we can't use the styleFrom() side parameter, because that creates the same
-                          // outline for all states. The ButtonStyle.copyWith() method is used to add
-                          // a MaterialState<BorderSide?> property that does the right thing.
-                          //
-                          // The gradient background is translucent - all of the colors have opacity 0.5 -
-                          // so the overlay's splash and highlight colors are visible even though they're
-                          // drawn on the Material widget that's effectively behind the background. The
-                          // border is also translucent, so if you look carefully, you'll see that the
-                          // background - which is part of the button's Material but is drawn on top of the
-                          // the background gradient - shows through the border.
-                          TextButton(
-                            onPressed: () {},
-                            style: TextButton.styleFrom(
-                              overlayColor: color2,
-                              backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                                return AnimatedContainer(
-                                  duration: const Duration(milliseconds: 500),
-                                  decoration: statesToDecoration(states),
-                                  child: child,
-                                );
-                              },
-                            ).copyWith(
-                              side: MaterialStateProperty.resolveWith<BorderSide?>((Set<MaterialState> states) {
-                                if (states.contains(MaterialState.hovered)) {
-                                  return BorderSide(width: 3, color: color3);
-                                }
-                                return null; // defer to the default
-                              }),
-                            ),
-                            child: const Text('TextButton #7'),
-                          ),
-                          verticalSpacer,
-
-                          // Override the backgroundBuilder to add a burlap image background.
-                          //
-                          // The image is clipped to the button's shape. We've included an Ink widget
-                          // because the background image is opaque and would otherwise obscure the splash
-                          // and highlight overlays that are painted on the button's Material widget
-                          // by default. They're drawn on the Ink widget instead. The foreground color
-                          // was overridden as well because black shows up a little better on the mottled
-                          // brown background.
-                          TextButton(
-                            onPressed: () {},
-                            style: TextButton.styleFrom(
-                              foregroundColor: Colors.black,
-                              backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                                return Ink(
-                                  decoration: const BoxDecoration(
-                                    image: DecorationImage(
-                                      image: NetworkImage(burlapUrl),
-                                      fit: BoxFit.cover,
-                                    ),
-                                  ),
-                                  child: child,
-                                );
-                              },
-                            ),
-                            child: const Text('TextButton #8'),
-                          ),
-                          verticalSpacer,
-
-                          // Override the foregroundBuilder to specify images for the button's pressed
-                          // hovered and inactive states.
-                          //
-                          // This is an example of completely changing the default appearance of a button
-                          // by specifying images for each state and by turning off the overlays by
-                          // overlayColor: Colors.transparent. AnimatedContainer takes care of the
-                          // fade in and out segues between images.
-                          //
-                          // This foregroundBuilder function ignores its child parameter. Unfortunately
-                          // TextButton's child parameter is required, so we still have
-                          // to provide one.
-                          TextButton(
-                            onPressed: () {},
-                            style: TextButton.styleFrom(
-                              overlayColor: Colors.transparent,
-                              foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                                String url = states.contains(MaterialState.hovered) ? smiley3Url : smiley1Url;
-                                if (states.contains(MaterialState.pressed)) {
-                                  url = smiley2Url;
-                                }
-                                return AnimatedContainer(
-                                  width: 64,
-                                  height: 64,
-                                  duration: const Duration(milliseconds: 300),
-                                  curve: Curves.fastOutSlowIn,
-                                  decoration: BoxDecoration(
-                                    image: DecorationImage(
-                                      image: NetworkImage(url),
-                                      fit: BoxFit.contain,
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                            child: const Text('This child is not used'),
-                          ),
-                        ],
+                        children: columnTwoButtons
                       ),
                     ),
                     horizontalSpacer,
@@ -436,6 +417,57 @@ class _TextButtonExampleState extends State<TextButtonExample> {
           ),
         ),
       ],
+    );
+  }
+}
+
+class TextButtonExampleSwitches extends StatelessWidget {
+  const TextButtonExampleSwitches({
+    super.key,
+    required this.darkMode,
+    required this.updateDarkMode,
+    required this.textDirection,
+    required this.updateRTL
+  });
+
+  final bool darkMode;
+  final ValueChanged<bool> updateDarkMode;
+  final TextDirection textDirection;
+  final ValueChanged<bool> updateRTL;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: IntrinsicWidth(
+          child: Column(
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  const Expanded(child: Text('Dark Mode')),
+                  const SizedBox(width: 4),
+                  Switch(
+                    value: darkMode,
+                    onChanged: updateDarkMode,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: <Widget>[
+                  const Expanded(child: Text('RTL Text')),
+                  const SizedBox(width: 4),
+                  Switch(
+                    value: textDirection == TextDirection.rtl,
+                    onChanged: updateRTL,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -67,8 +67,8 @@ class _TextButtonExampleState extends State<TextButtonExample> {
 
   @override
   void dispose() {
-    super.dispose();
     scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -185,7 +185,6 @@ class _TextButtonExampleState extends State<TextButtonExample> {
         child: const Text('TextButton #4'),
       ),
     ];
-
 
     final List<Widget> columnTwoButtons = <Widget>[
       // Override the foregroundBuilder: apply a ShaderMask.

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -55,8 +55,22 @@ class _TextButtonExampleState extends State<TextButtonExample> {
   TextDirection textDirection = TextDirection.ltr;
   ThemeMode themeMode = ThemeMode.light;
   VisualDensity visualDensity = VisualDensity.standard;
+  late final ScrollController scrollController;
 
   static const Widget verticalSpacer = SizedBox(height: 16);
+  static const Widget horizontalSpacer = SizedBox(width: 32);
+
+  @override
+  void initState() {
+    scrollController = ScrollController();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    scrollController.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,19 +80,10 @@ class _TextButtonExampleState extends State<TextButtonExample> {
     // Adapt colors that are not part of the color scheme to
     // the current dark/light mode. Used to define TextButton #7's
     // gradients.
-    final Color color1;
-    final Color color2;
-    final Color color3;
-    switch (colorScheme.brightness) {
-      case Brightness.light:
-        color1 = Colors.blue.withOpacity(0.5);
-        color2 = Colors.orange.withOpacity(0.5);
-        color3 = Colors.yellow.withOpacity(0.5);
-      case Brightness.dark:
-        color1 = Colors.purple.withOpacity(0.5);
-        color2 = Colors.cyan.withOpacity(0.5);
-        color3 = Colors.yellow.withOpacity(0.5);
-    }
+    final (Color color1, Color color2, Color color3) = switch (colorScheme.brightness) {
+      Brightness.light => (Colors.blue.withOpacity(1.0),  Colors.orange.withOpacity(1.0), Colors.yellow.withOpacity(1.0)),
+      Brightness.dark  => (Colors.purple.withOpacity(1.0), Colors.cyan.withOpacity(1.0),  Colors.yellow.withOpacity(1.0)),
+    };
 
     // This gradient's appearance reflects the button's state.
     // Always return a gradient decoration so that AnimatedContainer
@@ -144,6 +149,7 @@ class _TextButtonExampleState extends State<TextButtonExample> {
             ),
           ),
         ),
+        horizontalSpacer,
 
         // All of the button examples appear below. They're arranged in two columns.
 
@@ -157,257 +163,275 @@ class _TextButtonExampleState extends State<TextButtonExample> {
             ),
           ),
           child: Expanded(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: <Widget>[
-                Directionality(
-                  textDirection: textDirection,
-                  child: Column(
-                    children: <Widget>[
-                      TextButton(
-                        onPressed: () {},
-                        child: const Text('Enabled'),
-                      ),
-                      verticalSpacer,
-
-                      const TextButton(
-                        onPressed: null,
-                        child: Text('Disabled'),
-                      ),
-                      verticalSpacer,
-
-                      TextButton.icon(
-                        onPressed: () {},
-                        icon: const Icon(Icons.access_alarm),
-                        label: const Text('TextButton.icon #1'),
-                      ),
-                      verticalSpacer,
-
-                      // Override the foreground and background colors.
-                      //
-                      // In this example, and most of the ones that follow, we're using
-                      // the TextButton.styleFrom() convenience method to create a ButtonStyle.
-                      // The styleFrom method is a little easier because it creates
-                      // ButtonStyle MaterialStateProperty parameters for you.
-                      // In this case, Specifying foregroundColor overrides the text,
-                      // icon and overlay (splash and highlight) colors a little differently
-                      // depending on the button's state. BackgroundColor is just the background
-                      // color for all states.
-                      TextButton.icon(
-                        style: TextButton.styleFrom(
-                          foregroundColor: colorScheme.onError,
-                          backgroundColor: colorScheme.error,
-                        ),
-                        onPressed: () { },
-                        icon: const Icon(Icons.access_alarm),
-                        label: const Text('TextButton.icon #2'),
-                      ),
-                      verticalSpacer,
-
-                      // Override the button's shape and its border.
-                      //
-                      // In this case we've specified a shape that has border - the
-                      // RoundedRectangleBorder's side parameter. If the styleFrom
-                      // side parameter was also specified, or if the TextButtonTheme
-                      // defined above included a side parameter, then that would
-                      // override the RoundedRectangleBorder's side.
-                      TextButton(
-                        style: TextButton.styleFrom(
-                          shape: RoundedRectangleBorder(
-                            borderRadius: const BorderRadius.all(Radius.circular(8)),
-                            side: BorderSide(
-                              color: colorScheme.primary,
-                              width: 5,
-                            ),
+            child:  Scrollbar(
+              controller: scrollController,
+              thumbVisibility: true,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                controller: scrollController,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Directionality(
+                      textDirection: textDirection,
+                      child: Column(
+                        children: <Widget>[
+                          TextButton(
+                            onPressed: () {},
+                            child: const Text('Enabled'),
                           ),
-                        ),
-                        onPressed: () { },
-                        child: const Text('TextButton #3'),
-                      ),
-                      verticalSpacer,
+                          verticalSpacer,
 
-                      // Override overlay: the ink splash and highlight colors.
-                      //
-                      // The styleFrom method turns the specified overlayColor
-                      // into a value MaterialStyleProperty<Color> ButtonStyle.overlay
-                      // value that uses opacities depending on the button's state.
-                      // If the overlayColor was Colors.transparent, no splash
-                      // or highlights would be shown.
-                      TextButton(
-                        style: TextButton.styleFrom(
-                          overlayColor: Colors.yellow,
-                        ),
-                        onPressed: () { },
-                        child: const Text('TextButton #4'),
-                      ),
-                    ],
-                  ),
-                ),
+                          const TextButton(
+                            onPressed: null,
+                            child: Text('Disabled'),
+                          ),
+                          verticalSpacer,
 
-                Directionality(
-                  textDirection: textDirection,
-                  child: Column(
-                    children: <Widget>[
-                      // Override the foregroundBuilder: apply a ShaderMask.
-                      //
-                      // Apply a ShaderMask to the button's child. This kind of thing
-                      // can be applied to one button easily enough by just wrapping the
-                      // button's child directly. However to affect all buttons in this
-                      // way you can specify a similar foregroundBuilder in a TextButton
-                      // theme or the MaterialApp theme's ThemeData.textButtonTheme.
-                      TextButton(
-                        style: TextButton.styleFrom(
-                          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                            return ShaderMask(
-                              shaderCallback: (Rect bounds) {
-                                return LinearGradient(
-                                  begin: Alignment.bottomCenter,
-                                  end: Alignment.topCenter,
-                                  colors: <Color>[
-                                    colorScheme.primary,
-                                    colorScheme.onPrimary,
-                                  ],
-                                ).createShader(bounds);
+                          TextButton.icon(
+                            onPressed: () {},
+                            icon: const Icon(Icons.access_alarm),
+                            label: const Text('TextButton.icon #1'),
+                          ),
+                          verticalSpacer,
+
+                          // Override the foreground and background colors.
+                          //
+                          // In this example, and most of the ones that follow, we're using
+                          // the TextButton.styleFrom() convenience method to create a ButtonStyle.
+                          // The styleFrom method is a little easier because it creates
+                          // ButtonStyle MaterialStateProperty parameters for you.
+                          // In this case, Specifying foregroundColor overrides the text,
+                          // icon and overlay (splash and highlight) colors a little differently
+                          // depending on the button's state. BackgroundColor is just the background
+                          // color for all states.
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              foregroundColor: colorScheme.onError,
+                              backgroundColor: colorScheme.error,
+                            ),
+                            onPressed: () { },
+                            icon: const Icon(Icons.access_alarm),
+                            label: const Text('TextButton.icon #2'),
+                          ),
+                          verticalSpacer,
+
+                          // Override the button's shape and its border.
+                          //
+                          // In this case we've specified a shape that has border - the
+                          // RoundedRectangleBorder's side parameter. If the styleFrom
+                          // side parameter was also specified, or if the TextButtonTheme
+                          // defined above included a side parameter, then that would
+                          // override the RoundedRectangleBorder's side.
+                          TextButton(
+                            style: TextButton.styleFrom(
+                              shape: RoundedRectangleBorder(
+                                borderRadius: const BorderRadius.all(Radius.circular(8)),
+                                side: BorderSide(
+                                  color: colorScheme.primary,
+                                  width: 5,
+                                ),
+                              ),
+                            ),
+                            onPressed: () { },
+                            child: const Text('TextButton #3'),
+                          ),
+                          verticalSpacer,
+
+                          // Override overlay: the ink splash and highlight colors.
+                          //
+                          // The styleFrom method turns the specified overlayColor
+                          // into a value MaterialStyleProperty<Color> ButtonStyle.overlay
+                          // value that uses opacities depending on the button's state.
+                          // If the overlayColor was Colors.transparent, no splash
+                          // or highlights would be shown.
+                          TextButton(
+                            style: TextButton.styleFrom(
+                              overlayColor: Colors.yellow,
+                            ),
+                            onPressed: () { },
+                            child: const Text('TextButton #4'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    horizontalSpacer,
+
+                    Directionality(
+                      textDirection: textDirection,
+                      child: Column(
+                        children: <Widget>[
+                          // Override the foregroundBuilder: apply a ShaderMask.
+                          //
+                          // Apply a ShaderMask to the button's child. This kind of thing
+                          // can be applied to one button easily enough by just wrapping the
+                          // button's child directly. However to affect all buttons in this
+                          // way you can specify a similar foregroundBuilder in a TextButton
+                          // theme or the MaterialApp theme's ThemeData.textButtonTheme.
+                          TextButton(
+                            style: TextButton.styleFrom(
+                              foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                                return ShaderMask(
+                                  shaderCallback: (Rect bounds) {
+                                    return LinearGradient(
+                                      begin: Alignment.bottomCenter,
+                                      end: Alignment.topCenter,
+                                      colors: <Color>[
+                                        colorScheme.primary,
+                                        colorScheme.onPrimary,
+                                      ],
+                                    ).createShader(bounds);
+                                  },
+                                  blendMode: BlendMode.srcATop,
+                                  child: child,
+                                );
                               },
-                              blendMode: BlendMode.srcATop,
-                              child: child,
-                            );
-                          },
-                        ),
-                        onPressed: () { },
-                        child: const Text('TextButton #5'),
-                      ),
-                      verticalSpacer,
+                            ),
+                            onPressed: () { },
+                            child: const Text('TextButton #5'),
+                          ),
+                          verticalSpacer,
 
-                      // Override the foregroundBuilder: add an underline.
-                      //
-                      // Add a border around button's child. In this case the
-                      // border only appears when the button is hovered or pressed
-                      // (if it's pressed it's always hovered too). Not that this
-                      // border is different than the one specified with the styleFrom
-                      // side parameter (or the ButtonStyle.side property). The foregroundBuilder
-                      // is applied to a widget that contains the child and has already
-                      // included the button's padding. It is unaffected by the button's shape.
-                      // The styleFrom side parameter controls the button's outermost border and it
-                      // outlines the button's shape.
-                      TextButton(
-                        style: TextButton.styleFrom(
-                          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                            return DecoratedBox(
-                              decoration: BoxDecoration(
-                                border: states.contains(MaterialState.hovered)
-                                  ? Border(bottom: BorderSide(color: colorScheme.primary))
-                                  : const Border(), // essentially "no border"
-                              ),
-                              child: child,
-                            );
-                          },
-                        ),
-                        onPressed: () { },
-                        child: const Text('TextButton #6'),
-                      ),
-                      verticalSpacer,
+                          // Override the foregroundBuilder: add an underline.
+                          //
+                          // Add a border around button's child. In this case the
+                          // border only appears when the button is hovered or pressed
+                          // (if it's pressed it's always hovered too). Not that this
+                          // border is different than the one specified with the styleFrom
+                          // side parameter (or the ButtonStyle.side property). The foregroundBuilder
+                          // is applied to a widget that contains the child and has already
+                          // included the button's padding. It is unaffected by the button's shape.
+                          // The styleFrom side parameter controls the button's outermost border and it
+                          // outlines the button's shape.
+                          TextButton(
+                            style: TextButton.styleFrom(
+                              foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                                return DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    border: states.contains(MaterialState.hovered)
+                                      ? Border(bottom: BorderSide(color: colorScheme.primary))
+                                      : const Border(), // essentially "no border"
+                                  ),
+                                  child: child,
+                                );
+                              },
+                            ),
+                            onPressed: () { },
+                            child: const Text('TextButton #6'),
+                          ),
+                          verticalSpacer,
 
-                      // Override the backgroundBuilder to add a state specific gradient background
-                      // and add an outline that only appears when the button is hovered or pressed.
-                      //
-                      // The gradient background decoration is computed by the statesToDecoration()
-                      // method. The gradient flips horizontally when the button is hovered (watch
-                      // closely). Because we want the outline to only appear when the button is hovered
-                      // we can't use the styleFrom() side parameter, because that creates the same
-                      // outline for all states. The ButtonStyle.copyWith() method is used to add
-                      // a MaterialState<BorderSide?> property that does the right thing.
-                      TextButton(
-                        onPressed: () {},
-                        style: TextButton.styleFrom(
-                          overlayColor: color2,
-                          backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                            return AnimatedContainer(
-                              duration: const Duration(milliseconds: 500),
-                              decoration: statesToDecoration(states),
-                              child: child,
-                            );
-                          },
-                        ).copyWith(
-                          side: MaterialStateProperty.resolveWith<BorderSide?>((Set<MaterialState> states) {
-                            if (states.contains(MaterialState.hovered)) {
-                              return BorderSide(width: 3, color: color3);
-                            }
-                            return null; // defer to the default
-                          }),
-                        ),
-                        child: const Text('TextButton #7'),
-                      ),
-                      verticalSpacer,
+                          // Override the backgroundBuilder to add a state specific gradient background
+                          // and add an outline that only appears when the button is hovered or pressed.
+                          //
+                          // The gradient background decoration is computed by the statesToDecoration()
+                          // method. The gradient flips horizontally when the button is hovered (watch
+                          // closely). Because we want the outline to only appear when the button is hovered
+                          // we can't use the styleFrom() side parameter, because that creates the same
+                          // outline for all states. The ButtonStyle.copyWith() method is used to add
+                          // a MaterialState<BorderSide?> property that does the right thing.
+                          //
+                          // The gradient background is translucent - all of the colors have opacity 0.5 -
+                          // so the overlay's splash and highlight colors are visible even though they're
+                          // drawn on the Material widget that's effectively behind the background. The
+                          // border is also translucent, so if you look carefully, you'll see that the
+                          // background - which is part of the button's Material but is drawn on top of the
+                          // the background gradient - shows through the border.
+                          TextButton(
+                            onPressed: () {},
+                            style: TextButton.styleFrom(
+                              overlayColor: color2,
+                              backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                                return AnimatedContainer(
+                                  duration: const Duration(milliseconds: 500),
+                                  decoration: statesToDecoration(states),
+                                  child: child,
+                                );
+                              },
+                            ).copyWith(
+                              side: MaterialStateProperty.resolveWith<BorderSide?>((Set<MaterialState> states) {
+                                if (states.contains(MaterialState.hovered)) {
+                                  return BorderSide(width: 3, color: color3);
+                                }
+                                return null; // defer to the default
+                              }),
+                            ),
+                            child: const Text('TextButton #7'),
+                          ),
+                          verticalSpacer,
 
-                      // Override the backgroundBuilder to add a burlap image background.
-                      //
-                      // The image is clipped to the button's shape. We've included an Ink widget
-                      // because the background image is opaque and would otherwise obscure the splash
-                      // and highlight overlays that are painted on the button's Material widget
-                      // by default. They're drawn on the Ink widget instead. The foreground color
-                      // was overridden as well because black shows up a little better on the mottled
-                      // brown background.
-                      TextButton(
-                        onPressed: () {},
-                        style: TextButton.styleFrom(
-                          foregroundColor: Colors.black,
-                          backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                            return Ink(
-                              decoration: const BoxDecoration(
-                                image: DecorationImage(
-                                  image: NetworkImage(burlapUrl),
-                                  fit: BoxFit.cover,
-                                ),
-                              ),
-                              child: child,
-                            );
-                          },
-                        ),
-                        child: const Text('TextButton #8'),
-                      ),
-                      verticalSpacer,
+                          // Override the backgroundBuilder to add a burlap image background.
+                          //
+                          // The image is clipped to the button's shape. We've included an Ink widget
+                          // because the background image is opaque and would otherwise obscure the splash
+                          // and highlight overlays that are painted on the button's Material widget
+                          // by default. They're drawn on the Ink widget instead. The foreground color
+                          // was overridden as well because black shows up a little better on the mottled
+                          // brown background.
+                          TextButton(
+                            onPressed: () {},
+                            style: TextButton.styleFrom(
+                              foregroundColor: Colors.black,
+                              backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                                return Ink(
+                                  decoration: const BoxDecoration(
+                                    image: DecorationImage(
+                                      image: NetworkImage(burlapUrl),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                  child: child,
+                                );
+                              },
+                            ),
+                            child: const Text('TextButton #8'),
+                          ),
+                          verticalSpacer,
 
-                      // Override the foregroundBuilder to specify images for the button's pressed
-                      // hovered and inactive states.
-                      //
-                      // This is an example of completely changing the default appearance of a button
-                      // by specifying images for each state and by turning off the overlays by
-                      // overlayColor: Colors.transparent. AnimatedContainer takes care of the
-                      // fade in and out segues between images.
-                      //
-                      // This foregroundBuilder function ignores its child parameter. Unfortunately
-                      // TextButton's child parameter is required, so we still have
-                      // to provide one.
-                      TextButton(
-                        onPressed: () {},
-                        style: TextButton.styleFrom(
-                          overlayColor: Colors.transparent,
-                          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
-                            String url = states.contains(MaterialState.hovered) ? smiley3Url : smiley1Url;
-                            if (states.contains(MaterialState.pressed)) {
-                              url = smiley2Url;
-                            }
-                            return AnimatedContainer(
-                              width: 64,
-                              height: 64,
-                              duration: const Duration(milliseconds: 300),
-                              curve: Curves.fastOutSlowIn,
-                              decoration: BoxDecoration(
-                                image: DecorationImage(
-                                  image: NetworkImage(url),
-                                  fit: BoxFit.contain,
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                        child: const Text('This child is not used'),
+                          // Override the foregroundBuilder to specify images for the button's pressed
+                          // hovered and inactive states.
+                          //
+                          // This is an example of completely changing the default appearance of a button
+                          // by specifying images for each state and by turning off the overlays by
+                          // overlayColor: Colors.transparent. AnimatedContainer takes care of the
+                          // fade in and out segues between images.
+                          //
+                          // This foregroundBuilder function ignores its child parameter. Unfortunately
+                          // TextButton's child parameter is required, so we still have
+                          // to provide one.
+                          TextButton(
+                            onPressed: () {},
+                            style: TextButton.styleFrom(
+                              overlayColor: Colors.transparent,
+                              foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                                String url = states.contains(MaterialState.hovered) ? smiley3Url : smiley1Url;
+                                if (states.contains(MaterialState.pressed)) {
+                                  url = smiley2Url;
+                                }
+                                return AnimatedContainer(
+                                  width: 64,
+                                  height: 64,
+                                  duration: const Duration(milliseconds: 300),
+                                  curve: Curves.fastOutSlowIn,
+                                  decoration: BoxDecoration(
+                                    image: DecorationImage(
+                                      image: NetworkImage(url),
+                                      fit: BoxFit.contain,
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
+                            child: const Text('This child is not used'),
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                    horizontalSpacer,
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -6,78 +6,416 @@ import 'package:flutter/material.dart';
 
 /// Flutter code sample for [TextButton].
 
-void main() => runApp(const TextButtonExampleApp());
+void main() {
+  runApp(const TextButtonExampleApp());
+}
 
-class TextButtonExampleApp extends StatelessWidget {
-  const TextButtonExampleApp({super.key});
+class TextButtonExampleApp extends StatefulWidget {
+  const TextButtonExampleApp({ super.key });
+
+  @override
+  State<TextButtonExampleApp> createState() => _TextButtonExampleAppState();
+}
+
+class _TextButtonExampleAppState extends State<TextButtonExampleApp> {
+  bool darkMode = false;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      themeMode: darkMode ? ThemeMode.dark : ThemeMode.light,
+      theme: ThemeData(brightness: Brightness.light),
+      darkTheme: ThemeData(brightness: Brightness.dark),
       home: Scaffold(
-        appBar: AppBar(title: const Text('TextButton Sample')),
-        body: const TextButtonExample(),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: TextButtonExample(
+            darkMode: darkMode,
+            updateDarkMode: (bool value) {
+              setState(() { darkMode = value; });
+            },
+          ),
+        ),
       ),
     );
   }
 }
 
-class TextButtonExample extends StatelessWidget {
-  const TextButtonExample({super.key});
+class TextButtonExample extends StatefulWidget {
+  const TextButtonExample({ super.key, required this.darkMode, required this.updateDarkMode });
+
+  final bool darkMode;
+  final ValueChanged<bool> updateDarkMode;
+
+  @override
+  State<TextButtonExample> createState() => _TextButtonExampleState();
+}
+
+class _TextButtonExampleState extends State<TextButtonExample> {
+  TextDirection textDirection = TextDirection.ltr;
+  ThemeMode themeMode = ThemeMode.light;
+  VisualDensity visualDensity = VisualDensity.standard;
+
+  static const Widget verticalSpacer = SizedBox(height: 16);
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          TextButton(
-            style: TextButton.styleFrom(
-              textStyle: const TextStyle(fontSize: 20),
-            ),
-            onPressed: null,
-            child: const Text('Disabled'),
-          ),
-          const SizedBox(height: 30),
-          TextButton(
-            style: TextButton.styleFrom(
-              textStyle: const TextStyle(fontSize: 20),
-            ),
-            onPressed: () {},
-            child: const Text('Enabled'),
-          ),
-          const SizedBox(height: 30),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Stack(
-              children: <Widget>[
-                Positioned.fill(
-                  child: Container(
-                    decoration: const BoxDecoration(
-                      gradient: LinearGradient(
-                        colors: <Color>[
-                          Color(0xFF0D47A1),
-                          Color(0xFF1976D2),
-                          Color(0xFF42A5F5),
-                        ],
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    // Adapt colors that are not part of the color scheme to
+    // the current dark/light mode. Used to define TextButton #7's
+    // gradients.
+    final Color color1;
+    final Color color2;
+    final Color color3;
+    if (colorScheme.brightness == Brightness.light) {
+      color1 = Colors.blue.withOpacity(0.5);
+      color2 = Colors.orange.withOpacity(0.5);
+      color3 = Colors.yellow.withOpacity(0.5);
+    } else {
+      color1 = Colors.purple.withOpacity(0.5);
+      color2 = Colors.cyan.withOpacity(0.5);
+      color3 = Colors.yellow.withOpacity(0.5);
+    }
+
+    // This gradient's appearance reflects the button's state.
+    // Always return a gradient decoration so that AnimatedContainer
+    // can interpolorate in between. Used by TextButton #7.
+    Decoration? statesToDecoration(Set<MaterialState> states) {
+      if (states.contains(MaterialState.pressed)) {
+        return BoxDecoration(
+          gradient: LinearGradient(colors: <Color>[color2, color2]), // solid fill
+        );
+      }
+      return BoxDecoration(
+        gradient: LinearGradient(
+          colors: switch (states.contains(MaterialState.hovered)) {
+            true => <Color>[color1, color2],
+            false => <Color>[color2, color1],
+          },
+        ),
+      );
+    }
+
+    return Row(
+      children: <Widget> [
+        // The dark/light and LTR/RTL switches. We use the updateDarkMode function
+        // provided by the parent TextButtonExampleApp to rebuild the MaterialApp
+        // in the appropriate dark/light ThemeMdoe. The directionality of the rest
+        // of the UI is controlled by the Directionality widget below, and the
+        // textDirection local state variable.
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: IntrinsicWidth(
+              child: Column(
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      const Expanded(child: Text('Dark Mode')),
+                      const SizedBox(width: 4),
+                      Switch(
+                        value: widget.darkMode,
+                        onChanged: (bool value) {
+                          widget.updateDarkMode(value);
+                        },
                       ),
-                    ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: <Widget>[
+                      const Expanded(child: Text('RTL Text')),
+                      const SizedBox(width: 4),
+                      Switch(
+                        value: textDirection == TextDirection.rtl,
+                        onChanged: (bool value) {
+                          setState(() {
+                            textDirection = value ? TextDirection.rtl : TextDirection.ltr;
+                          });
+                        },
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+
+        // All of the button examples appear below. They're arranged in two columns.
+
+        // This theme defines default property overrides for all of the buttons
+        // that follow.
+        TextButtonTheme
+        (
+          data: TextButtonThemeData(
+            style: TextButton.styleFrom(
+              visualDensity: visualDensity,
+              textStyle: theme.textTheme.labelLarge,
+            ),
+          ),
+          child: Expanded(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: <Widget>[
+                Directionality(
+                  textDirection: textDirection,
+                  child: Column(
+                    children: <Widget>[
+                      TextButton(
+                        onPressed: () {},
+                        child: const Text('Enabled'),
+                      ),
+                      verticalSpacer,
+
+                      const TextButton(
+                        onPressed: null,
+                        child: Text('Disabled'),
+                      ),
+                      verticalSpacer,
+
+                      TextButton.icon(
+                        onPressed: () {},
+                        icon: const Icon(Icons.access_alarm),
+                        label: const Text('TextButton.icon #1'),
+                      ),
+                      verticalSpacer,
+
+                      // Override the foreground and background colors.
+                      //
+                      // In this example, and most of the ones that follow, we're using
+                      // the TextButton.styleFrom() convenience method to create a ButtonStyle.
+                      // The styleFrom method is a little easier because it creates
+                      // ButtonStyle MaterialStateProperty parameters for you.
+                      // In this case, Specifying foregroundColor overrides the text,
+                      // icon and overlay (splash and highlight) colors a little differently
+                      // depending on the button's state. BackgroundColor is just the background
+                      // color for all states.
+                      TextButton.icon(
+                        style: TextButton.styleFrom(
+                          foregroundColor: colorScheme.onError,
+                          backgroundColor: colorScheme.error,
+                        ),
+                        onPressed: () { },
+                        icon: const Icon(Icons.access_alarm),
+                        label: const Text('TextButton.icon #2'),
+                      ),
+                      verticalSpacer,
+
+                      // Override button's shape its border.
+                      //
+                      // In this case we've specified a shape that has border - the
+                      // RoundedRectangleBorder's side parameter. If the styleFrom
+                      // side parameter was also specified, or if the TextButtonTheme
+                      // defined above included a side parameter, then that would
+                      // override the RoundedRectangleBorder's side.
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          shape: RoundedRectangleBorder(
+                            borderRadius: const BorderRadius.all(Radius.circular(8)),
+                            side: BorderSide(
+                              color: colorScheme.primary,
+                              width: 5,
+                            ),
+                          ),
+                        ),
+                        onPressed: () { },
+                        child: const Text('TextButton #3'),
+                      ),
+                      verticalSpacer,
+
+                      // Override overlay: the ink splash and highlight colors.
+                      //
+                      // The styleFrom method turns the specified overlayColor
+                      // into a value MaterialStyleProperty<Color> ButtonStyle.overlay
+                      // value that uses opacities depending on the button's state.
+                      // If the overlayColor was Colors.transparent, no splash
+                      // or highlights would be shown.
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          overlayColor: Colors.yellow,
+                        ),
+                        onPressed: () { },
+                        child: const Text('TextButton #4'),
+                      ),
+                    ],
                   ),
                 ),
-                TextButton(
-                  style: TextButton.styleFrom(
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.all(16.0),
-                    textStyle: const TextStyle(fontSize: 20),
+
+                Directionality(
+                  textDirection: textDirection,
+                  child: Column(
+                    children: <Widget>[
+                      // Override the foregroundBuilder: apply a ShaderMask.
+                      //
+                      // Apply a ShaderMask to the button's child. This kind of thing
+                      // can be applied to one button easily enough by just wrapping the
+                      // button's child directly. However to affect all buttons in this
+                      // way you can specify a similar foregroundBuilder in a TextButton
+                      // theme or the MaterialApp theme's ThemeData.textButtonTheme.
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                            return ShaderMask(
+                              shaderCallback: (Rect bounds) {
+                                return LinearGradient(
+                                  begin: Alignment.bottomCenter,
+                                  end: Alignment.topCenter,
+                                  colors: <Color>[
+                                    colorScheme.primary,
+                                    colorScheme.onPrimary,
+                                  ],
+                                ).createShader(bounds);
+                              },
+                              blendMode: BlendMode.srcATop,
+                              child: child,
+                            );
+                          },
+                        ),
+                        onPressed: () { },
+                        child: const Text('TextButton #5'),
+                      ),
+                      verticalSpacer,
+
+                      // Override the foregroundBuilder: add an underline.
+                      //
+                      // Add a border around button's child. In this case the
+                      // border only appears when the button is hovered or pressed
+                      // (if it's pressed it's always hovered too). Not that this
+                      // border is different than the one specified with the styleFrom
+                      // side parameter (or the ButtonStyle.side property). The foregroundBuilder
+                      // is applied to a widget that contains the child and has already
+                      // included the button's padding. It is unaffected by the button's shape.
+                      // The styleFrom side parameter controls the button's outermost border and it
+                      // outlines the button's shape.
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                            return DecoratedBox(
+                              decoration: BoxDecoration(
+                                border: states.contains(MaterialState.hovered)
+                                  ? Border(bottom: BorderSide(color: colorScheme.primary))
+                                  : const Border(), // essentially "no border"
+                              ),
+                              child: child,
+                            );
+                          },
+                        ),
+                        onPressed: () { },
+                        child: const Text('TextButton #6'),
+                      ),
+                      verticalSpacer,
+
+                      // Override the backgroundBuilder to add a state specific gradient background
+                      // and add an outline that only appears when the button is hovered or pressed.
+                      //
+                      // The gradient background decoration is computed by the statesToDecoration()
+                      // method. The gradient flips horizontally when the button is hovered (watch
+                      // closely). Because we want the outline to only appear when the button is hovered
+                      // we can't use the styleFrom() side parameter, because that creates the same
+                      // outline for all states. The ButtonStyle.copyWith() method is used to add
+                      // a MaterialState<BorderSide?> property that does the right thing.
+                      TextButton(
+                        onPressed: () {},
+                        style: TextButton.styleFrom(
+                          overlayColor: color2,
+                          backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                            return AnimatedContainer(
+                              duration: const Duration(milliseconds: 500),
+                              decoration: statesToDecoration(states),
+                              child: child,
+                            );
+                          },
+                        ).copyWith(
+                          side: MaterialStateProperty.resolveWith<BorderSide?>((Set<MaterialState> states) {
+                            if (states.contains(MaterialState.hovered)) {
+                              return BorderSide(width: 3, color: color3);
+                            }
+                            return null; // defer to the default
+                          }),
+                        ),
+                        child: const Text('TextButton #7'),
+                      ),
+                      verticalSpacer,
+
+                      // Override the backgroundBuilder to add a burlap image background.
+                      //
+                      // The image is clipped to the button's shape. We've included an Ink widget
+                      // because the background image is opaque and would otherwise obscure the splash
+                      // and highlight overlays that are painted on the button's Material widget
+                      // by default. They're drawn on the Ink widget instead. The foreground color
+                      // was overridden as well because black shows up a little better on the mottled
+                      // brown background.
+                      TextButton(
+                        onPressed: () {},
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.black,
+                          backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                            return Ink(
+                              decoration: const BoxDecoration(
+                                image: DecorationImage(
+                                  image: NetworkImage(burlapUrl),
+                                  fit: BoxFit.cover,
+                                ),
+                              ),
+                              child: child,
+                            );
+                          },
+                        ),
+                        child: const Text('TextButton #8'),
+                      ),
+                      verticalSpacer,
+
+                      // Override the foregroundBuilder to specify images for the button's pressed
+                      // hovered and inactive states.
+                      //
+                      // This is an example of completely change the default appearance of a button
+                      // by specifying images for each state and by turning off the overlays by
+                      // overlayColor: Colors.transparent. AnimatedContainer takes care of the
+                      // fade in and out segues between images.
+                      //
+                      // The foregroundBuilder its child parameter. Unfortunately TextButton's child
+                      // parameter is required, so we still have to provide one.
+                      TextButton(
+                        onPressed: () {},
+                        style: TextButton.styleFrom(
+                          overlayColor: Colors.transparent,
+                          foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                            String url = states.contains(MaterialState.hovered) ? smiley3Url : smiley1Url;
+                            if (states.contains(MaterialState.pressed)) {
+                              url = smiley2Url;
+                            }
+                            return AnimatedContainer(
+                              width: 64,
+                              height: 64,
+                              duration: const Duration(milliseconds: 300),
+                              curve: Curves.fastOutSlowIn,
+                              decoration: BoxDecoration(
+                                image: DecorationImage(
+                                  image: NetworkImage(url),
+                                  fit: BoxFit.contain,
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                        child: const Text('This child is not used'),
+                      ),
+                    ],
                   ),
-                  onPressed: () {},
-                  child: const Text('Gradient'),
                 ),
               ],
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
+
+const String burlapUrl = 'https://media.istockphoto.com/id/152949844/photo/a-tan-burlap-textile-background-can-you-be-used-for-a-sack.jpg?s=612x612&w=0&k=20&c=AmUxRFPqpjzoi5D6r3flsRYANARdLQmyB5qt_LoryRs=';
+const String smiley1Url = 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/626f7f20-56da-4a6c-9996-50364c8b9ae2/dbc4dre-9244e67e-5e6b-44af-89e3-63cec6d18521.png/v1/fit/w_375,h_351/just_another_happy_smiley_____by_mondspeer_dbc4dre-375w.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9NTYxIiwicGF0aCI6IlwvZlwvNjI2ZjdmMjAtNTZkYS00YTZjLTk5OTYtNTAzNjRjOGI5YWUyXC9kYmM0ZHJlLTkyNDRlNjdlLTVlNmItNDRhZi04OWUzLTYzY2VjNmQxODUyMS5wbmciLCJ3aWR0aCI6Ijw9NjAwIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmltYWdlLm9wZXJhdGlvbnMiXX0.w7Xx-DmFGXjb6kbWn5_jXqcI6VKNZICN18hmkU8WmlQ';
+const String smiley2Url = 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/i/626f7f20-56da-4a6c-9996-50364c8b9ae2/d8gvlso-4b7bf222-1560-4f13-85b0-6a6371191aa3.png';
+const String smiley3Url = 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/i/626f7f20-56da-4a6c-9996-50364c8b9ae2/d8hfwwe-801502fe-7457-473e-9df2-b62e7bfdb1ff.png';

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -54,7 +54,6 @@ class TextButtonExample extends StatefulWidget {
 class _TextButtonExampleState extends State<TextButtonExample> {
   TextDirection textDirection = TextDirection.ltr;
   ThemeMode themeMode = ThemeMode.light;
-  VisualDensity visualDensity = VisualDensity.standard;
   late final ScrollController scrollController;
 
   static const Widget verticalSpacer = SizedBox(height: 16);
@@ -288,23 +287,23 @@ class _TextButtonExampleState extends State<TextButtonExample> {
       ),
       verticalSpacer,
 
-      // Override the backgroundBuilder to add a burlap image background.
+      // Override the backgroundBuilder to add a grass image background.
       //
       // The image is clipped to the button's shape. We've included an Ink widget
       // because the background image is opaque and would otherwise obscure the splash
       // and highlight overlays that are painted on the button's Material widget
       // by default. They're drawn on the Ink widget instead. The foreground color
-      // was overridden as well because black shows up a little better on the mottled
-      // brown background.
+      // was overridden as well because white shows up a little better on the mottled
+      // green background.
       TextButton(
         onPressed: () {},
         style: TextButton.styleFrom(
-          foregroundColor: Colors.black,
+          foregroundColor: Colors.white,
           backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
             return Ink(
               decoration: const BoxDecoration(
                 image: DecorationImage(
-                  image: NetworkImage(burlapUrl),
+                  image: NetworkImage(grassUrl),
                   fit: BoxFit.cover,
                 ),
               ),
@@ -375,43 +374,33 @@ class _TextButtonExampleState extends State<TextButtonExample> {
 
         // All of the button examples appear below. They're arranged in two columns.
 
-        // This theme defines default property overrides for all of the buttons
-        // that follow.
-        TextButtonTheme(
-          data: TextButtonThemeData(
-            style: TextButton.styleFrom(
-              visualDensity: visualDensity,
-              textStyle: theme.textTheme.labelLarge,
-            ),
-          ),
-          child: Expanded(
-            child:  Scrollbar(
+        Expanded(
+          child:  Scrollbar(
+            controller: scrollController,
+            thumbVisibility: true,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
               controller: scrollController,
-              thumbVisibility: true,
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                controller: scrollController,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Directionality(
-                      textDirection: textDirection,
-                      child: Column(
-                        children: columnOneButtons,
-                      ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Directionality(
+                    textDirection: textDirection,
+                    child: Column(
+                      children: columnOneButtons,
                     ),
-                    horizontalSpacer,
+                  ),
+                  horizontalSpacer,
 
-                    Directionality(
-                      textDirection: textDirection,
-                      child: Column(
-                        children: columnTwoButtons
-                      ),
+                  Directionality(
+                    textDirection: textDirection,
+                    child: Column(
+                      children: columnTwoButtons
                     ),
-                    horizontalSpacer,
-                  ],
-                ),
+                  ),
+                  horizontalSpacer,
+                ],
               ),
             ),
           ),
@@ -472,7 +461,7 @@ class TextButtonExampleSwitches extends StatelessWidget {
   }
 }
 
-const String burlapUrl = 'https://media.istockphoto.com/id/152949844/photo/a-tan-burlap-textile-background-can-you-be-used-for-a-sack.jpg?s=612x612&w=0&k=20&c=AmUxRFPqpjzoi5D6r3flsRYANARdLQmyB5qt_LoryRs=';
-const String smiley1Url = 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/626f7f20-56da-4a6c-9996-50364c8b9ae2/dbc4dre-9244e67e-5e6b-44af-89e3-63cec6d18521.png/v1/fit/w_375,h_351/just_another_happy_smiley_____by_mondspeer_dbc4dre-375w.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7ImhlaWdodCI6Ijw9NTYxIiwicGF0aCI6IlwvZlwvNjI2ZjdmMjAtNTZkYS00YTZjLTk5OTYtNTAzNjRjOGI5YWUyXC9kYmM0ZHJlLTkyNDRlNjdlLTVlNmItNDRhZi04OWUzLTYzY2VjNmQxODUyMS5wbmciLCJ3aWR0aCI6Ijw9NjAwIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmltYWdlLm9wZXJhdGlvbnMiXX0.w7Xx-DmFGXjb6kbWn5_jXqcI6VKNZICN18hmkU8WmlQ';
-const String smiley2Url = 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/i/626f7f20-56da-4a6c-9996-50364c8b9ae2/d8gvlso-4b7bf222-1560-4f13-85b0-6a6371191aa3.png';
-const String smiley3Url = 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/i/626f7f20-56da-4a6c-9996-50364c8b9ae2/d8hfwwe-801502fe-7457-473e-9df2-b62e7bfdb1ff.png';
+const String grassUrl = 'https://flutter.github.io/assets-for-api-docs/assets/material/text_button_grass.jpeg';
+const String smiley1Url = 'https://flutter.github.io/assets-for-api-docs/assets/material/text_button_smiley1.png';
+const String smiley2Url = 'https://flutter.github.io/assets-for-api-docs/assets/material/text_button_smiley2.png';
+const String smiley3Url = 'https://flutter.github.io/assets-for-api-docs/assets/material/text_button_smiley3.png';

--- a/examples/api/test/material/text_button/text_button.0_test.dart
+++ b/examples/api/test/material/text_button/text_button.0_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/text_button/text_button.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+
+  // The app being tested loads images via HTTP which the test
+  // framework defeats by default.
+  setUpAll(() {
+    HttpOverrides.global = null;
+  });
+
+  testWidgets('TextButtonExample smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.TextButtonExampleApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Enabled'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Disabled'));
+    await tester.pumpAndSettle();
+
+    // TextButton.icon buttons are _TextButtonWithIcons rather than TextButtons.
+    // For the purposes of this test, just tapping in the right place is OK.
+
+    await tester.tap(find.text('TextButton.icon #1'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('TextButton.icon #2'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'TextButton #3'));
+    await tester.pumpAndSettle();
+
+
+    await tester.tap(find.widgetWithText(TextButton, 'TextButton #4'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'TextButton #5'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'TextButton #6'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'TextButton #7'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'TextButton #8'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(TextButton).last); // Smiley image button
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch).at(0)); // Dark Mode Switch
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch).at(1)); // RTL Text Switch
+    await tester.pumpAndSettle();
+  });
+}

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -327,8 +327,7 @@ class ButtonStyle with Diagnosticable {
   /// and whose child is the rest of the button, including the button's
   /// `child` parameter.
   ///
-  /// By default the returned widget is clipped to the Material's [ButtonStyle.shape],
-  /// see [clipBehavior].
+  /// By default the returned widget is clipped to the Material's [ButtonStyle.shape].
   final ButtonLayerBuilder? backgroundBuilder;
 
   /// Creates a Widget that contains the button's child parameter which is used

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -16,6 +16,12 @@ import 'theme_data.dart';
 // late BuildContext context;
 // typedef MyAppHome = Placeholder;
 
+/// The type for [ButtonStyle.backgroundBuilder] and [ButtonStyle.foregroundBuilder].
+///
+/// The [states] parameter is the button's current pressed/hovered/etc state. The [child] is
+/// typically a descendant of the returned widget.
+typedef ButtonLayerBuilder = Widget Function(BuildContext context, Set<MaterialState> states, Widget? child);
+
 /// The visual properties that most buttons have in common.
 ///
 /// Buttons and their themes have a ButtonStyle property which defines the visual
@@ -162,6 +168,8 @@ class ButtonStyle with Diagnosticable {
     this.enableFeedback,
     this.alignment,
     this.splashFactory,
+    this.backgroundBuilder,
+    this.foregroundBuilder,
   });
 
   /// The style for a button's [Text] widget descendants.
@@ -315,6 +323,23 @@ class ButtonStyle with Diagnosticable {
   /// ```
   final InteractiveInkFeatureFactory? splashFactory;
 
+  /// Creates a widget that becomes the child of the button's [Material]
+  /// and whose child is the rest of the button, including the button's
+  /// `child` parameter.
+  ///
+  /// By default the returned widget is clipped to the Material's [ButtonStyle.shape],
+  /// see [clipBehavior].
+  final ButtonLayerBuilder? backgroundBuilder;
+
+  /// Creates a Widget that contains the button's child parameter which is used
+  /// instead of the button's child.
+  ///
+  /// The returned widget is clipped by the button's
+  /// [ButtonStyle.shape] inset by the button's [ButtonStyle.padding]
+  /// and aligned by the button's [ButtonStyle.alignment].
+  /// [ButtonStyle.shape].
+  final ButtonLayerBuilder? foregroundBuilder;
+
   /// Returns a copy of this ButtonStyle with the given fields replaced with
   /// the new values.
   ButtonStyle copyWith({
@@ -340,6 +365,8 @@ class ButtonStyle with Diagnosticable {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
+    ButtonLayerBuilder? backgroundBuilder,
+    ButtonLayerBuilder? foregroundBuilder,
   }) {
     return ButtonStyle(
       textStyle: textStyle ?? this.textStyle,
@@ -364,6 +391,8 @@ class ButtonStyle with Diagnosticable {
       enableFeedback: enableFeedback ?? this.enableFeedback,
       alignment: alignment ?? this.alignment,
       splashFactory: splashFactory ?? this.splashFactory,
+      backgroundBuilder: backgroundBuilder ?? this.backgroundBuilder,
+      foregroundBuilder: foregroundBuilder ?? this.foregroundBuilder,
     );
   }
 
@@ -399,6 +428,8 @@ class ButtonStyle with Diagnosticable {
       enableFeedback: enableFeedback ?? style.enableFeedback,
       alignment: alignment ?? style.alignment,
       splashFactory: splashFactory ?? style.splashFactory,
+      backgroundBuilder: backgroundBuilder ?? style.backgroundBuilder,
+      foregroundBuilder: foregroundBuilder ?? style.foregroundBuilder,
     );
   }
 
@@ -427,6 +458,8 @@ class ButtonStyle with Diagnosticable {
       enableFeedback,
       alignment,
       splashFactory,
+      backgroundBuilder,
+      foregroundBuilder,
     ];
     return Object.hashAll(values);
   }
@@ -461,7 +494,9 @@ class ButtonStyle with Diagnosticable {
         && other.animationDuration == animationDuration
         && other.enableFeedback == enableFeedback
         && other.alignment == alignment
-        && other.splashFactory == splashFactory;
+        && other.splashFactory == splashFactory
+        && other.backgroundBuilder == backgroundBuilder
+        && other.foregroundBuilder == foregroundBuilder;
   }
 
   @override
@@ -488,6 +523,8 @@ class ButtonStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<Duration>('animationDuration', animationDuration, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('enableFeedback', enableFeedback, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));
+    properties.add(DiagnosticsProperty<ButtonLayerBuilder>('backgroundBuilder', backgroundBuilder, defaultValue: null));
+    properties.add(DiagnosticsProperty<ButtonLayerBuilder>('foregroundBuilder', foregroundBuilder, defaultValue: null));
   }
 
   /// Linearly interpolate between two [ButtonStyle]s.
@@ -518,6 +555,8 @@ class ButtonStyle with Diagnosticable {
       enableFeedback: t < 0.5 ? a?.enableFeedback : b?.enableFeedback,
       alignment: AlignmentGeometry.lerp(a?.alignment, b?.alignment, t),
       splashFactory: t < 0.5 ? a?.splashFactory : b?.splashFactory,
+      backgroundBuilder: t < 0.5 ? a?.backgroundBuilder : b?.backgroundBuilder,
+      foregroundBuilder: t < 0.5 ? a?.foregroundBuilder : b?.foregroundBuilder,
     );
   }
 

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -327,7 +327,21 @@ class ButtonStyle with Diagnosticable {
   /// and whose child is the rest of the button, including the button's
   /// `child` parameter.
   ///
+  /// The widget created by [backgroundBuilder] is constrained to be
+  /// the same size as the overall button and will appear behind the
+  /// button's child. The widget created by [foregroundBuilder] is
+  /// constrained to be the same size as the button's child, i.e. it's
+  /// inset by [ButtonStyle.padding] and aligned by the button's
+  /// [ButtonStyle.alignment].
+  ///
   /// By default the returned widget is clipped to the Material's [ButtonStyle.shape].
+  ///
+  /// See also:
+  ///
+  ///  * [foregroundBuilder], to create a widget that's as big as the button's
+  ///    child and is layered behind the child.
+  ///  * [ButtonStyleButton.clipBehavior], for more information about
+  ///    configuring clipping.
   final ButtonLayerBuilder? backgroundBuilder;
 
   /// Creates a Widget that contains the button's child parameter which is used
@@ -336,7 +350,13 @@ class ButtonStyle with Diagnosticable {
   /// The returned widget is clipped by the button's
   /// [ButtonStyle.shape] inset by the button's [ButtonStyle.padding]
   /// and aligned by the button's [ButtonStyle.alignment].
-  /// [ButtonStyle.shape].
+  ///
+  /// See also:
+  ///
+  ///  * [backgroundBuilder], to create a widget that's as big as the button and
+  ///    is layered behind the button's child.
+  ///  * [ButtonStyleButton.clipBehavior], for more information about
+  ///    configuring clipping.
   final ButtonLayerBuilder? foregroundBuilder;
 
   /// Returns a copy of this ButtonStyle with the given fields replaced with

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -348,7 +348,7 @@ class ButtonStyle with Diagnosticable {
   /// instead of the button's child.
   ///
   /// The returned widget is clipped by the button's
-  /// [ButtonStyle.shape] inset by the button's [ButtonStyle.padding]
+  /// [ButtonStyle.shape], inset by the button's [ButtonStyle.padding]
   /// and aligned by the button's [ButtonStyle.alignment].
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -90,7 +90,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   /// {@macro flutter.material.Material.clipBehavior}
   ///
   /// Defaults to [Clip.none] unless [ButtonStyle.backgroundBuilder] or
-  /// [ButtonStyle.foregroundBulder] is specified. In those
+  /// [ButtonStyle.foregroundBuilder] is specified. In those
   /// cases the default is [Clip.antiAlias].
   final Clip? clipBehavior;
 
@@ -399,7 +399,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
         heightFactor: 1.0,
         child: resolvedForegroundBuilder != null
           ? resolvedForegroundBuilder(context, statesController.value, widget.child)
-          : widget.child
+          : widget.child,
       ),
     );
     if (resolvedBackgroundBuilder != null) {

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -89,8 +89,9 @@ abstract class ButtonStyleButton extends StatefulWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none].
-  final Clip clipBehavior;
+  /// Defaults to [Clip.none] unless [backgroundBuilder] or [foregroundBulder] is specified. In those
+  /// cases the default is [Clip.antiAlias].
+  final Clip? clipBehavior;
 
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
@@ -318,6 +319,11 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
     final AlignmentGeometry? resolvedAlignment = effectiveValue((ButtonStyle? style) => style?.alignment);
     final Offset densityAdjustment = resolvedVisualDensity!.baseSizeAdjustment;
     final InteractiveInkFeatureFactory? resolvedSplashFactory = effectiveValue((ButtonStyle? style) => style?.splashFactory);
+    final ButtonLayerBuilder? resolvedBackgroundBuilder = effectiveValue((ButtonStyle? style) => style?.backgroundBuilder);
+    final ButtonLayerBuilder? resolvedForegroundBuilder = effectiveValue((ButtonStyle? style) => style?.foregroundBuilder);
+
+    final Clip effectiveClipBehavior = widget.clipBehavior
+      ?? ((resolvedBackgroundBuilder ?? resolvedForegroundBuilder) != null ? Clip.antiAlias : Clip.none);
 
     BoxConstraints effectiveConstraints = resolvedVisualDensity.effectiveConstraints(
       BoxConstraints(
@@ -384,6 +390,21 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
     elevation = resolvedElevation;
     backgroundColor = resolvedBackgroundColor;
 
+    Widget effectiveChild = Padding(
+      padding: padding,
+      child: Align(
+        alignment: resolvedAlignment!,
+        widthFactor: 1.0,
+        heightFactor: 1.0,
+        child: resolvedForegroundBuilder != null
+          ? resolvedForegroundBuilder(context, statesController.value, widget.child)
+          : widget.child
+      ),
+    );
+    if (resolvedBackgroundBuilder != null) {
+      effectiveChild = resolvedBackgroundBuilder(context, statesController.value, effectiveChild);
+    }
+
     final Widget result = ConstrainedBox(
       constraints: effectiveConstraints,
       child: Material(
@@ -395,7 +416,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
         surfaceTintColor: resolvedSurfaceTintColor,
         type: resolvedBackgroundColor == null ? MaterialType.transparency : MaterialType.button,
         animationDuration: resolvedAnimationDuration,
-        clipBehavior: widget.clipBehavior,
+        clipBehavior: effectiveClipBehavior,
         child: InkWell(
           onTap: widget.onPressed,
           onLongPress: widget.onLongPress,
@@ -413,15 +434,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
           statesController: statesController,
           child: IconTheme.merge(
             data: IconThemeData(color: resolvedIconColor ?? resolvedForegroundColor, size: resolvedIconSize),
-            child: Padding(
-              padding: padding,
-              child: Align(
-                alignment: resolvedAlignment!,
-                widthFactor: 1.0,
-                heightFactor: 1.0,
-                child: widget.child,
-              ),
-            ),
+            child: effectiveChild,
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -89,7 +89,8 @@ abstract class ButtonStyleButton extends StatefulWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none] unless [backgroundBuilder] or [foregroundBulder] is specified. In those
+  /// Defaults to [Clip.none] unless [ButtonStyle.backgroundBuilder] or
+  /// [ButtonStyle.foregroundBulder] is specified. In those
   /// cases the default is [Clip.antiAlias].
   final Clip? clipBehavior;
 

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -184,24 +184,24 @@ class ElevatedButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch ((foregroundColor, disabledForegroundColor)) {
       (null, null) => null,
       (_, _) => _ElevatedButtonDefaultColor(foregroundColor, disabledForegroundColor),
     };
-    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch ((backgroundColor, disabledBackgroundColor)) {
       (null, null) => null,
       (_, _) => _ElevatedButtonDefaultColor(backgroundColor, disabledBackgroundColor),
     };
-    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+    final MaterialStateProperty<Color?>? iconColorProp = switch ((iconColor, disabledIconColor)) {
       (null, null) => null,
       (_, _) => _ElevatedButtonDefaultColor(iconColor, disabledIconColor),
     };
-    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+    final MaterialStateProperty<Color?>? overlayColorProp = switch ((foregroundColor, overlayColor)) {
       (null, null) => null,
       (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
       (_, _) => _ElevatedButtonDefaultOverlay((overlayColor ?? foregroundColor)!),
     };
-    final MaterialStateProperty<double>? elevationValue = switch(elevation) {
+    final MaterialStateProperty<double>? elevationValue = switch (elevation) {
       null => null,
       _ => _ElevatedButtonDefaultElevation(elevation),
     };

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -111,13 +111,15 @@ class ElevatedButton extends ButtonStyleButton {
   /// The [backgroundColor] and [disabledBackgroundColor] colors are
   /// used to create a [MaterialStateProperty] [ButtonStyle.backgroundColor].
   ///
+  /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
+  /// parameters are used to construct [ButtonStyle].mouseCursor and
+  /// [iconColor], [disabledIconColor] are used to construct
+  /// [ButtonStyle.iconColor].
+  ///
   /// The button's elevations are defined relative to the [elevation]
   /// parameter. The disabled elevation is the same as the parameter
   /// value, [elevation] + 2 is used when the button is hovered
   /// or focused, and elevation + 6 is used when the button is pressed.
-  ///
-  /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
-  /// parameters are used to construct [ButtonStyle].mouseCursor.
   ///
   /// All of the other parameters are either used directly or used to
   /// create a [MaterialStateProperty] with a single value for all
@@ -160,6 +162,8 @@ class ElevatedButton extends ButtonStyleButton {
     Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
+    Color? iconColor,
+    Color? disabledIconColor,
     Color? overlayColor,
     double? elevation,
     TextStyle? textStyle,
@@ -180,24 +184,27 @@ class ElevatedButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final Color? background = backgroundColor;
-    final Color? disabledBackground = disabledBackgroundColor;
-    final MaterialStateProperty<Color?>? backgroundColorProp = (background == null && disabledBackground == null)
-      ? null
-      : _ElevatedButtonDefaultColor(background, disabledBackground);
-    final Color? foreground = foregroundColor;
-    final Color? disabledForeground = disabledForegroundColor;
-    final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
-      ? null
-      : _ElevatedButtonDefaultColor(foreground, disabledForeground);
-    final MaterialStateProperty<Color?>? overlayColorProp = (foreground == null && overlayColor == null)
-      ? null
-      : overlayColor != null && overlayColor.value == 0
-        ? const MaterialStatePropertyAll<Color?>(Colors.transparent)
-        : _ElevatedButtonDefaultOverlay((overlayColor ?? foreground)!);
-    final MaterialStateProperty<double>? elevationValue = (elevation == null)
-      ? null
-      : _ElevatedButtonDefaultElevation(elevation);
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+      (null, null) => null,
+      (_, _) => _ElevatedButtonDefaultColor(foregroundColor, disabledForegroundColor),
+    };
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+      (null, null) => null,
+      (_, _) => _ElevatedButtonDefaultColor(backgroundColor, disabledBackgroundColor),
+    };
+    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+      (null, null) => null,
+      (_, _) => _ElevatedButtonDefaultColor(iconColor, disabledIconColor),
+    };
+    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+      (null, null) => null,
+      (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
+      (_, _) => _ElevatedButtonDefaultOverlay((overlayColor ?? foregroundColor)!),
+    };
+    final MaterialStateProperty<double>? elevationValue = switch(elevation) {
+      null => null,
+      _ => _ElevatedButtonDefaultElevation(elevation),
+    };
     final MaterialStateProperty<MouseCursor?> mouseCursor = _ElevatedButtonDefaultMouseCursor(enabledMouseCursor, disabledMouseCursor);
 
     return ButtonStyle(
@@ -207,6 +214,7 @@ class ElevatedButton extends ButtonStyleButton {
       overlayColor: overlayColorProp,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
+      iconColor: iconColorProp,
       elevation: elevationValue,
       padding: ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(padding),
       minimumSize: ButtonStyleButton.allOrNull<Size>(minimumSize),

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -112,7 +112,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// used to create a [MaterialStateProperty] [ButtonStyle.backgroundColor].
   ///
   /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
-  /// parameters are used to construct [ButtonStyle].mouseCursor and
+  /// parameters are used to construct [ButtonStyle.mouseCursor] and
   /// [iconColor], [disabledIconColor] are used to construct
   /// [ButtonStyle.iconColor].
   ///

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -227,19 +227,19 @@ class FilledButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch ((foregroundColor, disabledForegroundColor)) {
       (null, null) => null,
       (_, _) => _FilledButtonDefaultColor(foregroundColor, disabledForegroundColor),
     };
-    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch ((backgroundColor, disabledBackgroundColor)) {
       (null, null) => null,
       (_, _) => _FilledButtonDefaultColor(backgroundColor, disabledBackgroundColor),
     };
-    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+    final MaterialStateProperty<Color?>? iconColorProp = switch ((iconColor, disabledIconColor)) {
       (null, null) => null,
       (_, _) => _FilledButtonDefaultColor(iconColor, disabledIconColor),
     };
-    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+    final MaterialStateProperty<Color?>? overlayColorProp = switch ((foregroundColor, overlayColor)) {
       (null, null) => null,
       (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
       (_, _) => _FilledButtonDefaultOverlay((overlayColor ?? foregroundColor)!),

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -205,6 +205,8 @@ class FilledButton extends ButtonStyleButton {
     Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
+    Color? iconColor,
+    Color? disabledIconColor,
     Color? overlayColor,
     double? elevation,
     TextStyle? textStyle,
@@ -225,21 +227,23 @@ class FilledButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final MaterialStateProperty<Color?>? backgroundColorProp =
-      (backgroundColor == null && disabledBackgroundColor == null)
-        ? null
-        : _FilledButtonDefaultColor(backgroundColor, disabledBackgroundColor);
-    final Color? foreground = foregroundColor;
-    final Color? disabledForeground = disabledForegroundColor;
-    final MaterialStateProperty<Color?>? foregroundColorProp =
-      (foreground == null && disabledForeground == null)
-        ? null
-        : _FilledButtonDefaultColor(foreground, disabledForeground);
-    final MaterialStateProperty<Color?>? overlayColorProp = (foreground == null && overlayColor == null)
-      ? null
-      : overlayColor != null && overlayColor.value == 0
-        ? const MaterialStatePropertyAll<Color?>(Colors.transparent)
-        : _FilledButtonDefaultOverlay((overlayColor ?? foreground)!);
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+      (null, null) => null,
+      (_, _) => _FilledButtonDefaultColor(foregroundColor, disabledForegroundColor),
+    };
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+      (null, null) => null,
+      (_, _) => _FilledButtonDefaultColor(backgroundColor, disabledBackgroundColor),
+    };
+    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+      (null, null) => null,
+      (_, _) => _FilledButtonDefaultColor(iconColor, disabledIconColor),
+    };
+    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+      (null, null) => null,
+      (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
+      (_, _) => _FilledButtonDefaultOverlay((overlayColor ?? foregroundColor)!),
+    };
     final MaterialStateProperty<MouseCursor?> mouseCursor = _FilledButtonDefaultMouseCursor(enabledMouseCursor, disabledMouseCursor);
 
     return ButtonStyle(
@@ -249,6 +253,7 @@ class FilledButton extends ButtonStyleButton {
       overlayColor: overlayColorProp,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
+      iconColor: iconColorProp,
       elevation: ButtonStyleButton.allOrNull(elevation),
       padding: ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(padding),
       minimumSize: ButtonStyleButton.allOrNull<Size>(minimumSize),

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -153,18 +153,22 @@ class FilledButton extends ButtonStyleButton {
   /// A static convenience method that constructs a filled button
   /// [ButtonStyle] given simple values.
   ///
-  /// The [foregroundColor], and [disabledForegroundColor] colors are used to create a
-  /// [MaterialStateProperty] [ButtonStyle.foregroundColor] value. The
-  /// [backgroundColor] and [disabledBackgroundColor] are used to create a
-  /// [MaterialStateProperty] [ButtonStyle.backgroundColor] value.
+  /// The [foregroundColor] and [disabledForegroundColor] colors are used
+  /// to create a [MaterialStateProperty] [ButtonStyle.foregroundColor], and
+  /// a derived [ButtonStyle.overlayColor] if [overlayColor] isn't specified.
+  ///
+  /// If [overlayColor] is specified and its value is [Colors.transparent]
+  /// then the pressed/focused/hovered highlights are effectively defeated.
+  /// Otherwise a [MaterialStateProperty] with the same opacities as the
+  /// default is created.
+  ///
+  /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
+  /// parameters are used to construct [ButtonStyle.mouseCursor].
   ///
   /// The button's elevations are defined relative to the [elevation]
   /// parameter. The disabled elevation is the same as the parameter
   /// value, [elevation] + 2 is used when the button is hovered
   /// or focused, and elevation + 6 is used when the button is pressed.
-  ///
-  /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
-  /// parameters are used to construct [ButtonStyle.mouseCursor].
   ///
   /// All of the other parameters are either used directly or used to
   /// create a [MaterialStateProperty] with a single value for all
@@ -201,6 +205,7 @@ class FilledButton extends ButtonStyleButton {
     Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
+    Color? overlayColor,
     double? elevation,
     TextStyle? textStyle,
     EdgeInsetsGeometry? padding,
@@ -217,6 +222,8 @@ class FilledButton extends ButtonStyleButton {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
+    ButtonLayerBuilder? backgroundBuilder,
+    ButtonLayerBuilder? foregroundBuilder,
   }) {
     final MaterialStateProperty<Color?>? backgroundColorProp =
       (backgroundColor == null && disabledBackgroundColor == null)
@@ -228,16 +235,18 @@ class FilledButton extends ButtonStyleButton {
       (foreground == null && disabledForeground == null)
         ? null
         : _FilledButtonDefaultColor(foreground, disabledForeground);
-    final MaterialStateProperty<Color?>? overlayColor = (foreground == null)
+    final MaterialStateProperty<Color?>? overlayColorProp = (foreground == null && overlayColor == null)
       ? null
-      : _FilledButtonDefaultOverlay(foreground);
+      : overlayColor != null && overlayColor.value == 0
+        ? const MaterialStatePropertyAll<Color?>(Colors.transparent)
+        : _FilledButtonDefaultOverlay((overlayColor ?? foreground)!);
     final MaterialStateProperty<MouseCursor?> mouseCursor = _FilledButtonDefaultMouseCursor(enabledMouseCursor, disabledMouseCursor);
 
     return ButtonStyle(
       textStyle: MaterialStatePropertyAll<TextStyle?>(textStyle),
       backgroundColor: backgroundColorProp,
       foregroundColor: foregroundColorProp,
-      overlayColor: overlayColor,
+      overlayColor: overlayColorProp,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
       elevation: ButtonStyleButton.allOrNull(elevation),
@@ -254,6 +263,8 @@ class FilledButton extends ButtonStyleButton {
       enableFeedback: enableFeedback,
       alignment: alignment,
       splashFactory: splashFactory,
+      backgroundBuilder: backgroundBuilder,
+      foregroundBuilder: foregroundBuilder,
     );
   }
 
@@ -468,14 +479,13 @@ class _FilledButtonWithIcon extends FilledButton {
     super.style,
     super.focusNode,
     bool? autofocus,
-    Clip? clipBehavior,
+    super.clipBehavior,
     super.statesController,
     required Widget icon,
     required Widget label,
   }) : super(
          autofocus: autofocus ?? false,
-         clipBehavior: clipBehavior ?? Clip.none,
-         child: _FilledButtonWithIconChild(icon: icon, label: label, buttonStyle: style),
+         child: _FilledButtonWithIconChild(icon: icon, label: label, buttonStyle: style)
       );
 
   _FilledButtonWithIcon.tonal({
@@ -487,14 +497,13 @@ class _FilledButtonWithIcon extends FilledButton {
     super.style,
     super.focusNode,
     bool? autofocus,
-    Clip? clipBehavior,
+    super.clipBehavior,
     super.statesController,
     required Widget icon,
     required Widget label,
   }) : super.tonal(
          autofocus: autofocus ?? false,
-         clipBehavior: clipBehavior ?? Clip.none,
-         child: _FilledButtonWithIconChild(icon: icon, label: label, buttonStyle: style),
+         child: _FilledButtonWithIconChild(icon: icon, label: label, buttonStyle: style)
        );
 
   @override

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -168,6 +168,9 @@ abstract class MaterialStateColor extends Color implements MaterialStateProperty
   /// specified state.
   @override
   Color resolve(Set<MaterialState> states);
+
+  /// A constant whose value is [Colors.transparent] for all states.
+  static const MaterialStateColor transparent = _MaterialStateColorTransparent();
 }
 
 /// A [MaterialStateColor] created from a [MaterialPropertyResolver<Color>]
@@ -187,6 +190,13 @@ class _MaterialStateColor extends MaterialStateColor {
 
   @override
   Color resolve(Set<MaterialState> states) => _resolve(states);
+}
+
+class _MaterialStateColorTransparent extends MaterialStateColor {
+  const _MaterialStateColorTransparent() : super(0x00000000);
+
+  @override
+  Color resolve(Set<MaterialState> states) => const Color(0x00000000);
 }
 
 /// Defines a [MouseCursor] whose value depends on a set of [MaterialState]s which

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -169,19 +169,19 @@ class OutlinedButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch ((foregroundColor, disabledForegroundColor)) {
       (null, null) => null,
       (_, _) => _OutlinedButtonDefaultColor(foregroundColor, disabledForegroundColor),
     };
-    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch ((backgroundColor, disabledBackgroundColor)) {
       (null, null) => null,
       (_, _) => _OutlinedButtonDefaultColor(backgroundColor, disabledBackgroundColor),
     };
-    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+    final MaterialStateProperty<Color?>? iconColorProp = switch ((iconColor, disabledIconColor)) {
       (null, null) => null,
       (_, _) => _OutlinedButtonDefaultColor(iconColor, disabledIconColor),
     };
-    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+    final MaterialStateProperty<Color?>? overlayColorProp = switch ((foregroundColor, overlayColor)) {
       (null, null) => null,
       (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
       (_, _) => _OutlinedButtonDefaultOverlay((overlayColor ?? foregroundColor)!),

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -105,16 +105,18 @@ class OutlinedButton extends ButtonStyleButton {
   /// to create a [MaterialStateProperty] [ButtonStyle.foregroundColor], and
   /// a derived [ButtonStyle.overlayColor] if [overlayColor] isn't specified.
   ///
-  /// If [overlayColor] is specified and its value is [Colors.transparent]
-  /// then the pressed/focused/hovered highlights are effectively defeated.
-  /// Otherwise a [MaterialStateProperty] with the same opacities as the
-  /// default is created.
-  ///
   /// The [backgroundColor] and [disabledBackgroundColor] colors are
   /// used to create a [MaterialStateProperty] [ButtonStyle.backgroundColor].
   ///
   /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
-  /// parameters are used to construct [ButtonStyle.mouseCursor].
+  /// parameters are used to construct [ButtonStyle].mouseCursor and
+  /// [iconColor], [disabledIconColor] are used to construct
+  /// [ButtonStyle.iconColor].
+  ///
+  /// If [overlayColor] is specified and its value is [Colors.transparent]
+  /// then the pressed/focused/hovered highlights are effectively defeated.
+  /// Otherwise a [MaterialStateProperty] with the same opacities as the
+  /// default is created.
   ///
   /// All of the other parameters are either used directly or used to
   /// create a [MaterialStateProperty] with a single value for all
@@ -145,6 +147,8 @@ class OutlinedButton extends ButtonStyleButton {
     Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
+    Color? iconColor,
+    Color? disabledIconColor,
     Color? overlayColor,
     double? elevation,
     TextStyle? textStyle,
@@ -165,21 +169,23 @@ class OutlinedButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final Color? foreground = foregroundColor;
-    final Color? disabledForeground = disabledForegroundColor;
-    final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
-      ? null
-      : _OutlinedButtonDefaultColor(foreground, disabledForeground);
-    final MaterialStateProperty<Color?>? backgroundColorProp = (backgroundColor == null && disabledBackgroundColor == null)
-      ? null
-      : disabledBackgroundColor == null
-        ? ButtonStyleButton.allOrNull<Color?>(backgroundColor)
-        : _OutlinedButtonDefaultColor(backgroundColor, disabledBackgroundColor);
-    final MaterialStateProperty<Color?>? overlayColorProp = (foreground == null && overlayColor == null)
-      ? null
-      : overlayColor != null && overlayColor.value == 0
-        ? const MaterialStatePropertyAll<Color?>(Colors.transparent)
-        : _OutlinedButtonDefaultOverlay((overlayColor ?? foreground)!);
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+      (null, null) => null,
+      (_, _) => _OutlinedButtonDefaultColor(foregroundColor, disabledForegroundColor),
+    };
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+      (null, null) => null,
+      (_, _) => _OutlinedButtonDefaultColor(backgroundColor, disabledBackgroundColor),
+    };
+    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+      (null, null) => null,
+      (_, _) => _OutlinedButtonDefaultColor(iconColor, disabledIconColor),
+    };
+    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+      (null, null) => null,
+      (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
+      (_, _) => _OutlinedButtonDefaultOverlay((overlayColor ?? foregroundColor)!),
+    };
     final MaterialStateProperty<MouseCursor?> mouseCursor = _OutlinedButtonDefaultMouseCursor(enabledMouseCursor, disabledMouseCursor);
 
     return ButtonStyle(
@@ -189,6 +195,7 @@ class OutlinedButton extends ButtonStyleButton {
       overlayColor: overlayColorProp,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
+      iconColor: iconColorProp,
       elevation: ButtonStyleButton.allOrNull<double>(elevation),
       padding: ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(padding),
       minimumSize: ButtonStyleButton.allOrNull<Size>(minimumSize),
@@ -322,9 +329,7 @@ class OutlinedButton extends ButtonStyleButton {
           padding: _scaledPadding(context),
           minimumSize: const Size(64, 36),
           maximumSize: Size.infinite,
-          side: BorderSide(
-            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
-          ),
+          side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)),
           shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
           enabledMouseCursor: SystemMouseCursors.click,
           disabledMouseCursor: SystemMouseCursors.basic,

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -109,7 +109,7 @@ class OutlinedButton extends ButtonStyleButton {
   /// used to create a [MaterialStateProperty] [ButtonStyle.backgroundColor].
   ///
   /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
-  /// parameters are used to construct [ButtonStyle].mouseCursor and
+  /// parameters are used to construct [ButtonStyle.mouseCursor] and
   /// [iconColor], [disabledIconColor] are used to construct
   /// [ButtonStyle.iconColor].
   ///

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -50,8 +50,9 @@ import 'theme_data.dart';
 /// button will be disabled, it will not react to touch.
 ///
 /// {@tool dartpad}
-/// This sample shows how to render a disabled TextButton, an enabled TextButton
-/// and lastly a TextButton with gradient background.
+/// This sample shows various ways to configure TextButtons, from the
+/// simplest default appearance to versions that don't resemble
+/// Material Design at all.
 ///
 /// ** See code in examples/api/lib/material/text_button/text_button.0.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -178,19 +178,19 @@ class TextButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch ((foregroundColor, disabledForegroundColor)) {
       (null, null) => null,
       (_, _) => _TextButtonDefaultColor(foregroundColor, disabledForegroundColor),
     };
-    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch ((backgroundColor, disabledBackgroundColor)) {
       (null, null) => null,
       (_, _) => _TextButtonDefaultColor(backgroundColor, disabledBackgroundColor),
     };
-    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+    final MaterialStateProperty<Color?>? iconColorProp = switch ((iconColor, disabledIconColor)) {
       (null, null) => null,
       (_, _) => _TextButtonDefaultColor(iconColor, disabledIconColor),
     };
-    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+    final MaterialStateProperty<Color?>? overlayColorProp = switch ((foregroundColor, overlayColor)) {
       (null, null) => null,
       (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
       (_, _) => _TextButtonDefaultOverlay((overlayColor ?? foregroundColor)!),

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -115,16 +115,18 @@ class TextButton extends ButtonStyleButton {
   /// to create a [MaterialStateProperty] [ButtonStyle.foregroundColor], and
   /// a derived [ButtonStyle.overlayColor] if [overlayColor] isn't specified.
   ///
-  /// If [overlayColor] is specified and its value is [Colors.transparent]
-  /// then the pressed/focused/hovered highlights are effectively defeated.
-  /// Otherwise a [MaterialStateProperty] with the same opacities as the
-  /// default is created.
-  ///
   /// The [backgroundColor] and [disabledBackgroundColor] colors are
   /// used to create a [MaterialStateProperty] [ButtonStyle.backgroundColor].
   ///
   /// Similarly, the [enabledMouseCursor] and [disabledMouseCursor]
-  /// parameters are used to construct [ButtonStyle.mouseCursor].
+  /// parameters are used to construct [ButtonStyle.mouseCursor] and
+  /// [iconColor], [disabledIconColor] are used to construct
+  /// [ButtonStyle.iconColor].
+  ///
+  /// If [overlayColor] is specified and its value is [Colors.transparent]
+  /// then the pressed/focused/hovered highlights are effectively defeated.
+  /// Otherwise a [MaterialStateProperty] with the same opacities as the
+  /// default is created.
   ///
   /// All of the other parameters are either used directly or used to
   /// create a [MaterialStateProperty] with a single value for all
@@ -176,26 +178,23 @@ class TextButton extends ButtonStyleButton {
     ButtonLayerBuilder? backgroundBuilder,
     ButtonLayerBuilder? foregroundBuilder,
   }) {
-    final Color? foreground = foregroundColor;
-    final Color? disabledForeground = disabledForegroundColor;
-    final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
-      ? null
-      : _TextButtonDefaultColor(foreground, disabledForeground);
-    final MaterialStateProperty<Color?>? backgroundColorProp = (backgroundColor == null && disabledBackgroundColor == null)
-      ? null
-      : disabledBackgroundColor == null
-        ? ButtonStyleButton.allOrNull<Color?>(backgroundColor)
-        : _TextButtonDefaultColor(backgroundColor, disabledBackgroundColor);
-    final MaterialStateProperty<Color?>? overlayColorProp = (foreground == null && overlayColor == null)
-      ? null
-      : overlayColor != null && overlayColor.value == 0
-        ? const MaterialStatePropertyAll<Color?>(Colors.transparent)
-        : _TextButtonDefaultOverlay((overlayColor ?? foreground)!);
-    final MaterialStateProperty<Color?>? iconColorProp = (iconColor == null && disabledIconColor == null)
-      ? null
-      : disabledIconColor == null
-        ? ButtonStyleButton.allOrNull<Color?>(iconColor)
-        : _TextButtonDefaultIconColor(iconColor, disabledIconColor);
+    final MaterialStateProperty<Color?>? foregroundColorProp = switch((foregroundColor, disabledForegroundColor)) {
+      (null, null) => null,
+      (_, _) => _TextButtonDefaultColor(foregroundColor, disabledForegroundColor),
+    };
+    final MaterialStateProperty<Color?>? backgroundColorProp = switch((backgroundColor, disabledBackgroundColor)) {
+      (null, null) => null,
+      (_, _) => _TextButtonDefaultColor(backgroundColor, disabledBackgroundColor),
+    };
+    final MaterialStateProperty<Color?>? iconColorProp = switch((iconColor, disabledIconColor)) {
+      (null, null) => null,
+      (_, _) => _TextButtonDefaultColor(iconColor, disabledIconColor),
+    };
+    final MaterialStateProperty<Color?>? overlayColorProp = switch((foregroundColor, overlayColor)) {
+      (null, null) => null,
+      (_, final Color overlayColor) when overlayColor.value == 0 => const MaterialStatePropertyAll<Color?>(Colors.transparent),
+      (_, _) => _TextButtonDefaultOverlay((overlayColor ?? foregroundColor)!),
+    };
     final MaterialStateProperty<MouseCursor?> mouseCursor = _TextButtonDefaultMouseCursor(enabledMouseCursor, disabledMouseCursor);
 
     return ButtonStyle(
@@ -433,27 +432,6 @@ class _TextButtonDefaultOverlay extends MaterialStateProperty<Color?> {
   @override
   String toString() {
     return '{hovered: ${primary.withOpacity(0.04)}, focused,pressed: ${primary.withOpacity(0.12)}, otherwise: null}';
-  }
-}
-
-@immutable
-class _TextButtonDefaultIconColor extends MaterialStateProperty<Color?> {
-  _TextButtonDefaultIconColor(this.iconColor, this.disabledIconColor);
-
-  final Color? iconColor;
-  final Color? disabledIconColor;
-
-  @override
-  Color? resolve(Set<MaterialState> states) {
-    if (states.contains(MaterialState.disabled)) {
-      return disabledIconColor;
-    }
-    return iconColor;
-  }
-
-  @override
-  String toString() {
-    return '{disabled: $disabledIconColor, color: $iconColor}';
   }
 }
 

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -42,6 +42,8 @@ void main() {
     expect(style.tapTargetSize, null);
     expect(style.animationDuration, null);
     expect(style.enableFeedback, null);
+    expect(style.backgroundBuilder, null);
+    expect(style.foregroundBuilder, null);
   });
 
   testWidgets('Default ButtonStyle debugFillProperties', (WidgetTester tester) async {
@@ -107,6 +109,9 @@ void main() {
   });
 
   testWidgets('ButtonStyle copyWith, merge', (WidgetTester tester) async {
+    Widget backgroundBuilder(BuildContext context, Set<MaterialState> states, Widget? child) => child!;
+    Widget foregroundBuilder(BuildContext context, Set<MaterialState> states, Widget? child) => child!;
+
     const MaterialStateProperty<TextStyle> textStyle = MaterialStatePropertyAll<TextStyle>(TextStyle(fontSize: 10));
     const MaterialStateProperty<Color> backgroundColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
     const MaterialStateProperty<Color> foregroundColor = MaterialStatePropertyAll<Color>(Color(0xfffffff2));
@@ -128,7 +133,7 @@ void main() {
     const Duration animationDuration = Duration(seconds: 1);
     const bool enableFeedback = true;
 
-    const ButtonStyle style = ButtonStyle(
+    ButtonStyle style = ButtonStyle(
       textStyle: textStyle,
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
@@ -149,6 +154,8 @@ void main() {
       tapTargetSize: tapTargetSize,
       animationDuration: animationDuration,
       enableFeedback: enableFeedback,
+      backgroundBuilder: backgroundBuilder,
+      foregroundBuilder: foregroundBuilder,
     );
 
     expect(
@@ -174,6 +181,8 @@ void main() {
         tapTargetSize: tapTargetSize,
         animationDuration: animationDuration,
         enableFeedback: enableFeedback,
+        backgroundBuilder: backgroundBuilder,
+        foregroundBuilder:foregroundBuilder,
       ),
     );
 

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -133,7 +133,7 @@ void main() {
     const Duration animationDuration = Duration(seconds: 1);
     const bool enableFeedback = true;
 
-    ButtonStyle style = ButtonStyle(
+    final ButtonStyle style = ButtonStyle(
       textStyle: textStyle,
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -1942,6 +1942,203 @@ void main() {
     expect(controller.value, <MaterialState>{MaterialState.disabled});
     expect(count, 1);
   });
+
+  testWidgets('ElevatedButton backgroundBuilder and foregroundBuilder', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: backgroundColor,
+                ),
+                child: child,
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: foregroundColor,
+                ),
+                child: child,
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    BoxDecoration boxDecorationOf(Finder finder) {
+      return tester.widget<DecoratedBox>(finder).decoration as BoxDecoration;
+    }
+
+    final Finder decorations = find.descendant(
+      of: find.byType(ElevatedButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(boxDecorationOf(decorations.at(0)).color, backgroundColor);
+    expect(boxDecorationOf(decorations.at(1)).color, foregroundColor);
+
+    Text textChildOf(Finder finder) {
+      return tester.widget<Text>(
+        find.descendant(
+          of: finder,
+          matching: find.byType(Text),
+        ),
+      );
+    }
+
+    expect(textChildOf(decorations.at(0)).data, 'button');
+    expect(textChildOf(decorations.at(1)).data, 'button');
+  });
+
+
+  testWidgets('ElevatedButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                ),
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder background = find.descendant(
+      of: find.byType(ElevatedButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(background, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('ElevatedButton foregroundBuilder drops button child', (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder foreground = find.descendant(
+      of: find.byType(ElevatedButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(foreground, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('ElevatedButton foreground and background builders are applied to the correct states', (WidgetTester tester) async {
+    Set<MaterialState> foregroundStates = <MaterialState>{};
+    Set<MaterialState> backgroundStates = <MaterialState>{};
+    final FocusNode focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              style: ButtonStyle(
+                backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  backgroundStates = states;
+                  return child!;
+                },
+                foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  foregroundStates = states;
+                  return child!;
+                },
+              ),
+              onPressed: () {},
+              focusNode: focusNode,
+              child: const Text('button'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Default
+    expect(backgroundStates.isEmpty, isTrue);
+    expect(foregroundStates.isEmpty, isTrue);
+
+    const Set<MaterialState> focusedStates = <MaterialState>{MaterialState.focused};
+    const Set<MaterialState> focusedHoveredStates = <MaterialState>{MaterialState.focused, MaterialState.hovered};
+    const Set<MaterialState> focusedHoveredPressedStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
+
+    bool sameStates(Set<MaterialState> expectedValue, Set<MaterialState> actualValue) {
+      return expectedValue.difference(actualValue).isEmpty && actualValue.difference(expectedValue).isEmpty;
+    }
+
+    // Focused.
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedStates, foregroundStates), isTrue);
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(ElevatedButton));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedHoveredStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredStates, foregroundStates), isTrue);
+
+
+    // Highlighted (pressed).
+    await gesture.down(center);
+    await tester.pump(); // Start the splash and highlight animations.
+    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    expect(sameStates(focusedHoveredPressedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredPressedStates, foregroundStates), isTrue);
+
+    focusNode.dispose();
+  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -2100,7 +2100,7 @@ void main() {
       ),
     );
 
-    // Default
+    // Default.
     expect(backgroundStates.isEmpty, isTrue);
     expect(foregroundStates.isEmpty, isTrue);
 

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -2171,7 +2171,7 @@ void main() {
       ),
     );
 
-    // Default
+    // Default.
     expect(backgroundStates.isEmpty, isTrue);
     expect(foregroundStates.isEmpty, isTrue);
 

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -2014,6 +2014,202 @@ void main() {
     expect(count, 1);
   });
 
+  testWidgets('FilledButton backgroundBuilder and foregroundBuilder', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: backgroundColor,
+                ),
+                child: child,
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: foregroundColor,
+                ),
+                child: child,
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    BoxDecoration boxDecorationOf(Finder finder) {
+      return tester.widget<DecoratedBox>(finder).decoration as BoxDecoration;
+    }
+
+    final Finder decorations = find.descendant(
+      of: find.byType(FilledButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(boxDecorationOf(decorations.at(0)).color, backgroundColor);
+    expect(boxDecorationOf(decorations.at(1)).color, foregroundColor);
+
+    Text textChildOf(Finder finder) {
+      return tester.widget<Text>(
+        find.descendant(
+          of: finder,
+          matching: find.byType(Text),
+        ),
+      );
+    }
+
+    expect(textChildOf(decorations.at(0)).data, 'button');
+    expect(textChildOf(decorations.at(1)).data, 'button');
+  });
+
+
+  testWidgets('FilledButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FilledButton(
+          style: FilledButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                ),
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder background = find.descendant(
+      of: find.byType(FilledButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(background, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('FilledButton foregroundBuilder drops button child', (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FilledButton(
+          style: FilledButton.styleFrom(
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder foreground = find.descendant(
+      of: find.byType(FilledButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(foreground, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('FilledButton foreground and background builders are applied to the correct states', (WidgetTester tester) async {
+    Set<MaterialState> foregroundStates = <MaterialState>{};
+    Set<MaterialState> backgroundStates = <MaterialState>{};
+    final FocusNode focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: FilledButton(
+              style: ButtonStyle(
+                backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  backgroundStates = states;
+                  return child!;
+                },
+                foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  foregroundStates = states;
+                  return child!;
+                },
+              ),
+              onPressed: () {},
+              focusNode: focusNode,
+              child: const Text('button'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Default
+    expect(backgroundStates.isEmpty, isTrue);
+    expect(foregroundStates.isEmpty, isTrue);
+
+    const Set<MaterialState> focusedStates = <MaterialState>{MaterialState.focused};
+    const Set<MaterialState> focusedHoveredStates = <MaterialState>{MaterialState.focused, MaterialState.hovered};
+    const Set<MaterialState> focusedHoveredPressedStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
+
+    bool sameStates(Set<MaterialState> expectedValue, Set<MaterialState> actualValue) {
+      return expectedValue.difference(actualValue).isEmpty && actualValue.difference(expectedValue).isEmpty;
+    }
+
+    // Focused.
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedStates, foregroundStates), isTrue);
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(FilledButton));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedHoveredStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredStates, foregroundStates), isTrue);
+
+
+    // Highlighted (pressed).
+    await gesture.down(center);
+    await tester.pump(); // Start the splash and highlight animations.
+    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    expect(sameStates(focusedHoveredPressedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredPressedStates, foregroundStates), isTrue);
+
+    focusNode.dispose();
+  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -2250,7 +2250,7 @@ void main() {
       ),
     );
 
-    // Default
+    // Default.
     expect(backgroundStates.isEmpty, isTrue);
     expect(foregroundStates.isEmpty, isTrue);
 

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -2092,6 +2092,203 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('OutlinedButton backgroundBuilder and foregroundBuilder', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: backgroundColor,
+                ),
+                child: child,
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: foregroundColor,
+                ),
+                child: child,
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    BoxDecoration boxDecorationOf(Finder finder) {
+      return tester.widget<DecoratedBox>(finder).decoration as BoxDecoration;
+    }
+
+    final Finder decorations = find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(boxDecorationOf(decorations.at(0)).color, backgroundColor);
+    expect(boxDecorationOf(decorations.at(1)).color, foregroundColor);
+
+    Text textChildOf(Finder finder) {
+      return tester.widget<Text>(
+        find.descendant(
+          of: finder,
+          matching: find.byType(Text),
+        ),
+      );
+    }
+
+    expect(textChildOf(decorations.at(0)).data, 'button');
+    expect(textChildOf(decorations.at(1)).data, 'button');
+  });
+
+
+  testWidgets('OutlinedButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                ),
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder background = find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(background, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('OutlinedButton foregroundBuilder drops button child', (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder foreground = find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(foreground, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('OutlinedButton foreground and background builders are applied to the correct states', (WidgetTester tester) async {
+    Set<MaterialState> foregroundStates = <MaterialState>{};
+    Set<MaterialState> backgroundStates = <MaterialState>{};
+    final FocusNode focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: OutlinedButton(
+              style: ButtonStyle(
+                backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  backgroundStates = states;
+                  return child!;
+                },
+                foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  foregroundStates = states;
+                  return child!;
+                },
+              ),
+              onPressed: () {},
+              focusNode: focusNode,
+              child: const Text('button'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Default
+    expect(backgroundStates.isEmpty, isTrue);
+    expect(foregroundStates.isEmpty, isTrue);
+
+    const Set<MaterialState> focusedStates = <MaterialState>{MaterialState.focused};
+    const Set<MaterialState> focusedHoveredStates = <MaterialState>{MaterialState.focused, MaterialState.hovered};
+    const Set<MaterialState> focusedHoveredPressedStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
+
+    bool sameStates(Set<MaterialState> expectedValue, Set<MaterialState> actualValue) {
+      return expectedValue.difference(actualValue).isEmpty && actualValue.difference(expectedValue).isEmpty;
+    }
+
+    // Focused.
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedStates, foregroundStates), isTrue);
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(OutlinedButton));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedHoveredStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredStates, foregroundStates), isTrue);
+
+
+    // Highlighted (pressed).
+    await gesture.down(center);
+    await tester.pump(); // Start the splash and highlight animations.
+    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    expect(sameStates(focusedHoveredPressedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredPressedStates, foregroundStates), isTrue);
+
+    focusNode.dispose();
+  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2083,7 +2083,7 @@ void main() {
       ),
     );
 
-    // Default
+    // Default.
     expect(backgroundStates.isEmpty, isTrue);
     expect(foregroundStates.isEmpty, isTrue);
 

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -1925,6 +1925,203 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('TextButton backgroundBuilder and foregroundBuilder', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TextButton(
+          style: TextButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: backgroundColor,
+                ),
+                child: child,
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return DecoratedBox(
+                decoration: const BoxDecoration(
+                  color: foregroundColor,
+                ),
+                child: child,
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    BoxDecoration boxDecorationOf(Finder finder) {
+      return tester.widget<DecoratedBox>(finder).decoration as BoxDecoration;
+    }
+
+    final Finder decorations = find.descendant(
+      of: find.byType(TextButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(boxDecorationOf(decorations.at(0)).color, backgroundColor);
+    expect(boxDecorationOf(decorations.at(1)).color, foregroundColor);
+
+    Text textChildOf(Finder finder) {
+      return tester.widget<Text>(
+        find.descendant(
+          of: finder,
+          matching: find.byType(Text),
+        ),
+      );
+    }
+
+    expect(textChildOf(decorations.at(0)).data, 'button');
+    expect(textChildOf(decorations.at(1)).data, 'button');
+  });
+
+
+  testWidgets('TextButton backgroundBuilder drops button child and foregroundBuilder return value', (WidgetTester tester) async {
+    const Color backgroundColor = Color(0xFF000011);
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TextButton(
+          style: TextButton.styleFrom(
+            backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                ),
+              );
+            },
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder background = find.descendant(
+      of: find.byType(TextButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(background, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('TextButton foregroundBuilder drops button child', (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xFF000022);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TextButton(
+          style: TextButton.styleFrom(
+            foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+              return const DecoratedBox(
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                ),
+              );
+            },
+          ),
+          onPressed: () { },
+          child: const Text('button'),
+        ),
+      ),
+    );
+
+    final Finder foreground = find.descendant(
+      of: find.byType(TextButton),
+      matching: find.byType(DecoratedBox),
+    );
+
+    expect(foreground, findsOneWidget);
+    expect(find.text('button'), findsNothing);
+  });
+
+  testWidgets('TextButton foreground and background builders are applied to the correct states', (WidgetTester tester) async {
+    Set<MaterialState> foregroundStates = <MaterialState>{};
+    Set<MaterialState> backgroundStates = <MaterialState>{};
+    final FocusNode focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: TextButton(
+              style: ButtonStyle(
+                backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  backgroundStates = states;
+                  return child!;
+                },
+                foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
+                  foregroundStates = states;
+                  return child!;
+                },
+              ),
+              onPressed: () {},
+              focusNode: focusNode,
+              child: const Text('button'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Default
+    expect(backgroundStates.isEmpty, isTrue);
+    expect(foregroundStates.isEmpty, isTrue);
+
+    const Set<MaterialState> focusedStates = <MaterialState>{MaterialState.focused};
+    const Set<MaterialState> focusedHoveredStates = <MaterialState>{MaterialState.focused, MaterialState.hovered};
+    const Set<MaterialState> focusedHoveredPressedStates = <MaterialState>{MaterialState.focused, MaterialState.hovered, MaterialState.pressed};
+
+    bool sameStates(Set<MaterialState> expectedValue, Set<MaterialState> actualValue) {
+      return expectedValue.difference(actualValue).isEmpty && actualValue.difference(expectedValue).isEmpty;
+    }
+
+    // Focused.
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedStates, foregroundStates), isTrue);
+
+    // Hovered.
+    final Offset center = tester.getCenter(find.byType(TextButton));
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.addPointer();
+    await gesture.moveTo(center);
+    await tester.pumpAndSettle();
+    expect(sameStates(focusedHoveredStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredStates, foregroundStates), isTrue);
+
+
+    // Highlighted (pressed).
+    await gesture.down(center);
+    await tester.pump(); // Start the splash and highlight animations.
+    await tester.pump(const Duration(milliseconds: 800)); // Wait for splash and highlight to be well under way.
+    expect(sameStates(focusedHoveredPressedStates, backgroundStates), isTrue);
+    expect(sameStates(focusedHoveredPressedStates, foregroundStates), isTrue);
+
+    focusNode.dispose();
+  });
 }
 
 TextStyle? _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -104,6 +104,15 @@ void main() {
     const bool enableFeedback = false;
     const AlignmentGeometry alignment = Alignment.centerLeft;
 
+    final Key backgroundKey = UniqueKey();
+    final Key foregroundKey = UniqueKey();
+    Widget backgroundBuilder(BuildContext context, Set<MaterialState> states, Widget? child) {
+      return KeyedSubtree(key: backgroundKey, child: child!);
+    }
+    Widget foregroundBuilder(BuildContext context, Set<MaterialState> states, Widget? child) {
+      return KeyedSubtree(key: foregroundKey, child: child!);
+    }
+
     final ButtonStyle style = TextButton.styleFrom(
       foregroundColor: foregroundColor,
       disabledForegroundColor: disabledColor,
@@ -122,6 +131,8 @@ void main() {
       animationDuration: animationDuration,
       enableFeedback: enableFeedback,
       alignment: alignment,
+      backgroundBuilder: backgroundBuilder,
+      foregroundBuilder: foregroundBuilder,
     );
 
     Widget buildFrame({ ButtonStyle? buttonStyle, ButtonStyle? themeStyle, ButtonStyle? overallStyle }) {
@@ -185,6 +196,8 @@ void main() {
       expect(tester.getSize(find.byType(TextButton)), const Size(200, 200));
       final Align align = tester.firstWidget<Align>(find.ancestor(of: find.text('button'), matching: find.byType(Align)));
       expect(align.alignment, alignment);
+      expect(find.descendant(of: findMaterial, matching: find.byKey(backgroundKey)), findsOneWidget);
+      expect(find.descendant(of: findInkWell, matching: find.byKey(foregroundKey)), findsOneWidget);
     }
 
     testWidgets('Button style overrides defaults', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/139456, https://github.com/flutter/flutter/issues/130335, https://github.com/flutter/flutter/issues/89563.

Two new properties have been added to ButtonStyle to make it possible to insert arbitrary state-dependent widgets in a button's background or foreground. These properties can be specified for an individual button, using the style parameter, or for all buttons using a button theme's style parameter.

The new ButtonStyle properties are `backgroundBuilder` and `foregroundBuilder` and their (function) types are:

```dart
typedef ButtonLayerBuilder = Widget Function(
  BuildContext context,
  Set<MaterialState> states,
  Widget? child
);
```

The new builder functions are called whenever the button is built and the `states` parameter communicates the pressed/hovered/etc state fo the button.


## `backgroundBuilder`

Creates a widget that becomes the child of the button's Material and whose child is the rest of the button, including the button's `child` parameter.  By default the returned widget is clipped to the Material's ButtonStyle.shape.

The `backgroundBuilder` can be used to add a gradient to the button's background. Here's an example that creates a yellow/orange gradient background:

![opaque-gradient-bg](https://github.com/flutter/flutter/assets/1377460/80df8368-e7cf-49ef-aee7-2776a573644c)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      return DecoratedBox(
        decoration: BoxDecoration(
          gradient: LinearGradient(colors: [Colors.orange, Colors.yellow]),
        ),
        child: child,
      );
    },
  ),
  child: Text('Text Button'),
)
```


Because the background widget becomes the child of the button's Material, if it's opaque (as it is in this case) then it obscures the overlay highlights which are painted on the button's Material. To ensure that the highlights show through one can decorate the background with an `Ink` widget.  This version also overrides the overlay color to be (shades of) red, because that makes the highlights look a little nicer with the yellow/orange background.

![ink-gradient-bg](https://github.com/flutter/flutter/assets/1377460/68a49733-f30e-44a1-a948-dc8cc95e1716)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    overlayColor: Colors.red,
    backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      return Ink(
        decoration: BoxDecoration(
          gradient: LinearGradient(colors: [Colors.orange, Colors.yellow]),
        ),
        child: child,
      );
    },
  ),
  child: Text('Text Button'),
)
```

Now the button's overlay highlights are painted on the Ink widget. An Ink widget isn't needed if the background is sufficiently translucent. This version of the example creates a translucent backround widget. 

![translucent-graident-bg](https://github.com/flutter/flutter/assets/1377460/3b016e1f-200a-4d07-8111-e20d29f18014)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    overlayColor: Colors.red,
    backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      return DecoratedBox(
        decoration: BoxDecoration(
          gradient: LinearGradient(colors: [
            Colors.orange.withOpacity(0.5),
            Colors.yellow.withOpacity(0.5),
          ]),
        ),
        child: child,
      );
    },
  ),
  child: Text('Text Button'),
)
```

One can also decorate the background with an image. In this example, the button's background is an burlap texture image. The foreground color has been changed to black to make the button's text a little clearer relative to the mottled brown backround.

![burlap-bg](https://github.com/flutter/flutter/assets/1377460/f2f61ab1-10d9-43a4-bd63-beecdce33b45)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    foregroundColor: Colors.black,
    backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      return Ink(
        decoration: BoxDecoration(
          image: DecorationImage(
            image: NetworkImage(burlapUrl),
            fit: BoxFit.cover,
          ),
        ),
        child: child,
      );
    },
  ),
  child: Text('Text Button'),
)
```

The background widget can depend on the `states` parameter. In this example the blue/orange gradient flips horizontally when the button is hovered/pressed.

![gradient-flip](https://github.com/flutter/flutter/assets/1377460/c6c6fe26-ae47-445b-b82d-4605d9583bd8)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      final Color color1 = Colors.blue.withOpacity(0.5);
      final Color color2 = Colors.orange.withOpacity(0.5);
      return DecoratedBox(
        decoration: BoxDecoration(
          gradient: LinearGradient(
            colors: switch (states.contains(MaterialState.hovered)) {
              true => <Color>[color1, color2],
              false => <Color>[color2, color1],
            },
          ),
        ),
        child: child,
      );
    },
  ),
  child: Text('Text Button'),
)
```

The preceeding examples have not included a BoxDecoration border because ButtonStyle already supports `ButtonStyle.shape` and `ButtonStyle.side` parameters that can be uesd to define state-dependent borders. Borders defined with the ButtonStyle side parameter match the button's shape. To add a border that changes color when the button is hovered or pressed, one must specify the side property using `copyWith`, since there's no `styleFrom` shorthand for this case.

![border-gradient-bg](https://github.com/flutter/flutter/assets/1377460/63cffcd3-0dcf-4eb1-aed5-d14adf1e57f6)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    foregroundColor: Colors.indigo,
    backgroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      final Color color1 = Colors.blue.withOpacity(0.5);
      final Color color2 = Colors.orange.withOpacity(0.5);
      return DecoratedBox(
        decoration: BoxDecoration(
          gradient: LinearGradient(
            colors: switch (states.contains(MaterialState.hovered)) {
              true => <Color>[color1, color2],
              false => <Color>[color2, color1],
            },
          ),
        ),
        child: child,
      );
    },
  ).copyWith(
    side: MaterialStateProperty.resolveWith<BorderSide?>((Set<MaterialState> states) {
      if (states.contains(MaterialState.hovered)) {
        return BorderSide(width: 3, color: Colors.yellow);
      }
      return null; // defer to the default
    }),
  ),
  child: Text('Text Button'),
)
```

Although all of the examples have created a ButtonStyle locally and only applied it to one button, they could have configured the `ThemeData.textButtonTheme` instead and applied the style to all TextButtons. And, of course, all of this works for all of the ButtonStyleButton classes, not just TextButton.


## `foregroundBuilder`

Creates a Widget that contains the button's child parameter. The returned widget is clipped by the button's [ButtonStyle.shape] inset by the button's [ButtonStyle.padding] and aligned by the button's [ButtonStyle.alignment].

The `foregroundBuilder` can be used to wrap the button's child, e.g. with a border or a `ShaderMask` or as a state-dependent substitute for the child.

This example adds a border that's just applied to the child. The border only appears when the button is hovered/pressed.

![border-fg](https://github.com/flutter/flutter/assets/1377460/687a3245-fe68-4983-a04e-5fcc77f8aa21)

```dart
ElevatedButton(
  onPressed: () {},
  style: ElevatedButton.styleFrom(
    foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      final ColorScheme colorScheme = Theme.of(context).colorScheme;
      return DecoratedBox(
        decoration: BoxDecoration(
          border: states.contains(MaterialState.hovered)
            ? Border(bottom: BorderSide(color: colorScheme.primary))
            : Border(), // essentially "no border"
        ),
        child: child,
      );
    },
  ),
  child: Text('Text Button'),
)
```

The foregroundBuilder can be used with `ShaderMask` to change the way the button's child is rendered. In this example the ShaderMask's gradient causes the button's child to fade out on top.

![shader_mask_fg](https://github.com/flutter/flutter/assets/1377460/54010f24-e65d-4551-ae58-712135df3d8d)

```dart
ElevatedButton(
  onPressed: () { },
  style: ElevatedButton.styleFrom(
    foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      final ColorScheme colorScheme = Theme.of(context).colorScheme;
      return ShaderMask(
        shaderCallback: (Rect bounds) {
          return LinearGradient(
            begin: Alignment.bottomCenter,
            end: Alignment.topCenter,
            colors: <Color>[
              colorScheme.primary,
              colorScheme.primaryContainer,
            ],
          ).createShader(bounds);
        },
        blendMode: BlendMode.srcATop,
        child: child,
      );
    },
  ),
  child:  const Text('Elevated Button'),
)
```

A commonly requested configuration for butttons has the developer provide images, one for pressed/hovered/normal state. You can use the foregroundBuilder to create a button that fades between a normal image and another image when the button is pressed. In this case the foregroundBuilder doesn't use the child it's passed, even though we've provided the required TextButton child parameter.

![image-button](https://github.com/flutter/flutter/assets/1377460/f5b1a22f-43ce-4be3-8e70-06de4c958380)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      final String url = states.contains(MaterialState.pressed) ? smiley2Url : smiley1Url;
      return AnimatedContainer(
        width: 100,
        height: 100,
        duration: Duration(milliseconds: 300),
        decoration: BoxDecoration(
          image: DecorationImage(
            image: NetworkImage(url),
            fit: BoxFit.contain,
          ),
        ),
      );
    },
  ),
  child: Text('No Child'),
)
```

In this example the button's default overlay appears when the button is hovered and pressed. Another image can be used to indicate the hovered state and the default overlay can be defeated by specifying `Colors.transparent` for the `overlayColor`:

![image-per-state](https://github.com/flutter/flutter/assets/1377460/7ab9da2f-f661-4374-b395-c2e0c7c4cf13)

```dart
TextButton(
  onPressed: () {},
  style: TextButton.styleFrom(
    overlayColor: Colors.transparent,
    foregroundBuilder: (BuildContext context, Set<MaterialState> states, Widget? child) {
      String url = states.contains(MaterialState.hovered) ? smiley3Url : smiley1Url;
      if (states.contains(MaterialState.pressed)) {
        url = smiley2Url;
      }
      return AnimatedContainer(
        width: 100,
        height: 100,
        duration: Duration(milliseconds: 300),
        decoration: BoxDecoration(
          image: DecorationImage(
            image: NetworkImage(url),
            fit: BoxFit.contain,
          ),
        ),
      );
    },
  ),
  child: Text('No Child'),
)
```
