### PR TITLE
Remove unneeded expectation in test

### DIFF
--- a/packages/flutter/test/services/lifecycle_test.dart
+++ b/packages/flutter/test/services/lifecycle_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('initialLifecycleState is used to init state paused', (WidgetTester tester) async {
-    expect(ServicesBinding.instance.lifecycleState, isNull);
     final TestWidgetsFlutterBinding binding = tester.binding;
     binding.resetLifecycleState();
     // Use paused as the initial state.


### PR DESCRIPTION
## Description

This removes an unneeded expectation in the test for the AppLifecycleListener.  It's unneeded because the test immediately resets the state anyhow.  I'm removing it because the web implementation sets the value when initializing, so it's never initially null there.

## Related PR
 - https://github.com/flutter/engine/pull/44720#issuecomment-1898482363
