### PR TITLE
Fix `RangeSlider` throws a null-check error after `clearSemantics` is called

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1628,10 +1628,10 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   }
 
   /// Describe the semantics of the start thumb.
-  SemanticsNode? _startSemanticsNode = SemanticsNode();
+  SemanticsNode? _startSemanticsNode;
 
   /// Describe the semantics of the end thumb.
-  SemanticsNode? _endSemanticsNode = SemanticsNode();
+  SemanticsNode? _endSemanticsNode;
 
   // Create the semantics configuration for a single value.
   SemanticsConfiguration _createSemanticsConfiguration(
@@ -1697,6 +1697,10 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       width: kMinInteractiveDimension,
       height: kMinInteractiveDimension,
     );
+
+    _startSemanticsNode ??= SemanticsNode();
+    _endSemanticsNode ??= SemanticsNode();
+
     switch (textDirection) {
       case TextDirection.ltr:
         _startSemanticsNode!.rect = leftRect;

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/src/physics/utils.dart' show nearEqual;
 import 'package:flutter_test/flutter_test.dart';
 
+import '../widgets/semantics_tester.dart';
+
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/105833
   testWidgets('Drag gesture uses provided gesture settings', (WidgetTester tester) async {
@@ -2610,4 +2612,36 @@ void main() {
     // No exception should be thrown.
     expect(tester.takeException(), null);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/141953.
+  testWidgets('Semantic nodes do not throw an error after clearSemantics', (WidgetTester tester) async {
+    SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: RangeSlider(
+            values: const RangeValues(40, 80),
+            max: 100,
+            onChanged: (RangeValues newValue) { },
+          ),
+        ),
+      ),
+    );
+
+    // Dispose the semantics to trigger clearSemantics.
+    semantics.dispose();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+
+    // Initialize the semantics again.
+    semantics = SemanticsTester(tester);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+
+    semantics.dispose();
+  }, semanticsEnabled: false);
 }


### PR DESCRIPTION
fixes [Null-check operator on RangeSlider's _startSemanticsNode](https://github.com/flutter/flutter/issues/141953)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
