### PR TITLE
Remove unused clipBehavior from OverflowBar

### DIFF
--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -62,7 +62,6 @@ class OverflowBar extends MultiChildRenderObjectWidget {
     this.overflowAlignment = OverflowBarAlignment.start,
     this.overflowDirection = VerticalDirection.down,
     this.textDirection,
-    this.clipBehavior = Clip.none,
     super.children,
   });
 
@@ -192,11 +191,6 @@ class OverflowBar extends MultiChildRenderObjectWidget {
   ///    text and text-direction-sensitive render objects.
   final TextDirection? textDirection;
 
-  /// {@macro flutter.material.Material.clipBehavior}
-  ///
-  /// Defaults to [Clip.none].
-  final Clip clipBehavior;
-
   @override
   RenderObject createRenderObject(BuildContext context) {
     return _RenderOverflowBar(
@@ -206,7 +200,6 @@ class OverflowBar extends MultiChildRenderObjectWidget {
       overflowAlignment: overflowAlignment,
       overflowDirection: overflowDirection,
       textDirection: textDirection ?? Directionality.of(context),
-      clipBehavior: clipBehavior,
     );
   }
 
@@ -218,8 +211,7 @@ class OverflowBar extends MultiChildRenderObjectWidget {
       ..overflowSpacing = overflowSpacing
       ..overflowAlignment = overflowAlignment
       ..overflowDirection = overflowDirection
-      ..textDirection = textDirection ?? Directionality.of(context)
-      ..clipBehavior = clipBehavior;
+      ..textDirection = textDirection ?? Directionality.of(context);
   }
 
   @override
@@ -247,14 +239,12 @@ class _RenderOverflowBar extends RenderBox
     OverflowBarAlignment overflowAlignment = OverflowBarAlignment.start,
     VerticalDirection overflowDirection = VerticalDirection.down,
     required TextDirection textDirection,
-    Clip clipBehavior = Clip.none,
   }) : _spacing = spacing,
        _alignment = alignment,
        _overflowSpacing = overflowSpacing,
        _overflowAlignment = overflowAlignment,
        _overflowDirection = overflowDirection,
-       _textDirection = textDirection,
-       _clipBehavior = clipBehavior {
+       _textDirection = textDirection {
     addAll(children);
   }
 
@@ -316,17 +306,6 @@ class _RenderOverflowBar extends RenderBox
     }
     _textDirection = value;
     markNeedsLayout();
-  }
-
-  Clip get clipBehavior => _clipBehavior;
-  Clip _clipBehavior = Clip.none;
-  set clipBehavior(Clip value) {
-    if (value == _clipBehavior) {
-      return;
-    }
-    _clipBehavior = value;
-    markNeedsPaint();
-    markNeedsSemanticsUpdate();
   }
 
   @override

--- a/packages/flutter/test/widgets/overflow_bar_test.dart
+++ b/packages/flutter/test/widgets/overflow_bar_test.dart
@@ -13,7 +13,6 @@ void main() {
     expect(bar.overflowSpacing, 0);
     expect(bar.overflowDirection, VerticalDirection.down);
     expect(bar.textDirection, null);
-    expect(bar.clipBehavior, Clip.none);
     expect(bar.children, const <Widget>[]);
   });
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/141606.

OverflowBar doesn't do any clipping and therefore there's no need to specify a clip behavior.