### PR TITLE
[Windows Arm64] Run plugin test post-submit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5373,6 +5373,7 @@ targets:
   - name: Windows_arm64 plugin_test_windows
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/134083
+    presubmit: false
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
The Flutter try pool does not have any Windows Arm64 machines. Thus, any Windows Arm64 pre-submit tests will fail as there's no machines to run them.

This converts the only Windows Arm64 pre-submit test, the plugin test, to run post-submit.

See: https://github.com/flutter/flutter/issues/141986

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
