### PR TITLE
[github actions] FINALLY fix the mysterious token error in github actions

### DIFF
--- a/.github/workflows/easy-cp.yml
+++ b/.github/workflows/easy-cp.yml
@@ -5,7 +5,7 @@
 name: Cherry-pick Labeled PR to Release Branch
 
 on:
-  pull_request:
+  pull_request_target:
     branches: master
     types: [labeled]
 


### PR DESCRIPTION
This should finally (with high confidence) fix https://github.com/flutter/flutter/issues/141980, the mysterious error where git push sometimes fail.

**Root cause**:
When a pull request merges onto flutter's master branch, it is actually a merge from a branch on a flutter contributor's repository, to flutter's repository. Therefore, the [actor](https://stackoverflow.com/questions/58737785/github-actions-empty-env-secrets) of the pull request event, is the user that opened the pull request. And this actor would not have write access to repo and therefore the repo secret resolves to empty.

Therefore [running your pull_request workflow when a pull request merges](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges) doesn't work because even though we are not running our workflows on a forked repository, the **actor** of the pull_request event comes from a forked repository, and secrets are not passed to this actor.

The correct way is using [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event instead of pull_request event. In workflows triggered by this event, GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow **can** access secrets, even when the actor of the workflow trigger comes from a fork.
Note that workflows of this event runs in the context of the base commit and not the merge commit. But this doesn't matter for our use case since we are good with using the actions file from the base commit in the pull request event.

**Tested**:
I was finally able to reproduce the error by:
1. create a pull request under the username of different user other than the repository owner
2. merge and label the pull request, and use the token of this different user, but use it as repository secrets in the workflow
[reproduced error](https://github.com/XilaiZhang/miscellaneous-side-project/actions/runs/7619699924/job/20753210562)

previously I wasn't able to reproduce this error on my personal repo because the actors in my tests are the same user.

Also tested on my personal repo, following the steps mentioned above, that using the pull_request_event type fixes the error. [succeeded run](https://github.com/XilaiZhang/miscellaneous-side-project/actions/runs/7630017020/job/20784762242) 

**The Debug Process**:
spent quite a while looking at other things during debugging, but they turned out to be unrelated. things that we experimented with are workflow conditions, ssh setup, git push url, manual trigger, workflow env, secret setup, dependency on market place actions (actions/checkout and peter-evans/create-pullrequest)
