### PR TITLE
Run gradle_plugin_*_apk_test on presubmit on flutter_tool changes.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -788,6 +788,7 @@ targets:
       task_name: gradle_plugin_fat_apk_test
     runIf:
       - dev/**
+      - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
 
@@ -806,6 +807,7 @@ targets:
       task_name: gradle_plugin_light_apk_test
     runIf:
       - dev/**
+      - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
 


### PR DESCRIPTION
These tests were failing in postsubmit after a change to `packages/flutter_tools`. We should run these in presubmit when `packages/flutter_tools` changes.