### PR TITLE
flutter.groovy: update for Gradle Kotlin DSL compatibility

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -66,10 +66,10 @@ class FlutterExtension {
      * Specifies the relative directory to the Flutter project directory.
      * In an app project, this is ../.. since the app's Gradle build file is under android/app.
      */
-    public String source = "../.."
+    String source = "../.."
 
     /** Allows to override the target file. Otherwise, the target is lib/main.dart. */
-    public String target
+    String target
 
     /** The versionCode that was read from app's local.properties. */
     public String flutterVersionCode = null
@@ -684,7 +684,7 @@ class FlutterPlugin implements Plugin<Project> {
             if (pluginProject == null) {
                 // Plugin was not included in `settings.gradle`, but is listed in `.flutter-plugins`.
                 project.logger.error("Plugin project :${it.name} listed, but not found. Please fix your settings.gradle/settings.gradle.kts.")
-            } else if (doesSupportAndroidPlatform(project, pluginProject.projectDir.parentFile.path as String)) {
+            } else if (doesSupportAndroidPlatform(pluginProject.projectDir.parentFile.path as String)) {
                 // Plugin has a functioning `android` folder and is included successfully, although it's not supported.
                 // It must be configured nonetheless, to not throw an "Unresolved reference" exception.
                 configurePluginProject(it)
@@ -700,7 +700,7 @@ class FlutterPlugin implements Plugin<Project> {
      * Returns `true` if the given path contains an `android` directory
      * containing a `build.gradle` or `build.gradle.kts` file.
      */
-    private Boolean doesSupportAndroidPlatform(Project project, String path) {
+    private Boolean doesSupportAndroidPlatform(String path) {
         File buildGradle = new File(path, 'android' + File.separator + 'build.gradle')
         File buildGradleKts = new File(path, 'android' + File.separator + 'build.gradle.kts')
         if (buildGradle.exists() && buildGradleKts.exists()) {

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -684,7 +684,7 @@ class FlutterPlugin implements Plugin<Project> {
             if (pluginProject == null) {
                 // Plugin was not included in `settings.gradle`, but is listed in `.flutter-plugins`.
                 project.logger.error("Plugin project :${it.name} listed, but not found. Please fix your settings.gradle/settings.gradle.kts.")
-            } else if (doesSupportAndroidPlatform(pluginProject.projectDir.parentFile.path as String)) {
+            } else if (doesSupportAndroidPlatform(project, pluginProject.projectDir.parentFile.path as String)) {
                 // Plugin has a functioning `android` folder and is included successfully, although it's not supported.
                 // It must be configured nonetheless, to not throw an "Unresolved reference" exception.
                 configurePluginProject(it)
@@ -700,11 +700,11 @@ class FlutterPlugin implements Plugin<Project> {
      * Returns `true` if the given path contains an `android` directory
      * containing a `build.gradle` or `build.gradle.kts` file.
      */
-    private Boolean doesSupportAndroidPlatform(String path) {
+    private Boolean doesSupportAndroidPlatform(Project project, String path) {
         File buildGradle = new File(path, 'android' + File.separator + 'build.gradle')
         File buildGradleKts = new File(path, 'android' + File.separator + 'build.gradle.kts')
         if (buildGradle.exists() && buildGradleKts.exists()) {
-            logger.error(
+            project.logger.error(
                 "Both build.gradle and build.gradle.kts exist, so " +
                 "build.gradle.kts is ignored. This is likely a mistake."
             )
@@ -722,7 +722,7 @@ class FlutterPlugin implements Plugin<Project> {
         File settingsGradle = new File(project.projectDir.parentFile, "settings.gradle")
         File settingsGradleKts = new File(project.projectDir.parentFile, "settings.gradle.kts")
         if (settingsGradle.exists() && settingsGradleKts.exists()) {
-            logger.error(
+            project.logger.error(
                 "Both settings.gradle and settings.gradle.kts exist, so " +
                 "settings.gradle.kts is ignored. This is likely a mistake."
             )

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -42,10 +42,10 @@ import org.gradle.internal.os.OperatingSystem
 class FlutterExtension {
 
     /** Sets the compileSdkVersion used by default in Flutter app projects. */
-    final int compileSdkVersion = 34
+    public final int compileSdkVersion = 34
 
     /** Sets the minSdkVersion used by default in Flutter app projects. */
-    final int minSdkVersion = 19
+    public  final int minSdkVersion = 19
 
     /**
      * Sets the targetSdkVersion used by default in Flutter app projects.
@@ -53,32 +53,32 @@ class FlutterExtension {
      *
      * See https://developer.android.com/guide/topics/manifest/uses-sdk-element.
      */
-    final int targetSdkVersion = 33
+    public final int targetSdkVersion = 33
 
     /**
      * Sets the ndkVersion used by default in Flutter app projects.
      * Chosen as default version of the AGP version below as found in
      * https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp.
      */
-    final String ndkVersion = "23.1.7779620"
+    public final String ndkVersion = "23.1.7779620"
 
     /**
      * Specifies the relative directory to the Flutter project directory.
      * In an app project, this is ../.. since the app's Gradle build file is under android/app.
      */
-    String source = "../.."
+    public String source = "../.."
 
     /** Allows to override the target file. Otherwise, the target is lib/main.dart. */
-    String target
+    public String target
 
     /** The versionCode that was read from app's local.properties. */
-    String flutterVersionCode = null
+    public String flutterVersionCode = null
 
     /** The versionName that was read from app's local.properties. */
-    String flutterVersionName = null
+    public String flutterVersionName = null
 
     /** Returns flutterVersionCode as an integer with error handling. */
-    Integer versionCode() {
+    public Integer versionCode() {
         if (flutterVersionCode == null) {
             throw new GradleException("flutterVersionCode must not be null.")
         }
@@ -91,7 +91,7 @@ class FlutterExtension {
     }
 
     /** Returns flutterVersionName with error handling. */
-    String versionName() {
+    public String versionName() {
         if (flutterVersionName == null) {
             throw new GradleException("flutterVersionName must not be null.")
         }


### PR DESCRIPTION
This PR fixes 2 small mistakes in `FlutterExtension`:
- all fields must be `public` in order to be used in Gradle Kotlin DSL the same as in Gradle Groovy DSL
- using `logger` instead of `project.logger` throws an error when executed

This PR re-adds a subset of changes from #141541 which broke the tree and has been reverted.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.