### PR TITLE
Android Gradle file templates: make it easier to convert them to Kotlin DSL in the future

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -463,7 +463,7 @@ class AndroidProject extends FlutterProjectPlatform {
   /// Pattern used to find the assignment of the "group" property in Gradle.
   /// Expected example: `group "dev.flutter.plugin"`
   /// Regex is used in both Groovy and Kotlin Gradle files.
-  static final RegExp _groupPattern = RegExp('^\\s*group\\s+[\'"](.*)[\'"]\\s*\$');
+  static final RegExp _groupPattern = RegExp('^\\s*group\\s*=?\\s*[\'"](.*)[\'"]\\s*\$');
 
   /// The Gradle root directory of the Android host app. This is the directory
   /// containing the `app/` subdirectory and the `settings.gradle` file that

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -538,7 +538,7 @@ class AndroidProject extends FlutterProjectPlatform {
 
         // This case allows for flutter run/build to work for modules. It does
         // not guarantee the Flutter Gradle Plugin is applied.
-        final bool managed = line.contains("def flutterPluginVersion = 'managed'");
+        final bool managed = line.contains(RegExp('def flutterPluginVersion = [\'"]managed[\'"]'));
         if (fileBasedApply || declarativeApply || managed) {
           return true;
         }

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -6,21 +6,21 @@ plugins {
 }
 
 def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
+def localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
+    localPropertiesFile.withReader("UTF-8") { reader ->
         localProperties.load(reader)
     }
 }
 
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+def flutterVersionCode = localProperties.getProperty("flutter.versionCode")
 if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
+    flutterVersionCode = "1"
 }
 
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
+def flutterVersionName = localProperties.getProperty("flutter.versionName")
 if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
+    flutterVersionName = "1.0"
 }
 
 android {
@@ -54,5 +54,5 @@ android {
 }
 
 flutter {
-    source '../..'
+    source "../.."
 }

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -24,35 +24,35 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "{{androidIdentifier}}"
-    compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    namespace = "{{androidIdentifier}}"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "{{androidIdentifier}}"
+        applicationId = "{{androidIdentifier}}"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source "../.."
+    source = "../.."
 }

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/build.gradle.tmpl
@@ -5,12 +5,12 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
+rootProject.buildDir = "../build"
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }
 subprojects {
-    project.evaluationDependsOn(':app')
+    project.evaluationDependsOn(":app")
 }
 
 tasks.register("clean", Delete) {

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -24,45 +24,35 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "{{androidIdentifier}}"
-    compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    namespace = "{{androidIdentifier}}"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
-    sourceSets {
-        main.java.srcDirs += "src/main/kotlin"
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "{{androidIdentifier}}"
+        applicationId = "{{androidIdentifier}}"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source "../.."
+    source = "../.."
 }
-
-dependencies {}

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -6,21 +6,21 @@ plugins {
 }
 
 def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
+def localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
+    localPropertiesFile.withReader("UTF-8") { reader ->
         localProperties.load(reader)
     }
 }
 
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+def flutterVersionCode = localProperties.getProperty("flutter.versionCode")
 if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
+    flutterVersionCode = "1"
 }
 
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
+def flutterVersionName = localProperties.getProperty("flutter.versionName")
 if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
+    flutterVersionName = "1.0"
 }
 
 android {
@@ -34,11 +34,11 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "1.8"
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+        main.java.srcDirs += "src/main/kotlin"
     }
 
     defaultConfig {
@@ -62,7 +62,7 @@ android {
 }
 
 flutter {
-    source '../..'
+    source "../.."
 }
 
 dependencies {}

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/build.gradle.tmpl
@@ -5,12 +5,12 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
+rootProject.buildDir = "../build"
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }
 subprojects {
-    project.evaluationDependsOn(':app')
+    project.evaluationDependsOn(":app")
 }
 
 tasks.register("clean", Delete) {

--- a/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
@@ -1,19 +1,19 @@
 def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
+def localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
+    localPropertiesFile.withReader("UTF-8") { reader ->
         localProperties.load(reader)
     }
 }
 
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+def flutterVersionCode = localProperties.getProperty("flutter.versionCode")
 if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
+    flutterVersionCode = "1"
 }
 
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
+def flutterVersionName = localProperties.getProperty("flutter.versionName")
 if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
+    flutterVersionName = "1.0"
 }
 
 apply plugin: "com.android.dynamic-feature"

--- a/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
@@ -19,11 +19,11 @@ if (flutterVersionName == null) {
 apply plugin: "com.android.dynamic-feature"
 
 android {
-    compileSdk flutter.compileSdkVersion
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     sourceSets {
@@ -34,13 +34,13 @@ android {
     }
 
     defaultConfig {
-        minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 }
 
 dependencies {
-    implementation project(":app")
+    implementation(project(":app"))
 }

--- a/packages/flutter_tools/templates/module/android/gradle/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/gradle/build.gradle.tmpl
@@ -1,14 +1,14 @@
 // Generated file. Do not edit.
 
 buildscript {
-    ext.kotlin_version = '{{kotlinVersion}}'
+    ext.kotlin_version = "{{kotlinVersion}}"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersionForModule}}'
+        classpath "com.android.tools.build:gradle:{{agpVersionForModule}}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -20,13 +20,13 @@ allprojects {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
 
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-        namespace '{{androidIdentifier}}'
+        namespace "{{androidIdentifier}}"
     }
 
     compileSdk {{compileSdkVersion}}

--- a/packages/flutter_tools/templates/module/android/gradle/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/gradle/build.gradle.tmpl
@@ -8,8 +8,8 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:{{agpVersionForModule}}"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath("com.android.tools.build:gradle:{{agpVersionForModule}}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -26,15 +26,15 @@ apply plugin: "kotlin-android"
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-        namespace "{{androidIdentifier}}"
+        namespace = "{{androidIdentifier}}"
     }
 
-    compileSdk {{compileSdkVersion}}
+    compileSdk = {{compileSdkVersion}}
     defaultConfig {
-        minSdk {{minSdkVersion}}
+        minSdk = {{minSdkVersion}}
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version")
 }

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -5,22 +5,22 @@ apply plugin: "com.android.application"
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-        namespace "{{androidIdentifier}}.host"
+        namespace = "{{androidIdentifier}}.host"
     }
 
-    compileSdk {{compileSdkVersion}}
+    compileSdk = {{compileSdkVersion}}
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
-        applicationId "{{androidIdentifier}}.host"
-        minSdk {{minSdkVersion}}
-        targetSdk {{targetSdkVersion}}
-        versionCode 1
-        versionName "1.0"
+        applicationId = "{{androidIdentifier}}.host"
+        minSdk = {{minSdkVersion}}
+        targetSdk = {{targetSdkVersion}}
+        versionCode = 1
+        versionName = "1.0"
     }
 
     buildTypes {
@@ -30,15 +30,15 @@ android {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 
 }
 buildDir = new File(rootProject.projectDir, "../build/host")
 dependencies {
-    implementation project(":flutter")
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "androidx.appcompat:appcompat:1.0.2"
-    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+    implementation(project(":flutter"))
+    implementation(fileTree(dir: "libs", include: ["*.jar"]))
+    implementation("androidx.appcompat:appcompat:1.0.2")
+    implementation("androidx.constraintlayout:constraintlayout:1.1.3")
 }

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -1,6 +1,6 @@
-def flutterPluginVersion = 'managed'
+def flutterPluginVersion = "managed"
 
-apply plugin: 'com.android.application'
+apply plugin: "com.android.application"
 
 android {
     // Conditional for compatibility with AGP <4.2.
@@ -37,8 +37,8 @@ android {
 }
 buildDir = new File(rootProject.projectDir, "../build/host")
 dependencies {
-    implementation project(':flutter')
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation project(":flutter")
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 }

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -26,31 +26,31 @@ if (flutterVersionName == null) {
 apply plugin: "com.android.library"
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-group "{{androidIdentifier}}"
-version "1.0"
+group = "{{androidIdentifier}}"
+version = "1.0"
 
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-        namespace "{{androidIdentifier}}"
+        namespace = "{{androidIdentifier}}"
     }
 
-    compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
-        minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 }
 
 flutter {
-    source "../.."
+    source = "../.."
 }

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -1,38 +1,38 @@
 // Generated file. Do not edit.
 
 def localProperties = new Properties()
-def localPropertiesFile = new File(buildscript.sourceFile.parentFile.parentFile, 'local.properties')
+def localPropertiesFile = new File(buildscript.sourceFile.parentFile.parentFile, "local.properties")
 if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
+    localPropertiesFile.withReader("UTF-8") { reader ->
         localProperties.load(reader)
     }
 }
 
-def flutterRoot = localProperties.getProperty('flutter.sdk')
+def flutterRoot = localProperties.getProperty("flutter.sdk")
 if (flutterRoot == null) {
     throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+def flutterVersionCode = localProperties.getProperty("flutter.versionCode")
 if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
+    flutterVersionCode = "1"
 }
 
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
+def flutterVersionName = localProperties.getProperty("flutter.versionName")
 if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
+    flutterVersionName = "1.0"
 }
 
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-group '{{androidIdentifier}}'
-version '1.0'
+group "{{androidIdentifier}}"
+version "1.0"
 
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-        namespace '{{androidIdentifier}}'
+        namespace "{{androidIdentifier}}"
     }
 
     compileSdk flutter.compileSdkVersion
@@ -52,5 +52,5 @@ android {
 }
 
 flutter {
-    source '../..'
+    source "../.."
 }

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -1,5 +1,5 @@
-group "{{androidIdentifier}}"
-version "1.0"
+group = "{{androidIdentifier}}"
+version = "1.0"
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:{{agpVersion}}"
+        classpath("com.android.tools.build:gradle:{{agpVersion}}")
     }
 }
 
@@ -23,23 +23,23 @@ apply plugin: "com.android.library"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace "{{androidIdentifier}}"
+        namespace = "{{androidIdentifier}}"
     }
 
-    compileSdk {{compileSdkVersion}}
+    compileSdk = {{compileSdkVersion}}
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
-        minSdk {{minSdkVersion}}
+        minSdk = {{minSdkVersion}}
     }
 
     dependencies {
-        testImplementation "junit:junit:4.13.2"
-        testImplementation "org.mockito:mockito-core:5.0.0"
+        testImplementation("junit:junit:4.13.2")
+        testImplementation("org.mockito:mockito-core:5.0.0")
     }
 
     testOptions {

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -1,5 +1,5 @@
-group '{{androidIdentifier}}'
-version '1.0'
+group "{{androidIdentifier}}"
+version "1.0"
 
 buildscript {
     repositories {
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath "com.android.tools.build:gradle:{{agpVersion}}"
     }
 }
 
@@ -19,11 +19,11 @@ rootProject.allprojects {
     }
 }
 
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace '{{androidIdentifier}}'
+        namespace "{{androidIdentifier}}"
     }
 
     compileSdk {{compileSdkVersion}}
@@ -38,8 +38,8 @@ android {
     }
 
     dependencies {
-        testImplementation 'junit:junit:4.13.2'
-        testImplementation 'org.mockito:mockito-core:5.0.0'
+        testImplementation "junit:junit:4.13.2"
+        testImplementation "org.mockito:mockito-core:5.0.0"
     }
 
     testOptions {

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -1,15 +1,15 @@
-group '{{androidIdentifier}}'
-version '1.0-SNAPSHOT'
+group "{{androidIdentifier}}"
+version "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = '{{kotlinVersion}}'
+    ext.kotlin_version = "{{kotlinVersion}}"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath "com.android.tools.build:gradle:{{agpVersion}}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -21,12 +21,12 @@ allprojects {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace '{{androidIdentifier}}'
+        namespace "{{androidIdentifier}}"
     }
 
     compileSdk {{compileSdkVersion}}
@@ -37,12 +37,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "1.8"
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-        test.java.srcDirs += 'src/test/kotlin'
+        main.java.srcDirs += "src/main/kotlin"
+        test.java.srcDirs += "src/test/kotlin"
     }
 
     defaultConfig {
@@ -50,8 +50,8 @@ android {
     }
 
     dependencies {
-        testImplementation 'org.jetbrains.kotlin:kotlin-test'
-        testImplementation 'org.mockito:mockito-core:5.0.0'
+        testImplementation "org.jetbrains.kotlin:kotlin-test"
+        testImplementation "org.mockito:mockito-core:5.0.0"
     }
 
     testOptions {

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -1,5 +1,5 @@
-group "{{androidIdentifier}}"
-version "1.0-SNAPSHOT"
+group = "{{androidIdentifier}}"
+version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "{{kotlinVersion}}"
@@ -9,8 +9,8 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:{{agpVersion}}"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath("com.android.tools.build:gradle:{{agpVersion}}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
@@ -26,14 +26,14 @@ apply plugin: "kotlin-android"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace "{{androidIdentifier}}"
+        namespace = "{{androidIdentifier}}"
     }
 
-    compileSdk {{compileSdkVersion}}
+    compileSdk = {{compileSdkVersion}}
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
@@ -46,12 +46,12 @@ android {
     }
 
     defaultConfig {
-        minSdk {{minSdkVersion}}
+        minSdk = {{minSdkVersion}}
     }
 
     dependencies {
-        testImplementation "org.jetbrains.kotlin:kotlin-test"
-        testImplementation "org.mockito:mockito-core:5.0.0"
+        testImplementation("org.jetbrains.kotlin:kotlin-test")
+        testImplementation("org.mockito:mockito-core:5.0.0")
     }
 
     testOptions {

--- a/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
@@ -37,7 +37,7 @@ android {
     // declared in /android/app/build.gradle file of the Flutter project.
     // Replace it with a version number if this plugin requires a specific NDK version.
     // (e.g. ndkVersion "23.1.7779620")
-    ndkVersion android.ndkVersion
+    ndkVersion = android.ndkVersion
 
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {

--- a/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
@@ -1,7 +1,7 @@
 // The Android Gradle Plugin builds the native code with the Android NDK.
 
-group "{{androidIdentifier}}"
-version "1.0"
+group = "{{androidIdentifier}}"
+version = "1.0"
 
 buildscript {
     repositories {
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath "com.android.tools.build:gradle:{{agpVersion}}"
+        classpath("com.android.tools.build:gradle:{{agpVersion}}")
     }
 }
 
@@ -26,12 +26,12 @@ apply plugin: "com.android.library"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace "{{androidIdentifier}}"
+        namespace = "{{androidIdentifier}}"
     }
 
     // Bumping the plugin compileSdk version requires all clients of this plugin
     // to bump the version in their app.
-    compileSdk {{compileSdkVersion}}
+    compileSdk = {{compileSdkVersion}}
 
     // Use the NDK version
     // declared in /android/app/build.gradle file of the Flutter project.
@@ -42,7 +42,7 @@ android {
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {
         cmake {
-            path "../src/CMakeLists.txt"
+            path = "../src/CMakeLists.txt"
 
             // The default CMake version for the Android Gradle Plugin is 3.10.2.
             // https://developer.android.com/studio/projects/install-ndk#vanilla_cmake
@@ -55,11 +55,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     defaultConfig {
-        minSdk {{minSdkVersion}}
+        minSdk = {{minSdkVersion}}
     }
 }

--- a/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/android.tmpl/build.gradle.tmpl
@@ -1,7 +1,7 @@
 // The Android Gradle Plugin builds the native code with the Android NDK.
 
-group '{{androidIdentifier}}'
-version '1.0'
+group "{{androidIdentifier}}"
+version "1.0"
 
 buildscript {
     repositories {
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         // The Android Gradle Plugin knows how to build native code with the NDK.
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath "com.android.tools.build:gradle:{{agpVersion}}"
     }
 }
 
@@ -22,11 +22,11 @@ rootProject.allprojects {
     }
 }
 
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace '{{androidIdentifier}}'
+        namespace "{{androidIdentifier}}"
     }
 
     // Bumping the plugin compileSdk version requires all clients of this plugin

--- a/packages/flutter_tools/test/android_preview_integration.shard/flutter_build_preview_sdk_test.dart
+++ b/packages/flutter_tools/test/android_preview_integration.shard/flutter_build_preview_sdk_test.dart
@@ -13,7 +13,7 @@ void main() {
   late String flutterBin;
   late Directory exampleAppDir;
   late Directory pluginDir;
-  final RegExp compileSdkVersionMatch = RegExp(r'compileSdk [\w.]+');
+  final RegExp compileSdkVersionMatch = RegExp(r'compileSdk\s*=?\s*[\w.]+');
   final String builtApkPath = <String>['build', 'app', 'outputs', 'flutter-apk', 'app-debug.apk']
       .join(platform.pathSeparator);
 
@@ -47,10 +47,10 @@ void main() {
       final File buildGradleFile = exampleAppDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
       // write a build.gradle with compileSdkVersion as `android-UpsideDownCake` which is a string preview version
       buildGradleFile.writeAsStringSync(
-        buildGradleFile.readAsStringSync().replaceFirst(compileSdkVersionMatch, 'compileSdkVersion "android-UpsideDownCake"'),
+        buildGradleFile.readAsStringSync().replaceFirst(compileSdkVersionMatch, 'compileSdkVersion = "android-UpsideDownCake"'),
         flush: true
       );
-      expect(buildGradleFile.readAsStringSync(), contains('compileSdkVersion "android-UpsideDownCake"'));
+      expect(buildGradleFile.readAsStringSync(), contains('compileSdkVersion = "android-UpsideDownCake"'));
 
       final ProcessResult result = await processManager.run(<String>[
         flutterBin,
@@ -75,10 +75,10 @@ void main() {
       final File buildGradleFile = exampleAppDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
       // write a build.gradle with compileSdkPreview as `UpsideDownCake` which is a string preview version
       buildGradleFile.writeAsStringSync(
-        buildGradleFile.readAsStringSync().replaceFirst(compileSdkVersionMatch, 'compileSdkPreview "UpsideDownCake"'),
+        buildGradleFile.readAsStringSync().replaceFirst(compileSdkVersionMatch, 'compileSdkPreview = "UpsideDownCake"'),
         flush: true
       );
-      expect(buildGradleFile.readAsStringSync(), contains('compileSdkPreview "UpsideDownCake"'));
+      expect(buildGradleFile.readAsStringSync(), contains('compileSdkPreview = "UpsideDownCake"'));
 
       final ProcessResult result = await processManager.run(<String>[
         flutterBin,
@@ -103,10 +103,10 @@ void main() {
       final File appBuildGradleFile = exampleAppDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
       // write a build.gradle with compileSdkPreview as `UpsideDownCake` which is a string preview version
       appBuildGradleFile.writeAsStringSync(
-          appBuildGradleFile.readAsStringSync().replaceFirst(compileSdkVersionMatch, 'compileSdkPreview "UpsideDownCake"'),
+          appBuildGradleFile.readAsStringSync().replaceFirst(compileSdkVersionMatch, 'compileSdkPreview = "UpsideDownCake"'),
           flush: true
       );
-      expect(appBuildGradleFile.readAsStringSync(), contains('compileSdkPreview "UpsideDownCake"'));
+      expect(appBuildGradleFile.readAsStringSync(), contains('compileSdkPreview = "UpsideDownCake"'));
 
       final File pluginBuildGradleFile = pluginDir.childDirectory('android').childFile('build.gradle');
       // change the plugin build.gradle to use a preview compile sdk version

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2932,7 +2932,7 @@ void main() {
 
     final String buildGradleContent = await buildGradleFile.readAsString();
 
-    expect(buildGradleContent.contains("namespace 'com.bar.foo.flutter_project'"), true);
+    expect(buildGradleContent.contains('namespace "com.bar.foo.flutter_project"'), true);
     // The namespace should be conditionalized for AGP <4.2.
     expect(buildGradleContent.contains('if (project.android.hasProperty("namespace")) {'), true);
   });
@@ -2955,7 +2955,7 @@ void main() {
 
     final String buildGradleContent = await buildGradleFile.readAsString();
 
-    expect(buildGradleContent.contains("namespace 'com.bar.foo.flutter_project'"), true);
+    expect(buildGradleContent.contains('namespace "com.bar.foo.flutter_project"'), true);
     // The namespace should be conditionalized for AGP <4.2.
     expect(buildGradleContent.contains('if (project.android.hasProperty("namespace")) {'), true);
   });
@@ -2979,7 +2979,7 @@ void main() {
 
     final String buildGradleContent = await buildGradleFile.readAsString();
 
-    expect(buildGradleContent.contains("namespace 'com.bar.foo.flutter_project'"), true);
+    expect(buildGradleContent.contains('namespace "com.bar.foo.flutter_project"'), true);
     // The namespace should be conditionalized for AGP <4.2.
     expect(buildGradleContent.contains('if (project.android.hasProperty("namespace")) {'), true);
   });
@@ -3002,7 +3002,7 @@ void main() {
     final String moduleFlutterBuildGradleFileContent = await globals.fs.file(globals.fs.path.join(projectDir.path, moduleFlutterBuildGradleFilePath)).readAsString();
 
     // Each build file should contain the expected namespace.
-    const String expectedNameSpace = "namespace 'com.bar.foo.flutter_project'";
+    const String expectedNameSpace = 'namespace "com.bar.foo.flutter_project"';
     expect(moduleBuildGradleFileContent.contains(expectedNameSpace), true);
     expect(moduleFlutterBuildGradleFileContent.contains(expectedNameSpace), true);
     const String expectedHostNameSpace = 'namespace "com.bar.foo.flutter_project.host"';

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2907,10 +2907,10 @@ void main() {
 
     final String buildContent = await globals.fs.file('${projectDir.path}/android/app/build.gradle').readAsString();
 
-    expect(buildContent.contains('compileSdk flutter.compileSdkVersion'), true);
-    expect(buildContent.contains('ndkVersion flutter.ndkVersion'), true);
-    expect(buildContent.contains('minSdk flutter.minSdkVersion'), true);
-    expect(buildContent.contains('targetSdk flutter.targetSdkVersion'), true);
+    expect(buildContent.contains('compileSdk = flutter.compileSdkVersion'), true);
+    expect(buildContent.contains('ndkVersion = flutter.ndkVersion'), true);
+    expect(buildContent.contains('minSdk = flutter.minSdkVersion'), true);
+    expect(buildContent.contains('targetSdk = flutter.targetSdkVersion'), true);
   });
 
   testUsingContext('Android Java plugin contains namespace', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2932,7 +2932,7 @@ void main() {
 
     final String buildGradleContent = await buildGradleFile.readAsString();
 
-    expect(buildGradleContent.contains('namespace "com.bar.foo.flutter_project"'), true);
+    expect(buildGradleContent.contains('namespace = "com.bar.foo.flutter_project"'), true);
     // The namespace should be conditionalized for AGP <4.2.
     expect(buildGradleContent.contains('if (project.android.hasProperty("namespace")) {'), true);
   });
@@ -2955,7 +2955,7 @@ void main() {
 
     final String buildGradleContent = await buildGradleFile.readAsString();
 
-    expect(buildGradleContent.contains('namespace "com.bar.foo.flutter_project"'), true);
+    expect(buildGradleContent.contains('namespace = "com.bar.foo.flutter_project"'), true);
     // The namespace should be conditionalized for AGP <4.2.
     expect(buildGradleContent.contains('if (project.android.hasProperty("namespace")) {'), true);
   });
@@ -2979,7 +2979,7 @@ void main() {
 
     final String buildGradleContent = await buildGradleFile.readAsString();
 
-    expect(buildGradleContent.contains('namespace "com.bar.foo.flutter_project"'), true);
+    expect(buildGradleContent.contains('namespace = "com.bar.foo.flutter_project"'), true);
     // The namespace should be conditionalized for AGP <4.2.
     expect(buildGradleContent.contains('if (project.android.hasProperty("namespace")) {'), true);
   });
@@ -3002,10 +3002,10 @@ void main() {
     final String moduleFlutterBuildGradleFileContent = await globals.fs.file(globals.fs.path.join(projectDir.path, moduleFlutterBuildGradleFilePath)).readAsString();
 
     // Each build file should contain the expected namespace.
-    const String expectedNameSpace = 'namespace "com.bar.foo.flutter_project"';
+    const String expectedNameSpace = 'namespace = "com.bar.foo.flutter_project"';
     expect(moduleBuildGradleFileContent.contains(expectedNameSpace), true);
     expect(moduleFlutterBuildGradleFileContent.contains(expectedNameSpace), true);
-    const String expectedHostNameSpace = 'namespace "com.bar.foo.flutter_project.host"';
+    const String expectedHostNameSpace = 'namespace = "com.bar.foo.flutter_project.host"';
     expect(moduleAppBuildGradleFileContent.contains(expectedHostNameSpace), true);
 
     // The namespaces should be conditionalized for AGP <4.2.

--- a/packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
@@ -47,9 +47,9 @@ void main() {
     final String pluginBuildGradle = pluginGradleFile.readAsStringSync();
 
     // Bump up plugin compileSdk version to 31
-    final RegExp androidCompileSdkVersionRegExp = RegExp(r'compileSdk ([0-9]+|flutter.compileSdkVersion)');
+    final RegExp androidCompileSdkVersionRegExp = RegExp(r'compileSdk = ([0-9]+|flutter.compileSdkVersion)');
     final String newPluginGradleFile = pluginBuildGradle.replaceAll(
-      androidCompileSdkVersionRegExp, 'compileSdk 31');
+      androidCompileSdkVersionRegExp, 'compileSdk = 31');
     pluginGradleFile.writeAsStringSync(newPluginGradleFile);
 
     final Directory pluginExampleAppDir = pluginAppDir.childDirectory('example');
@@ -61,7 +61,7 @@ void main() {
 
     // Bump down plugin example app compileSdk version to 30
     final String newProjectGradleFile = projectBuildGradle.replaceAll(
-      androidCompileSdkVersionRegExp, 'compileSdk 30');
+      androidCompileSdkVersionRegExp, 'compileSdk = 30');
     projectGradleFile.writeAsStringSync(newProjectGradleFile);
 
     // Run flutter build apk to build plugin example project

--- a/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
@@ -46,8 +46,8 @@ void main() {
     final String pluginBuildGradle = pluginGradleFile.readAsStringSync();
 
     // Bump up plugin ndkVersion to 21.4.7075529.
-    final RegExp androidNdkVersionRegExp = RegExp(r'ndkVersion (\"[0-9\.]+\"|flutter.ndkVersion|android.ndkVersion)');
-    final String newPluginGradleFile = pluginBuildGradle.replaceAll(androidNdkVersionRegExp, 'ndkVersion "21.4.7075529"');
+    final RegExp androidNdkVersionRegExp = RegExp(r'ndkVersion = (\"[0-9\.]+\"|flutter.ndkVersion|android.ndkVersion)');
+    final String newPluginGradleFile = pluginBuildGradle.replaceAll(androidNdkVersionRegExp, 'ndkVersion = "21.4.7075529"');
     expect(newPluginGradleFile, contains('21.4.7075529'));
     pluginGradleFile.writeAsStringSync(newPluginGradleFile);
 
@@ -59,7 +59,7 @@ void main() {
     final String projectBuildGradle = projectGradleFile.readAsStringSync();
 
     // Bump down plugin example app ndkVersion to 21.1.6352462.
-    final String newProjectGradleFile = projectBuildGradle.replaceAll(androidNdkVersionRegExp, 'ndkVersion "21.1.6352462"');
+    final String newProjectGradleFile = projectBuildGradle.replaceAll(androidNdkVersionRegExp, 'ndkVersion = "21.1.6352462"');
     expect(newProjectGradleFile, contains('21.1.6352462'));
     projectGradleFile.writeAsStringSync(newProjectGradleFile);
 


### PR DESCRIPTION
This PR will make it easier for future Flutter-Android apps/plugins/modules etc. to migrate to Gradle Kotlin DSL.

This PR is similar to #140452 but concerns public Gradle templates instead of Flutter's internal Gradle code. It should be a no-op change.

**before**

![before](https://github.com/flutter/flutter/assets/40357511/5d0cb2bb-a693-43bc-aa10-b8f431e0c68c)

**after**

![after](https://github.com/flutter/flutter/assets/40357511/e4a945a5-866f-42f7-813b-b08b26bb89dc)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
