### PR TITLE
Fix incorrect zh-cn translation for Look Up Label in selection controls

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/cupertino_zh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/cupertino_zh.arb
@@ -24,7 +24,7 @@
   "searchTextFieldPlaceholderLabel": "搜索",
   "noSpellCheckReplacementsLabel": "找不到替换文字",
   "menuDismissLabel": "关闭菜单",
-  "lookUpButtonLabel": "向上看",
+  "lookUpButtonLabel": "查询",
   "searchWebButtonLabel": "在网络上搜索",
   "shareButtonLabel": "分享…",
   "clearButtonLabel": "Clear"

--- a/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_cupertino_localizations.dart
@@ -14015,7 +14015,7 @@ class CupertinoLocalizationZh extends GlobalCupertinoLocalizations {
   String? get datePickerMinuteSemanticsLabelZero => null;
 
   @override
-  String get lookUpButtonLabel => '向上看';
+  String get lookUpButtonLabel => '查询';
 
   @override
   String get menuDismissLabel => '关闭菜单';

--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -43724,7 +43724,7 @@ class MaterialLocalizationZh extends GlobalMaterialLocalizations {
   String get licensesPageTitle => '许可';
 
   @override
-  String get lookUpButtonLabel => '向上看';
+  String get lookUpButtonLabel => '查询';
 
   @override
   String get menuBarMenuLabel => '菜单栏的菜单';

--- a/packages/flutter_localizations/lib/src/l10n/material_zh.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_zh.arb
@@ -142,7 +142,7 @@
   "expandedHint": "已收起",
   "collapsedHint": "已展开",
   "menuDismissLabel": "关闭菜单",
-  "lookUpButtonLabel": "向上看",
+  "lookUpButtonLabel": "查询",
   "searchWebButtonLabel": "在网络上搜索",
   "shareButtonLabel": "分享…",
   "clearButtonTooltip": "Clear text"

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -231,6 +231,14 @@ void main() {
     expect(buttonItems.first.onPressed, isNull);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/141764
+  testWidgets('zh-CN translation for look up label', (WidgetTester tester) async {
+    const Locale locale = Locale('zh');
+    expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);
+    final CupertinoLocalizations localizations = await GlobalCupertinoLocalizations.delegate.load(locale);
+    expect(localizations, isA<CupertinoLocalizationZh>());
+    expect(localizations.lookUpButtonLabel, '查询');
+  });
 }
 
 class _FakeEditableText extends EditableText {

--- a/packages/flutter_localizations/test/material/translations_test.dart
+++ b/packages/flutter_localizations/test/material/translations_test.dart
@@ -549,4 +549,13 @@ void main() {
     expect(localizations, isA<MaterialLocalizationEn>());
     expect(localizations.shareButtonLabel, 'Share');
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/141764
+  testWidgets('zh-CN translation for look up label', (WidgetTester tester) async {
+    const Locale locale = Locale('zh');
+    expect(GlobalCupertinoLocalizations.delegate.isSupported(locale), isTrue);
+    final MaterialLocalizations localizations = await GlobalMaterialLocalizations.delegate.load(locale);
+    expect(localizations, isA<MaterialLocalizationZh>());
+    expect(localizations.lookUpButtonLabel, '查询');
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/141764

Translation suggestion here:
https://tc.corp.google.com/btviewer/edittranslation?project=Flutter&msgId=8222331119728136330&language=zh-CN

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.