### PR TITLE
PopScope example improvements

### DIFF
--- a/examples/api/lib/widgets/form/form.1.dart
+++ b/examples/api/lib/widgets/form/form.1.dart
@@ -65,7 +65,7 @@ class _SaveableFormState extends State<_SaveableForm> {
   /// Shows a dialog and resolves to true when the user has indicated that they
   /// want to pop.
   ///
-  /// A null should be interpreted as a desire not to pop.
+  /// A null indicates a desire not to pop.
   Future<bool?> _showDialog() {
     return showDialog<bool>(
       context: context,
@@ -114,8 +114,8 @@ class _SaveableFormState extends State<_SaveableForm> {
               if (didPop) {
                 return;
               }
-              final bool? shouldPop = await _showDialog();
-              if (shouldPop ?? false) {
+              final bool shouldPop = await _showDialog() ?? false;
+              if (shouldPop) {
                 // Since this is the root route, quit the app where possible by
                 // invoking the SystemNavigator. If this wasn't the root route,
                 // then Navigator.maybePop could be used instead.
@@ -152,8 +152,10 @@ class _SaveableFormState extends State<_SaveableForm> {
           ),
           TextButton(
             onPressed: () async {
-              final bool? shouldPop = _isDirty ? await _showDialog() : true;
-              if (shouldPop == null || shouldPop == false) {
+              final bool shouldPop = _isDirty
+                  ? await _showDialog() ?? false
+                  : true;
+              if (!shouldPop) {
                 return;
               }
               // Since this is the root route, quit the app where possible by

--- a/examples/api/lib/widgets/form/form.1.dart
+++ b/examples/api/lib/widgets/form/form.1.dart
@@ -152,9 +152,7 @@ class _SaveableFormState extends State<_SaveableForm> {
           ),
           TextButton(
             onPressed: () async {
-              final bool shouldPop = _isDirty
-                  ? await _showDialog() ?? false
-                  : true;
+              final bool shouldPop = !_isDirty || (await _showDialog() ?? false);
               if (!shouldPop) {
                 return;
               }

--- a/examples/api/lib/widgets/form/form.1.dart
+++ b/examples/api/lib/widgets/form/form.1.dart
@@ -97,8 +97,10 @@ class _SaveableFormState extends State<_SaveableForm> {
   }
 
   void _save(String? value) {
+    final String nextSavedValue = value ?? '';
     setState(() {
-      _savedValue = value ?? '';
+      _savedValue = nextSavedValue;
+      _isDirty = nextSavedValue != _controller.text;
     });
   }
 

--- a/examples/api/lib/widgets/form/form.1.dart
+++ b/examples/api/lib/widgets/form/form.1.dart
@@ -65,7 +65,8 @@ class _SaveableFormState extends State<_SaveableForm> {
   /// Shows a dialog and resolves to true when the user has indicated that they
   /// want to pop.
   ///
-  /// A null indicates a desire not to pop.
+  /// A return value of null indicates a desire not to pop, such as when the
+  /// user has dismissed the modal without tapping a button.
   Future<bool?> _showDialog() {
     return showDialog<bool>(
       context: context,

--- a/examples/api/lib/widgets/pop_scope/pop_scope.0.dart
+++ b/examples/api/lib/widgets/pop_scope/pop_scope.0.dart
@@ -65,7 +65,8 @@ class _PageTwoState extends State<_PageTwo> {
   /// Shows a dialog and resolves to true when the user has indicated that they
   /// want to pop.
   ///
-  /// A null indicates a desire not to pop.
+  /// A return value of null indicates a desire not to pop, such as when the
+  /// user has dismissed the modal without tapping a button.
   Future<bool?> _showBackDialog() {
     return showDialog<bool>(
       context: context,

--- a/examples/api/lib/widgets/pop_scope/pop_scope.0.dart
+++ b/examples/api/lib/widgets/pop_scope/pop_scope.0.dart
@@ -62,8 +62,12 @@ class _PageTwo extends StatefulWidget {
 }
 
 class _PageTwoState extends State<_PageTwo> {
-  void _showBackDialog() {
-    showDialog<void>(
+  /// Shows a dialog and resolves to true when the user has indicated that they
+  /// want to pop.
+  ///
+  /// A null indicates a desire not to pop.
+  Future<bool?> _showBackDialog() {
+    return showDialog<bool>(
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
@@ -78,7 +82,7 @@ class _PageTwoState extends State<_PageTwo> {
               ),
               child: const Text('Nevermind'),
               onPressed: () {
-                Navigator.pop(context);
+                Navigator.pop(context, false);
               },
             ),
             TextButton(
@@ -87,8 +91,7 @@ class _PageTwoState extends State<_PageTwo> {
               ),
               child: const Text('Leave'),
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
+                Navigator.pop(context, true);
               },
             ),
           ],
@@ -107,15 +110,21 @@ class _PageTwoState extends State<_PageTwo> {
             const Text('Page Two'),
             PopScope(
               canPop: false,
-              onPopInvoked: (bool didPop) {
+              onPopInvoked: (bool didPop) async {
                 if (didPop) {
                   return;
                 }
-                _showBackDialog();
+                final bool shouldPop = await _showBackDialog() ?? false;
+                if (context.mounted && shouldPop) {
+                  Navigator.pop(context);
+                }
               },
               child: TextButton(
-                onPressed: () {
-                  _showBackDialog();
+                onPressed: () async {
+                  final bool shouldPop = await _showBackDialog() ?? false;
+                  if (context.mounted && shouldPop) {
+                    Navigator.pop(context);
+                  }
                 },
                 child: const Text('Go back'),
               ),

--- a/packages/flutter/lib/src/widgets/pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/pop_scope.dart
@@ -26,8 +26,8 @@ import 'routes.dart';
 /// [PopScope], in which case it will be `false`.
 ///
 /// {@tool dartpad}
-/// This sample demonstrates how to use this widget to handle nested navigation
-/// in a bottom navigation bar.
+/// This sample demonstrates showing a confirmation dialog before navigating
+/// away from a page.
 ///
 /// ** See code in examples/api/lib/widgets/pop_scope/pop_scope.0.dart **
 /// {@end-tool}


### PR DESCRIPTION
Updates two PopScope examples to a more clear usage of showDialog.

This came up in https://github.com/flutter/flutter/issues/138614, where many users were confused about how to use a back confirmation dialog with PopScope. Two examples of this already exist, but now they are cleaner and follow more typical navigation patterns, so users should recognize their own code in them more easily.