### PR TITLE
Update _goldens_io.dart to generate failure images during a size mism…

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -210,9 +210,11 @@ Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async 
       error: 'Pixel test failed, image sizes do not match.\n'
         'Master Image: ${masterImage.width} X ${masterImage.height}\n'
         'Test Image: ${testImage.width} X ${testImage.height}',
+        diffs: <String, Image>{
+          'masterImage': masterImage,
+          'testImage': testImage,
+        },
     );
-    masterImage.dispose();
-    testImage.dispose();
     return result;
   }
 

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -244,6 +244,34 @@ void main() {
           expect(masked.existsSync(), isTrue);
         });
 
+        test('and generates correct output when images are not the same size', () async {
+          await fs.file(fix('/golden.png')).writeAsBytes(_kSizeFailurePngBytes);
+          await expectLater(
+            () => doComparison(),
+            throwsA(isFlutterError.having(
+              (FlutterError error) => error.message,
+              'message',
+              contains('image sizes do not match'),
+            )),
+          );
+          final io.File master = fs.file(
+            fix('/failures/golden_masterImage.png')
+          );
+          final io.File test = fs.file(
+            fix('/failures/golden_testImage.png')
+          );
+          final io.File isolated = fs.file(
+            fix('/failures/golden_isolatedDiff.png')
+          );
+          final io.File masked = fs.file(
+            fix('/failures/golden_maskedDiff.png')
+          );
+          expect(master.existsSync(), isTrue);
+          expect(test.existsSync(), isTrue);
+          expect(isolated.existsSync(), isFalse);
+          expect(masked.existsSync(), isFalse);
+        });
+
         test('when golden file does not exist', () async {
           await expectLater(
             () => doComparison(),


### PR DESCRIPTION
Update the `matchesGoldenFile()` / `LocalComparisonOutput` code to generate failure images for golden tests that fail when the image sizes do not match. This can make it far quicker to identify what is wrong with the test image.

Fixes https://github.com/flutter/flutter/issues/141488

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] N/A I updated/added relevant documentation (doc comments with `///`).
- [x] N/A I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
