### PR TITLE
Migrate android_view to linux_android_emu platform.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -44,6 +44,7 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
+      kvm: "1"
   linux_build_test:
     properties:
       dependencies: >-
@@ -348,6 +349,7 @@ targets:
     properties:
       tags: >
         ["framework","hostonly","linux"]
+      task_name: android_views
     timeout: 60
 
   - name: Linux build_tests_1_3

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -29,6 +29,21 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
+  linux_android_emu:
+    properties:
+      contexts: >-
+        [
+          "android_virtual_device"
+        ]
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:34v3"},
+          {"dependency": "android_virtual_device", "version": "34"},
+          {"dependency": "open_jdk", "version": "version:17"}
+        ]
+      os: Ubuntu
+      cores: "8"
+      device_type: none
   linux_build_test:
     properties:
       dependencies: >-
@@ -327,15 +342,10 @@ targets:
           {"dependency": "gh_cli", "version": "version:2.8.0-2-g32256d38"}
         ]
 
-  - name: Linux android views
-    recipe: flutter/android_views
+  - name: Linux_android_emu android views
+    recipe: devicelab/devicelab_drone
+    bringup: true
     properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:34v3"},
-          {"dependency": "android_virtual_device", "version": "34"},
-          {"dependency": "open_jdk", "version": "version:17"}
-        ]
       tags: >
         ["framework","hostonly","linux"]
     timeout: 60


### PR DESCRIPTION
A new top level platform configuration was created for android emulator tests running on linux vms.

This is also a preparation step to remove adhoc recipes created to run emulator tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
