### PR TITLE
Catch file system exceptions when trying to parse user-provided asset file paths

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -11,7 +11,6 @@ import 'package:standard_message_codec/standard_message_codec.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/deferred_component.dart';
-import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/platform.dart';

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -958,7 +958,7 @@ class ManifestAssetBundle implements AssetBundle {
     } on UnsupportedError catch (e) {
       throwToolExit(
         'Unable to search for asset files in directory path "${assetUri.path}". '
-        'Please ensure that this is valid URI that points to a directory '
+        'Please ensure that this is a valid URI that points to a directory '
         'that is available on the local file system.\nError details:\n$e');
     }
 

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -11,6 +11,7 @@ import 'package:standard_message_codec/standard_message_codec.dart';
 import 'base/common.dart';
 import 'base/context.dart';
 import 'base/deferred_component.dart';
+import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/platform.dart';
@@ -1298,8 +1299,16 @@ class _AssetDirectoryCache {
   List<String> variantsFor(String assetPath) {
     final String directory = _fileSystem.path.dirname(assetPath);
 
-    if (!_fileSystem.directory(directory).existsSync()) {
-      return const <String>[];
+    try {
+      if (!_fileSystem.directory(directory).existsSync()) {
+        return const <String>[];
+      }
+    } on FileSystemException catch (e) {
+      throwToolExit(
+        'Unable to check the existence of asset file "$assetPath". '
+        'Ensure that the asset file is declared is a valid local file system path.\n'
+        'Details: $e',
+      );
     }
 
     if (_cache.containsKey(assetPath)) {

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1296,10 +1296,10 @@ class _AssetDirectoryCache {
   final Map<String, List<File>> _variantsPerFolder = <String, List<File>>{};
 
   List<String> variantsFor(String assetPath) {
-    final String directory = _fileSystem.path.dirname(assetPath);
+    final String directoryName = _fileSystem.path.dirname(assetPath);
 
     try {
-      if (!_fileSystem.directory(directory).existsSync()) {
+      if (!_fileSystem.directory(directoryName).existsSync()) {
         return const <String>[];
       }
     } on FileSystemException catch (e) {
@@ -1313,8 +1313,8 @@ class _AssetDirectoryCache {
     if (_cache.containsKey(assetPath)) {
       return _cache[assetPath]!;
     }
-    if (!_variantsPerFolder.containsKey(directory)) {
-      _variantsPerFolder[directory] = _fileSystem.directory(directory)
+    if (!_variantsPerFolder.containsKey(directoryName)) {
+      _variantsPerFolder[directoryName] = _fileSystem.directory(directoryName)
         .listSync()
         .whereType<Directory>()
         .where((Directory dir) => _assetVariantDirectoryRegExp.hasMatch(dir.basename))
@@ -1323,7 +1323,7 @@ class _AssetDirectoryCache {
         .toList();
     }
     final File assetFile = _fileSystem.file(assetPath);
-    final List<File> potentialVariants = _variantsPerFolder[directory]!;
+    final List<File> potentialVariants = _variantsPerFolder[directoryName]!;
     final String basename = assetFile.basename;
     return _cache[assetPath] = <String>[
       // It's possible that the user specifies only explicit variants (e.g. .../1x/asset.png),

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1305,7 +1305,7 @@ class _AssetDirectoryCache {
     } on FileSystemException catch (e) {
       throwToolExit(
         'Unable to check the existence of asset file "$assetPath". '
-        'Ensure that the asset file is declared is a valid local file system path.\n'
+        'Ensure that the asset file is declared as a valid local file system path.\n'
         'Details: $e',
       );
     }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -958,8 +958,8 @@ class ManifestAssetBundle implements AssetBundle {
     } on UnsupportedError catch (e) {
       throwToolExit(
         'Unable to search for asset files in directory path "${assetUri.path}". '
-        'Please ensure that this is a valid URI that points to a directory '
-        'that is available on the local file system.\nError details:\n$e');
+        'Please ensure that this entry in pubspec.yaml is a valid file path.\n'
+        'Error details:\n$e');
     }
 
     if (!_fileSystem.directory(directoryPath).existsSync()) {

--- a/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
@@ -1,0 +1,245 @@
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/project.dart';
+
+import '../src/common.dart';
+
+void main() {
+  Future<ManifestAssetBundle> buildBundleWithFlavor(String? flavor, {
+    required Logger logger,
+    required FileSystem fileSystem,
+    required Platform platform,
+  }) async {
+    final ManifestAssetBundle bundle = ManifestAssetBundle(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+      flutterRoot: Cache.defaultFlutterRoot(
+        platform: platform,
+        fileSystem: fileSystem,
+        userMessages: UserMessages(),
+      ),
+      splitDeferredAssets: true,
+    );
+
+    await bundle.build(
+      packagesPath: '.packages',
+      flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      flavor: flavor,
+    );
+    return bundle;
+  }
+
+  testWithoutContext('correctly bundles assets given a simple asset manifest with flavors', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    fileSystem.currentDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+    final BufferLogger logger = BufferLogger.test();
+    final FakePlatform platform = FakePlatform();
+
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('assets', 'common', 'image.png')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('assets', 'vanilla', 'ice-cream.png')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('assets', 'strawberry', 'ice-cream.png')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('assets', 'orange', 'ice-cream.png')).createSync(recursive: true);
+    fileSystem.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+flutter:
+assets:
+- assets/common/
+- path: assets/vanilla/
+  flavors:
+    - vanilla
+- path: assets/strawberry/
+  flavors:
+    - strawberry
+- path: assets/orange/ice-cream.png
+  flavors:
+    - orange
+''');
+
+    ManifestAssetBundle bundle;
+    bundle = await buildBundleWithFlavor(
+      null,
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+    );
+    expect(bundle.entries.keys, contains('assets/common/image.png'));
+    expect(bundle.entries.keys, isNot(contains('assets/vanilla/ice-cream.png')));
+    expect(bundle.entries.keys, isNot(contains('assets/strawberry/ice-cream.png')));
+    expect(bundle.entries.keys, isNot(contains('assets/orange/ice-cream.png')));
+
+    bundle = await buildBundleWithFlavor(
+      'strawberry',
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+    );
+    expect(bundle.entries.keys, contains('assets/common/image.png'));
+    expect(bundle.entries.keys, isNot(contains('assets/vanilla/ice-cream.png')));
+    expect(bundle.entries.keys, contains('assets/strawberry/ice-cream.png'));
+    expect(bundle.entries.keys, isNot(contains('assets/orange/ice-cream.png')));
+
+    bundle = await buildBundleWithFlavor(
+      'orange',
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+    );
+    expect(bundle.entries.keys, contains('assets/common/image.png'));
+    expect(bundle.entries.keys, isNot(contains('assets/vanilla/ice-cream.png')));
+    expect(bundle.entries.keys, isNot(contains('assets/strawberry/ice-cream.png')));
+    expect(bundle.entries.keys, contains('assets/orange/ice-cream.png'));
+  });
+
+  testWithoutContext('throws a tool exit when a non-flavored folder contains a flavored asset', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    fileSystem.currentDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+    final BufferLogger logger = BufferLogger.test();
+    final FakePlatform platform = FakePlatform();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('assets', 'unflavored.png')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('assets', 'vanillaOrange.png')).createSync(recursive: true);
+
+    fileSystem.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+flutter:
+assets:
+  - assets/
+  - path: assets/vanillaOrange.png
+    flavors:
+      - vanilla
+      - orange
+''');
+
+    expect(
+      buildBundleWithFlavor(
+        null,
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+      ),
+      throwsToolExit(message: 'Multiple assets entries include the file '
+        '"assets/vanillaOrange.png", but they specify different lists of flavors.\n'
+        'An entry with the path "assets/" does not specify any flavors.\n'
+        'An entry with the path "assets/vanillaOrange.png" specifies the flavor(s): "vanilla", "orange".\n\n'
+        'Consider organizing assets with different flavors into different directories.'),
+    );
+  });
+
+  testWithoutContext('throws a tool exit when a flavored folder contains a flavorless asset', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    fileSystem.currentDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+    final BufferLogger logger = BufferLogger.test();
+    final FakePlatform platform = FakePlatform();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('vanilla', 'vanilla.png')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('vanilla', 'flavorless.png')).createSync(recursive: true);
+
+    fileSystem.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+flutter:
+assets:
+  - path: vanilla/
+    flavors:
+      - vanilla
+  - vanilla/flavorless.png
+''');
+    expect(
+      buildBundleWithFlavor(
+        null,
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+      ),
+      throwsToolExit(message: 'Multiple assets entries include the file '
+        '"vanilla/flavorless.png", but they specify different lists of flavors.\n'
+        'An entry with the path "vanilla/" specifies the flavor(s): "vanilla".\n'
+        'An entry with the path "vanilla/flavorless.png" does not specify any flavors.\n\n'
+        'Consider organizing assets with different flavors into different directories.'),
+    );
+  });
+
+  testWithoutContext('tool exits when two file-explicit entries give the same asset different flavors', () {
+    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    fileSystem.currentDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+    final BufferLogger logger = BufferLogger.test();
+    final FakePlatform platform = FakePlatform();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file('orange.png').createSync(recursive: true);
+    fileSystem.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+flutter:
+assets:
+  - path: orange.png
+    flavors:
+      - orange
+  - path: orange.png
+    flavors:
+      - mango
+''');
+
+    expect(
+      buildBundleWithFlavor(
+        null,
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+      ),
+      throwsToolExit(message: 'Multiple assets entries include the file '
+        '"orange.png", but they specify different lists of flavors.\n'
+        'An entry with the path "orange.png" specifies the flavor(s): "orange".\n'
+        'An entry with the path "orange.png" specifies the flavor(s): "mango".'),
+    );
+});
+
+  testWithoutContext('throws ToolExit when flavor from file-level declaration has different flavor from containing folder flavor declaration', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem();
+    fileSystem.currentDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_test.');
+    final BufferLogger logger = BufferLogger.test();
+    final FakePlatform platform = FakePlatform();
+    fileSystem.file('.packages').createSync();
+    fileSystem.file(fileSystem.path.join('vanilla', 'actually-strawberry.png')).createSync(recursive: true);
+    fileSystem.file(fileSystem.path.join('vanilla', 'vanilla.png')).createSync(recursive: true);
+
+    fileSystem.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+flutter:
+assets:
+  - path: vanilla/
+    flavors:
+      - vanilla
+  - path: vanilla/actually-strawberry.png
+    flavors:
+      - strawberry
+''');
+    expect(
+      buildBundleWithFlavor(
+        null,
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+      ),
+      throwsToolExit(message: 'Multiple assets entries include the file '
+        '"vanilla/actually-strawberry.png", but they specify different lists of flavors.\n'
+        'An entry with the path "vanilla/" specifies the flavor(s): "vanilla".\n'
+        'An entry with the path "vanilla/actually-strawberry.png" '
+        'specifies the flavor(s): "strawberry".'),
+    );
+  });
+}

--- a/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
@@ -51,17 +51,17 @@ void main() {
       ..writeAsStringSync(r'''
 name: example
 flutter:
-assets:
-- assets/common/
-- path: assets/vanilla/
-  flavors:
-    - vanilla
-- path: assets/strawberry/
-  flavors:
-    - strawberry
-- path: assets/orange/ice-cream.png
-  flavors:
-    - orange
+  assets:
+  - assets/common/
+  - path: assets/vanilla/
+    flavors:
+      - vanilla
+  - path: assets/strawberry/
+    flavors:
+      - strawberry
+  - path: assets/orange/ice-cream.png
+    flavors:
+      - orange
 ''');
 
     ManifestAssetBundle bundle;
@@ -113,12 +113,12 @@ assets:
       ..writeAsStringSync(r'''
 name: example
 flutter:
-assets:
-  - assets/
-  - path: assets/vanillaOrange.png
-    flavors:
-      - vanilla
-      - orange
+  assets:
+    - assets/
+    - path: assets/vanillaOrange.png
+      flavors:
+        - vanilla
+        - orange
 ''');
 
     expect(
@@ -150,11 +150,11 @@ assets:
       ..writeAsStringSync(r'''
 name: example
 flutter:
-assets:
-  - path: vanilla/
-    flavors:
-      - vanilla
-  - vanilla/flavorless.png
+  assets:
+    - path: vanilla/
+      flavors:
+        - vanilla
+    - vanilla/flavorless.png
 ''');
     expect(
       buildBundleWithFlavor(
@@ -183,13 +183,13 @@ assets:
       ..writeAsStringSync(r'''
 name: example
 flutter:
-assets:
-  - path: orange.png
-    flavors:
-      - orange
-  - path: orange.png
-    flavors:
-      - mango
+  assets:
+    - path: orange.png
+      flavors:
+        - orange
+    - path: orange.png
+      flavors:
+        - mango
 ''');
 
     expect(
@@ -220,13 +220,13 @@ assets:
       ..writeAsStringSync(r'''
 name: example
 flutter:
-assets:
-  - path: vanilla/
-    flavors:
-      - vanilla
-  - path: vanilla/actually-strawberry.png
-    flavors:
-      - strawberry
+  assets:
+    - path: vanilla/
+      flavors:
+        - vanilla
+    - path: vanilla/actually-strawberry.png
+      flavors:
+        - strawberry
 ''');
     expect(
       buildBundleWithFlavor(

--- a/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -24,9 +24,10 @@ import 'package:standard_message_codec/standard_message_codec.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 
-const String _shaderLibDir = '/./shader_lib';
 
 void main() {
+  const String shaderLibDir = '/./shader_lib';
+
   group('AssetBundle.build', () {
     late FileSystem testFileSystem;
     late Platform platform;
@@ -679,7 +680,7 @@ flutter:
             '--input=/$shaderPath',
             '--input-type=frag',
             '--include=/$assetsPath',
-            '--include=$_shaderLibDir',
+            '--include=$shaderLibDir',
           ],
           onRun: (_) {
             fileSystem.file(outputPath).createSync(recursive: true);
@@ -726,7 +727,7 @@ flutter:
             '--input=/$shaderPath',
             '--input-type=frag',
             '--include=/$assetsPath',
-            '--include=$_shaderLibDir',
+            '--include=$shaderLibDir',
           ],
           onRun: (_) {
             fileSystem.file(outputPath).createSync(recursive: true);
@@ -767,7 +768,7 @@ flutter:
             '--input=${fileSystem.path.join(materialDir.path, 'shaders', 'ink_sparkle.frag')}',
             '--input-type=frag',
             '--include=${fileSystem.path.join(materialDir.path, 'shaders')}',
-            '--include=$_shaderLibDir',
+            '--include=$shaderLibDir',
           ],
           onRun: (_) {
             fileSystem.file(outputPath).createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -27,7 +27,7 @@ import '../src/context.dart';
 void main() {
   const String shaderLibDir = '/./shader_lib';
 
-  group('AssetBundle.build', () {
+  group('AssetBundle.build (non-hermetic)', () {
     late FileSystem testFileSystem;
     late Platform platform;
 
@@ -337,8 +337,8 @@ flutter:
     });
   });
 
-  group('AssetBundle.build (hermetic)', () {
-    testUsingContext('throws ToolExit when directory entry contains invalid characters (Windows only)', () async {
+  group('AssetBundle.build', () {
+    testWithoutContext('throws ToolExit when directory entry contains invalid characters (Windows only)', () async {
       final MemoryFileSystem fileSystem = MemoryFileSystem(style: FileSystemStyle.windows);
       final BufferLogger logger = BufferLogger.test();
       final FakePlatform platform = FakePlatform(operatingSystem: 'windows');
@@ -373,8 +373,7 @@ flutter:
         ),
         throwsToolExit(
           message: 'Unable to search for asset files in directory path "https%3A//mywebsite.com/images/". '
-            'Please ensure that this is a valid URI that points to a directory '
-            'that is available on the local file system.\n'
+            'Please ensure that this entry in pubspec.yaml is a valid file path.\n'
             'Error details:\n'
             'Unsupported operation: Illegal character in path: https:',
         ),

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -27,7 +27,7 @@ import '../src/context.dart';
 void main() {
   const String shaderLibDir = '/./shader_lib';
 
-  group('AssetBundle.build (non-hermetic)', () {
+  group('AssetBundle.build (using context)', () {
     late FileSystem testFileSystem;
     late Platform platform;
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -24,7 +24,6 @@ import 'package:standard_message_codec/standard_message_codec.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 
-
 void main() {
   const String shaderLibDir = '/./shader_lib';
 


### PR DESCRIPTION
Fixes #141211

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
