### PR TITLE
Fix `SegmentedButton` default size and default tappable size

### DIFF
--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -468,7 +468,6 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
       ? widget.selectedIcon ?? theme.selectedIcon ?? defaults.selectedIcon
       : null;
 
-    print(segmentStyle.tapTargetSize);
     Widget buttonFor(ButtonSegment<T> segment) {
       final Widget label = segment.label ?? segment.icon ?? const SizedBox.shrink();
       final bool segmentSelected = widget.selected.contains(segment.value);
@@ -528,7 +527,6 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     //   case MaterialTapTargetSize.shrinkWrap:
     //
     // }
-    print('------- ${segmentStyle.tapTargetSize}');
     return Material(
       type: MaterialType.transparency,
       shape: enabledBorder.copyWith(side: BorderSide.none),
@@ -538,7 +536,8 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
       child: TextButtonTheme(
         data: TextButtonThemeData(style: segmentThemeStyle),
         child: _SegmentedButtonRenderWidget<T>(
-          tapTargetSize: segmentStyle.tapTargetSize ?? segmentThemeStyle.tapTargetSize ?? MaterialTapTargetSize.shrinkWrap,
+          visualDensity: segmentStyle.visualDensity ?? segmentThemeStyle.visualDensity ?? Theme.of(context).visualDensity,
+          tapTargetSize: segmentStyle.tapTargetSize ?? segmentThemeStyle.tapTargetSize ?? Theme.of(context).materialTapTargetSize,
           segments: widget.segments,
           enabledBorder: _enabled ? enabledBorder : disabledBorder,
           disabledBorder: disabledBorder,
@@ -581,6 +580,7 @@ class _SegmentButtonDefaultColor extends MaterialStateProperty<Color?> with Diag
 class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
   const _SegmentedButtonRenderWidget({
     super.key,
+    required this.visualDensity,
     required this.tapTargetSize,
     required this.segments,
     required this.enabledBorder,
@@ -589,6 +589,7 @@ class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
     required super.children,
   }) : assert(children.length == segments.length);
 
+  final VisualDensity visualDensity;
   final MaterialTapTargetSize tapTargetSize;
   final List<ButtonSegment<T>> segments;
   final OutlinedBorder enabledBorder;
@@ -597,8 +598,8 @@ class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    print('........ $tapTargetSize');
     return _RenderSegmentedButton<T>(
+      visualDensity: visualDensity,
       tapTargetSize: tapTargetSize,
       segments: segments,
       enabledBorder: enabledBorder,
@@ -627,16 +628,28 @@ class _RenderSegmentedButton<T> extends RenderBox with
      ContainerRenderObjectMixin<RenderBox, ContainerBoxParentData<RenderBox>>,
      RenderBoxContainerDefaultsMixin<RenderBox, ContainerBoxParentData<RenderBox>> {
   _RenderSegmentedButton({
+    required VisualDensity visualDensity,
     required MaterialTapTargetSize tapTargetSize,
     required List<ButtonSegment<T>> segments,
     required OutlinedBorder enabledBorder,
     required OutlinedBorder disabledBorder,
     required TextDirection textDirection,
-  }) : _tapTargetSize = tapTargetSize,
+  }) : _visualDensity = visualDensity,
+       _tapTargetSize = tapTargetSize,
        _segments = segments,
        _enabledBorder = enabledBorder,
        _disabledBorder = disabledBorder,
        _textDirection = textDirection;
+
+  VisualDensity get visualDensity => _visualDensity;
+  VisualDensity _visualDensity;
+  set visualDensity(VisualDensity value) {
+    if (visualDensity == value) {
+      return;
+    }
+    _visualDensity = value;
+    markNeedsLayout();
+  }
 
   MaterialTapTargetSize get tapTargetSize => _tapTargetSize;
   MaterialTapTargetSize _tapTargetSize;
@@ -833,11 +846,16 @@ class _RenderSegmentedButton<T> extends RenderBox with
   void paint(PaintingContext context, Offset offset) {
     // if tapTargetSize is MaterialTapTargetSize.padded -> segmentedButton is larger than expected
     // -> We should paint smaller segemented button
+    final Offset densityAdjustment = visualDensity.baseSizeAdjustment;
+    print('$tapTargetSize');
+    print('$visualDensity');
+    print('$densityAdjustment');
+    if (tapTargetSize == MaterialTapTargetSize.padded) {
+
+    }
     Size effectiveSize;
     double deltaHeight = 0;
-    print('$tapTargetSize ${size.height}');
     if (tapTargetSize == MaterialTapTargetSize.padded && size.height <= 48) {
-      print(size.height);
       deltaHeight = 48 - size.height;
     }
 

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -8,11 +8,12 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
-import '../widgets/constants.dart';
+
 import 'button_style.dart';
 import 'button_style_button.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
+import 'constants.dart';
 import 'icons.dart';
 import 'ink_well.dart';
 import 'material.dart';

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -513,21 +513,36 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     final BorderSide disabledSide = resolve<BorderSide?>((ButtonStyle? style) => style?.side, disabledState) ?? BorderSide.none;
     final OutlinedBorder enabledBorder = resolvedEnabledBorder.copyWith(side: enabledSide);
     final OutlinedBorder disabledBorder = resolvedDisabledBorder.copyWith(side: disabledSide);
+    final VisualDensity resolvedVisualDensity = segmentStyle.visualDensity ?? segmentThemeStyle.visualDensity ?? Theme.of(context).visualDensity;
+    final EdgeInsetsGeometry resolvedPadding = resolve<EdgeInsetsGeometry?>((ButtonStyle? style) => style?.padding, enabledState) ?? EdgeInsets.zero;
+    final MaterialTapTargetSize resolvedTapTargetSize = segmentStyle.tapTargetSize ?? segmentThemeStyle.tapTargetSize ?? Theme.of(context).materialTapTargetSize;
+    final double fontSize = resolve<TextStyle?>((ButtonStyle? style) => style?.textStyle, enabledState)?.fontSize ?? 20.0;
 
     final List<Widget> buttons = widget.segments.map(buttonFor).toList();
 
+    final Offset densityAdjustment = resolvedVisualDensity.baseSizeAdjustment;
+    const double textButtonMinHeight = 40.0;
+
+    final double adjustButtonMinHeight = textButtonMinHeight + densityAdjustment.dy;
+    final double effectiveVerticalPadding = resolvedPadding.vertical + densityAdjustment.dy * 2;
+    final double effectedButtonHeight = max(fontSize + effectiveVerticalPadding, adjustButtonMinHeight);
+    final double tapTargetVerticalPadding;
+    switch (resolvedTapTargetSize) {
+      case MaterialTapTargetSize.shrinkWrap:
+        tapTargetVerticalPadding = 0;
+      case MaterialTapTargetSize.padded:
+        tapTargetVerticalPadding = max(0, kMinInteractiveDimension + densityAdjustment.dy - effectedButtonHeight);
+    }
+
     return Material(
       type: MaterialType.transparency,
-      shape: enabledBorder.copyWith(side: BorderSide.none),
       elevation: resolve<double?>((ButtonStyle? style) => style?.elevation)!,
       shadowColor: resolve<Color?>((ButtonStyle? style) => style?.shadowColor),
       surfaceTintColor: resolve<Color?>((ButtonStyle? style) => style?.surfaceTintColor),
       child: TextButtonTheme(
         data: TextButtonThemeData(style: segmentThemeStyle),
         child: _SegmentedButtonRenderWidget<T>(
-          padding: resolve<EdgeInsetsGeometry?>((ButtonStyle? style) => style?.padding, enabledState) ?? EdgeInsets.zero,
-          visualDensity: segmentStyle.visualDensity ?? segmentThemeStyle.visualDensity ?? Theme.of(context).visualDensity,
-          tapTargetSize: segmentStyle.tapTargetSize ?? segmentThemeStyle.tapTargetSize ?? Theme.of(context).materialTapTargetSize,
+          tapTargetVerticalPadding: tapTargetVerticalPadding,
           segments: widget.segments,
           enabledBorder: _enabled ? enabledBorder : disabledBorder,
           disabledBorder: disabledBorder,
@@ -570,34 +585,28 @@ class _SegmentButtonDefaultColor extends MaterialStateProperty<Color?> with Diag
 class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
   const _SegmentedButtonRenderWidget({
     super.key,
-    required this.padding,
-    required this.visualDensity,
-    required this.tapTargetSize,
     required this.segments,
     required this.enabledBorder,
     required this.disabledBorder,
     required this.direction,
+    required this.tapTargetVerticalPadding,
     required super.children,
   }) : assert(children.length == segments.length);
 
-  final EdgeInsetsGeometry padding;
-  final VisualDensity visualDensity;
-  final MaterialTapTargetSize tapTargetSize;
   final List<ButtonSegment<T>> segments;
   final OutlinedBorder enabledBorder;
   final OutlinedBorder disabledBorder;
   final TextDirection direction;
+  final double tapTargetVerticalPadding;
 
   @override
   RenderObject createRenderObject(BuildContext context) {
     return _RenderSegmentedButton<T>(
-      padding: padding,
-      visualDensity: visualDensity,
-      tapTargetSize: tapTargetSize,
       segments: segments,
       enabledBorder: enabledBorder,
       disabledBorder: disabledBorder,
       textDirection: direction,
+      tapTargetVerticalPadding: tapTargetVerticalPadding,
     );
   }
 
@@ -621,50 +630,16 @@ class _RenderSegmentedButton<T> extends RenderBox with
      ContainerRenderObjectMixin<RenderBox, ContainerBoxParentData<RenderBox>>,
      RenderBoxContainerDefaultsMixin<RenderBox, ContainerBoxParentData<RenderBox>> {
   _RenderSegmentedButton({
-    required EdgeInsetsGeometry padding,
-    required VisualDensity visualDensity,
-    required MaterialTapTargetSize tapTargetSize,
     required List<ButtonSegment<T>> segments,
     required OutlinedBorder enabledBorder,
     required OutlinedBorder disabledBorder,
     required TextDirection textDirection,
-  }) : _padding = padding,
-       _visualDensity = visualDensity,
-       _tapTargetSize = tapTargetSize,
-       _segments = segments,
+    required double tapTargetVerticalPadding,
+  }) : _segments = segments,
        _enabledBorder = enabledBorder,
        _disabledBorder = disabledBorder,
-       _textDirection = textDirection;
-
-  EdgeInsetsGeometry get padding => _padding;
-  EdgeInsetsGeometry _padding;
-  set padding(EdgeInsetsGeometry value) {
-    if (padding == value) {
-      return;
-    }
-    _padding = value;
-    markNeedsLayout();
-  }
-
-  VisualDensity get visualDensity => _visualDensity;
-  VisualDensity _visualDensity;
-  set visualDensity(VisualDensity value) {
-    if (visualDensity == value) {
-      return;
-    }
-    _visualDensity = value;
-    markNeedsLayout();
-  }
-
-  MaterialTapTargetSize get tapTargetSize => _tapTargetSize;
-  MaterialTapTargetSize _tapTargetSize;
-  set tapTargetSize(MaterialTapTargetSize value) {
-    if (tapTargetSize == value) {
-      return;
-    }
-    _tapTargetSize = value;
-    markNeedsLayout();
-  }
+       _textDirection = textDirection,
+       _tapTargetVerticalPadding = tapTargetVerticalPadding;
 
   List<ButtonSegment<T>> get segments => _segments;
   List<ButtonSegment<T>> _segments;
@@ -703,6 +678,16 @@ class _RenderSegmentedButton<T> extends RenderBox with
       return;
     }
     _textDirection = value;
+    markNeedsLayout();
+  }
+
+  double get tapTargetVerticalPadding => _tapTargetVerticalPadding;
+  double _tapTargetVerticalPadding;
+  set tapTargetVerticalPadding(double value) {
+    if (value == _tapTargetVerticalPadding) {
+      return;
+    }
+    _tapTargetVerticalPadding = value;
     markNeedsLayout();
   }
 
@@ -849,20 +834,6 @@ class _RenderSegmentedButton<T> extends RenderBox with
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final Offset densityAdjustment = visualDensity.baseSizeAdjustment;
-    const double textButtonMinHeight = 40.0;
-
-    const double textSize = 20; // Need to use TextStyle.fontSize
-    final double adjustButtonMinHeight = textButtonMinHeight + densityAdjustment.dy;
-    final double effectiveVerticalPadding = padding.vertical + densityAdjustment.dy * 2;
-    final double effectedButtonHeight = max(textSize + effectiveVerticalPadding, adjustButtonMinHeight);
-    final double tapTargetVerticalPadding;
-    switch (tapTargetSize) {
-      case MaterialTapTargetSize.shrinkWrap:
-        tapTargetVerticalPadding = 0;
-      case MaterialTapTargetSize.padded:
-        tapTargetVerticalPadding = max(0, kMinInteractiveDimension + densityAdjustment.dy - effectedButtonHeight);
-    }
 
     final Rect borderRect = (offset + Offset(0, tapTargetVerticalPadding / 2)) & (Size(size.width, size.height - tapTargetVerticalPadding));
     final Path borderClipPath = enabledBorder.getInnerPath(borderRect, textDirection: textDirection);

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -527,13 +527,10 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     final double adjustButtonMinHeight = textButtonMinHeight + densityAdjustment.dy;
     final double effectiveVerticalPadding = resolvedPadding.vertical + densityAdjustment.dy * 2;
     final double effectedButtonHeight = max(fontSize + effectiveVerticalPadding, adjustButtonMinHeight);
-    final double tapTargetVerticalPadding;
-    switch (resolvedTapTargetSize) {
-      case MaterialTapTargetSize.shrinkWrap:
-        tapTargetVerticalPadding = 0;
-      case MaterialTapTargetSize.padded:
-        tapTargetVerticalPadding = max(0, kMinInteractiveDimension + densityAdjustment.dy - effectedButtonHeight);
-    }
+    final double tapTargetVerticalPadding = switch (resolvedTapTargetSize) {
+      MaterialTapTargetSize.shrinkWrap => 0.0,
+      MaterialTapTargetSize.padded => max(0, kMinInteractiveDimension + densityAdjustment.dy - effectedButtonHeight)
+    };
 
     return Material(
       type: MaterialType.transparency,

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -515,15 +515,7 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     final OutlinedBorder disabledBorder = resolvedDisabledBorder.copyWith(side: disabledSide);
 
     final List<Widget> buttons = widget.segments.map(buttonFor).toList();
-    //
-    // final MaterialTapTargetSize effectiveTTS = segmentStyle.tapTargetSize ?? segmentThemeStyle.tapTargetSize ?? MaterialTapTargetSize.shrinkWrap;
-    // final double HeightDelta;
-    // switch (effectiveTTS) {
-    //   case MaterialTapTargetSize.padded:
-    //     // mini
-    //   case MaterialTapTargetSize.shrinkWrap:
-    //
-    // }
+
     return Material(
       type: MaterialType.transparency,
       shape: enabledBorder.copyWith(side: BorderSide.none),

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -4,7 +4,6 @@
 
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
-import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -813,7 +813,8 @@ void main() {
     expect(state.statesControllers.values.first.value, states);
   });
 
-  testWidgets('Min button height is 48.0 with standard density and MaterialTapTargetSize.padded', (WidgetTester tester) async {
+  testWidgets('Min button hit target height is 48.0 and min (painted) button height is 40 '
+    'by default with standard density and MaterialTapTargetSize.padded', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(
       MaterialApp(
@@ -849,7 +850,7 @@ void main() {
       paints..rrect(
         style: PaintingStyle.stroke,
         strokeWidth: 1.0,
-        // Button border height is 43.5 - 4.5 + stoke width(1) = 40.
+        // Button border height is button.bottom(43.5) - button.top(4.5) + stoke width(1) = 40.
         rrect: RRect.fromLTRBR(0.5, 4.5, 497.5, 43.5, const Radius.circular(19.5))
       )
     );

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -4,6 +4,7 @@
 
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -811,6 +812,48 @@ void main() {
     // Check the states after the rebuild.
     state = tester.state(find.byType(SegmentedButton<int>));
     expect(state.statesControllers.values.first.value, states);
+  });
+
+  testWidgets('Min button height is 48.0 with standard density and MaterialTapTargetSize.padded', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Scaffold(
+          body: Center(
+            child: Column(
+              children: <Widget>[
+                SegmentedButton<int>(
+                  segments: const <ButtonSegment<int>>[
+                    ButtonSegment<int>(value: 0, label: Text('Day'), icon: Icon(Icons.calendar_view_day)),
+                    ButtonSegment<int>(value: 1, label: Text('Week'), icon: Icon(Icons.calendar_view_week)),
+                    ButtonSegment<int>(value: 2, label: Text('Month'), icon: Icon(Icons.calendar_view_month)),
+                    ButtonSegment<int>(value: 3, label: Text('Year'), icon: Icon(Icons.calendar_today)),
+                  ],
+                  selected: const <int>{0},
+                  onSelectionChanged: (Set<int> value) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(theme.visualDensity, VisualDensity.standard);
+    expect(theme.materialTapTargetSize, MaterialTapTargetSize.padded);
+
+    final Finder button = find.byType(SegmentedButton<int>);
+    expect(tester.getSize(button).height, 48.0);
+    expect(
+      find.byType(SegmentedButton<int>),
+      paints..rrect(
+        style: PaintingStyle.stroke,
+        strokeWidth: 1.0,
+        // Button border height is 43.5 - 4.5 + stoke width(1) = 40.
+        rrect: RRect.fromLTRBR(0.5, 4.5, 497.5, 43.5, const Radius.circular(19.5))
+      )
+    );
   });
 }
 

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -751,7 +751,6 @@ void main() {
       of: find.byType(SegmentedButton<int>),
       matching: find.byType(Material),
     ).first);
-    expect(material.shape, styleFromStyle.shape?.resolve(enabled)?.copyWith(side: BorderSide.none));
     expect(material.elevation, styleFromStyle.elevation?.resolve(enabled));
     expect(material.shadowColor, styleFromStyle.shadowColor?.resolve(enabled));
     expect(material.surfaceTintColor, styleFromStyle.surfaceTintColor?.resolve(enabled));


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/121493

`SegmentedButton` uses `TextButton` for each segments. When we have `MaterialTapTargetSize.padded` for `TextButton`, we make sure the minimum tap target size is 48.0( this value can be adjusted by visual density), even tough the actual button size is smaller. When `SegmentedButton` paints segments by using `MultiChildRenderObjectWidget`, it also includes the tap target size so the button that it actually draws always has the same height as the height of the tap target size.

To fix it, this PR firstly calculate the actual height of a text button in `SegmentedButton` class, then we can get the height delta if there is. Then the the value of (Segmented button render box height - the delta) would be the actual button size that we should see.

For now, we are not able to customize the min, max, fixed size in [`SegmentedButton` style](https://api.flutter.dev/flutter/material/SegmentedButton/style.html). So the standard button height is always 40 and can only be customized by `style.visualDensity` and `style.tapTargetSize`; `SegmentedButton` only simulates the `TextButton` behavior when `TextButton`'s height is its default value.

![Screenshot 2024-01-25 at 11 45 42 AM](https://github.com/flutter/flutter/assets/36861262/7451fa96-6d45-4cd3-a894-ca71e776c8ef)


https://github.com/flutter/flutter/assets/36861262/15ca6034-e6e0-4cc6-8fe3-808b4bd6a920



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
