### PR TITLE
Roll engine version to 968e2945.

### DIFF
--- a/bin/internal/engine.version
+++ b/bin/internal/engine.version
@@ -1,1 +1,1 @@
-4f18bb4dcb99d7e0d94aeff2ffa74e6ddef301cd
+968e2945c75c817f594e2e737bdd7bf68cba6bc0

--- a/packages/flutter_test/test/widget_tester_leaks_test.dart
+++ b/packages/flutter_test/test/widget_tester_leaks_test.dart
@@ -41,9 +41,6 @@ void main() {
     _test2TrackingOffLeaks = 'test2, tracking-off, leaks',
     experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester widgetTester) async {
-    expect(LeakTracking.isStarted, true);
-    expect(LeakTracking.phase.name, null);
-    expect(LeakTracking.phase.ignoreLeaks, true);
     await widgetTester.pumpWidget(StatelessLeakingWidget());
   });
 


### PR DESCRIPTION
Rolls engine version to: 968e2945c75c817f594e2e737bdd7bf68cba6bc0.

CP: 188d4d1fdfa93f6ff1a81be1317bc4533927a4eb

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
