### PR TITLE
Remove arch restrictions in mac tests that can run on any architecture.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -141,6 +141,25 @@ platform_properties:
         {
           "sdk_version": "15a240d"
         }
+  mac_android_benchmark:
+    properties:
+      contexts: >-
+        [
+          "osx_sdk"
+        ]
+      dependencies: >-
+        [
+          {"dependency": "apple_signing", "version": "version:to_2024"}
+        ]
+      device_type: "msm8952"
+      mac_model: "Macmini8,1"
+      os: Mac-13
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "15a240d"
+        }
   mac_x64:
     properties:
       contexts: >-
@@ -4102,7 +4121,7 @@ targets:
       task_name: hello_world_android__compile
 
   # mac motog4 benchmark
-  - name: Mac_arm64_android hot_mode_dev_cycle__benchmark
+  - name: Mac_android_benchmark hot_mode_dev_cycle__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
     bringup: true

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -185,7 +185,6 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       os: Mac-12|Mac-13
-      cpu: x86
       device_type: "msm8952"
   mac_arm64_android:
     properties:
@@ -205,7 +204,6 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       os: Mac-12|Mac-13
-      cpu: x86
       device_type: "Pixel 7 Pro"
   mac_ios:
     properties:
@@ -219,7 +217,6 @@ platform_properties:
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
       os: Mac-13
-      cpu: x86
       device_os: iOS-16|iOS-17
       $flutter/osx_sdk : >-
         {
@@ -4200,9 +4197,10 @@ targets:
       task_name: run_release_test
 
   # mac motog4 test
-  - name: Mac_arm64_android run_release_test
+  - name: Mac_android run_release_test
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     runIf:
       - .ci.yaml
       - dev/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4102,9 +4102,10 @@ targets:
       task_name: hello_world_android__compile
 
   # mac motog4 benchmark
-  - name: Mac_android hot_mode_dev_cycle__benchmark
+  - name: Mac_arm64_android hot_mode_dev_cycle__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
This is part of the process to use mac resources efficiently and address limited mac x64 capacity.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
