### PR TITLE
Fix unresponsive mouse tooltip

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -508,7 +508,8 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     );
     switch (_controller.status) {
       case AnimationStatus.dismissed when withDelay.inMicroseconds > 0:
-        _timer ??= Timer(withDelay, show);
+        _timer?.cancel();
+        _timer = Timer(withDelay, show);
       // If the tooltip is already fading in or fully visible, skip the
       // animation and show the tooltip immediately.
       case AnimationStatus.dismissed:

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1605,8 +1605,6 @@ void main() {
       for (final Future<void> Function() action in actions) {
         await action();
       }
-      // Wait for the first tooltip to appear / disappear.
-      await tester.pump(waitDuration);
     }
 
     await performSequence(<Future<void> Function()>[mouseEnterAndWaitUntilVisible]);

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1562,6 +1562,91 @@ void main() {
     expect(find.text('last tooltip'), findsOneWidget);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/142045.
+  testWidgets('Tooltip shows/hides when the mouse hovers, and then exits and re-enters in quick succession', (WidgetTester tester) async {
+    const Duration waitDuration = Durations.extralong1;
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: Tooltip(
+            message: tooltipText,
+            waitDuration: waitDuration,
+            exitDuration: waitDuration,
+            child: SizedBox(
+              width: 100.0,
+              height: 100.0,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    Future<void> mouseEnterAndWaitUntilVisible() async {
+      await gesture.moveTo(tester.getCenter(find.byType(Tooltip)));
+      await tester.pump();
+      await tester.pump(waitDuration);
+      await tester.pumpAndSettle();
+      expect(find.text(tooltipText), findsOne);
+    }
+
+    Future<void> mouseExit() async {
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+    }
+
+    Future<void> performSequence(Iterable<Future<void> Function()> actions) async {
+      for (final Future<void> Function() action in actions) {
+        await action();
+      }
+      // Wait for the first tooltip to appear / disappear.
+      await tester.pump(waitDuration);
+    }
+
+    await performSequence(<Future<void> Function()>[mouseEnterAndWaitUntilVisible]);
+    expect(find.text(tooltipText), findsOne);
+
+    // Wait for reset.
+    await mouseExit();
+    await tester.pump(const Duration(hours: 1));
+    await tester.pumpAndSettle();
+    expect(find.text(tooltipText), findsNothing);
+
+    await performSequence(<Future<void> Function()>[
+      mouseEnterAndWaitUntilVisible,
+      mouseExit,
+      mouseEnterAndWaitUntilVisible,
+    ]);
+    expect(find.text(tooltipText), findsOne);
+
+    // Wait for reset.
+    await mouseExit();
+    await tester.pump(const Duration(hours: 1));
+    await tester.pumpAndSettle();
+    expect(find.text(tooltipText), findsNothing);
+
+    await performSequence(<Future<void> Function()>[
+      mouseEnterAndWaitUntilVisible,
+      mouseExit,
+      mouseEnterAndWaitUntilVisible,
+      mouseExit,
+      mouseEnterAndWaitUntilVisible,
+    ]);
+    expect(find.text(tooltipText), findsOne);
+
+    // Wait for reset.
+    await mouseExit();
+    await tester.pump(const Duration(hours: 1));
+    await tester.pumpAndSettle();
+    expect(find.text(tooltipText), findsNothing);
+  });
+
   testWidgets('Tooltip text is also hoverable', (WidgetTester tester) async {
     const Duration waitDuration = Duration.zero;
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/142045

The intent of using `??=` was that if the tooltip is already scheduled for showing, rescheduling another show does nothing. But if the tooltip is already scheduled for dismissing, the `??=` won't cancel the dismiss timer and as a result the tooltip won't show. So the `??=` is now replaced by `=` to keep it consistent with the `_scheduleDismissTooltip` implementation.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
