### PR TITLE
[CP] Update tests to Xcode 15

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -79,11 +79,11 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13
       device_type: none
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   mac_arm64:
     properties:
@@ -91,12 +91,12 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13
       device_type: none
       cpu: arm64
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   mac_benchmark:
     properties:
@@ -106,12 +106,12 @@ platform_properties:
         ]
       device_type: none
       mac_model: "Macmini8,1"
-      os: Mac-12|Mac-13
+      os: Mac-13
       tags: >
         ["devicelab", "hostonly", "mac"]
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   mac_x64:
     properties:
@@ -119,12 +119,12 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   mac_build_test:
     properties:
@@ -133,12 +133,12 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   mac_android:
     properties:
@@ -178,12 +178,12 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13
       cpu: x86
       device_os: iOS-16
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   mac_arm64_ios:
     properties:
@@ -192,12 +192,12 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "none"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13
       cpu: arm64
       device_os: iOS-16
       $flutter/osx_sdk : >-
         {
-          "sdk_version": "14e300c"
+          "sdk_version": "15a240d"
         }
   windows:
     properties:
@@ -2977,12 +2977,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animated_advanced_blend_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   # Uses Impeller.
   - name: Linux_pixel_7pro animated_blur_backdrop_filter_perf_opengles__timeline_summary
@@ -3049,12 +3043,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: dynamic_path_tessellation_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Staging_build_linux analyze
     presubmit: false
@@ -3507,12 +3495,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: module_test_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -4007,12 +3989,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4031,12 +4007,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: basic_material_app_ios__compile
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios channels_integration_test_ios
     recipe: devicelab/devicelab_drone
@@ -4046,12 +4016,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: channels_integration_test_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios complex_layout_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -4070,12 +4034,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: complex_layout_scroll_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios complex_layout_scroll_perf_bad_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4094,12 +4052,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: color_filter_and_fade_perf_ios__e2e_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios imagefiltered_transform_animation_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4109,12 +4061,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: imagefiltered_transform_animation_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios external_ui_integration_test_ios
     recipe: devicelab/devicelab_drone
@@ -4134,12 +4080,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: route_test_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios flavors_test_ios
     recipe: devicelab/devicelab_drone
@@ -4158,26 +4098,20 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flavors_test_ios_xcode_debug
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
     bringup: true
 
-  # TODO(vashworth): Stop running in presubmit after macOS 13 upgrade is complete (https://github.com/flutter/flutter/issues/134737)
   - name: Mac_ios flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__compile
 
-  # TODO(vashworth): Stop running in presubmit after macOS 13 upgrade is complete (https://github.com/flutter/flutter/issues/134737)
   - name: Mac_arm64_ios flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
       tags: >
@@ -4201,12 +4135,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__start_up_xcode_debug
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
     bringup: true
 
   - name: Mac_ios flutter_view_ios__start_up
@@ -4217,12 +4145,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_view_ios__start_up
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
@@ -4241,12 +4163,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: hello_world_ios__compile
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_x64 hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
@@ -4287,12 +4203,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_test_test_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios integration_ui_ios_driver
     recipe: devicelab/devicelab_drone
@@ -4311,12 +4221,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_driver_xcode_debug
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
     bringup: true
 
   - name: Mac_ios integration_ui_ios_frame_number
@@ -4336,12 +4240,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_keyboard_resize
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios integration_ui_ios_textfield
     recipe: devicelab/devicelab_drone
@@ -4386,12 +4284,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_content_validation_test
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_arm64_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
@@ -4410,12 +4302,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_defines_test
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios ios_platform_view_tests
     recipe: devicelab/devicelab_drone
@@ -4425,12 +4311,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_platform_view_tests
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios large_image_changer_perf_ios
     recipe: devicelab/devicelab_drone
@@ -4440,12 +4320,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: large_image_changer_perf_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_x64 macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
@@ -4491,12 +4365,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios_xcode_debug
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
     bringup: true
 
   - name: Mac native_assets_ios_simulator
@@ -4520,12 +4388,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: native_assets_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios native_platform_view_ui_tests_ios
     recipe: devicelab/devicelab_drone
@@ -4544,12 +4406,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: new_gallery_ios__transition_perf
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios new_gallery_skia_ios__transition_perf
     recipe: devicelab/devicelab_drone
@@ -4577,12 +4433,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channel_sample_test_swift
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios platform_channels_benchmarks_ios
     recipe: devicelab/devicelab_drone
@@ -4592,12 +4442,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channels_benchmarks_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios platform_interaction_test_ios
     recipe: devicelab/devicelab_drone
@@ -4607,12 +4451,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_interaction_test_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios platform_view_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -4667,12 +4505,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: wide_gamut_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
@@ -4682,12 +4514,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_x64 hot_mode_dev_cycle_ios_simulator
     recipe: devicelab/devicelab_drone
@@ -4728,12 +4554,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_build_test flutter_gallery__transition_perf_e2e_ios
     recipe: devicelab/devicelab_drone_build_test
@@ -4743,7 +4563,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
       drone_dimensions: >
-        ["device_os=iOS-16","os=Mac-12|Mac-13", "cpu=x86"]
+        ["device_os=iOS-16","os=Mac-13", "cpu=x86"]
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4753,12 +4573,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animated_blur_backdrop_filter_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios draw_points_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4768,12 +4582,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: draw_points_perf_ios__timeline_summary
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac_ios spell_check_test
     recipe: devicelab/devicelab_drone
@@ -4783,12 +4591,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: spell_check_test_ios
-      # TODO(vashworth): Remove after Xcode 15 is default in CI (https://github.com/flutter/flutter/issues/132237)
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "15a240d"
-        }
-      os: Mac-13
 
   - name: Mac native_ui_tests_macos
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Tests have been running successfully on Mac-13 with Xcode 15 since 01/17/24. This is needed so we can eventually upgrade physical devices to iOS 17.

Original PR: https://github.com/flutter/flutter/pull/141706

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
