### PR TITLE
Roll deps from dart-lang/native in templates

### DIFF
--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -9,7 +9,7 @@ environment:
 dependencies:
   cli_config: ^0.1.2
   logging: ^1.2.0
-  native_assets_cli: ^0.4.1
+  native_assets_cli: ^0.4.2
   native_toolchain_c: ^0.3.4+1
 
 dev_dependencies:

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -14,6 +14,6 @@ dependencies:
 
 dev_dependencies:
   ffi: ^2.1.0
-  ffigen: ^9.0.1
+  ffigen: ^11.0.0
   flutter_lints: ^3.0.0
   test: ^1.24.9

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
 {{#withFfi}}
   ffi: ^2.1.0
-  ffigen: ^9.0.1
+  ffigen: ^11.0.0
 {{/withFfi}}
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Update packages from https://github.com/dart-lang/native to the last published stable versions in templates.

