### PR TITLE
Only use iOS 17 physical devices in staging tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -220,7 +220,7 @@ platform_properties:
         ]
       os: Mac-13
       cpu: x86
-      device_os: iOS-16|iOS-17
+      device_os: iOS-16
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -238,7 +238,7 @@ platform_properties:
         ]
       os: Mac-13
       cpu: x86
-      device_os: iOS-16|iOS-17
+      device_os: iOS-16
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -256,7 +256,7 @@ platform_properties:
         ]
       os: Mac-13
       cpu: arm64
-      device_os: iOS-16|iOS-17
+      device_os: iOS-16
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -4236,6 +4236,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: basic_material_app_ios__compile
@@ -4334,6 +4335,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flavors_test_ios_xcode_debug
@@ -4362,21 +4364,10 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__start_up_xcode_debug
-    bringup: true
-
-  # TODO(vashworth): Remove after https://github.com/flutter/flutter/issues/141383 is fixed.
-  - name: Mac_arm64_ios flutter_gallery_ios__start_up
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: flutter_gallery_ios__start_up
-      os: Mac-14
     bringup: true
 
   - name: Mac_ios flutter_view_ios__start_up
@@ -4434,6 +4425,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_test_test_ios
@@ -4444,6 +4436,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_test_test_ios
@@ -4462,6 +4455,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_driver_xcode_debug
@@ -4588,6 +4582,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios_xcode_debug
@@ -4738,6 +4733,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
@@ -4748,6 +4744,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
+      device_os: iOS-16|iOS-17
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
@@ -4800,7 +4797,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
       drone_dimensions: >
-        ["device_os=iOS-16|iOS-17","os=Mac-13", "cpu=x86"]
+        ["device_os=iOS-16","os=Mac-13", "cpu=x86"]
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Don't use iOS 17 devices in pre and post submit tests yet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
