### PR TITLE
Limit `fuchsia_precache` in presubmit to engine rolls

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -730,6 +730,9 @@ targets:
       shard: fuchsia_precache
       tags: >
         ["framework", "hostonly", "shard", "linux"]
+    runIf:
+      - bin/internal/engine.version
+      - .ci.yaml
 
   - name: Linux gradle_desugar_classes_test
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
This doesn't need to run on every PR in presubmit.  Limit to engine rolls to validate the artifacts have been published.

Fixes https://github.com/flutter/flutter/issues/142330

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
