### PR TITLE
[Windows] Fix signed/unsigned int comparison

### DIFF
--- a/dev/a11y_assessments/windows/runner/utils.cpp
+++ b/dev/a11y_assessments/windows/runner/utils.cpp
@@ -49,13 +49,13 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/dev/benchmarks/complex_layout/windows/runner/utils.cpp
+++ b/dev/benchmarks/complex_layout/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
@@ -49,13 +49,13 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/dev/integration_tests/ui/windows/runner/utils.cpp
+++ b/dev/integration_tests/ui/windows/runner/utils.cpp
@@ -49,13 +49,13 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
@@ -49,13 +49,13 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/dev/manual_tests/windows/runner/utils.cpp
+++ b/dev/manual_tests/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/examples/api/windows/runner/utils.cpp
+++ b/examples/api/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/examples/flutter_view/windows/runner/utils.cpp
+++ b/examples/flutter_view/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/examples/hello_world/windows/runner/utils.cpp
+++ b/examples/hello_world/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/examples/layers/windows/runner/utils.cpp
+++ b/examples/layers/windows/runner/utils.cpp
@@ -49,13 +49,13 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/examples/platform_channel/windows/runner/utils.cpp
+++ b/examples/platform_channel/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/examples/platform_view/windows/runner/utils.cpp
+++ b/examples/platform_view/windows/runner/utils.cpp
@@ -49,12 +49,12 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
@@ -45,13 +45,13 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length = ::WideCharToMultiByte(
+  unsigned int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
   int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
-  if (target_length <= 0 || target_length > utf8_string.max_size()) {
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);


### PR DESCRIPTION
Previously, we were comparing the signed int `target_length` (returned by WideCharToMultiByte) to a size_t string length, resulting in a signed/unsigned comparison warning as follows:

```
windows\runner\utils.cpp(54,43): warning C4018:  '>': signed/unsigned mismatch
```

WideCharToMultiByte returns:
* 0 on error
* the number of bytes written to the buffer pointed to by its fifth parameter, lpMultiByteStr, on success.

As a result it's safe to store the return value in an unsigned int, which eliminates the warning.

No changes to tests since this is dependent on end-user project settings/modifications and does not trigger a warning with default project settings.

Fixes: https://github.com/flutter/flutter/issues/134227

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] No animals were harmed in the making of this PR.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
