### PR TITLE
Add stateful reordering test for TwoDimensionalViewport

### DIFF
--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2712,6 +2712,54 @@ void main() {
       });
     });
 
+    testWidgets('correctly reorders children and wont throw assertion failure',
+        (WidgetTester tester) async {
+      final TwoDimensionalChildBuilderDelegate delegate1 =
+          TwoDimensionalChildBuilderDelegate(
+              maxXIndex: 5,
+              maxYIndex: 5,
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              builder: (BuildContext context, ChildVicinity vicinity) {
+                ValueKey<int>? key;
+                if (vicinity == const ChildVicinity(xIndex: 1, yIndex: 1)) {
+                  key = const ValueKey<int>(1);
+                } else if (vicinity ==
+                    const ChildVicinity(xIndex: 1, yIndex: 2)) {
+                  key = const ValueKey<int>(2);
+                }
+                return SizedBox.square(key: key, dimension: 200);
+              });
+      final TwoDimensionalChildBuilderDelegate delegate2 =
+          TwoDimensionalChildBuilderDelegate(
+              maxXIndex: 5,
+              maxYIndex: 5,
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              builder: (BuildContext context, ChildVicinity vicinity) {
+                ValueKey<int>? key;
+                if (vicinity == const ChildVicinity(xIndex: 0, yIndex: 0)) {
+                  key = const ValueKey<int>(1);
+                } else if (vicinity ==
+                    const ChildVicinity(xIndex: 1, yIndex: 1)) {
+                  key = const ValueKey<int>(2);
+                }
+                return SizedBox.square(key: key, dimension: 200);
+              });
+      addTearDown(delegate1.dispose);
+      addTearDown(delegate2.dispose);
+
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
+      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
+          const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate2));
+      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
+          const Rect.fromLTWH(0.0, 0.0, 200.0, 200.0));
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
+      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
+          const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
+    }, variant: TargetPlatformVariant.all());
+
     testWidgets('state is preserved after reordering',
         (WidgetTester tester) async {
       final TwoDimensionalChildBuilderDelegate delegate1 =
@@ -2752,20 +2800,14 @@ void main() {
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
       final State stateBeforeReordering =
           tester.state(find.byKey(const ValueKey<int>(2)));
-      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
-          const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
 
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate2));
       expect(tester.state(find.byKey(const ValueKey<int>(2))),
           stateBeforeReordering);
-      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
-          const Rect.fromLTWH(0.0, 0.0, 200.0, 200.0));
 
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
       expect(tester.state(find.byKey(const ValueKey<int>(2))),
           stateBeforeReordering);
-      expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
-          const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
     }, variant: TargetPlatformVariant.all());
   });
 }

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2712,7 +2712,7 @@ void main() {
       });
     });
 
-    testWidgets('correctly reorders children and wont throw assertion failure',
+    testWidgets('state is preserved after reordering',
         (WidgetTester tester) async {
       final TwoDimensionalChildBuilderDelegate delegate1 =
           TwoDimensionalChildBuilderDelegate(
@@ -2728,7 +2728,7 @@ void main() {
                     const ChildVicinity(xIndex: 1, yIndex: 2)) {
                   key = const ValueKey<int>(2);
                 }
-                return SizedBox.square(key: key, dimension: 200);
+                return Checkbox(key: key, value: false, onChanged: (_) {});
               });
       final TwoDimensionalChildBuilderDelegate delegate2 =
           TwoDimensionalChildBuilderDelegate(
@@ -2744,18 +2744,26 @@ void main() {
                     const ChildVicinity(xIndex: 1, yIndex: 1)) {
                   key = const ValueKey<int>(2);
                 }
-                return SizedBox.square(key: key, dimension: 200);
+                return Checkbox(key: key, value: false, onChanged: (_) {});
               });
       addTearDown(delegate1.dispose);
       addTearDown(delegate2.dispose);
 
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
+      final State stateBeforeReordering =
+          tester.state(find.byKey(const ValueKey<int>(2)));
       expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
           const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
+
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate2));
+      expect(tester.state(find.byKey(const ValueKey<int>(2))),
+          stateBeforeReordering);
       expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
           const Rect.fromLTWH(0.0, 0.0, 200.0, 200.0));
+
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate1));
+      expect(tester.state(find.byKey(const ValueKey<int>(2))),
+          stateBeforeReordering);
       expect(tester.getRect(find.byKey(const ValueKey<int>(1))),
           const Rect.fromLTWH(200.0, 200.0, 200.0, 200.0));
     }, variant: TargetPlatformVariant.all());


### PR DESCRIPTION
Adds a test to validate state is preserved after reordering in `TwoDimensionalViewport` (reference: https://github.com/flutter/flutter/pull/141504#pullrequestreview-1837501775).

- Fixes #130754 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
