### PR TITLE
Change `ItemExtentBuilder`'s return value nullable

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -18,8 +18,11 @@ import 'viewport_offset.dart';
 
 /// Called to get the item extent by the index of item.
 ///
+/// Should return null if asked to build an item extent with a greater index than
+/// exists.
+///
 /// Used by [ListView.itemExtentBuilder] and [SliverVariedExtentList.itemExtentBuilder].
-typedef ItemExtentBuilder = double Function(int index, SliverLayoutDimensions dimensions);
+typedef ItemExtentBuilder = double? Function(int index, SliverLayoutDimensions dimensions);
 
 /// Relates the dimensions of the [RenderSliver] during layout.
 ///

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -69,6 +69,9 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       double offset = 0.0;
       double? itemExtent;
       for (int i = 0; i < index; i++) {
+        if (_childCount != null && i > _childCount! - 1) {
+          break;
+        }
         itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
         if (itemExtent == null) {
           break;
@@ -224,6 +227,9 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     int index = 0;
     double? itemExtent;
     while (position < scrollOffset) {
+      if (_childCount != null && index > _childCount! - 1) {
+        break;
+      }
       itemExtent = callback(index, _currentLayoutDimensions);
       if (itemExtent == null) {
         break;
@@ -249,6 +255,20 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
 
   late SliverLayoutDimensions _currentLayoutDimensions;
 
+  // Used by itemExtentBuilder to prevent out-of-bounds access.
+  int? _childCount;
+  void _cacheChildCountIfNeeded() {
+    if (itemExtentBuilder != null) {
+      if (childManager.isFiniteChildren ?? false) {
+        _childCount = childManager.childCount;
+      } else {
+        _childCount = null;
+      }
+    } else {
+      _childCount = null;
+    }
+  }
+
   @override
   void performLayout() {
     assert((itemExtent != null && itemExtentBuilder == null) ||
@@ -258,6 +278,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     final SliverConstraints constraints = this.constraints;
     childManager.didStartLayout();
     childManager.setDidUnderflow(false);
+    _cacheChildCountIfNeeded();
 
     final double itemFixedExtent = itemExtent ?? 0;
     final double scrollOffset = constraints.scrollOffset + constraints.cacheOrigin;

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -67,8 +67,13 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       return itemExtent * index;
     } else {
       double offset = 0.0;
+      double? itemExtent;
       for (int i = 0; i < index; i++) {
-        offset += itemExtentBuilder!(i, _currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
+        if (itemExtent == null) {
+          break;
+        }
+        offset += itemExtent;
       }
       return offset;
     }
@@ -179,8 +184,13 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       return childManager.childCount * itemExtent;
     } else {
       double offset = 0.0;
+      double? itemExtent;
       for (int i = 0; i < childManager.childCount; i++) {
-        offset += itemExtentBuilder!(i, _currentLayoutDimensions);
+        itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
+        if (itemExtent == null) {
+          break;
+        }
+        offset += itemExtent;
       }
       return offset;
     }
@@ -212,8 +222,13 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     }
     double position = 0.0;
     int index = 0;
+    double? itemExtent;
     while (position < scrollOffset) {
-      position += callback(index, _currentLayoutDimensions);
+      itemExtent = callback(index, _currentLayoutDimensions);
+      if (itemExtent == null) {
+        break;
+      }
+      position += itemExtent;
       ++index;
     }
     return index - 1;
@@ -224,7 +239,7 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     if (itemExtentBuilder == null) {
       extent = itemExtent!;
     } else {
-      extent = itemExtentBuilder!(index, _currentLayoutDimensions);
+      extent = itemExtentBuilder!(index, _currentLayoutDimensions)!;
     }
     return constraints.asBoxConstraints(
       minExtent: extent,

--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -69,7 +69,8 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
       double offset = 0.0;
       double? itemExtent;
       for (int i = 0; i < index; i++) {
-        if (_childCount != null && i > _childCount! - 1) {
+        final int? childCount = childManager.estimatedChildCount;
+        if (childCount != null && i > childCount - 1) {
           break;
         }
         itemExtent = itemExtentBuilder!(i, _currentLayoutDimensions);
@@ -227,7 +228,8 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     int index = 0;
     double? itemExtent;
     while (position < scrollOffset) {
-      if (_childCount != null && index > _childCount! - 1) {
+      final int? childCount = childManager.estimatedChildCount;
+      if (childCount != null && index > childCount - 1) {
         break;
       }
       itemExtent = callback(index, _currentLayoutDimensions);
@@ -255,20 +257,6 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
 
   late SliverLayoutDimensions _currentLayoutDimensions;
 
-  // Used by itemExtentBuilder to prevent out-of-bounds access.
-  int? _childCount;
-  void _cacheChildCountIfNeeded() {
-    if (itemExtentBuilder != null) {
-      if (childManager.isFiniteChildren ?? false) {
-        _childCount = childManager.childCount;
-      } else {
-        _childCount = null;
-      }
-    } else {
-      _childCount = null;
-    }
-  }
-
   @override
   void performLayout() {
     assert((itemExtent != null && itemExtentBuilder == null) ||
@@ -278,7 +266,6 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
     final SliverConstraints constraints = this.constraints;
     childManager.didStartLayout();
     childManager.setDidUnderflow(false);
-    _cacheChildCountIfNeeded();
 
     final double itemFixedExtent = itemExtent ?? 0;
     final double scrollOffset = constraints.scrollOffset + constraints.cacheOrigin;

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -79,6 +79,9 @@ abstract class RenderSliverBoxChildManager {
   /// list).
   int get childCount;
 
+  /// Whether the number of children is finite.
+  bool? get isFiniteChildren => null;
+
   /// Called during [RenderSliverMultiBoxAdaptor.adoptChild] or
   /// [RenderSliverMultiBoxAdaptor.move].
   ///

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -79,8 +79,16 @@ abstract class RenderSliverBoxChildManager {
   /// list).
   int get childCount;
 
-  /// Whether the number of children is finite.
-  bool? get isFiniteChildren => null;
+  /// The best available estimate of [childCount], or null if no estimate is available.
+  ///
+  /// This differs from [childCount] in that [childCount] never returns null (and must
+  /// not be accessed if the child count is not yet available, meaning the [createChild]
+  /// method has not been provided an index that does not create a child).
+  ///
+  /// See also:
+  ///
+  ///  * [SliverChildDelegate.estimatedChildCount], to which this getter defers.
+  int? get estimatedChildCount => null;
 
   /// Called during [RenderSliverMultiBoxAdaptor.adoptChild] or
   /// [RenderSliverMultiBoxAdaptor.move].

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1506,6 +1506,9 @@ class ListView extends BoxScrollView {
   /// This will be called multiple times during the layout phase of a frame to find
   /// the items that should be loaded by the lazy loading process.
   ///
+  /// Should return null if asked to build an item extent with a greater index than
+  /// exists.
+  ///
   /// Unlike [itemExtent] or [prototypeItem], this allows children to have
   /// different extents.
   ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -949,6 +949,19 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   int? get estimatedChildCount => (widget as SliverMultiBoxAdaptorWidget).delegate.estimatedChildCount;
 
   @override
+  bool? get isFiniteChildren {
+    if (estimatedChildCount != null) {
+      return true;
+    } else {
+      final SliverMultiBoxAdaptorWidget adaptorWidget = widget as SliverMultiBoxAdaptorWidget;
+      const int max = kIsWeb
+        ? 9007199254740992 // max safe integer on JS (from 0 to this number x != x+1)
+        : ((1 << 63) - 1);
+      return _build(max - 1, adaptorWidget) == null;
+    }
+  }
+
+  @override
   int get childCount {
     int? result = estimatedChildCount;
     if (result == null) {

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -937,29 +937,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     );
   }
 
-  /// The best available estimate of [childCount], or null if no estimate is available.
-  ///
-  /// This differs from [childCount] in that [childCount] never returns null (and must
-  /// not be accessed if the child count is not yet available, meaning the [createChild]
-  /// method has not been provided an index that does not create a child).
-  ///
-  /// See also:
-  ///
-  ///  * [SliverChildDelegate.estimatedChildCount], to which this getter defers.
-  int? get estimatedChildCount => (widget as SliverMultiBoxAdaptorWidget).delegate.estimatedChildCount;
-
   @override
-  bool? get isFiniteChildren {
-    if (estimatedChildCount != null) {
-      return true;
-    } else {
-      final SliverMultiBoxAdaptorWidget adaptorWidget = widget as SliverMultiBoxAdaptorWidget;
-      const int max = kIsWeb
-        ? 9007199254740992 // max safe integer on JS (from 0 to this number x != x+1)
-        : ((1 << 63) - 1);
-      return _build(max - 1, adaptorWidget) == null;
-    }
-  }
+  int? get estimatedChildCount => (widget as SliverMultiBoxAdaptorWidget).delegate.estimatedChildCount;
 
   @override
   int get childCount {

--- a/packages/flutter/lib/src/widgets/sliver_varied_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_varied_extent_list.dart
@@ -98,6 +98,9 @@ class SliverVariedExtentList extends SliverMultiBoxAdaptorWidget {
   ));
 
   /// The children extent builder.
+  ///
+  /// Should return null if asked to build an item extent with a greater index than
+  /// exists.
   final ItemExtentBuilder itemExtentBuilder;
 
   @override

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -780,6 +780,42 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
+  // Regression test for https://github.com/flutter/flutter/pull/138912
+  testWidgets('itemExtentBuilder should respect item count', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    addTearDown(controller.dispose);
+    final List<double> numbers = <double>[
+      10, 20, 30, 40, 50,
+    ];
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ListView.builder(
+          controller: controller,
+          itemExtentBuilder: (int index, SliverLayoutDimensions dimensions) {
+            if (index > numbers.length - 1) {
+              return null;
+            }
+            return numbers[index];
+          },
+          itemBuilder: (BuildContext context, int index) {
+            if (index > numbers.length - 1) {
+              return null;
+            }
+            return SizedBox(
+              height: numbers[index],
+              child: Text('Item $index'),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 4'), findsOneWidget);
+    expect(find.text('Item 5'), findsNothing);
+  });
+
   // Regression test for https://github.com/flutter/flutter/pull/131393
   testWidgets('itemExtentBuilder test', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -827,10 +827,7 @@ void main() {
             return 100.0;
           },
           itemBuilder: (BuildContext context, int index) {
-            if (index < 10000) {
-              // Filter out the call with int.max (to determine whether children count finite).
-              buildLog.insert(0, index);
-            }
+            buildLog.insert(0, index);
             return Text('Item $index');
           },
         ),

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -792,16 +792,11 @@ void main() {
         textDirection: TextDirection.ltr,
         child: ListView.builder(
           controller: controller,
+          itemCount: numbers.length,
           itemExtentBuilder: (int index, SliverLayoutDimensions dimensions) {
-            if (index > numbers.length - 1) {
-              return null;
-            }
             return numbers[index];
           },
           itemBuilder: (BuildContext context, int index) {
-            if (index > numbers.length - 1) {
-              return null;
-            }
             return SizedBox(
               height: numbers[index],
               child: Text('Item $index'),
@@ -832,7 +827,10 @@ void main() {
             return 100.0;
           },
           itemBuilder: (BuildContext context, int index) {
-            buildLog.insert(0, index);
+            if (index < 10000) {
+              // Filter out the call with int.max (to determine whether children count finite).
+              buildLog.insert(0, index);
+            }
             return Text('Item $index');
           },
         ),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138912

Change `ItemExtentBuilder`'s return value nullable, it should return null if asked to build an item extent with a greater index than exists.