### PR TITLE
Enable cross compilation for windows-arm64

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -109,6 +109,11 @@ class BuildBundleCommand extends BuildSubCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final String targetPlatform = stringArg('target-platform')!;
+    final String channel = globals.flutterVersion.channel;
+    final bool onStableOrBetaChannel = channel == 'stable' || channel == 'beta';
+    if ((targetPlatform == 'windows-arm64') && onStableOrBetaChannel) {
+      throwToolExit('Option "--target-platform windows-arm64" can only be used on master channel.');
+    }
     final TargetPlatform platform = getTargetPlatformForName(targetPlatform);
     // Check for target platforms that are only allowed via feature flags.
     switch (platform) {

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -241,12 +241,15 @@ class FlutterSdk extends EngineCachedArtifact {
       <String>['common', 'flutter_patched_sdk.zip'],
       <String>['common', 'flutter_patched_sdk_product.zip'],
       if (cache.includeAllPlatforms) ...<List<String>>[
-        <String>['windows-$arch', 'windows-$arch/artifacts.zip'],
+        <String>['windows-x64', 'windows-x64/artifacts.zip'],
+        <String>['windows-arm64', 'windows-arm64/artifacts.zip'],
         <String>['linux-$arch', 'linux-$arch/artifacts.zip'],
         <String>['darwin-x64', 'darwin-$arch/artifacts.zip'],
       ]
-      else if (_platform.isWindows)
-        <String>['windows-$arch', 'windows-$arch/artifacts.zip']
+      else if (_platform.isWindows) ...<List<String>>[
+        <String>['windows-x64', 'windows-x64/artifacts.zip'],
+        <String>['windows-arm64', 'windows-arm64/artifacts.zip'],
+      ]
       else if (_platform.isMacOS)
         <String>['darwin-x64', 'darwin-$arch/artifacts.zip']
       else if (_platform.isLinux)
@@ -304,8 +307,7 @@ class WindowsEngineArtifacts extends EngineCachedArtifact {
   @override
   List<List<String>> getBinaryDirs() {
     if (_platform.isWindows || ignorePlatformFiltering) {
-      final String arch = cache.getHostPlatformArchName();
-      return _getWindowsDesktopBinaryDirs(arch);
+      return _getWindowsDesktopBinaryDirs();
     }
     return const <List<String>>[];
   }
@@ -848,12 +850,16 @@ class IosUsbArtifacts extends CachedArtifact {
 // remove from existing host folder.
 // https://github.com/flutter/flutter/issues/38935
 
-List<List<String>> _getWindowsDesktopBinaryDirs(String arch) {
+List<List<String>> _getWindowsDesktopBinaryDirs() {
   return <List<String>>[
-    <String>['windows-$arch', 'windows-$arch-debug/windows-$arch-flutter.zip'],
-    <String>['windows-$arch', 'windows-$arch/flutter-cpp-client-wrapper.zip'],
-    <String>['windows-$arch-profile', 'windows-$arch-profile/windows-$arch-flutter.zip'],
-    <String>['windows-$arch-release', 'windows-$arch-release/windows-$arch-flutter.zip'],
+    <String>['windows-x64', 'windows-x64-debug/windows-x64-flutter.zip'],
+    <String>['windows-x64', 'windows-x64/flutter-cpp-client-wrapper.zip'],
+    <String>['windows-x64-profile', 'windows-x64-profile/windows-x64-flutter.zip'],
+    <String>['windows-x64-release', 'windows-x64-release/windows-x64-flutter.zip'],
+    <String>['windows-arm64', 'windows-arm64-debug/windows-arm64-flutter.zip'],
+    <String>['windows-arm64', 'windows-arm64/flutter-cpp-client-wrapper.zip'],
+    <String>['windows-arm64-profile', 'windows-arm64-profile/windows-arm64-flutter.zip'],
+    <String>['windows-arm64-release', 'windows-arm64-release/windows-arm64-flutter.zip'],
   ];
 }
 


### PR DESCRIPTION
This is available only for master channel.

---

Added option --target-platform {windows-x64, windows-arm64} for flutter build windows command.

Without this option, it produces an x64 app on windows-x64, and arm64 app on windows-arm64.

This was successfully tested (on windows-x64 and windows-arm64) with: $ flutter create app
$ cd app
$ flutter build windows
$ flutter build windows --target-platform windows-x64 $ flutter build windows --target-platform windows-arm64

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
