### PR TITLE
Update .ci.yaml to run hello_world__memory if code changes

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2387,7 +2387,6 @@ targets:
   # linux motog4 benchmark
   - name: Linux_android hello_world__memory
     recipe: devicelab/devicelab_drone
-    presubmit: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2387,7 +2387,7 @@ targets:
   # linux motog4 benchmark
   - name: Linux_android hello_world__memory
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    presubmit: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2393,6 +2393,8 @@ targets:
       tags: >
         ["devicelab", "android", "linux"]
       task_name: hello_world__memory
+    runIf:
+      - examples/hello_world/android/app/**
 
   # linux motog4 benchmark
   - name: Linux_android home_scroll_perf__timeline_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2394,6 +2394,7 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: hello_world__memory
     runIf:
+      - .ci.yaml
       - examples/hello_world/android/app/**
 
   # linux motog4 benchmark


### PR DESCRIPTION
Looking for validation on the behavior of runif and how it interacts with presubmit. 

Fixes https://github.com/flutter/flutter/issues/142450

We had an issue where hello_world failed to compile and it broke the tree when a test should have caught the issue in presubmit.

From chat: All tests run in post submit, runif is a condition on presubmit only. This pr *should* keep the previous post submit behavior and trigger the test to run in presubmit if the code under test is changed. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
