### PR TITLE
Fix showDialog docs

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -1344,6 +1344,11 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 /// The `routeSettings` argument is passed to [showGeneralDialog],
 /// see [RouteSettings] for details.
 ///
+/// If not null, the `traversalEdgeBehavior` argument specifies the transfer of
+/// focus beyond the first and the last items of the dialog route. By default,
+/// [TraversalEdgeBehavior.closedLoop] is used, because it's typical for dialogs
+/// to allow users to cycle through dialog widgets without leaving the dialog.
+///
 /// {@macro flutter.widgets.RawDialogRoute}
 ///
 /// If the application has multiple [Navigator] objects, it may be necessary to
@@ -1381,12 +1386,6 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 /// push [DialogRoute] when the button is tapped.
 ///
 /// {@macro flutter.widgets.RestorationManager}
-///
-/// If not null, `traversalEdgeBehavior` argument specifies the transfer of
-/// focus beyond the first and the last items of the dialog route. By default,
-/// uses [TraversalEdgeBehavior.closedLoop], because it's typical for dialogs
-/// to allow users to cycle through widgets inside it without leaving the
-/// dialog.
 ///
 /// ** See code in examples/api/lib/material/dialog/show_dialog.2.dart **
 /// {@end-tool}


### PR DESCRIPTION
## Description

Fixes a paragraph in the `showDialog` docs that had strange placement due to evolution of the docs. Fixed some missing words too.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/142097
