### PR TITLE
Style correctness improvements for toStrings and related fixes

### DIFF
--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -3252,7 +3252,7 @@ mixin Diagnosticable {
   ///
   /// Used by [toDiagnosticsNode] and [toString].
   ///
-  /// Do not add values, that have lifetime shorter than the object.
+  /// Do not add values that have lifetime shorter than the object.
   @protected
   @mustCallSuper
   void debugFillProperties(DiagnosticPropertiesBuilder properties) { }

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -795,7 +795,6 @@ class IconButton extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Widget>('icon', icon, showName: false));
     properties.add(StringProperty('tooltip', tooltip, defaultValue: null, quoted: false));
     properties.add(ObjectFlagProperty<VoidCallback>('onPressed', onPressed, ifNull: 'disabled'));
     properties.add(ColorProperty('color', color, defaultValue: null));

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -897,10 +897,6 @@ class ListTile extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Widget>('leading', leading, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget>('title', title, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget>('subtitle', subtitle, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget>('trailing', trailing, defaultValue: null));
     properties.add(FlagProperty('isThreeLine', value: isThreeLine, ifTrue:'THREE_LINE', ifFalse: 'TWO_LINE', showName: true, defaultValue: false));
     properties.add(FlagProperty('dense', value: dense, ifTrue: 'true', ifFalse: 'false', showName: true));
     properties.add(DiagnosticsProperty<VisualDensity>('visualDensity', visualDensity, defaultValue: null));

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -283,7 +283,6 @@ class MenuAnchor extends StatefulWidget {
     properties.add(DiagnosticsProperty<MenuStyle?>('style', style));
     properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior));
     properties.add(DiagnosticsProperty<Offset?>('alignmentOffset', alignmentOffset));
-    properties.add(StringProperty('child', child.toString()));
   }
 }
 
@@ -1041,11 +1040,8 @@ class MenuItemButton extends StatefulWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(FlagProperty('enabled', value: onPressed != null, ifFalse: 'DISABLED'));
-    properties.add(DiagnosticsProperty<String>('child', child.toString()));
     properties.add(DiagnosticsProperty<ButtonStyle?>('style', style, defaultValue: null));
     properties.add(DiagnosticsProperty<MenuSerializableShortcut?>('shortcut', shortcut, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget?>('leadingIcon', leadingIcon, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget?>('trailingIcon', trailingIcon, defaultValue: null));
     properties.add(DiagnosticsProperty<FocusNode?>('focusNode', focusNode, defaultValue: null));
     properties.add(EnumProperty<Clip>('clipBehavior', clipBehavior, defaultValue: Clip.none));
     properties.add(DiagnosticsProperty<MaterialStatesController?>('statesController', statesController, defaultValue: null));
@@ -1802,9 +1798,6 @@ class SubmenuButton extends StatefulWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<Widget>('leadingIcon', leadingIcon, defaultValue: null));
-    properties.add(DiagnosticsProperty<String>('child', child.toString()));
-    properties.add(DiagnosticsProperty<Widget>('trailingIcon', trailingIcon, defaultValue: null));
     properties.add(DiagnosticsProperty<FocusNode?>('focusNode', focusNode));
     properties.add(DiagnosticsProperty<MenuStyle>('menuStyle', menuStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<Offset>('alignmentOffset', alignmentOffset));
@@ -3140,7 +3133,6 @@ class _MenuItemLabel extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<String>('child', child.toString()));
     properties.add(DiagnosticsProperty<MenuSerializableShortcut>('shortcut', shortcut, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('hasSubmenu', hasSubmenu));
     properties.add(DiagnosticsProperty<bool>('showDecoration', showDecoration));

--- a/packages/flutter/lib/src/material/segmented_button_theme.dart
+++ b/packages/flutter/lib/src/material/segmented_button_theme.dart
@@ -94,7 +94,6 @@ class SegmentedButtonThemeData with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<ButtonStyle>('style', style, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget>('selectedIcon', selectedIcon, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -191,7 +191,6 @@ class Tab extends StatelessWidget implements PreferredSizeWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('text', text, defaultValue: null));
-    properties.add(DiagnosticsProperty<Widget>('icon', icon, defaultValue: null));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/placeholder.dart
+++ b/packages/flutter/lib/src/widgets/placeholder.dart
@@ -111,6 +111,5 @@ class Placeholder extends StatelessWidget {
     properties.add(DoubleProperty('strokeWidth', strokeWidth, defaultValue: 2.0));
     properties.add(DoubleProperty('fallbackWidth', fallbackWidth, defaultValue: 400.0));
     properties.add(DoubleProperty('fallbackHeight', fallbackHeight, defaultValue: 400.0));
-    properties.add(DiagnosticsProperty<Widget>('child', child, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/widgets/spell_check.dart
+++ b/packages/flutter/lib/src/widgets/spell_check.dart
@@ -2,13 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart'
     show SpellCheckResults, SpellCheckService, SuggestionSpan, TextEditingValue;
 
 import 'editable_text.dart' show EditableTextContextMenuBuilder;
-import 'framework.dart' show immutable;
 
 /// Controls how spell check is performed for text input.
 ///
@@ -83,26 +82,24 @@ class SpellCheckConfiguration {
 
   @override
   String toString() {
-    return '''
-  spell check enabled   : $_spellCheckEnabled
-  spell check service   : $spellCheckService
-  misspelled text style : $misspelledTextStyle
-  spell check suggestions toolbar builder: $spellCheckSuggestionsToolbarBuilder
-'''
-        .trim();
+    return '${objectRuntimeType(this, 'SpellCheckConfiguration')}('
+             '${_spellCheckEnabled ? 'enabled' : 'disabled'}, '
+             'service: $spellCheckService, '
+             'text style: $misspelledTextStyle, '
+             'toolbar builder: $spellCheckSuggestionsToolbarBuilder'
+           ')';
   }
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) {
-        return true;
+    if (other.runtimeType != runtimeType) {
+      return false;
     }
-
     return other is SpellCheckConfiguration
-      && other.spellCheckService == spellCheckService
-      && other.misspelledTextStyle == misspelledTextStyle
-      && other.spellCheckSuggestionsToolbarBuilder == spellCheckSuggestionsToolbarBuilder
-      && other._spellCheckEnabled == _spellCheckEnabled;
+        && other.spellCheckService == spellCheckService
+        && other.misspelledTextStyle == misspelledTextStyle
+        && other.spellCheckSuggestionsToolbarBuilder == spellCheckSuggestionsToolbarBuilder
+        && other._spellCheckEnabled == _spellCheckEnabled;
   }
 
   @override

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2016,10 +2016,6 @@ void main() {
     expect(
       description,
       equalsIgnoringHashCodes(<String>[
-        'leading: Text',
-        'title: Text',
-        'subtitle: Text',
-        'trailing: Text',
         'isThreeLine: THREE_LINE',
         'dense: true',
         'visualDensity: VisualDensity#00000(h: 0.0, v: 0.0)',

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2356,7 +2356,6 @@ void main() {
         description,
         equalsIgnoringHashCodes(
           <String>[
-            'child: Text("Menu 0")',
             'focusNode: null',
             'menuStyle: MenuStyle#00000(backgroundColor: MaterialStatePropertyAll(MaterialColor(primary value: Color(0xff4caf50))), elevation: MaterialStatePropertyAll(20.0), shape: MaterialStatePropertyAll(RoundedRectangleBorder(BorderSide(width: 0.0, style: none), BorderRadius.zero)))',
             'alignmentOffset: null',


### PR DESCRIPTION
Children should be omitted from debugFillProperties (if they really need to be included they should be in debugDescribeChildren, but in general for widgets we don't bother including them since they are eventually included anyway).

toStrings should not contain newlines (or, ideally, should use Diagnosticable).

Also some minor tweaks to match grammar and style guide conventions.
