### PR TITLE
barrierColor property in DialogTheme

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -1429,7 +1429,7 @@ Future<T?> showDialog<T>({
   return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(DialogRoute<T>(
     context: context,
     builder: builder,
-    barrierColor: barrierColor ?? Colors.black54,
+    barrierColor: barrierColor ?? Theme.of(context).dialogTheme.barrierColor ?? Colors.black54,
     barrierDismissible: barrierDismissible,
     barrierLabel: barrierLabel,
     useSafeArea: useSafeArea,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -1327,7 +1327,8 @@ Widget _buildMaterialDialogTransitions(BuildContext context, Animation<double> a
 /// barrier will dismiss the dialog. It is `true` by default and can not be `null`.
 ///
 /// The `barrierColor` argument is used to specify the color of the modal
-/// barrier that darkens everything below the dialog. If `null` the default color
+/// barrier that darkens everything below the dialog. If `null` the `barrierColor`
+/// field from `DialogTheme` is used. If that is `null` the default color
 /// `Colors.black54` is used.
 ///
 /// The `useSafeArea` argument is used to indicate if the dialog should only

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -38,6 +38,7 @@ class DialogTheme with Diagnosticable {
     this.titleTextStyle,
     this.contentTextStyle,
     this.actionsPadding,
+    this.barrierColor,
   });
 
   /// Overrides the default value for [Dialog.backgroundColor].
@@ -72,6 +73,9 @@ class DialogTheme with Diagnosticable {
   /// Used to configure the [IconTheme] for the [AlertDialog.icon] widget.
   final Color? iconColor;
 
+  /// Overrides the default value for [barrierColor] in [showDialog].
+  final Color? barrierColor;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   DialogTheme copyWith({
@@ -85,6 +89,7 @@ class DialogTheme with Diagnosticable {
     TextStyle? titleTextStyle,
     TextStyle? contentTextStyle,
     EdgeInsetsGeometry? actionsPadding,
+    Color? barrierColor,
   }) {
     return DialogTheme(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -97,6 +102,7 @@ class DialogTheme with Diagnosticable {
       titleTextStyle: titleTextStyle ?? this.titleTextStyle,
       contentTextStyle: contentTextStyle ?? this.contentTextStyle,
       actionsPadding: actionsPadding ?? this.actionsPadding,
+      barrierColor: barrierColor ?? this.barrierColor,
     );
   }
 
@@ -123,6 +129,7 @@ class DialogTheme with Diagnosticable {
       titleTextStyle: TextStyle.lerp(a?.titleTextStyle, b?.titleTextStyle, t),
       contentTextStyle: TextStyle.lerp(a?.contentTextStyle, b?.contentTextStyle, t),
       actionsPadding: EdgeInsetsGeometry.lerp(a?.actionsPadding, b?.actionsPadding, t),
+      barrierColor: Color.lerp(a?.barrierColor, b?.barrierColor, t),
     );
   }
 
@@ -147,7 +154,8 @@ class DialogTheme with Diagnosticable {
         && other.iconColor == iconColor
         && other.titleTextStyle == titleTextStyle
         && other.contentTextStyle == contentTextStyle
-        && other.actionsPadding == actionsPadding;
+        && other.actionsPadding == actionsPadding
+        && other.barrierColor == barrierColor;
   }
 
   @override
@@ -163,5 +171,6 @@ class DialogTheme with Diagnosticable {
     properties.add(DiagnosticsProperty<TextStyle>('titleTextStyle', titleTextStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<TextStyle>('contentTextStyle', contentTextStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('actionsPadding', actionsPadding, defaultValue: null));
+    properties.add(ColorProperty('barrierColor', barrierColor));
   }
 }

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -66,6 +66,7 @@ void main() {
       titleTextStyle: TextStyle(color: Color(0xffffffff)),
       contentTextStyle: TextStyle(color: Color(0xff000000)),
       actionsPadding: EdgeInsets.all(8.0),
+      barrierColor: Color(0xff000005),
     ).debugFillProperties(builder);
     final List<String> description = builder.properties
         .where((DiagnosticsNode n) => !n.isFiltered(DiagnosticLevel.info))
@@ -80,6 +81,7 @@ void main() {
       'titleTextStyle: TextStyle(inherit: true, color: Color(0xffffffff))',
       'contentTextStyle: TextStyle(inherit: true, color: Color(0xff000000))',
       'actionsPadding: EdgeInsets.all(8.0)',
+      'barrierColor: Color(0xff000005)',
     ]);
   });
 
@@ -498,5 +500,18 @@ void main() {
 
     final RenderParagraph content = _getTextRenderObject(tester, contentText);
     expect(content.text.style!.color, contentTextStyle.color);
+  });
+
+  testWidgets('Custom barrierColor - Theme', (WidgetTester tester) async {
+    const Color barrierColor = Colors.blue;
+    const SimpleDialog dialog = SimpleDialog();
+    final ThemeData theme = ThemeData(dialogTheme: const DialogTheme(barrierColor: barrierColor));
+
+    await tester.pumpWidget(_appWithDialog(tester, dialog, theme: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final ModalBarrier modalBarrier = tester.widget(find.byType(ModalBarrier).last);
+    expect(modalBarrier.color, barrierColor);
   });
 }


### PR DESCRIPTION
Customize the `barrierColor` used in `showDialog` via `DialogTheme`. Equivalent implementation as the modal bottom sheets.

https://github.com/flutter/flutter/blob/995e3fad7c9f6130e250f7f64ac922a5317f342d/packages/flutter/lib/src/material/bottom_sheet.dart#L1272  

Fixes #142489

Demo:

```dart
void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        dialogTheme: const DialogTheme(
          barrierColor: Colors.green,
        ),
      ),
      home: const DialogExample(),
    );
  }
}

class DialogExample extends StatefulWidget {
  const DialogExample({super.key});

  @override
  State<DialogExample> createState() => _DialogExampleState();
}

class _DialogExampleState extends State<DialogExample> {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            FilledButton(
              onPressed: () {
                showDialog(
                  context: context,
                  builder: (context) {
                    return const Dialog(
                      child: Text("Dialog"),
                    );
                  },
                );
              },
              child: const Text("Show Dialog"),
            ),
            FilledButton(
              onPressed: () {
                showDialog(
                  context: context,
                  builder: (context) {
                    return const AlertDialog(
                      content: Text("Alert"),
                    );
                  },
                );
              },
              child: const Text("Show AlertDialog"),
            ),
          ],
        ),
      ),
    );
  }
}
```

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
