### PR TITLE
Introduce tone-based surfaces and accent color add-ons - Part 1

### DIFF
--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -41,7 +41,7 @@ import 'theme_data.dart';
 /// '-Dim' color roles, such as [primaryFixed] and [primaryFixedDim]. Fixed roles
 /// are appropriate to use in places where Container roles are normally used,
 /// but they stay the same color between light and dark themes. The '-Dim' roles
-/// provides a stronger, more emphasized color with the same fixed behavior.
+/// provide a stronger, more emphasized color with the same fixed behavior.
 ///
 /// The remaining colors of the scheme are composed of neutral colors used for
 /// backgrounds and surfaces, as well as specific colors for errors, dividers

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -13,7 +13,7 @@ import 'colors.dart';
 import 'theme_data.dart';
 
 /// {@template flutter.material.color_scheme.ColorScheme}
-/// A set of 30 colors based on the
+/// A set of colors based on the
 /// [Material spec](https://m3.material.io/styles/color/the-color-system/color-roles)
 /// that can be used to configure the color properties of most components.
 /// {@endtemplate}
@@ -37,21 +37,36 @@ import 'theme_data.dart';
 ///   for makers to use at their discretion and are intended to support
 ///   broader color expression in products.
 ///
+/// Each accent color group (primary, secondary and tertiary) includes '-Fixed'
+/// '-Dim' color roles, such as [primaryFixed] and [primaryFixedDim]. Fixed roles
+/// are appropriate to use in places where Container roles are normally used,
+/// but they stay the same color between light and dark themes. The '-Dim' roles
+/// provides a stronger, more emphasized color with the same fixed behavior.
+///
 /// The remaining colors of the scheme are composed of neutral colors used for
 /// backgrounds and surfaces, as well as specific colors for errors, dividers
-/// and shadows.
+/// and shadows. Surface colors are used for backgrounds and large, low-emphasis
+/// areas of the screen.
+///
+/// Material 3 also introduces tone-based surfaces and surface containers.
+/// They replace the old opacity-based model which applied a tinted overlay on
+/// top of surfaces based on their elevation. These colors include: [surfaceBright],
+/// [surfaceDim], [surfaceContainerLowest], [surfaceContainerLow], [surfaceContainer],
+/// [surfaceContainerHigh], and [surfaceContainerHighest].
 ///
 /// Many of the colors have matching 'on' colors, which are used for drawing
 /// content on top of the matching color. For example, if something is using
 /// [primary] for a background color, [onPrimary] would be used to paint text
 /// and icons on top of it. For this reason, the 'on' colors should have a
 /// contrast ratio with their matching colors of at least 4.5:1 in order to
-/// be readable.
+/// be readable. On '-FixedVariant' roles, such as [onPrimaryFixedVariant],
+/// also have the same color between light and dark themes, but compared
+/// with on '-Fixed' roles, such as [onPrimaryFixed], they provide a
+/// lower-emphasis option for text and icons.
 ///
 /// ### Setting Colors in Flutter
 ///
 ///{@macro flutter.material.colors.settingColors}
-//
 @immutable
 class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance from the given colors.
@@ -90,14 +105,26 @@ class ColorScheme with Diagnosticable {
     required this.onPrimary,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? primaryFixed,
+    Color? primaryFixedDim,
+    Color? onPrimaryFixed,
+    Color? onPrimaryFixedVariant,
     required this.secondary,
     required this.onSecondary,
     Color? secondaryContainer,
     Color? onSecondaryContainer,
+    Color? secondaryFixed,
+    Color? secondaryFixedDim,
+    Color? onSecondaryFixed,
+    Color? onSecondaryFixedVariant,
     Color? tertiary,
     Color? onTertiary,
     Color? tertiaryContainer,
     Color? onTertiaryContainer,
+    Color? tertiaryFixed,
+    Color? tertiaryFixedDim,
+    Color? onTertiaryFixed,
+    Color? onTertiaryFixedVariant,
     required this.error,
     required this.onError,
     Color? errorContainer,
@@ -106,6 +133,13 @@ class ColorScheme with Diagnosticable {
     required this.onBackground,
     required this.surface,
     required this.onSurface,
+    Color? surfaceDim,
+    Color? surfaceBright,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? outline,
@@ -118,14 +152,33 @@ class ColorScheme with Diagnosticable {
     Color? surfaceTint,
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
+       _primaryFixed = primaryFixed,
+       _primaryFixedDim = primaryFixedDim,
+       _onPrimaryFixed = onPrimaryFixed,
+       _onPrimaryFixedVariant = onPrimaryFixedVariant,
        _secondaryContainer = secondaryContainer,
        _onSecondaryContainer = onSecondaryContainer,
+       _secondaryFixed = secondaryFixed,
+       _secondaryFixedDim = secondaryFixedDim,
+       _onSecondaryFixed = onSecondaryFixed,
+       _onSecondaryFixedVariant = onSecondaryFixedVariant,
        _tertiary = tertiary,
        _onTertiary = onTertiary,
        _tertiaryContainer = tertiaryContainer,
        _onTertiaryContainer = onTertiaryContainer,
+       _tertiaryFixed = tertiaryFixed,
+       _tertiaryFixedDim = tertiaryFixedDim,
+       _onTertiaryFixed = onTertiaryFixed,
+       _onTertiaryFixedVariant = onTertiaryFixedVariant,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
+       _surfaceDim = surfaceDim,
+       _surfaceBright = surfaceBright,
+       _surfaceContainerLowest = surfaceContainerLowest,
+       _surfaceContainerLow = surfaceContainerLow,
+       _surfaceContainer = surfaceContainer,
+       _surfaceContainerHigh = surfaceContainerHigh,
+       _surfaceContainerHighest = surfaceContainerHighest,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _outline = outline,
@@ -261,14 +314,26 @@ class ColorScheme with Diagnosticable {
     this.onPrimary = Colors.white,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? primaryFixed,
+    Color? primaryFixedDim,
+    Color? onPrimaryFixed,
+    Color? onPrimaryFixedVariant,
     this.secondary = const Color(0xff03dac6),
     this.onSecondary = Colors.black,
     Color? secondaryContainer,
     Color? onSecondaryContainer,
+    Color? secondaryFixed,
+    Color? secondaryFixedDim,
+    Color? onSecondaryFixed,
+    Color? onSecondaryFixedVariant,
     Color? tertiary,
     Color? onTertiary,
     Color? tertiaryContainer,
     Color? onTertiaryContainer,
+    Color? tertiaryFixed,
+    Color? tertiaryFixedDim,
+    Color? onTertiaryFixed,
+    Color? onTertiaryFixedVariant,
     this.error = const Color(0xffb00020),
     this.onError = Colors.white,
     Color? errorContainer,
@@ -277,6 +342,13 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.black,
     this.surface = Colors.white,
     this.onSurface = Colors.black,
+    Color? surfaceDim,
+    Color? surfaceBright,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? outline,
@@ -289,14 +361,33 @@ class ColorScheme with Diagnosticable {
     Color? surfaceTint,
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
+       _primaryFixed = primaryFixed,
+       _primaryFixedDim = primaryFixedDim,
+       _onPrimaryFixed = onPrimaryFixed,
+       _onPrimaryFixedVariant = onPrimaryFixedVariant,
        _secondaryContainer = secondaryContainer,
        _onSecondaryContainer = onSecondaryContainer,
+       _secondaryFixed = secondaryFixed,
+       _secondaryFixedDim = secondaryFixedDim,
+       _onSecondaryFixed = onSecondaryFixed,
+       _onSecondaryFixedVariant = onSecondaryFixedVariant,
        _tertiary = tertiary,
        _onTertiary = onTertiary,
        _tertiaryContainer = tertiaryContainer,
        _onTertiaryContainer = onTertiaryContainer,
+       _tertiaryFixed = tertiaryFixed,
+       _tertiaryFixedDim = tertiaryFixedDim,
+       _onTertiaryFixed = onTertiaryFixed,
+       _onTertiaryFixedVariant = onTertiaryFixedVariant,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
+       _surfaceDim = surfaceDim,
+       _surfaceBright = surfaceBright,
+       _surfaceContainerLowest = surfaceContainerLowest,
+       _surfaceContainerLow = surfaceContainerLow,
+       _surfaceContainer = surfaceContainer,
+       _surfaceContainerHigh = surfaceContainerHigh,
+       _surfaceContainerHighest = surfaceContainerHighest,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _outline = outline,
@@ -342,14 +433,26 @@ class ColorScheme with Diagnosticable {
     this.onPrimary = Colors.black,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? primaryFixed,
+    Color? primaryFixedDim,
+    Color? onPrimaryFixed,
+    Color? onPrimaryFixedVariant,
     this.secondary = const Color(0xff03dac6),
     this.onSecondary = Colors.black,
     Color? secondaryContainer,
     Color? onSecondaryContainer,
+    Color? secondaryFixed,
+    Color? secondaryFixedDim,
+    Color? onSecondaryFixed,
+    Color? onSecondaryFixedVariant,
     Color? tertiary,
     Color? onTertiary,
     Color? tertiaryContainer,
     Color? onTertiaryContainer,
+    Color? tertiaryFixed,
+    Color? tertiaryFixedDim,
+    Color? onTertiaryFixed,
+    Color? onTertiaryFixedVariant,
     this.error = const Color(0xffcf6679),
     this.onError = Colors.black,
     Color? errorContainer,
@@ -358,6 +461,13 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.white,
     this.surface = const Color(0xff121212),
     this.onSurface = Colors.white,
+    Color? surfaceDim,
+    Color? surfaceBright,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? outline,
@@ -370,14 +480,33 @@ class ColorScheme with Diagnosticable {
     Color? surfaceTint,
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
+       _primaryFixed = primaryFixed,
+       _primaryFixedDim = primaryFixedDim,
+       _onPrimaryFixed = onPrimaryFixed,
+       _onPrimaryFixedVariant = onPrimaryFixedVariant,
        _secondaryContainer = secondaryContainer,
        _onSecondaryContainer = onSecondaryContainer,
+       _secondaryFixed = secondaryFixed,
+       _secondaryFixedDim = secondaryFixedDim,
+       _onSecondaryFixed = onSecondaryFixed,
+       _onSecondaryFixedVariant = onSecondaryFixedVariant,
        _tertiary = tertiary,
        _onTertiary = onTertiary,
        _tertiaryContainer = tertiaryContainer,
        _onTertiaryContainer = onTertiaryContainer,
+       _tertiaryFixed = tertiaryFixed,
+       _tertiaryFixedDim = tertiaryFixedDim,
+       _onTertiaryFixed = onTertiaryFixed,
+       _onTertiaryFixedVariant = onTertiaryFixedVariant,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
+       _surfaceDim = surfaceDim,
+       _surfaceBright = surfaceBright,
+       _surfaceContainerLowest = surfaceContainerLowest,
+       _surfaceContainerLow = surfaceContainerLow,
+       _surfaceContainer = surfaceContainer,
+       _surfaceContainerHigh = surfaceContainerHigh,
+       _surfaceContainerHighest = surfaceContainerHighest,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _outline = outline,
@@ -418,14 +547,26 @@ class ColorScheme with Diagnosticable {
     this.onPrimary = Colors.white,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? primaryFixed,
+    Color? primaryFixedDim,
+    Color? onPrimaryFixed,
+    Color? onPrimaryFixedVariant,
     this.secondary = const Color(0xff66fff9),
     this.onSecondary = Colors.black,
     Color? secondaryContainer,
     Color? onSecondaryContainer,
+    Color? secondaryFixed,
+    Color? secondaryFixedDim,
+    Color? onSecondaryFixed,
+    Color? onSecondaryFixedVariant,
     Color? tertiary,
     Color? onTertiary,
     Color? tertiaryContainer,
     Color? onTertiaryContainer,
+    Color? tertiaryFixed,
+    Color? tertiaryFixedDim,
+    Color? onTertiaryFixed,
+    Color? onTertiaryFixedVariant,
     this.error = const Color(0xff790000),
     this.onError = Colors.white,
     Color? errorContainer,
@@ -434,6 +575,13 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.black,
     this.surface = Colors.white,
     this.onSurface = Colors.black,
+    Color? surfaceDim,
+    Color? surfaceBright,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? outline,
@@ -446,14 +594,33 @@ class ColorScheme with Diagnosticable {
     Color? surfaceTint,
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
+       _primaryFixed = primaryFixed,
+       _primaryFixedDim = primaryFixedDim,
+       _onPrimaryFixed = onPrimaryFixed,
+       _onPrimaryFixedVariant = onPrimaryFixedVariant,
        _secondaryContainer = secondaryContainer,
        _onSecondaryContainer = onSecondaryContainer,
+       _secondaryFixed = secondaryFixed,
+       _secondaryFixedDim = secondaryFixedDim,
+       _onSecondaryFixed = onSecondaryFixed,
+       _onSecondaryFixedVariant = onSecondaryFixedVariant,
        _tertiary = tertiary,
        _onTertiary = onTertiary,
        _tertiaryContainer = tertiaryContainer,
        _onTertiaryContainer = onTertiaryContainer,
+       _tertiaryFixed = tertiaryFixed,
+       _tertiaryFixedDim = tertiaryFixedDim,
+       _onTertiaryFixed = onTertiaryFixed,
+       _onTertiaryFixedVariant = onTertiaryFixedVariant,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
+       _surfaceDim = surfaceDim,
+       _surfaceBright = surfaceBright,
+       _surfaceContainerLowest = surfaceContainerLowest,
+       _surfaceContainerLow = surfaceContainerLow,
+       _surfaceContainer = surfaceContainer,
+       _surfaceContainerHigh = surfaceContainerHigh,
+       _surfaceContainerHighest = surfaceContainerHighest,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _outline = outline,
@@ -499,14 +666,26 @@ class ColorScheme with Diagnosticable {
     this.onPrimary = Colors.black,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? primaryFixed,
+    Color? primaryFixedDim,
+    Color? onPrimaryFixed,
+    Color? onPrimaryFixedVariant,
     this.secondary = const Color(0xff66fff9),
     this.onSecondary = Colors.black,
     Color? secondaryContainer,
     Color? onSecondaryContainer,
+    Color? secondaryFixed,
+    Color? secondaryFixedDim,
+    Color? onSecondaryFixed,
+    Color? onSecondaryFixedVariant,
     Color? tertiary,
     Color? onTertiary,
     Color? tertiaryContainer,
     Color? onTertiaryContainer,
+    Color? tertiaryFixed,
+    Color? tertiaryFixedDim,
+    Color? onTertiaryFixed,
+    Color? onTertiaryFixedVariant,
     this.error = const Color(0xff9b374d),
     this.onError = Colors.black,
     Color? errorContainer,
@@ -515,6 +694,13 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.white,
     this.surface = const Color(0xff121212),
     this.onSurface = Colors.white,
+    Color? surfaceDim,
+    Color? surfaceBright,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? outline,
@@ -527,14 +713,33 @@ class ColorScheme with Diagnosticable {
     Color? surfaceTint,
   }) : _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
+       _primaryFixed = primaryFixed,
+       _primaryFixedDim = primaryFixedDim,
+       _onPrimaryFixed = onPrimaryFixed,
+       _onPrimaryFixedVariant = onPrimaryFixedVariant,
        _secondaryContainer = secondaryContainer,
        _onSecondaryContainer = onSecondaryContainer,
+       _secondaryFixed = secondaryFixed,
+       _secondaryFixedDim = secondaryFixedDim,
+       _onSecondaryFixed = onSecondaryFixed,
+       _onSecondaryFixedVariant = onSecondaryFixedVariant,
        _tertiary = tertiary,
        _onTertiary = onTertiary,
        _tertiaryContainer = tertiaryContainer,
        _onTertiaryContainer = onTertiaryContainer,
+       _tertiaryFixed = tertiaryFixed,
+       _tertiaryFixedDim = tertiaryFixedDim,
+       _onTertiaryFixed = onTertiaryFixed,
+       _onTertiaryFixedVariant = onTertiaryFixedVariant,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
+       _surfaceDim = surfaceDim,
+       _surfaceBright = surfaceBright,
+       _surfaceContainerLowest = surfaceContainerLowest,
+       _surfaceContainerLow = surfaceContainerLow,
+       _surfaceContainer = surfaceContainer,
+       _surfaceContainerHigh = surfaceContainerHigh,
+       _surfaceContainerHighest = surfaceContainerHighest,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _outline = outline,
@@ -612,6 +817,25 @@ class ColorScheme with Diagnosticable {
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onPrimaryContainer => _onPrimaryContainer ?? onPrimary;
 
+  final Color? _primaryFixed;
+  /// A substitute for [primaryContainer] that's the same color for the dark
+  /// and light themes.
+  Color get primaryFixed => _primaryFixed ?? primary;
+
+  final Color? _primaryFixedDim;
+  /// A color used for elements needing more emphasis than [primaryFixed].
+  Color get primaryFixedDim => _primaryFixedDim ?? primary;
+
+  final Color? _onPrimaryFixed;
+  /// A color that is used for text and icons that exist on top of elements having
+  /// [primaryFixed] color.
+  Color get onPrimaryFixed => _onPrimaryFixed ?? onPrimary;
+
+  final Color? _onPrimaryFixedVariant;
+  /// A color that provides a lower-emphasis option for text and icons than
+  /// [onPrimaryFixed].
+  Color get onPrimaryFixedVariant => _onPrimaryFixedVariant ?? onPrimary;
+
   /// An accent color used for less prominent components in the UI, such as
   /// filter chips, while expanding the opportunity for color expression.
   final Color secondary;
@@ -635,6 +859,25 @@ class ColorScheme with Diagnosticable {
   /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onSecondaryContainer => _onSecondaryContainer ?? onSecondary;
+
+  final Color? _secondaryFixed;
+  /// A substitute for [secondaryContainer] that's the same color for the dark
+  /// and light themes.
+  Color get secondaryFixed => _secondaryFixed ?? secondary;
+
+  final Color? _secondaryFixedDim;
+  /// A color used for elements needing more emphasis than [secondaryFixed].
+  Color get secondaryFixedDim => _secondaryFixedDim ?? secondary;
+
+  final Color? _onSecondaryFixed;
+  /// A color that is used for text and icons that exist on top of elements having
+  /// [secondaryFixed] color.
+  Color get onSecondaryFixed => _onSecondaryFixed ?? onSecondary;
+
+  final Color? _onSecondaryFixedVariant;
+  /// A color that provides a lower-emphasis option for text and icons than
+  /// [onSecondaryFixed].
+  Color get onSecondaryFixedVariant => _onSecondaryFixedVariant ?? onSecondary;
 
   final Color? _tertiary;
   /// A color used as a contrasting accent that can balance [primary]
@@ -662,6 +905,25 @@ class ColorScheme with Diagnosticable {
   /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onTertiaryContainer => _onTertiaryContainer ?? onTertiary;
+
+  final Color? _tertiaryFixed;
+  /// A substitute for [tertiaryContainer] that's the same color for dark
+  /// and light themes.
+  Color get tertiaryFixed => _tertiaryFixed ?? tertiary;
+
+  final Color? _tertiaryFixedDim;
+  /// A color used for elements needing more emphasis than [tertiaryFixed].
+  Color get tertiaryFixedDim => _tertiaryFixedDim ?? tertiary;
+
+  final Color? _onTertiaryFixed;
+  /// A color that is used for text and icons that exist on top of elements having
+  /// [tertiaryFixed] color.
+  Color get onTertiaryFixed => _onTertiaryFixed ?? onTertiary;
+
+  final Color? _onTertiaryFixedVariant;
+  /// A color that provides a lower-emphasis option for text and icons than
+  /// [onTertiaryFixed].
+  Color get onTertiaryFixedVariant => _onTertiaryFixedVariant ?? onTertiary;
 
   /// The color to use for input validation errors, e.g. for
   /// [InputDecoration.errorText].
@@ -711,6 +973,45 @@ class ColorScheme with Diagnosticable {
   /// A color variant of [surface] that can be used for differentiation against
   /// a component using [surface].
   Color get surfaceVariant => _surfaceVariant ?? surface;
+
+  final Color? _surfaceDim;
+  /// A color that's always darkest in the dark or light theme.
+  Color get surfaceDim => _surfaceDim ?? surface;
+
+  final Color? _surfaceBright;
+  /// A color that's always the lightest in the dark or light theme.
+  Color get surfaceBright => _surfaceBright ?? surface;
+
+  final Color? _surfaceContainerLowest;
+  /// A surface container color with the lightest tone and the least emphasis
+  /// relative to the surface.
+  Color get surfaceContainerLowest => _surfaceContainerLowest ?? surface;
+
+  final Color? _surfaceContainerLow;
+  /// A surface container color with a lighter tone that creates less emphasis
+  /// than [surfaceContainer] but more emphasis than [surfaceContainerLowest].
+  Color get surfaceContainerLow => _surfaceContainerLow ?? surface;
+
+  final Color? _surfaceContainer;
+  /// A recommended color role for a distinct area within the surface.
+  ///
+  /// Surface container color roles are independent of elevation. They replace the old
+  /// opacity-based model which applied a tinted overlay on top of
+  /// surfaces based on their elevation.
+  ///
+  /// Surface container colors include [surfaceContainerLowest], [surfaceContainerLow],
+  /// [surfaceContainer], [surfaceContainerHigh] and [surfaceContainerHighest].
+  Color get surfaceContainer => _surfaceContainer ?? surface;
+
+  final Color? _surfaceContainerHigh;
+  /// A surface container color with a darker tone. It is used to create more
+  /// emphasis than [surfaceContainer] but less emphasis than [surfaceContainerHighest].
+  Color get surfaceContainerHigh => _surfaceContainerHigh ?? surface;
+
+  final Color? _surfaceContainerHighest;
+  /// A surface container color with the darkest tone. It is used to create the
+  /// most emphasis against the surface.
+  Color get surfaceContainerHighest => _surfaceContainerHighest ?? surface;
 
   final Color? _onSurfaceVariant;
   /// A color that's clearly legible when drawn on [surfaceVariant].
@@ -771,14 +1072,26 @@ class ColorScheme with Diagnosticable {
     Color? onPrimary,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? primaryFixed,
+    Color? primaryFixedDim,
+    Color? onPrimaryFixed,
+    Color? onPrimaryFixedVariant,
     Color? secondary,
     Color? onSecondary,
     Color? secondaryContainer,
     Color? onSecondaryContainer,
+    Color? secondaryFixed,
+    Color? secondaryFixedDim,
+    Color? onSecondaryFixed,
+    Color? onSecondaryFixedVariant,
     Color? tertiary,
     Color? onTertiary,
     Color? tertiaryContainer,
     Color? onTertiaryContainer,
+    Color? tertiaryFixed,
+    Color? tertiaryFixedDim,
+    Color? onTertiaryFixed,
+    Color? onTertiaryFixedVariant,
     Color? error,
     Color? onError,
     Color? errorContainer,
@@ -787,6 +1100,13 @@ class ColorScheme with Diagnosticable {
     Color? onBackground,
     Color? surface,
     Color? onSurface,
+    Color? surfaceDim,
+    Color? surfaceBright,
+    Color? surfaceContainerLowest,
+    Color? surfaceContainerLow,
+    Color? surfaceContainer,
+    Color? surfaceContainerHigh,
+    Color? surfaceContainerHighest,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? outline,
@@ -804,14 +1124,26 @@ class ColorScheme with Diagnosticable {
       onPrimary : onPrimary ?? this.onPrimary,
       primaryContainer : primaryContainer ?? this.primaryContainer,
       onPrimaryContainer : onPrimaryContainer ?? this.onPrimaryContainer,
+      primaryFixed: primaryFixed ?? this.primaryFixed,
+      primaryFixedDim: primaryFixedDim ?? this.primaryFixedDim,
+      onPrimaryFixed: onPrimaryFixed ?? this.onPrimaryFixed,
+      onPrimaryFixedVariant: onPrimaryFixedVariant ?? this.onPrimaryFixedVariant,
       secondary : secondary ?? this.secondary,
       onSecondary : onSecondary ?? this.onSecondary,
       secondaryContainer : secondaryContainer ?? this.secondaryContainer,
       onSecondaryContainer : onSecondaryContainer ?? this.onSecondaryContainer,
+      secondaryFixed: secondaryFixed ?? this.secondaryFixed,
+      secondaryFixedDim: secondaryFixedDim ?? this.secondaryFixedDim,
+      onSecondaryFixed: onSecondaryFixed ?? this.onSecondaryFixed,
+      onSecondaryFixedVariant: onSecondaryFixedVariant ?? this.onSecondaryFixedVariant,
       tertiary : tertiary ?? this.tertiary,
       onTertiary : onTertiary ?? this.onTertiary,
       tertiaryContainer : tertiaryContainer ?? this.tertiaryContainer,
       onTertiaryContainer : onTertiaryContainer ?? this.onTertiaryContainer,
+      tertiaryFixed: tertiaryFixed ?? this.tertiaryFixed,
+      tertiaryFixedDim: tertiaryFixedDim ?? this.tertiaryFixedDim,
+      onTertiaryFixed: onTertiaryFixed ?? this.onTertiaryFixed,
+      onTertiaryFixedVariant: onTertiaryFixedVariant ?? this.onTertiaryFixedVariant,
       error : error ?? this.error,
       onError : onError ?? this.onError,
       errorContainer : errorContainer ?? this.errorContainer,
@@ -820,6 +1152,13 @@ class ColorScheme with Diagnosticable {
       onBackground : onBackground ?? this.onBackground,
       surface : surface ?? this.surface,
       onSurface : onSurface ?? this.onSurface,
+      surfaceDim : surfaceDim ?? this.surfaceDim,
+      surfaceBright : surfaceBright ?? this.surfaceBright,
+      surfaceContainerLowest : surfaceContainerLowest ?? this.surfaceContainerLowest,
+      surfaceContainerLow : surfaceContainerLow ?? this.surfaceContainerLow,
+      surfaceContainer : surfaceContainer ?? this.surfaceContainer,
+      surfaceContainerHigh : surfaceContainerHigh ?? this.surfaceContainerHigh,
+      surfaceContainerHighest : surfaceContainerHighest ?? this.surfaceContainerHighest,
       surfaceVariant : surfaceVariant ?? this.surfaceVariant,
       onSurfaceVariant : onSurfaceVariant ?? this.onSurfaceVariant,
       outline : outline ?? this.outline,
@@ -846,14 +1185,26 @@ class ColorScheme with Diagnosticable {
       onPrimary: Color.lerp(a.onPrimary, b.onPrimary, t)!,
       primaryContainer: Color.lerp(a.primaryContainer, b.primaryContainer, t),
       onPrimaryContainer: Color.lerp(a.onPrimaryContainer, b.onPrimaryContainer, t),
+      primaryFixed: Color.lerp(a.primaryFixed, b.primaryFixed, t),
+      primaryFixedDim: Color.lerp(a.primaryFixedDim, b.primaryFixedDim, t),
+      onPrimaryFixed: Color.lerp(a.onPrimaryFixed, b.onPrimaryFixed, t),
+      onPrimaryFixedVariant: Color.lerp(a.onPrimaryFixedVariant, b.onPrimaryFixedVariant, t),
       secondary: Color.lerp(a.secondary, b.secondary, t)!,
       onSecondary: Color.lerp(a.onSecondary, b.onSecondary, t)!,
       secondaryContainer: Color.lerp(a.secondaryContainer, b.secondaryContainer, t),
       onSecondaryContainer: Color.lerp(a.onSecondaryContainer, b.onSecondaryContainer, t),
+      secondaryFixed: Color.lerp(a.secondaryFixed, b.secondaryFixed, t),
+      secondaryFixedDim: Color.lerp(a.secondaryFixedDim, b.secondaryFixedDim, t),
+      onSecondaryFixed: Color.lerp(a.onSecondaryFixed, b.onSecondaryFixed, t),
+      onSecondaryFixedVariant: Color.lerp(a.onSecondaryFixedVariant, b.onSecondaryFixedVariant, t),
       tertiary: Color.lerp(a.tertiary, b.tertiary, t),
       onTertiary: Color.lerp(a.onTertiary, b.onTertiary, t),
       tertiaryContainer: Color.lerp(a.tertiaryContainer, b.tertiaryContainer, t),
       onTertiaryContainer: Color.lerp(a.onTertiaryContainer, b.onTertiaryContainer, t),
+      tertiaryFixed: Color.lerp(a.tertiaryFixed, b.tertiaryFixed, t),
+      tertiaryFixedDim: Color.lerp(a.tertiaryFixedDim, b.tertiaryFixedDim, t),
+      onTertiaryFixed: Color.lerp(a.onTertiaryFixed, b.onTertiaryFixed, t),
+      onTertiaryFixedVariant: Color.lerp(a.onTertiaryFixedVariant, b.onTertiaryFixedVariant, t),
       error: Color.lerp(a.error, b.error, t)!,
       onError: Color.lerp(a.onError, b.onError, t)!,
       errorContainer: Color.lerp(a.errorContainer, b.errorContainer, t),
@@ -862,6 +1213,13 @@ class ColorScheme with Diagnosticable {
       onBackground: Color.lerp(a.onBackground, b.onBackground, t)!,
       surface: Color.lerp(a.surface, b.surface, t)!,
       onSurface: Color.lerp(a.onSurface, b.onSurface, t)!,
+      surfaceDim: Color.lerp(a.surfaceDim, b.surfaceDim, t),
+      surfaceBright: Color.lerp(a.surfaceBright, b.surfaceBright, t),
+      surfaceContainerLowest: Color.lerp(a.surfaceContainerLowest, b.surfaceContainerLowest, t),
+      surfaceContainerLow: Color.lerp(a.surfaceContainerLow, b.surfaceContainerLow, t),
+      surfaceContainer: Color.lerp(a.surfaceContainer, b.surfaceContainer, t),
+      surfaceContainerHigh: Color.lerp(a.surfaceContainerHigh, b.surfaceContainerHigh, t),
+      surfaceContainerHighest: Color.lerp(a.surfaceContainerHighest, b.surfaceContainerHighest, t),
       surfaceVariant: Color.lerp(a.surfaceVariant, b.surfaceVariant, t),
       onSurfaceVariant: Color.lerp(a.onSurfaceVariant, b.onSurfaceVariant, t),
       outline: Color.lerp(a.outline, b.outline, t),
@@ -889,14 +1247,26 @@ class ColorScheme with Diagnosticable {
       && other.onPrimary == onPrimary
       && other.primaryContainer == primaryContainer
       && other.onPrimaryContainer == onPrimaryContainer
+      && other.primaryFixed == primaryFixed
+      && other.primaryFixedDim == primaryFixedDim
+      && other.onPrimaryFixed == onPrimaryFixed
+      && other.onPrimaryFixedVariant == onPrimaryFixedVariant
       && other.secondary == secondary
       && other.onSecondary == onSecondary
       && other.secondaryContainer == secondaryContainer
       && other.onSecondaryContainer == onSecondaryContainer
+      && other.secondaryFixed == secondaryFixed
+      && other.secondaryFixedDim == secondaryFixedDim
+      && other.onSecondaryFixed == onSecondaryFixed
+      && other.onSecondaryFixedVariant == onSecondaryFixedVariant
       && other.tertiary == tertiary
       && other.onTertiary == onTertiary
       && other.tertiaryContainer == tertiaryContainer
       && other.onTertiaryContainer == onTertiaryContainer
+      && other.tertiaryFixed == tertiaryFixed
+      && other.tertiaryFixedDim == tertiaryFixedDim
+      && other.onTertiaryFixed == onTertiaryFixed
+      && other.onTertiaryFixedVariant == onTertiaryFixedVariant
       && other.error == error
       && other.onError == onError
       && other.errorContainer == errorContainer
@@ -905,6 +1275,13 @@ class ColorScheme with Diagnosticable {
       && other.onBackground == onBackground
       && other.surface == surface
       && other.onSurface == onSurface
+      && other.surfaceDim == surfaceDim
+      && other.surfaceBright == surfaceBright
+      && other.surfaceContainerLowest == surfaceContainerLowest
+      && other.surfaceContainerLow == surfaceContainerLow
+      && other.surfaceContainer == surfaceContainer
+      && other.surfaceContainerHigh == surfaceContainerHigh
+      && other.surfaceContainerHighest == surfaceContainerHighest
       && other.surfaceVariant == surfaceVariant
       && other.onSurfaceVariant == onSurfaceVariant
       && other.outline == outline
@@ -941,6 +1318,13 @@ class ColorScheme with Diagnosticable {
     Object.hash(
       surface,
       onSurface,
+      surfaceDim,
+      surfaceBright,
+      surfaceContainerLowest,
+      surfaceContainerLow,
+      surfaceContainer,
+      surfaceContainerHigh,
+      surfaceContainerHighest,
       surfaceVariant,
       onSurfaceVariant,
       outline,
@@ -951,6 +1335,20 @@ class ColorScheme with Diagnosticable {
       onInverseSurface,
       inversePrimary,
       surfaceTint,
+      Object.hash(
+        primaryFixed,
+        primaryFixedDim,
+        onPrimaryFixed,
+        onPrimaryFixedVariant,
+        secondaryFixed,
+        secondaryFixedDim,
+        onSecondaryFixed,
+        onSecondaryFixedVariant,
+        tertiaryFixed,
+        tertiaryFixedDim,
+        onTertiaryFixed,
+        onTertiaryFixedVariant,
+      )
     ),
   );
 
@@ -963,14 +1361,26 @@ class ColorScheme with Diagnosticable {
     properties.add(ColorProperty('onPrimary', onPrimary, defaultValue: defaultScheme.onPrimary));
     properties.add(ColorProperty('primaryContainer', primaryContainer, defaultValue: defaultScheme.primaryContainer));
     properties.add(ColorProperty('onPrimaryContainer', onPrimaryContainer, defaultValue: defaultScheme.onPrimaryContainer));
+    properties.add(ColorProperty('primaryFixed', primaryFixed, defaultValue: defaultScheme.primaryFixed));
+    properties.add(ColorProperty('primaryFixedDim', primaryFixedDim, defaultValue: defaultScheme.primaryFixedDim));
+    properties.add(ColorProperty('onPrimaryFixed', onPrimaryFixed, defaultValue: defaultScheme.onPrimaryFixed));
+    properties.add(ColorProperty('onPrimaryFixedVariant', onPrimaryFixedVariant, defaultValue: defaultScheme.onPrimaryFixedVariant));
     properties.add(ColorProperty('secondary', secondary, defaultValue: defaultScheme.secondary));
     properties.add(ColorProperty('onSecondary', onSecondary, defaultValue: defaultScheme.onSecondary));
     properties.add(ColorProperty('secondaryContainer', secondaryContainer, defaultValue: defaultScheme.secondaryContainer));
     properties.add(ColorProperty('onSecondaryContainer', onSecondaryContainer, defaultValue: defaultScheme.onSecondaryContainer));
+    properties.add(ColorProperty('secondaryFixed', secondaryFixed, defaultValue: defaultScheme.secondaryFixed));
+    properties.add(ColorProperty('secondaryFixedDim', secondaryFixedDim, defaultValue: defaultScheme.secondaryFixedDim));
+    properties.add(ColorProperty('onSecondaryFixed', onSecondaryFixed, defaultValue: defaultScheme.onSecondaryFixed));
+    properties.add(ColorProperty('onSecondaryFixedVariant', onSecondaryFixedVariant, defaultValue: defaultScheme.onSecondaryFixedVariant));
     properties.add(ColorProperty('tertiary', tertiary, defaultValue: defaultScheme.tertiary));
     properties.add(ColorProperty('onTertiary', onTertiary, defaultValue: defaultScheme.onTertiary));
     properties.add(ColorProperty('tertiaryContainer', tertiaryContainer, defaultValue: defaultScheme.tertiaryContainer));
     properties.add(ColorProperty('onTertiaryContainer', onTertiaryContainer, defaultValue: defaultScheme.onTertiaryContainer));
+    properties.add(ColorProperty('tertiaryFixed', tertiaryFixed, defaultValue: defaultScheme.tertiaryFixed));
+    properties.add(ColorProperty('tertiaryFixedDim', tertiaryFixedDim, defaultValue: defaultScheme.tertiaryFixedDim));
+    properties.add(ColorProperty('onTertiaryFixed', onTertiaryFixed, defaultValue: defaultScheme.onTertiaryFixed));
+    properties.add(ColorProperty('onTertiaryFixedVariant', onTertiaryFixedVariant, defaultValue: defaultScheme.onTertiaryFixedVariant));
     properties.add(ColorProperty('error', error, defaultValue: defaultScheme.error));
     properties.add(ColorProperty('onError', onError, defaultValue: defaultScheme.onError));
     properties.add(ColorProperty('errorContainer', errorContainer, defaultValue: defaultScheme.errorContainer));
@@ -979,6 +1389,13 @@ class ColorScheme with Diagnosticable {
     properties.add(ColorProperty('onBackground', onBackground, defaultValue: defaultScheme.onBackground));
     properties.add(ColorProperty('surface', surface, defaultValue: defaultScheme.surface));
     properties.add(ColorProperty('onSurface', onSurface, defaultValue: defaultScheme.onSurface));
+    properties.add(ColorProperty('surfaceDim', surfaceDim, defaultValue: defaultScheme.surfaceDim));
+    properties.add(ColorProperty('surfaceBright', surfaceBright, defaultValue: defaultScheme.surfaceBright));
+    properties.add(ColorProperty('surfaceContainerLowest', surfaceContainerLowest, defaultValue: defaultScheme.surfaceContainerLowest));
+    properties.add(ColorProperty('surfaceContainerLow', surfaceContainerLow, defaultValue: defaultScheme.surfaceContainerLow));
+    properties.add(ColorProperty('surfaceContainer', surfaceContainer, defaultValue: defaultScheme.surfaceContainer));
+    properties.add(ColorProperty('surfaceContainerHigh', surfaceContainerHigh, defaultValue: defaultScheme.surfaceContainerHigh));
+    properties.add(ColorProperty('surfaceContainerHighest', surfaceContainerHighest, defaultValue: defaultScheme.surfaceContainerHighest));
     properties.add(ColorProperty('surfaceVariant', surfaceVariant, defaultValue: defaultScheme.surfaceVariant));
     properties.add(ColorProperty('onSurfaceVariant', onSurfaceVariant, defaultValue: defaultScheme.onSurfaceVariant));
     properties.add(ColorProperty('outline', outline, defaultValue: defaultScheme.outline));
@@ -1156,7 +1573,8 @@ class ColorScheme with Diagnosticable {
         canvas: canvas,
         rect: Rect.fromLTRB(0, 0, paintWidth, paintHeight),
         image: image,
-        filterQuality: FilterQuality.none);
+        filterQuality: FilterQuality.none,
+      );
 
       final ui.Picture picture = pictureRecorder.endRecording();
       scaledImage = await picture.toImage(paintWidth.toInt(), paintHeight.toInt());

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -431,7 +431,7 @@ void main() {
     final ImageProvider image = MemoryImage(blueSquareBytes);
 
     final ColorScheme scheme =
-    await ColorScheme.fromImageProvider(provider: image);
+        await ColorScheme.fromImageProvider(provider: image);
 
     expect(scheme.brightness, Brightness.light);
     expect(scheme.primary, const Color(0xff4040f3));
@@ -465,7 +465,7 @@ void main() {
     expect(scheme.inversePrimary, const Color(0xffc0c1ff));
     expect(scheme.surfaceTint, const Color(0xff4040f3));
   }, skip: isBrowser, // [intended] uses dart:typed_data.
-  );
+);
 
   test('can generate a dark scheme from an imageProvider', () async {
     final Uint8List blueSquareBytes = Uint8List.fromList(kBlueSquarePng);
@@ -514,8 +514,8 @@ void main() {
 
     expect(() async => ColorScheme.fromImageProvider(provider: image), throwsA(
       isA<Exception>().having((Exception e) => e.toString(),
-          'Timeout occurred trying to load image', contains('TimeoutException')),
-    ),
+        'Timeout occurred trying to load image', contains('TimeoutException')),
+      ),
     );
   });
 

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -26,14 +26,26 @@ void main() {
     expect(scheme.onPrimary, const Color(0xffffffff));
     expect(scheme.primaryContainer, scheme.primary);
     expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.primaryFixed, scheme.primary);
+    expect(scheme.primaryFixedDim, scheme.primary);
+    expect(scheme.onPrimaryFixed, scheme.onPrimary);
+    expect(scheme.onPrimaryFixedVariant, scheme.onPrimary);
     expect(scheme.secondary, const Color(0xff03dac6));
     expect(scheme.onSecondary, const Color(0xff000000));
     expect(scheme.secondaryContainer, scheme.secondary);
     expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.secondaryFixed, scheme.secondary);
+    expect(scheme.secondaryFixedDim, scheme.secondary);
+    expect(scheme.onSecondaryFixed, scheme.onSecondary);
+    expect(scheme.onSecondaryFixedVariant, scheme.onSecondary);
     expect(scheme.tertiary, scheme.secondary);
     expect(scheme.onTertiary, scheme.onSecondary);
     expect(scheme.tertiaryContainer, scheme.tertiary);
     expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.tertiaryFixed, scheme.tertiary);
+    expect(scheme.tertiaryFixedDim, scheme.tertiary);
+    expect(scheme.onTertiaryFixed, scheme.onTertiary);
+    expect(scheme.onTertiaryFixedVariant, scheme.onTertiary);
     expect(scheme.error, const Color(0xffb00020));
     expect(scheme.onError, const Color(0xffffffff));
     expect(scheme.errorContainer, scheme.error);
@@ -41,6 +53,13 @@ void main() {
     expect(scheme.background, const Color(0xffffffff));
     expect(scheme.onBackground, const Color(0xff000000));
     expect(scheme.surface, const Color(0xffffffff));
+    expect(scheme.surfaceBright, scheme.surface);
+    expect(scheme.surfaceDim, scheme.surface);
+    expect(scheme.surfaceContainerLowest, scheme.surface);
+    expect(scheme.surfaceContainerLow, scheme.surface);
+    expect(scheme.surfaceContainer, scheme.surface);
+    expect(scheme.surfaceContainerHigh, scheme.surface);
+    expect(scheme.surfaceContainerHighest, scheme.surface);
     expect(scheme.onSurface, const Color(0xff000000));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
@@ -65,14 +84,26 @@ void main() {
     expect(scheme.onPrimary, const Color(0xff000000));
     expect(scheme.primaryContainer, scheme.primary);
     expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.primaryFixed, scheme.primary);
+    expect(scheme.primaryFixedDim, scheme.primary);
+    expect(scheme.onPrimaryFixed, scheme.onPrimary);
+    expect(scheme.onPrimaryFixedVariant, scheme.onPrimary);
     expect(scheme.secondary, const Color(0xff03dac6));
     expect(scheme.onSecondary, const Color(0xff000000));
     expect(scheme.secondaryContainer, scheme.secondary);
     expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.secondaryFixed, scheme.secondary);
+    expect(scheme.secondaryFixedDim, scheme.secondary);
+    expect(scheme.onSecondaryFixed, scheme.onSecondary);
+    expect(scheme.onSecondaryFixedVariant, scheme.onSecondary);
     expect(scheme.tertiary, scheme.secondary);
     expect(scheme.onTertiary, scheme.onSecondary);
     expect(scheme.tertiaryContainer, scheme.tertiary);
     expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.tertiaryFixed, scheme.tertiary);
+    expect(scheme.tertiaryFixedDim, scheme.tertiary);
+    expect(scheme.onTertiaryFixed, scheme.onTertiary);
+    expect(scheme.onTertiaryFixedVariant, scheme.onTertiary);
     expect(scheme.error, const Color(0xffcf6679));
     expect(scheme.onError, const Color(0xff000000));
     expect(scheme.errorContainer, scheme.error);
@@ -80,6 +111,13 @@ void main() {
     expect(scheme.background, const Color(0xff121212));
     expect(scheme.onBackground, const Color(0xffffffff));
     expect(scheme.surface, const Color(0xff121212));
+    expect(scheme.surfaceBright, scheme.surface);
+    expect(scheme.surfaceDim, scheme.surface);
+    expect(scheme.surfaceContainerLowest, scheme.surface);
+    expect(scheme.surfaceContainerLow, scheme.surface);
+    expect(scheme.surfaceContainer, scheme.surface);
+    expect(scheme.surfaceContainerHigh, scheme.surface);
+    expect(scheme.surfaceContainerHighest, scheme.surface);
     expect(scheme.onSurface, const Color(0xffffffff));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
@@ -104,14 +142,26 @@ void main() {
     expect(scheme.onPrimary, const Color(0xffffffff));
     expect(scheme.primaryContainer, scheme.primary);
     expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.primaryFixed, scheme.primary);
+    expect(scheme.primaryFixedDim, scheme.primary);
+    expect(scheme.onPrimaryFixed, scheme.onPrimary);
+    expect(scheme.onPrimaryFixedVariant, scheme.onPrimary);
     expect(scheme.secondary, const Color(0xff66fff9));
     expect(scheme.onSecondary, const Color(0xff000000));
     expect(scheme.secondaryContainer, scheme.secondary);
     expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.secondaryFixed, scheme.secondary);
+    expect(scheme.secondaryFixedDim, scheme.secondary);
+    expect(scheme.onSecondaryFixed, scheme.onSecondary);
+    expect(scheme.onSecondaryFixedVariant, scheme.onSecondary);
     expect(scheme.tertiary, scheme.secondary);
     expect(scheme.onTertiary, scheme.onSecondary);
     expect(scheme.tertiaryContainer, scheme.tertiary);
     expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.tertiaryFixed, scheme.tertiary);
+    expect(scheme.tertiaryFixedDim, scheme.tertiary);
+    expect(scheme.onTertiaryFixed, scheme.onTertiary);
+    expect(scheme.onTertiaryFixedVariant, scheme.onTertiary);
     expect(scheme.error, const Color(0xff790000));
     expect(scheme.onError, const Color(0xffffffff));
     expect(scheme.errorContainer, scheme.error);
@@ -119,6 +169,13 @@ void main() {
     expect(scheme.background, const Color(0xffffffff));
     expect(scheme.onBackground, const Color(0xff000000));
     expect(scheme.surface, const Color(0xffffffff));
+    expect(scheme.surfaceBright, scheme.surface);
+    expect(scheme.surfaceDim, scheme.surface);
+    expect(scheme.surfaceContainerLowest, scheme.surface);
+    expect(scheme.surfaceContainerLow, scheme.surface);
+    expect(scheme.surfaceContainer, scheme.surface);
+    expect(scheme.surfaceContainerHigh, scheme.surface);
+    expect(scheme.surfaceContainerHighest, scheme.surface);
     expect(scheme.onSurface, const Color(0xff000000));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
@@ -143,14 +200,26 @@ void main() {
     expect(scheme.onPrimary, const Color(0xff000000));
     expect(scheme.primaryContainer, scheme.primary);
     expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.primaryFixed, scheme.primary);
+    expect(scheme.primaryFixedDim, scheme.primary);
+    expect(scheme.onPrimaryFixed, scheme.onPrimary);
+    expect(scheme.onPrimaryFixedVariant, scheme.onPrimary);
     expect(scheme.secondary, const Color(0xff66fff9));
     expect(scheme.onSecondary, const Color(0xff000000));
     expect(scheme.secondaryContainer, scheme.secondary);
     expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.secondaryFixed, scheme.secondary);
+    expect(scheme.secondaryFixedDim, scheme.secondary);
+    expect(scheme.onSecondaryFixed, scheme.onSecondary);
+    expect(scheme.onSecondaryFixedVariant, scheme.onSecondary);
     expect(scheme.tertiary, scheme.secondary);
     expect(scheme.onTertiary, scheme.onSecondary);
     expect(scheme.tertiaryContainer, scheme.tertiary);
     expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.tertiaryFixed, scheme.tertiary);
+    expect(scheme.tertiaryFixedDim, scheme.tertiary);
+    expect(scheme.onTertiaryFixed, scheme.onTertiary);
+    expect(scheme.onTertiaryFixedVariant, scheme.onTertiary);
     expect(scheme.error, const Color(0xff9b374d));
     expect(scheme.onError, const Color(0xff000000));
     expect(scheme.errorContainer, scheme.error);
@@ -158,6 +227,13 @@ void main() {
     expect(scheme.background, const Color(0xff121212));
     expect(scheme.onBackground, const Color(0xffffffff));
     expect(scheme.surface, const Color(0xff121212));
+    expect(scheme.surfaceBright, scheme.surface);
+    expect(scheme.surfaceDim, scheme.surface);
+    expect(scheme.surfaceContainerLowest, scheme.surface);
+    expect(scheme.surfaceContainerLow, scheme.surface);
+    expect(scheme.surfaceContainer, scheme.surface);
+    expect(scheme.surfaceContainerHigh, scheme.surface);
+    expect(scheme.surfaceContainerHighest, scheme.surface);
     expect(scheme.onSurface, const Color(0xffffffff));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
@@ -208,37 +284,37 @@ void main() {
 
   test('copyWith overrides given colors', () {
     final ColorScheme scheme = const ColorScheme.light().copyWith(
-        brightness: Brightness.dark,
-        primary: const Color(0x00000001),
-        onPrimary: const Color(0x00000002),
-        primaryContainer: const Color(0x00000003),
-        onPrimaryContainer: const Color(0x00000004),
-        secondary: const Color(0x00000005),
-        onSecondary: const Color(0x00000006),
-        secondaryContainer: const Color(0x00000007),
-        onSecondaryContainer: const Color(0x00000008),
-        tertiary: const Color(0x00000009),
-        onTertiary: const Color(0x0000000A),
-        tertiaryContainer: const Color(0x0000000B),
-        onTertiaryContainer: const Color(0x0000000C),
-        error: const Color(0x0000000D),
-        onError: const Color(0x0000000E),
-        errorContainer: const Color(0x0000000F),
-        onErrorContainer: const Color(0x00000010),
-        background: const Color(0x00000011),
-        onBackground: const Color(0x00000012),
-        surface: const Color(0x00000013),
-        onSurface: const Color(0x00000014),
-        surfaceVariant: const Color(0x00000015),
-        onSurfaceVariant: const Color(0x00000016),
-        outline: const Color(0x00000017),
-        outlineVariant: const Color(0x00000117),
-        shadow: const Color(0x00000018),
-        scrim: const Color(0x00000118),
-        inverseSurface: const Color(0x00000019),
-        onInverseSurface: const Color(0x0000001A),
-        inversePrimary: const Color(0x0000001B),
-        surfaceTint: const Color(0x0000001C),
+      brightness: Brightness.dark,
+      primary: const Color(0x00000001),
+      onPrimary: const Color(0x00000002),
+      primaryContainer: const Color(0x00000003),
+      onPrimaryContainer: const Color(0x00000004),
+      secondary: const Color(0x00000005),
+      onSecondary: const Color(0x00000006),
+      secondaryContainer: const Color(0x00000007),
+      onSecondaryContainer: const Color(0x00000008),
+      tertiary: const Color(0x00000009),
+      onTertiary: const Color(0x0000000A),
+      tertiaryContainer: const Color(0x0000000B),
+      onTertiaryContainer: const Color(0x0000000C),
+      error: const Color(0x0000000D),
+      onError: const Color(0x0000000E),
+      errorContainer: const Color(0x0000000F),
+      onErrorContainer: const Color(0x00000010),
+      background: const Color(0x00000011),
+      onBackground: const Color(0x00000012),
+      surface: const Color(0x00000013),
+      onSurface: const Color(0x00000014),
+      surfaceVariant: const Color(0x00000015),
+      onSurfaceVariant: const Color(0x00000016),
+      outline: const Color(0x00000017),
+      outlineVariant: const Color(0x00000117),
+      shadow: const Color(0x00000018),
+      scrim: const Color(0x00000118),
+      inverseSurface: const Color(0x00000019),
+      onInverseSurface: const Color(0x0000001A),
+      inversePrimary: const Color(0x0000001B),
+      surfaceTint: const Color(0x0000001C),
     );
 
     expect(scheme.brightness, Brightness.dark);
@@ -350,12 +426,12 @@ void main() {
     expect(scheme.brightness, baseScheme.brightness);
   });
 
-   test('can generate a light scheme from an imageProvider', () async {
+  test('can generate a light scheme from an imageProvider', () async {
     final Uint8List blueSquareBytes = Uint8List.fromList(kBlueSquarePng);
     final ImageProvider image = MemoryImage(blueSquareBytes);
 
     final ColorScheme scheme =
-        await ColorScheme.fromImageProvider(provider: image);
+    await ColorScheme.fromImageProvider(provider: image);
 
     expect(scheme.brightness, Brightness.light);
     expect(scheme.primary, const Color(0xff4040f3));
@@ -389,7 +465,7 @@ void main() {
     expect(scheme.inversePrimary, const Color(0xffc0c1ff));
     expect(scheme.surfaceTint, const Color(0xff4040f3));
   }, skip: isBrowser, // [intended] uses dart:typed_data.
-);
+  );
 
   test('can generate a dark scheme from an imageProvider', () async {
     final Uint8List blueSquareBytes = Uint8List.fromList(kBlueSquarePng);
@@ -426,7 +502,7 @@ void main() {
     expect(scheme.onInverseSurface, const Color(0xff313034));
     expect(scheme.inversePrimary, const Color(0xff4040f3));
     expect(scheme.surfaceTint, const Color(0xffc0c1ff));
-    }, skip: isBrowser, // [intended] uses dart:isolate and io.
+  }, skip: isBrowser, // [intended] uses dart:isolate and io.
   );
 
   test('fromImageProvider() propagates TimeoutException when image cannot be rendered', () async {
@@ -438,8 +514,8 @@ void main() {
 
     expect(() async => ColorScheme.fromImageProvider(provider: image), throwsA(
       isA<Exception>().having((Exception e) => e.toString(),
-        'Timeout occurred trying to load image', contains('TimeoutException')),
-      ),
+          'Timeout occurred trying to load image', contains('TimeoutException')),
+    ),
     );
   });
 


### PR DESCRIPTION
This PR is to add 19 new `ColorScheme` roles following the Material Design 3 specs. This PR doesn't apply the new colors to `ThemeData`  or any widgets.

This PR is created to split the big change in #138521, once this is merged, another PR that contains the rest of the changes(apply new color roles to widgets and deprecate 3 more colors) will follow.

**Tone-based surface colors** (7 colors): 
* surfaceBright
* surfaceDim
* surfaceContainer
* surfaceContainerLowest
* surfaceContainerLow
* surfaceContainerHigh
* surfaceContainerHighest

**Accent color add-ons** (12 colors):
* primary/secondary/tertiary-Fixed
* primary/secondary/tertiary-FixedDim
* onPrimary/onSecondary/onTertiary-Fixed
* onPrimary/onSecondary/onTertiary-FixedVariant

Please checkout this [design doc](https://docs.google.com/document/d/1ODqivpM_6c490T4j5XIiWCDKo5YqHy78YEFqDm4S8h4/edit?usp=sharing) for more information:)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
