### PR TITLE
[github actions] ping actor of workflow on cherry pick pr creation

### DIFF
--- a/.github/workflows/easy-cp.yml
+++ b/.github/workflows/easy-cp.yml
@@ -73,8 +73,7 @@ jobs:
         run: |
           echo $PR_URL
           NEW_PR_NUMBER="${PR_URL##*/}"
-          SUCCESS_MSG="Hello @${{ github.actor }}! Looks like you attached the cp label and successfully created a cherry pick pr.<br>"
-          SUCCESS_MSG+="Please fill in the information in PR description above, and a release engineer will review this request."
+          SUCCESS_MSG=" @${{ github.actor }} please fill out the PR description above, afterwards the release team will review this request."
           gh pr comment $NEW_PR_NUMBER -R flutter/flutter -b "${SUCCESS_MSG}"
         env:
           GITHUB_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}

--- a/.github/workflows/easy-cp.yml
+++ b/.github/workflows/easy-cp.yml
@@ -57,12 +57,27 @@ jobs:
       - name: Create PR on CP success
         if: ${{ steps.attempt-cp.conclusion == 'success' }}
         working-directory: ./flutter
+        id: create-pr
         run: |
           git push https://${{ env.GITHUB_TOKEN }}@github.com/flutteractionsbot/flutter cp-${CHANNEL}-${COMMIT_SHA}
-          gh pr create --title "[CP-${CHANNEL}]${PR_TITLE}" --body-file ../PULL_REQUEST_CP_TEMPLATE.md --base ${RELEASE_BRANCH} --label "cp: review" --repo flutter/flutter --head flutteractionsbot:cp-${CHANNEL}-${COMMIT_SHA}
+          {
+            echo 'PR_URL<<EOF'
+            gh pr create --title "[CP-${CHANNEL}]${PR_TITLE}" --body-file ../PULL_REQUEST_CP_TEMPLATE.md --base ${RELEASE_BRANCH} --label "cp: review" --repo flutter/flutter --head flutteractionsbot:cp-${CHANNEL}-${COMMIT_SHA}
+            echo EOF
+          } >> "$GITHUB_ENV"
         env:
           GITHUB_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+      - name: Leave Comment on CP success
+        if: ${{ steps.create-pr.conclusion == 'success' }}
+        run: |
+          echo $PR_URL
+          NEW_PR_NUMBER="${PR_URL##*/}"
+          SUCCESS_MSG="Hello @${{ github.actor }}! Looks like you attached the cp label and successfully created a cherry pick pr.<br>"
+          SUCCESS_MSG+="Please fill in the information in PR description above, and a release engineer will review this request."
+          gh pr comment $NEW_PR_NUMBER -R flutter/flutter -b "${SUCCESS_MSG}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
       - name: Leave Comment on CP failure
         if: ${{ failure() && steps.attempt-cp.conclusion == 'failure' }}
         run: |


### PR DESCRIPTION
Context: Follow up from sync with @itsjustkevin today. Tag and ping the actor of workflow, when the cherry pick pull request is successfully created.

1. actor of workflow will be the username of the user that triggered the initial workflow run. i.e., whoever labels the PR. This person might not necessarily be the author of the cherry pick PR.
2. PR number of newly created cherry pick PR is parsed from the output of "gh pr create" as a multi line string.

Tested: on cp success: https://github.com/flutter/flutter/pull/142674 pings the actor of workflow (not the pr author). on cp failure: [example workflow](https://github.com/XilaiZhang/miscellaneous-side-project/actions/runs/7734400373/job/21088324523) leaves a msg on the original PR.