### PR TITLE
Remove outdated arm64_armv7 check

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -278,7 +278,6 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       throw TaskResult.failure('$pluginFrameworkPath does not link on Flutter');
     }
 
-    // TODO(jmagman): Remove ios-arm64_armv7 checks when CI is updated to Xcode 14.
     final String transitiveDependencyFrameworkPath = path.join(
       outputPath,
       mode,
@@ -288,23 +287,11 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       'Reachability',
     );
 
-    final String armv7TransitiveDependencyFrameworkPath = path.join(
-      outputPath,
-      mode,
-      'Reachability.xcframework',
-      'ios-arm64_armv7',
-      'Reachability.framework',
-      'Reachability',
-    );
-
-    final bool transitiveDependencyExists = exists(File(transitiveDependencyFrameworkPath));
-    final bool armv7TransitiveDependencyExists = exists(File(armv7TransitiveDependencyFrameworkPath));
-    if (!transitiveDependencyExists && !armv7TransitiveDependencyExists) {
+    if (!exists(File(transitiveDependencyFrameworkPath))) {
       throw TaskResult.failure('Expected debug Flutter engine artifact binary to exist');
     }
 
-    if ((transitiveDependencyExists && await _linksOnFlutter(transitiveDependencyFrameworkPath)) ||
-        (armv7TransitiveDependencyExists && await _linksOnFlutter(armv7TransitiveDependencyFrameworkPath))) {
+    if (await _linksOnFlutter(transitiveDependencyFrameworkPath)) {
       throw TaskResult.failure(
           'Transitive dependency $transitiveDependencyFrameworkPath unexpectedly links on Flutter');
     }


### PR DESCRIPTION
CI is running Xcode 15, remove outdated arm64_armv7 framework checks.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
