### PR TITLE
Fix gen_defaults test randomness

### DIFF
--- a/dev/tools/gen_defaults/test/gen_defaults_test.dart
+++ b/dev/tools/gen_defaults/test/gen_defaults_test.dart
@@ -12,7 +12,15 @@ import 'package:test/test.dart';
 
 void main() {
   final TokenLogger logger = tokenLogger;
+  // Required init with empty at least once to init late fields.
+  // Then we can use the `clear` method.
   logger.init(allTokens: <String, dynamic>{}, versionMap: <String, List<String>>{});
+
+  setUp(() {
+    // Cleanup the global token logger before each test, to not be tied to a particular
+    // test order.
+    logger.clear();
+  });
 
   test('Templates will append to the end of a file', () {
     final Directory tempDir = Directory.systemTemp.createTempSync('gen_defaults');


### PR DESCRIPTION
This PR improves the gen_defaults tests to not be tied to a particular order of execution.
Since there is a global class that holds the state of the used/not used tokens, we need to clear this logger before each test.

Fixes https://github.com/flutter/flutter/issues/142716

cc @zanderso @QuncCccccc 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
