### PR TITLE
Magnifier cleanup

### DIFF
--- a/packages/flutter/lib/src/cupertino/magnifier.dart
+++ b/packages/flutter/lib/src/cupertino/magnifier.dart
@@ -245,6 +245,7 @@ class CupertinoMagnifier extends StatelessWidget {
         color: Color.fromARGB(25, 0, 0, 0),
         blurRadius: 11,
         spreadRadius: 0.2,
+        blurStyle: BlurStyle.outer,
       ),
     ],
     this.borderSide =
@@ -252,22 +253,27 @@ class CupertinoMagnifier extends StatelessWidget {
     this.inOutAnimation,
   });
 
-  /// The shadows displayed under the magnifier.
+  /// A list of shadows cast by the [Magnifier].
+  ///
+  /// The blur should use [BlurStyle.outer] to avoid the shadow itself occluding
+  /// the magnifier (the shadow is drawn above the magnifier).
   final List<BoxShadow> shadows;
 
   /// The border, or "rim", of this magnifier.
+  ///
+  /// This border is drawn on a [RoundedRectangleBorder] with radius
+  /// [borderRadius], and increases the [size] of the magnifier by the
+  /// [BorderSide.width].
   final BorderSide borderSide;
 
   /// The vertical offset that the magnifier is along the Y axis above
   /// the focal point.
-  @visibleForTesting
   static const double kMagnifierAboveFocalPoint = -26;
 
   /// The default size of the magnifier.
   ///
   /// This is public so that positioners can choose to depend on it, although
   /// it is overridable.
-  @visibleForTesting
   static const Size kDefaultSize = Size(80, 47.5);
 
   /// The duration that this magnifier animates in / out for.
@@ -278,9 +284,13 @@ class CupertinoMagnifier extends StatelessWidget {
   static const Duration _kInOutAnimationDuration = Duration(milliseconds: 150);
 
   /// The size of this magnifier.
+  ///
+  /// The size does not include the [borderSide] or [shadows].
   final Size size;
 
   /// The border radius of this magnifier.
+  ///
+  /// The magnifier's shape is a [RoundedRectangleBorder] with this radius.
   final BorderRadius borderRadius;
 
   /// This [RawMagnifier]'s controller.

--- a/packages/flutter/lib/src/material/magnifier.dart
+++ b/packages/flutter/lib/src/material/magnifier.dart
@@ -7,39 +7,38 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
-/// {@template widgets.material.magnifier.magnifier}
 /// A [Magnifier] positioned by rules dictated by the native Android magnifier.
-/// {@endtemplate}
 ///
-/// {@template widgets.material.magnifier.positionRules}
-/// Positions itself based on [magnifierInfo]. Specifically, follows the
-/// following rules:
-/// - Tracks the gesture's x coordinate, but clamped to the beginning and end of the
-///   currently editing line.
-/// - Focal point may never contain anything out of bounds.
-/// - Never goes out of bounds vertically; offset until the entire magnifier is in the screen. The
-///   focal point, regardless of this transformation, always points to the touch y coordinate.
-/// - If just jumped between lines (prevY != currentY) then animate for duration
-///   [jumpBetweenLinesAnimationDuration].
-/// {@endtemplate}
+/// The positioning rules are based on [magnifierInfo], as follows:
+///
+/// - The loupe tracks the gesture's _x_ coordinate, clamping to the beginning
+///   and end of the currently editing line.
+///
+/// - The focal point never contains anything out of the bounds of the text
+///   field or other widget being magnified (the [MagnifierInfo.fieldBounds]).
+///
+/// - The focal point always remains aligned with the _y_ cordinate of the touch.
+///
+/// - The loupe always remains on the screen.
+///
+/// - When the line targeted by the touch's _y_ coordinate changes, the position
+///   is animated over [jumpBetweenLinesAnimationDuration].
+///
+/// This behavior was based on the Android 12 source code, where possible, and
+/// on eyeballing a Pixel 6 running Android 12 otherwise.
 class TextMagnifier extends StatefulWidget {
-  /// {@macro widgets.material.magnifier.magnifier}
+  /// Creates a [TextMagnifier].
   ///
-  /// {@template widgets.material.magnifier.androidDisclaimer}
-  /// These constants and default parameters were taken from the
-  /// Android 12 source code where directly transferable, and eyeballed on
-  /// a Pixel 6 running Android 12 otherwise.
-  /// {@endtemplate}
-  ///
-  /// {@macro widgets.material.magnifier.positionRules}
+  /// The [magnifierInfo] must be provided, and must be updated with new values
+  /// as the user's touch changes.
   const TextMagnifier({
     super.key,
     required this.magnifierInfo,
   });
 
-  /// A [TextMagnifierConfiguration] that returns a [CupertinoTextMagnifier] on iOS,
-  /// [TextMagnifier] on Android, and null on all other platforms, and shows the editing handles
-  /// only on iOS.
+  /// A [TextMagnifierConfiguration] that returns a [CupertinoTextMagnifier] on
+  /// iOS, [TextMagnifier] on Android, and null on all other platforms, and
+  /// shows the editing handles only on iOS.
   static TextMagnifierConfiguration adaptiveMagnifierConfiguration = TextMagnifierConfiguration(
     shouldDisplayHandlesInMagnifier: defaultTargetPlatform == TargetPlatform.iOS,
     magnifierBuilder: (
@@ -55,7 +54,7 @@ class TextMagnifier extends StatefulWidget {
           );
         case TargetPlatform.android:
           return TextMagnifier(
-              magnifierInfo: magnifierInfo,
+            magnifierInfo: magnifierInfo,
           );
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
@@ -68,15 +67,14 @@ class TextMagnifier extends StatefulWidget {
 
   /// The duration that the position is animated if [TextMagnifier] just switched
   /// between lines.
-  @visibleForTesting
-  static const Duration jumpBetweenLinesAnimationDuration =
-      Duration(milliseconds: 70);
+  static const Duration jumpBetweenLinesAnimationDuration = Duration(milliseconds: 70);
 
-  /// [TextMagnifier] positions itself based on [magnifierInfo].
+  /// The current status of the user's touch.
   ///
-  /// {@macro widgets.material.magnifier.positionRules}
-  final ValueNotifier<MagnifierInfo>
-      magnifierInfo;
+  /// As the value of the [magnifierInfo] changes, the position of the loupe is
+  /// adjusted automatically, according to the rules described in the
+  /// [TextMagnifier] class description.
+  final ValueNotifier<MagnifierInfo> magnifierInfo;
 
   @override
   State<TextMagnifier> createState() => _TextMagnifierState();
@@ -130,7 +128,6 @@ class _TextMagnifierState extends State<TextMagnifier> {
     super.didUpdateWidget(oldWidget);
   }
 
-  /// {@macro widgets.material.magnifier.positionRules}
   void _determineMagnifierPositionAndFocalPoint() {
     final MagnifierInfo selectionInfo =
         widget.magnifierInfo.value;
@@ -250,16 +247,22 @@ class _TextMagnifierState extends State<TextMagnifier> {
   }
 }
 
-/// A Material styled magnifying glass.
+/// A Material-styled magnifying glass.
 ///
 /// {@macro flutter.widgets.magnifier.intro}
 ///
-/// This widget focuses on mimicking the _style_ of the magnifier on material. For a
-/// widget that is focused on mimicking the behavior of a material magnifier, see [TextMagnifier].
+/// This widget focuses on mimicking the _style_ of the magnifier on material.
+/// For a widget that is focused on mimicking the _behavior_ of a material
+/// magnifier, see [TextMagnifier], which uses [Magnifier].
+///
+/// The styles implemented in this widget were based on the Android 12 source
+/// code, where possible, and on eyeballing a Pixel 6 running Android 12
+/// otherwise.
 class Magnifier extends StatelessWidget {
   /// Creates a [RawMagnifier] in the Material style.
   ///
-  /// {@macro widgets.material.magnifier.androidDisclaimer}
+  /// The shadows, if specified, should use [BlurStyle.outer] to avoid obscuring
+  /// the magnified image.
   const Magnifier({
     super.key,
     this.additionalFocalPointOffset = Offset.zero,
@@ -267,10 +270,12 @@ class Magnifier extends StatelessWidget {
     this.filmColor = const Color.fromARGB(8, 158, 158, 158),
     this.shadows = const <BoxShadow>[
       BoxShadow(
-          blurRadius: 1.5,
-          offset: Offset(0, 2),
-          spreadRadius: 0.75,
-          color: Color.fromARGB(25, 0, 0, 0))
+        blurRadius: 1.5,
+        offset: Offset(0, 2),
+        spreadRadius: 0.75,
+        color: Color.fromARGB(25, 0, 0, 0),
+        blurStyle: BlurStyle.outer,
+      )
     ],
     this.size = Magnifier.kDefaultMagnifierSize,
   });
@@ -280,14 +285,13 @@ class Magnifier extends StatelessWidget {
   /// The size of the magnifier may be modified through the constructor;
   /// [kDefaultMagnifierSize] is extracted from the default parameter of
   /// [Magnifier]'s constructor so that positioners may depend on it.
-  @visibleForTesting
   static const Size kDefaultMagnifierSize = Size(77.37, 37.9);
 
   /// The vertical distance that the magnifier should be above the focal point.
   ///
-  /// [kStandardVerticalFocalPointShift] is an unmodifiable constant so that positioning of this
-  /// [Magnifier] can be done with a guaranteed size, as opposed to an estimate.
-  @visibleForTesting
+  /// [kStandardVerticalFocalPointShift] is an unmodifiable constant so that
+  /// positioning of this [Magnifier] can be done with a guaranteed size, as
+  /// opposed to an estimate.
   static const double kStandardVerticalFocalPointShift = 22;
 
   static const double _borderRadius = 40;
@@ -296,11 +300,13 @@ class Magnifier extends StatelessWidget {
   /// Any additional offset the focal point requires to "point"
   /// to the correct place.
   ///
-  /// This is useful for instances where the magnifier is not pointing to something
-  /// directly below it.
+  /// This is useful for instances where the magnifier is not pointing to
+  /// something directly below it.
   final Offset additionalFocalPointOffset;
 
   /// The border radius for this magnifier.
+  ///
+  /// The magnifier's shape is a [RoundedRectangleBorder] with this radius.
   final BorderRadius borderRadius;
 
   /// The color to tint the image in this [Magnifier].
@@ -310,12 +316,15 @@ class Magnifier extends StatelessWidget {
   /// the background.
   final Color filmColor;
 
-  /// The shadows for this [Magnifier].
+  /// A list of shadows cast by the [Magnifier].
+  ///
+  /// The blur should use [BlurStyle.outer] to avoid the shadow itself occluding
+  /// the magnifier (the shadow is drawn above the magnifier).
   final List<BoxShadow> shadows;
 
   /// The [Size] of this [Magnifier].
   ///
-  /// This size does not include the border.
+  /// The [shadows] are drawn outside of the [size].
   final Size size;
 
   @override

--- a/packages/flutter/lib/src/material/shadows.dart
+++ b/packages/flutter/lib/src/material/shadows.dart
@@ -18,6 +18,15 @@ import 'package:flutter/painting.dart';
 /// This is useful when simulating a shadow with a [BoxDecoration] or other
 /// class that uses a list of [BoxShadow] objects.
 ///
+/// Shadows defined by [kElevationToShadow] use [BlurStyle.normal]. To convert a
+/// shadow from [kElevationToShadow] to use a different [BlurStyle] (e.g. to use
+/// it in a [MagnifierDecoration]), consider an expression such as the
+/// following:
+///
+/// ```dart
+/// kElevationToShadow[12]!.map((BoxShadow shadow) => shadow.copyWith(blurStyle: BlurStyle.outer)).toList(),
+/// ```
+///
 /// See also:
 ///
 ///  * [Material], which takes an arbitrary double for its elevation and generates

--- a/packages/flutter/lib/src/painting/box_shadow.dart
+++ b/packages/flutter/lib/src/painting/box_shadow.dart
@@ -44,6 +44,9 @@ class BoxShadow extends ui.Shadow {
   /// The [BlurStyle] to use for this shadow.
   ///
   /// Defaults to [BlurStyle.normal].
+  ///
+  /// When [debugDisableShadows] is true, the [blurStyle] is ignored and acts as
+  /// if [BlurStyle.normal] was used.
   final BlurStyle blurStyle;
 
   /// Create the [Paint] object that corresponds to this shadow description.
@@ -75,6 +78,24 @@ class BoxShadow extends ui.Shadow {
       blurRadius: blurRadius * factor,
       spreadRadius: spreadRadius * factor,
       blurStyle: blurStyle,
+    );
+  }
+
+  /// Creates a copy of this object but with the given fields replaced with the
+  /// new values.
+  BoxShadow copyWith({
+    Color? color,
+    Offset? offset,
+    double? blurRadius,
+    double? spreadRadius,
+    BlurStyle? blurStyle,
+  }) {
+    return BoxShadow(
+      color: color ?? this.color,
+      offset: offset ?? this.offset,
+      blurRadius: blurRadius ?? this.blurRadius,
+      spreadRadius: spreadRadius ?? this.spreadRadius,
+      blurStyle: blurStyle ?? this.blurStyle,
     );
   }
 

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -13,11 +13,11 @@ import 'package:flutter/foundation.dart';
 /// the rendering of shadows is not guaranteed to be pixel-for-pixel identical from
 /// version to version (or even from run to run).
 ///
-/// In those tests, this is usually set to false at the beginning of a test and back
-/// to true before the end of the test case.
+/// This is set to true in [AutomatedTestWidgetsFlutterBinding]. Tests will fail
+/// if they change this value and do not reset it before the end of the test.
 ///
-/// If it remains true when the test ends, an exception is thrown to avoid state
-/// leaking from one test case to another.
+/// When this is set, [BoxShadow]s render as the [BoxShadow.blurStyle] was
+/// [BlurStyle.normal] regardless of the actual specified blur style.
 bool debugDisableShadows = false;
 
 /// Signature for a method that returns an [HttpClient].

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -812,4 +812,17 @@ void main() {
 
     info.dispose();
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/87442
+
+  test('BoxShadow.copyWith', () {
+    expect(const BoxShadow(), isNot(const BoxShadow(color: Color(0xFF112233))));
+    expect(const BoxShadow().copyWith(color: const Color(0xFF112233)), const BoxShadow(color: Color(0xFF112233)));
+    expect(const BoxShadow(), isNot(const BoxShadow(offset: Offset(1.0, 2.0))));
+    expect(const BoxShadow().copyWith(offset: Offset(1.0, 2.0)), const BoxShadow(offset: Offset(1.0, 2.0)));
+    expect(const BoxShadow(), isNot(const BoxShadow(blurRadius: 123.0)));
+    expect(const BoxShadow().copyWith(blurRadius: 123.0), const BoxShadow(blurRadius: 123.0));
+    expect(const BoxShadow(), isNot(const BoxShadow(spreadRadius: 123.0)));
+    expect(const BoxShadow().copyWith(spreadRadius: 123.0), const BoxShadow(spreadRadius: 123.0));
+    expect(const BoxShadow(), isNot(const BoxShadow(blurStyle: BlurStyle.outer)));
+    expect(const BoxShadow().copyWith(blurStyle: BlurStyle.outer), const BoxShadow(blurStyle: BlurStyle.outer));
+  });
 }

--- a/packages/flutter/test/widgets/magnifier_test.dart
+++ b/packages/flutter/test/widgets/magnifier_test.dart
@@ -80,10 +80,11 @@ void main() {
                     magnificationScale: magnificationScale,
                     decoration: MagnifierDecoration(shadows: <BoxShadow>[
                       BoxShadow(
-                        spreadRadius: 10,
-                        blurRadius: 10,
-                        color: Colors.green,
-                        offset: Offset(5, 5),
+                        spreadRadius: 10.0,
+                        blurRadius: 10.0,
+                        color: Color(0x804caf50), // semi-transparent so that we can see the magnifier below the shadow
+                        offset: Offset(5.0, 5.0),
+                        blurStyle: BlurStyle.outer, // this is ignored because debugDisableShadows is enabled
                       ),
                     ]),
                   ),
@@ -92,12 +93,10 @@ void main() {
             ),
           )));
 
-      await tester.pumpAndSettle();
-
-      // Should look like an orange screen, with two pink boxes.
-      // One pink box is in the magnifier (so has a green shadow) and is double
-      // size (from magnification). Also, the magnifier should be slightly orange
-      // since it has opacity.
+      // This should be an orange screen with a pink box in the center, and a green box offset to its upper left.
+      // Where the green box overlaps the pink box it should be purpleish gray.
+      // The green box should also contain its own purpleish gray box (the magnified pink box).
+      // The purpleish gray is semitransparent green blended with pink.
       await expectLater(
         find.byKey(appKey),
         matchesGoldenFile('widgets.magnifier.styled.png'),
@@ -324,5 +323,12 @@ void main() {
         });
       }
     });
+  });
+
+  testWidgets('MagnifierInfo.toString', (WidgetTester tester) async {
+    expect(MagnifierInfo.empty.toString(),
+      'MagnifierInfo(position: Offset(0.0, 0.0), line: Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), '
+      'caret: Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), field: Rect.fromLTRB(0.0, 0.0, 0.0, 0.0))',
+    );
   });
 }


### PR DESCRIPTION
- Refactor the MagnifierDecoration to be its own class rather than being a stunted subclass of ShapeDecoration.
- Remove some of the clips involved in magnifiers (should in theory improve performance, but that's untested). Instead, use BlurStyle.outer to avoid painting the shadow in the magnifier. (We could continue to push on this and eventually replace MagnifierDecoration with a fully-fledged ShapeDecoration itself, but that's something for another PR.)
- Improve the magnifier documentation.
- Fix some `operator ==`s and add a missing `toString`.
- Remove some unnecessary `@visibleForTesting`s.
- Add `BoxShadow.copyWith` which somehow we've failed to add all this time.