### PR TITLE
Fix CupertinoPageScaffold resizeToAvoidBottomInset

### DIFF
--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -151,15 +151,17 @@ class _CupertinoPageScaffoldState extends State<CupertinoPageScaffold> {
           ),
         );
       }
-    } else {
+    } else if (widget.resizeToAvoidBottomInset) {
       // If there is no navigation bar, still may need to add padding in order
       // to support resizeToAvoidBottomInset.
-      final double bottomPadding = widget.resizeToAvoidBottomInset
-          ? existingMediaQuery.viewInsets.bottom
-          : 0.0;
-      paddedContent = Padding(
-        padding: EdgeInsets.only(bottom: bottomPadding),
-        child: paddedContent,
+      paddedContent = MediaQuery(
+        data: existingMediaQuery.copyWith(
+          viewInsets: existingMediaQuery.viewInsets.copyWith(bottom: 0)
+        ),
+        child: Padding(
+          padding: EdgeInsets.only(bottom: existingMediaQuery.viewInsets.bottom),
+          child: paddedContent,
+        ),
       );
     }
 

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -495,29 +495,39 @@ void main() {
             navigationBar: showNavigationBar ? const CupertinoNavigationBar(
               middle: Text('Title'),
             ) : null,
-            child: const Center(
-              child: CupertinoTextField(),
+            child: Builder(
+              builder: (BuildContext context) => Center(
+                child: CupertinoTextField(
+                  placeholder: MediaQuery.viewInsetsOf(context).toString(),
+                ),
+              ),
             ),
           ),
         ),
       );
     }
 
+    // CupertinoPageScaffold should consume the viewInsets in all cases
+    final String expectedViewInsets = EdgeInsets.zero.toString();
+
     // When there is a nav bar and no keyboard.
     await tester.pumpWidget(buildFrame(true, false));
     final Offset positionNoInsetWithNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
+    expect((find.byType(CupertinoTextField).evaluate().first.widget as CupertinoTextField).placeholder, expectedViewInsets);
 
     // When there is a nav bar and keyboard, the CupertinoTextField moves up.
     await tester.pumpWidget(buildFrame(true, true));
     await tester.pumpAndSettle();
     final Offset positionWithInsetWithNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
     expect(positionWithInsetWithNavBar.dy, lessThan(positionNoInsetWithNavBar.dy));
+    expect((find.byType(CupertinoTextField).evaluate().first.widget as CupertinoTextField).placeholder, expectedViewInsets);
 
     // When there is no nav bar and no keyboard, the CupertinoTextField is still
     // centered.
     await tester.pumpWidget(buildFrame(false, false));
     final Offset positionNoInsetNoNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
     expect(positionNoInsetNoNavBar, equals(positionNoInsetWithNavBar));
+    expect((find.byType(CupertinoTextField).evaluate().first.widget as CupertinoTextField).placeholder, expectedViewInsets);
 
     // When there is a keyboard but no nav bar, the CupertinoTextField also
     // moves up to the same position as when there is a keyboard and nav bar.
@@ -526,6 +536,7 @@ void main() {
     final Offset positionWithInsetNoNavBar = tester.getTopLeft(find.byType(CupertinoTextField));
     expect(positionWithInsetNoNavBar.dy, lessThan(positionNoInsetNoNavBar.dy));
     expect(positionWithInsetNoNavBar, equals(positionWithInsetWithNavBar));
+    expect((find.byType(CupertinoTextField).evaluate().first.widget as CupertinoTextField).placeholder, expectedViewInsets);
   });
 
   testWidgets('textScaleFactor is set to 1.0', (WidgetTester tester) async {


### PR DESCRIPTION
Need to create a `MediaQuery` to expose the fact that the `viewInsets` have been consumed.

Fixes #142775

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
