### PR TITLE
Fixed test in language_version_test.dart that failed when shuffling, …

### DIFF
--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -2,13 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(team-tool): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/142376
-// Fails with "flutter test --test-randomize-ordering-seed=20240127"
-@Tags(<String>['no-shuffle'])
-library;
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/dart/language_version.dart';
@@ -282,6 +275,7 @@ library funstuff;
 
   testWithoutContext('defaults to current version if package lookup returns null', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license


### PR DESCRIPTION
…and removed the no-shuffle tag.

This PR fixes #142376 by fixing the flaky test in language_version_test.dart and removes the no-shuffle tag.
 
## The Problem
The test expected the language version that is set at the top of the test file ('2.13' set in language_version_test.dart – line 14) but defaulted to the language version set in the file it is testing ('2.12' is set in language_version.dart).

This problem was hidden when some other test ran before this test and set up the language version correctly.
 
## The Fix
Make the test itself load the default language version we are testing against.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.