### PR TITLE
Fix: performance improvement on golden test comparison

### DIFF
--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -175,7 +175,7 @@ mixin LocalComparisonOutput {
 /// Returns a [ComparisonResult] to describe the pixel differential of the
 /// [test] and [master] image bytes provided.
 Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async {
-  if (identical(test, master)) {
+  if (listEquals(test, master)) {
     return ComparisonResult(
       passed: true,
       diffPercent: 0.0,

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -175,18 +175,18 @@ mixin LocalComparisonOutput {
 /// Returns a [ComparisonResult] to describe the pixel differential of the
 /// [test] and [master] image bytes provided.
 Future<ComparisonResult> compareLists(List<int>? test, List<int>? master) async {
-  if (listEquals(test, master)) {
-    return ComparisonResult(
-      passed: true,
-      diffPercent: 0.0,
-    );
-  }
-
   if (test == null || master == null || test.isEmpty || master.isEmpty) {
     return ComparisonResult(
       passed: false,
       diffPercent: 1.0,
       error: 'Pixel test failed, null image provided.',
+    );
+  }
+
+  if (listEquals(test, master)) {
+    return ComparisonResult(
+      passed: true,
+      diffPercent: 0.0,
     );
   }
 

--- a/packages/flutter_test/test/goldens_test.dart
+++ b/packages/flutter_test/test/goldens_test.dart
@@ -9,8 +9,8 @@ import 'dart:ui' as ui;
 
 import 'package:file/memory.dart';
 import 'package:flutter/foundation.dart' show DiagnosticLevel, DiagnosticPropertiesBuilder, DiagnosticsNode, FlutterError;
-import 'package:flutter_test/flutter_test.dart' hide test;
 import 'package:flutter_test/flutter_test.dart' as test_package;
+import 'package:flutter_test/flutter_test.dart' hide test;
 
 // 1x1 transparent pixel
 const List<int> _kExpectedPngBytes = <int>[
@@ -84,6 +84,15 @@ void main() {
       expect(goldenFileComparator, isA<LocalFileComparator>());
       final LocalFileComparator comparator = goldenFileComparator as LocalFileComparator;
       expect(comparator.basedir.path, contains('flutter_test'));
+    });
+
+    test('image comparison should not loop over all pixels when the data is the same', () async {
+      final List<int> invalidImageData1 = Uint8List.fromList(<int>[127]);
+      final List<int> invalidImageData2 = Uint8List.fromList(<int>[127]);
+      // This will fail if the comparison algorithm tries to generate the images
+      // to loop over every pixel which is not necessary when test and master
+      // is exactly the same (for performance reasons).
+      await GoldenFileComparator.compareLists(invalidImageData1, invalidImageData2);
     });
   });
 


### PR DESCRIPTION
During golden test image comparison 2 lists of a different type are compared with the method "identical", so this will never be true. The test image is a _Uint8ArrayView while the master image is an Uint8List. So that results in always a heavy computation to get the difference between the test and the master image.

When you run this test snippet I go from 51 seconds to 14 seconds:
```dart
import 'package:flutter/material.dart';
import 'package:flutter_test/flutter_test.dart';

void main() {
  for (int i = 0; i < 100; i++) {
    testWidgets('Small test', (WidgetTester tester) async {
      await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Text('jo')));
      await expectLater(find.byType(Text), matchesGoldenFile('main.png'));
    });
  }
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
