### PR TITLE
Fix M3 text field height + initial step for input decorator M3 test migration [prod-leak-fix]

### DIFF
--- a/examples/api/test/material/input_decorator/input_decoration.prefix_icon.0_test.dart
+++ b/examples/api/test/material/input_decorator/input_decoration.prefix_icon.0_test.dart
@@ -11,6 +11,6 @@ void main() {
     await tester.pumpWidget(
       const example.PrefixIconExampleApp(),
     );
-    expect(tester.getCenter(find.byIcon(Icons.person)).dy, 32.0);
+    expect(tester.getCenter(find.byIcon(Icons.person)).dy, 28.0);
   });
 }

--- a/examples/api/test/material/input_decorator/input_decoration.suffix_icon.0_test.dart
+++ b/examples/api/test/material/input_decorator/input_decoration.suffix_icon.0_test.dart
@@ -11,6 +11,6 @@ void main() {
     await tester.pumpWidget(
       const example.SuffixIconExampleApp(),
     );
-    expect(tester.getCenter(find.byIcon(Icons.remove_red_eye)).dy, 32.0);
+    expect(tester.getCenter(find.byIcon(Icons.remove_red_eye)).dy, 28.0);
   });
 }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2393,30 +2393,42 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 
     final EdgeInsets contentPadding;
     final double floatingLabelHeight;
-    if (decoration.isCollapsed
-        ?? themeData.inputDecorationTheme.isCollapsed) {
+
+    if (decoration.isCollapsed ?? themeData.inputDecorationTheme.isCollapsed) {
       floatingLabelHeight = 0.0;
       contentPadding = decorationContentPadding ?? EdgeInsets.zero;
     } else if (!border.isOutline) {
       // 4.0: the vertical gap between the inline elements and the floating label.
       floatingLabelHeight = MediaQuery.textScalerOf(context).scale(4.0 + 0.75 * labelStyle.fontSize!);
       if (decoration.filled ?? false) {
-        contentPadding = decorationContentPadding ?? (decorationIsDense
-          ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
-          : const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 12.0));
+        contentPadding = decorationContentPadding ?? (Theme.of(context).useMaterial3
+          ? decorationIsDense
+            ? const EdgeInsets.fromLTRB(12.0, 4.0, 12.0, 4.0)
+            : const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
+          : decorationIsDense
+            ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
+            : const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 12.0));
       } else {
-        // Not left or right padding for underline borders that aren't filled
+        // No left or right padding for underline borders that aren't filled
         // is a small concession to backwards compatibility. This eliminates
         // the most noticeable layout change introduced by #13734.
-        contentPadding = decorationContentPadding ?? (decorationIsDense
-          ? const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
-          : const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
+        contentPadding = decorationContentPadding ?? (Theme.of(context).useMaterial3
+          ? decorationIsDense
+            ? const EdgeInsets.fromLTRB(0.0, 4.0, 0.0, 4.0)
+            : const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
+          : decorationIsDense
+            ? const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
+            : const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
       }
     } else {
       floatingLabelHeight = 0.0;
-      contentPadding = decorationContentPadding ?? (decorationIsDense
-        ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
-        : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
+      contentPadding = decorationContentPadding ?? (Theme.of(context).useMaterial3
+        ? decorationIsDense
+          ? const EdgeInsets.fromLTRB(12.0, 16.0, 12.0, 8.0)
+          : const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
+        : decorationIsDense
+          ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
+          : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
     }
 
     final _Decorator decorator = _Decorator(

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -234,7 +234,7 @@ void main() {
 
     expect(value, null); // disabledHint shown.
     final Offset hintEmptyLabel = tester.getTopLeft(find.text('labelText'));
-    expect(hintEmptyLabel, const Offset(0.0, 12.0));
+    expect(hintEmptyLabel, const Offset(0.0, 8.0));
   });
 
   testWidgets('label position test - show disabledHint: enable + null item', (WidgetTester tester) async {
@@ -259,7 +259,7 @@ void main() {
 
     expect(value, null); // disabledHint shown.
     final Offset hintEmptyLabel = tester.getTopLeft(find.text('labelText'));
-    expect(hintEmptyLabel, const Offset(0.0, 12.0));
+    expect(hintEmptyLabel, const Offset(0.0, 8.0));
   });
 
   testWidgets('label position test - show disabledHint: enable + empty item', (WidgetTester tester) async {
@@ -284,7 +284,7 @@ void main() {
 
     expect(value, null); // disabledHint shown.
     final Offset hintEmptyLabel = tester.getTopLeft(find.text('labelText'));
-    expect(hintEmptyLabel, const Offset(0.0, 12.0));
+    expect(hintEmptyLabel, const Offset(0.0, 8.0));
   });
 
   testWidgets('label position test - show hint: enable + empty item', (WidgetTester tester) async {
@@ -309,7 +309,7 @@ void main() {
 
     expect(value, null); // hint shown.
     final Offset hintEmptyLabel = tester.getTopLeft(find.text('labelText'));
-    expect(hintEmptyLabel, const Offset(0.0, 12.0));
+    expect(hintEmptyLabel, const Offset(0.0, 8.0));
   });
 
   testWidgets('label position test - no hint shown: enable + no selected + disabledHint', (WidgetTester tester) async {
@@ -347,7 +347,7 @@ void main() {
 
     expect(value, null);
     final Offset hintEmptyLabel = tester.getTopLeft(find.text('labelText'));
-    expect(hintEmptyLabel, const Offset(0.0, 24.0));
+    expect(hintEmptyLabel, const Offset(0.0, 20.0));
   });
 
   testWidgets('label position test - show selected item: disabled + hint + disabledHint', (WidgetTester tester) async {
@@ -386,7 +386,7 @@ void main() {
 
     expect(value, 1);
     final Offset hintEmptyLabel = tester.getTopLeft(find.text('labelText'));
-    expect(hintEmptyLabel, const Offset(0.0, 12.0));
+    expect(hintEmptyLabel, const Offset(0.0, 8.0));
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/82910
@@ -603,7 +603,7 @@ void main() {
 
     final RenderBox box =
     tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
-    expect(box.size.height, 72.0);
+    expect(box.size.height, 64.0);
   });
 
   testWidgets('DropdownButtonFormField.isDense is true by default', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2408,11 +2408,11 @@ void main() {
     await tester.pumpWidget(buildFrame(isFormField: true, buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, autofocus: true));
     await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
     expect(focusNode.hasPrimaryFocus, isTrue);
-    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 264.0, 800.0, 336.0), color: const Color(0x1f000000)));
+    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 264.0, 800.0, 332.0), color: const Color(0x1f000000)));
 
     await tester.pumpWidget(buildFrame(isFormField: true, buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, focusColor: const Color(0xff00ff00)));
     await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
-    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 264.0, 800.0, 336.0), color: const Color(0x1f00ff00)));
+    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 264.0, 800.0, 332.0), color: const Color(0x1f00ff00)));
   });
 
   testWidgets("DropdownButton won't be focused if not enabled", (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -2408,11 +2408,11 @@ void main() {
     await tester.pumpWidget(buildFrame(isFormField: true, buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, autofocus: true));
     await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
     expect(focusNode.hasPrimaryFocus, isTrue);
-    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 264.0, 800.0, 332.0), color: const Color(0x1f000000)));
+    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 268.0, 800.0, 332.0), color: const Color(0x1f000000)));
 
     await tester.pumpWidget(buildFrame(isFormField: true, buttonKey: buttonKey, onChanged: onChanged, focusNode: focusNode, focusColor: const Color(0xff00ff00)));
     await tester.pumpAndSettle(); // Pump a frame for autofocus to take effect.
-    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 264.0, 800.0, 332.0), color: const Color(0x1f00ff00)));
+    expect(find.byType(Material), paints ..rect(rect: const Rect.fromLTRB(0.0, 268.0, 800.0, 332.0), color: const Color(0x1f00ff00)));
   });
 
   testWidgets("DropdownButton won't be focused if not enabled", (WidgetTester tester) async {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -303,10 +303,7 @@ void main() {
 }
 
 void runAllM2Tests() {
-  testWidgets('InputDecorator input/label text layout',
-  // TODO(polina-c): clean up leaks, https://github.com/flutter/flutter/issues/134787 [leaks-to-clean]
-  experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
-  (WidgetTester tester) async {
+  testWidgets('InputDecorator input/label text layout', (WidgetTester tester) async {
     // The label appears above the input text
     await tester.pumpWidget(
       buildInputDecoratorM2(

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5132,8 +5132,8 @@ void runAllM2Tests() {
             enabled: enabled,
             filled: filled,
             hoverColor: hoverColor,
-            disabledBorder: OutlineInputBorder(borderSide: BorderSide(color: disabledColor)),
-            border:  OutlineInputBorder(borderSide: BorderSide(color: enabledBorderColor)),
+            disabledBorder: const OutlineInputBorder(borderSide: BorderSide(color: disabledColor)),
+            border: const OutlineInputBorder(borderSide: BorderSide(color: enabledBorderColor)),
           ),
         ),
       );
@@ -5213,7 +5213,7 @@ void runAllM2Tests() {
             focusColor: focusColor,
             focusedBorder: const OutlineInputBorder(borderSide: BorderSide(color: focusColor)),
             disabledBorder: const OutlineInputBorder(borderSide: BorderSide(color: disabledColor)),
-            border: OutlineInputBorder(borderSide: BorderSide(color: enabledBorderColor)),
+            border: const OutlineInputBorder(borderSide: BorderSide(color: enabledBorderColor)),
           ),
         ),
       );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -221,43 +221,10 @@ TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
 void main() {
   runAllM2Tests();
 
-  testWidgets('Material3 - Default height is 56dp on mobile', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          labelText: 'label',
-        ),
-      ),
-    );
-
-    // Overall height for this InputDecorator is 56dp on mobile:
-    //    8 - top padding
-    //   12 - floating label (font size = 16 * 0.75, line height is forced to 1.0)
-    //    4 - gap between label and input
-    //   24 - input text (font size = 16, line height = 1.5)
-    //    8 - bottom padding
-    // TODO(bleroux): fix input decorator to not rely on a 4 pixels gap between the label and the input,
-    // this gap is not complient with the M3 spec (M3 spec uses line height for this purpose).
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-  }, variant: TargetPlatformVariant.mobile());
-
-  testWidgets('Material3 - Default height is 48dp on desktop', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      buildInputDecorator(
-        decoration: const InputDecoration(
-          labelText: 'label',
-        ),
-      ),
-    );
-
-    // Overall height for this InputDecorator is 48dp on desktop:
-    //    4 - top padding
-    //   12 - floating label (font size = 16 * 0.75, line height is forced to 1.0)
-    //    4 - gap between label and input
-    //   24 - input text (font size = 16, line height = 1.5)
-    //    4 - bottom padding
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 48.0));
-  }, variant: TargetPlatformVariant.desktop());
+  // TODO(bleroux): migrate all M2 tests to M3.
+  // See https://github.com/flutter/flutter/issues/139076?
+  // For illustration, two of the existing tests are migrated below.
+  // Work is in progress to migrate the other tests.
 
   testWidgets('Material3 - Input/label layout: label appears above input', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -300,6 +267,47 @@ void main() {
     expect(tester.getBottomLeft(find.text('text')).dx, 48.0);
     expect(getBorderWeight(tester), 2.0);
   });
+
+  // During the tests migration to M3, add new M3 tests below.
+  // TODO(bleroux): remove this comment when migration is done.
+
+  testWidgets('Material3 - Default height is 56dp on mobile', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'label',
+        ),
+      ),
+    );
+
+    // Overall height for this InputDecorator is 56dp on mobile:
+    //    8 - top padding
+    //   12 - floating label (font size = 16 * 0.75, line height is forced to 1.0)
+    //    4 - gap between label and input
+    //   24 - input text (font size = 16, line height = 1.5)
+    //    8 - bottom padding
+    // TODO(bleroux): fix input decorator to not rely on a 4 pixels gap between the label and the input,
+    // this gap is not compliant with the M3 spec (M3 spec uses line height for this purpose).
+    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
+  }, variant: TargetPlatformVariant.mobile());
+
+  testWidgets('Material3 - Default height is 48dp on desktop', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'label',
+        ),
+      ),
+    );
+
+    // Overall height for this InputDecorator is 48dp on desktop:
+    //    4 - top padding
+    //   12 - floating label (font size = 16 * 0.75, line height is forced to 1.0)
+    //    4 - gap between label and input
+    //   24 - input text (font size = 16, line height = 1.5)
+    //    4 - bottom padding
+    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 48.0));
+  }, variant: TargetPlatformVariant.desktop());
 }
 
 void runAllM2Tests() {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -16,10 +16,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-// TODO(bleroux): when the M3 test migration will be completed:
-//  - rename buildInputDecoratorLegacy to buildInputDecoratorM2.
-//  - remove its useMaterial3 parameter.
-Widget buildInputDecoratorLegacy({
+Widget buildInputDecoratorM2({
   InputDecoration decoration = const InputDecoration(),
   ThemeData? theme,
   InputDecorationTheme? inputDecorationTheme,
@@ -28,7 +25,6 @@ Widget buildInputDecoratorLegacy({
   bool isEmpty = false,
   bool isFocused = false,
   bool isHovering = false,
-  bool useMaterial3 = false,
   bool useIntrinsicWidth = false,
   TextStyle? baseStyle,
   TextAlignVertical? textAlignVertical,
@@ -62,7 +58,6 @@ Widget buildInputDecoratorLegacy({
             data: (theme ?? Theme.of(context)).copyWith(
               inputDecorationTheme: inputDecorationTheme,
               visualDensity: visualDensity,
-              useMaterial3: useMaterial3,
               textTheme: const TextTheme(bodyLarge: TextStyle(fontSize: 16.0)),
             ),
             child: Align(
@@ -223,26 +218,17 @@ TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
 }
 
 void main() {
-  runAllTests(useMaterial3: true);
-  runAllTests(useMaterial3: false);
-
-  // TODO(bleroux): remove below comment when the M3 migration is done.
-  // During M3 test migration, add new tests here and not in runAllTests.
-  // - runAllTest(useMaterial3: true) is misleading because it forced
-  // a Material2 theme at the MaterialApp level.
-  // - runAllTest(useMaterial3: false) is not a requirement for new tests
-  // When migration is done runAllTests will be removed.
+  runAllM2Tests();
 }
 
-void runAllTests({ required bool useMaterial3 }) {
+void runAllM2Tests() {
   testWidgets('InputDecorator input/label text layout',
   // TODO(polina-c): clean up leaks, https://github.com/flutter/flutter/issues/134787 [leaks-to-clean]
   experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester tester) async {
     // The label appears above the input text
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -269,8 +255,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears within the input when there is no text content
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -284,8 +269,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears above the input text when there is no content and floatingLabelBehavior is always
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -300,8 +284,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears within the input text when there is content and floatingLabelBehavior is never
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           labelText: 'label',
@@ -325,8 +308,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // isFocused: true increases the border's weight from 1.0 to 2.0
     // but does not change the overall height.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         isFocused: true,
         decoration: const InputDecoration(
@@ -345,8 +327,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isEmpty: true causes the label to be aligned with the input text
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -375,8 +356,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isFocused: true causes the label to move back up above the input text.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration(
@@ -406,8 +386,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // enabled: false produces a hairline border if filled: false (the default)
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -421,13 +400,12 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
-    expect(getBorderWeight(tester), useMaterial3 ? 1.0 : 0.0);
+    expect(getBorderWeight(tester), 0.0);
 
     // enabled: false produces a transparent border if filled: true.
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -442,14 +420,12 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
-    final ThemeData theme = ThemeData.from(colorScheme: const ColorScheme.light());
-    expect(getBorderColor(tester), useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.38) : Colors.transparent);
+    expect(getBorderColor(tester), Colors.transparent);
 
     // alignLabelWithHint: true positions the label at the text baseline,
     // aligned with the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -460,10 +436,8 @@ void runAllTests({ required bool useMaterial3 }) {
     );
     await tester.pumpAndSettle();
     expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-    if (!useMaterial3) {
-      expect(tester.getTopLeft(find.text('label')).dy, tester.getTopLeft(find.text('hint')).dy);
-      expect(tester.getBottomLeft(find.text('label')).dy, tester.getBottomLeft(find.text('hint')).dy);
-    }
+    expect(tester.getTopLeft(find.text('label')).dy, tester.getTopLeft(find.text('hint')).dy);
+    expect(tester.getBottomLeft(find.text('label')).dy, tester.getBottomLeft(find.text('hint')).dy);
   });
 
   testWidgets('InputDecorator input/label widget layout', (WidgetTester tester) async {
@@ -471,8 +445,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears above the input text.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -510,8 +483,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears within the input when there is no text content.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -537,8 +509,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // The label appears above the input text when there is no content and the
     // floatingLabelBehavior is set to always.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -565,8 +536,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // The label appears within the input text when there is content and
     // the floatingLabelBehavior is set to never.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           label: Text.rich(
@@ -601,8 +571,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // isFocused: true increases the border's weight from 1.0 to 2.0
     // but does not change the overall height.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         isFocused: true,
         decoration: const InputDecoration(
@@ -632,8 +601,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isEmpty: true causes the label to be aligned with the input text.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           label: Text.rich(
@@ -672,8 +640,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isFocused: true causes the label to move back up above the input text.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration(
@@ -716,8 +683,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // enabled: false produces a hairline border if filled: false (the default)
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           label: Text.rich(
@@ -742,13 +708,12 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(tester.getBottomLeft(find.text('text')).dy,44.0);
     expect(tester.getTopLeft(find.byKey(key)).dy, 20.0);
     expect(tester.getBottomLeft(find.byKey(key)).dy, 36.0);
-    expect(getBorderWeight(tester),useMaterial3 ? 1.0 : 0.0);
+    expect(getBorderWeight(tester), 0.0);
 
     // enabled: false produces a transparent border if filled: true.
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           label: Text.rich(
@@ -774,14 +739,12 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.byKey(key)).dy, 20.0);
     expect(tester.getBottomLeft(find.byKey(key)).dy, 36.0);
-    final ThemeData theme = ThemeData.from(colorScheme: const ColorScheme.light());
-    expect(getBorderColor(tester), useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.38) : Colors.transparent);
+    expect(getBorderColor(tester), Colors.transparent);
 
     // alignLabelWithHint: true positions the label at the text baseline,
     // aligned with the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           label: Text.rich(
@@ -803,11 +766,8 @@ void runAllTests({ required bool useMaterial3 }) {
     );
     await tester.pumpAndSettle();
     expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-    if (!useMaterial3) {
-      expect(tester.getTopLeft(find.byKey(key)).dy, tester.getTopLeft(find.text('hint')).dy);
-      expect(tester.getBottomLeft(find.byKey(key)).dy, tester.getBottomLeft(find.text('hint')).dy);
-    }
-
+    expect(tester.getTopLeft(find.byKey(key)).dy, tester.getTopLeft(find.text('hint')).dy);
+    expect(tester.getBottomLeft(find.byKey(key)).dy, tester.getBottomLeft(find.text('hint')).dy);
   });
 
   testWidgets('InputDecorator floating label animation duration and curve', (WidgetTester tester) async {
@@ -815,7 +775,7 @@ void runAllTests({ required bool useMaterial3 }) {
       required bool isFocused,
     }) async {
       return tester.pumpWidget(
-        buildInputDecoratorLegacy(
+        buildInputDecoratorM2(
           isEmpty: true,
           isFocused: isFocused,
           decoration: const InputDecoration(
@@ -1090,8 +1050,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator input/hint layout', (WidgetTester tester) async {
     // The hint aligns with the input text
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1114,8 +1073,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator input/label/hint layout', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1153,8 +1111,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label moves upwards, hint is visible (opacity 1.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1188,8 +1145,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 2.0);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -1225,8 +1181,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator input/label/hint dense layout', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1264,8 +1219,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1288,8 +1242,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator default hint animation duration', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -1303,8 +1256,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focus to show the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1329,8 +1281,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Unfocus to hide the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -1355,8 +1306,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator custom hint animation duration', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -1371,8 +1321,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focus to show the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1398,8 +1347,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Unfocus to hide the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -1425,8 +1373,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator custom hint animation duration from theme', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         inputDecorationTheme: const InputDecorationTheme(
           hintFadeDuration: Duration(milliseconds: 120),
         ),
@@ -1443,8 +1390,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focus to show the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         inputDecorationTheme: const InputDecorationTheme(
           hintFadeDuration: Duration(milliseconds: 120),
         ),
@@ -1472,8 +1418,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Unfocus to hide the hint.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         inputDecorationTheme: const InputDecorationTheme(
           hintFadeDuration: Duration(milliseconds: 120),
         ),
@@ -1502,8 +1447,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator with no input border', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1516,8 +1460,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator error/helper/counter layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1562,8 +1505,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // If errorText is specified then the helperText isn't shown
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1610,8 +1552,7 @@ void runAllTests({ required bool useMaterial3 }) {
     //   12 - help/error/counter text (font size 12dps)
     // The layout of the error/helper/counter subtext doesn't change for dense layout.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1638,8 +1579,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 56.0));
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1774,8 +1714,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const String kError3 = 'e0\ne1\ne2';
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1806,8 +1745,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because errorText only occupies two lines.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1828,8 +1766,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because errorText only occupies one line.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1853,8 +1790,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const String kHelper3 = 'e0\ne1\ne2';
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1884,8 +1820,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because helperText only occupies two lines.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1905,8 +1840,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because helperText only occupies two lines.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1926,8 +1860,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because helperText only occupies one line.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1946,8 +1879,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator shows error text', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           errorText: 'errorText',
         ),
@@ -1966,8 +1898,7 @@ void runAllTests({ required bool useMaterial3 }) {
     );
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           errorText: 'error',
@@ -1981,8 +1912,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedErrorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           errorText: 'error',
@@ -1996,8 +1926,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           errorText: 'error',
@@ -2011,8 +1940,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           error: Text('error'),
@@ -2026,8 +1954,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedErrorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           error: Text('error'),
@@ -2041,8 +1968,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           error: Text('error'),
@@ -2058,8 +1984,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator shows error widget', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           error: Text('error', style: TextStyle(fontSize: 20.0)),
         ),
@@ -2072,8 +1997,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator throws when error text and error widget are provided', (WidgetTester tester) async {
     expect(
       () {
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           decoration: InputDecoration(
             errorText: 'errorText',
             error: const Text('error', style: TextStyle(fontSize: 20.0)),
@@ -2086,8 +2010,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefix/suffix texts', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2124,8 +2047,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator icon/prefix/suffix', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2252,8 +2174,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const Key pKey = Key('p');
     const Key sKey = Key('s');
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2303,8 +2224,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator tall prefix', (WidgetTester tester) async {
     const Key pKey = Key('p');
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2348,8 +2268,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator tall prefix with border', (WidgetTester tester) async {
     const Key pKey = Key('p');
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2398,8 +2317,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefixIcon/suffixIcon', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2434,8 +2352,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefixIconConstraints/suffixIconConstraints', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -2473,8 +2390,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('prefix/suffix icons are centered when smaller than 48 by 48', (WidgetTester tester) async {
     const Key prefixKey = Key('prefix');
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           prefixIcon: Padding(
             padding: EdgeInsets.all(16.0),
@@ -2499,8 +2415,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator respects reduced theme visualDensity', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         visualDensity: VisualDensity.compact,
         decoration: const InputDecoration(
@@ -2522,8 +2437,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label moves upwards, hint is visible (opacity 1.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         visualDensity: VisualDensity.compact,
@@ -2558,8 +2472,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 2.0);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         visualDensity: VisualDensity.compact,
         decoration: const InputDecoration(
@@ -2596,8 +2509,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator respects increased theme visualDensity', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         visualDensity: const VisualDensity(horizontal: 2.0, vertical: 2.0),
         decoration: const InputDecoration(
@@ -2619,8 +2531,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label moves upwards, hint is visible (opacity 1.0).
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         visualDensity: const VisualDensity(horizontal: 2.0, vertical: 2.0),
@@ -2655,8 +2566,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 2.0);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         visualDensity: const VisualDensity(horizontal: 2.0, vertical: 2.0),
         decoration: const InputDecoration(
@@ -2693,8 +2603,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('prefix/suffix icons increase height of decoration when larger than 48 by 48', (WidgetTester tester) async {
     const Key prefixKey = Key('prefix');
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           prefixIcon: SizedBox(width: 100.0, height: 100.0, key: prefixKey),
           filled: true,
@@ -2715,9 +2624,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   group('constraints', () {
     testWidgets('No InputDecorator constraints', (WidgetTester tester) async {
-      await tester.pumpWidget(buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
-      ));
+      await tester.pumpWidget(buildInputDecoratorM2());
 
       // Should fill the screen width and be default height
       expect(tester.getSize(find.byType(InputDecorator)), const Size(800, 48));
@@ -2725,8 +2632,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     testWidgets('InputDecoratorThemeData constraints', (WidgetTester tester) async {
       await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             theme: ThemeData(
               inputDecorationTheme: const InputDecorationTheme(
                 constraints: BoxConstraints(maxWidth: 300, maxHeight: 40),
@@ -2741,8 +2647,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     testWidgets('InputDecorator constraints', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           theme: ThemeData(
             inputDecorationTheme: const InputDecorationTheme(
               constraints: BoxConstraints(maxWidth: 300, maxHeight: 40),
@@ -2765,8 +2670,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align top (default)', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true, // so we have a tall input where align can vary
@@ -2789,8 +2693,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align center', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -2813,8 +2716,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align bottom', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -2837,8 +2739,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align as a double', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -2871,8 +2772,7 @@ void runAllTests({ required bool useMaterial3 }) {
             child: SizedBox(
               key: containerKey,
               height: totalHeight,
-              child: buildInputDecoratorLegacy(
-                useMaterial3: useMaterial3,
+              child: buildInputDecoratorM2(
                 // isEmpty: false (default)
                 // isFocused: false (default)
                 expands: true,
@@ -2911,8 +2811,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align top', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true, // so we have a tall input where align can vary
@@ -2937,8 +2836,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align center (default)', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -2962,8 +2860,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align bottom', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -2990,8 +2887,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             decoration: const InputDecoration(
@@ -3020,8 +2916,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             decoration: const InputDecoration(
@@ -3050,8 +2945,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             decoration: const InputDecoration(
@@ -3082,8 +2976,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -3114,8 +3007,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -3148,8 +3040,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -3180,8 +3071,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true,
@@ -3213,8 +3103,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align top (default)', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true, // so we have a tall input where align can vary
@@ -3239,8 +3128,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align center', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true, // so we have a tall input where align can vary
@@ -3265,8 +3153,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align bottom', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             expands: true, // so we have a tall input where align can vary
@@ -3294,8 +3181,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('default alignment', () {
       testWidgets('Centers when border', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             decoration: const InputDecoration(
               border: OutlineInputBorder(),
             ),
@@ -3311,8 +3197,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and label', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             decoration: const InputDecoration(
               labelText: 'label',
               border: OutlineInputBorder(),
@@ -3329,8 +3214,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and contentPadding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             decoration: const InputDecoration(
               border: OutlineInputBorder(),
               contentPadding: EdgeInsets.fromLTRB(
@@ -3350,8 +3234,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and contentPadding and label', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             decoration: const InputDecoration(
               labelText: 'label',
               border: OutlineInputBorder(),
@@ -3371,8 +3254,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and lopsided contentPadding and label', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             decoration: const InputDecoration(
               labelText: 'label',
               border: OutlineInputBorder(),
@@ -3391,29 +3273,9 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(getBorderWeight(tester), 1.0);
       });
 
-      testWidgets('Floating label is aligned with prefixIcon by default in M3', (WidgetTester tester) async {
-        await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
-            decoration: const InputDecoration(
-              prefixIcon: Icon(Icons.ac_unit),
-              labelText: 'label',
-              border: OutlineInputBorder(),
-            ),
-            isFocused: true,
-          ),
-        );
-
-        expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-        expect(tester.getTopLeft(find.text('label')).dx, useMaterial3 ? 12.0 : 48.0);
-        expect(tester.getBottomLeft(find.text('text')).dx, 48.0);
-        expect(getBorderWeight(tester), 2.0);
-      });
-
       testWidgets('Floating label for filled input decoration is aligned with text', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             decoration: const InputDecoration(
               prefixIcon: Icon(Icons.ac_unit),
               labelText: 'label',
@@ -3433,8 +3295,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('3 point interpolation alignment', () {
       testWidgets('top align includes padding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             expands: true,
             textAlignVertical: TextAlignVertical.top,
             decoration: const InputDecoration(
@@ -3457,8 +3318,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center align ignores padding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             expands: true,
             textAlignVertical: TextAlignVertical.center,
             decoration: const InputDecoration(
@@ -3481,8 +3341,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('bottom align includes padding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             expands: true,
             textAlignVertical: TextAlignVertical.bottom,
             decoration: const InputDecoration(
@@ -3505,8 +3364,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('padding exceeds middle keeps top at middle', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             expands: true,
             textAlignVertical: TextAlignVertical.top,
             decoration: const InputDecoration(
@@ -3531,8 +3389,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - LTR, not dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -3551,8 +3408,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - RTL, not dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         textDirection: TextDirection.rtl,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3571,8 +3427,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - LTR, dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -3592,8 +3447,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - RTL, dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         textDirection: TextDirection.rtl,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3613,8 +3467,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator error/helper/counter RTL layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         textDirection: TextDirection.rtl,
@@ -3648,8 +3501,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // If both error and helper are specified, show the error
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         textDirection: TextDirection.rtl,
@@ -3670,8 +3522,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefix/suffix RTL', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         textDirection: TextDirection.rtl,
@@ -3705,8 +3556,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator contentPadding RTL layout', (WidgetTester tester) async {
     // LTR: content left edge is contentPadding.start: 40.0
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -3724,8 +3574,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // RTL: content right edge is 800 - contentPadding.start: 760.0.
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         isFocused: true, // label is floating, still adjusted for contentPadding
         textDirection: TextDirection.rtl,
@@ -3751,8 +3600,7 @@ void runAllTests({ required bool useMaterial3 }) {
   group('inputText width', () {
     testWidgets('outline textField', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           decoration: const InputDecoration(
             border: OutlineInputBorder(),
           ),
@@ -3764,8 +3612,7 @@ void runAllTests({ required bool useMaterial3 }) {
     });
     testWidgets('outline textField with prefix and suffix icons', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           decoration: const InputDecoration(
             border: OutlineInputBorder(),
             prefixIcon: Icon(Icons.visibility),
@@ -3779,8 +3626,7 @@ void runAllTests({ required bool useMaterial3 }) {
     });
     testWidgets('filled textField', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           decoration: const InputDecoration(
             filled: true,
           ),
@@ -3792,8 +3638,7 @@ void runAllTests({ required bool useMaterial3 }) {
     });
     testWidgets('filled textField with prefix and suffix icons', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           decoration: const InputDecoration(
             filled: true,
             prefixIcon: Icon(Icons.visibility),
@@ -3808,12 +3653,13 @@ void runAllTests({ required bool useMaterial3 }) {
   });
 
   group('floatingLabelAlignment', () {
-    Widget buildInputDecoratorLegacyWithFloatingLabel({required TextDirection textDirection,
-          required bool hasIcon,
-          required FloatingLabelAlignment alignment,
-          bool borderIsOutline = false,
-    }) => buildInputDecoratorLegacy(
-      useMaterial3: useMaterial3,
+    Widget buildInputDecoratorM2WithFloatingLabel({
+      required TextDirection textDirection,
+      required bool hasIcon,
+      required FloatingLabelAlignment alignment,
+      bool borderIsOutline = false,
+    }) {
+      return buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         textDirection: textDirection,
@@ -3827,11 +3673,12 @@ void runAllTests({ required bool useMaterial3 }) {
           border: borderIsOutline ? const OutlineInputBorder() : null,
         ),
       );
+    }
 
     group('LTR with icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3842,7 +3689,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopLeft(find.text('label')).dx, 80.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3855,7 +3702,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3866,7 +3713,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 420.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3881,7 +3728,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('LTR without icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3892,7 +3739,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopLeft(find.text('label')).dx, 40.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3905,7 +3752,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -3916,7 +3763,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 400.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -3931,7 +3778,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('RTL with icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3942,7 +3789,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopRight(find.text('label')).dx, 720.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3955,7 +3802,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3966,7 +3813,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 380.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3981,7 +3828,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('RTL without icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3992,7 +3839,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopRight(find.text('label')).dx, 760.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -4005,7 +3852,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -4016,7 +3863,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 400.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorLegacyWithFloatingLabel(
+          buildInputDecoratorM2WithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -4031,8 +3878,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefix/suffix dense layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         isFocused: true,
         decoration: const InputDecoration(
@@ -4072,9 +3918,7 @@ void runAllTests({ required bool useMaterial3 }) {
   });
 
   testWidgets('InputDecorator with empty InputDecoration', (WidgetTester tester) async {
-    await tester.pumpWidget(buildInputDecoratorLegacy(
-      useMaterial3: useMaterial3,
-    ));
+    await tester.pumpWidget(buildInputDecoratorM2());
 
     // Overall height for this InputDecorator is 40dps:
     //   12 - top padding
@@ -4092,8 +3936,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // Regression test for https://github.com/flutter/flutter/issues/42449
     const double verticalPadding = 1.0;
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default),
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -4117,8 +3960,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 1.0);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default),
         // isFocused: false (default)
         decoration: const InputDecoration.collapsed(
@@ -4141,8 +3983,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 1.0);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default),
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -4166,8 +4007,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator.collapsed', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default),
         // isFocused: false (default)
         decoration: const InputDecoration.collapsed(
@@ -4188,8 +4028,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The hint should appear
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true,
         decoration: const InputDecoration.collapsed(
@@ -4212,8 +4051,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // text child to a smaller font reduces the InputDecoration's vertical size.
     const TextStyle style = TextStyle(fontSize: 10.0);
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         baseStyle: style,
         decoration: const InputDecoration(
@@ -4239,20 +4077,19 @@ void runAllTests({ required bool useMaterial3 }) {
     //      10 - label (font size 10dps)
     //   17.75 - bottom padding (empty input text still appears here)
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 50.0 : kMinInteractiveDimension)); // 45.5 bumped up to minimum.
+    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, kMinInteractiveDimension)); // 45.5 bumped up to minimum.
     expect(tester.getSize(find.text('hint')).height, 10.0);
-    expect(tester.getSize(find.text('label')).height, useMaterial3 ? 16.0 : 10.0);
+    expect(tester.getSize(find.text('label')).height, 10.0);
     expect(tester.getSize(find.text('text')).height, 10.0);
-    expect(tester.getTopLeft(find.text('hint')).dy, useMaterial3 ? 28 : 24.75);
-    expect(tester.getTopLeft(find.text('label')).dy, useMaterial3 ? 17 : 19.0);
-    expect(tester.getTopLeft(find.text('text')).dy, useMaterial3 ? 28 : 24.75);
+    expect(tester.getTopLeft(find.text('hint')).dy, 24.75);
+    expect(tester.getTopLeft(find.text('label')).dy, 19.0);
+    expect(tester.getTopLeft(find.text('text')).dy, 24.75);
   });
 
   testWidgets('InputDecorator with empty style overrides', (WidgetTester tester) async {
     // Same as not specifying any style overrides
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -4293,8 +4130,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecoration outline shape with no border and no floating placeholder', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         isEmpty: true,
         decoration: const InputDecoration(
@@ -4318,8 +4154,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecoration outline shape with no border and no floating placeholder not empty', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -4470,8 +4305,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorationTheme outline border', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true, // label appears, vertically centered
         // isFocused: false (default)
         inputDecorationTheme: const InputDecorationTheme(
@@ -4496,8 +4330,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorationTheme outline border, dense layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true, // label appears, vertically centered
         // isFocused: false (default)
         inputDecorationTheme: const InputDecorationTheme(
@@ -4539,8 +4372,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true, // label appears, vertically centered
         // isFocused: false (default)
         inputDecorationTheme: InputDecorationTheme(
@@ -4606,8 +4438,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true, // Label appears floating above input field.
         inputDecorationTheme: InputDecorationTheme(
@@ -4672,8 +4503,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator.debugDescribeChildren', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           icon: Text('icon'),
           labelText: 'label',
@@ -4715,8 +4545,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator with empty border and label', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/14165
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5017,8 +4846,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // This is a regression test for https://github.com/flutter/flutter/issues/15742
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5056,8 +4884,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator UnderlineInputBorder fillColor is clipped by border', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5203,10 +5030,10 @@ void runAllTests({ required bool useMaterial3 }) {
   );
 
   testWidgets('InputDecorator draws and animates hoverColor', (WidgetTester tester) async {
-    final Color fillColor = useMaterial3 ? const Color(0xffffffff) : const Color(0x0A000000);
+    const Color fillColor = Color(0x0A000000);
     const Color hoverColor = Color(0xFF00FF00);
-    final Color disabledColor =useMaterial3 ? const Color(0x0A000000) : const  Color(0x05000000);
-    final Color enabledBorderColor = useMaterial3 ? const Color(0xffffffff) : const Color(0x61000000);
+    const Color disabledColor = Color(0x05000000);
+    const Color enabledBorderColor = Color(0x61000000);
 
     Future<void> pumpDecorator({
       required bool hovering,
@@ -5214,8 +5041,7 @@ void runAllTests({ required bool useMaterial3 }) {
       bool filled = true,
     }) async {
       return tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           isHovering: hovering,
           decoration: InputDecoration(
             enabled: enabled,
@@ -5255,7 +5081,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getContainerColor(tester), equals(disabledColor));
 
     // Test outline text field.
-    final Color blendedHoverColor = useMaterial3 ? const Color(0xff000000) : const Color(0x74004400);
+    const Color blendedHoverColor = Color(0x74004400);
     await pumpDecorator(hovering: false, filled: false);
     await tester.pumpAndSettle();
     expect(getBorderColor(tester), equals(enabledBorderColor));
@@ -5286,7 +5112,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator draws and animates focusColor', (WidgetTester tester) async {
     const Color focusColor = Color(0xFF0000FF);
     const Color disabledColor = Color(0x05000000);
-    final Color enabledBorderColor = useMaterial3 ? const Color(0xffffffff) : const Color(0x61000000);
+    const Color enabledBorderColor = Color(0x61000000);
 
     Future<void> pumpDecorator({
       required bool focused,
@@ -5294,8 +5120,7 @@ void runAllTests({ required bool useMaterial3 }) {
       bool filled = true,
     }) async {
       return tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           isFocused: focused,
           decoration: InputDecoration(
             enabled: enabled,
@@ -5346,8 +5171,7 @@ void runAllTests({ required bool useMaterial3 }) {
       bool directional = false,
     }) async {
       return tester.pumpWidget(
-        buildInputDecoratorLegacy(
-          useMaterial3: useMaterial3,
+        buildInputDecoratorM2(
           isEmpty: empty,
           isFocused: focused,
           decoration: InputDecoration(
@@ -5458,15 +5282,14 @@ void runAllTests({ required bool useMaterial3 }) {
 
 
   testWidgets('InputDecoration default border uses colorScheme', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData.from(colorScheme: const ColorScheme.light());
-    final Color enabledColor = useMaterial3 ? theme.colorScheme.onSurfaceVariant : theme.colorScheme.onSurface.withOpacity(0.38);
-    final Color disabledColor = useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.12) : theme.disabledColor;
+    final ThemeData theme = ThemeData.light(useMaterial3: false);
+    final Color enabledColor = theme.colorScheme.onSurface.withOpacity(0.38);
+    final Color disabledColor = theme.disabledColor;
     final Color hoverColor = Color.alphaBlend(theme.hoverColor.withOpacity(0.12), enabledColor);
 
     // Enabled
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
       ),
     );
@@ -5475,8 +5298,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Filled
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
         decoration: const InputDecoration(
           filled: true,
@@ -5484,12 +5306,11 @@ void runAllTests({ required bool useMaterial3 }) {
       ),
     );
     await tester.pumpAndSettle();
-    expect(getBorderColor(tester), useMaterial3 ? theme.colorScheme.onSurfaceVariant : theme.hintColor);
+    expect(getBorderColor(tester), theme.hintColor);
 
     // Hovering
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
         isHovering: true,
       ),
@@ -5499,8 +5320,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focused
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
         isFocused: true,
       ),
@@ -5510,8 +5330,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Error
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
         decoration: const InputDecoration(
           errorText: 'Nope',
@@ -5523,8 +5342,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Disabled
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
         decoration: const InputDecoration(
           enabled: false,
@@ -5536,8 +5354,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Disabled, filled
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         theme: theme,
         decoration: const InputDecoration(
           enabled: false,
@@ -5546,7 +5363,7 @@ void runAllTests({ required bool useMaterial3 }) {
       ),
     );
     await tester.pumpAndSettle();
-    expect(getBorderColor(tester), useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.38) : Colors.transparent);
+    expect(getBorderColor(tester), Colors.transparent);
   });
 
   testWidgets('InputDecoration borders', (WidgetTester tester) async {
@@ -5567,8 +5384,7 @@ void runAllTests({ required bool useMaterial3 }) {
     );
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           // errorText: null (default)
@@ -5584,8 +5400,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), enabledBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           // errorText: null (default)
@@ -5602,8 +5417,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           errorText: 'error',
@@ -5620,8 +5434,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedErrorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           errorText: 'error',
@@ -5638,8 +5451,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           errorText: 'error',
@@ -5656,8 +5468,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         decoration: const InputDecoration(
           enabled: false,
@@ -5673,8 +5484,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), disabledBorder);
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           // errorText: null (default)
@@ -5706,8 +5516,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const double inputDecoratorWidth = 800.0;
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           filled: true,
           fillColor: Color(0xFF00FF00),
@@ -5811,8 +5620,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const double inputDecoratorWidth = 800.0;
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: InputDecoration(
           filled: true,
           fillColor: const Color(0xFF00FF00),
@@ -5904,7 +5712,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     const double borderWidth = 4.0;
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
+      buildInputDecoratorM2(
         isFocused: true,
         decoration: const InputDecoration(
           filled: false,
@@ -6223,8 +6031,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
   testWidgets('InputDecorator floating label Y coordinate', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/54028
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -6245,8 +6052,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
 
   testWidgets('InputDecorator floating label obeys floatingLabelBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         decoration: const InputDecoration(
           labelText: 'label',
           floatingLabelBehavior: FloatingLabelBehavior.never,
@@ -6262,8 +6068,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
 
   testWidgets('InputDecorator hint is displayed when floatingLabelBehavior is always', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isFocused: false (default)
         isEmpty: true,
         decoration: const InputDecoration(
@@ -6287,8 +6092,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
         child: SizedBox(
           width: 100,
           height: 100,
-          child: buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          child: buildInputDecoratorM2(
             // isFocused: false (default)
             isEmpty: true,
             decoration: InputDecoration(
@@ -6311,8 +6115,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
         child: SizedBox(
           width: 100,
           height: 100,
-          child: buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          child: buildInputDecoratorM2(
             isFocused: true,
             isEmpty: true,
             decoration: InputDecoration(
@@ -6836,8 +6639,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true,
         isFocused: true, // Label appears floating above input field.
         inputDecorationTheme: InputDecorationTheme(
@@ -6878,8 +6680,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         isEmpty: true, // Label appears inline, on top of the input field.
         inputDecorationTheme: InputDecorationTheme(
           labelStyle: labelStyle,
@@ -6921,8 +6722,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     );
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: decoration,
@@ -6943,8 +6743,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     );
 
     await tester.pumpWidget(
-      buildInputDecoratorLegacy(
-        useMaterial3: useMaterial3,
+      buildInputDecoratorM2(
         // isEmpty: false (default)
         // isFocused: false (default)
         decoration: decoration,
@@ -6970,8 +6769,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     for (final TextDirection direction in TextDirection.values) {
       Future<Size> measureText(InputDecoration decoration) async {
         await tester.pumpWidget(
-          buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          buildInputDecoratorM2(
             // isEmpty: false (default)
             // isFocused: false (default)
             decoration: decoration,
@@ -7019,8 +6817,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
       Center(
         child: SizedBox.square(
           dimension: 0.0,
-          child: buildInputDecoratorLegacy(
-            useMaterial3: useMaterial3,
+          child: buildInputDecoratorM2(
             decoration: decoration,
           ),
         ),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 Widget buildInputDecoratorM2({
   InputDecoration decoration = const InputDecoration(),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -16,7 +16,10 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
-Widget buildInputDecorator({
+// TODO(bleroux): when the M3 test migration will be completed:
+//  - rename buildInputDecoratorLegacy to buildInputDecoratorM2.
+//  - remove its useMaterial3 parameter.
+Widget buildInputDecoratorLegacy({
   InputDecoration decoration = const InputDecoration(),
   ThemeData? theme,
   InputDecorationTheme? inputDecorationTheme,
@@ -76,6 +79,62 @@ Widget buildInputDecorator({
   );
 }
 
+Widget buildInputDecorator({
+  InputDecoration decoration = const InputDecoration(),
+  ThemeData? theme,
+  InputDecorationTheme? inputDecorationTheme,
+  TextDirection textDirection = TextDirection.ltr,
+  bool expands = false,
+  bool isEmpty = false,
+  bool isFocused = false,
+  bool isHovering = false,
+  bool useIntrinsicWidth = false,
+  TextStyle? baseStyle,
+  TextAlignVertical? textAlignVertical,
+  VisualDensity? visualDensity,
+  Widget child = const Text(
+    'text',
+    style: TextStyle(fontSize: 16.0),
+  ),
+}) {
+  Widget widget = InputDecorator(
+    expands: expands,
+    decoration: decoration,
+    isEmpty: isEmpty,
+    isFocused: isFocused,
+    isHovering: isHovering,
+    baseStyle: baseStyle,
+    textAlignVertical: textAlignVertical,
+    child: child,
+  );
+
+  if (useIntrinsicWidth) {
+    widget = IntrinsicWidth(child: widget);
+  }
+
+  return MaterialApp(
+    home: Material(
+      child: Builder(
+        builder: (BuildContext context) {
+          return Theme(
+            data: (theme ?? Theme.of(context)).copyWith(
+              inputDecorationTheme: inputDecorationTheme,
+              visualDensity: visualDensity,
+            ),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Directionality(
+                textDirection: textDirection,
+                child: widget,
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+}
+
 Finder findBorderPainter() {
   return find.descendant(
     of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_BorderContainer'),
@@ -102,7 +161,7 @@ Rect getLabelRect(WidgetTester tester) {
 TextStyle getLabelStyle(WidgetTester tester) {
   return tester.firstWidget<AnimatedDefaultTextStyle>(
     find.ancestor(
-      of: find.text('label'),
+      of: findLabel(),
       matching: find.byType(AnimatedDefaultTextStyle),
     ),
   ).style;
@@ -166,6 +225,13 @@ TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
 void main() {
   runAllTests(useMaterial3: true);
   runAllTests(useMaterial3: false);
+
+  // TODO(bleroux): remove below comment when the M3 migration is done.
+  // During M3 test migration, add new tests here and not in runAllTests.
+  // - runAllTest(useMaterial3: true) is misleading because it forced
+  // a Material2 theme at the MaterialApp level.
+  // - runAllTest(useMaterial3: false) is not a requirement for new tests
+  // When migration is done runAllTests will be removed.
 }
 
 void runAllTests({ required bool useMaterial3 }) {
@@ -175,7 +241,7 @@ void runAllTests({ required bool useMaterial3 }) {
   (WidgetTester tester) async {
     // The label appears above the input text
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -203,7 +269,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears within the input when there is no text content
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -218,7 +284,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears above the input text when there is no content and floatingLabelBehavior is always
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -234,7 +300,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears within the input text when there is content and floatingLabelBehavior is never
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -259,7 +325,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // isFocused: true increases the border's weight from 1.0 to 2.0
     // but does not change the overall height.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         isFocused: true,
@@ -279,7 +345,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isEmpty: true causes the label to be aligned with the input text
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -309,7 +375,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isFocused: true causes the label to move back up above the input text.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -340,7 +406,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // enabled: false produces a hairline border if filled: false (the default)
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -360,7 +426,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // enabled: false produces a transparent border if filled: true.
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -382,7 +448,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // alignLabelWithHint: true positions the label at the text baseline,
     // aligned with the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -405,7 +471,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears above the input text.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -444,7 +510,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The label appears within the input when there is no text content.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -471,7 +537,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // The label appears above the input text when there is no content and the
     // floatingLabelBehavior is set to always.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -499,7 +565,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // The label appears within the input text when there is content and
     // the floatingLabelBehavior is set to never.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -535,7 +601,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // isFocused: true increases the border's weight from 1.0 to 2.0
     // but does not change the overall height.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         isFocused: true,
@@ -566,7 +632,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isEmpty: true causes the label to be aligned with the input text.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -606,7 +672,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // isFocused: true causes the label to move back up above the input text.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -650,7 +716,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // enabled: false produces a hairline border if filled: false (the default)
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -681,7 +747,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // enabled: false produces a transparent border if filled: true.
     // The widget's size and layout is the same as for enabled: true.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -714,7 +780,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // alignLabelWithHint: true positions the label at the text baseline,
     // aligned with the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -749,7 +815,7 @@ void runAllTests({ required bool useMaterial3 }) {
       required bool isFocused,
     }) async {
       return tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           isEmpty: true,
           isFocused: isFocused,
           decoration: const InputDecoration(
@@ -1024,7 +1090,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator input/hint layout', (WidgetTester tester) async {
     // The hint aligns with the input text
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1048,7 +1114,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator input/label/hint layout', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1087,7 +1153,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label moves upwards, hint is visible (opacity 1.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -1122,7 +1188,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 2.0);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1159,7 +1225,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator input/label/hint dense layout', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1198,7 +1264,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -1222,7 +1288,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator default hint animation duration', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -1237,7 +1303,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focus to show the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -1263,7 +1329,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Unfocus to hide the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -1289,7 +1355,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator custom hint animation duration', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -1305,7 +1371,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focus to show the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -1332,7 +1398,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Unfocus to hide the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -1359,7 +1425,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator custom hint animation duration from theme', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         inputDecorationTheme: const InputDecorationTheme(
           hintFadeDuration: Duration(milliseconds: 120),
@@ -1377,7 +1443,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focus to show the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         inputDecorationTheme: const InputDecorationTheme(
           hintFadeDuration: Duration(milliseconds: 120),
@@ -1406,7 +1472,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Unfocus to hide the hint.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         inputDecorationTheme: const InputDecorationTheme(
           hintFadeDuration: Duration(milliseconds: 120),
@@ -1436,7 +1502,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator with no input border', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1450,7 +1516,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator error/helper/counter layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1496,7 +1562,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // If errorText is specified then the helperText isn't shown
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -1544,7 +1610,7 @@ void runAllTests({ required bool useMaterial3 }) {
     //   12 - help/error/counter text (font size 12dps)
     // The layout of the error/helper/counter subtext doesn't change for dense layout.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -1572,7 +1638,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 56.0));
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1708,7 +1774,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const String kError3 = 'e0\ne1\ne2';
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1740,7 +1806,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because errorText only occupies two lines.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1762,7 +1828,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because errorText only occupies one line.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1787,7 +1853,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const String kHelper3 = 'e0\ne1\ne2';
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1818,7 +1884,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because helperText only occupies two lines.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1839,7 +1905,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because helperText only occupies two lines.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1860,7 +1926,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // one, 88dps, because helperText only occupies one line.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         // isFocused: false (default)
@@ -1880,7 +1946,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator shows error text', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           errorText: 'errorText',
@@ -1900,7 +1966,7 @@ void runAllTests({ required bool useMaterial3 }) {
     );
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1915,7 +1981,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedErrorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1930,7 +1996,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1945,7 +2011,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         decoration: const InputDecoration(
@@ -1960,7 +2026,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedErrorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1975,7 +2041,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -1992,7 +2058,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator shows error widget', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           error: Text('error', style: TextStyle(fontSize: 20.0)),
@@ -2006,7 +2072,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator throws when error text and error widget are provided', (WidgetTester tester) async {
     expect(
       () {
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           decoration: InputDecoration(
             errorText: 'errorText',
@@ -2020,7 +2086,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefix/suffix texts', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2058,7 +2124,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator icon/prefix/suffix', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2186,7 +2252,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const Key pKey = Key('p');
     const Key sKey = Key('s');
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2237,7 +2303,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator tall prefix', (WidgetTester tester) async {
     const Key pKey = Key('p');
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2282,7 +2348,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator tall prefix with border', (WidgetTester tester) async {
     const Key pKey = Key('p');
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2332,7 +2398,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefixIcon/suffixIcon', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2368,7 +2434,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefixIconConstraints/suffixIconConstraints', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -2407,7 +2473,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('prefix/suffix icons are centered when smaller than 48 by 48', (WidgetTester tester) async {
     const Key prefixKey = Key('prefix');
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           prefixIcon: Padding(
@@ -2433,7 +2499,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator respects reduced theme visualDensity', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         visualDensity: VisualDensity.compact,
@@ -2456,7 +2522,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label moves upwards, hint is visible (opacity 1.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -2492,7 +2558,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 2.0);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         visualDensity: VisualDensity.compact,
@@ -2530,7 +2596,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator respects increased theme visualDensity', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         visualDensity: const VisualDensity(horizontal: 2.0, vertical: 2.0),
@@ -2553,7 +2619,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Label moves upwards, hint is visible (opacity 1.0).
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -2589,7 +2655,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 2.0);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         visualDensity: const VisualDensity(horizontal: 2.0, vertical: 2.0),
@@ -2627,7 +2693,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('prefix/suffix icons increase height of decoration when larger than 48 by 48', (WidgetTester tester) async {
     const Key prefixKey = Key('prefix');
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           prefixIcon: SizedBox(width: 100.0, height: 100.0, key: prefixKey),
@@ -2649,7 +2715,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   group('constraints', () {
     testWidgets('No InputDecorator constraints', (WidgetTester tester) async {
-      await tester.pumpWidget(buildInputDecorator(
+      await tester.pumpWidget(buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
       ));
 
@@ -2659,7 +2725,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     testWidgets('InputDecoratorThemeData constraints', (WidgetTester tester) async {
       await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             theme: ThemeData(
               inputDecorationTheme: const InputDecorationTheme(
@@ -2675,7 +2741,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     testWidgets('InputDecorator constraints', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           theme: ThemeData(
             inputDecorationTheme: const InputDecorationTheme(
@@ -2699,7 +2765,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align top (default)', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2723,7 +2789,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align center', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2747,7 +2813,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align bottom', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2771,7 +2837,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align as a double', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2805,7 +2871,7 @@ void runAllTests({ required bool useMaterial3 }) {
             child: SizedBox(
               key: containerKey,
               height: totalHeight,
-              child: buildInputDecorator(
+              child: buildInputDecoratorLegacy(
                 useMaterial3: useMaterial3,
                 // isEmpty: false (default)
                 // isFocused: false (default)
@@ -2845,7 +2911,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align top', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2871,7 +2937,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align center (default)', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2896,7 +2962,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align bottom', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2924,7 +2990,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2954,7 +3020,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -2984,7 +3050,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3016,7 +3082,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3048,7 +3114,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3082,7 +3148,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3114,7 +3180,7 @@ void runAllTests({ required bool useMaterial3 }) {
         const Key pKey = Key('p');
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3147,7 +3213,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align top (default)', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3173,7 +3239,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align center', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3199,7 +3265,7 @@ void runAllTests({ required bool useMaterial3 }) {
       testWidgets('align bottom', (WidgetTester tester) async {
         const String text = 'text';
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -3228,7 +3294,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('default alignment', () {
       testWidgets('Centers when border', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               border: OutlineInputBorder(),
@@ -3245,7 +3311,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and label', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               labelText: 'label',
@@ -3263,7 +3329,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and contentPadding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               border: OutlineInputBorder(),
@@ -3284,7 +3350,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and contentPadding and label', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               labelText: 'label',
@@ -3305,7 +3371,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Centers when border and lopsided contentPadding and label', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               labelText: 'label',
@@ -3327,7 +3393,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Floating label is aligned with prefixIcon by default in M3', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               prefixIcon: Icon(Icons.ac_unit),
@@ -3346,7 +3412,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('Floating label for filled input decoration is aligned with text', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: const InputDecoration(
               prefixIcon: Icon(Icons.ac_unit),
@@ -3367,7 +3433,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('3 point interpolation alignment', () {
       testWidgets('top align includes padding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             expands: true,
             textAlignVertical: TextAlignVertical.top,
@@ -3391,7 +3457,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center align ignores padding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             expands: true,
             textAlignVertical: TextAlignVertical.center,
@@ -3415,7 +3481,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('bottom align includes padding', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             expands: true,
             textAlignVertical: TextAlignVertical.bottom,
@@ -3439,7 +3505,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('padding exceeds middle keeps top at middle', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             expands: true,
             textAlignVertical: TextAlignVertical.top,
@@ -3465,7 +3531,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - LTR, not dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3485,7 +3551,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - RTL, not dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         textDirection: TextDirection.rtl,
         // isEmpty: false (default)
@@ -3505,7 +3571,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - LTR, dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3526,7 +3592,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('counter text has correct right margin - RTL, dense', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         textDirection: TextDirection.rtl,
         // isEmpty: false (default)
@@ -3547,7 +3613,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator error/helper/counter RTL layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3582,7 +3648,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // If both error and helper are specified, show the error
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3604,7 +3670,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefix/suffix RTL', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3639,7 +3705,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator contentPadding RTL layout', (WidgetTester tester) async {
     // LTR: content left edge is contentPadding.start: 40.0
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3658,7 +3724,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // RTL: content right edge is 800 - contentPadding.start: 760.0.
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         isFocused: true, // label is floating, still adjusted for contentPadding
@@ -3685,7 +3751,7 @@ void runAllTests({ required bool useMaterial3 }) {
   group('inputText width', () {
     testWidgets('outline textField', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           decoration: const InputDecoration(
             border: OutlineInputBorder(),
@@ -3698,7 +3764,7 @@ void runAllTests({ required bool useMaterial3 }) {
     });
     testWidgets('outline textField with prefix and suffix icons', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           decoration: const InputDecoration(
             border: OutlineInputBorder(),
@@ -3713,7 +3779,7 @@ void runAllTests({ required bool useMaterial3 }) {
     });
     testWidgets('filled textField', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           decoration: const InputDecoration(
             filled: true,
@@ -3726,7 +3792,7 @@ void runAllTests({ required bool useMaterial3 }) {
     });
     testWidgets('filled textField with prefix and suffix icons', (WidgetTester tester) async {
       await tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           decoration: const InputDecoration(
             filled: true,
@@ -3742,11 +3808,11 @@ void runAllTests({ required bool useMaterial3 }) {
   });
 
   group('floatingLabelAlignment', () {
-    Widget buildInputDecoratorWithFloatingLabel({required TextDirection textDirection,
+    Widget buildInputDecoratorLegacyWithFloatingLabel({required TextDirection textDirection,
           required bool hasIcon,
           required FloatingLabelAlignment alignment,
           bool borderIsOutline = false,
-    }) => buildInputDecorator(
+    }) => buildInputDecoratorLegacy(
       useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -3765,7 +3831,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('LTR with icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3776,7 +3842,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopLeft(find.text('label')).dx, 80.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3789,7 +3855,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3800,7 +3866,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 420.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3815,7 +3881,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('LTR without icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3826,7 +3892,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopLeft(find.text('label')).dx, 40.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3839,7 +3905,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -3850,7 +3916,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 400.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.ltr,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -3865,7 +3931,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('RTL with icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3876,7 +3942,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopRight(find.text('label')).dx, 720.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.start,
@@ -3889,7 +3955,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3900,7 +3966,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 380.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: true,
             alignment: FloatingLabelAlignment.center,
@@ -3915,7 +3981,7 @@ void runAllTests({ required bool useMaterial3 }) {
     group('RTL without icon aligned', () {
       testWidgets('start', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3926,7 +3992,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getTopRight(find.text('label')).dx, 760.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.start,
@@ -3939,7 +4005,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
       testWidgets('center', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -3950,7 +4016,7 @@ void runAllTests({ required bool useMaterial3 }) {
         expect(tester.getCenter(find.text('label')).dx, 400.0);
 
         await tester.pumpWidget(
-          buildInputDecoratorWithFloatingLabel(
+          buildInputDecoratorLegacyWithFloatingLabel(
             textDirection: TextDirection.rtl,
             hasIcon: false,
             alignment: FloatingLabelAlignment.center,
@@ -3965,7 +4031,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator prefix/suffix dense layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         isFocused: true,
@@ -4006,7 +4072,7 @@ void runAllTests({ required bool useMaterial3 }) {
   });
 
   testWidgets('InputDecorator with empty InputDecoration', (WidgetTester tester) async {
-    await tester.pumpWidget(buildInputDecorator(
+    await tester.pumpWidget(buildInputDecoratorLegacy(
       useMaterial3: useMaterial3,
     ));
 
@@ -4026,7 +4092,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // Regression test for https://github.com/flutter/flutter/issues/42449
     const double verticalPadding = 1.0;
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default),
         // isFocused: false (default)
@@ -4051,7 +4117,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 1.0);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default),
         // isFocused: false (default)
@@ -4075,7 +4141,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorderWeight(tester), 1.0);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default),
         // isFocused: false (default)
@@ -4100,7 +4166,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator.collapsed', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default),
         // isFocused: false (default)
@@ -4122,7 +4188,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // The hint should appear
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true,
@@ -4146,7 +4212,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // text child to a smaller font reduces the InputDecoration's vertical size.
     const TextStyle style = TextStyle(fontSize: 10.0);
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         baseStyle: style,
@@ -4185,7 +4251,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator with empty style overrides', (WidgetTester tester) async {
     // Same as not specifying any style overrides
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -4227,7 +4293,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecoration outline shape with no border and no floating placeholder', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         isEmpty: true,
@@ -4252,7 +4318,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecoration outline shape with no border and no floating placeholder not empty', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -4404,7 +4470,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorationTheme outline border', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true, // label appears, vertically centered
         // isFocused: false (default)
@@ -4430,7 +4496,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorationTheme outline border, dense layout', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true, // label appears, vertically centered
         // isFocused: false (default)
@@ -4473,7 +4539,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true, // label appears, vertically centered
         // isFocused: false (default)
@@ -4540,7 +4606,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true, // Label appears floating above input field.
@@ -4606,7 +4672,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator.debugDescribeChildren', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           icon: Text('icon'),
@@ -4649,7 +4715,7 @@ void runAllTests({ required bool useMaterial3 }) {
   testWidgets('InputDecorator with empty border and label', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/14165
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -4951,7 +5017,7 @@ void runAllTests({ required bool useMaterial3 }) {
     // This is a regression test for https://github.com/flutter/flutter/issues/15742
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -4990,7 +5056,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
   testWidgets('InputDecorator UnderlineInputBorder fillColor is clipped by border', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -5148,7 +5214,7 @@ void runAllTests({ required bool useMaterial3 }) {
       bool filled = true,
     }) async {
       return tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           isHovering: hovering,
           decoration: InputDecoration(
@@ -5228,7 +5294,7 @@ void runAllTests({ required bool useMaterial3 }) {
       bool filled = true,
     }) async {
       return tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           isFocused: focused,
           decoration: InputDecoration(
@@ -5280,7 +5346,7 @@ void runAllTests({ required bool useMaterial3 }) {
       bool directional = false,
     }) async {
       return tester.pumpWidget(
-        buildInputDecorator(
+        buildInputDecoratorLegacy(
           useMaterial3: useMaterial3,
           isEmpty: empty,
           isFocused: focused,
@@ -5399,7 +5465,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Enabled
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
       ),
@@ -5409,7 +5475,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Filled
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
         decoration: const InputDecoration(
@@ -5422,7 +5488,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Hovering
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
         isHovering: true,
@@ -5433,7 +5499,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Focused
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
         isFocused: true,
@@ -5444,7 +5510,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Error
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
         decoration: const InputDecoration(
@@ -5457,7 +5523,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Disabled
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
         decoration: const InputDecoration(
@@ -5470,7 +5536,7 @@ void runAllTests({ required bool useMaterial3 }) {
 
     // Disabled, filled
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         theme: theme,
         decoration: const InputDecoration(
@@ -5501,7 +5567,7 @@ void runAllTests({ required bool useMaterial3 }) {
     );
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5518,7 +5584,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), enabledBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         decoration: const InputDecoration(
@@ -5536,7 +5602,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         decoration: const InputDecoration(
@@ -5554,7 +5620,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), focusedErrorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5572,7 +5638,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5590,7 +5656,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), errorBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         decoration: const InputDecoration(
@@ -5607,7 +5673,7 @@ void runAllTests({ required bool useMaterial3 }) {
     expect(getBorder(tester), disabledBorder);
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isFocused: true,
         decoration: const InputDecoration(
@@ -5640,7 +5706,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const double inputDecoratorWidth = 800.0;
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           filled: true,
@@ -5745,7 +5811,7 @@ void runAllTests({ required bool useMaterial3 }) {
     const double inputDecoratorWidth = 800.0;
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: InputDecoration(
           filled: true,
@@ -5838,7 +5904,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     const double borderWidth = 4.0;
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         isFocused: true,
         decoration: const InputDecoration(
           filled: false,
@@ -6157,7 +6223,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
   testWidgets('InputDecorator floating label Y coordinate', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/54028
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         decoration: const InputDecoration(
@@ -6179,7 +6245,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
 
   testWidgets('InputDecorator floating label obeys floatingLabelBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         decoration: const InputDecoration(
           labelText: 'label',
@@ -6196,7 +6262,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
 
   testWidgets('InputDecorator hint is displayed when floatingLabelBehavior is always', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isFocused: false (default)
         isEmpty: true,
@@ -6221,7 +6287,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
         child: SizedBox(
           width: 100,
           height: 100,
-          child: buildInputDecorator(
+          child: buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isFocused: false (default)
             isEmpty: true,
@@ -6245,7 +6311,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
         child: SizedBox(
           width: 100,
           height: 100,
-          child: buildInputDecorator(
+          child: buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             isFocused: true,
             isEmpty: true,
@@ -6770,7 +6836,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true,
         isFocused: true, // Label appears floating above input field.
@@ -6812,7 +6878,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     // provided then the horizontal padding is included.
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         isEmpty: true, // Label appears inline, on top of the input field.
         inputDecorationTheme: InputDecorationTheme(
@@ -6855,7 +6921,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     );
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -6877,7 +6943,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     );
 
     await tester.pumpWidget(
-      buildInputDecorator(
+      buildInputDecoratorLegacy(
         useMaterial3: useMaterial3,
         // isEmpty: false (default)
         // isFocused: false (default)
@@ -6904,7 +6970,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     for (final TextDirection direction in TextDirection.values) {
       Future<Size> measureText(InputDecoration decoration) async {
         await tester.pumpWidget(
-          buildInputDecorator(
+          buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             // isEmpty: false (default)
             // isFocused: false (default)
@@ -6953,7 +7019,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
       Center(
         child: SizedBox.square(
           dimension: 0.0,
-          child: buildInputDecorator(
+          child: buildInputDecoratorLegacy(
             useMaterial3: useMaterial3,
             decoration: decoration,
           ),


### PR DESCRIPTION
## Description

This PR main purpose is to make progress on the M3 test migration for `InputDecorator` (see https://github.com/flutter/flutter/issues/139076).

Before this PR more than 80 of the 156 tests defined in `input_decorator_test.dart` fail on M3.
Migrating all those tests in one shot is not easy at all because many failures are related to wrong positionning due to M3 typography changes. Another reason is that several M3 specific changes are required in order to get a proper M3 compliant text field, for instance:
- https://github.com/flutter/flutter/issues/142972
- https://github.com/flutter/flutter/issues/141354

Most of the tests were relying on an helper function (`buildInputDecorator`) which had a `useMaterial3` parameter. Unfortunately when `useMaterial3: true `was passed to this function it forced `useMaterial3: false` at the top level but overrided it at a lower level, which was very misleading because people could assume that the tests are ok with M3 (but in fact they were run using M2 typography but have some M3 logic in use).
I considered various way to make this change and I finally decided to run all existing tests only on M2 for the moment. Next step will be to move most of those tests to M3. In this PR, I migrated two of these existing tests for illustration.

Because many of the existing tests are checking input decorator height, I think it would also make sense to fix https://github.com/flutter/flutter/issues/142972 first. That's why I choosed to include a fix to https://github.com/flutter/flutter/issues/142972 in this PR.

A M3 filled `TextField` on Android:

| Before this PR | After this PR |
|--------|--------|
| ![image](https://github.com/flutter/flutter/assets/840911/403225b7-4c91-4aee-b19c-0490447ae7e3) | ![image](https://github.com/flutter/flutter/assets/840911/e96cf786-a9f5-4e15-bcdd-078350ff1608) | 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/142972
Related to https://github.com/flutter/flutter/issues/139076

## Tests

Updates many existing tests 
+ adds 2 tests related to the fix for https://github.com/flutter/flutter/issues/142972
+ adds 1 tests for the M3 migration
+ move 1 tests related to M3