### PR TITLE
Highlight the links to the release branches more prominently in the CP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/7_cherry_pick.yml
+++ b/.github/ISSUE_TEMPLATE/7_cherry_pick.yml
@@ -3,6 +3,9 @@ description: As a contributor, you would like to request that a feature be cherr
 title: '[CP] <title>'
 labels: ['cp: review']
 body:
+  - type: markdown
+    attributes:
+      value: "### The current branches can be found under release-candidate-branch.version for [beta](https://github.com/flutter/flutter/blob/beta/bin/internal/release-candidate-branch.version) and [stable](https://github.com/flutter/flutter/blob/stable/bin/internal/release-candidate-branch.version)"
   - type: input
     id: issue_link
     attributes:


### PR DESCRIPTION
Unfortunately, there's no option to preview these changes in the GitHub UI, so I may need to iterate on this...

