### PR TITLE
Instrument BoxPainter.

### DIFF
--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -198,9 +198,18 @@ abstract class Decoration with Diagnosticable {
 /// happens, the [onChanged] callback will be invoked. To stop this callback
 /// from being called after the painter has been discarded, call [dispose].
 abstract class BoxPainter {
-  /// Abstract const constructor. This constructor enables subclasses to provide
-  /// const constructors so that they can be used in const expressions.
-  const BoxPainter([this.onChanged]);
+  /// Default abstract constructor for box painters.
+  BoxPainter([this.onChanged]) {
+    // TODO(polina-c): stop duplicating code across disposables
+    // https://github.com/flutter/flutter/issues/137435
+    if (kFlutterMemoryAllocationsEnabled) {
+      FlutterMemoryAllocations.instance.dispatchObjectCreated(
+        library: 'package:flutter/painting.dart',
+        className: '$BoxPainter',
+        object: this,
+      );
+    }
+  }
 
   /// Paints the [Decoration] for which this object was created on the
   /// given canvas using the given configuration.
@@ -243,5 +252,9 @@ abstract class BoxPainter {
   /// The [onChanged] callback will not be invoked after this method has been
   /// called.
   @mustCallSuper
-  void dispose() { }
+  void dispose() {
+    if (kFlutterMemoryAllocationsEnabled) {
+      FlutterMemoryAllocations.instance.dispatchObjectDisposed(object: this);
+    }
+  }
 }

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -9,6 +9,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../image_data.dart';
 import '../painting/mocks_for_image_cache.dart';
@@ -812,4 +813,16 @@ void main() {
 
     info.dispose();
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/87442
+
+  test('$BoxPainter dispatches memory events', () async {
+    await expectLater(
+      await memoryEvents(() => _BoxPainter().dispose(), _BoxPainter),
+      areCreateAndDispose,
+    );
+  });
+}
+
+class _BoxPainter extends BoxPainter {
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {}
 }


### PR DESCRIPTION
It is ok to convert const constructor to non-const, because all non-test descendants of BoxPainter are non-const.

Copied from https://github.com/flutter/flutter/pull/141526

Most likely g3 fixes will be needed.