### PR TITLE
Example Windows platform view widget

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -386,6 +386,59 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
   void updateGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers);
 }
 
+/// Windows platform view prototype.
+class RenderWin32View extends RenderBox {
+  /// Creates the view.
+  RenderWin32View(Win32ViewController viewController): _viewController = viewController;
+
+  /// The unique identifier of the platform view controlled by this controller.
+  Win32ViewController get viewController => _viewController;
+  Win32ViewController _viewController;
+  set viewController(Win32ViewController value) {
+    if (_viewController == value) {
+      return;
+    }
+    final bool needsSemanticsUpdate = _viewController.id != value.id;
+    _viewController = value;
+    markNeedsPaint();
+    if (needsSemanticsUpdate) {
+      markNeedsSemanticsUpdate();
+    }
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    context.addLayer(PlatformViewLayer(
+      rect: offset & size,
+      viewId: viewController.id,
+    ));
+  }
+
+  @override
+  bool get sizedByParent => true;
+
+  @override
+  bool get alwaysNeedsCompositing => true;
+
+  @override
+  bool get isRepaintBoundary => true;
+
+  @override
+  @protected
+  Size computeDryLayout(covariant BoxConstraints constraints) {
+    return constraints.biggest;
+  }
+
+  @override
+  bool hitTest(BoxHitTestResult result, { Offset? position }) {
+    if (!size.contains(position!)) {
+      return false;
+    }
+    result.add(BoxHitTestEntry(this, position));
+    return true;
+  }
+}
+
 /// A render object for an iOS UIKit UIView.
 ///
 /// [RenderUiKitView] is responsible for sizing and displaying an iOS

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -295,7 +295,8 @@ class PlatformViewsService {
 
   static Future<Win32ViewController> initWin32View({
     required int id,
-    required String viewType
+    required String viewType,
+    VoidCallback? onFocus
   }) async {
     // TODO(schectman): send message
     final Map<String, dynamic> args = <String, dynamic>{
@@ -303,7 +304,18 @@ class PlatformViewsService {
       'viewType': viewType,
     };
     await SystemChannels.platform_views.invokeMethod<void>('create', args);
+    if (onFocus != null) {
+      _instance._focusCallbacks[id] = onFocus;
+    }
     return Win32ViewController._(id);
+  }
+
+  static Future<void> focusWin32View({required int id, required bool focus}) async {
+    final Map<String, dynamic> args = <String, dynamic>{
+      'id': id,
+      'focus': focus,
+    };
+    await SystemChannels.platform_views.invokeMethod('focus', args);
   }
 }
 
@@ -1405,6 +1417,10 @@ class Win32ViewController {
   Win32ViewController._(this.id);
 
   final int id;
+
+  Future<void> focus(bool focus) async {
+    await PlatformViewsService.focusWin32View(id: id, focus: focus);
+  }
 }
 
 /// Base class for iOS and macOS view controllers.

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -292,6 +292,19 @@ class PlatformViewsService {
     }
     return AppKitViewController._(id, layoutDirection);
   }
+
+  static Future<Win32ViewController> initWin32View({
+    required int id,
+    required String viewType
+  }) async {
+    // TODO(schectman): send message
+    final Map<String, dynamic> args = <String, dynamic>{
+      'id': id,
+      'viewType': viewType,
+    };
+    await SystemChannels.platform_views.invokeMethod<void>('create', args);
+    return Win32ViewController._(id);
+  }
 }
 
 /// Properties of an Android pointer.
@@ -1386,6 +1399,12 @@ class _HybridAndroidViewControllerInternals extends _AndroidViewControllerIntern
       'hybrid': true,
     });
   }
+}
+
+class Win32ViewController {
+  Win32ViewController._(this.id);
+
+  final int id;
 }
 
 /// Base class for iOS and macOS view controllers.

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -619,6 +619,7 @@ class _AndroidViewState extends State<AndroidView> {
 class _WindowsViewState extends State<Win32View> {
   bool _initialized = false;
   Win32ViewController? _controller;
+  late FocusNode _node;
 
   void _initializeOnce() {
     if (_initialized) {
@@ -646,7 +647,11 @@ class _WindowsViewState extends State<Win32View> {
 
   Future<void> _createNewWin32View() async {
     final int id = platformViewsRegistry.getNextPlatformViewId();
-    final Win32ViewController controller = await PlatformViewsService.initWin32View(id: id, viewType: widget.viewType);
+    _node = FocusNode(debugLabel: 'Windows view: $id');
+    final Win32ViewController controller = await PlatformViewsService.initWin32View(id: id, viewType: widget.viewType, onFocus: () {
+      _node.requestFocus();
+      print('Node $id stole focus');
+    });
     setState(() {
       _controller = controller;
     });
@@ -658,7 +663,18 @@ class _WindowsViewState extends State<Win32View> {
     if (controller == null) {
       return const SizedBox.expand();
     }
-    return _Win32View(controller: controller);
+    return Semantics(
+      label: 'Platform view placeholder',
+      child: Focus(
+        focusNode: _node,
+        onFocusChange: (focus) {
+          if (focus) {
+            controller.focus(focus);
+          }
+        },
+        child: _Win32View(controller: controller)
+        ),
+    );
   }
 }
 


### PR DESCRIPTION
At least temporarily, this PR serves to demonstrate the planned framework widget changes to enable platform views on Windows. In its current state, it will not be merged.

See https://github.com/flutter/engine/pull/50446 for the engine side changes

Part of https://github.com/flutter/flutter/issues/138431

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
