### PR TITLE
Fix cursor  overlapping label on iOS and macOS

### DIFF
--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -1042,6 +1042,28 @@ void main() {
     ));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
+  testWidgets('Cursor layout has correct height and width when specified', (WidgetTester tester) async {
+    const double cursorWidth = 15.0;
+    const double cursorHeight = 30.0;
+
+    await tester.pumpWidget(
+       const MaterialApp(
+        home: Material(
+          child: TextField(
+            autofocus: true,
+            cursorWidth: cursorWidth,
+            cursorHeight: cursorHeight,
+          ),
+        ),
+      ),
+    );
+
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    expect(renderEditable, paints..rect(
+      rect: const Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight),
+    ));
+  });
+
   testWidgets('Material3 - Default cursor layout has correct height and vertical offset', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
## Description

This PR updates the cursor height computation on macOS and iOS in order to get a better result with M3 default text style.
Previously, on macOS and iOS, the cursor height was slightly extended for fidelity. Because M3 default text styles relies on line height (for instance 1.5 for bodyLarge), and because the cursor height reflects this line height, extending the cursor height leads to the cursor overlapping the label or being very close to it.

This PR applies the cursor height extension only when line height is small enough (< 1.3). When line height is equal or superior to 1.3, the cursor height is slightly decreased to get a better result.

Default M3 TextField on macOS:

|  | Before | After |
|--------|--------|--------|
| macOS | ![Capture d’écran 2024-02-09 à 15 53 17](https://github.com/flutter/flutter/assets/840911/bab586fa-234b-4454-9abc-ced4c8e38ee7) | ![Capture d’écran 2024-02-09 à 16 04 49](https://github.com/flutter/flutter/assets/840911/86e43e0c-0de9-4aec-9bd2-40fee39ee037)  |
| iOS |  ![Capture d’écran 2024-02-09 à 15 55 33](https://github.com/flutter/flutter/assets/840911/76d509ce-094b-4cc8-ba5b-60c03a24ed1b) | ![Capture d’écran 2024-02-09 à 16 06 28](https://github.com/flutter/flutter/assets/840911/8c0b4084-58ef-4db7-a71f-5c1d26db430e) | 


## Related Issue

Fixes https://github.com/flutter/flutter/issues/141354.

## Tests

Adds 2 tests for M3.
Updates 1 existing test (replace golden with a paint expect clause. (Will do the same in another PR to make existing tests shorter and more accurate).