### PR TITLE
Pass-Through `inputFormatters` in `DropdownMenu`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -390,7 +390,18 @@ class DropdownMenu<T> extends StatefulWidget {
   /// which contains the contents of the text input field.
   final SearchCallback<T>? searchCallback;
 
-  /// {@macro flutter.widgets.editableText.inputFormatters}
+  /// Optional input validation and formatting overrides.
+  ///
+  /// Formatters are run in the provided order when the user changes the text
+  /// this widget contains. When this parameter changes, the new formatters will
+  /// not be applied until the next time the user inserts or deletes text.
+  /// Formatters don't run when the text is changed
+  /// programmatically via [controller].
+  ///
+  /// See also:
+  ///
+  ///  * [TextEditingController], which implements the [Listenable] interface
+  ///    and notifies its listeners on [TextEditingValue] changes.
   final List<TextInputFormatter>? inputFormatters;
 
   @override

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -759,6 +759,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                 _enableFilter = widget.enableFilter;
               });
             },
+            inputFormatters: widget.inputFormatters,
             decoration: InputDecoration(
               enabled: widget.enabled,
               label: widget.label,
@@ -770,8 +771,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                   child: widget.leadingIcon
               ) : null,
               suffixIcon: trailingButton,
-            ).applyDefaults(effectiveInputDecorationTheme),
-            inputFormatters: widget.inputFormatters,
+            ).applyDefaults(effectiveInputDecorationTheme)
         );
 
         if (widget.expandedInsets != null) {

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -164,6 +164,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.expandedInsets,
     this.searchCallback,
     required this.dropdownMenuEntries,
+    this.inputFormatters,
   });
 
   /// Determine if the [DropdownMenu] is enabled.
@@ -388,6 +389,9 @@ class DropdownMenu<T> extends StatefulWidget {
   /// the default function will return the index of the first matching result
   /// which contains the contents of the text input field.
   final SearchCallback<T>? searchCallback;
+
+  /// {@macro flutter.widgets.editableText.inputFormatters}
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<DropdownMenu<T>> createState() => _DropdownMenuState<T>();
@@ -766,7 +770,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                   child: widget.leadingIcon
               ) : null,
               suffixIcon: trailingButton,
-            ).applyDefaults(effectiveInputDecorationTheme)
+            ).applyDefaults(effectiveInputDecorationTheme),
+            inputFormatters: widget.inputFormatters,
         );
 
         if (widget.expandedInsets != null) {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1972,6 +1972,54 @@ void main() {
     // Test input border when focused.
     expect(box, paints..rrect(color: theme.colorScheme.primary));
   });
+
+  testWidgets('DropdownMenu honor inputFormatters', (WidgetTester tester) async {
+    int called = 0;
+    final TextInputFormatter formatter = TextInputFormatter.withFunction(
+      (TextEditingValue oldValue, TextEditingValue newValue) {
+        called += 1;
+        return newValue;
+      },
+    );
+    final TextEditingController controller = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenu<String>(
+            controller: controller,
+            dropdownMenuEntries: const <DropdownMenuEntry<String>>[
+              DropdownMenuEntry<String>(
+                value: 'Blue',
+                label: 'Blue',
+              ),
+              DropdownMenuEntry<String>(
+                value: 'Green',
+                label: 'Green',
+              ),
+            ],
+            inputFormatters: <TextInputFormatter>[
+              formatter,
+              FilteringTextInputFormatter.deny(RegExp('[0-9]'))
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final EditableTextState state = tester.firstState(find.byType(EditableText));
+    state.updateEditingValue(const TextEditingValue(text: 'Blue'));
+    expect(called, 1);
+    expect(controller.text, 'Blue');
+
+    state.updateEditingValue(const TextEditingValue(text: 'Green'));
+    expect(called, 2);
+    expect(controller.text, 'Green');
+
+    state.updateEditingValue(const TextEditingValue(text: 'Green2'));
+    expect(called, 3);
+    expect(controller.text, 'Green');
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1973,7 +1973,7 @@ void main() {
     expect(box, paints..rrect(color: theme.colorScheme.primary));
   });
 
-  testWidgets('DropdownMenu honor inputFormatters', (WidgetTester tester) async {
+  testWidgets('DropdownMenu honors inputFormatters', (WidgetTester tester) async {
     int called = 0;
     final TextInputFormatter formatter = TextInputFormatter.withFunction(
       (TextEditingValue oldValue, TextEditingValue newValue) {


### PR DESCRIPTION
Pass-Through `inputFormatters` in `DropdownMenu`.

Fixes: #142374 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
