### PR TITLE
Remove unnecessary 'debugLabel: null'.

### DIFF
--- a/dev/integration_tests/release_smoke_test/lib/main.dart
+++ b/dev/integration_tests/release_smoke_test/lib/main.dart
@@ -15,7 +15,7 @@ Future<void> main() async {
   print(text.toDiagnosticsNode());
   print(text.toStringDeep());
   // regression test for https://github.com/flutter/flutter/issues/49601
-  final List<int> computed = await compute(_utf8Encode, 'test', debugLabel: null);
+  final List<int> computed = await compute(_utf8Encode, 'test');
   print(computed);
   runApp(
     const Center(


### PR DESCRIPTION
There was a change https://dart-review.googlesource.com/c/sdk/+/350920 to the analyzer that caused reporting this lint.

https://github.com/flutter/flutter/issues/143254

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
