### PR TITLE
[tool] Add flutter version in pubspec of new projects

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -24,6 +24,7 @@ import '../ios/code_signing.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';
+import '../version.dart';
 import 'create_base.dart';
 
 const String kPlatformHelp =
@@ -318,6 +319,13 @@ class CreateCommand extends CreateBase {
     // The dart project_name is in snake_case, this variable is the Title Case of the Project Name.
     final String titleCaseProjectName = snakeCaseToTitleCase(projectName);
 
+    // Only channels that have prereleases should allow them.
+    final String flutterSdkVersionBounds = switch(globals.flutterVersion.channel) {
+      'main' || 'master' || 'beta' || kUserBranch => "'^${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0-0'",
+      'stable' => "'^${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0'",
+      _ => "'^${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0'",
+    };
+
     final Map<String, Object?> templateContext = createTemplateContext(
       organization: organization,
       projectName: projectName,
@@ -338,7 +346,7 @@ class CreateCommand extends CreateBase {
       macos: includeMacos,
       windows: includeWindows,
       dartSdkVersionBounds: "'>=$dartSdk <4.0.0'",
-      flutterSdkVersionBounds: "'>=${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0'",
+      flutterSdkVersionBounds: flutterSdkVersionBounds,
       implementationTests: boolArg('implementation-tests'),
       agpVersion: gradle.templateAndroidGradlePluginVersion,
       kotlinVersion: gradle.templateKotlinGradlePluginVersion,

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -320,7 +320,7 @@ class CreateCommand extends CreateBase {
     final String titleCaseProjectName = snakeCaseToTitleCase(projectName);
 
     // Only channels that have prereleases should allow them.
-    final String flutterSdkVersionBounds = switch(globals.flutterVersion.channel) {
+    final String flutterSdkVersionBounds = switch (globals.flutterVersion.channel) {
       'main' || 'master' || 'beta' || kUserBranch => "'^${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0-0'",
       'stable' => "'^${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0'",
       _ => "'^${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0'",

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -272,6 +272,7 @@ class CreateCommand extends CreateBase {
     }
 
     final String dartSdk = globals.cache.dartSdkBuild;
+    final Version flutterSdkVersion = Version.parse(globals.flutterVersion.frameworkVersion)!;
     final bool includeIos;
     final bool includeAndroid;
     final bool includeWeb;
@@ -337,6 +338,7 @@ class CreateCommand extends CreateBase {
       macos: includeMacos,
       windows: includeWindows,
       dartSdkVersionBounds: "'>=$dartSdk <4.0.0'",
+      flutterSdkVersionBounds: "'>=${flutterSdkVersion.major}.${flutterSdkVersion.minor}.0'",
       implementationTests: boolArg('implementation-tests'),
       agpVersion: gradle.templateAndroidGradlePluginVersion,
       kotlinVersion: gradle.templateKotlinGradlePluginVersion,

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -346,6 +346,7 @@ abstract class CreateBase extends FlutterCommand {
     String? iosDevelopmentTeam,
     String? iosLanguage,
     required String flutterRoot,
+    required String flutterSdkVersionBounds,
     required String dartSdkVersionBounds,
     String? agpVersion,
     String? kotlinVersion,
@@ -410,6 +411,7 @@ abstract class CreateBase extends FlutterCommand {
       'iosLanguage': iosLanguage,
       'hasIosDevelopmentTeam': iosDevelopmentTeam != null && iosDevelopmentTeam.isNotEmpty,
       'iosDevelopmentTeam': iosDevelopmentTeam ?? '',
+      'flutterSdkVersionBounds': flutterSdkVersionBounds,
       'flutterRevision': escapeYamlString(globals.flutterVersion.frameworkRevision),
       'flutterChannel': escapeYamlString(globals.flutterVersion.getBranchName()), // may contain PII
       'ios': ios,

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -6,6 +6,7 @@ version: 0.1.0
 
 environment:
   sdk: {{dartSdkVersionBounds}}
+  flutter: {{flutterSdkVersionBounds}}
 
 dependencies:
   flutter:
@@ -42,6 +43,7 @@ version: 1.0.0+1
 
 environment:
   sdk: {{dartSdkVersionBounds}}
+  flutter: {{flutterSdkVersionBounds}}
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -19,6 +19,7 @@ version: 1.0.0+1
 
 environment:
   sdk: {{dartSdkVersionBounds}}
+  flutter: {{flutterSdkVersionBounds}}
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -19,7 +19,7 @@ version: 1.0.0+1
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: {{flutterSdkVersionBounds}}
+  flutter: '>=3.10.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: ">=1.17.0"
+  flutter: {{flutterSdkVersionBounds}}
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: {{flutterSdkVersionBounds}}
+  flutter: '>=3.10.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -5,6 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
+  flutter: {{flutterSdkVersionBounds}}
 
 dependencies:
   cli_config: ^0.1.2

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: {{flutterSdkVersionBounds}}
+  flutter: '>=3.10.0'
 
 dependencies:
   cli_config: ^0.1.2

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: '>=3.3.0'
+  flutter: {{flutterSdkVersionBounds}}
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: {{flutterSdkVersionBounds}}
+  flutter: '>=3.10.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/templates/skeleton/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/skeleton/pubspec.yaml.tmpl
@@ -8,6 +8,7 @@ version: 1.0.0+1
 
 environment:
   sdk: {{dartSdkVersionBounds}}
+  flutter: {{flutterSdkVersionBounds}}
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -286,81 +286,68 @@ void main() {
     ),
   });
 
-  testUsingContext('creates a new project with pre-release flutter version constraint in pubspec', () async {
+  testUsingContext('creates a new app/skeleton project with pre-release flutter version constraint in pubspec', () async {
     Cache.flutterRoot = '../..';
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=app', projectDir.path]);
+    final List<String> templates = <String>['app', 'skeleton'];
 
-    final String rawPubspec = await projectDir.childFile('pubspec.yaml').readAsString();
-    final Pubspec pubspec = Pubspec.parse(rawPubspec);
-    final VersionConstraint? flutterVersionConstraint = pubspec.environment?['flutter'];
+    for (final String template in templates) {
+      final String templateProjectPath = globals.fs.path.join(projectDir.path, '${template}_project_dir');
+      final Directory templateProjectDir = globals.fs.directory(templateProjectPath);
 
-    expect(flutterVersionConstraint, isNotNull);
-    expect(flutterVersionConstraint, isA<VersionRange>());
+      await runner.run(<String>['create', '--no-pub', '--template=$template', templateProjectDir.path]);
+      final String rawPubspec = await templateProjectDir.childFile('pubspec.yaml').readAsString();
+      final Pubspec pubspec = Pubspec.parse(rawPubspec);
+      final VersionConstraint? flutterVersionConstraint = pubspec.environment?['flutter'];
 
-    final VersionRange flutterVersionRange = flutterVersionConstraint! as VersionRange;
+      expect(flutterVersionConstraint, isNotNull);
+      expect(flutterVersionConstraint, isA<VersionRange>());
 
-    final Version flutterSdkVersion = Version.parse(globals.flutterVersion.frameworkVersion);
+      final VersionRange flutterVersionRange = flutterVersionConstraint! as VersionRange;
 
-    expect(flutterSdkVersion, isNot(Version.none));
-
-    // The version pin should allow minor & patch releases,
-    // both of which are allowed to be pre-releases.
-    expect(flutterVersionRange.allows(Version(1, 1, 0)), isFalse);
-    expect(flutterVersionRange.allows(Version(1, 2, 0)), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 3)), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 4)), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 3, 0)), isTrue);
-    expect(flutterVersionRange.allows(Version(2, 0, 0)), isFalse);
-
-    expect(flutterVersionRange.allows(Version(1, 1, 0, pre: '10')), isFalse);
-    expect(flutterVersionRange.allows(Version(1, 2, 0, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 3, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 4, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 3, 0, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(2, 0, 0, pre: '10')), isFalse);
+      expect(flutterVersionRange.min, equals(Version(1, 2, 0, pre: '0')));
+      expect(flutterVersionRange.allows(Version(1, 1, 0)), isFalse);
+      expect(flutterVersionRange.allows(Version(1, 1, 0, pre: '0')), isFalse);
+      expect(flutterVersionRange.allows(Version(1, 2, 0, pre: '10')), isTrue);
+      expect(flutterVersionRange.allows(Version(1, 3, 0)), isTrue);
+      expect(flutterVersionRange.allows(Version(1, 3, 0, pre: '0')), isTrue);
+    }
   }, overrides: <Type, Generator>{
     FlutterVersion: () => FakeFlutterVersion(frameworkVersion: '1.2.3'),
   });
 
-  testUsingContext('creates a new project with stable flutter version constraint in pubspec', () async {
+  testUsingContext('creates a new app/skeleton project with stable flutter version constraint in pubspec', () async {
     Cache.flutterRoot = '../..';
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=app', projectDir.path]);
+    final List<String> templates = <String>['app', 'skeleton'];
 
-    final String rawPubspec = await projectDir.childFile('pubspec.yaml').readAsString();
-    final Pubspec pubspec = Pubspec.parse(rawPubspec);
-    final VersionConstraint? flutterVersionConstraint = pubspec.environment?['flutter'];
+    for (final String template in templates) {
+      final String templateProjectPath = globals.fs.path.join(projectDir.path, '${template}_project_dir');
+      final Directory templateProjectDir = globals.fs.directory(templateProjectPath);
 
-    expect(flutterVersionConstraint, isNotNull);
-    expect(flutterVersionConstraint, isA<VersionRange>());
+      await runner.run(<String>['create', '--no-pub', '--template=$template', templateProjectDir.path]);
+      final String rawPubspec = await templateProjectDir.childFile('pubspec.yaml').readAsString();
+      final Pubspec pubspec = Pubspec.parse(rawPubspec);
+      final VersionConstraint? flutterVersionConstraint = pubspec.environment?['flutter'];
 
-    final VersionRange flutterVersionRange = flutterVersionConstraint! as VersionRange;
+      expect(flutterVersionConstraint, isNotNull);
+      expect(flutterVersionConstraint, isA<VersionRange>());
 
-    final Version flutterSdkVersion = Version.parse(globals.flutterVersion.frameworkVersion);
+      final VersionRange flutterVersionRange = flutterVersionConstraint! as VersionRange;
 
-    expect(flutterSdkVersion, isNot(Version.none));
-
-    // The version pin should allow minor & patch releases.
-    expect(flutterVersionRange.allows(Version(1, 1, 0)), isFalse);
-    expect(flutterVersionRange.allows(Version(1, 2, 0)), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 3)), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 4)), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 3, 0)), isTrue);
-    expect(flutterVersionRange.allows(Version(2, 0, 0)), isFalse);
-
-    expect(flutterVersionRange.allows(Version(1, 1, 0, pre: '10')), isFalse);
-    expect(flutterVersionRange.allows(Version(1, 2, 0, pre: '10')), isFalse);
-    expect(flutterVersionRange.allows(Version(1, 2, 3, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 2, 4, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(1, 3, 0, pre: '10')), isTrue);
-    expect(flutterVersionRange.allows(Version(2, 0, 0, pre: '10')), isFalse);
+      expect(flutterVersionRange.min, equals(Version(1, 2, 0)));
+      expect(flutterVersionRange.allows(Version(1, 1, 0)), isFalse);
+      expect(flutterVersionRange.allows(Version(1, 1, 0, pre: '0')), isFalse);
+      expect(flutterVersionRange.allows(Version(1, 2, 0, pre: '10')), isFalse);
+      expect(flutterVersionRange.allows(Version(1, 3, 0)), isTrue);
+      expect(flutterVersionRange.allows(Version(1, 3, 0, pre: '0')), isTrue);
+    }
   }, overrides: <Type, Generator>{
     FlutterVersion: () => FakeFlutterVersion(frameworkVersion: '1.2.3', branch: 'stable'),
   });
@@ -2949,17 +2936,26 @@ dependencies:
     Logger: () => logger,
   });
 
-  testUsingContext('newly created plugin has min flutter sdk version as 3.3.0', () async {
+  testUsingContext('newly created package / plugin / module has min flutter sdk version 3.10.0', () async {
     Cache.flutterRoot = '../..';
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    final String rawPubspec = await projectDir.childFile('pubspec.yaml').readAsString();
-    final Pubspec pubspec = Pubspec.parse(rawPubspec);
-    final Map<String, VersionConstraint?> env = pubspec.environment!;
-    expect(env['flutter']!.allows(Version(3, 3, 0)), true);
-    expect(env['flutter']!.allows(Version(3, 2, 9)), false);
+    final List<String> templates = <String>['plugin', 'plugin_ffi', 'package', 'module'];
+
+    for (final String template in templates) {
+      final String templateProjectPath = globals.fs.path.join(projectDir.path, '${template}_project_dir');
+      final Directory templateProjectDir = globals.fs.directory(templateProjectPath);
+
+      await runner.run(<String>['create', '--no-pub', '--template=$template', templateProjectDir.path]);
+      final String rawPubspec = await templateProjectDir.childFile('pubspec.yaml').readAsString();
+      final Pubspec pubspec = Pubspec.parse(rawPubspec);
+      final Map<String, VersionConstraint?> env = pubspec.environment!;
+
+      expect(env['flutter']!.allows(Version(3, 10, 0)), isTrue);
+      expect(env['flutter']!.allows(Version(3, 11, 0)), isTrue);
+      expect(env['flutter']!.allows(Version(3, 9, 9)), isFalse);
+    }
   });
 
   testUsingContext('newly created iOS plugins has correct min iOS version', () async {


### PR DESCRIPTION
This PR adds a Flutter version pin to the pubspec.yaml templates.

App templates (app & skeleton) use the user's Flutter version, taking into account if we _can_ allow prerelease versions. The plugin / package / module templates now specify a pinned Flutter version, to keep the flexibility of rolling that version manually when needed.

Fixes #143159

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
