### PR TITLE
Fix `InputDecorator`s `suffix` and `prefix` widgets are tappable when hidden

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1728,14 +1728,17 @@ class _AffixText extends StatelessWidget {
   Widget build(BuildContext context) {
     return DefaultTextStyle.merge(
       style: style,
-      child: AnimatedOpacity(
-        duration: _kTransitionDuration,
-        curve: _kTransitionCurve,
-        opacity: labelIsFloating ? 1.0 : 0.0,
-        child: Semantics(
-          sortKey: semanticsSortKey,
-          tagForChildren: semanticsTag,
-          child: child ?? (text == null ? null : Text(text!, style: style)),
+      child: IgnorePointer(
+        ignoring: !labelIsFloating,
+        child: AnimatedOpacity(
+          duration: _kTransitionDuration,
+          curve: _kTransitionCurve,
+          opacity: labelIsFloating ? 1.0 : 0.0,
+          child: Semantics(
+            sortKey: semanticsSortKey,
+            tagForChildren: semanticsTag,
+            child: child ?? (text == null ? null : Text(text!, style: style)),
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6972,7 +6972,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     );
   });
 
-  testWidgets('Ensure the height of labelStyle remains unchanged when TextField is focused.', (WidgetTester tester) async {
+  testWidgets('Ensure the height of labelStyle remains unchanged when TextField is focused', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     final ThemeData theme = ThemeData(useMaterial3: true);
@@ -7007,5 +7007,131 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     final InputDecorationTheme copy2 = original.copyWith(iconColor: const Color(0xDEADCAFE));
     expect(copy2.iconColor, const Color(0xDEADCAFE));
     expect(copy2.fillColor, isNot(const Color(0xDEADCAFE)));
+  });
+
+  testWidgets('Prefix ignores pointer when hidden', (WidgetTester tester) async {
+    bool tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return TextField(
+                decoration: InputDecoration(
+                  labelText: 'label',
+                  prefix: GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        tapped = true;
+                      });
+                    },
+                    child: const Icon(Icons.search),
+                  ),
+                ),
+              );
+            }
+          ),
+        ),
+      ),
+    );
+
+    expect(tapped, isFalse);
+
+    double prefixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // Initiially the prefix icon should be hidden.
+    expect(prefixOpacity, 0.0);
+
+    await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
+    await tester.pump();
+
+    // The suffix icon should ignore pointer events when hidden.
+    expect(tapped, isFalse);
+
+    // Tap the text field to show the prefix icon.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    prefixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // The prefix icon should be visible.
+    expect(prefixOpacity, 1.0);
+
+    // Tap the prefix icon.
+    await tester.tap(find.byType(Icon));
+    await tester.pump();
+
+    // The prefix icon should be tapped.
+    expect(tapped, isTrue);
+  });
+
+  testWidgets('Suffix ignores pointer when hidden', (WidgetTester tester) async {
+    bool tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return TextField(
+                decoration: InputDecoration(
+                  labelText: 'label',
+                  suffix: GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        tapped = true;
+                      });
+                    },
+                    child: const Icon(Icons.search),
+                  ),
+                ),
+              );
+            }
+          ),
+        ),
+      ),
+    );
+
+    expect(tapped, isFalse);
+
+    double suffixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // Initiially the suffix icon should be hidden.
+    expect(suffixOpacity, 0.0);
+
+    await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
+    await tester.pump();
+
+    // The suffix icon should ignore pointer events when hidden.
+    expect(tapped, isFalse);
+
+    // Tap the text field to show the suffix icon.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    suffixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // The suffix icon should be visible.
+    expect(suffixOpacity, 1.0);
+
+    // Tap the suffix icon.
+    await tester.tap(find.byType(Icon));
+    await tester.pump();
+
+    // The suffix icon should be tapped.
+    expect(tapped, isTrue);
   });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -343,7 +343,7 @@ void main() {
       matching: find.byType(AnimatedOpacity),
     )).opacity;
 
-    // Initiially the prefix icon should be hidden.
+    // Initially the prefix icon should be hidden.
     expect(prefixOpacity, 0.0);
 
     await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
@@ -407,7 +407,7 @@ void main() {
       matching: find.byType(AnimatedOpacity),
     )).opacity;
 
-    // Initiially the suffix icon should be hidden.
+    // Initially the suffix icon should be hidden.
     expect(suffixOpacity, 0.0);
 
     await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -307,6 +307,134 @@ void main() {
     //    4 - bottom padding
     expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 48.0));
   }, variant: TargetPlatformVariant.desktop());
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/139916.
+  testWidgets('Prefix ignores pointer when hidden', (WidgetTester tester) async {
+    bool tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return TextField(
+                decoration: InputDecoration(
+                  labelText: 'label',
+                  prefix: GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        tapped = true;
+                      });
+                    },
+                    child: const Icon(Icons.search),
+                  ),
+                ),
+              );
+            }
+          ),
+        ),
+      ),
+    );
+
+    expect(tapped, isFalse);
+
+    double prefixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // Initiially the prefix icon should be hidden.
+    expect(prefixOpacity, 0.0);
+
+    await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
+    await tester.pump();
+
+    // The suffix icon should ignore pointer events when hidden.
+    expect(tapped, isFalse);
+
+    // Tap the text field to show the prefix icon.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    prefixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // The prefix icon should be visible.
+    expect(prefixOpacity, 1.0);
+
+    // Tap the prefix icon.
+    await tester.tap(find.byType(Icon));
+    await tester.pump();
+
+    // The prefix icon should be tapped.
+    expect(tapped, isTrue);
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/139916.
+  testWidgets('Suffix ignores pointer when hidden', (WidgetTester tester) async {
+    bool tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return TextField(
+                decoration: InputDecoration(
+                  labelText: 'label',
+                  suffix: GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        tapped = true;
+                      });
+                    },
+                    child: const Icon(Icons.search),
+                  ),
+                ),
+              );
+            }
+          ),
+        ),
+      ),
+    );
+
+    expect(tapped, isFalse);
+
+    double suffixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // Initiially the suffix icon should be hidden.
+    expect(suffixOpacity, 0.0);
+
+    await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
+    await tester.pump();
+
+    // The suffix icon should ignore pointer events when hidden.
+    expect(tapped, isFalse);
+
+    // Tap the text field to show the suffix icon.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    suffixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
+      of: find.byType(Icon),
+      matching: find.byType(AnimatedOpacity),
+    )).opacity;
+
+    // The suffix icon should be visible.
+    expect(suffixOpacity, 1.0);
+
+    // Tap the suffix icon.
+    await tester.tap(find.byType(Icon));
+    await tester.pump();
+
+    // The suffix icon should be tapped.
+    expect(tapped, isTrue);
+  });
 }
 
 void runAllM2Tests() {
@@ -6972,7 +7100,7 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     );
   });
 
-  testWidgets('Ensure the height of labelStyle remains unchanged when TextField is focused', (WidgetTester tester) async {
+  testWidgets('Ensure the height of labelStyle remains unchanged when TextField is focused.', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     final ThemeData theme = ThemeData(useMaterial3: true);
@@ -7007,131 +7135,5 @@ testWidgets('OutlineInputBorder with BorderRadius.zero should draw a rectangular
     final InputDecorationTheme copy2 = original.copyWith(iconColor: const Color(0xDEADCAFE));
     expect(copy2.iconColor, const Color(0xDEADCAFE));
     expect(copy2.fillColor, isNot(const Color(0xDEADCAFE)));
-  });
-
-  testWidgets('Prefix ignores pointer when hidden', (WidgetTester tester) async {
-    bool tapped = false;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return TextField(
-                decoration: InputDecoration(
-                  labelText: 'label',
-                  prefix: GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        tapped = true;
-                      });
-                    },
-                    child: const Icon(Icons.search),
-                  ),
-                ),
-              );
-            }
-          ),
-        ),
-      ),
-    );
-
-    expect(tapped, isFalse);
-
-    double prefixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
-      of: find.byType(Icon),
-      matching: find.byType(AnimatedOpacity),
-    )).opacity;
-
-    // Initiially the prefix icon should be hidden.
-    expect(prefixOpacity, 0.0);
-
-    await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
-    await tester.pump();
-
-    // The suffix icon should ignore pointer events when hidden.
-    expect(tapped, isFalse);
-
-    // Tap the text field to show the prefix icon.
-    await tester.tap(find.byType(TextField));
-    await tester.pump();
-
-    prefixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
-      of: find.byType(Icon),
-      matching: find.byType(AnimatedOpacity),
-    )).opacity;
-
-    // The prefix icon should be visible.
-    expect(prefixOpacity, 1.0);
-
-    // Tap the prefix icon.
-    await tester.tap(find.byType(Icon));
-    await tester.pump();
-
-    // The prefix icon should be tapped.
-    expect(tapped, isTrue);
-  });
-
-  testWidgets('Suffix ignores pointer when hidden', (WidgetTester tester) async {
-    bool tapped = false;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return TextField(
-                decoration: InputDecoration(
-                  labelText: 'label',
-                  suffix: GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        tapped = true;
-                      });
-                    },
-                    child: const Icon(Icons.search),
-                  ),
-                ),
-              );
-            }
-          ),
-        ),
-      ),
-    );
-
-    expect(tapped, isFalse);
-
-    double suffixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
-      of: find.byType(Icon),
-      matching: find.byType(AnimatedOpacity),
-    )).opacity;
-
-    // Initiially the suffix icon should be hidden.
-    expect(suffixOpacity, 0.0);
-
-    await tester.tap(find.byType(Icon), warnIfMissed: false); // Not expected to find the target.
-    await tester.pump();
-
-    // The suffix icon should ignore pointer events when hidden.
-    expect(tapped, isFalse);
-
-    // Tap the text field to show the suffix icon.
-    await tester.tap(find.byType(TextField));
-    await tester.pump();
-
-    suffixOpacity = tester.widget<AnimatedOpacity>(find.ancestor(
-      of: find.byType(Icon),
-      matching: find.byType(AnimatedOpacity),
-    )).opacity;
-
-    // The suffix icon should be visible.
-    expect(suffixOpacity, 1.0);
-
-    // Tap the suffix icon.
-    await tester.tap(find.byType(Icon));
-    await tester.pump();
-
-    // The suffix icon should be tapped.
-    expect(tapped, isTrue);
   });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -15570,10 +15570,12 @@ void main() {
     int prefixTapCount = 0;
     int suffixTapCount = 0;
 
+    final FocusNode focusNode = _focusNode();
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: TextField(
+            focusNode: focusNode,
             onTap: () { textFieldTapCount += 1; },
             decoration: InputDecoration(
               labelText: 'Label',
@@ -15590,6 +15592,10 @@ void main() {
         ),
       ),
     );
+
+    // Focus to show the prefix and suffix buttons.
+    focusNode.requestFocus();
+    await tester.pump();
 
     TestGesture gesture =
         await tester.startGesture(
@@ -15622,10 +15628,12 @@ void main() {
     int prefixTapCount = 0;
     int suffixTapCount = 0;
 
+    final FocusNode focusNode = _focusNode();
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: TextField(
+            focusNode: focusNode,
             onTap: () { textFieldTapCount += 1; },
             decoration: InputDecoration(
               labelText: 'Label',
@@ -15642,6 +15650,10 @@ void main() {
         ),
       ),
     );
+
+    // Focus to show the prefix and suffix buttons.
+    focusNode.requestFocus();
+    await tester.pump();
 
     await tester.tap(find.text('prefix'));
     expect(textFieldTapCount, 0);


### PR DESCRIPTION
fixes [The InputDecoration's suffix and prefix widget can be tapped even if it does not appear](https://github.com/flutter/flutter/issues/139916)

This PR also updates two existing tests to pass the tests for this PR. These tests are trying to tap prefix and  suffix widgets when they're hidden. While the linked issue had visible prefix and suffix widgets https://github.com/flutter/flutter/issues/39376 for reproduction.


### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(MainApp());
}

class MainApp extends StatelessWidget {
  final _messangerKey = GlobalKey<ScaffoldMessengerState>();

  MainApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      scaffoldMessengerKey: _messangerKey,
      home: Scaffold(
        body: Container(
          alignment: Alignment.center,
          padding: const EdgeInsets.all(16.0),
          child: TextField(
            decoration: InputDecoration(
              labelText: 'Something',
              prefix: GestureDetector(
                onTap: () {
                  _messangerKey.currentState?.showSnackBar(
                      const SnackBar(content: Text('A tap has occurred')));
                },
                child: const Icon(Icons.search),
              ),
              suffix: GestureDetector(
                onTap: () {
                  _messangerKey.currentState?.showSnackBar(
                      const SnackBar(content: Text('A tap has occurred')));
                },
                child: const Icon(Icons.search),
              ),
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

### Before
![ScreenRecording2024-02-12at18 40 34-ezgif com-video-to-gif-converter](https://github.com/flutter/flutter/assets/48603081/c101e0d6-ce5a-4b28-9626-28bcb83d2a5c)

### After
![ScreenRecording2024-02-12at18 40 10-ezgif com-video-to-gif-converter](https://github.com/flutter/flutter/assets/48603081/923b348e-8adf-4d64-9dc3-e75d30e3e2fb)




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
