### PR TITLE
Fix `AssetsEntry::equals`

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -949,7 +949,7 @@ class ManifestAssetBundle implements AssetBundle {
     Uri assetUri, {
     String? packageName,
     Package? attributedPackage,
-    List<String>? flavors,
+    Set<String>? flavors,
   }) {
     final String directoryPath;
     try {
@@ -1000,7 +1000,7 @@ class ManifestAssetBundle implements AssetBundle {
     String? packageName,
     Package? attributedPackage,
     AssetKind assetKind = AssetKind.regular,
-    List<String>? flavors,
+    Set<String>? flavors,
   }) {
     final _Asset asset = _resolveAsset(
       packageConfig,
@@ -1116,7 +1116,7 @@ class ManifestAssetBundle implements AssetBundle {
     Package? attributedPackage, {
     Uri? originUri,
     AssetKind assetKind = AssetKind.regular,
-    List<String>? flavors,
+    Set<String>? flavors,
   }) {
     final String assetPath = _fileSystem.path.fromUri(assetUri);
     if (assetUri.pathSegments.first == 'packages'
@@ -1155,7 +1155,7 @@ class ManifestAssetBundle implements AssetBundle {
     Package? attributedPackage, {
     AssetKind assetKind = AssetKind.regular,
     Uri? originUri,
-    List<String>? flavors,
+    Set<String>? flavors,
   }) {
     assert(assetUri.pathSegments.first == 'packages');
     if (assetUri.pathSegments.length > 1) {
@@ -1192,8 +1192,8 @@ class _Asset {
     required this.entryUri,
     required this.package,
     this.kind = AssetKind.regular,
-    List<String>? flavors,
-  }): originUri = originUri ?? entryUri, flavors = flavors ?? const <String>[];
+    Set<String>? flavors,
+  }): originUri = originUri ?? entryUri, flavors = flavors ?? const <String>{};
 
   final String baseDir;
 
@@ -1212,7 +1212,7 @@ class _Asset {
 
   final AssetKind kind;
 
-  final List<String> flavors;
+  final Set<String> flavors;
 
   File lookupAssetFile(FileSystem fileSystem) {
     return fileSystem.file(fileSystem.path.join(baseDir, fileSystem.path.fromUri(relativeUri)));

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -480,16 +480,19 @@ Match? firstMatchInFile(File file, RegExp regExp) {
   return null;
 }
 
-/// Tests for shallow equality on two lists.
-bool listEquals<T>(List<T> a, List<T> b) {
+/// Tests for shallow equality on two sets.
+bool setEquals<T>(Set<T>? a, Set<T>? b) {
+  if (a == null) {
+    return b == null;
+  }
+  if (b == null || a.length != b.length) {
+    return false;
+  }
   if (identical(a, b)) {
     return true;
   }
-  if (a.length != b.length) {
-    return false;
-  }
-  for (int index = 0; index < a.length; index++) {
-    if (a[index] != b[index]) {
+  for (final T value in a) {
+    if (!b.contains(value)) {
       return false;
     }
   }

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -479,3 +479,19 @@ Match? firstMatchInFile(File file, RegExp regExp) {
   }
   return null;
 }
+
+/// Tests for shallow equality on two lists.
+bool listEquals<T>(List<T> a, List<T> b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a.length != b.length) {
+    return false;
+  }
+  for (int index = 0; index < a.length; index++) {
+    if (a[index] != b[index]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -696,11 +696,11 @@ void _validateFonts(YamlList fonts, List<String> errors) {
 class AssetsEntry {
   const AssetsEntry({
     required this.uri,
-    this.flavors = const <String>[],
+    this.flavors = const <String>{},
   });
 
   final Uri uri;
-  final List<String> flavors;
+  final Set<String> flavors;
 
   static const String _pathKey = 'path';
   static const String _flavorKey = 'flavors';
@@ -771,7 +771,7 @@ class AssetsEntry {
 
       final AssetsEntry entry = AssetsEntry(
         uri: Uri(pathSegments: path.split('/')),
-        flavors: List<String>.from(flavors),
+        flavors: Set<String>.from(flavors),
       );
 
       return (entry, null);
@@ -787,13 +787,13 @@ class AssetsEntry {
       return false;
     }
 
-    return uri == other.uri && listEquals(flavors, other.flavors);
+    return uri == other.uri && setEquals(flavors, other.flavors);
   }
 
   @override
   int get hashCode => Object.hashAll(<Object?>[
     uri.hashCode,
-    ...flavors,
+    Object.hashAllUnordered(flavors),
   ]);
 
   @override

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -788,9 +788,15 @@ class AssetsEntry {
       return false;
     }
 
-    return uri == other.uri && flavors == other.flavors;
+    return uri == other.uri && listEquals(flavors, other.flavors);
   }
 
   @override
-  int get hashCode => Object.hash(uri.hashCode, flavors.hashCode);
+  int get hashCode => Object.hashAll(<Object?>[
+    uri.hashCode,
+    ...flavors,
+  ]);
+
+  @override
+  String toString() => 'AssetsEntry(uri: $uri, flavors: $flavors)';
 }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -15,10 +15,10 @@ void main() {
       const String manifest = '''
 name: test
 dependencies:
+  flutter:
+    sdk: flutter
 flutter:
-  sdk: flutter
-flutter:
-assets: []
+  assets: []
 ''';
 
       final FlutterManifest? flutterManifest = FlutterManifest.createFromString(
@@ -53,30 +53,6 @@ flutter:
         AssetsEntry(uri: Uri.parse('a/foo')),
         AssetsEntry(uri: Uri.parse('a/bar')),
       ]);
-    });
-
-    testWithoutContext("prints an error when an asset entry's flavor is not a string", () async {
-      final BufferLogger logger = BufferLogger.test();
-
-      const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  uses-material-design: true
-  assets:
-    - assets/folder/
-    - path: assets/vanilla/
-      flavors:
-        - key1: value1
-          key2: value2
-''';
-      FlutterManifest.createFromString(manifest, logger: logger);
-      expect(logger.errorText, contains(
-        'Asset manifest entry is malformed. '
-        'Expected "flavors" entry to be a list of strings.',
-      ));
     });
 
     testWithoutContext('does not crash on empty entry', () {
@@ -128,6 +104,58 @@ flutter:
         AssetsEntry(uri: Uri.parse('lib/gallery/abc%3Fxyz')),
         AssetsEntry(uri: Uri.parse('lib/gallery/aaa%20bbb')),
       ]);
+    });
+    testWithoutContext('parses an asset with flavors', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: a/foo
+      flavors:
+        - apple
+        - strawberry
+''';
+
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+        manifest,
+        logger: logger,
+      )!;
+
+      expect(flutterManifest.assets, <AssetsEntry>[
+        AssetsEntry(
+          uri: Uri.parse('a/foo'),
+          flavors: const <String>['apple', 'strawberry'],
+        ),
+      ]);
+    });
+
+    testWithoutContext("prints an error when an asset entry's flavor is not a string", () async {
+      final BufferLogger logger = BufferLogger.test();
+
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/folder/
+    - path: assets/vanilla/
+      flavors:
+        - key1: value1
+          key2: value2
+''';
+      FlutterManifest.createFromString(manifest, logger: logger);
+      expect(logger.errorText, contains(
+        'Asset manifest entry is malformed. '
+        'Expected "flavors" entry to be a list of strings.',
+      ));
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -130,7 +130,7 @@ flutter:
       expect(flutterManifest.assets, <AssetsEntry>[
         AssetsEntry(
           uri: Uri.parse('a/foo'),
-          flavors: const <String>['apple', 'strawberry'],
+          flavors: const <String>{'apple', 'strawberry'},
         ),
       ]);
     });

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -105,6 +105,7 @@ flutter:
         AssetsEntry(uri: Uri.parse('lib/gallery/aaa%20bbb')),
       ]);
     });
+
     testWithoutContext('parses an asset with flavors', () async {
       final BufferLogger logger = BufferLogger.test();
       const String manifest = '''

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -1,0 +1,133 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
+
+import '../src/common.dart';
+
+void main() {
+  group('parsing of assets section in flutter manifests', () {
+    testWithoutContext('ignores empty list of assets', () {
+      final BufferLogger logger = BufferLogger.test();
+
+      const String manifest = '''
+name: test
+dependencies:
+flutter:
+  sdk: flutter
+flutter:
+assets: []
+''';
+
+      final FlutterManifest? flutterManifest = FlutterManifest.createFromString(
+        manifest,
+        logger: logger,
+      );
+
+      expect(flutterManifest, isNotNull);
+      expect(flutterManifest!.assets, isEmpty);
+    });
+
+    testWithoutContext('parses two simple asset declarations', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - a/foo
+    - a/bar
+''';
+
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+        manifest,
+        logger: logger,
+      )!;
+
+      expect(flutterManifest.assets, <AssetsEntry>[
+        AssetsEntry(uri: Uri.parse('a/foo')),
+        AssetsEntry(uri: Uri.parse('a/bar')),
+      ]);
+    });
+
+    testWithoutContext("prints an error when an asset entry's flavor is not a string", () async {
+      final BufferLogger logger = BufferLogger.test();
+
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/folder/
+    - path: assets/vanilla/
+      flavors:
+        - key1: value1
+          key2: value2
+''';
+      FlutterManifest.createFromString(manifest, logger: logger);
+      expect(logger.errorText, contains(
+        'Asset manifest entry is malformed. '
+        'Expected "flavors" entry to be a list of strings.',
+      ));
+    });
+
+    testWithoutContext('does not crash on empty entry', () {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - lib/gallery/example_code.dart
+    -
+''';
+
+      FlutterManifest.createFromString(
+        manifest,
+        logger: logger,
+      );
+
+      expect(logger.errorText, contains('Asset manifest contains a null or empty uri.'));
+    });
+
+    testWithoutContext('handles special characters in asset URIs', () {
+      final BufferLogger logger = BufferLogger.test();
+
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - lib/gallery/abc#xyz
+    - lib/gallery/abc?xyz
+    - lib/gallery/aaa bbb
+''';
+
+      final FlutterManifest flutterManifest = FlutterManifest.createFromString(
+        manifest,
+        logger: logger,
+      )!;
+      final List<AssetsEntry> assets = flutterManifest.assets;
+
+      expect(assets, <AssetsEntry>[
+        AssetsEntry(uri: Uri.parse('lib/gallery/abc%23xyz')),
+        AssetsEntry(uri: Uri.parse('lib/gallery/abc%3Fxyz')),
+        AssetsEntry(uri: Uri.parse('lib/gallery/aaa%20bbb')),
+      ]);
+    });
+  });
+}

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -1074,7 +1074,7 @@ flutter:
     );
 
     expect(flutterManifest, null);
-    expect(logger.errorText, 'Expected "licenses" to be a list of files, but got foo.txt (String)\n');
+    expect(logger.errorText, 'Expected "licenses" to be a list of files, but got foo.txt (String).\n');
   });
 
   testWithoutContext('FlutterManifest validates individual list items', () async {
@@ -1095,7 +1095,8 @@ flutter:
     );
 
     expect(flutterManifest, null);
-    expect(logger.errorText, 'Expected "licenses" to be a list of files, but element 1 was a YamlMap\n');
+    expect(logger.errorText, 'Expected "licenses" to be a list of files, but '
+      'element at index 1 was a YamlMap.\n');
   });
 
   testWithoutContext('FlutterManifest parses single deferred components', () async {
@@ -1248,7 +1249,9 @@ flutter:
     );
 
     expect(flutterManifest, null);
-    expect(logger.errorText, 'Expected "libraries" key in the 0 element of "deferred-components" to be a list, but got blah (String).\n');
+    expect(logger.errorText, 'Expected "libraries" key in the element at '
+      'index 0 of "deferred-components" to be a list of String, but '
+      'got blah (String).\n');
   });
 
   testWithoutContext('FlutterManifest deferred component libraries is string', () async {
@@ -1270,7 +1273,9 @@ flutter:
     );
 
     expect(flutterManifest, null);
-    expect(logger.errorText, 'Expected "libraries" key in the 0 element of "deferred-components" to be a list of dart library Strings, but element 0 was a YamlMap\n');
+    expect(logger.errorText, 'Expected "libraries" key in the element at '
+      'index 0 of "deferred-components" to be a list of String, but '
+      'element at index 0 was a YamlMap.\n');
   });
 
   testWithoutContext('FlutterManifest deferred component assets is string', () async {

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -136,50 +136,6 @@ flutter:
     expect(flutterManifest.generateSyntheticPackage, false);
   });
 
-  testWithoutContext('FlutterManifest has two assets', () async {
-    const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  uses-material-design: true
-  assets:
-    - a/foo
-    - a/bar
-''';
-
-    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
-      manifest,
-      logger: logger,
-    )!;
-
-    expect(flutterManifest.assets, <AssetsEntry>[
-      AssetsEntry(uri: Uri.parse('a/foo')),
-      AssetsEntry(uri: Uri.parse('a/bar')),
-    ]);
-  });
-
-  testWithoutContext('FlutterManifest assets entry flavor is not a string', () async {
-    const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  uses-material-design: true
-  assets:
-    - assets/folder/
-    - path: assets/vanilla/
-      flavors:
-        - key1: value1
-          key2: value2
-''';
-    FlutterManifest.createFromString(manifest, logger: logger);
-    expect(logger.errorText, contains('Asset manifest entry is malformed. '
-      'Expected "flavors" entry to be a list of strings.'));
-  });
-
   testWithoutContext('FlutterManifest has one font family with one asset', () async {
     const String manifest = '''
 name: test
@@ -796,25 +752,6 @@ flutter:
     expect(flutterManifest!.fonts.length, 0);
   });
 
-  testWithoutContext('FlutterManifest ignores empty list of assets', () {
-    const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  assets: []
-''';
-
-    final FlutterManifest? flutterManifest = FlutterManifest.createFromString(
-      manifest,
-      logger: logger,
-    );
-
-    expect(flutterManifest, isNotNull);
-    expect(flutterManifest!.assets.length, 0);
-  });
-
   testWithoutContext('FlutterManifest returns proper error when font detail is '
     'not a list of maps', () {
     const String manifest = '''
@@ -885,55 +822,6 @@ flutter:
 
     expect(flutterManifest, null);
     expect(logger.errorText, contains('Expected a map.'));
-  });
-
-  testWithoutContext('FlutterManifest does not crash on empty entry', () {
-    const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  uses-material-design: true
-  assets:
-    - lib/gallery/example_code.dart
-    -
-''';
-
-    FlutterManifest.createFromString(
-      manifest,
-      logger: logger,
-    );
-
-    expect(logger.errorText, contains('Asset manifest contains a null or empty uri.'));
-  });
-
-  testWithoutContext('FlutterManifest handles special characters in asset URIs', () {
-    const String manifest = '''
-name: test
-dependencies:
-  flutter:
-    sdk: flutter
-flutter:
-  uses-material-design: true
-  assets:
-    - lib/gallery/abc#xyz
-    - lib/gallery/abc?xyz
-    - lib/gallery/aaa bbb
-''';
-
-    final FlutterManifest flutterManifest = FlutterManifest.createFromString(
-      manifest,
-      logger: logger,
-    )!;
-    final List<AssetsEntry> assets = flutterManifest.assets;
-
-    expect(assets, hasLength(3));
-    expect(assets, <AssetsEntry>[
-      AssetsEntry(uri: Uri.parse('lib/gallery/abc%23xyz')),
-      AssetsEntry(uri: Uri.parse('lib/gallery/abc%3Fxyz')),
-      AssetsEntry(uri: Uri.parse('lib/gallery/aaa%20bbb')),
-    ]);
   });
 
   testWithoutContext('FlutterManifest returns proper error when flutter is a '


### PR DESCRIPTION
In service of https://github.com/flutter/flutter/issues/143348.

**Issue.** The `equals` implementation of `AssetsEntry` is incorrect. It compares `flavors` lists using reference equality. This PR addresses this.

This also adds a test to make sure valid asset `flavors` declarations are parsed correctly.

While we are here, this PR also includes a couple of refactorings:
  * `flutter_manifest_test.dart` is a bit large. To better match our style guide, I've factored out some related tests into their own file.
  *  A couple of changes to the `_validateListType` function in `flutter_manifest.dart`:
      * The function now returns a list of errors instead of accepting a list to append onto. This is more readable and also allows callers to know which errors were found by the call.
      * The function is renamed to `_validateList` and now accepts an `Object?` instead of an `YamlList`. If the argument is null, an appropriate error message is contained in the output. This saves callers that are only interested in validation from having to write their own null-check, which they all did before.
      * Some error strings were tweaked for increased readability and/or grammatical correctness.