### PR TITLE
Modify `plugin_ffi` and `package_ffi` template

### DIFF
--- a/packages/flutter_tools/templates/package_ffi/README.md.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/README.md.tmpl
@@ -31,7 +31,7 @@ Bundling is done by Flutter based on the output from `build.dart`.
 To use the native code, bindings in Dart are needed.
 To avoid writing these by hand, they are generated from the header file
 (`src/{{projectName}}.h`) by `package:ffigen`.
-Regenerate the bindings by running `flutter pub run ffigen --config ffigen.yaml`.
+Regenerate the bindings by running `dart run ffigen --config ffigen.yaml`.
 
 ## Invoking native code
 

--- a/packages/flutter_tools/templates/package_ffi/ffigen.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/ffigen.yaml.tmpl
@@ -1,9 +1,9 @@
-# Run with `flutter pub run ffigen --config ffigen.yaml`.
+# Run with `dart run ffigen --config ffigen.yaml`.
 name: {{pluginDartClass}}Bindings
 description: |
   Bindings for `src/{{projectName}}.h`.
 
-  Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
+  Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
 output: 'lib/{{projectName}}_bindings_generated.dart'
 headers:
   entry-points:

--- a/packages/flutter_tools/templates/plugin_ffi/README.md.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/README.md.tmpl
@@ -73,7 +73,7 @@ The native build systems that are invoked by FFI (and method channel) plugins ar
 To use the native code, bindings in Dart are needed.
 To avoid writing these by hand, they are generated from the header file
 (`src/{{projectName}}.h`) by `package:ffigen`.
-Regenerate the bindings by running `flutter pub run ffigen --config ffigen.yaml`.
+Regenerate the bindings by running `dart run ffigen --config ffigen.yaml`.
 
 ## Invoking native code
 

--- a/packages/flutter_tools/templates/plugin_ffi/ffigen.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/ffigen.yaml.tmpl
@@ -1,9 +1,9 @@
-# Run with `flutter pub run ffigen --config ffigen.yaml`.
+# Run with `dart run ffigen --config ffigen.yaml`.
 name: {{pluginDartClass}}Bindings
 description: |
   Bindings for `src/{{projectName}}.h`.
 
-  Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
+  Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
 output: 'lib/{{projectName}}_bindings_generated.dart'
 headers:
   entry-points:

--- a/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
@@ -10,7 +10,7 @@ import 'dart:ffi' as ffi;
 
 /// Bindings for `src/{{projectName}}.h`.
 ///
-/// Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
+/// Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
 ///
 class {{pluginDartClass}}Bindings {
   /// Holds the symbol lookup function.
@@ -43,7 +43,7 @@ class {{pluginDartClass}}Bindings {
   }
 
   late final _sumPtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr)>>(
+      _lookup<ffi.NativeFunction<ffi.Int64 Function(ffi.Int64, ffi.Int64)>>(
           'sum');
   late final _sum = _sumPtr.asFunction<int Function(int, int)>();
 
@@ -63,7 +63,7 @@ class {{pluginDartClass}}Bindings {
   }
 
   late final _sum_long_runningPtr =
-      _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.IntPtr, ffi.IntPtr)>>(
+      _lookup<ffi.NativeFunction<ffi.Int64 Function(ffi.Int64, ffi.Int64)>>(
           'sum_long_running');
   late final _sum_long_running =
       _sum_long_runningPtr.asFunction<int Function(int, int)>();

--- a/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
@@ -43,7 +43,7 @@ class {{pluginDartClass}}Bindings {
   }
 
   late final _sumPtr =
-      _lookup<ffi.NativeFunction<ffi.Int64 Function(ffi.Int64, ffi.Int64)>>(
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int, ffi.Int)>>(
           'sum');
   late final _sum = _sumPtr.asFunction<int Function(int, int)>();
 
@@ -63,7 +63,7 @@ class {{pluginDartClass}}Bindings {
   }
 
   late final _sum_long_runningPtr =
-      _lookup<ffi.NativeFunction<ffi.Int64 Function(ffi.Int64, ffi.Int64)>>(
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int, ffi.Int)>>(
           'sum_long_running');
   late final _sum_long_running =
       _sum_long_runningPtr.asFunction<int Function(int, int)>();

--- a/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.c.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.c.tmpl
@@ -5,14 +5,14 @@
 // For very short-lived functions, it is fine to call them on the main isolate.
 // They will block the Dart execution while running the native function, so
 // only do this for native functions which are guaranteed to be short-lived.
-FFI_PLUGIN_EXPORT intptr_t sum(intptr_t a, intptr_t b) { return a + b; }
+FFI_PLUGIN_EXPORT int64_t sum(int64_t a, int64_t b) { return a + b; }
 
 // A longer-lived native function, which occupies the thread calling it.
 //
 // Do not call these kind of native functions in the main isolate. They will
 // block Dart execution. This will cause dropped frames in Flutter applications.
 // Instead, call these native functions on a separate isolate.
-FFI_PLUGIN_EXPORT intptr_t sum_long_running(intptr_t a, intptr_t b) {
+FFI_PLUGIN_EXPORT int64_t sum_long_running(int64_t a, int64_t b) {
   // Simulate work.
 #if _WIN32
   Sleep(5000);

--- a/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.c.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.c.tmpl
@@ -5,14 +5,14 @@
 // For very short-lived functions, it is fine to call them on the main isolate.
 // They will block the Dart execution while running the native function, so
 // only do this for native functions which are guaranteed to be short-lived.
-FFI_PLUGIN_EXPORT int64_t sum(int64_t a, int64_t b) { return a + b; }
+FFI_PLUGIN_EXPORT int sum(int a, int b) { return a + b; }
 
 // A longer-lived native function, which occupies the thread calling it.
 //
 // Do not call these kind of native functions in the main isolate. They will
 // block Dart execution. This will cause dropped frames in Flutter applications.
 // Instead, call these native functions on a separate isolate.
-FFI_PLUGIN_EXPORT int64_t sum_long_running(int64_t a, int64_t b) {
+FFI_PLUGIN_EXPORT int sum_long_running(int a, int b) {
   // Simulate work.
 #if _WIN32
   Sleep(5000);

--- a/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.h.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.h.tmpl
@@ -20,11 +20,11 @@
 // For very short-lived functions, it is fine to call them on the main isolate.
 // They will block the Dart execution while running the native function, so
 // only do this for native functions which are guaranteed to be short-lived.
-FFI_PLUGIN_EXPORT intptr_t sum(intptr_t a, intptr_t b);
+FFI_PLUGIN_EXPORT int64_t sum(int64_t a, int64_t b);
 
 // A longer lived native function, which occupies the thread calling it.
 //
 // Do not call these kind of native functions in the main isolate. They will
 // block Dart execution. This will cause dropped frames in Flutter applications.
 // Instead, call these native functions on a separate isolate.
-FFI_PLUGIN_EXPORT intptr_t sum_long_running(intptr_t a, intptr_t b);
+FFI_PLUGIN_EXPORT int64_t sum_long_running(int64_t a, int64_t b);

--- a/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.h.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/src.tmpl/projectName.h.tmpl
@@ -20,11 +20,11 @@
 // For very short-lived functions, it is fine to call them on the main isolate.
 // They will block the Dart execution while running the native function, so
 // only do this for native functions which are guaranteed to be short-lived.
-FFI_PLUGIN_EXPORT int64_t sum(int64_t a, int64_t b);
+FFI_PLUGIN_EXPORT int sum(int a, int b);
 
 // A longer lived native function, which occupies the thread calling it.
 //
 // Do not call these kind of native functions in the main isolate. They will
 // block Dart execution. This will cause dropped frames in Flutter applications.
 // Instead, call these native functions on a separate isolate.
-FFI_PLUGIN_EXPORT int64_t sum_long_running(int64_t a, int64_t b);
+FFI_PLUGIN_EXPORT int sum_long_running(int a, int b);


### PR DESCRIPTION
* Use `dart run` instead of `flutter pub run` in the documentation as it is now deprecated.
* Use `int64_t` instead of `intptr_t` for `sum` examples.
