### PR TITLE
cleanup now-irrelevant ignores for `deprecated_member_use`

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
@@ -487,7 +487,7 @@ class _AnimationDemoHomeState extends State<AnimationDemoHome> {
     if (notification.depth == 0 && notification is ScrollUpdateNotification) {
       selectedIndex.value = leader.page;
       if (follower.page != leader.page) {
-        follower.position.jumpToWithoutSettling(leader.position.pixels); // ignore: deprecated_member_use
+        follower.position.jumpToWithoutSettling(leader.position.pixels);
       }
     }
     return false;

--- a/dev/integration_tests/flutter_gallery/lib/gallery/options.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/options.dart
@@ -100,7 +100,6 @@ class _OptionsItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // ignore: deprecated_member_use, https://github.com/flutter/flutter/issues/128825
     final double textScaleFactor = MediaQuery.textScalerOf(context).textScaleFactor;
 
     return MergeSemantics(

--- a/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
+++ b/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 
 // TODO(gspencergoog): Delete this example when deprecated RawKeyEvent API is
 // removed.
-// ignore_for_file: deprecated_member_use
 
 /// Flutter code sample for [KeyEventManager.keyMessageHandler].
 

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -429,7 +429,6 @@ class CupertinoContextMenu extends StatefulWidget {
   ///   // The FittedBox in the preview here allows the image to animate its
   ///   // aspect ratio when the CupertinoContextMenu is animating its preview
   ///   // widget open and closed.
-  ///   // ignore: deprecated_member_use
   ///   previewBuilder: (BuildContext context, Animation<double> animation, Widget child) {
   ///     return FittedBox(
   ///       fit: BoxFit.cover,

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:developer' as developer;
 import 'dart:io' show exit;
-import 'dart:ui' as ui show Brightness, PlatformDispatcher, SingletonFlutterWindow, window; // ignore: deprecated_member_use
+import 'dart:ui' as ui show Brightness, PlatformDispatcher, SingletonFlutterWindow, window;
 
 // Before adding any more dart:ui imports, please read the README.
 
@@ -22,7 +22,7 @@ import 'print.dart';
 import 'service_extensions.dart';
 import 'timeline.dart';
 
-export 'dart:ui' show PlatformDispatcher, SingletonFlutterWindow, clampDouble; // ignore: deprecated_member_use
+export 'dart:ui' show PlatformDispatcher, SingletonFlutterWindow, clampDouble;
 
 export 'basic_types.dart' show AsyncCallback, AsyncValueGetter, AsyncValueSetter;
 

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -2929,7 +2929,6 @@ String describeIdentity(Object? object) => '${objectRuntimeType(object, '<optimi
 ///
 /// void validateDescribeEnum() {
 ///   assert(Day.monday.toString() == 'Day.monday');
-///   // ignore: deprecated_member_use
 ///   assert(describeEnum(Day.monday) == 'monday');
 ///   assert(Day.monday.name == 'monday'); // preferred for real enums
 /// }

--- a/packages/flutter/lib/src/painting/basic_types.dart
+++ b/packages/flutter/lib/src/painting/basic_types.dart
@@ -47,10 +47,8 @@ export 'dart:ui' show
   TextPosition,
   TileMode,
   VertexMode,
-  // TODO(werainkhatri): remove these after their deprecation period in engine
-  // https://github.com/flutter/flutter/pull/99505
-  hashList, // ignore: deprecated_member_use
-  hashValues; // ignore: deprecated_member_use
+  hashList,
+  hashValues;
 
 export 'package:flutter/foundation.dart' show VoidCallback;
 

--- a/packages/flutter/lib/src/services/hardware_keyboard.dart
+++ b/packages/flutter/lib/src/services/hardware_keyboard.dart
@@ -777,7 +777,6 @@ enum KeyDataTransitMode {
 /// using [combineKeyEventResults].
 ///
 /// ```dart
-/// // ignore: deprecated_member_use
 /// void handleMessage(FocusNode node, KeyMessage message) {
 ///   final List<KeyEventResult> results = <KeyEventResult>[];
 ///   if (node.onKeyEvent != null) {
@@ -785,9 +784,7 @@ enum KeyDataTransitMode {
 ///       results.add(node.onKeyEvent!(node, event));
 ///     }
 ///   }
-///   // ignore: deprecated_member_use
 ///   if (node.onKey != null && message.rawEvent != null) {
-///     // ignore: deprecated_member_use
 ///     results.add(node.onKey!(node, message.rawEvent!));
 ///   }
 ///   final KeyEventResult result = combineKeyEventResults(results);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -7832,9 +7832,6 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pump();
     expect(focusNode3.hasPrimaryFocus, isTrue);
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Scrolling shortcuts are disabled in text fields', (WidgetTester tester) async {
@@ -7869,9 +7866,6 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     expect(scrollInvoked, isFalse);
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Cupertino text field semantics', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7093,9 +7093,6 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
       expect(controller.selection.extentOffset - controller.selection.baseOffset, -1);
-      // TODO(gspencergoog): Remove the variant when the deprecated
-      // KeySimulatorTransitModeVariant API is removed.
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Shift test 2', (WidgetTester tester) async {
@@ -7114,9 +7111,6 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 1);
-      // TODO(gspencergoog): Remove the variant when the deprecated
-      // KeySimulatorTransitModeVariant API is removed.
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Control Shift test', (WidgetTester tester) async {
@@ -7134,9 +7128,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 5);
-      // TODO(gspencergoog): Remove the variant when the deprecated
-      // KeySimulatorTransitModeVariant API is removed.
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Down and up test', (WidgetTester tester) async {
@@ -7164,9 +7155,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 0);
-      // TODO(gspencergoog): Remove the variant when the deprecated
-      // KeySimulatorTransitModeVariant API is removed.
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Down and up test 2', (WidgetTester tester) async {
@@ -7223,9 +7211,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, -5);
-      // TODO(gspencergoog): Remove the variant when the deprecated
-      // KeySimulatorTransitModeVariant API is removed.
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Read only keyboard selection test', (WidgetTester tester) async {
@@ -7246,9 +7231,6 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
       expect(controller.selection.extentOffset - controller.selection.baseOffset, -1);
-      // TODO(gspencergoog): Remove the variant when the deprecated
-      // KeySimulatorTransitModeVariant API is removed.
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
   }, skip: areKeyEventsHandledByPlatform); // [intended] only applies to platforms where we handle key events.
 
@@ -7326,9 +7308,6 @@ void main() {
     expect(find.text(expected), findsOneWidget, reason: 'Because text contains ${controller.text}');
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all()
   );
 
@@ -7382,9 +7361,6 @@ void main() {
     expect(find.text(clipboardContent), findsOneWidget);
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all(),
   );
 
@@ -7464,9 +7440,6 @@ void main() {
     expect(find.text(expected), findsOneWidget);
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all()
   );
 
@@ -7518,9 +7491,6 @@ void main() {
     expect(find.text(expected), findsOneWidget);
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all()
   );
 
@@ -7575,9 +7545,6 @@ void main() {
     expect(find.text(expected2), findsOneWidget);
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all(),
   );
 
@@ -7673,9 +7640,6 @@ void main() {
     expect(c1.selection.extentOffset - c1.selection.baseOffset, -10);
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all()
   );
 
@@ -7753,9 +7717,6 @@ void main() {
     expect(c2.selection.extentOffset - c2.selection.baseOffset, -5);
   },
     skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
-    // TODO(gspencergoog): Remove the variant when the deprecated
-    // KeySimulatorTransitModeVariant API is removed.
-    // ignore: deprecated_member_use
     variant: KeySimulatorTransitModeVariant.all()
   );
 

--- a/packages/flutter/test/painting/binding_test.dart
+++ b/packages/flutter/test/painting/binding_test.dart
@@ -91,7 +91,7 @@ class TestBindingBase implements BindingBase {
   void unlocked() {}
 
   @override
-  ui.SingletonFlutterWindow get window => throw UnimplementedError(); // ignore: deprecated_member_use
+  ui.SingletonFlutterWindow get window => throw UnimplementedError();
 
   @override
   ui.PlatformDispatcher get platformDispatcher => throw UnimplementedError();

--- a/packages/flutter/test/services/hardware_keyboard_test.dart
+++ b/packages/flutter/test/services/hardware_keyboard_test.dart
@@ -66,7 +66,6 @@ void main() {
       equals(<LogicalKeyboardKey>{}));
     expect(HardwareKeyboard.instance.lockModesEnabled,
       equals(<KeyboardLockMode>{}));
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
   testWidgets('KeyEvent can tell which keys are pressed', (WidgetTester tester) async {
@@ -101,7 +100,6 @@ void main() {
     await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'windows');
     expect(HardwareKeyboard.instance.isPhysicalKeyPressed(PhysicalKeyboardKey.numLock), isFalse);
     expect(HardwareKeyboard.instance.isLogicalKeyPressed(LogicalKeyboardKey.numLock), isFalse);
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
   testWidgets('KeyboardManager synthesizes modifier keys in rawKeyData mode', (WidgetTester tester) async {
@@ -229,7 +227,6 @@ void main() {
       true);
     expect(logs, <int>[3, 2, 1]);
     logs.clear();
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   // Regression test for https://github.com/flutter/flutter/issues/99196 .
@@ -279,7 +276,6 @@ void main() {
     expect(ServicesBinding.instance.keyboard.physicalKeysPressed, equals(<PhysicalKeyboardKey>{
       PhysicalKeyboardKey.keyA,
     }));
-  // ignore: deprecated_member_use
   }, variant: const KeySimulatorTransitModeVariant(<KeyDataTransitMode>{
     KeyDataTransitMode.rawKeyData,
   }));
@@ -315,7 +311,6 @@ void main() {
     )), false);
     expect(logs, <int>[2, 1]);
     logs.clear();
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
   testWidgets('Postpone synthesized key events when the queue is not empty', (WidgetTester tester) async {
@@ -370,7 +365,6 @@ void main() {
 
     expect(logs, <String>['RawKeyDownEvent', 'KeyDownEvent', 'KeyUpEvent']);
     logs.clear();
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
   // The first key data received from the engine might be an empty key data.
@@ -510,7 +504,6 @@ void main() {
     // If the previous state (key down) wasn't recorded, this key up event will
     // trigger assertions.
     expect(record, isNull);
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('debugPrintKeyboardEvents causes logging of key events', (WidgetTester tester) async {

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -1013,7 +1013,6 @@ void main() {
         false);
       expect(logs, <int>[1, 3, 2]);
       logs.clear();
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Exceptions from RawKeyboard listeners are caught and reported', (WidgetTester tester) async {
@@ -2154,7 +2153,6 @@ void main() {
       expect(events, isEmpty);
       expect(lastHandled, true);
       expect(RawKeyboard.instance.keysPressed, isEmpty);
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.keyDataThenRawKeyData());
 
     test('data.toString', () {

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -151,7 +151,6 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.select);
     await tester.pumpAndSettle();
     expect(checked, isTrue);
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   group('error control test', () {

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -444,7 +444,6 @@ void main() {
 
     debugDefaultTargetPlatformOverride = null;
   },
-  // ignore: deprecated_member_use
   variant: KeySimulatorTransitModeVariant.all(),
   );
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -12556,7 +12556,6 @@ void main() {
       expect(controller.selection.isCollapsed, true);
       expect(controller.selection.baseOffset, 0);
     }
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('the toolbar is disposed when selection changes and there is no selectionControls', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -352,7 +352,6 @@ void main() {
           false);
       expect(logs, <int>[20, 21, 10, 11]);
       logs.clear();
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('FocusManager responds to app lifecycle changes.', (WidgetTester tester) async {
@@ -1327,7 +1326,6 @@ void main() {
       // Since none of the focused nodes handle this event, nothing should
       // receive it.
       expect(receivedAnEvent, isEmpty);
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Initial highlight mode guesses correctly.', (WidgetTester tester) async {
@@ -1960,7 +1958,6 @@ void main() {
     expect(await simulateKeyDownEvent(LogicalKeyboardKey.digit1), true);
     expect(await simulateKeyUpEvent(LogicalKeyboardKey.digit1), false);
     expect(logs, <int>[0, 1, 0, 1]);
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('FocusManager.addLateKeyEventHandler works', (WidgetTester tester) async {
@@ -2040,7 +2037,6 @@ void main() {
     expect(await simulateKeyDownEvent(LogicalKeyboardKey.digit1), true);
     expect(await simulateKeyUpEvent(LogicalKeyboardKey.digit1), false);
     expect(logs, <int>[0, 1, 0, 1]);
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('FocusManager notifies listeners when a widget loses focus because it was removed.', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -2402,7 +2402,6 @@ void main() {
       expect(Focus.of(lowerLeftKey.currentContext!).hasPrimaryFocus, isTrue);
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       expect(Focus.of(upperLeftKey.currentContext!).hasPrimaryFocus, isTrue);
-    // ignore: deprecated_member_use
     }, skip: isBrowser, variant: KeySimulatorTransitModeVariant.all()); // https://github.com/flutter/flutter/issues/35347
 
     testWidgets('Focus traversal actions works when current focus skip traversal', (WidgetTester tester) async {
@@ -2458,7 +2457,6 @@ void main() {
       expect(Focus.of(key2.currentContext!).hasPrimaryFocus, isTrue);
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       expect(Focus.of(key3.currentContext!).hasPrimaryFocus, isTrue);
-    // ignore: deprecated_member_use
     }, skip: isBrowser, variant: KeySimulatorTransitModeVariant.all()); // https://github.com/flutter/flutter/issues/35347
 
     testWidgets('Focus traversal inside a vertical scrollable scrolls to stay visible.', (WidgetTester tester) async {
@@ -2565,7 +2563,6 @@ void main() {
       await tester.pump();
       expect(topNode.hasPrimaryFocus, isTrue);
       expect(controller.offset, equals(0.0));
-    // ignore: deprecated_member_use
     }, skip: isBrowser, variant: KeySimulatorTransitModeVariant.all()); // https://github.com/flutter/flutter/issues/35347
 
     testWidgets('Focus traversal inside a horizontal scrollable scrolls to stay visible.', (WidgetTester tester) async {
@@ -2673,7 +2670,6 @@ void main() {
       await tester.pump();
       expect(leftNode.hasPrimaryFocus, isTrue);
       expect(controller.offset, equals(0.0));
-    // ignore: deprecated_member_use
     }, skip: isBrowser, variant: KeySimulatorTransitModeVariant.all()); // https://github.com/flutter/flutter/issues/35347
 
     testWidgets('Arrow focus traversal actions can be re-enabled for text fields.', (WidgetTester tester) async {
@@ -2805,7 +2801,6 @@ void main() {
       expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       expect(focusNodeUpperLeft.hasPrimaryFocus, isTrue);
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Focus traversal does not break when no focusable is available on a MaterialApp', (WidgetTester tester) async {
@@ -2823,7 +2818,6 @@ void main() {
       await tester.idle();
 
       expect(events.length, 2);
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Focus traversal does not throw when no focusable is available in a group', (WidgetTester tester) async {
@@ -2859,7 +2853,6 @@ void main() {
       await tester.idle();
 
       expect(events.length, 2);
-    // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Custom requestFocusCallback gets called on focusInDirection up/down/left/right.', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/scrollable_helpers_test.dart
+++ b/packages/flutter/test/widgets/scrollable_helpers_test.dart
@@ -154,7 +154,6 @@ void main() {
       tester.getRect(find.byKey(const ValueKey<String>('Box 0'), skipOffstage: false)),
       equals(const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0)),
     );
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Vertical scrollables are scrolled when activated via keyboard.', (WidgetTester tester) async {
@@ -227,7 +226,6 @@ void main() {
       tester.getRect(find.byKey(const ValueKey<String>('Box 0'), skipOffstage: false)),
       equals(const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0)),
     );
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Horizontal scrollables are scrolled when activated via keyboard.', (WidgetTester tester) async {
@@ -289,7 +287,6 @@ void main() {
       tester.getRect(find.byKey(const ValueKey<String>('Box 0'), skipOffstage: false)),
       equals(const Rect.fromLTRB(0.0, 0.0, 50.0, 600.0)),
     );
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Horizontal scrollables are scrolled the correct direction in RTL locales.', (WidgetTester tester) async {
@@ -354,7 +351,6 @@ void main() {
       tester.getRect(find.byKey(const ValueKey<String>('Box 0'), skipOffstage: false)),
       equals(const Rect.fromLTRB(750.0, 0.0, 800.0, 600.0)),
     );
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Reversed vertical scrollables are scrolled when activated via keyboard.', (WidgetTester tester) async {
@@ -431,7 +427,6 @@ void main() {
       tester.getRect(find.byKey(const ValueKey<String>('Box 0'), skipOffstage: false)),
       equals(const Rect.fromLTRB(0.0, 550.0, 800.0, 600.0)),
     );
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Reversed horizontal scrollables are scrolled when activated via keyboard.', (WidgetTester tester) async {
@@ -493,7 +488,6 @@ void main() {
       await tester.sendKeyUpEvent(modifierKey);
     }
     await tester.pumpAndSettle();
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Custom scrollables with a center sliver are scrolled when activated via keyboard.', (WidgetTester tester) async {
@@ -566,7 +560,6 @@ void main() {
       tester.getRect(find.byKey(const ValueKey<String>('Item 10'), skipOffstage: false)),
       equals(const Rect.fromLTRB(0.0, 100.0, 800.0, 200.0)),
     );
-  // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Can scroll using intents only', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -1688,7 +1688,6 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowLeft);
       expect(controller.selection.extentOffset - controller.selection.baseOffset, -1);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Shift test 2', (WidgetTester tester) async {
@@ -1701,7 +1700,6 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
       await tester.pumpAndSettle();
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 1);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Control Shift test', (WidgetTester tester) async {
@@ -1714,7 +1712,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, -5);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Down and up test', (WidgetTester tester) async {
@@ -1733,7 +1730,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, 0);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('Down and up test 2', (WidgetTester tester) async {
@@ -1785,7 +1781,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(controller.selection.extentOffset - controller.selection.baseOffset, -5);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
   });
 
@@ -1846,7 +1841,6 @@ void main() {
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Select all test', (WidgetTester tester) async {
@@ -1882,7 +1876,6 @@ void main() {
 
     expect(controller.selection.baseOffset, 0);
     expect(controller.selection.extentOffset, 31);
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('keyboard selection should call onSelectionChanged', (WidgetTester tester) async {
@@ -1930,7 +1923,6 @@ void main() {
       expect(newSelection!.extentOffset, i + 1);
       newSelection = null;
     }
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Changing positions of selectable text', (WidgetTester tester) async {
@@ -2022,7 +2014,6 @@ void main() {
     c1 = editableTextWidget.controller;
 
     expect(c1.selection.extentOffset - c1.selection.baseOffset, -10);
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Changing focus test', (WidgetTester tester) async {
@@ -2093,7 +2084,6 @@ void main() {
 
     expect(c1.selection.extentOffset - c1.selection.baseOffset, -5);
     expect(c2.selection.extentOffset - c2.selection.baseOffset, -5);
-    // ignore: deprecated_member_use
   }, variant: KeySimulatorTransitModeVariant.all());
 
   testWidgets('Caret works when maxLines is null', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -353,7 +353,6 @@ void main() {
       invoked = 0;
 
       expect(HardwareKeyboard.instance.logicalKeysPressed, isEmpty);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('handles repeated events', (WidgetTester tester) async {
@@ -380,7 +379,6 @@ void main() {
       invoked = 0;
 
       expect(HardwareKeyboard.instance.logicalKeysPressed, isEmpty);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('rejects repeated events if requested', (WidgetTester tester) async {
@@ -408,7 +406,6 @@ void main() {
       invoked = 0;
 
       expect(HardwareKeyboard.instance.logicalKeysPressed, isEmpty);
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('handles Shift-Ctrl-C', (WidgetTester tester) async {
@@ -1172,7 +1169,6 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
       expect(invoked, 1);
       invoked = 0;
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('handles repeated events', (WidgetTester tester) async {
@@ -1193,7 +1189,6 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
       expect(invoked, 2);
       invoked = 0;
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('rejects repeated events if requested', (WidgetTester tester) async {
@@ -1214,7 +1209,6 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
       expect(invoked, 1);
       invoked = 0;
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('handles Alt, Ctrl and Meta', (WidgetTester tester) async {
@@ -1261,7 +1255,6 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlRight);
       expect(invoked, 1);
       invoked = 0;
-      // ignore: deprecated_member_use
     }, variant: KeySimulatorTransitModeVariant.all());
 
     testWidgets('isActivatedBy works as expected', (WidgetTester tester) async {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -550,7 +550,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     if (_insideAddRenderView
         && renderView.hasConfiguration
         && renderView.configuration is TestViewConfiguration
-        && renderView == this.renderView) { // ignore: deprecated_member_use
+        && renderView == this.renderView) {
       // If a test has reached out to the now deprecated renderView property to set a custom TestViewConfiguration
       // we are not replacing it. This is to maintain backwards compatibility with how things worked prior to the
       // deprecation of that property.
@@ -1161,18 +1161,17 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     }
     _announcements = <CapturedAccessibilityAnnouncement>[];
 
-  // ignore: deprecated_member_use
     ServicesBinding.instance.keyEventManager.keyMessageHandler = null;
     buildOwner!.focusManager = FocusManager()..registerGlobalHandlers();
 
     // Disabling the warning because @visibleForTesting doesn't take the testing
     // framework itself into account, but we don't want it visible outside of
     // tests.
-    // ignore: invalid_use_of_visible_for_testing_member, deprecated_member_use
+    // ignore: invalid_use_of_visible_for_testing_member
     RawKeyboard.instance.clearKeysPressed();
     // ignore: invalid_use_of_visible_for_testing_member
     HardwareKeyboard.instance.clearState();
-    // ignore: invalid_use_of_visible_for_testing_member, deprecated_member_use
+    // ignore: invalid_use_of_visible_for_testing_member
     keyEventManager.clearState();
     // ignore: invalid_use_of_visible_for_testing_member
     RendererBinding.instance.initMouseTracker();

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -309,7 +309,6 @@ abstract final class KeyEventSimulator {
 
   static int _getAndroidModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-    // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -317,51 +316,39 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
-    // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierLeftShift | RawKeyEventDataAndroid.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierRightShift | RawKeyEventDataAndroid.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierLeftMeta | RawKeyEventDataAndroid.modifierMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierRightMeta | RawKeyEventDataAndroid.modifierMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierLeftControl | RawKeyEventDataAndroid.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierRightControl | RawKeyEventDataAndroid.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierLeftAlt | RawKeyEventDataAndroid.modifierAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierRightAlt | RawKeyEventDataAndroid.modifierAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.fn)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierFunction;
     }
     if (pressed.contains(LogicalKeyboardKey.scrollLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierScrollLock;
     }
     if (pressed.contains(LogicalKeyboardKey.numLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierNumLock;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataAndroid.modifierCapsLock;
     }
     return result;
@@ -369,7 +356,6 @@ abstract final class KeyEventSimulator {
 
   static int _getGlfwModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-    // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -377,23 +363,18 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft) || pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= GLFWKeyHelper.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft) || pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= GLFWKeyHelper.modifierMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft) || pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= GLFWKeyHelper.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft) || pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= GLFWKeyHelper.modifierAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= GLFWKeyHelper.modifierCapsLock;
     }
     return result;
@@ -401,7 +382,6 @@ abstract final class KeyEventSimulator {
 
   static int _getWindowsModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-    // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -409,59 +389,45 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shift)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierLeftShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierRightShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierLeftMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierRightMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.control)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierLeftControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierRightControl;
     }
     if (pressed.contains(LogicalKeyboardKey.alt)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierLeftAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierRightAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierCaps;
     }
     if (pressed.contains(LogicalKeyboardKey.numLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierNumLock;
     }
     if (pressed.contains(LogicalKeyboardKey.scrollLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWindows.modifierScrollLock;
     }
     return result;
@@ -469,7 +435,6 @@ abstract final class KeyEventSimulator {
 
   static int _getFuchsiaModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-    // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -477,39 +442,30 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierLeftShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierRightShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierLeftMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierRightMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierLeftControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierRightControl;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierLeftAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierRightAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataFuchsia.modifierCapsLock;
     }
     return result;
@@ -517,7 +473,6 @@ abstract final class KeyEventSimulator {
 
   static int _getWebModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-    // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -525,47 +480,36 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierMeta;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierAlt;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierCapsLock;
     }
     if (pressed.contains(LogicalKeyboardKey.numLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierNumLock;
     }
     if (pressed.contains(LogicalKeyboardKey.scrollLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataWeb.modifierScrollLock;
     }
     return result;
@@ -573,7 +517,6 @@ abstract final class KeyEventSimulator {
 
   static int _getMacOsModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-      // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -581,35 +524,27 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierLeftShift | RawKeyEventDataMacOs.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierRightShift | RawKeyEventDataMacOs.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierLeftCommand | RawKeyEventDataMacOs.modifierCommand;
     }
     if (pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierRightCommand | RawKeyEventDataMacOs.modifierCommand;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierLeftControl | RawKeyEventDataMacOs.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierRightControl | RawKeyEventDataMacOs.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierLeftOption | RawKeyEventDataMacOs.modifierOption;
     }
     if (pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierRightOption | RawKeyEventDataMacOs.modifierOption;
     }
     final Set<LogicalKeyboardKey> functionKeys = <LogicalKeyboardKey>{
@@ -636,15 +571,12 @@ abstract final class KeyEventSimulator {
       LogicalKeyboardKey.f21,
     };
     if (pressed.intersection(functionKeys).isNotEmpty) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierFunction;
     }
     if (pressed.intersection(kMacOsNumPadMap.values.toSet()).isNotEmpty) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierNumericPad;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataMacOs.modifierCapsLock;
     }
     return result;
@@ -652,7 +584,6 @@ abstract final class KeyEventSimulator {
 
   static int _getIOSModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
     int result = 0;
-    // ignore: deprecated_member_use
     final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
     if (isDown) {
       pressed.add(newKey);
@@ -660,35 +591,27 @@ abstract final class KeyEventSimulator {
       pressed.remove(newKey);
     }
     if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierLeftShift | RawKeyEventDataIos.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierRightShift | RawKeyEventDataIos.modifierShift;
     }
     if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierLeftCommand | RawKeyEventDataIos.modifierCommand;
     }
     if (pressed.contains(LogicalKeyboardKey.metaRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierRightCommand | RawKeyEventDataIos.modifierCommand;
     }
     if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierLeftControl | RawKeyEventDataIos.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.controlRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierRightControl | RawKeyEventDataIos.modifierControl;
     }
     if (pressed.contains(LogicalKeyboardKey.altLeft)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierLeftOption | RawKeyEventDataIos.modifierOption;
     }
     if (pressed.contains(LogicalKeyboardKey.altRight)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierRightOption | RawKeyEventDataIos.modifierOption;
     }
     final Set<LogicalKeyboardKey> functionKeys = <LogicalKeyboardKey>{
@@ -715,15 +638,12 @@ abstract final class KeyEventSimulator {
       LogicalKeyboardKey.f21,
     };
     if (pressed.intersection(functionKeys).isNotEmpty) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierFunction;
     }
     if (pressed.intersection(kMacOsNumPadMap.values.toSet()).isNotEmpty) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierNumericPad;
     }
     if (pressed.contains(LogicalKeyboardKey.capsLock)) {
-      // ignore: deprecated_member_use
       result |= RawKeyEventDataIos.modifierCapsLock;
     }
     return result;
@@ -764,7 +684,6 @@ abstract final class KeyEventSimulator {
     return result!;
   }
 
-  // ignore: deprecated_member_use
   static const KeyDataTransitMode _defaultTransitMode = KeyDataTransitMode.rawKeyData;
 
   // The simulation transit mode for [simulateKeyDownEvent], [simulateKeyUpEvent],
@@ -777,12 +696,9 @@ abstract final class KeyEventSimulator {
   // The `_transitMode` defaults to [KeyDataTransitMode.rawKeyEvent], and can be
   // overridden with [debugKeyEventSimulatorTransitModeOverride]. In widget tests, it
   // is often set with [KeySimulationModeVariant].
-  // ignore: deprecated_member_use
   static KeyDataTransitMode get _transitMode {
-    // ignore: deprecated_member_use
     KeyDataTransitMode? result;
     assert(() {
-      // ignore: deprecated_member_use
       result = debugKeyEventSimulatorTransitModeOverride;
       return true;
     }());
@@ -820,13 +736,10 @@ abstract final class KeyEventSimulator {
       });
     }
     switch (_transitMode) {
-      // ignore: deprecated_member_use
       case KeyDataTransitMode.rawKeyData:
         return simulateByRawEvent();
-      // ignore: deprecated_member_use
       case KeyDataTransitMode.keyDataThenRawKeyData:
         final LogicalKeyboardKey logicalKey = _getKeySynonym(key);
-        // ignore: deprecated_member_use
         final bool resultByKeyEvent = ServicesBinding.instance.keyEventManager.handleKeyData(
           ui.KeyData(
             type: ui.KeyEventType.down,
@@ -867,13 +780,10 @@ abstract final class KeyEventSimulator {
       });
     }
     switch (_transitMode) {
-      // ignore: deprecated_member_use
       case KeyDataTransitMode.rawKeyData:
         return simulateByRawEvent();
-      // ignore: deprecated_member_use
       case KeyDataTransitMode.keyDataThenRawKeyData:
         final LogicalKeyboardKey logicalKey = _getKeySynonym(key);
-        // ignore: deprecated_member_use
         final bool resultByKeyEvent = ServicesBinding.instance.keyEventManager.handleKeyData(
           ui.KeyData(
             type: ui.KeyEventType.up,
@@ -915,13 +825,10 @@ abstract final class KeyEventSimulator {
       });
     }
     switch (_transitMode) {
-      // ignore: deprecated_member_use
       case KeyDataTransitMode.rawKeyData:
         return simulateByRawEvent();
-      // ignore: deprecated_member_use
       case KeyDataTransitMode.keyDataThenRawKeyData:
         final LogicalKeyboardKey logicalKey = _getKeySynonym(key);
-        // ignore: deprecated_member_use
         final bool resultByKeyEvent = ServicesBinding.instance.keyEventManager.handleKeyData(
           ui.KeyData(
             type: ui.KeyEventType.repeat,

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -19,7 +19,6 @@ import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_impo
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 
-// ignore: deprecated_member_use
 export 'package:test_api/fake.dart' show Fake;
 
 Declarer? _localDeclarer;

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -1083,7 +1083,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   int? _lastRecordedSemanticsHandles;
 
   // TODO(goderbauer): Only use binding.debugOutstandingSemanticsHandles when deprecated binding.pipelineOwner is removed.
-  // ignore: deprecated_member_use
   int get _currentSemanticsHandles => binding.debugOutstandingSemanticsHandles + binding.pipelineOwner.debugOutstandingSemanticsHandles;
 
   void _recordNumberOfSemanticsHandles() {

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -611,9 +611,6 @@ class TestPlatformDispatcher implements PlatformDispatcher {
 
   @override
   void updateSemantics(SemanticsUpdate update) {
-    // Using the deprecated method to maintain backwards compatibility during
-    // the multi-view transition window.
-    // ignore: deprecated_member_use
     _platformDispatcher.updateSemantics(update);
   }
 

--- a/packages/flutter_test/test/event_simulation_test.dart
+++ b/packages/flutter_test/test/event_simulation_test.dart
@@ -17,7 +17,6 @@ void _verifyKeyEvent<T extends KeyEvent>(KeyEvent event, PhysicalKeyboardKey phy
   expect(event.synthesized, false);
 }
 
-// ignore: deprecated_member_use
 void _verifyRawKeyEvent<T extends RawKeyEvent>(RawKeyEvent event, PhysicalKeyboardKey physical, LogicalKeyboardKey logical, String? character) {
   expect(event, isA<T>());
   expect(event.physicalKey, physical);
@@ -39,16 +38,13 @@ Future<void> _shouldThrow<T extends Error>(AsyncValueGetter<void> func) async {
 
 void main() {
   testWidgets('simulates keyboard events (RawEvent)', (WidgetTester tester) async {
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.rawKeyData;
 
-    // ignore: deprecated_member_use
     final List<RawKeyEvent> events = <RawKeyEvent>[];
 
     final FocusNode focusNode = FocusNode();
 
     await tester.pumpWidget(
-      // ignore: deprecated_member_use
       RawKeyboardListener(
         focusNode: focusNode,
         onKey: events.add,
@@ -72,14 +68,11 @@ void main() {
       for (int i = 0; i < events.length; ++i) {
         final bool isEven = i.isEven;
         if (isEven) {
-          // ignore: deprecated_member_use
           expect(events[i].runtimeType, equals(RawKeyDownEvent));
         } else {
-          // ignore: deprecated_member_use
           expect(events[i].runtimeType, equals(RawKeyUpEvent));
         }
         if (i < 4) {
-          // ignore: deprecated_member_use
           expect(events[i].data.isModifierPressed(ModifierKey.shiftModifier, side: KeyboardSide.left), equals(isEven));
         }
       }
@@ -89,12 +82,10 @@ void main() {
     await tester.pumpWidget(Container());
     focusNode.dispose();
 
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = null;
   });
 
   testWidgets('simulates keyboard events (KeyData then RawKeyEvent)', (WidgetTester tester) async {
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
 
     final List<KeyEvent> events = <KeyEvent>[];
@@ -254,12 +245,10 @@ void main() {
     await tester.pumpWidget(Container());
     focusNode.dispose();
 
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = null;
   });
 
   testWidgets('simulates using the correct transit mode: rawKeyData', (WidgetTester tester) async {
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.rawKeyData;
 
     final List<Object> events = <Object>[];
@@ -268,7 +257,6 @@ void main() {
     await tester.pumpWidget(
       Focus(
         focusNode: focusNode,
-        // ignore: deprecated_member_use
         onKey: (FocusNode node, RawKeyEvent event) {
           events.add(event);
           return KeyEventResult.ignored;
@@ -289,9 +277,7 @@ void main() {
     expect(events.length, 2);
     expect(events[0], isA<KeyEvent>());
     _verifyKeyEvent<KeyDownEvent>(events[0] as KeyEvent, PhysicalKeyboardKey.keyA, LogicalKeyboardKey.keyA, 'a');
-    // ignore: deprecated_member_use
     expect(events[1], isA<RawKeyEvent>());
-    // ignore: deprecated_member_use
     _verifyRawKeyEvent<RawKeyDownEvent>(events[1] as RawKeyEvent, PhysicalKeyboardKey.keyA, LogicalKeyboardKey.keyA, 'a');
     events.clear();
 
@@ -303,27 +289,22 @@ void main() {
     expect(events.length, 2);
     expect(events[0], isA<KeyEvent>());
     _verifyKeyEvent<KeyUpEvent>(events[0] as KeyEvent, PhysicalKeyboardKey.keyA, LogicalKeyboardKey.keyA, null);
-    // ignore: deprecated_member_use
     expect(events[1], isA<RawKeyEvent>());
-    // ignore: deprecated_member_use
     _verifyRawKeyEvent<RawKeyUpEvent>(events[1] as RawKeyEvent, PhysicalKeyboardKey.keyA, LogicalKeyboardKey.keyB, null);
     events.clear();
 
     // Manually switch the transit mode to `keyDataThenRawKeyData`. This will
     // never happen in real applications so the assertion error can verify that
     // the transit mode is correctly applied.
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
 
     await _shouldThrow<AssertionError>(() =>
       simulateKeyUpEvent(LogicalKeyboardKey.keyB, physicalKey: PhysicalKeyboardKey.keyA));
 
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = null;
   });
 
   testWidgets('simulates using the correct transit mode: keyDataThenRawKeyData', (WidgetTester tester) async {
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
 
     final List<Object> events = <Object>[];
@@ -332,7 +313,6 @@ void main() {
     await tester.pumpWidget(
       Focus(
         focusNode: focusNode,
-        // ignore: deprecated_member_use
         onKey: (FocusNode node, RawKeyEvent event) {
           events.add(event);
           return KeyEventResult.ignored;
@@ -353,9 +333,7 @@ void main() {
     expect(events.length, 2);
     expect(events[0], isA<KeyEvent>());
     _verifyKeyEvent<KeyDownEvent>(events[0] as KeyEvent, PhysicalKeyboardKey.keyA, LogicalKeyboardKey.keyA, 'a');
-    // ignore: deprecated_member_use
     expect(events[1], isA<RawKeyEvent>());
-    // ignore: deprecated_member_use
     _verifyRawKeyEvent<RawKeyDownEvent>(events[1] as RawKeyEvent, PhysicalKeyboardKey.keyA, LogicalKeyboardKey.keyA, 'a');
     events.clear();
 
@@ -367,7 +345,6 @@ void main() {
     await _shouldThrow<AssertionError>(() =>
       simulateKeyUpEvent(LogicalKeyboardKey.keyB, physicalKey: PhysicalKeyboardKey.keyA));
 
-    // ignore: deprecated_member_use
     debugKeyEventSimulatorTransitModeOverride = null;
   });
 }

--- a/packages/flutter_test/test/widget_tester_live_device_test.dart
+++ b/packages/flutter_test/test/widget_tester_live_device_test.dart
@@ -83,7 +83,7 @@ No widgets found at Offset(1.0, 1.0).
       ),
     );
 
-    final Size originalSize = tester.binding.renderView.size; // ignore: deprecated_member_use
+    final Size originalSize = tester.binding.renderView.size;
     await tester.binding.setSurfaceSize(const Size(2000, 1800));
     try {
       await tester.pump();

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 // TODO(goderbauer): Delete these tests when the deprecated window property is removed.
-// ignore_for_file: deprecated_member_use
 
 import 'dart:ui' as ui show window;
 import 'dart:ui';

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -133,7 +133,7 @@ Future<int> run(
         firstStackTrace = stackTrace;
         return _handleToolError(error, stackTrace, verbose, args, reportCrashes!, getVersion, shutdownHooks);
       }
-    }, onError: (Object error, StackTrace stackTrace) async { // ignore: deprecated_member_use
+    }, onError: (Object error, StackTrace stackTrace) async {
       // If sending a crash report throws an error into the zone, we don't want
       // to re-try sending the crash report with *that* error. Rather, we want
       // to send the original error that triggered the crash report.

--- a/packages/flutter_tools/lib/src/base/async_guard.dart
+++ b/packages/flutter_tools/lib/src/base/async_guard.dart
@@ -117,7 +117,7 @@ Future<T> asyncGuard<T>(
     } catch (e, s) { // ignore: avoid_catches_without_on_clauses, forwards to Future
       handleError(e, s);
     }
-  }, onError: (Object e, StackTrace s) { // ignore: deprecated_member_use
+  }, onError: (Object e, StackTrace s) {
     handleError(e, s);
   });
 

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/test/flutter_platform.dart';
-import 'package:test_core/backend.dart'; // ignore: deprecated_member_use
+import 'package:test_core/backend.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -86,7 +86,7 @@ void main() {
           ));
           return null;
         },
-        onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
+        onError: (Object error, StackTrace stack) {
           expect(firstExitCode, isNotNull);
           expect(firstExitCode, isNot(0));
           expect(error.toString(), 'Exception: test exit');
@@ -141,7 +141,7 @@ void main() {
           ));
           return null;
         },
-        onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
+        onError: (Object error, StackTrace stack) {
           expect(firstExitCode, isNotNull);
           expect(firstExitCode, isNot(0));
           expect(error.toString(), 'Exception: test exit');
@@ -189,7 +189,7 @@ void main() {
           ));
           return null;
         },
-        onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
+        onError: (Object error, StackTrace stack) {
           expect(firstExitCode, isNotNull);
           expect(firstExitCode, isNot(0));
           expect(error.toString(), 'Exception: test exit');
@@ -284,7 +284,7 @@ void main() {
             ));
             return null;
           },
-          onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
+          onError: (Object error, StackTrace stack) {
             expect(firstExitCode, isNotNull);
             expect(firstExitCode, isNot(0));
             expect(error.toString(), 'Exception: test exit');


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/143347.