### PR TITLE
Rename `external_ui` to `external_textures`.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2192,7 +2192,7 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: external_textures_integration_test
 
-  - name: Linux_android_emu external_ui_integration_test
+  - name: Linux_android_emu external_textures_integration_test
     recipe: devicelab/devicelab_drone
     # TODO(https://github.com/flutter/flutter/issues/142178): Enable this.
     bringup: true
@@ -2206,7 +2206,6 @@ targets:
     properties:
       tags: >
         ["devicelab", "linux"]
-      # TODO(https://github.com/flutter/flutter/issues/142178): Rename this.
       task_name: external_textures_integration_test
 
   # linux motog4 benchmark


### PR DESCRIPTION
My understanding is I can do this safely because the task is marked `bringup: true`?

Next PR will remove `bringup` and take down the old tasks.

Partial work towards https://github.com/flutter/flutter/issues/142178.