### PR TITLE
(In the context of flutter manifest parsing) Introduce the concept of a result type

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -26,7 +26,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../convert.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -19,7 +19,7 @@ import 'cache.dart';
 import 'convert.dart';
 import 'dart/package_map.dart';
 import 'devfs.dart';
-import 'flutter_manifest.dart';
+import 'flutter_manifest/flutter_manifest.dart';
 import 'license_collector.dart';
 import 'project.dart';
 

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -19,6 +19,7 @@ import 'cache.dart';
 import 'convert.dart';
 import 'dart/package_map.dart';
 import 'devfs.dart';
+import 'flutter_manifest/assets_entry.dart';
 import 'flutter_manifest/flutter_manifest.dart';
 import 'license_collector.dart';
 import 'project.dart';

--- a/packages/flutter_tools/lib/src/base/deferred_component.dart
+++ b/packages/flutter_tools/lib/src/base/deferred_component.dart
@@ -5,7 +5,7 @@
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../convert.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 
 /// Represents a configured deferred component as defined in
 /// the app's pubspec.yaml.

--- a/packages/flutter_tools/lib/src/base/deferred_component.dart
+++ b/packages/flutter_tools/lib/src/base/deferred_component.dart
@@ -5,7 +5,7 @@
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../convert.dart';
-import '../flutter_manifest/flutter_manifest.dart';
+import '../flutter_manifest/assets_entry.dart';
 
 /// Represents a configured deferred component as defined in
 /// the app's pubspec.yaml.

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -17,7 +17,7 @@ import '../base/version_range.dart';
 import '../convert.dart';
 import '../dart/pub.dart';
 import '../features.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 import '../flutter_project_metadata.dart';
 import '../globals.dart' as globals;
 import '../ios/code_signing.dart';

--- a/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
@@ -1,0 +1,112 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import '../base/utils.dart';
+import 'flutter_manifest.dart';
+import 'parse_result.dart';
+
+/// Represents an entry under the `assets` section of a pubspec.
+@immutable
+class AssetsEntry {
+  const AssetsEntry({
+    required this.uri,
+    this.flavors = const <String>{},
+  });
+
+  final Uri uri;
+  final Set<String> flavors;
+
+  static const String _pathKey = 'path';
+  static const String _flavorKey = 'flavors';
+
+  static ParseResult<AssetsEntry?> parseFromYaml(Object? yaml) {
+
+    (Uri?, String?) tryParseUri(String uri) {
+      try {
+        return (Uri(pathSegments: uri.split('/')), null);
+      } on FormatException {
+        return (null, 'Asset manifest contains invalid uri: $uri.');
+      }
+    }
+
+    if (yaml == null || yaml == '') {
+      return const ErrorParseResult<AssetsEntry>(<String>['Asset manifest contains a null or empty uri.']);
+    }
+
+    if (yaml is String) {
+      final (Uri? uri, String? error) = tryParseUri(yaml);
+      if (uri == null) {
+        return ErrorParseResult<AssetsEntry>(<String>[error!]);
+      }
+      return ValueParseResult<AssetsEntry>(AssetsEntry(uri: uri));
+    }
+
+    if (yaml is Map) {
+      if (yaml.keys.isEmpty) {
+        return const ValueParseResult<AssetsEntry?>(null);
+      }
+
+      final Object? path = yaml[_pathKey];
+      final Object? flavorsYaml = yaml[_flavorKey];
+
+      if (path == null || path is! String) {
+        final String message = 'Asset manifest entry is malformed. '
+          'Expected asset entry to be either a string or a map '
+          'containing a "$_pathKey" entry. Got ${path.runtimeType} instead.';
+        return ErrorParseResult<AssetsEntry>(<String>[message]);
+      }
+
+      final Uri uri = Uri(pathSegments: path.split('/'));
+
+      if (flavorsYaml == null) {
+        return ValueParseResult<AssetsEntry>(AssetsEntry(uri: uri));
+      }
+
+      final ParseResult<List<String>> flavorsParseResult = parseList<String>(
+        flavorsYaml,
+        'flavors list of assets entry "$path"',
+        'String',
+      );
+
+      late Set<String> flavors;
+      switch (flavorsParseResult) {
+        case ValueParseResult<List<String>>():
+          flavors = Set<String>.from(flavorsParseResult.value);
+        case ErrorParseResult<List<String>>():
+          return ErrorParseResult<AssetsEntry>(flavorsParseResult.errors);
+      }
+
+      final AssetsEntry entry = AssetsEntry(
+        uri: Uri(pathSegments: path.split('/')),
+        flavors: flavors,
+      );
+
+      return ValueParseResult<AssetsEntry>(entry);
+    }
+
+    final String message = 'Assets entry had unexpected shape. '
+      'Expected a string or an object. Got ${yaml.runtimeType} instead.';
+    return ErrorParseResult<AssetsEntry>(<String>[message]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! AssetsEntry) {
+      return false;
+    }
+
+    return uri == other.uri && setEquals(flavors, other.flavors);
+  }
+
+  @override
+  int get hashCode => Object.hashAll(<Object?>[
+    uri.hashCode,
+    Object.hashAllUnordered(flavors),
+  ]);
+
+  @override
+  String toString() => 'AssetsEntry(uri: $uri, flavors: $flavors)';
+}

--- a/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
@@ -24,11 +24,11 @@ class AssetsEntry {
 
   static ParseResult<AssetsEntry?> parseFromYaml(Object? yaml) {
 
-    (Uri?, String?) tryParseUri(String uri) {
+    ParseResult<Uri> tryParseUri(String uri) {
       try {
-        return (Uri(pathSegments: uri.split('/')), null);
+        return ValueParseResult<Uri>(Uri(pathSegments: uri.split('/')));
       } on FormatException {
-        return (null, 'Asset manifest contains invalid uri: $uri.');
+        return ErrorParseResult<Uri>(<String>['Asset manifest contains invalid uri: $uri.']);
       }
     }
 
@@ -37,11 +37,11 @@ class AssetsEntry {
     }
 
     if (yaml is String) {
-      final (Uri? uri, String? error) = tryParseUri(yaml);
-      if (uri == null) {
-        return ErrorParseResult<AssetsEntry>(<String>[error!]);
-      }
-      return ValueParseResult<AssetsEntry>(AssetsEntry(uri: uri));
+      final ParseResult<Uri> uriParseResult = tryParseUri(yaml);
+      return switch (uriParseResult) {
+        ValueParseResult<Uri>() => ValueParseResult<AssetsEntry>(AssetsEntry(uri: uriParseResult.value)),
+        ErrorParseResult<Uri>() => ErrorParseResult<AssetsEntry>(uriParseResult.errors),
+      };
     }
 
     if (yaml is Map) {

--- a/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
@@ -5,7 +5,7 @@
 import 'package:meta/meta.dart';
 
 import '../base/utils.dart';
-import 'flutter_manifest.dart';
+import 'parse_list.dart';
 import 'parse_result.dart';
 
 /// Represents an entry under the `assets` section of a pubspec.

--- a/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/assets_entry.dart
@@ -28,19 +28,19 @@ class AssetsEntry {
       try {
         return ValueParseResult<Uri>(Uri(pathSegments: uri.split('/')));
       } on FormatException {
-        return ErrorParseResult<Uri>(<String>['Asset manifest contains invalid uri: $uri.']);
+        return ErrorParseResult.single('Asset manifest contains invalid uri: $uri.');
       }
     }
 
     if (yaml == null || yaml == '') {
-      return const ErrorParseResult<AssetsEntry>(<String>['Asset manifest contains a null or empty uri.']);
+      return ErrorParseResult.single('Asset manifest contains a null or empty uri.');
     }
 
     if (yaml is String) {
       final ParseResult<Uri> uriParseResult = tryParseUri(yaml);
       return switch (uriParseResult) {
         ValueParseResult<Uri>() => ValueParseResult<AssetsEntry>(AssetsEntry(uri: uriParseResult.value)),
-        ErrorParseResult<Uri>() => ErrorParseResult<AssetsEntry>(uriParseResult.errors),
+        ErrorParseResult<Uri>() => uriParseResult.cast<AssetsEntry>(),
       };
     }
 
@@ -53,10 +53,11 @@ class AssetsEntry {
       final Object? flavorsYaml = yaml[_flavorKey];
 
       if (path == null || path is! String) {
-        final String message = 'Asset manifest entry is malformed. '
-          'Expected asset entry to be either a string or a map '
-          'containing a "$_pathKey" entry. Got ${path.runtimeType} instead.';
-        return ErrorParseResult<AssetsEntry>(<String>[message]);
+        return ErrorParseResult.single(
+          'Asset manifest entry is malformed. Expected asset entry to be '
+          'either a string or a map containing a "$_pathKey" entry. '
+          'Got ${path.runtimeType} instead.',
+        );
       }
 
       final Uri uri = Uri(pathSegments: path.split('/'));
@@ -87,9 +88,10 @@ class AssetsEntry {
       return ValueParseResult<AssetsEntry>(entry);
     }
 
-    final String message = 'Assets entry had unexpected shape. '
-      'Expected a string or an object. Got ${yaml.runtimeType} instead.';
-    return ErrorParseResult<AssetsEntry>(<String>[message]);
+    return ErrorParseResult.single(
+      'Assets entry had unexpected shape. Expected a string or an object. '
+      'Got ${yaml.runtimeType} instead.',
+    );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/flutter_manifest/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/flutter_manifest.dart
@@ -6,12 +6,12 @@ import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
-import 'base/deferred_component.dart';
-import 'base/file_system.dart';
-import 'base/logger.dart';
-import 'base/utils.dart';
-import 'globals.dart' as globals;
-import 'plugins.dart';
+import '../base/deferred_component.dart';
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/utils.dart';
+import '../globals.dart' as globals;
+import '../plugins.dart';
 
 /// Whether or not Impeller Scene 3D model import is enabled.
 const bool kIs3dSceneSupported = true;

--- a/packages/flutter_tools/lib/src/flutter_manifest/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/flutter_manifest.dart
@@ -13,6 +13,7 @@ import '../base/utils.dart';
 import '../globals.dart' as globals;
 import '../plugins.dart';
 import 'assets_entry.dart';
+import 'parse_list.dart';
 import 'parse_result.dart';
 
 /// Whether or not Impeller Scene 3D model import is enabled.
@@ -553,31 +554,6 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         break;
     }
   }
-}
-
-ParseResult<List<T>> parseList<T>(Object? yamlList, String context, String typeAlias) {
-  final List<T> result = <T>[];
-  final List<String> errors = <String>[];
-
-  if (yamlList is! YamlList) {
-    return ErrorParseResult<List<T>>(
-      <String>['Expected $context to be a list of $typeAlias, but got $yamlList (${yamlList.runtimeType}).']
-    );
-  }
-
-  for (final (int i, Object? item) in yamlList.indexed) {
-    if (item is! T) {
-      // ignore: avoid_dynamic_calls
-      errors.add('Expected $context to be a list of $typeAlias, but element at index $i was a ${yamlList[i].runtimeType}.');
-    } else {
-      result.add(item);
-    }
-  }
-
-  if (errors.isEmpty) {
-    return ValueParseResult<List<T>>(result);
-  }
-  return ErrorParseResult<List<T>>(errors);
 }
 
 void _validateDeferredComponents(MapEntry<Object?, Object?> kvp, List<String> errors) {

--- a/packages/flutter_tools/lib/src/flutter_manifest/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/flutter_manifest.dart
@@ -607,15 +607,11 @@ List<String> _validateAssets(Object? yaml) {
   final List<AssetsEntry> results = <AssetsEntry>[];
   final List<String> errors = <String>[];
   for (final Object? rawAssetEntry in yaml) {
-    final ParseResult<AssetsEntry?> parseResult = AssetsEntry.parseFromYaml(rawAssetEntry);
-    switch (parseResult) {
-      case ValueParseResult<AssetsEntry?>():
-      final AssetsEntry? value = parseResult.value;
-        if (value != null) {
-          results.add(value);
-        }
-      case ErrorParseResult<AssetsEntry?>():
-        errors.addAll(parseResult.errors);
+    final ParseResult<AssetsEntry> parseResult = AssetsEntry.parseFromYaml(rawAssetEntry);
+    if (parseResult.hasValue) {
+      results.add(parseResult.value());
+    } else {
+      errors.addAll(parseResult.errors);
     }
   }
   return (results, errors);

--- a/packages/flutter_tools/lib/src/flutter_manifest/parse_list.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/parse_list.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+import 'parse_result.dart';
+
+ParseResult<List<T>> parseList<T>(Object? yamlList, String context, String typeAlias) {
+  final List<T> result = <T>[];
+  final List<String> errors = <String>[];
+
+  if (yamlList is! YamlList) {
+    return ErrorParseResult<List<T>>(
+      <String>['Expected $context to be a list of $typeAlias, but got $yamlList (${yamlList.runtimeType}).']
+    );
+  }
+
+  for (final (int i, Object? item) in yamlList.indexed) {
+    if (item is! T) {
+      // ignore: avoid_dynamic_calls
+      errors.add('Expected $context to be a list of $typeAlias, but element at index $i was a ${yamlList[i].runtimeType}.');
+    } else {
+      result.add(item);
+    }
+  }
+
+  if (errors.isEmpty) {
+    return ValueParseResult<List<T>>(result);
+  }
+  return ErrorParseResult<List<T>>(errors);
+}

--- a/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
@@ -35,6 +35,6 @@ final class ErrorParseResult<T> extends ParseResult<T> {
   }
 
   ErrorParseResult<S> cast<S>() {
-    return this as ErrorParseResult<S>;
+    return ErrorParseResult<S>(errors);
   }
 }

--- a/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
@@ -2,39 +2,39 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-sealed class ParseResult<T> {
-  const ParseResult();
+final class ParseResult<T> {
+  factory ParseResult.value(T value) {
+    return ParseResult<T>._(_ParseResultValue<T>(value), <String>[]);
+  }
 
-  List<String> get errors;
-}
+  factory ParseResult.error(String error) {
+    return ParseResult<T>._(null, <String>[error]);
+  }
 
-final class ValueParseResult<T> extends ParseResult<T> {
-  const ValueParseResult(this.value);
-  final T value;
+  factory ParseResult.errors(List<String> errors) {
+    return ParseResult<T>._(null, errors);
+  }
 
-  // Defining `errors` here allows callers only interested in validation (and not
-  // getting the parsed value) to simply call `errors` without having to `switch`
-  // on this object's type.
-  @override
-  List<String> get errors => const <String>[];
-}
+  ParseResult._(this._value, this.errors);
 
-final class ErrorParseResult<T> extends ParseResult<T> {
-  const ErrorParseResult(this.errors);
-
-  @override
+  final _ParseResultValue<T>? _value;
   final List<String> errors;
 
-  // Convenience factory method for generating an error result that contains
-  // only one error. This is useful because callers can write
-  // ErrorParseResult.single(my_string) instead of
-  // ErrorParseResult<MyTypeParameter>(<String>['my_string']) and also avoid
-  // violating the no_adjacent_strings_in_list lint.
-  static ErrorParseResult<S> single<S>(String error) {
-    return ErrorParseResult<S>(<String>[error]);
-  }
+  bool get hasValue => _value != null;
+  bool get hasErrors => errors.isNotEmpty;
 
-  ErrorParseResult<S> cast<S>() {
-    return ErrorParseResult<S>(errors);
+  /// Will throw if this result contains no value.
+  T value() {
+    if (_value == null) {
+      throw Exception('Cannot read value from result that has no value.');
+    }
+
+    return _value.value;
   }
+}
+
+final class _ParseResultValue<T> {
+  _ParseResultValue(this.value);
+
+  final T value;
 }

--- a/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
@@ -21,6 +21,20 @@ final class ValueParseResult<T> extends ParseResult<T> {
 
 final class ErrorParseResult<T> extends ParseResult<T> {
   const ErrorParseResult(this.errors);
+
   @override
   final List<String> errors;
+
+  // Convenience factory method for generating an error result that contains
+  // only one error. This is useful because callers can write
+  // ErrorParseResult.single(my_string) instead of
+  // ErrorParseResult<MyTypeParameter>(<String>['my_string']) and also avoid
+  // violating the no_adjacent_strings_in_list lint.
+  static ErrorParseResult<S> single<S>(String error) {
+    return ErrorParseResult<S>(<String>[error]);
+  }
+
+  ErrorParseResult<S> cast<S>() {
+    return this as ErrorParseResult<S>;
+  }
 }

--- a/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest/parse_result.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+sealed class ParseResult<T> {
+  const ParseResult();
+
+  List<String> get errors;
+}
+
+final class ValueParseResult<T> extends ParseResult<T> {
+  const ValueParseResult(this.value);
+  final T value;
+
+  // Defining `errors` here allows callers only interested in validation (and not
+  // getting the parsed value) to simply call `errors` without having to `switch`
+  // on this object's type.
+  @override
+  List<String> get errors => const <String>[];
+}
+
+final class ErrorParseResult<T> extends ParseResult<T> {
+  const ErrorParseResult(this.errors);
+  @override
+  final List<String> errors;
+}

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -18,7 +18,7 @@ import '../base/utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../device.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../macos/cocoapod_utils.dart';
 import '../macos/xcode.dart';

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -7,7 +7,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../cache.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -11,7 +11,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../convert.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 import 'gen_l10n_templates.dart';
 import 'gen_l10n_types.dart';
 import 'localizations_utils.dart';

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -19,7 +19,7 @@ import 'base/version.dart';
 import 'bundle.dart' as bundle;
 import 'cmake_project.dart';
 import 'features.dart';
-import 'flutter_manifest.dart';
+import 'flutter_manifest/flutter_manifest.dart';
 import 'flutter_plugins.dart';
 import 'globals.dart' as globals;
 import 'platform_plugins.dart';

--- a/packages/flutter_tools/lib/src/project_validator.dart
+++ b/packages/flutter_tools/lib/src/project_validator.dart
@@ -13,7 +13,7 @@ import 'base/platform.dart';
 import 'cache.dart';
 import 'convert.dart';
 import 'dart_pub_json_formatter.dart';
-import 'flutter_manifest.dart';
+import 'flutter_manifest/flutter_manifest.dart';
 import 'project.dart';
 import 'project_validator_result.dart';
 import 'version.dart';

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -14,7 +14,7 @@ import '../base/process.dart';
 import '../build_system/exceptions.dart';
 import '../convert.dart';
 import '../devfs.dart';
-import '../flutter_manifest.dart';
+import '../flutter_manifest/flutter_manifest.dart';
 import '../flutter_project_metadata.dart';
 import '../project.dart';
 import '../version.dart';

--- a/packages/flutter_tools/test/general.shard/base/deferred_component_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/deferred_component_test.dart
@@ -6,7 +6,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/deferred_component.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 
 import '../../src/common.dart';
 

--- a/packages/flutter_tools/test/general.shard/base/deferred_component_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/deferred_component_test.dart
@@ -6,7 +6,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/deferred_component.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/assets_entry.dart';
 
 import '../../src/common.dart';
 

--- a/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart_plugin_test.dart
@@ -5,7 +5,7 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/dart/package_map.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/plugins.dart';

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 
 import '../src/common.dart';
 

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/flutter_manifest/assets_entry.dart';
 import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 
 import '../src/common.dart';
@@ -154,8 +155,8 @@ flutter:
 ''';
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(logger.errorText, contains(
-        'Asset manifest entry is malformed. '
-        'Expected "flavors" entry to be a list of strings.',
+        'Expected flavors list of assets entry "assets/vanilla/" to be a list of '
+        'String, but element at index 0 was a YamlMap.\n',
       ));
     });
   });

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_tools/src/base/deferred_component.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 
 import '../src/common.dart';
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 import 'package:flutter_tools/src/flutter_plugins.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';

--- a/packages/flutter_tools/test/src/pubspec_schema.dart
+++ b/packages/flutter_tools/test/src/pubspec_schema.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/flutter_manifest.dart';
+import 'package:flutter_tools/src/flutter_manifest/flutter_manifest.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:yaml/yaml.dart';
 


### PR DESCRIPTION
In service of https://github.com/flutter/flutter/issues/143348.
Arguably makes fixing https://github.com/flutter/flutter/issues/139183 easier.

The `flutter` tool has a sizeable amount of code devoted to parsing the flutter manifest (`flutter` section in a project's pubspec.yaml file). In parsing code, in useful to have a type that represents and contains _either_ a successfully parsed value _or_ an error message.

This experimental PR proposes introducing a `ParseResult` type, which is parent to two subtypes `ValueParseResult` and `ErrorParseResult` (the naming is similar to [`Result`](https://api.flutter.dev/flutter/async/Result-class.html) from `dart:async`). Some code is also refactored to utilize this new type.

This PR also moves the `AssetsEntry` class to its own file, as flutter_manifest.dart is becoming quite a large file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
