### PR TITLE
Add animation for menus

### DIFF
--- a/dev/tools/gen_defaults/lib/menu_template.dart
+++ b/dev/tools/gen_defaults/lib/menu_template.dart
@@ -264,13 +264,13 @@ class _MenuDefaultsM3 extends MenuStyle {
   VisualDensity get visualDensity => Theme.of(context).visualDensity;
 
   @override
-  AnimationStyle get animationStyle {
+  AnimationStyle get sizeAnimationStyle {
     return switch (Theme.of(context).platform) {
       TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
         => AnimationStyle(
           curve: Curves.easeInOutCubicEmphasized,
           reverseCurve: Curves.easeInOutCubicEmphasized.flipped,
-          duration: const Duration(milliseconds: 500),
+          duration: const Duration(milliseconds: ${(getToken('md.sys.motion.duration.long2Ms') as double).round()}),
         ),
       TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
         => AnimationStyle.noAnimation,

--- a/dev/tools/gen_defaults/lib/menu_template.dart
+++ b/dev/tools/gen_defaults/lib/menu_template.dart
@@ -262,6 +262,20 @@ class _MenuDefaultsM3 extends MenuStyle {
 
   @override
   VisualDensity get visualDensity => Theme.of(context).visualDensity;
+
+  @override
+  AnimationStyle get animationStyle {
+    return switch (Theme.of(context).platform) {
+      TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
+        => AnimationStyle(
+          curve: Curves.easeInOutCubicEmphasized,
+          reverseCurve: Curves.easeInOutCubicEmphasized.flipped,
+          duration: const Duration(milliseconds: 500),
+        ),
+      TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
+        => AnimationStyle.noAnimation,
+    };
+  }
 }
 ''';
 }

--- a/examples/api/test/material/menu_anchor/menu_anchor.0_test.dart
+++ b/examples/api/test/material/menu_anchor/menu_anchor.0_test.dart
@@ -28,7 +28,7 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('Background Color'), findsOneWidget);
 

--- a/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
+++ b/examples/api/test/material/menu_anchor/radio_menu_button.0_test.dart
@@ -15,7 +15,7 @@ void main() {
 
     await tester.tap(find.byType(TextButton));
     await tester.pump();
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('Red Background'), findsOneWidget);
     expect(find.text('Green Background'), findsOneWidget);

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -758,6 +758,10 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     if (widget.width != null) {
       effectiveMenuStyle = effectiveMenuStyle.copyWith(minimumSize: MaterialStatePropertyAll<Size?>(Size(widget.width!, 0.0)));
     } else if (anchorWidth != null){
+      // The width of `_MenuPanel` in `MenuAnchor` will be constrained further
+      // based on visual density, so it might result a menu whose width is
+      // different from the width of the text field. This calcaulation is
+      // reverting the visual density adjustment.
       final VisualDensity visualDensity = effectiveMenuStyle.visualDensity ?? Theme.of(context).visualDensity;
       final double dx = (visualDensity.horizontal) * 4;
       effectiveMenuStyle = effectiveMenuStyle.copyWith(minimumSize: MaterialStatePropertyAll<Size?>(Size(anchorWidth - dx, 0.0)));

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -758,7 +758,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     if (widget.width != null) {
       effectiveMenuStyle = effectiveMenuStyle.copyWith(minimumSize: MaterialStatePropertyAll<Size?>(Size(widget.width!, 0.0)));
     } else if (anchorWidth != null){
-      effectiveMenuStyle = effectiveMenuStyle.copyWith(minimumSize: MaterialStatePropertyAll<Size?>(Size(anchorWidth, 0.0)));
+      final VisualDensity visualDensity = effectiveMenuStyle.visualDensity ?? Theme.of(context).visualDensity;
+      final double dx = (visualDensity.horizontal) * 4;
+      effectiveMenuStyle = effectiveMenuStyle.copyWith(minimumSize: MaterialStatePropertyAll<Size?>(Size(anchorWidth - dx, 0.0)));
     }
 
     if (widget.menuHeight != null) {
@@ -1138,10 +1140,10 @@ class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
 
   @override
   MenuStyle get menuStyle {
-    return const MenuStyle(
-      minimumSize: MaterialStatePropertyAll<Size>(Size(_kMinimumWidth, 0.0)),
-      maximumSize: MaterialStatePropertyAll<Size>(Size.infinite),
-      visualDensity: VisualDensity.standard,
+    return MenuStyle(
+      minimumSize: const MaterialStatePropertyAll<Size>(Size(_kMinimumWidth, 0.0)),
+      maximumSize: const MaterialStatePropertyAll<Size>(Size.infinite),
+      visualDensity: _theme.visualDensity,
     );
   }
 

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1144,16 +1144,6 @@ class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
       minimumSize: const MaterialStatePropertyAll<Size>(Size(_kMinimumWidth, 0.0)),
       maximumSize: const MaterialStatePropertyAll<Size>(Size.infinite),
       visualDensity: _theme.visualDensity,
-      sizeAnimationStyle: switch (Theme.of(context).platform) {
-        TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
-          => AnimationStyle(
-            curve: Curves.easeInOutCubicEmphasized,
-            reverseCurve: Curves.easeInOutCubicEmphasized.flipped,
-            duration: const Duration(milliseconds: 500),
-          ),
-        TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
-          => AnimationStyle.noAnimation,
-        }
     );
   }
 

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1147,9 +1147,9 @@ class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
       animationStyle: switch (Theme.of(context).platform) {
         TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
           => AnimationStyle(
-            curve: Curves.easeIn,
-            reverseCurve: Curves.easeOut,
-            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOutCubicEmphasized,
+            reverseCurve: Curves.easeInOutCubicEmphasized.flipped,
+            duration: const Duration(milliseconds: 500),
           ),
         TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
           => AnimationStyle.noAnimation,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1144,7 +1144,7 @@ class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
       minimumSize: const MaterialStatePropertyAll<Size>(Size(_kMinimumWidth, 0.0)),
       maximumSize: const MaterialStatePropertyAll<Size>(Size.infinite),
       visualDensity: _theme.visualDensity,
-      animationStyle: switch (Theme.of(context).platform) {
+      sizeAnimationStyle: switch (Theme.of(context).platform) {
         TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
           => AnimationStyle(
             curve: Curves.easeInOutCubicEmphasized,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1144,6 +1144,16 @@ class _DropdownMenuDefaultsM3 extends DropdownMenuThemeData {
       minimumSize: const MaterialStatePropertyAll<Size>(Size(_kMinimumWidth, 0.0)),
       maximumSize: const MaterialStatePropertyAll<Size>(Size.infinite),
       visualDensity: _theme.visualDensity,
+      animationStyle: switch (Theme.of(context).platform) {
+        TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
+          => AnimationStyle(
+            curve: Curves.easeIn,
+            reverseCurve: Curves.easeOut,
+            duration: const Duration(milliseconds: 200),
+          ),
+        TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
+          => AnimationStyle.noAnimation,
+        }
     );
   }
 

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -328,10 +328,7 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
       _internalMenuController = MenuController();
     }
     _menuController._attach(this);
-    _animateController = AnimationController(
-      duration: const Duration(milliseconds: 500),
-      vsync: this,
-    );
+    _animateController = AnimationController(vsync: this);
   }
 
   @override

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -366,7 +366,7 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
       _root._close();
     }
     _viewSize = newSize;
-    updateAnimation(widget.style?.animationStyle);
+    updateAnimation();
   }
 
   @override
@@ -385,35 +385,19 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
     }
     assert(_menuController._anchor == this);
     if (oldWidget.style?.animationStyle != widget.style?.animationStyle) {
-      updateAnimation(widget.style?.animationStyle);
+      updateAnimation();
     }
   }
 
-  void updateAnimation(AnimationStyle? style) {
-    final AnimationStyle animationStyle;
-    if (style != null) {
-      animationStyle = style;
-    } else {
-      switch (Theme.of(context).platform) {
-        case TargetPlatform.iOS:
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          animationStyle = AnimationStyle(
-            curve: Curves.easeIn,
-            reverseCurve: Curves.easeOut,
-            duration: const Duration(milliseconds: 200),
-          );
-        case TargetPlatform.macOS:
-        case TargetPlatform.linux:
-        case TargetPlatform.windows:
-          animationStyle = AnimationStyle.noAnimation;
-      }
-    }
+  void updateAnimation() {
+    final AnimationStyle effectiveAnimationStyle = widget.style?.animationStyle
+      ?? MenuTheme.of(context).style?.animationStyle
+      ?? _MenuDefaultsM3(context).animationStyle;
 
-    _animateController.duration = animationStyle.duration;
-    _animateController.reverseDuration = animationStyle.reverseDuration;
-    _menuAnimation.curve = animationStyle.curve ?? _menuAnimation.curve;
-    _menuAnimation.reverseCurve = animationStyle.reverseCurve;
+    _animateController.duration = effectiveAnimationStyle.duration;
+    _animateController.reverseDuration = effectiveAnimationStyle.reverseDuration;
+    _menuAnimation.curve = effectiveAnimationStyle.curve ?? _menuAnimation.curve;
+    _menuAnimation.reverseCurve = effectiveAnimationStyle.reverseCurve;
   }
 
   @override
@@ -3985,6 +3969,24 @@ class _MenuDefaultsM3 extends MenuStyle {
 
   @override
   VisualDensity get visualDensity => Theme.of(context).visualDensity;
+
+  @override
+  AnimationStyle get animationStyle {
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        return AnimationStyle(
+          curve: Curves.easeIn,
+          reverseCurve: Curves.easeOut,
+          duration: const Duration(milliseconds: 200),
+        );
+      case TargetPlatform.macOS:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return AnimationStyle.noAnimation;
+    }
+  }
 }
 
 // END GENERATED TOKEN PROPERTIES - Menu

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -3351,8 +3351,10 @@ class _MenuPanel extends StatefulWidget {
   /// The menu style that has all the attributes for this menu panel.
   final MenuStyle? menuStyle;
 
+  /// The animation driving the size of the menu panel.
   final Animation<double>? menuSize;
 
+  /// The animation driving the opacity of the menu panel.
   final Animation<double>? menuOpacity;
 
   /// {@macro flutter.material.Material.clipBehavior}

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -390,13 +390,9 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
   }
 
   void updateAnimation() {
-    final (MenuStyle? themeStyle, MenuStyle defaultStyle) = switch (_orientation) {
-    Axis.horizontal => (MenuBarTheme.of(context).style, _MenuBarDefaultsM3(context)),
-    Axis.vertical => (MenuTheme.of(context).style, _MenuDefaultsM3(context)),
-    };
     final AnimationStyle effectiveAnimationStyle = widget.style?.animationStyle
-      ?? themeStyle?.animationStyle
-      ?? defaultStyle.animationStyle;
+      ?? MenuTheme.of(context).style?.animationStyle
+      ?? _MenuDefaultsM3(context).animationStyle;
 
     _animateController.duration = effectiveAnimationStyle.duration;
     _animateController.reverseDuration = effectiveAnimationStyle.reverseDuration;

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -323,6 +323,14 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
       _internalMenuController = MenuController();
     }
     _menuController._attach(this);
+    _animateController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _menuAnimation = CurvedAnimation(
+      parent: _animateController,
+      curve: Curves.linear,
+    );
   }
 
   @override
@@ -358,7 +366,7 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
       _root._close();
     }
     _viewSize = newSize;
-    createAnimation();
+    updateAnimation(widget.style?.animationStyle);
   }
 
   @override
@@ -376,12 +384,15 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
       }
     }
     assert(_menuController._anchor == this);
+    if (oldWidget.style?.animationStyle != widget.style?.animationStyle) {
+      updateAnimation(widget.style?.animationStyle);
+    }
   }
 
-  void createAnimation() {
-    AnimationStyle animationStyle;
-    if (widget.style?.animationStyle != null) {
-      animationStyle = widget.style!.animationStyle!;
+  void updateAnimation(AnimationStyle? style) {
+    final AnimationStyle animationStyle;
+    if (style != null) {
+      animationStyle = style;
     } else {
       switch (Theme.of(context).platform) {
         case TargetPlatform.iOS:
@@ -399,16 +410,10 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
       }
     }
 
-    _animateController = AnimationController(
-      duration: animationStyle.duration,
-      reverseDuration: animationStyle.reverseDuration,
-      vsync: this,
-    );
-    _menuAnimation = CurvedAnimation(
-      parent: _animateController,
-      curve: animationStyle.curve ?? Curves.linear,
-      reverseCurve: animationStyle.reverseCurve ?? Curves.linear,
-    );
+    _animateController.duration = animationStyle.duration;
+    _animateController.reverseDuration = animationStyle.reverseDuration;
+    _menuAnimation.curve = animationStyle.curve ?? _menuAnimation.curve;
+    _menuAnimation.reverseCurve = animationStyle.reverseCurve;
   }
 
   @override
@@ -605,7 +610,6 @@ _MenuAnchorState? get _previousFocusableSibling {
     _parent?._childChangedOpenState();
     _menuPosition = position;
     _overlayController.show();
-    _animateController.forward();
 
     widget.onOpen?.call();
   }
@@ -614,7 +618,7 @@ _MenuAnchorState? get _previousFocusableSibling {
   ///
   /// Call this when the menu should be closed. Has no effect if the menu is
   /// already closed.
-  Future<void> _close({bool inDispose = false}) async {
+  void _close({bool inDispose = false}) {
     assert(_debugMenuInfo('Closing $this'));
     if (!_isOpen) {
       return;
@@ -623,7 +627,7 @@ _MenuAnchorState? get _previousFocusableSibling {
       FocusManager.instance.removeEarlyKeyEventHandler(_checkForEscape);
     }
     _closeChildren(inDispose: inDispose);
-    await _animateController.reverse();
+
     // Don't hide if we're in the middle of a build.
     if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks) {
       _overlayController.hide();
@@ -699,8 +703,9 @@ class MenuController {
   /// If the menu's anchor point (either a [MenuBar] or a [MenuAnchor]) is
   /// scrolled by an ancestor, or the view changes size, then any open menu will
   /// automatically close.
-  void close() {
+  Future<void> close() async {
     assert(_anchor != null);
+    await _anchor?._animateController.reverse();
     _anchor!._close();
   }
 
@@ -718,6 +723,7 @@ class MenuController {
   void open({Offset? position}) {
     assert(_anchor != null);
     _anchor!._open(position: position);
+    _anchor!._animateController.forward();
   }
 
   // ignore: use_setters_to_change_properties
@@ -3505,6 +3511,12 @@ class _MenuPanelState extends State<_MenuPanel> {
       );
     }
 
+    if (widget.menuAnimation == null) {
+      return ConstrainedBox(
+        constraints: effectiveConstraints,
+        child: menuPanel,
+      );
+    }
     return SizeTransition(
       sizeFactor: widget.menuAnimation!,
       axisAlignment: -1,

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -3496,16 +3496,11 @@ class _MenuPanelState extends State<_MenuPanel> {
     );
 
     if (widget.crossAxisUnconstrained) {
-      menuPanel = SizeTransition(
-        sizeFactor: widget.menuAnimation!,
-        axisAlignment: -1,
-        fixedCrossAxisSizeFactor: 1,
-        child: UnconstrainedBox(
-          constrainedAxis: widget.orientation,
-          clipBehavior: Clip.hardEdge,
-          alignment: AlignmentDirectional.centerStart,
-          child: menuPanel,
-        ),
+      menuPanel = UnconstrainedBox(
+        constrainedAxis: widget.orientation,
+        clipBehavior: Clip.hardEdge,
+        alignment: AlignmentDirectional.centerStart,
+        child: menuPanel,
       );
     }
 

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -336,6 +336,7 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
     _menuController._detach(this);
     _internalMenuController = null;
     _menuScopeNode.dispose();
+    _animateController.dispose();
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -390,9 +390,13 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
   }
 
   void updateAnimation() {
+    final (MenuStyle? themeStyle, MenuStyle defaultStyle) = switch (_orientation) {
+    Axis.horizontal => (MenuBarTheme.of(context).style, _MenuBarDefaultsM3(context)),
+    Axis.vertical => (MenuTheme.of(context).style, _MenuDefaultsM3(context)),
+    };
     final AnimationStyle effectiveAnimationStyle = widget.style?.animationStyle
-      ?? MenuTheme.of(context).style?.animationStyle
-      ?? _MenuDefaultsM3(context).animationStyle;
+      ?? themeStyle?.animationStyle
+      ?? defaultStyle.animationStyle;
 
     _animateController.duration = effectiveAnimationStyle.duration;
     _animateController.reverseDuration = effectiveAnimationStyle.reverseDuration;
@@ -3972,20 +3976,16 @@ class _MenuDefaultsM3 extends MenuStyle {
 
   @override
   AnimationStyle get animationStyle {
-    switch (Theme.of(context).platform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        return AnimationStyle(
+    return switch (Theme.of(context).platform) {
+      TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
+        => AnimationStyle(
           curve: Curves.easeIn,
           reverseCurve: Curves.easeOut,
           duration: const Duration(milliseconds: 200),
-        );
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return AnimationStyle.noAnimation;
-    }
+        ),
+      TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
+        => AnimationStyle.noAnimation,
+    };
   }
 }
 

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -3486,7 +3486,7 @@ class _MenuPanelState extends State<_MenuPanel> {
                 textDirection: Directionality.of(context),
                 direction: widget.orientation,
                 mainAxisSize: MainAxisSize.min,
-                children: widget.children,
+                children: children,
               ),
             ),
           ),

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -324,7 +324,7 @@ class _MenuAnchorState extends State<MenuAnchor> with TickerProviderStateMixin {
     }
     _menuController._attach(this);
     _animateController = AnimationController(
-      duration: const Duration(milliseconds: 200),
+      duration: const Duration(milliseconds: 500),
       vsync: this,
     );
     _menuAnimation = CurvedAnimation(
@@ -602,7 +602,7 @@ _MenuAnchorState? get _previousFocusableSibling {
   ///
   /// Call this when the menu should be closed. Has no effect if the menu is
   /// already closed.
-  void _close({bool inDispose = false}) {
+  Future<void> _close({bool inDispose = false}) async {
     assert(_debugMenuInfo('Closing $this'));
     if (!_isOpen) {
       return;
@@ -624,6 +624,7 @@ _MenuAnchorState? get _previousFocusableSibling {
       // Notify that _childIsOpen changed state, but only if not
       // currently disposing.
       _parent?._childChangedOpenState();
+      await _animateController.reverse();
       widget.onClose?.call();
       if (mounted && SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks) {
         setState(() {
@@ -3975,9 +3976,9 @@ class _MenuDefaultsM3 extends MenuStyle {
     return switch (Theme.of(context).platform) {
       TargetPlatform.iOS || TargetPlatform.android || TargetPlatform.fuchsia
         => AnimationStyle(
-          curve: Curves.easeIn,
-          reverseCurve: Curves.easeOut,
-          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOutCubicEmphasized,
+          reverseCurve: Curves.easeInOutCubicEmphasized.flipped,
+          duration: const Duration(milliseconds: 500),
         ),
       TargetPlatform.macOS || TargetPlatform.linux || TargetPlatform.windows
         => AnimationStyle.noAnimation,

--- a/packages/flutter/lib/src/material/menu_style.dart
+++ b/packages/flutter/lib/src/material/menu_style.dart
@@ -199,13 +199,13 @@ class MenuStyle with Diagnosticable {
   /// as much of itself as possible, possibly overlapping the parent button.
   final AlignmentGeometry? alignment;
 
-  /// Used to override the menu animation curve and duration.
+  /// Used to override the menu size's animation curve and duration.
   ///
   /// If [AnimationStyle.duration] is provided, it will be used to override
-  /// the menu animation duration. Otherwise, defaults to 200ms.
+  /// the menu size's animation duration. Otherwise, defaults to 500ms.
   ///
   /// If [AnimationStyle.curve] is provided, it will be used to override
-  /// the menu animation curve. Otherwise, defaults to [Curves.easeIn].
+  /// the menu size's animation curve. Otherwise, defaults to [Curves.easeInOutCubicEmphasized].
   ///
   /// To disable the animation when menu is open/close, use [AnimationStyle.noAnimation].
   final AnimationStyle? sizeAnimationStyle;

--- a/packages/flutter/lib/src/material/menu_style.dart
+++ b/packages/flutter/lib/src/material/menu_style.dart
@@ -199,6 +199,15 @@ class MenuStyle with Diagnosticable {
   /// as much of itself as possible, possibly overlapping the parent button.
   final AlignmentGeometry? alignment;
 
+  /// Used to override the menu animation curve and duration.
+  ///
+  /// If [AnimationStyle.duration] is provided, it will be used to override
+  /// the menu animation duration. Otherwise, defaults to 200ms.
+  ///
+  /// If [AnimationStyle.curve] is provided, it will be used to override
+  /// the menu animation curve. Otherwise, defaults to [Curves.easeIn].
+  ///
+  /// To disable the animation when menu is open/close, use [AnimationStyle.noAnimation].
   final AnimationStyle? animationStyle;
 
   @override

--- a/packages/flutter/lib/src/material/menu_style.dart
+++ b/packages/flutter/lib/src/material/menu_style.dart
@@ -114,6 +114,7 @@ class MenuStyle with Diagnosticable {
     this.mouseCursor,
     this.visualDensity,
     this.alignment,
+    this.animationStyle,
   });
 
   /// The menu's background fill color.
@@ -198,6 +199,8 @@ class MenuStyle with Diagnosticable {
   /// as much of itself as possible, possibly overlapping the parent button.
   final AlignmentGeometry? alignment;
 
+  final AnimationStyle? animationStyle;
+
   @override
   int get hashCode {
     final List<Object?> values = <Object?>[
@@ -214,6 +217,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor,
       visualDensity,
       alignment,
+      animationStyle,
     ];
     return Object.hashAll(values);
   }
@@ -239,7 +243,8 @@ class MenuStyle with Diagnosticable {
         && other.shape == shape
         && other.mouseCursor == mouseCursor
         && other.visualDensity == visualDensity
-        && other.alignment == alignment;
+        && other.alignment == alignment
+        && other.animationStyle == animationStyle;
   }
 
   /// Returns a copy of this MenuStyle with the given fields replaced with
@@ -258,6 +263,7 @@ class MenuStyle with Diagnosticable {
     MaterialStateProperty<MouseCursor?>? mouseCursor,
     VisualDensity? visualDensity,
     AlignmentGeometry? alignment,
+    AnimationStyle? animationStyle,
   }) {
     return MenuStyle(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -273,6 +279,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor: mouseCursor ?? this.mouseCursor,
       visualDensity: visualDensity ?? this.visualDensity,
       alignment: alignment ?? this.alignment,
+      animationStyle: animationStyle ?? this.animationStyle,
     );
   }
 
@@ -299,6 +306,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor: mouseCursor ?? style.mouseCursor,
       visualDensity: visualDensity ?? style.visualDensity,
       alignment: alignment ?? style.alignment,
+      animationStyle: animationStyle ?? style.animationStyle,
     );
   }
 
@@ -321,6 +329,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
       visualDensity: t < 0.5 ? a?.visualDensity : b?.visualDensity,
       alignment: AlignmentGeometry.lerp(a?.alignment, b?.alignment, t),
+      animationStyle: AnimationStyle.lerp(a?.animationStyle, b?.animationStyle, t),
     );
   }
 
@@ -340,5 +349,6 @@ class MenuStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('mouseCursor', mouseCursor, defaultValue: null));
     properties.add(DiagnosticsProperty<VisualDensity>('visualDensity', visualDensity, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));
+    properties.add(DiagnosticsProperty<AnimationStyle>('animationStyle', animationStyle, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/material/menu_style.dart
+++ b/packages/flutter/lib/src/material/menu_style.dart
@@ -114,7 +114,7 @@ class MenuStyle with Diagnosticable {
     this.mouseCursor,
     this.visualDensity,
     this.alignment,
-    this.animationStyle,
+    this.sizeAnimationStyle,
   });
 
   /// The menu's background fill color.
@@ -208,7 +208,7 @@ class MenuStyle with Diagnosticable {
   /// the menu animation curve. Otherwise, defaults to [Curves.easeIn].
   ///
   /// To disable the animation when menu is open/close, use [AnimationStyle.noAnimation].
-  final AnimationStyle? animationStyle;
+  final AnimationStyle? sizeAnimationStyle;
 
   @override
   int get hashCode {
@@ -226,7 +226,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor,
       visualDensity,
       alignment,
-      animationStyle,
+      sizeAnimationStyle,
     ];
     return Object.hashAll(values);
   }
@@ -253,7 +253,7 @@ class MenuStyle with Diagnosticable {
         && other.mouseCursor == mouseCursor
         && other.visualDensity == visualDensity
         && other.alignment == alignment
-        && other.animationStyle == animationStyle;
+        && other.sizeAnimationStyle == sizeAnimationStyle;
   }
 
   /// Returns a copy of this MenuStyle with the given fields replaced with
@@ -272,7 +272,7 @@ class MenuStyle with Diagnosticable {
     MaterialStateProperty<MouseCursor?>? mouseCursor,
     VisualDensity? visualDensity,
     AlignmentGeometry? alignment,
-    AnimationStyle? animationStyle,
+    AnimationStyle? sizeAnimationStyle,
   }) {
     return MenuStyle(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -288,7 +288,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor: mouseCursor ?? this.mouseCursor,
       visualDensity: visualDensity ?? this.visualDensity,
       alignment: alignment ?? this.alignment,
-      animationStyle: animationStyle ?? this.animationStyle,
+      sizeAnimationStyle: sizeAnimationStyle ?? this.sizeAnimationStyle,
     );
   }
 
@@ -315,7 +315,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor: mouseCursor ?? style.mouseCursor,
       visualDensity: visualDensity ?? style.visualDensity,
       alignment: alignment ?? style.alignment,
-      animationStyle: animationStyle ?? style.animationStyle,
+      sizeAnimationStyle: sizeAnimationStyle ?? style.sizeAnimationStyle,
     );
   }
 
@@ -338,7 +338,7 @@ class MenuStyle with Diagnosticable {
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
       visualDensity: t < 0.5 ? a?.visualDensity : b?.visualDensity,
       alignment: AlignmentGeometry.lerp(a?.alignment, b?.alignment, t),
-      animationStyle: AnimationStyle.lerp(a?.animationStyle, b?.animationStyle, t),
+      sizeAnimationStyle: AnimationStyle.lerp(a?.sizeAnimationStyle, b?.sizeAnimationStyle, t),
     );
   }
 
@@ -358,6 +358,6 @@ class MenuStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('mouseCursor', mouseCursor, defaultValue: null));
     properties.add(DiagnosticsProperty<VisualDensity>('visualDensity', visualDensity, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));
-    properties.add(DiagnosticsProperty<AnimationStyle>('animationStyle', animationStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<AnimationStyle>('sizeAnimationStyle', sizeAnimationStyle, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1197,7 +1197,7 @@ void main() {
   testWidgets('The controller can access the value in the input field', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData(
       dropdownMenuTheme: DropdownMenuThemeData(
-        menuStyle: MenuStyle(animationStyle: AnimationStyle.noAnimation),
+        menuStyle: MenuStyle(sizeAnimationStyle: AnimationStyle.noAnimation),
       )
     );
     final TextEditingController controller = TextEditingController();
@@ -1268,7 +1268,7 @@ void main() {
     final ThemeData themeData = ThemeData(
       dropdownMenuTheme: DropdownMenuThemeData(
         menuStyle: MenuStyle(
-          animationStyle: AnimationStyle.noAnimation,
+          sizeAnimationStyle: AnimationStyle.noAnimation,
         )
       )
     );
@@ -1452,7 +1452,7 @@ void main() {
     final ThemeData themeData = ThemeData(
       dropdownMenuTheme: DropdownMenuThemeData(
         menuStyle: MenuStyle(
-          animationStyle: AnimationStyle.noAnimation,
+          sizeAnimationStyle: AnimationStyle.noAnimation,
         )
       )
     );
@@ -2059,12 +2059,12 @@ void main() {
     final ThemeData themeData = ThemeData(
       menuTheme: MenuThemeData(
         style: MenuStyle(
-          animationStyle: AnimationStyle.noAnimation,
+          sizeAnimationStyle: AnimationStyle.noAnimation,
         )
       ),
       dropdownMenuTheme: DropdownMenuThemeData(
         menuStyle: MenuStyle(
-          animationStyle: AnimationStyle.noAnimation,
+          sizeAnimationStyle: AnimationStyle.noAnimation,
         )
       )
     );
@@ -2121,7 +2121,7 @@ void main() {
     final ThemeData themeData = ThemeData(
       dropdownMenuTheme: DropdownMenuThemeData(
         menuStyle: MenuStyle(
-          animationStyle: AnimationStyle.noAnimation,
+          sizeAnimationStyle: AnimationStyle.noAnimation,
         )
       )
     );
@@ -2135,7 +2135,7 @@ void main() {
         return Scaffold(
           body: MenuAnchor(
             style: MenuStyle(
-              animationStyle: AnimationStyle.noAnimation,
+              sizeAnimationStyle: AnimationStyle.noAnimation,
             ),
             menuChildren: <Widget>[
               DropdownMenu<TestMenu>(
@@ -2368,7 +2368,7 @@ void main() {
         home: Scaffold(
           body: DropdownMenu<String>(
             menuStyle: MenuStyle(
-              animationStyle: AnimationStyle(
+              sizeAnimationStyle: AnimationStyle(
                 duration: const Duration(milliseconds: 500),
                 curve: Curves.linear,
               )

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2311,6 +2311,101 @@ void main() {
     expect(controller.text, 'Green');
   });
 
+  testWidgets('DropdownMenu default animation', (WidgetTester tester) async {
+    Widget buildDropdownMenu(TargetPlatform platform) {
+      return MaterialApp(
+        theme: ThemeData(platform: platform),
+        home: const Scaffold(
+          body: DropdownMenu<String>(
+            dropdownMenuEntries: <DropdownMenuEntry<String>>[
+              DropdownMenuEntry<String>(
+                value: 'Yolk',
+                label: 'Yolk',
+              ),
+              DropdownMenuEntry<String>(
+                value: 'Eggbert',
+                label: 'Eggbert',
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS,
+      TargetPlatform.android, TargetPlatform.fuchsia]) {
+      await tester.pumpWidget(Container());
+      await tester.pumpWidget(buildDropdownMenu(platform));
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.widgetWithText(MenuItemButton, 'Eggbert').hitTestable(), findsNothing);
+
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.widgetWithText(MenuItemButton, 'Eggbert').hitTestable(), findsOneWidget);
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.macOS, TargetPlatform.linux, TargetPlatform.windows ]) {
+      await tester.pumpWidget(buildDropdownMenu(platform));
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      expect(find.widgetWithText(MenuItemButton, 'Eggbert').hitTestable(), findsOneWidget);
+    }
+  });
+
+  testWidgets('DropdownMenu with custom animation style', (WidgetTester tester) async {
+    Widget buildDropdownMenu(TargetPlatform platform) {
+      return MaterialApp(
+        theme: ThemeData(platform: platform),
+        home: Scaffold(
+          body: DropdownMenu<String>(
+            menuStyle: MenuStyle(
+              animationStyle: AnimationStyle(
+                duration: const Duration(milliseconds: 500),
+                curve: Curves.linear,
+              )
+            ),
+            dropdownMenuEntries: const <DropdownMenuEntry<String>>[
+              DropdownMenuEntry<String>(
+                value: 'Yolk',
+                label: 'Yolk',
+              ),
+              DropdownMenuEntry<String>(
+                value: 'Eggbert',
+                label: 'Eggbert',
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS,
+      TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.macOS,
+      TargetPlatform.linux, TargetPlatform.windows]) {
+      await tester.pumpWidget(Container());
+      await tester.pumpWidget(buildDropdownMenu(platform));
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.widgetWithText(MenuItemButton, 'Eggbert').hitTestable(), findsNothing);
+
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(find.widgetWithText(MenuItemButton, 'Eggbert').hitTestable(), findsOneWidget);
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.macOS, TargetPlatform.linux, TargetPlatform.windows ]) {
+      await tester.pumpWidget(buildDropdownMenu(platform));
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      expect(find.widgetWithText(MenuItemButton, 'Eggbert').hitTestable(), findsOneWidget);
+    }
+  });
+
   // This is a regression test for https://github.com/flutter/flutter/issues/140596.
   testWidgets('Long text item does not overflow', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1195,7 +1195,11 @@ void main() {
   });
 
   testWidgets('The controller can access the value in the input field', (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData();
+    final ThemeData themeData = ThemeData(
+      dropdownMenuTheme: DropdownMenuThemeData(
+        menuStyle: MenuStyle(animationStyle: AnimationStyle.noAnimation),
+      )
+    );
     final TextEditingController controller = TextEditingController();
     addTearDown(controller.dispose);
 
@@ -1439,7 +1443,13 @@ void main() {
 
   testWidgets('If requestFocusOnTap is true, the text input field can request focus, '
     'otherwise it cannot request focus', (WidgetTester tester) async {
-    final ThemeData themeData = ThemeData();
+    final ThemeData themeData = ThemeData(
+      dropdownMenuTheme: DropdownMenuThemeData(
+        menuStyle: MenuStyle(
+          animationStyle: AnimationStyle.noAnimation,
+        )
+      )
+    );
 
     Widget buildDropdownMenu({required bool requestFocusOnTap}) => MaterialApp(
       theme: themeData,
@@ -2040,7 +2050,18 @@ void main() {
    testWidgets('onSelected gets called when a selection is made in a nested menu', (WidgetTester tester) async {
     int selectionCount = 0;
 
-    final ThemeData themeData = ThemeData();
+    final ThemeData themeData = ThemeData(
+      menuTheme: MenuThemeData(
+        style: MenuStyle(
+          animationStyle: AnimationStyle.noAnimation,
+        )
+      ),
+      dropdownMenuTheme: DropdownMenuThemeData(
+        menuStyle: MenuStyle(
+          animationStyle: AnimationStyle.noAnimation,
+        )
+      )
+    );
     final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
       const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
     ];
@@ -2091,7 +2112,13 @@ void main() {
       (WidgetTester tester) async {
     int selectionCount = 0;
 
-    final ThemeData themeData = ThemeData();
+    final ThemeData themeData = ThemeData(
+      dropdownMenuTheme: DropdownMenuThemeData(
+        menuStyle: MenuStyle(
+          animationStyle: AnimationStyle.noAnimation,
+        )
+      )
+    );
     final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
       const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
     ];
@@ -2101,6 +2128,9 @@ void main() {
       home: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
         return Scaffold(
           body: MenuAnchor(
+            style: MenuStyle(
+              animationStyle: AnimationStyle.noAnimation,
+            ),
             menuChildren: <Widget>[
               DropdownMenu<TestMenu>(
                 dropdownMenuEntries: menuWithDisabledItems,

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1265,7 +1265,13 @@ void main() {
   testWidgets('The onSelected gets called only when a selection is made', (WidgetTester tester) async {
     int selectionCount = 0;
 
-    final ThemeData themeData = ThemeData();
+    final ThemeData themeData = ThemeData(
+      dropdownMenuTheme: DropdownMenuThemeData(
+        menuStyle: MenuStyle(
+          animationStyle: AnimationStyle.noAnimation,
+        )
+      )
+    );
     final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
       const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
       const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 1', enabled: false),

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -110,14 +110,17 @@ void main() {
           decoration: TextDecoration.underline,
           wordSpacing: 2.0,
         ),
-        menuStyle: const MenuStyle(
-          backgroundColor: MaterialStatePropertyAll<Color>(Colors.grey),
-          shadowColor: MaterialStatePropertyAll<Color>(Colors.brown),
-          surfaceTintColor: MaterialStatePropertyAll<Color>(Colors.amberAccent),
-          elevation: MaterialStatePropertyAll<double>(10.0),
-          shape: MaterialStatePropertyAll<OutlinedBorder>(
+        menuStyle: MenuStyle(
+          backgroundColor: const MaterialStatePropertyAll<Color>(Colors.grey),
+          shadowColor: const MaterialStatePropertyAll<Color>(Colors.brown),
+          surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.amberAccent),
+          elevation: const MaterialStatePropertyAll<double>(10.0),
+          shape: const MaterialStatePropertyAll<OutlinedBorder>(
             RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
           ),
+          animationStyle: AnimationStyle(
+            duration: const Duration(milliseconds: 700),
+          )
         ),
         inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.lightGreen),
       )
@@ -154,11 +157,15 @@ void main() {
     await tester.tap(find.widgetWithIcon(IconButton, Icons.arrow_drop_down).first);
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
+    final Finder item0 = find.widgetWithText(MenuItemButton, 'Item 0').hitTestable();
+    expect(item0, findsNothing);
+    await tester.pump(const Duration(milliseconds: 700));
+    expect(item0, findsOneWidget);
 
     final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
+      of: item0,
       matching: find.byType(Material),
-    ).at(1);
+    ).first;
     Material material = tester.widget<Material>(menuMaterial);
     expect(material.color, Colors.grey);
     expect(material.shadowColor, Colors.brown);
@@ -188,13 +195,16 @@ void main() {
         decoration: TextDecoration.underline,
         wordSpacing: 2.0,
       ),
-      menuStyle: const MenuStyle(
-        backgroundColor: MaterialStatePropertyAll<Color>(Colors.grey),
-        shadowColor: MaterialStatePropertyAll<Color>(Colors.brown),
-        surfaceTintColor: MaterialStatePropertyAll<Color>(Colors.amberAccent),
-        elevation: MaterialStatePropertyAll<double>(10.0),
-        shape: MaterialStatePropertyAll<OutlinedBorder>(
+      menuStyle: MenuStyle(
+        backgroundColor: const MaterialStatePropertyAll<Color>(Colors.grey),
+        shadowColor: const MaterialStatePropertyAll<Color>(Colors.brown),
+        surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.amberAccent),
+        elevation: const MaterialStatePropertyAll<double>(10.0),
+        shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
+        ),
+        animationStyle: AnimationStyle(
+          duration: const Duration(milliseconds: 200),
         ),
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.lightGreen),
@@ -209,14 +219,15 @@ void main() {
         decoration: TextDecoration.lineThrough,
         wordSpacing: 5.0,
       ),
-      menuStyle: const MenuStyle(
-        backgroundColor: MaterialStatePropertyAll<Color>(Colors.yellow),
-        shadowColor: MaterialStatePropertyAll<Color>(Colors.green),
-        surfaceTintColor: MaterialStatePropertyAll<Color>(Colors.teal),
-        elevation: MaterialStatePropertyAll<double>(15.0),
-        shape: MaterialStatePropertyAll<OutlinedBorder>(
+      menuStyle: MenuStyle(
+        backgroundColor: const MaterialStatePropertyAll<Color>(Colors.yellow),
+        shadowColor: const MaterialStatePropertyAll<Color>(Colors.green),
+        surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.teal),
+        elevation: const MaterialStatePropertyAll<double>(15.0),
+        shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))),
         ),
+        animationStyle: AnimationStyle.noAnimation,
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.blue),
     );
@@ -257,11 +268,14 @@ void main() {
     await tester.tap(find.widgetWithIcon(IconButton, Icons.arrow_drop_down).first);
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
+    final Finder item0 = find.widgetWithText(MenuItemButton, 'Item 0').hitTestable();
+    // DropdownMenuTheme has no animation, so menu should show immediately.
+    expect(item0, findsOneWidget);
 
     final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
+      of: item0,
       matching: find.byType(Material),
-    ).at(1);
+    ).first;
     Material material = tester.widget<Material>(menuMaterial);
     expect(material.color, Colors.yellow);
     expect(material.shadowColor, Colors.green);
@@ -291,14 +305,15 @@ void main() {
         decoration: TextDecoration.underline,
         wordSpacing: 2.0,
       ),
-      menuStyle: const MenuStyle(
-        backgroundColor: MaterialStatePropertyAll<Color>(Colors.grey),
-        shadowColor: MaterialStatePropertyAll<Color>(Colors.brown),
-        surfaceTintColor: MaterialStatePropertyAll<Color>(Colors.amberAccent),
-        elevation: MaterialStatePropertyAll<double>(10.0),
-        shape: MaterialStatePropertyAll<OutlinedBorder>(
+      menuStyle: MenuStyle(
+        backgroundColor: const MaterialStatePropertyAll<Color>(Colors.grey),
+        shadowColor: const MaterialStatePropertyAll<Color>(Colors.brown),
+        surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.amberAccent),
+        elevation: const MaterialStatePropertyAll<double>(10.0),
+        shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
         ),
+        animationStyle: AnimationStyle.noAnimation,
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.lightGreen),
     );
@@ -312,14 +327,15 @@ void main() {
         decoration: TextDecoration.lineThrough,
         wordSpacing: 5.0,
       ),
-      menuStyle: const MenuStyle(
-        backgroundColor: MaterialStatePropertyAll<Color>(Colors.yellow),
-        shadowColor: MaterialStatePropertyAll<Color>(Colors.green),
-        surfaceTintColor: MaterialStatePropertyAll<Color>(Colors.teal),
-        elevation: MaterialStatePropertyAll<double>(15.0),
-        shape: MaterialStatePropertyAll<OutlinedBorder>(
+      menuStyle: MenuStyle(
+        backgroundColor: const MaterialStatePropertyAll<Color>(Colors.yellow),
+        shadowColor: const MaterialStatePropertyAll<Color>(Colors.green),
+        surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.teal),
+        elevation: const MaterialStatePropertyAll<double>(15.0),
+        shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))),
         ),
+        animationStyle: AnimationStyle.noAnimation,
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.blue),
     );
@@ -341,14 +357,17 @@ void main() {
                   decoration: TextDecoration.overline,
                   wordSpacing: 3.0,
                 ),
-                menuStyle: const MenuStyle(
-                  backgroundColor: MaterialStatePropertyAll<Color>(Colors.limeAccent),
-                  shadowColor: MaterialStatePropertyAll<Color>(Colors.deepOrangeAccent),
-                  surfaceTintColor: MaterialStatePropertyAll<Color>(Colors.lightBlue),
-                  elevation: MaterialStatePropertyAll<double>(21.0),
-                  shape: MaterialStatePropertyAll<OutlinedBorder>(
+                menuStyle: MenuStyle(
+                  backgroundColor: const MaterialStatePropertyAll<Color>(Colors.limeAccent),
+                  shadowColor: const MaterialStatePropertyAll<Color>(Colors.deepOrangeAccent),
+                  surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.lightBlue),
+                  elevation: const MaterialStatePropertyAll<double>(21.0),
+                  shape: const MaterialStatePropertyAll<OutlinedBorder>(
                     RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15.0))),
                   ),
+                  animationStyle: AnimationStyle(
+                    duration: const Duration(milliseconds: 300),
+                  )
                 ),
                 inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.deepPurple),
                 dropdownMenuEntries: const <DropdownMenuEntry<int>>[
@@ -378,11 +397,15 @@ void main() {
     await tester.tap(find.widgetWithIcon(IconButton, Icons.arrow_drop_down).first);
     await tester.pump();
     expect(find.byType(MenuAnchor), findsOneWidget);
+    final Finder item0 = find.widgetWithText(MenuItemButton, 'Item 0').hitTestable();
+    expect(item0, findsNothing);
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(item0, findsOneWidget);
 
     final Finder menuMaterial = find.ancestor(
-      of: find.widgetWithText(TextButton, 'Item 0'),
+      of: item0,
       matching: find.byType(Material),
-    ).at(1);
+    ).first;
     Material material = tester.widget<Material>(menuMaterial);
     expect(material.color, Colors.limeAccent);
     expect(material.shadowColor, Colors.deepOrangeAccent);

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -118,7 +118,7 @@ void main() {
           shape: const MaterialStatePropertyAll<OutlinedBorder>(
             RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
           ),
-          animationStyle: AnimationStyle(
+          sizeAnimationStyle: AnimationStyle(
             duration: const Duration(milliseconds: 700),
           )
         ),
@@ -203,7 +203,7 @@ void main() {
         shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
         ),
-        animationStyle: AnimationStyle(
+        sizeAnimationStyle: AnimationStyle(
           duration: const Duration(milliseconds: 200),
         ),
       ),
@@ -227,7 +227,7 @@ void main() {
         shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))),
         ),
-        animationStyle: AnimationStyle.noAnimation,
+        sizeAnimationStyle: AnimationStyle.noAnimation,
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.blue),
     );
@@ -313,7 +313,7 @@ void main() {
         shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
         ),
-        animationStyle: AnimationStyle.noAnimation,
+        sizeAnimationStyle: AnimationStyle.noAnimation,
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.lightGreen),
     );
@@ -335,7 +335,7 @@ void main() {
         shape: const MaterialStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))),
         ),
-        animationStyle: AnimationStyle.noAnimation,
+        sizeAnimationStyle: AnimationStyle.noAnimation,
       ),
       inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.blue),
     );
@@ -365,7 +365,7 @@ void main() {
                   shape: const MaterialStatePropertyAll<OutlinedBorder>(
                     RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15.0))),
                   ),
-                  animationStyle: AnimationStyle(
+                  sizeAnimationStyle: AnimationStyle(
                     duration: const Duration(milliseconds: 300),
                   )
                 ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -102,7 +102,7 @@ void main() {
                 controller: controller,
                 alignmentOffset: alignmentOffset,
                 consumeOutsideTap: consumesOutsideTap,
-                style: MenuStyle(alignment: alignment),
+                style: MenuStyle(alignment: alignment, animationStyle: AnimationStyle.noAnimation),
                 onOpen: () {
                   onOpen?.call(TestMenu.anchorButton);
                 },
@@ -1643,6 +1643,9 @@ void main() {
                 height: 1000,
                 alignment: Alignment.topLeft,
                 child: MenuAnchor(
+                  style: MenuStyle(
+                    animationStyle: AnimationStyle.noAnimation,
+                  ),
                   controller: controller,
                   alignmentOffset: const Offset(0, 10),
                   builder: (BuildContext context, MenuController controller, Widget? child) {
@@ -2379,6 +2382,9 @@ void main() {
           child: Center(
             child: MenuAnchor(
               controller: controller,
+              style: MenuStyle(
+                animationStyle: AnimationStyle.noAnimation,
+              ),
               menuChildren: <Widget>[
                 MenuItemButton(
                   onPressed: () {},
@@ -2721,6 +2727,9 @@ void main() {
           home: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
               return MenuAnchor(
+                style: MenuStyle(
+                  animationStyle: AnimationStyle.noAnimation,
+                ),
                 menuChildren: <Widget>[
                   MenuItemButton(
                     focusNode: buttonFocusNode,
@@ -2809,6 +2818,7 @@ void main() {
     });
 
     testWidgets('constrained menus show up in the right place with offset in LTR', (WidgetTester tester) async {
+      final MenuStyle menuStyle = MenuStyle(animationStyle: AnimationStyle.noAnimation);
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
@@ -2820,27 +2830,32 @@ void main() {
                 child: Align(
                   alignment: Alignment.topLeft,
                   child: MenuAnchor(
-                    menuChildren: const <Widget>[
+                    style: menuStyle,
+                    menuChildren: <Widget>[
                       SubmenuButton(
-                        alignmentOffset: Offset(10, 0),
+                        menuStyle: menuStyle,
+                        alignmentOffset: const Offset(10, 0),
                         menuChildren: <Widget>[
                           SubmenuButton(
+                            menuStyle: menuStyle,
                             menuChildren: <Widget>[
                               SubmenuButton(
+                                menuStyle: menuStyle,
                                 alignmentOffset: Offset(10, 0),
                                 menuChildren: <Widget>[
                                   SubmenuButton(
+                                    menuStyle: menuStyle,
                                     menuChildren: <Widget>[],
-                                    child: Text('SubMenuButton4'),
+                                    child: const Text('SubMenuButton4'),
                                   ),
                                 ],
-                                child: Text('SubMenuButton3'),
+                                child: const Text('SubMenuButton3'),
                               ),
                             ],
-                            child: Text('SubMenuButton2'),
+                            child: const Text('SubMenuButton2'),
                           ),
                         ],
-                        child: Text('SubMenuButton1'),
+                        child: const Text('SubMenuButton1'),
                       ),
                     ],
                     builder: (BuildContext context, MenuController controller, Widget? child) {
@@ -2886,6 +2901,7 @@ void main() {
     });
 
     testWidgets('constrained menus show up in the right place with offset in RTL', (WidgetTester tester) async {
+      final MenuStyle menuStyle = MenuStyle(animationStyle: AnimationStyle.noAnimation);
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
@@ -2897,27 +2913,32 @@ void main() {
                 child: Align(
                   alignment: Alignment.topRight,
                   child: MenuAnchor(
-                    menuChildren: const <Widget>[
+                    style: menuStyle,
+                    menuChildren: <Widget>[
                       SubmenuButton(
-                        alignmentOffset: Offset(10, 0),
+                        menuStyle: menuStyle,
+                        alignmentOffset: const Offset(10, 0),
                         menuChildren: <Widget>[
                           SubmenuButton(
+                            menuStyle: menuStyle,
                             menuChildren: <Widget>[
                               SubmenuButton(
-                                alignmentOffset: Offset(10, 0),
+                                menuStyle: menuStyle,
+                                alignmentOffset: const Offset(10, 0),
                                 menuChildren: <Widget>[
                                   SubmenuButton(
-                                    menuChildren: <Widget>[],
-                                    child: Text('SubMenuButton4'),
+                                    menuStyle: menuStyle,
+                                    menuChildren: const <Widget>[],
+                                    child: const Text('SubMenuButton4'),
                                   ),
                                 ],
-                                child: Text('SubMenuButton3'),
+                                child: const Text('SubMenuButton3'),
                               ),
                             ],
-                            child: Text('SubMenuButton2'),
+                            child: const Text('SubMenuButton2'),
                           ),
                         ],
-                        child: Text('SubMenuButton1'),
+                        child: const Text('SubMenuButton1'),
                       ),
                     ],
                     builder: (BuildContext context, MenuController controller, Widget? child) {
@@ -2974,6 +2995,9 @@ void main() {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: MenuAnchor(
+                    style: MenuStyle(
+                      animationStyle: AnimationStyle.noAnimation,
+                    ),
                     menuChildren: const <Widget>[
                       MenuItemButton(
                         child: Text('Button1'),
@@ -3026,6 +3050,7 @@ void main() {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: MenuAnchor(
+                    style: MenuStyle(animationStyle: AnimationStyle.noAnimation),
                     alignmentOffset: const Offset(0, 50),
                     menuChildren: const <Widget>[
                       MenuItemButton(
@@ -3283,6 +3308,7 @@ void main() {
               return MenuBar(
                 children: <Widget>[
                   SubmenuButton(
+                    menuStyle: MenuStyle(animationStyle: AnimationStyle.noAnimation),
                     menuChildren: <Widget>[
                       CheckboxMenuButton(
                         value: checkBoxValue,
@@ -3337,6 +3363,7 @@ void main() {
               return MenuBar(
                 children: <Widget>[
                   SubmenuButton(
+                    menuStyle: MenuStyle(animationStyle: AnimationStyle.noAnimation),
                     menuChildren: <Widget>[
                       RadioMenuButton<int>(
                         value: 0,
@@ -3817,6 +3844,9 @@ List<Widget> createTestMenus({
     required List<Widget> menuChildren,
   }) {
     return SubmenuButton(
+      menuStyle: MenuStyle(
+        animationStyle: AnimationStyle.noAnimation,
+      ),
       onOpen: onOpen != null ? () => onOpen(menu) : null,
       onClose: onClose != null ? () => onClose(menu) : null,
       menuChildren: menuChildren,

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -102,7 +102,7 @@ void main() {
                 controller: controller,
                 alignmentOffset: alignmentOffset,
                 consumeOutsideTap: consumesOutsideTap,
-                style: MenuStyle(alignment: alignment, animationStyle: AnimationStyle.noAnimation),
+                style: MenuStyle(alignment: alignment, sizeAnimationStyle: AnimationStyle.noAnimation),
                 onOpen: () {
                   onOpen?.call(TestMenu.anchorButton);
                 },
@@ -1644,7 +1644,7 @@ void main() {
                 alignment: Alignment.topLeft,
                 child: MenuAnchor(
                   style: MenuStyle(
-                    animationStyle: AnimationStyle.noAnimation,
+                    sizeAnimationStyle: AnimationStyle.noAnimation,
                   ),
                   controller: controller,
                   alignmentOffset: const Offset(0, 10),
@@ -2383,7 +2383,7 @@ void main() {
             child: MenuAnchor(
               controller: controller,
               style: MenuStyle(
-                animationStyle: AnimationStyle.noAnimation,
+                sizeAnimationStyle: AnimationStyle.noAnimation,
               ),
               menuChildren: <Widget>[
                 MenuItemButton(
@@ -2420,7 +2420,7 @@ void main() {
           child: Center(
             child: MenuAnchor(
               style: MenuStyle(
-                animationStyle: AnimationStyle.noAnimation,
+                sizeAnimationStyle: AnimationStyle.noAnimation,
               ),
               controller: controller,
               menuChildren: <Widget>[
@@ -2731,7 +2731,7 @@ void main() {
             builder: (BuildContext context, StateSetter setState) {
               return MenuAnchor(
                 style: MenuStyle(
-                  animationStyle: AnimationStyle.noAnimation,
+                  sizeAnimationStyle: AnimationStyle.noAnimation,
                 ),
                 menuChildren: <Widget>[
                   MenuItemButton(
@@ -2821,7 +2821,7 @@ void main() {
     });
 
     testWidgets('constrained menus show up in the right place with offset in LTR', (WidgetTester tester) async {
-      final MenuStyle menuStyle = MenuStyle(animationStyle: AnimationStyle.noAnimation);
+      final MenuStyle menuStyle = MenuStyle(sizeAnimationStyle: AnimationStyle.noAnimation);
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
@@ -2904,7 +2904,7 @@ void main() {
     });
 
     testWidgets('constrained menus show up in the right place with offset in RTL', (WidgetTester tester) async {
-      final MenuStyle menuStyle = MenuStyle(animationStyle: AnimationStyle.noAnimation);
+      final MenuStyle menuStyle = MenuStyle(sizeAnimationStyle: AnimationStyle.noAnimation);
       await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
@@ -2999,7 +2999,7 @@ void main() {
                   alignment: Alignment.bottomLeft,
                   child: MenuAnchor(
                     style: MenuStyle(
-                      animationStyle: AnimationStyle.noAnimation,
+                      sizeAnimationStyle: AnimationStyle.noAnimation,
                     ),
                     menuChildren: const <Widget>[
                       MenuItemButton(
@@ -3053,7 +3053,7 @@ void main() {
                 child: Align(
                   alignment: Alignment.bottomLeft,
                   child: MenuAnchor(
-                    style: MenuStyle(animationStyle: AnimationStyle.noAnimation),
+                    style: MenuStyle(sizeAnimationStyle: AnimationStyle.noAnimation),
                     alignmentOffset: const Offset(0, 50),
                     menuChildren: const <Widget>[
                       MenuItemButton(
@@ -3311,7 +3311,7 @@ void main() {
               return MenuBar(
                 children: <Widget>[
                   SubmenuButton(
-                    menuStyle: MenuStyle(animationStyle: AnimationStyle.noAnimation),
+                    menuStyle: MenuStyle(sizeAnimationStyle: AnimationStyle.noAnimation),
                     menuChildren: <Widget>[
                       CheckboxMenuButton(
                         value: checkBoxValue,
@@ -3366,7 +3366,7 @@ void main() {
               return MenuBar(
                 children: <Widget>[
                   SubmenuButton(
-                    menuStyle: MenuStyle(animationStyle: AnimationStyle.noAnimation),
+                    menuStyle: MenuStyle(sizeAnimationStyle: AnimationStyle.noAnimation),
                     menuChildren: <Widget>[
                       RadioMenuButton<int>(
                         value: 0,
@@ -3848,7 +3848,7 @@ List<Widget> createTestMenus({
   }) {
     return SubmenuButton(
       menuStyle: MenuStyle(
-        animationStyle: AnimationStyle.noAnimation,
+        sizeAnimationStyle: AnimationStyle.noAnimation,
       ),
       onOpen: onOpen != null ? () => onOpen(menu) : null,
       onClose: onClose != null ? () => onClose(menu) : null,

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -355,6 +355,219 @@ void main() {
     expect(iconRichText.text.style?.color, themeData.colorScheme.onSurfaceVariant);
   });
 
+  testWidgets('Menu animation defaults', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: MenuAnchor(
+            builder: (BuildContext context, MenuController controller, Widget? child) {
+              return IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {
+                  if (controller.isOpen) {
+                    controller.close();
+                  } else {
+                    controller.open();
+                  }
+                },
+              );
+            },
+            menuChildren: <Widget>[
+              SubmenuButton(
+                menuChildren: <Widget>[
+                  MenuItemButton(
+                    child: const Text('Item 0.0'),
+                    onPressed: () {},
+                  ),
+                  MenuItemButton(
+                    child: const Text('Item 0.1'),
+                    onPressed: () {},
+                  ),
+                  MenuItemButton(
+                    child: const Text('Item 0.2'),
+                    onPressed: () {},
+                  ),
+                  MenuItemButton(
+                    child: const Text('Item 0.3'),
+                    onPressed: () {},
+                  )
+                ],
+                child: const Text('Item 0'),
+              ),
+              MenuItemButton(
+                child: const Text('Item 1'),
+                onPressed: () {},
+              ),
+              MenuItemButton(
+                child: const Text('Item 2'),
+                onPressed: () {},
+              ),
+            ],
+          )
+        ),
+      ),
+    );
+
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.search));
+    await tester.pump();
+
+    final Rect menuPanel = tester.getRect(findMenuPanels());
+    expect(menuPanel.height, 0);
+
+    // Menu height(160) = button height(48) * 3 + top vertical padding(8) + bottom vertical padding
+    await tester.pump(const Duration(milliseconds: 50));
+    // After 50 ms, the animated height should be less than half of the menu height
+    // based on Curves.easeInOutCubicEmphasized.
+    expect(tester.getRect(findMenuPanels().last).height, lessThan(80));
+
+    await tester.pump(const Duration(milliseconds: 300));
+    // After 350 ms, the animated height should be less than menu height based on
+    // Curves.easeInOutCubicEmphasized.
+    expect(tester.getRect(findMenuPanels().last).height, lessThan(160));
+
+    await tester.pump(const Duration(milliseconds: 150));
+    // Default duration is 500ms. After 500 ms, the animated height should be equal
+    // to the menu height based on Curves.easeInOutCubicEmphasized.
+    expect(tester.getRect(findMenuPanels().last).height, 160);
+
+    await tester.tap(find.widgetWithText(SubmenuButton, 'Item 0'));
+    await tester.pump();
+    final Rect submenuPanel = tester.getRect(findMenuPanels().last);
+    expect(submenuPanel.height, 0);
+
+    // Menu height is 208 (48 * 4 + 8 * 2).
+    await tester.pump(const Duration(milliseconds: 50));
+    // After 50 ms, the animated height should be less than half of the menu height
+    // based on Curves.easeInOutCubicEmphasized.
+    expect(tester.getRect(findMenuPanels().last).height, lessThan(104));
+
+    await tester.pump(const Duration(milliseconds: 300));
+    // After 350 ms, the animated height should be less than menu height based on
+    // Curves.easeInOutCubicEmphasized.
+    expect(tester.getRect(findMenuPanels().last).height, lessThan(208));
+
+    await tester.pump(const Duration(milliseconds: 150));
+    // Default duration is 500ms. After 500 ms, the animated height should be equal
+    // to the menu height based on Curves.easeInOutCubicEmphasized.
+    expect(tester.getRect(findMenuPanels().last).height, 208);
+  });
+
+  testWidgets('Custom menuStyle.sizeAnimationStyle', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+            child: MenuAnchor(
+              style: MenuStyle(
+                sizeAnimationStyle: AnimationStyle(
+                  duration: const Duration(milliseconds: 1000),
+                  curve: Curves.linear,
+                  reverseCurve: Curves.linear,
+                )
+              ),
+              builder: (BuildContext context, MenuController controller, Widget? child) {
+                return IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    if (controller.isOpen) {
+                      controller.close();
+                    } else {
+                      controller.open();
+                    }
+                  },
+                );
+              },
+              menuChildren: <Widget>[
+                SubmenuButton(
+                  menuStyle: MenuStyle(
+                    sizeAnimationStyle: AnimationStyle(
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.linear,
+                      reverseCurve: Curves.linear,
+                    )
+                  ),
+                  menuChildren: <Widget>[
+                    MenuItemButton(
+                      child: const Text('Item 0.0'),
+                      onPressed: () {},
+                    ),
+                    MenuItemButton(
+                      child: const Text('Item 0.1'),
+                      onPressed: () {},
+                    ),
+                    MenuItemButton(
+                      child: const Text('Item 0.2'),
+                      onPressed: () {},
+                    )
+                  ],
+                  child: const Text('Item 0'),
+                ),
+                MenuItemButton(
+                  child: const Text('Item 1'),
+                  onPressed: () {},
+                ),
+                MenuItemButton(
+                  child: const Text('Item 2'),
+                  onPressed: () {},
+                ),
+              ],
+            )
+        ),
+      ),
+    );
+
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.search));
+    await tester.pump();
+
+    final Rect menuPanel = tester.getRect(findMenuPanels());
+    expect(menuPanel.height, 0);
+
+    // Menu height(160) = button height(48) * 3 + top vertical padding(8) + bottom vertical padding
+    await tester.pump(const Duration(milliseconds: 100));
+    // After 100 ms, the animated height should be 1/10 of the menu height because
+    // curve is Curves.linear.
+    expect(tester.getRect(findMenuPanels().last).height, 16);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    // After 600 ms, the animated height should be half of menu height because of
+    // Curves.linear.
+    expect(tester.getRect(findMenuPanels().last).height, 96);
+
+    await tester.pump(const Duration(milliseconds: 400));
+    // Default duration is 500ms. After 500 ms, the animated height should be equal
+    // to the menu height based on Curves.linear.
+    expect(tester.getRect(findMenuPanels().last).height, 160);
+
+    // Open submenu
+    await tester.tap(find.widgetWithText(SubmenuButton, 'Item 0'));
+    await tester.pump();
+    final Rect submenuPanel = tester.getRect(findMenuPanels().last);
+    expect(submenuPanel.height, 0);
+
+    // Menu height is 160 (48 * 3 + 8 * 2).
+    await tester.pump(const Duration(milliseconds: 50));
+    // After 50 ms, the animated height should be less than half of the menu height
+    // based on Curves.linear.
+    expect(tester.getRect(findMenuPanels().last).height, 40);
+
+    await tester.pump(const Duration(milliseconds: 50));
+    // After 100 ms, the animated height should be less than menu height based on
+    // Curves.linear.
+    expect(tester.getRect(findMenuPanels().last).height, 80);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    // Default duration is 200. After 200 ms, the animated height should be equal
+    // to the menu height based on Curves.linear.
+    expect(tester.getRect(findMenuPanels().last).height, 160);
+
+    // close menu
+    await tester.tap(find.widgetWithText(SubmenuButton, 'Item 0'));
+    await tester.pump();
+    expect(tester.getRect(findMenuPanels().last).height, 160);
+
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(tester.getRect(findMenuPanels().last).height, 80);
+  });
+
   testWidgets('Menu defaults - disabled', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();
     await tester.pumpWidget(
@@ -3753,6 +3966,44 @@ void main() {
                 child: const Text('Submenu 0'),
               );
             }
+          ),
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, true);
+    expect(onFocusChangeCalled, 1);
+
+    focusNode.unfocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, false);
+    expect(onFocusChangeCalled, 2);
+  });
+
+  testWidgets('SubmenuButton.onFocusChange is respected', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    int onFocusChangeCalled = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return SubmenuButton(
+                  focusNode: focusNode,
+                  onFocusChange: (bool value) {
+                    setState(() {
+                      onFocusChangeCalled += 1;
+                    });
+                  },
+                  menuChildren: const <Widget>[
+                    MenuItemButton(child: Text('item 0'))
+                  ],
+                  child: const Text('Submenu 0'),
+                );
+              }
           ),
         ),
       ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2419,6 +2419,9 @@ void main() {
         home: Material(
           child: Center(
             child: MenuAnchor(
+              style: MenuStyle(
+                animationStyle: AnimationStyle.noAnimation,
+              ),
               controller: controller,
               menuChildren: <Widget>[
                 MenuItemButton(

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2841,11 +2841,11 @@ void main() {
                             menuChildren: <Widget>[
                               SubmenuButton(
                                 menuStyle: menuStyle,
-                                alignmentOffset: Offset(10, 0),
+                                alignmentOffset: const Offset(10, 0),
                                 menuChildren: <Widget>[
                                   SubmenuButton(
                                     menuStyle: menuStyle,
-                                    menuChildren: <Widget>[],
+                                    menuChildren: const <Widget>[],
                                     child: const Text('SubMenuButton4'),
                                   ),
                                 ],

--- a/packages/flutter/test/material/menu_bar_theme_test.dart
+++ b/packages/flutter/test/material/menu_bar_theme_test.dart
@@ -62,7 +62,7 @@ void main() {
                 style: MenuStyle(
                   backgroundColor: const MaterialStatePropertyAll<Color?>(Colors.green),
                   elevation: const MaterialStatePropertyAll<double?>(20.0),
-                  animationStyle: AnimationStyle.noAnimation,
+                  sizeAnimationStyle: AnimationStyle.noAnimation,
                 ),
               ),
               child: MenuBarTheme(
@@ -220,7 +220,7 @@ List<Widget> createTestMenus({
     backgroundColor: menuBackground != null ? MaterialStatePropertyAll<Color>(menuBackground) : null,
     elevation: menuElevation != null ? MaterialStatePropertyAll<double>(menuElevation) : null,
     shape: menuShape != null ? MaterialStatePropertyAll<OutlinedBorder>(menuShape) : null,
-    animationStyle: AnimationStyle.noAnimation,
+    sizeAnimationStyle: AnimationStyle.noAnimation,
   );
   final ButtonStyle itemStyle = ButtonStyle(
     padding: itemPadding != null ? MaterialStatePropertyAll<EdgeInsetsGeometry>(itemPadding) : null,

--- a/packages/flutter/test/material/menu_bar_theme_test.dart
+++ b/packages/flutter/test/material/menu_bar_theme_test.dart
@@ -58,10 +58,11 @@ void main() {
         home: Material(
           child: Builder(builder: (BuildContext context) {
             return MenuTheme(
-              data: const MenuThemeData(
+              data: MenuThemeData(
                 style: MenuStyle(
-                  backgroundColor: MaterialStatePropertyAll<Color?>(Colors.green),
-                  elevation: MaterialStatePropertyAll<double?>(20.0),
+                  backgroundColor: const MaterialStatePropertyAll<Color?>(Colors.green),
+                  elevation: const MaterialStatePropertyAll<double?>(20.0),
+                  animationStyle: AnimationStyle.noAnimation,
                 ),
               ),
               child: MenuBarTheme(
@@ -219,6 +220,7 @@ List<Widget> createTestMenus({
     backgroundColor: menuBackground != null ? MaterialStatePropertyAll<Color>(menuBackground) : null,
     elevation: menuElevation != null ? MaterialStatePropertyAll<double>(menuElevation) : null,
     shape: menuShape != null ? MaterialStatePropertyAll<OutlinedBorder>(menuShape) : null,
+    animationStyle: AnimationStyle.noAnimation,
   );
   final ButtonStyle itemStyle = ButtonStyle(
     padding: itemPadding != null ? MaterialStatePropertyAll<EdgeInsetsGeometry>(itemPadding) : null,

--- a/packages/flutter/test/material/menu_style_test.dart
+++ b/packages/flutter/test/material/menu_style_test.dart
@@ -55,9 +55,10 @@ void main() {
                     ),
                   ),
                   child: MenuTheme(
-                    data: const MenuThemeData(
+                    data: MenuThemeData(
                       style: MenuStyle(
-                        fixedSize: MaterialStatePropertyAll<Size>(Size(100, 100)),
+                        fixedSize: const MaterialStatePropertyAll<Size>(Size(100, 100)),
+                        animationStyle: AnimationStyle.noAnimation,
                       ),
                     ),
                     child: MenuBar(
@@ -100,9 +101,10 @@ void main() {
                     ),
                   ),
                   child: MenuTheme(
-                    data: const MenuThemeData(
+                    data: MenuThemeData(
                       style: MenuStyle(
-                        maximumSize: MaterialStatePropertyAll<Size>(Size(100, 100)),
+                        maximumSize: const MaterialStatePropertyAll<Size>(Size(100, 100)),
+                        animationStyle: AnimationStyle.noAnimation,
                       ),
                     ),
                     child: MenuBar(
@@ -143,9 +145,10 @@ void main() {
                     ),
                   ),
                   child: MenuTheme(
-                    data: const MenuThemeData(
+                    data: MenuThemeData(
                       style: MenuStyle(
-                        minimumSize: MaterialStatePropertyAll<Size>(Size(300, 300)),
+                        minimumSize: const MaterialStatePropertyAll<Size>(Size(300, 300)),
+                        animationStyle: AnimationStyle.noAnimation,
                       ),
                     ),
                     child: MenuBar(

--- a/packages/flutter/test/material/menu_style_test.dart
+++ b/packages/flutter/test/material/menu_style_test.dart
@@ -252,13 +252,14 @@ void main() {
                 MenuBarTheme(
                   data: const MenuBarThemeData(
                     style: MenuStyle(
-                      visualDensity: VisualDensity(horizontal: 1.5, vertical: -1.5),
+                      visualDensity:  VisualDensity(horizontal: 1.5, vertical: -1.5),
                     ),
                   ),
                   child: MenuTheme(
-                    data: const MenuThemeData(
+                    data: MenuThemeData(
                       style: MenuStyle(
-                        visualDensity: VisualDensity(horizontal: 0.5, vertical: -0.5),
+                        sizeAnimationStyle: AnimationStyle.noAnimation,
+                        visualDensity: const VisualDensity(horizontal: 0.5, vertical: -0.5),
                       ),
                     ),
                     child: MenuBar(

--- a/packages/flutter/test/material/menu_style_test.dart
+++ b/packages/flutter/test/material/menu_style_test.dart
@@ -58,7 +58,7 @@ void main() {
                     data: MenuThemeData(
                       style: MenuStyle(
                         fixedSize: const MaterialStatePropertyAll<Size>(Size(100, 100)),
-                        animationStyle: AnimationStyle.noAnimation,
+                        sizeAnimationStyle: AnimationStyle.noAnimation,
                       ),
                     ),
                     child: MenuBar(
@@ -104,7 +104,7 @@ void main() {
                     data: MenuThemeData(
                       style: MenuStyle(
                         maximumSize: const MaterialStatePropertyAll<Size>(Size(100, 100)),
-                        animationStyle: AnimationStyle.noAnimation,
+                        sizeAnimationStyle: AnimationStyle.noAnimation,
                       ),
                     ),
                     child: MenuBar(
@@ -148,7 +148,7 @@ void main() {
                     data: MenuThemeData(
                       style: MenuStyle(
                         minimumSize: const MaterialStatePropertyAll<Size>(Size(300, 300)),
-                        animationStyle: AnimationStyle.noAnimation,
+                        sizeAnimationStyle: AnimationStyle.noAnimation,
                       ),
                     ),
                     child: MenuBar(

--- a/packages/flutter/test/material/menu_theme_test.dart
+++ b/packages/flutter/test/material/menu_theme_test.dart
@@ -68,7 +68,7 @@ void main() {
               child: MenuTheme(
                 data: MenuThemeData(
                   style: MenuStyle(
-                    animationStyle: AnimationStyle.noAnimation,
+                    sizeAnimationStyle: AnimationStyle.noAnimation,
                     backgroundColor: const MaterialStatePropertyAll<Color?>(Colors.red),
                     elevation: const MaterialStatePropertyAll<double?>(15.0),
                     shape: const MaterialStatePropertyAll<OutlinedBorder?>(StadiumBorder()),
@@ -222,7 +222,7 @@ List<Widget> createTestMenus({
     backgroundColor: menuBackground != null ? MaterialStatePropertyAll<Color>(menuBackground) : null,
     elevation: menuElevation != null ? MaterialStatePropertyAll<double>(menuElevation) : null,
     shape: menuShape != null ? MaterialStatePropertyAll<OutlinedBorder>(menuShape) : null,
-    animationStyle: AnimationStyle.noAnimation,
+    sizeAnimationStyle: AnimationStyle.noAnimation,
   );
   final ButtonStyle itemStyle = ButtonStyle(
     padding: itemPadding != null ? MaterialStatePropertyAll<EdgeInsetsGeometry>(itemPadding) : null,

--- a/packages/flutter/test/material/menu_theme_test.dart
+++ b/packages/flutter/test/material/menu_theme_test.dart
@@ -66,12 +66,13 @@ void main() {
                 ),
               ),
               child: MenuTheme(
-                data: const MenuThemeData(
+                data: MenuThemeData(
                   style: MenuStyle(
-                    backgroundColor: MaterialStatePropertyAll<Color?>(Colors.red),
-                    elevation: MaterialStatePropertyAll<double?>(15.0),
-                    shape: MaterialStatePropertyAll<OutlinedBorder?>(StadiumBorder()),
-                    padding: MaterialStatePropertyAll<EdgeInsetsGeometry>(
+                    animationStyle: AnimationStyle.noAnimation,
+                    backgroundColor: const MaterialStatePropertyAll<Color?>(Colors.red),
+                    elevation: const MaterialStatePropertyAll<double?>(15.0),
+                    shape: const MaterialStatePropertyAll<OutlinedBorder?>(StadiumBorder()),
+                    padding: const MaterialStatePropertyAll<EdgeInsetsGeometry>(
                       EdgeInsetsDirectional.all(10.0),
                     ),
                   ),
@@ -221,6 +222,7 @@ List<Widget> createTestMenus({
     backgroundColor: menuBackground != null ? MaterialStatePropertyAll<Color>(menuBackground) : null,
     elevation: menuElevation != null ? MaterialStatePropertyAll<double>(menuElevation) : null,
     shape: menuShape != null ? MaterialStatePropertyAll<OutlinedBorder>(menuShape) : null,
+    animationStyle: AnimationStyle.noAnimation,
   );
   final ButtonStyle itemStyle = ButtonStyle(
     padding: itemPadding != null ? MaterialStatePropertyAll<EdgeInsetsGeometry>(itemPadding) : null,


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/143316 & https://github.com/flutter/flutter/issues/143781
This PR is to 
 * add expand/collapse animation to `MenuAnchor` and `DropdownMenu`. On desktop, menus don't show any animations; On mobile, menu size shows animation when it is expanded and collapsed.
 * add `sizeAnimationStyle` to `MenuStyle` so we can customize the menu animation.

Default animation:

https://github.com/flutter/flutter/assets/36861262/e86d9fa1-96a4-47ef-a08a-791b4c1658ab

Custom animation:

https://github.com/flutter/flutter/assets/36861262/1a92d4b4-eadc-43c3-9293-296170c9d1fa

Default animation in slow mode:


https://github.com/flutter/flutter/assets/36861262/fc0ab2a4-6e63-4929-aea7-7429de91854b









## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
