### PR TITLE
[devicelab] retain first frame data in certain integration tests.

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_bad_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_bad_test.dart
@@ -44,7 +44,7 @@ void main() {
           await driver.scroll(list, 0.0, 300.0, const Duration(milliseconds: 300));
           await Future<void>.delayed(const Duration(milliseconds: 500));
         }
-      });
+      }, retainPriorEvents: true);
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
       await summary.writeTimelineToFile(summaryName, pretty: true);

--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -46,7 +46,7 @@ void main() {
           await driver.scroll(list, 0.0, 300.0, const Duration(milliseconds: 300));
           await Future<void>.delayed(const Duration(milliseconds: 500));
         }
-      });
+      }, retainPriorEvents: true);
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
       await summary.writeTimelineToFile(summaryName, pretty: true);

--- a/dev/integration_tests/flutter_gallery/test_driver/page_transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/page_transitions_perf_test.dart
@@ -30,7 +30,7 @@ void main() {
           await driver.tap(find.byTooltip('Back'));
           await Future<void>.delayed(const Duration(milliseconds: 500));
         }
-      });
+      }, retainPriorEvents: true);
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
       await summary.writeTimelineToFile('page_transition_perf', pretty: true);

--- a/dev/integration_tests/flutter_gallery/test_driver/scroll_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/scroll_perf_test.dart
@@ -25,9 +25,6 @@ void main() {
 
         final SerializableFinder demoList = find.byValueKey('GalleryDemoList');
 
-        // TODO(eseidel): These are very artificial scrolls, we should use better
-        // https://github.com/flutter/flutter/issues/3316
-        // Scroll down
         for (int i = 0; i < 5; i++) {
           await driver.scroll(demoList, 0.0, -300.0, const Duration(milliseconds: 300));
           await Future<void>.delayed(const Duration(milliseconds: 500));
@@ -38,7 +35,7 @@ void main() {
           await driver.scroll(demoList, 0.0, 300.0, const Duration(milliseconds: 300));
           await Future<void>.delayed(const Duration(milliseconds: 500));
         }
-      });
+      }, retainPriorEvents: true);
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);
       await summary.writeTimelineToFile('home_scroll_perf', pretty: true);

--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -212,6 +212,7 @@ void main([List<String> args = const <String>[]]) {
           TimelineStream.embedder,
           TimelineStream.gc,
         ],
+        retainPriorEvents: true,
       );
 
       // Save the duration (in microseconds) of the first timeline Frame event


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/143404

We currently drop the first N frames of all benchmarks. For the app based benchmarks (not microbenchmarks) this is harmful as we miss first time initialization costs in our CI.


Still need to do this with flutter/gallery, but that lives in a different repo.
