### PR TITLE
Disable deprecation warnings for mega_gallery

### DIFF
--- a/dev/tools/mega_gallery.dart
+++ b/dev/tools/mega_gallery.dart
@@ -85,8 +85,17 @@ void main(List<String> args) {
   pubspec = pubspec.replaceAll('../../packages/flutter', '../../../packages/flutter');
   _file(out, 'pubspec.yaml').writeAsStringSync(pubspec);
 
-  // Remove the (flutter_gallery specific) analysis_options.yaml file.
+  // Replace the (flutter_gallery specific) analysis_options.yaml file with a default one.
   _file(out, 'analysis_options.yaml').deleteSync();
+  _file(out, 'analysis_options.yaml').writeAsStringSync(
+    '''
+analyzer:
+  errors:
+    # See analysis_options.yaml in the flutter root for context.
+    deprecated_member_use: ignore
+    deprecated_member_use_from_same_package: ignore
+'''
+  );
 
   _file(out, '.dartignore').writeAsStringSync('');
 

--- a/dev/tools/mega_gallery.dart
+++ b/dev/tools/mega_gallery.dart
@@ -86,7 +86,6 @@ void main(List<String> args) {
   _file(out, 'pubspec.yaml').writeAsStringSync(pubspec);
 
   // Replace the (flutter_gallery specific) analysis_options.yaml file with a default one.
-  _file(out, 'analysis_options.yaml').deleteSync();
   _file(out, 'analysis_options.yaml').writeAsStringSync(
     '''
 analyzer:


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/143347.

As https://github.com/flutter/flutter/pull/143403 uncovered, deprecation warnings were still enabled for the mega_gallery because it doesn't use the analysis_options.yaml file from the flutter root. This change injects a analysis_options.yaml file for the mega_gallery that disables those warnings.

Submitting this separately from https://github.com/flutter/flutter/pull/143403 in case it affects the mega_gallery benchmark to get a clean new baseline before removing all the `deprecated_member_use` ignores.