### PR TITLE
Roll native_assets_builder to 0.5.0

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
-import 'package:native_assets_cli/native_assets_cli_internal.dart' show Asset;
+import 'package:native_assets_builder/native_assets_builder.dart' hide NativeAssetsBuildRunner;
 import 'package:package_config/package_config_types.dart';
 
 import '../../android/gradle_utils.dart';
@@ -56,7 +56,7 @@ class NativeAssets extends Target {
     final File nativeAssetsFile = environment.buildDir.childFile('native_assets.yaml');
     if (nativeAssetsEnvironment == 'false') {
       dependencies = <Uri>[];
-      await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
+      await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), environment.buildDir.uri, fileSystem);
     } else {
       final String? targetPlatformEnvironment = environment.defines[kTargetPlatform];
       if (targetPlatformEnvironment == null) {
@@ -145,7 +145,7 @@ class NativeAssets extends Target {
           } else {
             // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
             // Write the file we claim to have in the [outputs].
-            await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
+            await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), environment.buildDir.uri, fileSystem);
             dependencies = <Uri>[];
           }
         case TargetPlatform.android_arm:
@@ -165,7 +165,7 @@ class NativeAssets extends Target {
         case TargetPlatform.web_javascript:
           // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
           // Write the file we claim to have in the [outputs].
-          await writeNativeAssetsYaml(<Asset>[], environment.buildDir.uri, fileSystem);
+          await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), environment.buildDir.uri, fileSystem);
           dependencies = <Uri>[];
       }
     }

--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -56,7 +56,7 @@ class NativeAssets extends Target {
     final File nativeAssetsFile = environment.buildDir.childFile('native_assets.yaml');
     if (nativeAssetsEnvironment == 'false') {
       dependencies = <Uri>[];
-      await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), environment.buildDir.uri, fileSystem);
+      await writeNativeAssetsYaml(KernelAssets(), environment.buildDir.uri, fileSystem);
     } else {
       final String? targetPlatformEnvironment = environment.defines[kTargetPlatform];
       if (targetPlatformEnvironment == null) {
@@ -145,7 +145,7 @@ class NativeAssets extends Target {
           } else {
             // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
             // Write the file we claim to have in the [outputs].
-            await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), environment.buildDir.uri, fileSystem);
+            await writeNativeAssetsYaml(KernelAssets(), environment.buildDir.uri, fileSystem);
             dependencies = <Uri>[];
           }
         case TargetPlatform.android_arm:
@@ -165,7 +165,7 @@ class NativeAssets extends Target {
         case TargetPlatform.web_javascript:
           // TODO(dacoharkes): Implement other OSes. https://github.com/flutter/flutter/issues/129757
           // Write the file we claim to have in the [outputs].
-          await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), environment.buildDir.uri, fileSystem);
+          await writeNativeAssetsYaml(KernelAssets(), environment.buildDir.uri, fileSystem);
           dependencies = <Uri>[];
       }
     }

--- a/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:native_assets_builder/native_assets_builder.dart'
-    show BuildResult, DryRunResult;
+  hide NativeAssetsBuildRunner;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
     as native_assets_cli;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
@@ -31,21 +31,21 @@ Future<Uri?> dryRunNativeAssetsAndroid({
   }
 
   final Uri buildUri_ = nativeAssetsBuildUri(projectUri, OS.android);
-  final Iterable<Asset> nativeAssetPaths =
+  final Iterable<KernelAsset> nativeAssetPaths =
       await dryRunNativeAssetsAndroidInternal(
     fileSystem,
     projectUri,
     buildRunner,
   );
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-    nativeAssetPaths,
+    KernelAssets(nativeAssetPaths.toList()),
     buildUri_,
     fileSystem,
   );
   return nativeAssetsUri;
 }
 
-Future<Iterable<Asset>> dryRunNativeAssetsAndroidInternal(
+Future<Iterable<KernelAsset>> dryRunNativeAssetsAndroidInternal(
   FileSystem fileSystem,
   Uri projectUri,
   NativeAssetsBuildRunner buildRunner,
@@ -63,10 +63,9 @@ Future<Iterable<Asset>> dryRunNativeAssetsAndroidInternal(
   final List<Asset> nativeAssets = dryRunResult.assets;
   ensureNoLinkModeStatic(nativeAssets);
   globals.logger.printTrace('Dry running native assets for $targetOS done.');
-  final Map<Asset, Asset> assetTargetLocations =
+  final Map<Asset, KernelAsset> assetTargetLocations =
       _assetTargetLocations(nativeAssets);
-  final Iterable<Asset> nativeAssetPaths = assetTargetLocations.values;
-  return nativeAssetPaths;
+  return assetTargetLocations.values;
 }
 
 /// Builds native assets.
@@ -85,7 +84,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)>
   final Uri buildUri_ = nativeAssetsBuildUri(projectUri, targetOS);
   if (!await nativeBuildRequired(buildRunner)) {
     final Uri nativeAssetsYaml = await writeNativeAssetsYaml(
-      <Asset>[],
+      KernelAssets(<KernelAsset>[]),
       yamlParentDirectory ?? buildUri_,
       fileSystem,
     );
@@ -116,11 +115,11 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)>
   }
   ensureNoLinkModeStatic(nativeAssets);
   globals.logger.printTrace('Building native assets for $targets done.');
-  final Map<Asset, Asset> assetTargetLocations =
+  final Map<Asset, KernelAsset> assetTargetLocations =
       _assetTargetLocations(nativeAssets);
   await _copyNativeAssetsAndroid(buildUri_, assetTargetLocations, fileSystem);
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-      assetTargetLocations.values,
+      KernelAssets(assetTargetLocations.values.toList()),
       yamlParentDirectory ?? buildUri_,
       fileSystem);
   return (nativeAssetsUri, dependencies.toList());
@@ -128,7 +127,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)>
 
 Future<void> _copyNativeAssetsAndroid(
   Uri buildUri,
-  Map<Asset, Asset> assetTargetLocations,
+  Map<Asset, KernelAsset> assetTargetLocations,
   FileSystem fileSystem,
 ) async {
   if (assetTargetLocations.isNotEmpty) {
@@ -142,10 +141,10 @@ Future<void> _copyNativeAssetsAndroid(
       final Uri archUri = buildUri.resolve('jniLibs/lib/$jniArchDir/');
       await fileSystem.directory(archUri).create(recursive: true);
     }
-    for (final MapEntry<Asset, Asset> assetMapping
+    for (final MapEntry<Asset, KernelAsset> assetMapping
         in assetTargetLocations.entries) {
       final Uri source = (assetMapping.key.path as AssetAbsolutePath).uri;
-      final Uri target = (assetMapping.value.path as AssetAbsolutePath).uri;
+      final Uri target = (assetMapping.value.path as KernelAssetAbsolutePath).uri;
       final AndroidArch androidArch =
           _getAndroidArch(assetMapping.value.target);
       final String jniArchDir = androidArch.archName;
@@ -190,8 +189,8 @@ AndroidArch _getAndroidArch(Target target) {
   }
 }
 
-Map<Asset, Asset> _assetTargetLocations(List<Asset> nativeAssets) {
-  return <Asset, Asset>{
+Map<Asset, KernelAsset> _assetTargetLocations(List<Asset> nativeAssets) {
+  return <Asset, KernelAsset>{
     for (final Asset asset in nativeAssets)
       asset: _targetLocationAndroid(asset),
   };
@@ -199,19 +198,28 @@ Map<Asset, Asset> _assetTargetLocations(List<Asset> nativeAssets) {
 
 /// Converts the `path` of [asset] as output from a `build.dart` invocation to
 /// the path used inside the Flutter app bundle.
-Asset _targetLocationAndroid(Asset asset) {
+KernelAsset _targetLocationAndroid(Asset asset) {
   final AssetPath path = asset.path;
+  final KernelAssetPath kernelAssetPath;
   switch (path) {
     case AssetSystemPath _:
+      kernelAssetPath = KernelAssetSystemPath(path.uri);
     case AssetInExecutable _:
+      kernelAssetPath = KernelAssetInExecutable();
     case AssetInProcess _:
-      return asset;
+      kernelAssetPath = KernelAssetInProcess();
     case AssetAbsolutePath _:
       final String fileName = path.uri.pathSegments.last;
-      return asset.copyWith(path: AssetAbsolutePath(Uri(path: fileName)));
+      kernelAssetPath = KernelAssetAbsolutePath(Uri(path: fileName));
+    default:
+      throw Exception(
+        'Unsupported asset path type ${path.runtimeType} in asset $asset',
+      );
   }
-  throw Exception(
-    'Unsupported asset path type ${path.runtimeType} in asset $asset',
+  return KernelAsset(
+    id: asset.id,
+    target: asset.target,
+    path: kernelAssetPath,
   );
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/android/native_assets.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:native_assets_builder/native_assets_builder.dart'
-  hide NativeAssetsBuildRunner;
+    hide NativeAssetsBuildRunner;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
     as native_assets_cli;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
@@ -38,7 +38,7 @@ Future<Uri?> dryRunNativeAssetsAndroid({
     buildRunner,
   );
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-    KernelAssets(nativeAssetPaths.toList()),
+    KernelAssets(nativeAssetPaths),
     buildUri_,
     fileSystem,
   );
@@ -84,7 +84,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)>
   final Uri buildUri_ = nativeAssetsBuildUri(projectUri, targetOS);
   if (!await nativeBuildRequired(buildRunner)) {
     final Uri nativeAssetsYaml = await writeNativeAssetsYaml(
-      KernelAssets(<KernelAsset>[]),
+      KernelAssets(),
       yamlParentDirectory ?? buildUri_,
       fileSystem,
     );
@@ -119,7 +119,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)>
       _assetTargetLocations(nativeAssets);
   await _copyNativeAssetsAndroid(buildUri_, assetTargetLocations, fileSystem);
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-      KernelAssets(assetTargetLocations.values.toList()),
+      KernelAssets(assetTargetLocations.values),
       yamlParentDirectory ?? buildUri_,
       fileSystem);
   return (nativeAssetsUri, dependencies.toList());

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:native_assets_builder/native_assets_builder.dart' 
+import 'package:native_assets_builder/native_assets_builder.dart'
     hide NativeAssetsBuildRunner;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
     hide BuildMode;

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -37,7 +37,7 @@ Future<Uri?> dryRunNativeAssetsIOS({
     buildRunner,
   );
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-    KernelAssets(assetTargetLocations.toList()),
+    KernelAssets(assetTargetLocations),
     buildUri,
     fileSystem,
   );
@@ -76,7 +76,7 @@ Future<List<Uri>> buildNativeAssetsIOS({
   required FileSystem fileSystem,
 }) async {
   if (!await nativeBuildRequired(buildRunner)) {
-    await writeNativeAssetsYaml(KernelAssets(<KernelAsset>[]), yamlParentDirectory, fileSystem);
+    await writeNativeAssetsYaml(KernelAssets(), yamlParentDirectory, fileSystem);
     return <Uri>[];
   }
 
@@ -117,7 +117,7 @@ Future<List<Uri>> buildNativeAssetsIOS({
 
   final Map<Asset, KernelAsset> assetTargetLocations = _assetTargetLocations(nativeAssets);
   await writeNativeAssetsYaml(
-    KernelAssets(assetTargetLocations.values.toList()),
+    KernelAssets(assetTargetLocations.values),
     yamlParentDirectory,
     fileSystem,
   );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:native_assets_builder/native_assets_builder.dart'
+    hide NativeAssetsBuildRunner;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
     hide BuildMode;
 
@@ -31,7 +33,7 @@ Future<Uri?> dryRunNativeAssetsLinux({
   );
 }
 
-Future<Iterable<Asset>> dryRunNativeAssetsLinuxInternal(
+Future<Iterable<KernelAsset>> dryRunNativeAssetsLinuxInternal(
   FileSystem fileSystem,
   Uri projectUri,
   bool flutterTester,

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -38,7 +38,7 @@ Future<Uri?> dryRunNativeAssetsMacOS({
     buildRunner,
   );
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-    KernelAssets(nativeAssetPaths.toList()),
+    KernelAssets(nativeAssetPaths),
     buildUri,
     fileSystem,
   );
@@ -94,7 +94,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)> buildNativeAssetsMacOS({
   final Uri buildUri = nativeAssetsBuildUri(projectUri, targetOS);
   if (!await nativeBuildRequired(buildRunner)) {
     final Uri nativeAssetsYaml = await writeNativeAssetsYaml(
-      KernelAssets(<KernelAsset>[]),
+      KernelAssets(),
       yamlParentDirectory ?? buildUri,
       fileSystem,
     );
@@ -149,7 +149,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)> buildNativeAssetsMacOS({
     );
   }
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-    KernelAssets(assetTargetLocations.values.toList()),
+    KernelAssets(assetTargetLocations.values),
     yamlParentDirectory ?? buildUri,
     fileSystem,
   );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/native_assets.dart
@@ -498,7 +498,7 @@ Future<Uri?> dryRunNativeAssetsMultipleOSes({
       ),
   ];
   final Uri nativeAssetsUri = await writeNativeAssetsYaml(
-    KernelAssets(nativeAssetPaths.toList()),
+    KernelAssets(nativeAssetPaths),
     buildUri,
     fileSystem,
   );
@@ -598,7 +598,7 @@ Future<(Uri? nativeAssetsYaml, List<Uri> dependencies)> buildNativeAssetsSingleA
   }
   if (!await nativeBuildRequired(buildRunner)) {
     final Uri nativeAssetsYaml = await writeNativeAssetsYaml(
-      KernelAssets(<KernelAsset>[]),
+      KernelAssets(),
       yamlParentDirectory ?? buildUri,
       fileSystem,
     );

--- a/packages/flutter_tools/lib/src/isolated/native_assets/windows/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/windows/native_assets.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:native_assets_builder/native_assets_builder.dart'
+    hide NativeAssetsBuildRunner;
 import 'package:native_assets_cli/native_assets_cli_internal.dart'
     hide BuildMode;
 
@@ -30,7 +32,7 @@ Future<Uri?> dryRunNativeAssetsWindows({
   );
 }
 
-Future<Iterable<Asset>> dryRunNativeAssetsWindowsInternal(
+Future<Iterable<KernelAsset>> dryRunNativeAssetsWindowsInternal(
   FileSystem fileSystem,
   Uri projectUri,
   bool flutterTester,

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -117,4 +117,5 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: 980d
+
+# PUBSPEC CHECKSUM: 370c

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
 
   cli_config: 0.1.2
   graphs: 2.3.1
-  native_assets_builder: 0.3.2
+  native_assets_builder: 0.4.0
   native_assets_cli: 0.4.2
 
   # We depend on very specific internal implementation details of the
@@ -117,5 +117,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-
 # PUBSPEC CHECKSUM: 980d

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
 
   cli_config: 0.1.2
   graphs: 2.3.1
-  native_assets_builder: 0.4.0
+  native_assets_builder: 0.5.0
   native_assets_cli: 0.4.2
 
   # We depend on very specific internal implementation details of the
@@ -118,4 +118,4 @@ dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
 
-# PUBSPEC CHECKSUM: 370c
+# PUBSPEC CHECKSUM: a00d


### PR DESCRIPTION
Roll of https://github.com/dart-lang/native/pull/964, which separates the KernelAssets (the asset information embedded in the Dart kernel snapshot) from Assets (the assets in the build.dart protocol). See the linked issue for why they ought to be different instead of shared.

This PR does not change any functionality in Flutter.

(Now that https://github.com/flutter/flutter/pull/143055 has landed, we can land breaking changes.)

For reference, the same roll in the Dart SDK: https://dart-review.googlesource.com/c/sdk/+/352642

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
