### PR TITLE
Disentangle and align `flutter build web --wasm` flags

### DIFF
--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -34,9 +34,9 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
     await evalFlutter('build', options: <String>[
       'web',
       if (benchmarkOptions.useWasm) ...<String>[
+        '--O4',
         '--wasm',
-        '--wasm-opt=debug',
-        '--omit-type-checks',
+        '--no-strip-wasm',
       ],
       '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
       if (!benchmarkOptions.useWasm) '--web-renderer=${benchmarkOptions.webRenderer}',

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -44,8 +44,6 @@ enum Artifact {
   dart2jsSnapshot,
   /// The dart snapshot of the dart2wasm compiler.
   dart2wasmSnapshot,
-  /// The wasm-opt binary that ships with the dart-sdk
-  wasmOptBinary,
 
   /// The root of the Linux desktop sources.
   linuxDesktopPath,
@@ -194,8 +192,6 @@ String? _artifactToFileName(Artifact artifact, Platform hostPlatform, [ BuildMod
       return 'dart2js.dart.snapshot';
     case Artifact.dart2wasmSnapshot:
       return 'dart2wasm_product.snapshot';
-    case Artifact.wasmOptBinary:
-      return 'wasm-opt$exe';
     case Artifact.frontendServerSnapshotForEngineDartSdk:
       return 'frontend_server_aot.dart.snapshot';
     case Artifact.linuxDesktopPath:
@@ -566,7 +562,6 @@ class CachedArtifacts implements Artifacts {
       case Artifact.engineDartAotRuntime:
       case Artifact.dart2jsSnapshot:
       case Artifact.dart2wasmSnapshot:
-      case Artifact.wasmOptBinary:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
       case Artifact.constFinder:
       case Artifact.flutterFramework:
@@ -608,7 +603,6 @@ class CachedArtifacts implements Artifacts {
       case Artifact.engineDartAotRuntime:
       case Artifact.dart2jsSnapshot:
       case Artifact.dart2wasmSnapshot:
-      case Artifact.wasmOptBinary:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
       case Artifact.constFinder:
       case Artifact.flutterMacOSFramework:
@@ -668,7 +662,6 @@ class CachedArtifacts implements Artifacts {
       case Artifact.engineDartAotRuntime:
       case Artifact.dart2jsSnapshot:
       case Artifact.dart2wasmSnapshot:
-      case Artifact.wasmOptBinary:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
       case Artifact.icuData:
       case Artifact.isolateSnapshotData:
@@ -706,11 +699,6 @@ class CachedArtifacts implements Artifacts {
       case Artifact.frontendServerSnapshotForEngineDartSdk:
         return _fileSystem.path.join(
           _dartSdkPath(_cache), 'bin', 'snapshots',
-          _artifactToFileName(artifact, _platform),
-        );
-      case Artifact.wasmOptBinary:
-        return _fileSystem.path.join(
-          _dartSdkPath(_cache), 'bin', 'utils',
           _artifactToFileName(artifact, _platform),
         );
       case Artifact.flutterTester:
@@ -1039,8 +1027,6 @@ class CachedLocalEngineArtifacts implements Artifacts {
       case Artifact.dart2wasmSnapshot:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
         return _fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', artifactFileName);
-      case Artifact.wasmOptBinary:
-        return _fileSystem.path.join(_getDartSdkPath(), 'bin', 'utils', artifactFileName);
       case Artifact.flutterToolsFileGenerators:
         return _getFileGeneratorsPath();
       case Artifact.flutterPreviewDevice:
@@ -1176,11 +1162,6 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
         case Artifact.frontendServerSnapshotForEngineDartSdk:
           return _fileSystem.path.join(
             _getDartSdkPath(), 'bin', 'snapshots',
-            _artifactToFileName(artifact, _platform, mode),
-          );
-        case Artifact.wasmOptBinary:
-          return _fileSystem.path.join(
-            _getDartSdkPath(), 'bin', 'utils',
             _artifactToFileName(artifact, _platform, mode),
           );
         case Artifact.genSnapshot:

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -58,10 +58,11 @@ class BuildWebCommand extends BuildSubCommand {
     //
     // Common compilation options among JavaScript and Wasm
     //
-    argParser.addOption('optimization-level',
+    argParser.addOption(
+      'optimization-level',
       abbr: 'O',
-      help: 'Sets the optimization level used for Dart compilation to JavaScript/Wasm. '
-          'Valid values range from 1 to 4.',
+      help:
+          'Sets the optimization level used for Dart compilation to JavaScript/Wasm.',
       defaultsTo: '${WebCompilerConfig.kDefaultOptimizationLevel}',
       allowed: const <String>['1', '2', '3', '4'],
     );
@@ -83,10 +84,9 @@ class BuildWebCommand extends BuildSubCommand {
     );
     argParser.addOption('dart2js-optimization',
       help: 'Sets the optimization level used for Dart compilation to JavaScript. '
-          'Valid values range from O1 to O4. '
-          '(Deprecated: Please use -O/--optimization-level.)',
-      allowed: const <String>['O1', 'O2', 'O3', 'O4'],
-    );
+            'Deprecated: Please use "-O=<level>" / "--optimization-level=<level>".',
+       allowed: const <String>['O1', 'O2', 'O3', 'O4'],
+     );
     argParser.addFlag('dump-info', negatable: false,
       help: 'Passes "--dump-info" to the Javascript compiler which generates '
           'information about the generated code is a .js.info.json file.'

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -139,9 +139,12 @@ class BuildWebCommand extends BuildSubCommand {
       throwToolExit('"build web" is not currently supported. To enable, run "flutter config --enable-web".');
     }
 
-    final int wasmOptimizationLevel = int.parse(stringArg('optimization-level')!);
-    final int jsOptimizationLevel =  int.parse(stringArg('dart2js-optimization')
-        ?? stringArg('optimization-level')!);
+    final int optimizationLevel = int.parse(stringArg('optimization-level')!);
+
+    final String? dart2jsOptimizationLevelValue = stringArg('dart2js-optimization');
+    final int jsOptimizationLevel =  dart2jsOptimizationLevelValue != null
+        ? int.parse(dart2jsOptimizationLevelValue.substring(1))
+        : optimizationLevel;
 
     final List<WebCompilerConfig> compilerConfigs;
     if (boolArg('wasm')) {
@@ -160,7 +163,7 @@ class BuildWebCommand extends BuildSubCommand {
 
       compilerConfigs = <WebCompilerConfig>[
         WasmCompilerConfig(
-          optimizationLevel: wasmOptimizationLevel,
+          optimizationLevel: optimizationLevel,
           stripWasm: boolArg('strip-wasm'),
           renderer: WebRendererMode.skwasm,
         ),

--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../base/utils.dart';
 import '../convert.dart';
 import 'compile.dart';
 
@@ -12,7 +11,18 @@ enum CompileTarget {
 }
 
 sealed class WebCompilerConfig {
-  const WebCompilerConfig({required this.renderer});
+  const WebCompilerConfig({required this.renderer, required this.optimizationLevel});
+
+  /// The default optimization level for dart2js/dart2wasm.
+  static const int kDefaultOptimizationLevel = 4;
+
+  /// Build environment flag for [optimizationLevel].
+  static const String kOptimizationLevel = 'OptimizationLevel';
+
+  /// The compiler optimization level.
+  ///
+  /// Valid values are O1 (lowest, profile default) to O4 (highest, release default).
+  final int optimizationLevel;
 
   /// Returns which target this compiler outputs (js or wasm)
   CompileTarget get compileTarget;
@@ -20,7 +30,14 @@ sealed class WebCompilerConfig {
 
   String get buildKey;
 
-  Map<String, Object> get buildEventAnalyticsValues => <String, Object>{};
+  Map<String, Object> get buildEventAnalyticsValues => <String, Object>{
+    kOptimizationLevel: optimizationLevel,
+  };
+
+
+  Map<String, dynamic> get _buildKeyMap => <String, dynamic>{
+    'optimizationLevel': optimizationLevel,
+  };
 }
 
 /// Configuration for the Dart-to-Javascript compiler (dart2js).
@@ -29,7 +46,7 @@ class JsCompilerConfig extends WebCompilerConfig {
     this.csp = false,
     this.dumpInfo = false,
     this.nativeNullAssertions = false,
-    this.optimizationLevel = kDart2jsDefaultOptimizationLevel,
+    super.optimizationLevel = WebCompilerConfig.kDefaultOptimizationLevel,
     this.noFrequencyBasedMinification = false,
     this.sourceMaps = true,
     super.renderer = WebRendererMode.auto,
@@ -41,17 +58,9 @@ class JsCompilerConfig extends WebCompilerConfig {
     required WebRendererMode renderer,
   }) : this(
           nativeNullAssertions: nativeNullAssertions,
-          optimizationLevel: kDart2jsDefaultOptimizationLevel,
+          optimizationLevel: WebCompilerConfig.kDefaultOptimizationLevel ,
           renderer: renderer,
         );
-
-  /// The default optimization level for dart2js.
-  ///
-  /// Maps to [kDart2jsOptimization].
-  static const String kDart2jsDefaultOptimizationLevel = 'O4';
-
-  /// Build environment flag for [optimizationLevel].
-  static const String kDart2jsOptimization = 'Dart2jsOptimization';
 
   /// Build environment flag for [dumpInfo].
   static const String kDart2jsDumpInfo = 'Dart2jsDumpInfo';
@@ -82,12 +91,6 @@ class JsCompilerConfig extends WebCompilerConfig {
   // TODO(kevmoo): consider renaming this to be "positive". Double negatives are confusing.
   final bool noFrequencyBasedMinification;
 
-  /// The compiler optimization level.
-  ///
-  /// Valid values are O1 (lowest, profile default) to O4 (highest, release default).
-  // TODO(kevmoo): consider storing this as an [int] and validating it!
-  final String optimizationLevel;
-
   /// `true` if the JavaScript compiler build should output source maps.
   final bool sourceMaps;
 
@@ -105,7 +108,7 @@ class JsCompilerConfig extends WebCompilerConfig {
   /// Includes the contents of [toSharedCommandOptions].
   List<String> toCommandOptions() => <String>[
         ...toSharedCommandOptions(),
-        '-$optimizationLevel',
+        '-O$optimizationLevel',
         if (dumpInfo) '--dump-info',
         if (noFrequencyBasedMinification) '--no-frequency-based-minification',
         if (csp) '--csp',
@@ -114,11 +117,11 @@ class JsCompilerConfig extends WebCompilerConfig {
   @override
   String get buildKey {
     final Map<String, dynamic> settings = <String, dynamic>{
+      ...super._buildKeyMap,
       'csp': csp,
       'dumpInfo': dumpInfo,
       'nativeNullAssertions': nativeNullAssertions,
       'noFrequencyBasedMinification': noFrequencyBasedMinification,
-      'optimizationLevel': optimizationLevel,
       'sourceMaps': sourceMaps,
     };
     return jsonEncode(settings);
@@ -128,79 +131,40 @@ class JsCompilerConfig extends WebCompilerConfig {
 /// Configuration for the Wasm compiler.
 class WasmCompilerConfig extends WebCompilerConfig {
   const WasmCompilerConfig({
-    this.omitTypeChecks = false,
-    this.wasmOpt = WasmOptLevel.defaultValue,
+    super.optimizationLevel = WebCompilerConfig.kDefaultOptimizationLevel,
+    this.stripWasm = false,
     super.renderer = WebRendererMode.auto,
   });
 
-  /// Build environment for [omitTypeChecks].
-  static const String kOmitTypeChecks = 'WasmOmitTypeChecks';
+  /// Build environment for [stripWasm].
+  static const String kDart2WasmStripWasm = 'Dart2WasmStripWasm';
 
-  /// Build environment for [wasmOpt].
-  static const String kRunWasmOpt = 'RunWasmOpt';
-
-  /// If `omit-type-checks` should be passed to `dart2wasm`.
-  final bool omitTypeChecks;
-
-  /// Run wasm-opt on the resulting module.
-  final WasmOptLevel wasmOpt;
+  /// Whether to strip the wasm file of static symbols.
+  final bool stripWasm;
 
   @override
   CompileTarget get compileTarget => CompileTarget.wasm;
 
   List<String> toCommandOptions() {
-    // -O1: Optimizes
-    // -O2: Same as -O1 but also minifies (still semantics preserving)
-    // -O3: Same as -O2 but also omits implicit type checks.
-    // -O4: Same as -O3 but also omits explicit type checks.
-    //      (NOTE: This differs from dart2js -O4 semantics atm.)
-
-    // Ortogonal: The name section is always kept by default and we emit it only
-    // in [WasmOptLevel.full] mode (similar to `--strip` of static symbols in
-    // AOT mode).
-    final String level = !omitTypeChecks ? '-O2' : '-O4';
-    return switch (wasmOpt) {
-      WasmOptLevel.none => <String>['-O0'],
-      WasmOptLevel.debug => <String>[level, '--no-minify'],
-      WasmOptLevel.full => <String>[level, '--no-name-section'],
-    };
+    return <String>[
+      '-O$optimizationLevel',
+      '--${stripWasm? 'no-' : ''}name-section',
+    ];
   }
 
   @override
   Map<String, Object> get buildEventAnalyticsValues => <String, Object>{
-        ...super.buildEventAnalyticsValues,
-        kOmitTypeChecks: omitTypeChecks.toString(),
-        kRunWasmOpt: wasmOpt.name,
-      };
+    ...super.buildEventAnalyticsValues,
+    kDart2WasmStripWasm: stripWasm.toString(),
+  };
 
   @override
   String get buildKey {
     final Map<String, dynamic> settings = <String, dynamic>{
-      'omitTypeChecks': omitTypeChecks,
-      'wasmOpt': wasmOpt.name,
+      ...super._buildKeyMap,
+      'wasmStripWasm': stripWasm,
     };
     return jsonEncode(settings);
   }
-
 }
 
-enum WasmOptLevel implements CliEnum {
-  full,
-  debug,
-  none;
-
-  static const WasmOptLevel defaultValue = WasmOptLevel.full;
-
-  @override
-  String get cliName => name;
-
-  @override
-  String get helpText => switch (this) {
-        WasmOptLevel.none =>
-          'wasm-opt is not run. Fastest build; bigger, slower output.',
-        WasmOptLevel.debug =>
-          'Similar to `${WasmOptLevel.full.name}`, but member names are preserved. Debugging is easier, but size is a bit bigger.',
-        WasmOptLevel.full =>
-          'wasm-opt is run. Build time is slower, but output is smaller and faster.',
-      };
-}

--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -31,7 +31,7 @@ sealed class WebCompilerConfig {
   String get buildKey;
 
   Map<String, Object> get buildEventAnalyticsValues => <String, Object>{
-    kOptimizationLevel: optimizationLevel,
+    'optimizationLevel': optimizationLevel,
   };
 
 
@@ -132,12 +132,12 @@ class JsCompilerConfig extends WebCompilerConfig {
 class WasmCompilerConfig extends WebCompilerConfig {
   const WasmCompilerConfig({
     super.optimizationLevel = WebCompilerConfig.kDefaultOptimizationLevel,
-    this.stripWasm = false,
+    this.stripWasm = true,
     super.renderer = WebRendererMode.auto,
   });
 
   /// Build environment for [stripWasm].
-  static const String kDart2WasmStripWasm = 'Dart2WasmStripWasm';
+  static const String kStripWasm = 'StripWasm';
 
   /// Whether to strip the wasm file of static symbols.
   final bool stripWasm;
@@ -153,18 +153,11 @@ class WasmCompilerConfig extends WebCompilerConfig {
   }
 
   @override
-  Map<String, Object> get buildEventAnalyticsValues => <String, Object>{
-    ...super.buildEventAnalyticsValues,
-    kDart2WasmStripWasm: stripWasm.toString(),
-  };
-
-  @override
   String get buildKey {
     final Map<String, dynamic> settings = <String, dynamic>{
       ...super._buildKeyMap,
-      'wasmStripWasm': stripWasm,
+      'stripWasm': stripWasm,
     };
     return jsonEncode(settings);
   }
 }
-

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -427,13 +427,6 @@ void main() {
         fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk',
             'bin', 'snapshots', 'dart2js.dart.snapshot'),
       );
-      expect(
-        artifacts.getArtifactPath(
-          Artifact.wasmOptBinary,
-          platform: TargetPlatform.web_javascript),
-        fileSystem.path.join('/flutter', 'prebuilts', 'linux-x64', 'dart-sdk',
-            'bin', 'utils', 'wasm-opt'),
-      );
     });
 
     testWithoutContext('getEngineType', () {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -615,7 +615,6 @@ void main() {
 
   test('Dart2JSTarget calls dart2js with expected args in release with dart2js optimization override', () => testbed.run(() async {
     environment.defines[kBuildMode] = 'release';
-    environment.defines[WebCompilerConfig.kOptimizationLevel] = 'O3';
     processManager.addCommand(FakeCommand(
       command: <String>[
         ..._kDart2jsLinuxArgs,
@@ -902,13 +901,11 @@ void main() {
   }));
 
   for (final WebRendererMode renderer in <WebRendererMode>[WebRendererMode.canvaskit, WebRendererMode.skwasm]) {
-      for (int level = 1; level <= 4; level++) {
-        for (final bool strip in <bool>[true, false]) {
-          for (final List<String> defines in const <List<String>>[<String>[], <String>['FOO=bar', 'BAZ=qux']]) {
-          test('Dart2WasmTarget invokes dart2wasm with -O$level with stripping=$strip and defines=$defines', () => testbed.run(() async {
+    for (int level = 1; level <= 4; level++) {
+      for (final bool strip in <bool>[true, false]) {
+        for (final List<String> defines in const <List<String>>[<String>[], <String>['FOO=bar', 'BAZ=qux']]) {
+          test('Dart2WasmTarget invokes dart2wasm with renderer=$renderer, -O$level, stripping=$strip, defines=$defines', () => testbed.run(() async {
             environment.defines[kBuildMode] = 'release';
-            environment.defines[WebCompilerConfig.kOptimizationLevel] = '$level';
-            environment.defines[WasmCompilerConfig.kDart2WasmStripWasm] = '$strip';
             environment.defines[kDartDefines] = encodeDartDefines(defines);
 
             final File depFile = environment.buildDir.childFile('dart2wasm.d');

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -615,7 +615,7 @@ void main() {
 
   test('Dart2JSTarget calls dart2js with expected args in release with dart2js optimization override', () => testbed.run(() async {
     environment.defines[kBuildMode] = 'release';
-    environment.defines[JsCompilerConfig.kDart2jsOptimization] = 'O3';
+    environment.defines[WebCompilerConfig.kOptimizationLevel] = 'O3';
     processManager.addCommand(FakeCommand(
       command: <String>[
         ..._kDart2jsLinuxArgs,
@@ -644,7 +644,7 @@ void main() {
 
     await Dart2JSTarget(
       const JsCompilerConfig(
-        optimizationLevel: 'O3',
+        optimizationLevel: 3,
         sourceMaps: false,
       )
     ).build(environment);
@@ -901,176 +901,63 @@ void main() {
     ProcessManager: () => processManager,
   }));
 
-  test('Dart2WasmTarget invokes dart2wasm with dart defines', () => testbed.run(() async {
-    environment.defines[kBuildMode] = 'profile';
-    environment.defines[WasmCompilerConfig.kRunWasmOpt] = WasmOptLevel.defaultValue.name;
-    environment.defines[kDartDefines] = encodeDartDefines(<String>['FOO=bar', 'BAZ=qux']);
+  for (final WebRendererMode renderer in <WebRendererMode>[WebRendererMode.canvaskit, WebRendererMode.skwasm]) {
+      for (int level = 1; level <= 4; level++) {
+        for (final bool strip in <bool>[true, false]) {
+          for (final List<String> defines in const <List<String>>[<String>[], <String>['FOO=bar', 'BAZ=qux']]) {
+          test('Dart2WasmTarget invokes dart2wasm with -O$level with stripping=$strip and defines=$defines', () => testbed.run(() async {
+            environment.defines[kBuildMode] = 'release';
+            environment.defines[WebCompilerConfig.kOptimizationLevel] = '$level';
+            environment.defines[WasmCompilerConfig.kDart2WasmStripWasm] = '$strip';
+            environment.defines[kDartDefines] = encodeDartDefines(defines);
 
-    final File depFile = environment.buildDir.childFile('dart2wasm.d');
+            final File depFile = environment.buildDir.childFile('dart2wasm.d');
 
-    final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ..._kDart2WasmLinuxArgs,
-        '-Ddart.vm.profile=true',
-        '-DFOO=bar',
-        '-DBAZ=qux',
-        '-DFLUTTER_WEB_AUTO_DETECT=false',
-        '-DFLUTTER_WEB_USE_SKIA=true',
-        '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-        '-O2',
-        '--no-name-section',
-        '-o',
-        environment.buildDir.childFile('main.dart.wasm').absolute.path,
-        environment.buildDir.childFile('main.dart').absolute.path,
-      ],
-      onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo'))
-    );
+            final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
+            processManager.addCommand(FakeCommand(
+              command: <String>[
+                ..._kDart2WasmLinuxArgs,
+                if (renderer == WebRendererMode.skwasm) ...<String>[
+                  '--extra-compiler-option=--import-shared-memory',
+                  '--extra-compiler-option=--shared-memory-max-pages=32768',
+                ],
+                '-Ddart.vm.product=true',
+                ...defines.map((String define) => '-D$define'),
+                if (renderer == WebRendererMode.skwasm) ...<String>[
+                  '-DFLUTTER_WEB_AUTO_DETECT=false',
+                  '-DFLUTTER_WEB_USE_SKIA=false',
+                  '-DFLUTTER_WEB_USE_SKWASM=true',
+                ],
+                if (renderer == WebRendererMode.canvaskit) ...<String>[
+                  '-DFLUTTER_WEB_AUTO_DETECT=false',
+                  '-DFLUTTER_WEB_USE_SKIA=true',
+                ],
+                '--extra-compiler-option=--depfile=${depFile.absolute.path}',
+                '-O$level',
+                if (strip) '--no-name-section' else '--name-section',
+                '-o',
+                environment.buildDir.childFile('main.dart.wasm').absolute.path,
+                environment.buildDir.childFile('main.dart').absolute.path,
+              ],
+              onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo'))
+            );
 
-    await Dart2WasmTarget(
-      const WasmCompilerConfig(
-        renderer: WebRendererMode.canvaskit
-      )
-    ).build(environment);
+            await Dart2WasmTarget(
+              WasmCompilerConfig(
+                optimizationLevel: level,
+                stripWasm: strip,
+                renderer: renderer,
+              )
+            ).build(environment);
 
-    expect(outputJsFile.existsSync(), isTrue);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-  }));
-
-  test('Dart2WasmTarget invokes dart2wasm with omit checks', () => testbed.run(() async {
-    environment.defines[kBuildMode] = 'release';
-    environment.defines[WasmCompilerConfig.kRunWasmOpt] = WasmOptLevel.defaultValue.name;
-    environment.defines[WasmCompilerConfig.kOmitTypeChecks] = 'true';
-
-    final File depFile = environment.buildDir.childFile('dart2wasm.d');
-
-    final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ..._kDart2WasmLinuxArgs,
-        '-Ddart.vm.product=true',
-        '-DFLUTTER_WEB_AUTO_DETECT=false',
-        '-DFLUTTER_WEB_USE_SKIA=true',
-        '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-        '-O4',
-        '--no-name-section',
-        '-o',
-        environment.buildDir.childFile('main.dart.wasm').absolute.path,
-        environment.buildDir.childFile('main.dart').absolute.path,
-      ],
-      onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo'))
-    );
-
-    await Dart2WasmTarget(
-      const WasmCompilerConfig(
-        omitTypeChecks: true,
-        renderer: WebRendererMode.canvaskit
-      )
-    ).build(environment);
-
-    expect(outputJsFile.existsSync(), isTrue);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-  }));
-
-  test('Dart2WasmTarget invokes dart2wasm and wasm-opt with debug info in wasmopt debug mode', () => testbed.run(() async {
-    environment.defines[kBuildMode] = 'release';
-    environment.defines[WasmCompilerConfig.kRunWasmOpt] = WasmOptLevel.debug.name;
-
-    final File depFile = environment.buildDir.childFile('dart2wasm.d');
-
-    final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ..._kDart2WasmLinuxArgs,
-        '-Ddart.vm.product=true',
-        '-DFLUTTER_WEB_AUTO_DETECT=false',
-        '-DFLUTTER_WEB_USE_SKIA=true',
-        '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-        '-O2',
-        '--no-minify',
-        '-o',
-        environment.buildDir.childFile('main.dart.wasm').absolute.path,
-        environment.buildDir.childFile('main.dart').absolute.path,
-      ], onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo')));
-
-    await Dart2WasmTarget(
-      const WasmCompilerConfig(
-        wasmOpt: WasmOptLevel.debug,
-        renderer: WebRendererMode.canvaskit
-      )
-    ).build(environment);
-
-    expect(outputJsFile.existsSync(), isTrue);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-  }));
-
-  test('Dart2WasmTarget invokes dart2wasm (but not wasm-opt) with wasm-opt none option', () => testbed.run(() async {
-    environment.defines[kBuildMode] = 'debug';
-    environment.defines[WasmCompilerConfig.kRunWasmOpt] = WasmOptLevel.none.name;
-
-    final File depFile = environment.buildDir.childFile('dart2wasm.d');
-
-    final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ..._kDart2WasmLinuxArgs,
-        '-Ddart.vm.product=true',
-        '-DFLUTTER_WEB_AUTO_DETECT=false',
-        '-DFLUTTER_WEB_USE_SKIA=true',
-        '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-        '-O0',
-        '-o',
-        environment.buildDir.childFile('main.dart.wasm').absolute.path,
-        environment.buildDir.childFile('main.dart').absolute.path,
-      ], onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo')));
-
-    await Dart2WasmTarget(
-      const WasmCompilerConfig(
-        wasmOpt: WasmOptLevel.none,
-        renderer: WebRendererMode.canvaskit
-      )
-    ).build(environment);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-  }));
-
-  test('Dart2WasmTarget with skwasm renderer adds extra flags', () => testbed.run(() async {
-    environment.defines[kBuildMode] = 'release';
-    environment.defines[WasmCompilerConfig.kRunWasmOpt] = WasmOptLevel.defaultValue.name;
-    final File depFile = environment.buildDir.childFile('dart2wasm.d');
-
-    final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ..._kDart2WasmLinuxArgs,
-        '--extra-compiler-option=--import-shared-memory',
-        '--extra-compiler-option=--shared-memory-max-pages=32768',
-        '-Ddart.vm.product=true',
-        '-DFLUTTER_WEB_AUTO_DETECT=false',
-        '-DFLUTTER_WEB_USE_SKIA=false',
-        '-DFLUTTER_WEB_USE_SKWASM=true',
-        '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-        '-O2',
-        '--no-name-section',
-        '-o',
-        environment.buildDir.childFile('main.dart.wasm').absolute.path,
-        environment.buildDir.childFile('main.dart').absolute.path,
-      ],
-      onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo'))
-    );
-
-
-    await Dart2WasmTarget(
-      const WasmCompilerConfig(
-        renderer: WebRendererMode.skwasm,
-      )
-    ).build(environment);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-  }));
+            expect(outputJsFile.existsSync(), isTrue);
+          }, overrides: <Type, Generator>{
+            ProcessManager: () => processManager,
+          }));
+        }
+      }
+    }
+  }
 
   test('Generated service worker is empty with none-strategy', () => testbed.run(() {
     final String fileGeneratorsPath =

--- a/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/compile_web_test.dart
@@ -74,7 +74,8 @@ void main() {
       ServiceWorkerStrategy.offlineFirst,
       compilerConfigs: <WebCompilerConfig>[
         const WasmCompilerConfig(
-          wasmOpt: WasmOptLevel.none,
+          optimizationLevel: 0,
+          stripWasm: false,
           renderer: WebRendererMode.skwasm,
         ),
         const JsCompilerConfig.run(
@@ -103,7 +104,8 @@ void main() {
         label: 'web-compile',
             parameters: CustomDimensions(
               buildEventSettings:
-                  'RunWasmOpt: none; WasmOmitTypeChecks: false; web-renderer: skwasm,canvaskit; web-target: wasm,js;',
+                  'optimizationLevel: 4; web-renderer: skwasm,canvaskit; web-target: wasm,js;',
+
       ),
           ),
         ],
@@ -116,7 +118,7 @@ void main() {
         Event.flutterBuildInfo(
           label: 'web-compile',
           buildType: 'web',
-          settings: 'RunWasmOpt: none; WasmOmitTypeChecks: false; web-renderer: skwasm,canvaskit; web-target: wasm,js;',
+          settings: 'optimizationLevel: 4; web-renderer: skwasm,canvaskit; web-target: wasm,js;',
         ),
       ]),
     );


### PR DESCRIPTION
* Make `flutter build web` have one option that determins the optimization level: `-O<level>` / `--optimization-level=<level>` => Defaulting to -O4 => Will apply to both dart2js and dart2wasm

* Deprecate `--dart2js-optimization=O<level>`

* Disentagle concept of optimization from concept of static symbols => Add a `--strip-wasm` / `--no-strip-wasm` flag that determins whether static symbols are kept in the resulting wasm file.

* Remove copy&past'ed code in the tests for wasm build tests

* Cleanup some artifacts code, now that we no longer use `wasm-opt` inside flutter tools