### PR TITLE
Reland simulatedAccessibilityTraversal fix

### DIFF
--- a/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_semantics_controller.yaml
+++ b/packages/flutter_test/lib/fix_data/fix_flutter_test/fix_semantics_controller.yaml
@@ -1,0 +1,79 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/docs/development/tools/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the
+# flutter/packages/flutter_test/test_fixes/README.md file for instructions
+# on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for the flutter_test/controller.dart file. *
+
+version: 1
+transforms:
+  # Changes made in TBD
+  - title: "Migrate to startNode and endNode."
+    date: 2024-02-13
+    element:
+      uris: [ 'flutter_test.dart' ]
+      method: simulatedAccessibilityTraversal
+      inClass: SemanticsController
+    oneOf:
+      - if: "start != '' && end != ''"
+        changes:
+          - kind: 'addParameter'
+            index: 2
+            name: 'startNode'
+            style: optional_named
+            argumentValue:
+              expression: '{% start %}'
+              requiredIf: "start != '' && end != ''"
+          - kind: 'addParameter'
+            index: 3
+            name: 'endNode'
+            style: optional_named
+            argumentValue:
+              expression: '{% end %}'
+              requiredIf: "start != '' && end != ''"
+          - kind: 'removeParameter'
+            name: 'start'
+          - kind: 'removeParameter'
+            name: 'end'
+      - if: "start != '' && end == ''"
+        changes:
+          - kind: 'addParameter'
+            index: 2
+            name: 'startNode'
+            style: optional_named
+            argumentValue:
+              expression: '{% start %}'
+              requiredIf: "start != '' && end == ''"
+          - kind: 'removeParameter'
+            name: 'start'
+      - if: "start == '' && end != ''"
+        changes:
+          - kind: 'addParameter'
+            index: 2
+            name: 'endNode'
+            style: optional_named
+            argumentValue:
+              expression: '{% end %}'
+              requiredIf: "start == '' && end != ''"
+          - kind: 'removeParameter'
+            name: 'end'
+    variables:
+      start:
+        kind: 'fragment'
+        value: 'arguments[start]'
+      end:
+        kind: 'fragment'
+        value: 'arguments[end]'

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -289,7 +289,7 @@ class SemanticsController {
         'Traversal: [\n  ${traversal.join('\n  ')}\n]');
     }
 
-    int endIndex;
+    int? endIndex;
     if (end != null) {
       node = find(end);
       endIndex = traversal.indexOf(node);
@@ -298,8 +298,6 @@ class SemanticsController {
       node = endNode.evaluate().single;
       endIndex = traversal.indexOf(node);
       errorString = endNode.toString(describeSelf: true);
-    } else {
-      endIndex = traversal.length - 1;
     }
     if (endIndex == -1) {
       throw StateError(
@@ -308,6 +306,7 @@ class SemanticsController {
         'Expected End Node: $node\n\n'
         'Traversal: [\n  ${traversal.join('\n  ')}\n]');
     }
+    endIndex ??= traversal.length - 1;
 
     return traversal.getRange(startIndex, endIndex + 1);
   }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -183,8 +183,14 @@ class SemanticsController {
     FlutterView? view,
   }) {
     TestAsyncUtils.guardSync();
-    assert(start == null || startNode == null, 'Cannot provide both start and startNode. Prefer startNode as start is deprecated.');
-    assert(end == null || endNode == null, 'Cannot provide both end and endNode. Prefer endNode as end is deprecated.');
+    assert(
+      start == null || startNode == null,
+      'Cannot provide both start and startNode. Prefer startNode as start is deprecated.',
+    );
+    assert(
+      end == null || endNode == null,
+      'Cannot provide both end and endNode. Prefer endNode as end is deprecated.',
+    );
 
     FlutterView? startView;
     if (start != null) {
@@ -197,8 +203,7 @@ class SemanticsController {
           'Specified view: $view'
         );
       }
-    }
-    if (startNode != null) {
+    } else if (startNode != null) {
       final SemanticsOwner owner = startNode.evaluate().single.owner!;
       final RenderView renderView = _controller.binding.renderViews.firstWhere(
         (RenderView render) => render.owner!.semanticsOwner == owner,
@@ -206,9 +211,9 @@ class SemanticsController {
       startView = renderView.flutterView;
       if (view != null && startView != view) {
         throw StateError(
-          'The end node is not part of the provided view.\n'
+          'The start node is not part of the provided view.\n'
           'Finder: ${startNode.toString(describeSelf: true)}\n'
-          'View of end node: $startView\n'
+          'View of start node: $startView\n'
           'Specified view: $view'
         );
       }
@@ -225,8 +230,7 @@ class SemanticsController {
           'Specified view: $view'
         );
       }
-    }
-    if (endNode != null) {
+    } else if (endNode != null) {
       final SemanticsOwner owner = endNode.evaluate().single.owner!;
       final RenderView renderView = _controller.binding.renderViews.firstWhere(
         (RenderView render) => render.owner!.semanticsOwner == owner,
@@ -261,31 +265,48 @@ class SemanticsController {
       traversal,
     );
 
-    int startIndex = 0;
-    int endIndex = traversal.length - 1;
+    // Setting the range
+    SemanticsNode? node;
+    String? errorString;
 
+    int startIndex;
     if (start != null) {
-      final SemanticsNode startNode = find(start);
-      startIndex = traversal.indexOf(startNode);
-      if (startIndex == -1) {
-        throw StateError(
-          'The expected starting node was not found.\n'
-          'Finder: ${start.toString(describeSelf: true)}\n\n'
-          'Expected Start Node: $startNode\n\n'
-          'Traversal: [\n  ${traversal.join('\n  ')}\n]');
-      }
+      node = find(start);
+      startIndex = traversal.indexOf(node);
+      errorString = start.toString(describeSelf: true);
+    } else if (startNode != null) {
+      node = startNode.evaluate().single;
+      startIndex = traversal.indexOf(node);
+      errorString = startNode.toString(describeSelf: true);
+    } else {
+      startIndex = 0;
+    }
+    if (startIndex == -1) {
+      throw StateError(
+        'The expected starting node was not found.\n'
+        'Finder: $errorString\n\n'
+        'Expected Start Node: $node\n\n'
+        'Traversal: [\n  ${traversal.join('\n  ')}\n]');
     }
 
+    int endIndex;
     if (end != null) {
-      final SemanticsNode endNode = find(end);
-      endIndex = traversal.indexOf(endNode);
-      if (endIndex == -1) {
-        throw StateError(
-          'The expected ending node was not found.\n'
-          'Finder: ${end.toString(describeSelf: true)}\n\n'
-          'Expected End Node: $endNode\n\n'
-          'Traversal: [\n  ${traversal.join('\n  ')}\n]');
-      }
+      node = find(end);
+      endIndex = traversal.indexOf(node);
+      errorString = end.toString(describeSelf: true);
+    } else if (endNode != null) {
+      node = endNode.evaluate().single;
+      endIndex = traversal.indexOf(node);
+      errorString = endNode.toString(describeSelf: true);
+    } else {
+      endIndex = traversal.length - 1;
+    }
+    if (endIndex == -1) {
+      throw StateError(
+        'The expected ending node was not found.\n'
+        'Finder: $errorString\n\n'
+        'Expected End Node: $node\n\n'
+        'Traversal: [\n  ${traversal.join('\n  ')}\n]');
     }
 
     return traversal.getRange(startIndex, endIndex + 1);

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -920,6 +920,18 @@ void main() {
           orderedEquals(expectedMatchers));
       });
 
+      testWidgets('simulatedAccessibilityTraversal end Index supports empty traversal', (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(
+          home: Center(
+            child: Column(), // No nodes!
+          ),
+        ));
+        expect(
+          tester.semantics.simulatedAccessibilityTraversal().map((SemanticsNode node) => node.label),
+          <String>[],
+        );
+      });
+
       testWidgets('starts traversal at semantics node for `startNode`', (WidgetTester tester) async {
         await tester.pumpWidget(MaterialApp(
           home: Center(

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -920,6 +920,30 @@ void main() {
           orderedEquals(expectedMatchers));
       });
 
+      testWidgets('starts traversal at semantics node for `startNode`', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                for (int c = 0; c < 5; c++)
+                  Semantics(container: true, child: Text('Child$c')),
+              ]
+            ),
+          ),
+        ));
+        expect(
+          tester.semantics.simulatedAccessibilityTraversal(
+            startNode: find.semantics.byLabel('Child1'),
+          ).map((SemanticsNode node) => node.label),
+          <String>[
+            'Child1',
+            'Child2',
+            'Child3',
+            'Child4',
+          ],
+        );
+      });
+
       testWidgets('throws StateError if `start` not found in traversal', (WidgetTester tester) async {
         await tester.pumpWidget(const MaterialApp(home: _SemanticsTestWidget()));
 
@@ -927,6 +951,23 @@ void main() {
         // important for accessibility, so it won't show up in the traversal
         expect(
           () => tester.semantics.simulatedAccessibilityTraversal(start: find.byType(SingleChildScrollView)),
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      testWidgets('throws StateError if `startNode` not found in traversal', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                for (int c = 0; c < 5; c++)
+                  Semantics(container: true, child: Text('Child$c')),
+              ]
+            ),
+          ),
+        ));
+        expect(
+          () => tester.semantics.simulatedAccessibilityTraversal(startNode: find.semantics.byLabel('Child20')),
           throwsA(isA<StateError>()),
         );
       });
@@ -942,6 +983,28 @@ void main() {
           orderedEquals(expectedMatchers));
       });
 
+      testWidgets('ends traversal at semantics node for `endNode`', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                for (int c = 0; c < 5; c++)
+                  Semantics(container: true, child: Text('Child$c')),
+              ]
+            ),
+          ),
+        ));
+        expect(
+          tester.semantics.simulatedAccessibilityTraversal(
+            endNode: find.semantics.byLabel('Child1'),
+          ).map((SemanticsNode node) => node.label),
+          <String>[
+            'Child0',
+            'Child1',
+          ],
+        );
+      });
+
       testWidgets('throws StateError if `end` not found in traversal', (WidgetTester tester) async {
         await tester.pumpWidget(const MaterialApp(home: _SemanticsTestWidget()));
 
@@ -949,6 +1012,23 @@ void main() {
         // important for semantics, so it won't show up in the traversal
         expect(
           () => tester.semantics.simulatedAccessibilityTraversal(end: find.byType(SingleChildScrollView)),
+          throwsA(isA<StateError>()),
+        );
+      });
+
+      testWidgets('throws StateError if `endNode` not found in traversal', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                for (int c = 0; c < 5; c++)
+                  Semantics(container: true, child: Text('Child$c')),
+              ]
+            ),
+          ),
+        ));
+        expect(
+          () => tester.semantics.simulatedAccessibilityTraversal(endNode: find.semantics.byLabel('Child20')),
           throwsA(isA<StateError>()),
         );
       });
@@ -965,6 +1045,30 @@ void main() {
             end: find.byType(Slider),
           ),
           orderedEquals(expectedMatchers));
+      });
+
+      testWidgets('returns traversal between `startNode` and `endNode` if both are provided', (WidgetTester tester) async {
+        await tester.pumpWidget(MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                for (int c = 0; c < 5; c++)
+                  Semantics(container: true, child: Text('Child$c')),
+              ]
+            ),
+          ),
+        ));
+        expect(
+          tester.semantics.simulatedAccessibilityTraversal(
+            startNode: find.semantics.byLabel('Child1'),
+            endNode: find.semantics.byLabel('Child3'),
+          ).map((SemanticsNode node) => node.label),
+          <String>[
+            'Child1',
+            'Child2',
+            'Child3',
+          ],
+        );
       });
 
       testWidgets('can do fuzzy traversal match with `containsAllInOrder`', (WidgetTester tester) async {

--- a/packages/flutter_test/test/multi_view_controller_test.dart
+++ b/packages/flutter_test/test/multi_view_controller_test.dart
@@ -24,22 +24,6 @@ void main() {
     );
   });
 
-  testWidgets('simulatedAccessibilityTraversal - startNode and endNode in same view', (WidgetTester tester) async {
-    tester.binding.ensureSemantics();
-    await pumpViews(tester: tester);
-    expect(
-      tester.semantics.simulatedAccessibilityTraversal(
-        startNode: find.semantics.byValue('View2Child1'),
-        endNode: find.semantics.byValue('View2Child3'),
-      ).map((SemanticsNode node) => node.label),
-      <String>[
-        'View2Child1',
-        'View2Child2',
-        'View2Child3',
-      ],
-    );
-  });
-
   testWidgets('simulatedAccessibilityTraversal - start not specified', (WidgetTester tester) async {
     await pumpViews(tester: tester);
     expect(

--- a/packages/flutter_test/test/multi_view_controller_test.dart
+++ b/packages/flutter_test/test/multi_view_controller_test.dart
@@ -24,6 +24,22 @@ void main() {
     );
   });
 
+  testWidgets('simulatedAccessibilityTraversal - startNode and endNode in same view', (WidgetTester tester) async {
+    tester.binding.ensureSemantics();
+    await pumpViews(tester: tester);
+    expect(
+      tester.semantics.simulatedAccessibilityTraversal(
+        startNode: find.semantics.byValue('View2Child1'),
+        endNode: find.semantics.byValue('View2Child3'),
+      ).map((SemanticsNode node) => node.label),
+      <String>[
+        'View2Child1',
+        'View2Child2',
+        'View2Child3',
+      ],
+    );
+  });
+
   testWidgets('simulatedAccessibilityTraversal - start not specified', (WidgetTester tester) async {
     await pumpViews(tester: tester);
     expect(

--- a/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Generic reference variables.
+  finders.FinderBase<Element> theStart;
+  finders.FinderBase<Element> theEnd;
+
+  testWidgets('simulatedAccessibilityTraversal', (WidgetTester tester) async {
+    // Changes made in TBD
+    tester.semantics.simulatedAccessibilityTraversal();
+    tester.semantics.simulatedAccessibilityTraversal(start: theStart);
+    tester.semantics.simulatedAccessibilityTraversal(end: theEnd);
+    tester.semantics.simulatedAccessibilityTraversal(start: theStart, end: theEnd);
+  });
+}

--- a/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart
+++ b/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart
@@ -10,7 +10,7 @@ void main() {
   finders.FinderBase<Element> theEnd;
 
   testWidgets('simulatedAccessibilityTraversal', (WidgetTester tester) async {
-    // Changes made in TBD
+    // Changes made in https://github.com/flutter/flutter/pull/143386
     tester.semantics.simulatedAccessibilityTraversal();
     tester.semantics.simulatedAccessibilityTraversal(start: theStart);
     tester.semantics.simulatedAccessibilityTraversal(end: theEnd);

--- a/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart.expect
@@ -10,7 +10,7 @@ void main() {
   finders.FinderBase<Element> theEnd;
 
   testWidgets('simulatedAccessibilityTraversal', (WidgetTester tester) async {
-    // Changes made in TBD
+    // Changes made in https://github.com/flutter/flutter/pull/143386
     tester.semantics.simulatedAccessibilityTraversal();
     tester.semantics.simulatedAccessibilityTraversal(startNode: theStart);
     tester.semantics.simulatedAccessibilityTraversal(endNode: theEnd);

--- a/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart.expect
+++ b/packages/flutter_test/test_fixes/flutter_test/semantics_controller.dart.expect
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Generic reference variables.
+  finders.FinderBase<Element> theStart;
+  finders.FinderBase<Element> theEnd;
+
+  testWidgets('simulatedAccessibilityTraversal', (WidgetTester tester) async {
+    // Changes made in TBD
+    tester.semantics.simulatedAccessibilityTraversal();
+    tester.semantics.simulatedAccessibilityTraversal(startNode: theStart);
+    tester.semantics.simulatedAccessibilityTraversal(endNode: theEnd);
+    tester.semantics.simulatedAccessibilityTraversal(startNode: theStart, endNode: theEnd);
+  });
+}


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/143386
Which was reverted in https://github.com/flutter/flutter/pull/143523
Fixes https://github.com/flutter/flutter/issues/143173
Unblocks https://github.com/flutter/flutter/pull/143485

⭐ ➡️  Update from the revert is in this commit: https://github.com/flutter/flutter/pull/143527/commits/1e6853291eba42ee7005f284265118be33c99673

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
