### PR TITLE
[devicelab] migrate new gallery benchmarks to local copy.

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -9,8 +9,6 @@ import 'dart:io';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/versions/gallery.dart' show galleryVersion;
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   await task(const NewGalleryChromeRunTest().run);
@@ -34,16 +32,15 @@ class NewGalleryChromeRunTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    final Directory galleryParentDir =
-        Directory.systemTemp.createTempSync('flutter_gallery_v2_chrome_run.');
-    final Directory galleryDir =
-        Directory(path.join(galleryParentDir.path, 'gallery'));
-
-    await getNewGallery(galleryVersion, galleryDir);
-
-    final TaskResult result = await inDirectory<TaskResult>(galleryDir, () async {
+    final TaskResult result = await inDirectory<TaskResult>('dev/integration_tests/new_gallery', () async {
       await flutter('doctor');
       await flutter('packages', options: <String>['get']);
+      await flutter('create', options: <String>[
+        '--platforms',
+        'web',
+        '--no-overwrite',
+        '.'
+      ]);
 
       await flutter('build', options: <String>[
         'web',
@@ -104,8 +101,6 @@ class NewGalleryChromeRunTest {
         return TaskResult.failure('An exception was thrown.');
       }
     });
-
-    rmTree(galleryParentDir);
 
     return result;
   }

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -32,15 +32,15 @@ class NewGalleryChromeRunTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    final TaskResult result = await inDirectory<TaskResult>('dev/integration_tests/new_gallery', () async {
-      await flutter('doctor');
-      await flutter('packages', options: <String>['get']);
+    final TaskResult result = await inDirectory<TaskResult>('${flutterDirectory.path}/dev/integration_tests/new_gallery/', () async {
       await flutter('create', options: <String>[
         '--platforms',
-        'web',
+        'web,android,ios',
         '--no-overwrite',
         '.'
       ]);
+      await flutter('doctor');
+      await flutter('packages', options: <String>['get']);
 
       await flutter('build', options: <String>[
         'web',

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -21,19 +21,19 @@ class NewGalleryWebCompileTest {
   /// Runs the test.
   Future<TaskResult> run() async {
     final Map<String, Object> metrics = await inDirectory<Map<String, int>>(
-      'dev/integration_tests/new_gallery',
+      '${flutterDirectory.path}/dev/integration_tests/new_gallery/',
       () async {
         await flutter('doctor');
 
-      await flutter('create', options: <String>[
+        await flutter('create', options: <String>[
           '--platforms',
-          'web',
+          'web,android,ios',
           '--no-overwrite',
           '.'
         ]);
 
         return WebCompileTest.runSingleBuildTest(
-          directory: 'dev/integration_tests/new_gallery',
+          directory: '${flutterDirectory.path}/dev/integration_tests/new_gallery/',
           metric: metricKeyPrefix,
           measureBuildTime: true,
         );

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -2,14 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart' show WebCompileTest;
-import 'package:flutter_devicelab/versions/gallery.dart' show galleryVersion;
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   await task(const NewGalleryWebCompileTest().run);
@@ -24,27 +20,25 @@ class NewGalleryWebCompileTest {
 
   /// Runs the test.
   Future<TaskResult> run() async {
-    final Directory galleryParentDir =
-        Directory.systemTemp.createTempSync('flutter_gallery_v2_web_compile.');
-    final Directory galleryDir =
-        Directory(path.join(galleryParentDir.path, 'gallery'));
-
-    await getNewGallery(galleryVersion, galleryDir);
-
     final Map<String, Object> metrics = await inDirectory<Map<String, int>>(
-      galleryDir,
+      'dev/integration_tests/new_gallery',
       () async {
         await flutter('doctor');
 
+      await flutter('create', options: <String>[
+          '--platforms',
+          'web',
+          '--no-overwrite',
+          '.'
+        ]);
+
         return WebCompileTest.runSingleBuildTest(
-          directory: galleryDir.path,
+          directory: 'dev/integration_tests/new_gallery',
           metric: metricKeyPrefix,
           measureBuildTime: true,
         );
       },
     );
-
-    rmTree(galleryParentDir);
 
     return TaskResult.success(metrics, benchmarkScoreKeys: metrics.keys.toList());
   }

--- a/dev/devicelab/bin/tasks/new_gallery__crane_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery__crane_perf.dart
@@ -2,31 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
 
-  final Directory galleryParentDir =
-      Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir =
-      Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(
-      NewGalleryPerfTest(
-        galleryDir,
-        timelineFileName: 'transitions-crane',
-        dartDefine: 'onlyCrane=true',
-      ).run,
-    );
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(
+    NewGalleryPerfTest(
+      timelineFileName: 'transitions-crane',
+      dartDefine: 'onlyCrane=true',
+    ).run,
+  );
 }

--- a/dev/devicelab/bin/tasks/new_gallery__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery__transition_perf.dart
@@ -2,30 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
 
-  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(
-      NewGalleryPerfTest(
-        galleryDir,
-        // time out after 20 minutes allowing the tool to take a screenshot to debug
-        // https://github.com/flutter/flutter/issues/114025.
-        timeoutSeconds: 20 * 60,
-      ).run,
-    );
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(
+    NewGalleryPerfTest(
+      // time out after 20 minutes allowing the tool to take a screenshot to debug
+      // https://github.com/flutter/flutter/issues/114025.
+      timeoutSeconds: 20 * 60,
+    ).run,
+  );
 }

--- a/dev/devicelab/bin/tasks/new_gallery_impeller__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_impeller__transition_perf.dart
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
 
-  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(NewGalleryPerfTest(galleryDir, enableImpeller: true).run);
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(NewGalleryPerfTest(enableImpeller: true).run);
 }

--- a/dev/devicelab/bin/tasks/new_gallery_impeller_old_zoom__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_impeller_old_zoom__transition_perf.dart
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
 
-  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(NewGalleryPerfTest(galleryDir, enableImpeller: true, dartDefine: 'flutter.benchmarks.force_disable_snapshot=true').run);
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(NewGalleryPerfTest(enableImpeller: true, dartDefine: 'flutter.benchmarks.force_disable_snapshot=true').run);
 }

--- a/dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
 
-  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(NewGalleryPerfTest(galleryDir).run);
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(NewGalleryPerfTest().run);
 }

--- a/dev/devicelab/bin/tasks/new_gallery_opengles_impeller__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_opengles_impeller__transition_perf.dart
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
 
-  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(NewGalleryPerfTest(galleryDir, enableImpeller: true, forceOpenGLES: true).run);
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(NewGalleryPerfTest(enableImpeller: true, forceOpenGLES: true).run);
 }

--- a/dev/devicelab/bin/tasks/new_gallery_skia_ios__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_skia_ios__transition_perf.dart
@@ -2,23 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/new_gallery.dart';
-import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
 
-  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
-  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
-
-  try {
-    await task(NewGalleryPerfTest(galleryDir, enableImpeller: false).run);
-  } finally {
-    rmTree(galleryParentDir);
-  }
+  await task(NewGalleryPerfTest(enableImpeller: false).run);
 }

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -706,22 +706,6 @@ String jsonEncode(dynamic data) {
   return '$jsonValue\n';
 }
 
-Future<void> getNewGallery(String revision, Directory galleryDir) async {
-  section('Get New Flutter Gallery!');
-
-  if (exists(galleryDir)) {
-    galleryDir.deleteSync(recursive: true);
-  }
-
-  await inDirectory<void>(galleryDir.parent, () async {
-    await exec('git', <String>['clone', 'https://github.com/flutter/gallery.git']);
-  });
-
-  await inDirectory<void>(galleryDir, () async {
-    await exec('git', <String>['checkout', revision]);
-  });
-}
-
 /// Splits [from] into lines and selects those that contain [pattern].
 Iterable<String> grep(Pattern pattern, {required String from}) {
   return from.split('\n').where((String line) {

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -2,36 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
-import '../framework/task_result.dart';
-import '../framework/utils.dart';
-import '../versions/gallery.dart' show galleryVersion;
 import 'perf_tests.dart';
 
 class NewGalleryPerfTest extends PerfTest {
-  NewGalleryPerfTest(
-    this.galleryDir, {
+  NewGalleryPerfTest({
     String timelineFileName = 'transitions',
     String dartDefine = '',
     super.enableImpeller,
     super.timeoutSeconds,
     super.forceOpenGLES,
   }) : super(
-    galleryDir.path,
+    'dev/integration_tests/new_gallery',
     'test_driver/transitions_perf.dart',
     timelineFileName,
     dartDefine: dartDefine,
+    createPlatforms: ['android', 'ios', 'web']
   );
-
-  @override
-  Future<TaskResult> run() async {
-    // Manually roll the new gallery version for now. If the new gallery repo
-    // turns out to be updated frequently in the future, we can set up an auto
-    // roller to update this version.
-    await getNewGallery(galleryVersion, galleryDir);
-    return super.run();
-  }
-
-  final Directory galleryDir;
 }

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../framework/utils.dart';
 import 'perf_tests.dart';
 
 class NewGalleryPerfTest extends PerfTest {
@@ -12,10 +13,10 @@ class NewGalleryPerfTest extends PerfTest {
     super.timeoutSeconds,
     super.forceOpenGLES,
   }) : super(
-    'dev/integration_tests/new_gallery',
+    '${flutterDirectory.path}/dev/integration_tests/new_gallery',
     'test_driver/transitions_perf.dart',
     timelineFileName,
     dartDefine: dartDefine,
-    createPlatforms: ['android', 'ios', 'web']
+    createPlatforms: <String>['android', 'ios', 'web']
   );
 }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1185,6 +1185,7 @@ class PerfTest {
     this.enableImpeller,
     this.forceOpenGLES,
     this.disablePartialRepaint = false,
+    this.createPlatforms = const <String>[],
   }): _resultFilename = resultFilename;
 
   const PerfTest.e2e(
@@ -1204,6 +1205,7 @@ class PerfTest {
     this.enableImpeller,
     this.forceOpenGLES,
     this.disablePartialRepaint = false,
+    this.createPlatforms = const <String>[],
   }) : saveTraceFile = false, timelineFileName = null, _resultFilename = resultFilename;
 
   /// The directory where the app under test is defined.
@@ -1274,6 +1276,10 @@ class PerfTest {
   /// Additional flags for `--dart-define` to control the test
   final String dartDefine;
 
+  /// Additional platforms to create with `flutter create` before running
+  /// the test.
+  final List<String> createPlatforms;
+
   Future<TaskResult> run() {
     return internalRun();
   }
@@ -1294,6 +1300,15 @@ class PerfTest {
       final String? localEngine = localEngineFromEnv;
       final String? localEngineHost = localEngineHostFromEnv;
       final String? localEngineSrcPath = localEngineSrcPathFromEnv;
+
+      if (createPlatforms.isNotEmpty) {
+        await flutter('create', options: <String>[
+          '--platforms',
+          createPlatforms.join(','),
+          '--no-overwrite',
+          '.'
+        ]);
+      }
 
       bool changedPlist = false;
       bool changedManifest = false;

--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -1,6 +1,0 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-/// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = 'fa031bfe9d131010e7a56ee5d343f9f85b367d64';


### PR DESCRIPTION
This is the next step in archiving flutter/gallery - move devicelab tests to use the local copy.