### PR TITLE
[Draft] Add delegate route logic

### DIFF
--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -5,6 +5,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+/// Example creating a modal bottom sheet in an app with mixed transitions. This
+/// example is mostly a POC for route transition mixing, and the actual example
+/// for routes will be simpler.
+
 void main() {
   runApp(const MyApp());
 }
@@ -130,7 +134,7 @@ class MBSTransition extends StatelessWidget {
                  reverseCurve: Curves.easeInToLinear,
                )
            .drive(_kMidUpTween),
-      _tertiaryPositionAnimation =
+      _primaryPositionAnimationMBS =
             CurvedAnimation(
                  parent: primaryRouteAnimation,
                  curve: Curves.linearToEaseOut,
@@ -141,10 +145,13 @@ class MBSTransition extends StatelessWidget {
   // When this page is coming in to cover another page.
   final Animation<Offset> _primaryPositionAnimation;
 
-  // When this page is coming in to cover another page.
-  final Animation<Offset> _tertiaryPositionAnimation;
+  // When this page is coming in to cover another MBS. Because it's nested within
+  // a MBS, a 0 y offset is not the top of the physical screen, but the top of
+  // the previous MBS.
+  final Animation<Offset> _primaryPositionAnimationMBS;
 
-  // When this page is coming in to cover another page.
+  // When this page is being covered by another MBS. It slides up slightly to
+  // look like it's joining the stack of previous routes.
   final Animation<Offset> _secondaryPositionAnimation;
 
   /// Animation
@@ -153,7 +160,7 @@ class MBSTransition extends StatelessWidget {
   /// The widget below this widget in the tree.
   final Widget child;
 
-  /// The delegated transition.
+  /// The primary delegated transition. Will slide a non MBS page down.
   static Widget delegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
     const Offset begin = Offset.zero;
     const Offset end = Offset(0.0, 0.05);
@@ -167,7 +174,7 @@ class MBSTransition extends StatelessWidget {
     );
   }
 
-  /// The secondary delegated transition.
+  /// The secondary delegated transition. Will slide a MBS page up.
   static Widget secondaryDelegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
     const Offset begin = Offset.zero;
     const Offset end = Offset(0.0, -0.05);
@@ -198,7 +205,7 @@ class MBSTransition extends StatelessWidget {
         );
       },
       child: SlideTransition(
-        position: topLevelMBS ? _primaryPositionAnimation : _tertiaryPositionAnimation,
+        position: topLevelMBS ? _primaryPositionAnimation : _primaryPositionAnimationMBS,
         textDirection: textDirection,
         child: ClipRRect(
           borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
@@ -251,7 +258,6 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
   @override
   Duration get transitionDuration => const Duration(milliseconds: 500);
 
-
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     final Widget child = buildContent(context);
@@ -299,7 +305,7 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
 
 class MBSNavigator extends Navigator {
 
-  MBSNavigator({
+  const MBSNavigator({
     super.key,
     super.pages,
     super.onPopPage,

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -53,7 +53,7 @@ class MyHomePage extends StatelessWidget {
               TextButton(
                 onPressed: () {
                   Navigator.of(context).push(
-                  MaterialPageRoute(
+                  MaterialPageRoute<void>(
                     builder: (BuildContext context) {
                       return  const MyHomePage(title: 'Zoom Transition');
                     },
@@ -64,7 +64,7 @@ class MyHomePage extends StatelessWidget {
               TextButton(
                 onPressed: () {
                   Navigator.of(context).push(
-                  CupertinoPageRoute(
+                  CupertinoPageRoute<void>(
                     builder: (BuildContext context) {
                       return  const MyHomePage(title: 'Cupertino Transition');
                     }
@@ -75,7 +75,7 @@ class MyHomePage extends StatelessWidget {
               TextButton(
                 onPressed: () {
                   Navigator.of(context).push(
-                  MBSPageRoute(
+                  MBSPageRoute<void>(
                     context: context,
                     pageBuilder: (BuildContext buildContext) {
                       return  const MyHomePage(title: 'MBS Transition');
@@ -265,7 +265,7 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
       parentNavigatorContext: context,
       initialRoute: '/',
       onGenerateRoute: (RouteSettings settings) {
-        return CupertinoPageRoute(
+        return CupertinoPageRoute<void>(
           builder: (BuildContext context) {
             return Semantics(
               scopesRoute: true,

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -209,17 +209,20 @@ class MBSTransition extends StatelessWidget {
   }
 }
 
-class MBSPageRoute<T> extends PageRoute<T> with MBSRouteTransitionMixin<T> {
+class MBSPageRoute<T> extends PageRoute<T> with MBSRouteTransitionMixin<T>,FlexibleTransitionRouteMixin<T> {
   /// Creates a page route for use in an iOS designed app.
   MBSPageRoute({
     required this.pageBuilder,
     required BuildContext context,
-  }) : super(
-    delegatedTransition: (Navigator.of(context).widget is MBSNavigator) ?
-      MBSTransition.secondaryDelegateTransition : MBSTransition.delegateTransition,
-  );
+  }) : _delegatedTransition = (Navigator.of(context).widget is MBSNavigator) ?
+      MBSTransition.secondaryDelegateTransition : MBSTransition.delegateTransition;
 
   final WidgetBuilder pageBuilder;
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition => _delegatedTransition;
+
+  final DelegatedTransitionBuilder _delegatedTransition;
 
   @override
   Widget buildContent(BuildContext context) => pageBuilder(context);

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -71,11 +71,11 @@ class MyHomePage extends StatelessWidget {
                   MBSPageRoute(
                     context: context,
                     pageBuilder: (BuildContext buildContext) {
-                      return  const MyHomePage(title: "MBS Transition");
+                      return  const MyHomePage(title: 'MBS Transition');
                     },
                   ),
                 );},
-                child: const Text("Modal Bottom Sheet"),
+                child: const Text('Modal Bottom Sheet'),
               ),
               if (MBSNavigator.of(context) != null)
                 TextButton(

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -47,23 +47,23 @@ class MyHomePage extends StatelessWidget {
                 onPressed: () {
                   Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (context) {
-                      return  const MyHomePage(title: "Zoom Transition");
+                    builder: (BuildContext context) {
+                      return  const MyHomePage(title: 'Zoom Transition');
                     },
                   ),
                 );},
-                child: const Text("Zoom Transition"),
+                child: const Text('Zoom Transition'),
               ),
               TextButton(
                 onPressed: () {
                   Navigator.of(context).push(
                   CupertinoPageRoute(
-                    builder: (context) {
-                      return  const MyHomePage(title: "Cupertino Transition");
+                    builder: (BuildContext context) {
+                      return  const MyHomePage(title: 'Cupertino Transition');
                     }
                   ),
                 );},
-                child: const Text("Cupertino Transition"),
+                child: const Text('Cupertino Transition'),
               ),
               TextButton(
                 onPressed: () {
@@ -82,7 +82,7 @@ class MyHomePage extends StatelessWidget {
                   onPressed: () {
                     (Navigator.of(context).widget as MBSNavigator).popMBS();
                   },
-                  child: const Text("Pop Bottom Sheet")
+                  child: const Text('Pop Bottom Sheet')
                 ),
             ],
           ),
@@ -99,12 +99,12 @@ final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
 
 final Animatable<Offset> _kFullBottomUpTween = Tween<Offset>(
   begin: const Offset(0.0, 1.0),
-  end: const Offset(0.0, 0.0),
+  end: Offset.zero,
 );
 
 // Offset from offscreen below to stopping below the top of the screen.
 final Animatable<Offset> _kMidUpTween = Tween<Offset>(
-  begin: const Offset(0.0, 0),
+  begin: Offset.zero,
   end: const Offset(0.0, -0.05),
 );
 
@@ -243,7 +243,6 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
   Widget buildContent(BuildContext context);
 
   @override
-  // A relatively rigorous eyeball estimation.
   Duration get transitionDuration => const Duration(milliseconds: 500);
 
 
@@ -267,20 +266,6 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
     );
   }
 
-  /// Returns a [CupertinoFullscreenDialogTransition] if [route] is a full
-  /// screen dialog, otherwise a [CupertinoPageTransition] is returned.
-  ///
-  /// Used by [CupertinoPageRoute.buildTransitions].
-  ///
-  /// This method can be applied to any [PageRoute], not just
-  /// [CupertinoPageRoute]. It's typically used to provide a Cupertino style
-  /// horizontal transition for material widgets when the target platform
-  /// is [TargetPlatform.iOS].
-  ///
-  /// See also:
-  ///
-  ///  * [CupertinoPageTransitionsBuilder], which uses this method to define a
-  ///    [PageTransitionsBuilder] for the [PageTransitionsTheme].
   static Widget buildPageTransitions<T>(
     ModalRoute<T> route,
     BuildContext context,
@@ -325,7 +310,6 @@ class MBSNavigator extends Navigator {
 
   void popMBS() {
     Navigator.of(parentNavigatorContext).pop();
-    // Navigator.of(parentNavigatorContext).delegateTransitionBuilder = null;
   }
 
   static NavigatorState? of(

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -287,6 +287,11 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
   }
 
   @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    return nextRoute is MBSRouteTransitionMixin;
+  }
+
+  @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     return buildPageTransitions<T>(this, context, animation, secondaryAnimation, child);
   }

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -1,7 +1,3 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -52,16 +48,7 @@ class MyHomePage extends StatelessWidget {
                   Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) {
-                      return  Theme(
-                        data: ThemeData(
-                          pageTransitionsTheme: const PageTransitionsTheme(
-                            builders: <TargetPlatform, PageTransitionsBuilder>{
-                              TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-                            },
-                          )
-                        ),
-                        child: const MyHomePage(title: "Zoom Transition")
-                      );
+                      return  const MyHomePage(title: "Zoom Transition");
                     },
                   ),
                 );},
@@ -72,16 +59,7 @@ class MyHomePage extends StatelessWidget {
                   Navigator.of(context).push(
                   CupertinoPageRoute(
                     builder: (context) {
-                      return  Theme(
-                        data: ThemeData(
-                          pageTransitionsTheme: const PageTransitionsTheme(
-                            builders: <TargetPlatform, PageTransitionsBuilder>{
-                              TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-                            },
-                          )
-                        ),
-                        child: const MyHomePage(title: "Cupertino Transition")
-                      );
+                      return  const MyHomePage(title: "Cupertino Transition");
                     }
                   ),
                 );},

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.0.dart
@@ -1,0 +1,373 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Mixing Routes',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: <TargetPlatform, PageTransitionsBuilder>{
+            TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
+          },
+        ),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(title: 'Zoom Transition'),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          title: Text(title),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) {
+                      return  Theme(
+                        data: ThemeData(
+                          pageTransitionsTheme: const PageTransitionsTheme(
+                            builders: <TargetPlatform, PageTransitionsBuilder>{
+                              TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
+                            },
+                          )
+                        ),
+                        child: const MyHomePage(title: "Zoom Transition")
+                      );
+                    },
+                  ),
+                );},
+                child: const Text("Zoom Transition"),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                  CupertinoPageRoute(
+                    builder: (context) {
+                      return  Theme(
+                        data: ThemeData(
+                          pageTransitionsTheme: const PageTransitionsTheme(
+                            builders: <TargetPlatform, PageTransitionsBuilder>{
+                              TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
+                            },
+                          )
+                        ),
+                        child: const MyHomePage(title: "Cupertino Transition")
+                      );
+                    }
+                  ),
+                );},
+                child: const Text("Cupertino Transition"),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                  MBSPageRoute(
+                    context: context,
+                    pageBuilder: (BuildContext buildContext) {
+                      return  const MyHomePage(title: "MBS Transition");
+                    },
+                  ),
+                );},
+                child: const Text("Modal Bottom Sheet"),
+              ),
+              if (MBSNavigator.of(context) != null)
+                TextButton(
+                  onPressed: () {
+                    (Navigator.of(context).widget as MBSNavigator).popMBS();
+                  },
+                  child: const Text("Pop Bottom Sheet")
+                ),
+            ],
+          ),
+        ),
+    );
+  }
+}
+
+// Offset from offscreen below to stopping below the top of the screen.
+final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
+  begin: const Offset(0.0, 1.0),
+  end: const Offset(0.0, 0.1),
+);
+
+final Animatable<Offset> _kFullBottomUpTween = Tween<Offset>(
+  begin: const Offset(0.0, 1.0),
+  end: const Offset(0.0, 0.0),
+);
+
+// Offset from offscreen below to stopping below the top of the screen.
+final Animatable<Offset> _kMidUpTween = Tween<Offset>(
+  begin: const Offset(0.0, 0),
+  end: const Offset(0.0, -0.05),
+);
+
+class MBSTransition extends StatelessWidget {
+  MBSTransition({
+    super.key,
+    required Animation<double> primaryRouteAnimation,
+    required this.secondaryRouteAnimation,
+    required this.child,
+  }) : _primaryPositionAnimation =
+           CurvedAnimation(
+                 parent: primaryRouteAnimation,
+                 curve: Curves.fastEaseInToSlowEaseOut,
+                 reverseCurve: Curves.fastEaseInToSlowEaseOut.flipped,
+               ).drive(_kBottomUpTween),
+      _secondaryPositionAnimation =
+           CurvedAnimation(
+                 parent: secondaryRouteAnimation,
+                 curve: Curves.linearToEaseOut,
+                 reverseCurve: Curves.easeInToLinear,
+               )
+           .drive(_kMidUpTween),
+      _tertiaryPositionAnimation =
+            CurvedAnimation(
+                 parent: primaryRouteAnimation,
+                 curve: Curves.linearToEaseOut,
+                 reverseCurve: Curves.easeInToLinear,
+               )
+           .drive(_kFullBottomUpTween);
+
+  // When this page is coming in to cover another page.
+  final Animation<Offset> _primaryPositionAnimation;
+
+  // When this page is coming in to cover another page.
+  final Animation<Offset> _tertiaryPositionAnimation;
+
+  // When this page is coming in to cover another page.
+  final Animation<Offset> _secondaryPositionAnimation;
+
+  /// Animation
+  final Animation<double> secondaryRouteAnimation;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// The delegated transition.
+  static Widget delegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
+    const Offset begin = Offset.zero;
+    const Offset end = Offset(0.0, 0.05);
+    const Curve curve = Curves.ease;
+
+    final Animatable<Offset> tween = Tween<Offset>(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+    return SlideTransition(
+      position: secondaryAnimation.drive(tween),
+      child: child,
+    );
+  }
+
+  /// The secondary delegated transition.
+  static Widget secondaryDelegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
+    const Offset begin = Offset.zero;
+    const Offset end = Offset(0.0, -0.05);
+    const Curve curve = Curves.ease;
+
+    final Animatable<Offset> tween = Tween<Offset>(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+    return SlideTransition(
+      position: secondaryAnimation.drive(tween),
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasDirectionality(context));
+    final TextDirection textDirection = Directionality.of(context);
+    final bool topLevelMBS = Navigator.of(context).widget is! MBSNavigator;
+    return DelegatedTransition(
+      context: context,
+      animation: secondaryRouteAnimation,
+      builder: (BuildContext context, Widget? child) {
+        return SlideTransition(
+          position: _secondaryPositionAnimation,
+          textDirection: textDirection,
+          transformHitTests: false,
+          child: child,
+        );
+      },
+      child: SlideTransition(
+        position: topLevelMBS ? _primaryPositionAnimation : _tertiaryPositionAnimation,
+        textDirection: textDirection,
+        child: ClipRRect(
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+          child: child,
+        )
+      ),
+    );
+  }
+}
+
+class MBSPageRoute<T> extends PageRoute<T> with MBSRouteTransitionMixin<T> {
+  /// Creates a page route for use in an iOS designed app.
+  MBSPageRoute({
+    required this.pageBuilder,
+    required BuildContext context,
+  }) : super(
+    delegatedTransition: (Navigator.of(context).widget is MBSNavigator) ?
+      MBSTransition.secondaryDelegateTransition : MBSTransition.delegateTransition,
+  );
+
+  final WidgetBuilder pageBuilder;
+
+  @override
+  Widget buildContent(BuildContext context) => pageBuilder(context);
+
+  @override
+  Color? get barrierColor => const Color(0x20000000);
+
+  @override
+  bool get barrierDismissible => false;
+
+  @override
+  String? get barrierLabel => 'Stacked card appearance for modal bottom sheet';
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  bool get opaque => false;
+}
+
+mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
+  /// Builds the primary contents of the route.
+  @protected
+  Widget buildContent(BuildContext context);
+
+  @override
+  // A relatively rigorous eyeball estimation.
+  Duration get transitionDuration => const Duration(milliseconds: 500);
+
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+    final Widget child = buildContent(context);
+    return MBSNavigator(
+      parentNavigatorContext: context,
+      initialRoute: '/',
+      onGenerateRoute: (RouteSettings settings) {
+        return CupertinoPageRoute(
+          builder: (BuildContext context) {
+            return Semantics(
+              scopesRoute: true,
+              explicitChildNodes: true,
+              child: child,
+            );
+          }
+        );
+      }
+    );
+  }
+
+  /// Returns a [CupertinoFullscreenDialogTransition] if [route] is a full
+  /// screen dialog, otherwise a [CupertinoPageTransition] is returned.
+  ///
+  /// Used by [CupertinoPageRoute.buildTransitions].
+  ///
+  /// This method can be applied to any [PageRoute], not just
+  /// [CupertinoPageRoute]. It's typically used to provide a Cupertino style
+  /// horizontal transition for material widgets when the target platform
+  /// is [TargetPlatform.iOS].
+  ///
+  /// See also:
+  ///
+  ///  * [CupertinoPageTransitionsBuilder], which uses this method to define a
+  ///    [PageTransitionsBuilder] for the [PageTransitionsTheme].
+  static Widget buildPageTransitions<T>(
+    ModalRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return MBSTransition(
+      primaryRouteAnimation: animation,
+      secondaryRouteAnimation: secondaryAnimation,
+      child: child,
+    );
+  }
+
+  @override
+  Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+    return buildPageTransitions<T>(this, context, animation, secondaryAnimation, child);
+  }
+}
+
+class MBSNavigator extends Navigator {
+
+  MBSNavigator({
+    super.key,
+    super.pages,
+    super.onPopPage,
+    super.initialRoute,
+    super.onGenerateInitialRoutes,
+    super.onGenerateRoute,
+    super.onUnknownRoute,
+    super.transitionDelegate,
+    super.reportsRouteUpdateToEngine,
+    super.clipBehavior,
+    super.observers,
+    super.requestFocus,
+    super.restorationScopeId,
+    super.routeTraversalEdgeBehavior,
+    required this.parentNavigatorContext,
+  });
+
+  final BuildContext parentNavigatorContext;
+
+  void popMBS() {
+    Navigator.of(parentNavigatorContext).pop();
+    // Navigator.of(parentNavigatorContext).delegateTransitionBuilder = null;
+  }
+
+  static NavigatorState? of(
+    BuildContext context, {
+    bool rootNavigator = false,
+  }) {
+    // Handles the case where the input context is a navigator element.
+    NavigatorState? navigator;
+    if (context is StatefulElement && context.state is NavigatorState) {
+      navigator = context.state as NavigatorState;
+    }
+    if (rootNavigator) {
+      navigator = context.findRootAncestorStateOfType<NavigatorState>() ?? navigator;
+    } else {
+      navigator = navigator ?? context.findAncestorStateOfType<NavigatorState>();
+    }
+    if (navigator?.widget is! MBSNavigator) {
+      return null;
+    }
+
+    return navigator;
+  }
+}

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.1.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.1.dart
@@ -5,6 +5,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+/// The same as the other example, excepts uses named routing in the MBS. Allows
+/// for linking directly to a subpage.
+
 void main() {
   runApp(const MyApp());
 }
@@ -236,7 +239,7 @@ class MBSTransition extends StatelessWidget {
                  reverseCurve: Curves.easeInToLinear,
                )
            .drive(_kMidUpTween),
-      _tertiaryPositionAnimation =
+      _primaryPositionAnimationMBS =
             CurvedAnimation(
                  parent: primaryRouteAnimation,
                  curve: Curves.linearToEaseOut,
@@ -247,10 +250,13 @@ class MBSTransition extends StatelessWidget {
   // When this page is coming in to cover another page.
   final Animation<Offset> _primaryPositionAnimation;
 
-  // When this page is coming in to cover another page.
-  final Animation<Offset> _tertiaryPositionAnimation;
+  // When this page is coming in to cover another MBS. Because it's nested within
+  // a MBS, a 0 y offset is not the top of the physical screen, but the top of
+  // the previous MBS.
+  final Animation<Offset> _primaryPositionAnimationMBS;
 
-  // When this page is coming in to cover another page.
+  // When this page is being covered by another MBS. It slides up slightly to
+  // look like it's joining the stack of previous routes.
   final Animation<Offset> _secondaryPositionAnimation;
 
   /// Animation
@@ -259,7 +265,7 @@ class MBSTransition extends StatelessWidget {
   /// The widget below this widget in the tree.
   final Widget child;
 
-  /// The delegated transition.
+  /// The primary delegated transition. Will slide a non MBS page down.
   static Widget delegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
     const Offset begin = Offset.zero;
     const Offset end = Offset(0.0, 0.05);
@@ -273,7 +279,7 @@ class MBSTransition extends StatelessWidget {
     );
   }
 
-  /// The secondary delegated transition.
+  /// The secondary delegated transition. Will slide a MBS page up.
   static Widget secondaryDelegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
     const Offset begin = Offset.zero;
     const Offset end = Offset(0.0, -0.05);
@@ -304,7 +310,7 @@ class MBSTransition extends StatelessWidget {
         );
       },
       child: SlideTransition(
-        position: topLevelMBS ? _primaryPositionAnimation : _tertiaryPositionAnimation,
+        position: topLevelMBS ? _primaryPositionAnimation : _primaryPositionAnimationMBS,
         textDirection: textDirection,
         child: ClipRRect(
           borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
@@ -357,7 +363,6 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
   @override
   // A relatively rigorous eyeball estimation.
   Duration get transitionDuration => const Duration(milliseconds: 500);
-
 
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.1.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.1.dart
@@ -418,6 +418,11 @@ mixin MBSRouteTransitionMixin<T> on PageRoute<T> {
   }
 
   @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    return nextRoute is MBSRouteTransitionMixin;
+  }
+
+  @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     return buildPageTransitions<T>(this, context, animation, secondaryAnimation, child);
   }

--- a/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.1.dart
+++ b/examples/api/lib/cupertino/modal_bottom_sheet/modal_bottom_sheet.1.dart
@@ -315,15 +315,18 @@ class MBSTransition extends StatelessWidget {
   }
 }
 
-class MBSPageRoute<T> extends PageRoute<T> with MBSRouteTransitionMixin<T> {
+class MBSPageRoute<T> extends PageRoute<T> with MBSRouteTransitionMixin<T>,FlexibleTransitionRouteMixin<T> {
   /// Creates a page route for use in an iOS designed app.
   MBSPageRoute({
     required BuildContext context,
     this.firstRoute,
-  }) : super(
-    delegatedTransition: (Navigator.of(context).widget is MBSNavigator) ?
-      MBSTransition.secondaryDelegateTransition : MBSTransition.delegateTransition,
-  );
+  }) : _delegatedTransition = (Navigator.of(context).widget is MBSNavigator) ?
+      MBSTransition.secondaryDelegateTransition : MBSTransition.delegateTransition;
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition => _delegatedTransition;
+
+  final DelegatedTransitionBuilder _delegatedTransition;
 
   final String? firstRoute;
 

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -153,7 +153,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
-    return nextRoute is ModalRoute || nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
+    return nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
     // return !(nextRoute is CupertinoRouteTransitionMixin && nextRoute.fullscreenDialog);
   }
 

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -153,7 +153,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
-    return nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
+    return !(nextRoute is CupertinoRouteTransitionMixin && nextRoute.fullscreenDialog);
   }
 
   @override
@@ -487,10 +487,17 @@ class _CupertinoPageTransitionState extends State<CupertinoPageTransition> {
   Widget build(BuildContext context) {
     assert(debugCheckHasDirectionality(context));
     final TextDirection textDirection = Directionality.of(context);
-    return SlideTransition(
-      position: _secondaryPositionAnimation,
-      textDirection: textDirection,
-      transformHitTests: false,
+    return DelegatedTransition(
+      context: context,
+      animation: widget.secondaryRouteAnimation,
+      builder: (BuildContext context, Widget? child) {
+        return SlideTransition(
+          position: _secondaryPositionAnimation,
+          textDirection: textDirection,
+          transformHitTests: false,
+          child: child,
+        );
+      },
       child: SlideTransition(
         position: _primaryPositionAnimation,
         textDirection: textDirection,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -153,7 +153,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
-    return nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
+    return nextRoute is ModalRoute || nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
     // return !(nextRoute is CupertinoRouteTransitionMixin && nextRoute.fullscreenDialog);
   }
 

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -153,7 +153,8 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
-    return !(nextRoute is CupertinoRouteTransitionMixin && nextRoute.fullscreenDialog);
+    return nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
+    // return !(nextRoute is CupertinoRouteTransitionMixin && nextRoute.fullscreenDialog);
   }
 
   @override
@@ -273,6 +274,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
     super.fullscreenDialog,
     super.allowSnapshotting = true,
     super.barrierDismissible = false,
+    super.delegatedTransition = CupertinoPageTransition.delegateTransition,
   }) {
     assert(opaque);
   }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -152,16 +152,19 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransi
 
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    if (controller != null && controller!.isAnimating) {
+      return false;
+    }
+    if (nextRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
+      navigator!.delegateTransitionBuilder = (nextRoute as FlexibleTransitionRouteMixin<T>).delegatedTransition;
+    }
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
-    // For MBS: we need to allow for transitioning to a route that will provide a secondary animation to use.
-    // This always plays the transition, but it would be better to check if the next route provides a delegated
-    // transition.
     return nextRoute is FlexibleTransitionRouteMixin<T> || nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
   }
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
+    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null && previousRoute.controller?.isAnimating != true) {
       previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
     }
     return previousRoute is FlexibleTransitionRouteMixin<T> || previousRoute is CupertinoRouteTransitionMixin && !previousRoute.fullscreenDialog;

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -182,67 +182,6 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransi
     return route.navigator!.userGestureInProgress;
   }
 
-  /// True if an iOS-style back swipe pop gesture is currently underway for this route.
-  ///
-  /// See also:
-  ///
-  ///  * [isPopGestureInProgress], which returns true if a Cupertino pop gesture
-  ///    is currently underway for specific route.
-  ///  * [popGestureEnabled], which returns true if a user-triggered pop gesture
-  ///    would be allowed.
-  bool get popGestureInProgress => isPopGestureInProgress(this);
-
-  /// Whether a pop gesture can be started by the user.
-  ///
-  /// Returns true if the user can edge-swipe to a previous route.
-  ///
-  /// Returns false once [isPopGestureInProgress] is true, but
-  /// [isPopGestureInProgress] can only become true if [popGestureEnabled] was
-  /// true first.
-  ///
-  /// This should only be used between frames, not during build.
-  bool get popGestureEnabled => _isPopGestureEnabled(this);
-
-  static bool _isPopGestureEnabled<T>(PageRoute<T> route) {
-    // If there's nothing to go back to, then obviously we don't support
-    // the back gesture.
-    if (route.isFirst) {
-      return false;
-    }
-    // If the route wouldn't actually pop if we popped it, then the gesture
-    // would be really confusing (or would skip internal routes), so disallow it.
-    if (route.willHandlePopInternally) {
-      return false;
-    }
-    // If attempts to dismiss this route might be vetoed such as in a page
-    // with forms, then do not allow the user to dismiss the route with a swipe.
-    if (route.hasScopedWillPopCallback
-        || route.popDisposition == RoutePopDisposition.doNotPop) {
-      return false;
-    }
-    // Fullscreen dialogs aren't dismissible by back swipe.
-    if (route.fullscreenDialog) {
-      return false;
-    }
-    // If we're in an animation already, we cannot be manually swiped.
-    if (route.animation!.status != AnimationStatus.completed) {
-      return false;
-    }
-    // If we're being popped into, we also cannot be swiped until the pop above
-    // it completes. This translates to our secondary animation being
-    // dismissed.
-    if (route.secondaryAnimation!.status != AnimationStatus.dismissed) {
-      return false;
-    }
-    // If we're in a gesture already, we cannot start another.
-    if (isPopGestureInProgress(route)) {
-      return false;
-    }
-
-    // Looks like a back gesture would be welcome!
-    return true;
-  }
-
   @override
   Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
     final Widget child = buildContent(context);

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -159,8 +159,8 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is ModalRoute<T> && this.navigator != null) {
-      this.navigator!.delegateTransitionBuilder = (previousRoute as ModalRoute<T>).delegatedTransition;
+    if (previousRoute is ModalRoute<T> && navigator != null) {
+      navigator!.delegateTransitionBuilder = previousRoute.delegatedTransition;
     }
     return previousRoute is ModalRoute || previousRoute is CupertinoRouteTransitionMixin && !previousRoute.fullscreenDialog;
   }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -163,7 +163,6 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
     if (previousRoute is ModalRoute<T> && navigator != null) {
       previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
-      // navigator!.delegateTransitionBuilder = previousRoute.delegatedTransition;
     }
     return previousRoute is ModalRoute || previousRoute is CupertinoRouteTransitionMixin && !previousRoute.fullscreenDialog;
   }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -83,7 +83,7 @@ final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
 ///  * [MaterialRouteTransitionMixin], which is a mixin that provides
 ///    platform-appropriate transitions for a [PageRoute].
 ///  * [CupertinoPageRoute], which is a [PageRoute] that leverages this mixin.
-mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
+mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransitionRouteMixin<T> {
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -156,15 +156,15 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
     // For MBS: we need to allow for transitioning to a route that will provide a secondary animation to use.
     // This always plays the transition, but it would be better to check if the next route provides a delegated
     // transition.
-    return nextRoute is ModalRoute || nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
+    return nextRoute is FlexibleTransitionRouteMixin<T> || nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
   }
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is ModalRoute<T> && navigator != null) {
+    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
       previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
     }
-    return previousRoute is ModalRoute || previousRoute is CupertinoRouteTransitionMixin && !previousRoute.fullscreenDialog;
+    return previousRoute is FlexibleTransitionRouteMixin<T> || previousRoute is CupertinoRouteTransitionMixin && !previousRoute.fullscreenDialog;
   }
 
   /// True if an iOS-style back swipe pop gesture is currently underway for [route].
@@ -357,10 +357,12 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
     super.fullscreenDialog,
     super.allowSnapshotting = true,
     super.barrierDismissible = false,
-    super.delegatedTransition = CupertinoPageTransition.delegateTransition,
   }) {
     assert(opaque);
   }
+
+  @override
+  DelegatedTransitionBuilder? delegatedTransition = CupertinoPageTransition.delegateTransition;
 
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
@@ -389,6 +391,9 @@ class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTr
   }) : super(settings: page) {
     assert(opaque);
   }
+
+  @override
+  DelegatedTransitionBuilder? delegatedTransition = CupertinoPageTransition.delegateTransition;
 
   CupertinoPage<T> get _page => settings as CupertinoPage<T>;
 

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -83,7 +83,7 @@ final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
 ///  * [MaterialRouteTransitionMixin], which is a mixin that provides
 ///    platform-appropriate transitions for a [PageRoute].
 ///  * [CupertinoPageRoute], which is a [PageRoute] that leverages this mixin.
-mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransitionRouteMixin<T> {
+mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -155,18 +155,12 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransi
     if (controller != null && controller!.isAnimating) {
       return false;
     }
-    if (nextRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
-      navigator!.delegateTransitionBuilder = (nextRoute as FlexibleTransitionRouteMixin<T>).delegatedTransition;
-    }
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return nextRoute is FlexibleTransitionRouteMixin<T> || nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog;
   }
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null && previousRoute.controller?.isAnimating != true) {
-      previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
-    }
     return previousRoute is FlexibleTransitionRouteMixin<T> || previousRoute is CupertinoRouteTransitionMixin && !previousRoute.fullscreenDialog;
   }
 
@@ -286,7 +280,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransi
 ///  * [CupertinoTabScaffold], for applications that have a tab bar at the
 ///    bottom with multiple pages.
 ///  * [CupertinoPage], for a [Page] version of this class.
-class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T> {
+class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T>, FlexibleTransitionRouteMixin<T> {
   /// Creates a page route for use in an iOS designed app.
   ///
   /// The [builder], [maintainState], and [fullscreenDialog] arguments must not
@@ -326,7 +320,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
 //
 // This route uses the builder from the page to build its content. This ensures
 // the content is up to date after page updates.
-class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T> {
+class _PageBasedCupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMixin<T>, FlexibleTransitionRouteMixin<T> {
   _PageBasedCupertinoPageRoute({
     required CupertinoPage<T> page,
     super.allowSnapshotting = true,

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -106,6 +106,12 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransit
 
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    if (controller != null && controller!.isAnimating) {
+      return false;
+    }
+    if (nextRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
+      navigator!.delegateTransitionBuilder = (nextRoute as FlexibleTransitionRouteMixin<T>).delegatedTransition;
+    }
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return (nextRoute is MaterialRouteTransitionMixin && !nextRoute.fullscreenDialog)
       || (nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog)
@@ -114,7 +120,7 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransit
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
+    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null && previousRoute.controller?.isAnimating != true) {
       previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
     }
     return previousRoute is PageRoute;

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -104,6 +104,14 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   }
 
   @override
+  bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
+    if (previousRoute is ModalRoute<T> && this.navigator != null) {
+      this.navigator!.delegateTransitionBuilder = (previousRoute as ModalRoute<T>).delegatedTransition;
+    }
+    return (previousRoute is PageRoute);
+  }
+
+  @override
   Widget buildPage(
     BuildContext context,
     Animation<double> animation,

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -32,7 +32,7 @@ import 'theme.dart';
 ///  * [MaterialRouteTransitionMixin], which provides the material transition
 ///    for this route.
 ///  * [MaterialPage], which is a [Page] of this class.
-class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
+class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T>, FlexibleTransitionRouteMixin<T> {
   /// Construct a MaterialPageRoute whose contents are defined by [builder].
   MaterialPageRoute({
     required this.builder,
@@ -99,7 +99,6 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransit
   @override
   DelegatedTransitionBuilder? get delegatedTransition => _delegatedTransition;
 
-  @override
   set delegatedTransition(DelegatedTransitionBuilder? newTransition) {
     _delegatedTransition = newTransition;
   }
@@ -109,10 +108,6 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransit
     if (controller != null && controller!.isAnimating) {
       return false;
     }
-    if (nextRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
-      navigator!.delegateTransitionBuilder = (nextRoute as FlexibleTransitionRouteMixin<T>).delegatedTransition;
-    }
-    // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return (nextRoute is MaterialRouteTransitionMixin && !nextRoute.fullscreenDialog)
       || (nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog)
       || (nextRoute is FlexibleTransitionRouteMixin<T>);
@@ -120,9 +115,6 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransit
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null && previousRoute.controller?.isAnimating != true) {
-      previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
-    }
     return previousRoute is PageRoute;
   }
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -41,6 +41,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
     super.fullscreenDialog,
     super.allowSnapshotting = true,
     super.barrierDismissible = false,
+    super.delegatedTransition,
   }) {
     assert(opaque);
   }

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -99,7 +99,8 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return (nextRoute is MaterialRouteTransitionMixin && !nextRoute.fullscreenDialog)
-      || (nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog);
+      || (nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog)
+      || (nextRoute is PageRoute);
   }
 
   @override

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -41,8 +41,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
     super.fullscreenDialog,
     super.allowSnapshotting = true,
     super.barrierDismissible = false,
-    super.delegatedTransition,
-  }) {
+  })  {
     assert(opaque);
   }
 
@@ -81,7 +80,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 ///    by the [PageTransitionsTheme].
 ///  * [CupertinoPageTransitionsBuilder], which is the default page transition
 ///    for iOS and macOS.
-mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
+mixin MaterialRouteTransitionMixin<T> on PageRoute<T> implements FlexibleTransitionRouteMixin<T>{
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -95,17 +94,27 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   @override
   String? get barrierLabel => null;
 
+  DelegatedTransitionBuilder? _delegatedTransition;
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition => _delegatedTransition;
+
+  @override
+  set delegatedTransition(DelegatedTransitionBuilder? newTransition) {
+    _delegatedTransition = newTransition;
+  }
+
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
     // Don't perform outgoing animation if the next route is a fullscreen dialog.
     return (nextRoute is MaterialRouteTransitionMixin && !nextRoute.fullscreenDialog)
       || (nextRoute is CupertinoRouteTransitionMixin && !nextRoute.fullscreenDialog)
-      || (nextRoute is PageRoute);
+      || (nextRoute is FlexibleTransitionRouteMixin<T>);
   }
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is ModalRoute<T> && navigator != null) {
+    if (previousRoute is FlexibleTransitionRouteMixin<T> && navigator != null) {
       previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
     }
     return previousRoute is PageRoute;
@@ -128,6 +137,7 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
+    delegatedTransition = theme.delegatedTransition(context);
     return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child);
   }
 }

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -41,7 +41,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
     super.fullscreenDialog,
     super.allowSnapshotting = true,
     super.barrierDismissible = false,
-  })  {
+  }) {
     assert(opaque);
   }
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -105,10 +105,10 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
-    if (previousRoute is ModalRoute<T> && this.navigator != null) {
-      this.navigator!.delegateTransitionBuilder = (previousRoute as ModalRoute<T>).delegatedTransition;
+    if (previousRoute is ModalRoute<T> && navigator != null) {
+      navigator!.delegateTransitionBuilder = previousRoute.delegatedTransition;
     }
-    return (previousRoute is PageRoute);
+    return previousRoute is PageRoute;
   }
 
   @override

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -106,7 +106,7 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) {
     if (previousRoute is ModalRoute<T> && navigator != null) {
-      navigator!.delegateTransitionBuilder = previousRoute.delegatedTransition;
+      previousRoute.navigator!.delegateTransitionBuilder = delegatedTransition;
     }
     return previousRoute is PageRoute;
   }

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -197,7 +197,7 @@ class MaterialPage<T> extends Page<T> {
 //
 // This route uses the builder from the page to build its content. This ensures
 // the content is up to date after page updates.
-class _PageBasedMaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T> {
+class _PageBasedMaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixin<T>, FlexibleTransitionRouteMixin<T> {
   _PageBasedMaterialPageRoute({
     required MaterialPage<T> page,
     super.allowSnapshotting,

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -655,11 +655,6 @@ class OpenUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Android P.
   const OpenUpwardsPageTransitionsBuilder();
 
-  /// Delegate animation
-  static Widget delegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
-    return _OpenUpwardsPageTransition.delegateTransition(context, child, secondaryAnimation);
-  }
-
   @override
   Widget buildTransitions<T>(
     PageRoute<T>? route,

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -86,14 +86,6 @@ class _OpenUpwardsPageTransition extends StatefulWidget {
       ),
     );
 
-    final CurvedAnimation primaryAnimation = CurvedAnimation(
-      parent: ReverseAnimation(secondaryAnimation),
-      curve: _transitionCurve,
-      reverseCurve: _transitionCurve.flipped,
-    );
-
-    final Animation<Offset> primaryTranslationAnimation = _primaryTranslationTween.animate(primaryAnimation);
-
     return AnimatedBuilder(
       animation: secondaryAnimation,
       child: FractionalTranslation(
@@ -899,6 +891,19 @@ class PageTransitionsTheme with Diagnosticable {
       secondaryAnimation: secondaryAnimation,
       child: child,
     );
+  }
+
+  /// Provide delegate transition for platform.
+  DelegatedTransitionBuilder? delegatedTransition(BuildContext context) {
+    final TargetPlatform platform = Theme.of(context).platform;
+
+    final PageTransitionsBuilder matchingBuilder =
+      builders[platform] ?? const ZoomPageTransitionsBuilder();
+
+    if (matchingBuilder == const ZoomPageTransitionsBuilder()) {
+      return ZoomPageTransitionsBuilder.delegateTransition;
+    }
+    return null;
   }
 
   // Map the builders to a list with one PageTransitionsBuilder per platform for

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -77,30 +77,6 @@ class _OpenUpwardsPageTransition extends StatefulWidget {
   // Used by all of the transition animations.
   static const Curve _transitionCurve = Cubic(0.20, 0.00, 0.00, 1.00);
 
-  static Widget delegateTransition(BuildContext context, Widget? child, Animation<double> secondaryAnimation) {
-    final Animation<Offset> secondaryTranslationAnimation = _secondaryTranslationTween.animate(
-      CurvedAnimation(
-        parent: secondaryAnimation,
-        curve: _transitionCurve,
-        reverseCurve: _transitionCurve.flipped,
-      ),
-    );
-
-    return AnimatedBuilder(
-      animation: secondaryAnimation,
-      child: FractionalTranslation(
-        translation: secondaryTranslationAnimation.value,
-        child: child,
-      ),
-      builder: (BuildContext context, Widget? child) {
-        return FractionalTranslation(
-          translation: secondaryTranslationAnimation.value,
-          child: child,
-        );
-      },
-    );
-  }
-
   final Animation<double> animation;
   final Animation<double> secondaryAnimation;
   final Widget child;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -22,6 +22,7 @@ import 'framework.dart';
 import 'heroes.dart';
 import 'notification_listener.dart';
 import 'overlay.dart';
+import 'pages.dart';
 import 'restoration.dart';
 import 'restoration_properties.dart';
 import 'routes.dart';
@@ -4850,9 +4851,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///  * [restorablePush], which pushes a route that can be restored during
   ///    state restoration.
   @optionalTypeArgs
-  Future<T?> push<T extends Object?>(Route<T> route, [DelegatedTransitionBuilder? delegateBuilder]) {
+  Future<T?> push<T extends Object?>(Route<T> route) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
-    delegateTransitionBuilder = delegateBuilder;
+    if (route is PageRoute<T>) {
+      delegateTransitionBuilder = route.delegatedTransition;
+    }
     return route.popped;
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4853,7 +4853,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   Future<T?> push<T extends Object?>(Route<T> route) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
-    if (route is PageRoute<T>) {
+    if (route is ModalRoute<T>) {
       delegateTransitionBuilder = route.delegatedTransition;
     }
     return route.popped;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4853,9 +4853,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   Future<T?> push<T extends Object?>(Route<T> route) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
-    if (route is FlexibleTransitionRouteMixin<T>) {
-      delegateTransitionBuilder = (route as FlexibleTransitionRouteMixin<T>).delegatedTransition;
-    }
+    // if (route is FlexibleTransitionRouteMixin<T>) {
+    //   delegateTransitionBuilder = (route as FlexibleTransitionRouteMixin<T>).delegatedTransition;
+    // }
     return route.popped;
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4853,9 +4853,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   Future<T?> push<T extends Object?>(Route<T> route) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
-    // if (route is FlexibleTransitionRouteMixin<T>) {
-    //   delegateTransitionBuilder = (route as FlexibleTransitionRouteMixin<T>).delegatedTransition;
-    // }
     return route.popped;
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4847,8 +4847,9 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///  * [restorablePush], which pushes a route that can be restored during
   ///    state restoration.
   @optionalTypeArgs
-  Future<T?> push<T extends Object?>(Route<T> route) {
+  Future<T?> push<T extends Object?>(Route<T> route, [Widget Function(BuildContext context, Widget? child, Animation<double> animation)? delegateBuilder]) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
+    delegateTransitionBuilder = delegateBuilder;
     return route.popped;
   }
 
@@ -5515,6 +5516,15 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
 
   /// Notifies its listeners if the value of [userGestureInProgress] changes.
   final ValueNotifier<bool> userGestureInProgressNotifier = ValueNotifier<bool>(false);
+
+  /// Notifies its listeners if there is a delegate transition from the top route.
+  final ValueNotifier<Widget Function(BuildContext context, Widget? child, Animation<double> animation)?> delegateTransitionBuilderNotifier = ValueNotifier<Widget Function(BuildContext context, Widget? child, Animation<double> animation)?>(null);
+
+  /// Sets the delegate transition.
+  set delegateTransitionBuilder(Widget Function(BuildContext context, Widget? child, Animation<double> animation)? builder) => delegateTransitionBuilderNotifier.value = builder;
+
+  /// Gets the delegate transition.
+  Widget Function(BuildContext context, Widget? child, Animation<double> animation)? get delegateTransitionBuilder => delegateTransitionBuilderNotifier.value;
 
   /// The navigator is being controlled by a user gesture.
   ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5361,7 +5361,10 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     }());
     final _RouteEntry entry = _history.lastWhere(_RouteEntry.isPresentPredicate);
     if (entry.pageBased && widget.onPopPage != null) {
-      if (widget.onPopPage!(entry.route, result) && entry.currentState.index <= _RouteLifecycle.idle.index) {
+      // if (entry.route is ModalRoute<T>) {
+      //     delegateTransitionBuilder = (entry.route as ModalRoute<T>).delegatedTransition;
+      //   }
+      if (widget.onPopPage!(entry.route, result) && entry.currentState == _RouteLifecycle.idle) {
         // The entry may have been disposed if the pop finishes synchronously.
         assert(entry.route._popCompleter.isCompleted);
         entry.currentState = _RouteLifecycle.pop;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -67,6 +67,9 @@ typedef RestorableRouteBuilder<T> = Route<T> Function(BuildContext context, Obje
 /// Signature for the [Navigator.popUntil] predicate argument.
 typedef RoutePredicate = bool Function(Route<dynamic> route);
 
+/// Convenience function for passing around a builder for a transiton's secondary animation.
+typedef DelegatedTransitionBuilder = Widget Function(BuildContext context, Widget? child, Animation<double> animation);
+
 /// Signature for a callback that verifies that it's OK to call [Navigator.pop].
 ///
 /// Used by [Form.onWillPop], [ModalRoute.addScopedWillPopCallback],
@@ -4847,7 +4850,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   ///  * [restorablePush], which pushes a route that can be restored during
   ///    state restoration.
   @optionalTypeArgs
-  Future<T?> push<T extends Object?>(Route<T> route, [Widget Function(BuildContext context, Widget? child, Animation<double> animation)? delegateBuilder]) {
+  Future<T?> push<T extends Object?>(Route<T> route, [DelegatedTransitionBuilder? delegateBuilder]) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
     delegateTransitionBuilder = delegateBuilder;
     return route.popped;
@@ -5518,13 +5521,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   final ValueNotifier<bool> userGestureInProgressNotifier = ValueNotifier<bool>(false);
 
   /// Notifies its listeners if there is a delegate transition from the top route.
-  final ValueNotifier<Widget Function(BuildContext context, Widget? child, Animation<double> animation)?> delegateTransitionBuilderNotifier = ValueNotifier<Widget Function(BuildContext context, Widget? child, Animation<double> animation)?>(null);
+  final ValueNotifier<DelegatedTransitionBuilder?> delegateTransitionBuilderNotifier = ValueNotifier<Widget Function(BuildContext context, Widget? child, Animation<double> animation)?>(null);
 
   /// Sets the delegate transition.
-  set delegateTransitionBuilder(Widget Function(BuildContext context, Widget? child, Animation<double> animation)? builder) => delegateTransitionBuilderNotifier.value = builder;
+  set delegateTransitionBuilder(DelegatedTransitionBuilder? builder) => delegateTransitionBuilderNotifier.value = builder;
 
   /// Gets the delegate transition.
-  Widget Function(BuildContext context, Widget? child, Animation<double> animation)? get delegateTransitionBuilder => delegateTransitionBuilderNotifier.value;
+  DelegatedTransitionBuilder? get delegateTransitionBuilder => delegateTransitionBuilderNotifier.value;
 
   /// The navigator is being controlled by a user gesture.
   ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -4853,8 +4853,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @optionalTypeArgs
   Future<T?> push<T extends Object?>(Route<T> route) {
     _pushEntry(_RouteEntry(route, pageBased: false, initialState: _RouteLifecycle.push));
-    if (route is ModalRoute<T>) {
-      delegateTransitionBuilder = route.delegatedTransition;
+    if (route is FlexibleTransitionRouteMixin<T>) {
+      delegateTransitionBuilder = (route as FlexibleTransitionRouteMixin<T>).delegatedTransition;
     }
     return route.popped;
   }

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -25,7 +25,7 @@ abstract class PageRoute<T> extends ModalRoute<T> {
     this.fullscreenDialog = false,
     this.allowSnapshotting = true,
     bool barrierDismissible = false,
-    this.delegatedTransition,
+    super.delegatedTransition,
   }) : _barrierDismissible = barrierDismissible;
 
   /// {@template flutter.widgets.PageRoute.fullscreenDialog}
@@ -37,9 +37,6 @@ abstract class PageRoute<T> extends ModalRoute<T> {
   /// with the back swipe gesture.
   /// {@endtemplate}
   final bool fullscreenDialog;
-
-  /// The delegated transition provided to the previous route.
-  final DelegatedTransitionBuilder? delegatedTransition;
 
   @override
   final bool allowSnapshotting;

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -4,6 +4,7 @@
 
 import 'basic.dart';
 import 'framework.dart';
+import 'navigator.dart';
 import 'routes.dart';
 
 /// A modal route that replaces the entire screen.
@@ -24,6 +25,7 @@ abstract class PageRoute<T> extends ModalRoute<T> {
     this.fullscreenDialog = false,
     this.allowSnapshotting = true,
     bool barrierDismissible = false,
+    this.delegatedTransition,
   }) : _barrierDismissible = barrierDismissible;
 
   /// {@template flutter.widgets.PageRoute.fullscreenDialog}
@@ -35,6 +37,9 @@ abstract class PageRoute<T> extends ModalRoute<T> {
   /// with the back swipe gesture.
   /// {@endtemplate}
   final bool fullscreenDialog;
+
+  /// The delegated transition provided to the previous route.
+  final DelegatedTransitionBuilder? delegatedTransition;
 
   @override
   final bool allowSnapshotting;

--- a/packages/flutter/lib/src/widgets/pages.dart
+++ b/packages/flutter/lib/src/widgets/pages.dart
@@ -25,7 +25,6 @@ abstract class PageRoute<T> extends ModalRoute<T> {
     this.fullscreenDialog = false,
     this.allowSnapshotting = true,
     bool barrierDismissible = false,
-    super.delegatedTransition,
   }) : _barrierDismissible = barrierDismissible;
 
   /// {@template flutter.widgets.PageRoute.fullscreenDialog}

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2489,7 +2489,24 @@ abstract class PopEntry<T> {
 
 /// Mixin for a route that can provide a delegated secondary transition to the
 /// outgoing route.
-abstract mixin class FlexibleTransitionRouteMixin<T> {
+mixin FlexibleTransitionRouteMixin<T> on TransitionRoute<T> {
   /// The delegated transition provided to the previous route.
-  late DelegatedTransitionBuilder? delegatedTransition;
+  DelegatedTransitionBuilder? get delegatedTransition;
+
+  @override
+  void didChangeNext(Route<dynamic>? nextRoute) {
+    if (nextRoute is FlexibleTransitionRouteMixin<T> && canTransitionTo(nextRoute) && navigator != null) {
+      debugPrint('Ping the navigator state');
+      navigator!.delegateTransitionBuilder = nextRoute.delegatedTransition;
+    }
+    super.didChangeNext(nextRoute);
+  }
+
+  @override
+  void didPopNext(Route<dynamic> nextRoute) {
+    if (nextRoute is FlexibleTransitionRouteMixin<T> && canTransitionTo(nextRoute) && navigator != null) {
+      navigator!.delegateTransitionBuilder = nextRoute.delegatedTransition;
+    }
+    super.didPopNext(nextRoute);
+  }
 }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1132,6 +1132,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     super.settings,
     this.filter,
     this.traversalEdgeBehavior,
+    this.delegatedTransition,
   });
 
   /// The filter to add to the barrier.
@@ -1462,6 +1463,9 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [ModalBarrier], the widget that implements this feature.
   /// {@endtemplate}
   bool get barrierDismissible;
+
+  /// The delegated transition provided to the previous route.
+  final DelegatedTransitionBuilder? delegatedTransition;
 
   /// Whether the semantics of the modal barrier are included in the
   /// semantics tree.
@@ -2078,6 +2082,7 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
     super.settings,
     super.filter,
     super.traversalEdgeBehavior,
+    super.delegatedTransition,
   });
 
   @override
@@ -2279,6 +2284,7 @@ class RawDialogRoute<T> extends PopupRoute<T> {
     super.settings,
     this.anchorPoint,
     super.traversalEdgeBehavior,
+    super.delegatedTransition,
   }) : _pageBuilder = pageBuilder,
        _barrierDismissible = barrierDismissible,
        _barrierLabel = barrierLabel,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2496,7 +2496,6 @@ mixin FlexibleTransitionRouteMixin<T> on TransitionRoute<T> {
   @override
   void didChangeNext(Route<dynamic>? nextRoute) {
     if (nextRoute is FlexibleTransitionRouteMixin<T> && canTransitionTo(nextRoute) && navigator != null) {
-      debugPrint('Ping the navigator state');
       navigator!.delegateTransitionBuilder = nextRoute.delegatedTransition;
     }
     super.didChangeNext(nextRoute);

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1132,7 +1132,6 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     super.settings,
     this.filter,
     this.traversalEdgeBehavior,
-    this.delegatedTransition,
   });
 
   /// The filter to add to the barrier.
@@ -1463,9 +1462,6 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   ///  * [ModalBarrier], the widget that implements this feature.
   /// {@endtemplate}
   bool get barrierDismissible;
-
-  /// The delegated transition provided to the previous route.
-  final DelegatedTransitionBuilder? delegatedTransition;
 
   /// Whether the semantics of the modal barrier are included in the
   /// semantics tree.
@@ -2082,7 +2078,6 @@ abstract class PopupRoute<T> extends ModalRoute<T> {
     super.settings,
     super.filter,
     super.traversalEdgeBehavior,
-    super.delegatedTransition,
   });
 
   @override
@@ -2284,7 +2279,6 @@ class RawDialogRoute<T> extends PopupRoute<T> {
     super.settings,
     this.anchorPoint,
     super.traversalEdgeBehavior,
-    super.delegatedTransition,
   }) : _pageBuilder = pageBuilder,
        _barrierDismissible = barrierDismissible,
        _barrierLabel = barrierLabel,
@@ -2491,4 +2485,11 @@ abstract class PopEntry<T> {
   String toString() {
     return 'PopEntry canPop: ${canPopNotifier.value}, onPopInvoked: $onPopInvokedWithResult';
   }
+}
+
+/// Mixin for a route that can provide a delegated secondary transition to the
+/// outgoing route.
+abstract mixin class FlexibleTransitionRouteMixin<T> {
+  /// The delegated transition provided to the previous route.
+  late DelegatedTransitionBuilder? delegatedTransition;
 }

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'basic.dart';
 import 'container.dart';
 import 'framework.dart';
+import 'navigator.dart';
 import 'text.dart';
 
 export 'package:flutter/rendering.dart' show RelativeRect;
@@ -136,6 +137,32 @@ class _AnimatedState extends State<AnimatedWidget> {
 
   @override
   Widget build(BuildContext context) => widget.build(context);
+}
+
+/// Delegates to transition from navigator if available, or returns default.
+class DelegatedTransition extends AnimatedBuilder {
+
+  /// Creates a DelegatedTransiton
+  const DelegatedTransition({
+    super.key,
+    super.child,
+    required super.animation,
+    required super.builder,
+    required this.context,
+  });
+
+  /// context
+  final BuildContext context;
+
+  @override
+  Widget build(BuildContext context) {
+    final NavigatorState navigatorState = Navigator.of(context);
+    final Widget Function(BuildContext context, Widget? child, Animation<double> animation)? delegateTransitionBuilder = navigatorState.delegateTransitionBuilder;
+    if (delegateTransitionBuilder == null) {
+      return builder(context, child);
+    }
+    return delegateTransitionBuilder(context, child, animation as Animation<double>);
+  }
 }
 
 /// Animates the position of a widget relative to its normal position.

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -157,7 +157,7 @@ class DelegatedTransition extends AnimatedBuilder {
   @override
   Widget build(BuildContext context) {
     final NavigatorState navigatorState = Navigator.of(context);
-    final Widget Function(BuildContext context, Widget? child, Animation<double> animation)? delegateTransitionBuilder = navigatorState.delegateTransitionBuilder;
+    final DelegatedTransitionBuilder? delegateTransitionBuilder = navigatorState.delegateTransitionBuilder;
     if (delegateTransitionBuilder == null) {
       return builder(context, child);
     }


### PR DESCRIPTION
Adds logic that allows an incoming route to inform the existing route of the transition animation it should play.

This is a proof of concept, and is limited in functionality.

Before:

https://github.com/flutter/flutter/assets/58190796/48402740-29f0-41cd-9314-dd0680baff9c

After:

https://github.com/flutter/flutter/assets/58190796/3d8b204e-6a0e-4882-b248-a3b142d5fb88

Update:

Made some changes to passing the delegate animation when pushing and popping a route. Added a placeholder example that uses a nested navigator to get a rough approximation of an iOS bottom sheet animation. It looks like this

https://github.com/flutter/flutter/assets/58190796/b5959f57-9ec6-49d4-850f-c4c288cc29a5

