### PR TITLE
[devicelab] retain prior events for flutter gallery.

### DIFF
--- a/dev/integration_tests/new_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/new_gallery/test_driver/transitions_perf_test.dart
@@ -354,6 +354,7 @@ void main([List<String> args = const <String>[]]) {
           TimelineStream.dart,
           TimelineStream.embedder,
         ],
+        retainPriorEvents: true,
       );
 
       final TimelineSummary summary = TimelineSummary.summarize(timeline);


### PR DESCRIPTION
Capture first frames in gallery benchmarks


Calling https://github.com/flutter/flutter/issues/143404 fixed, since all the full app benchmarks capture the start now.


Fixes https://github.com/flutter/flutter/issues/143404
