### PR TITLE
Implement `_suspendedNode` fix

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1711,10 +1711,9 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
         _suspendedNode = null;
       }
       else if (_suspendedNode != null) {
-        assert(_focusDebug(() => 'marking node $_suspendedNode to be focused'));
-        _markedForFocus = _suspendedNode;
+        assert(_focusDebug(() => 'requesting focus for $_suspendedNode'));
+        _suspendedNode!.requestFocus();
         _suspendedNode = null;
-        applyFocusChangesIfNeeded();
       }
     } else if (_primaryFocus != rootScope) {
       assert(_focusDebug(() => 'suspending $_primaryFocus'));


### PR DESCRIPTION
Previously we merged #142930, to solve issue #87061.

Since then, I discovered that the keyboard input wasn't being captured after the app had been paused and resumed. After some digging, I realized that the problem was due to [a line in editable_text.dart](https://github.com/flutter/flutter/blob/d4b1b6e744ba6196e14fb49904f07a4aea4d5869/packages/flutter/lib/src/widgets/editable_text.dart#L3589) that called the `focusNode.consumeKeyboardToken()` method.

Luckily, it's a very easy fix: we just use `requestFocus()` instead of `applyFocusChangesIfNeeded()`. @gspencergoog could you take a look when you have a chance?