### PR TITLE
add parsing of assets transformer declarations in pubspec.yaml

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -866,17 +866,9 @@ final class AssetTransformerEntry {
       return (null, <String>['Expected "package" to be a String. Found ${package.runtimeType} instead.']);
     }
 
-    final Object? argsYaml = yaml['args'];
-    late final List<String> args;
-    if (argsYaml != null) {
-      final (List<String>? parsedArgs, List<String> argsErrors) = _parseList(yaml['args'], 'args', 'String');
-
-      if (argsErrors.isNotEmpty) {
-        return (null, argsErrors.map((String e) => 'In args section of transformer using package "$package": $e').toList());
-      }
-      args = parsedArgs!;
-    } else {
-      args = <String>[];
+    final (List<String>? args, List<String> argsErrors) = _parseArgsSection(yaml['args']);
+    if (argsErrors.isNotEmpty) {
+      return (null, argsErrors.map((String e) => 'In args section of transformer using package "$package": $e').toList());
     }
 
     return (
@@ -886,6 +878,13 @@ final class AssetTransformerEntry {
       ),
       <String>[],
     );
+  }
+
+  static (List<String>? args, List<String> errors) _parseArgsSection(Object? yaml) {
+    if (yaml == null) {
+      return (null, <String>[]);
+    }
+    return _parseList(yaml, 'args', 'String');
   }
 
   @override

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -774,7 +774,7 @@ class AssetsEntry {
         return (
           null,
           <String>[
-            'Unable to parse the assets section in the pubspec.yaml file.',
+            'Unable to parse assets section.',
             ...errors
           ].join('\n'),
         );

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -764,7 +764,7 @@ class AssetsEntry {
         '$_flavorKey list of entry "$path"',
         'String',
       );
-      final (List<AssetTransformerEntry>? transformers, List<String> transformersErrors) = parseTransformersSection(yaml[_transformersKey]);
+      final (List<AssetTransformerEntry>? transformers, List<String> transformersErrors) = _parseTransformersSection(yaml[_transformersKey]);
       final List<String> errors = <String>[
         ...flavorsErrors.map((String e) => 'In $_flavorKey section of asset "$path": $e'),
         ...transformersErrors.map((String e) => 'In $_transformersKey section of asset "$path": $e'),
@@ -794,12 +794,8 @@ class AssetsEntry {
       'Expected a string or an object. Got ${yaml.runtimeType} instead.');
   }
 
-  static (List<AssetTransformerEntry>?, List<String> errors)
-      parseTransformersSection(Object? yaml) {
-    if (yaml == null) {
-      return (null, <String>[]);
-    }
-    final (List<YamlMap>? yamlObjects, List<String> listErrors) = _validateList<YamlMap>(
+  static (List<AssetTransformerEntry>?, List<String> errors) _parseTransformersSection(Object? yaml) {
+    final (List<YamlMap>? yamlObjects, List<String> listErrors) = _validateListNullable<YamlMap>(
       yaml,
       '$_transformersKey list',
       'Map',

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -519,7 +519,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
           _validateFonts(yamlValue, errors);
         }
       case 'licenses':
-        final (_, List<String> filesErrors) = _validateList<String>(yamlValue, '"$yamlKey"', 'files');
+        final (_, List<String> filesErrors) = _parseList<String>(yamlValue, '"$yamlKey"', 'files');
         errors.addAll(filesErrors);
       case 'module':
         if (yamlValue is! YamlMap) {
@@ -554,7 +554,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
   }
 }
 
-(List<T>? result, List<String> errors) _validateList<T>(Object? yamlList, String context, String typeAlias) {
+(List<T>? result, List<String> errors) _parseList<T>(Object? yamlList, String context, String typeAlias) {
   final List<String> errors = <String>[];
 
   if (yamlList is! YamlList) {
@@ -572,11 +572,11 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
   return errors.isEmpty ? (List<T>.from(yamlList), <String>[]) : (null, errors);
 }
 
-(List<T>? result, List<String> errors) _validateListNullable<T>(Object? yamlList, String context, String typeAlias) {
+(List<T>? result, List<String> errors) _parseNullableList<T>(Object? yamlList, String context, String typeAlias) {
   if (yamlList == null) {
     return (null, <String>[]);
   }
-  return _validateList<T>(yamlList, context, typeAlias);
+  return _parseList<T>(yamlList, context, typeAlias);
 }
 
 void _validateDeferredComponents(MapEntry<Object?, Object?> kvp, List<String> errors) {
@@ -595,7 +595,7 @@ void _validateDeferredComponents(MapEntry<Object?, Object?> kvp, List<String> er
         errors.add('Expected the $i element in "${kvp.key}" to have required key "name" of type String');
       }
       if (valueMap.containsKey('libraries')) {
-        final (_, List<String> librariesErrors) = _validateList<String>(
+        final (_, List<String> librariesErrors) = _parseList<String>(
           valueMap['libraries'],
           '"libraries" key in the element at index $i of "${kvp.key}"',
           'String',
@@ -759,7 +759,7 @@ class AssetsEntry {
           'containing a "$_pathKey" entry. Got ${path.runtimeType} instead.');
       }
 
-      final (List<String>? flavors, List<String> flavorsErrors) = _validateListNullable<String>(
+      final (List<String>? flavors, List<String> flavorsErrors) = _parseNullableList<String>(
         yaml[_flavorKey],
         '$_flavorKey list of entry "$path"',
         'String',
@@ -798,7 +798,7 @@ class AssetsEntry {
     if (yaml == null) {
       return (null, <String>[]);
     }
-    final (List<YamlMap>? yamlObjects, List<String> listErrors) = _validateList<YamlMap>(
+    final (List<YamlMap>? yamlObjects, List<String> listErrors) = _parseList<YamlMap>(
       yaml,
       '$_transformersKey list',
       'Map',
@@ -869,7 +869,7 @@ final class AssetTransformerEntry {
       return (null, <String>['Expected "package" to be a String. Found ${package.runtimeType} instead.']);
     }
 
-    final (List<String>? args, List<String> argsErrors) = _validateListNullable(yaml['args'], 'args', 'String');
+    final (List<String>? args, List<String> argsErrors) = _parseNullableList(yaml['args'], 'args', 'String');
 
     if (argsErrors.isNotEmpty) {
       return (null, argsErrors.map((String e) => 'In args section of transformer $package: $e').toList());

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -761,7 +761,7 @@ class AssetsEntry {
 
       final (List<String>? flavors, List<String> flavorsErrors) = _parseNullableList<String>(
         yaml[_flavorKey],
-        '$_flavorKey list of entry "$path"',
+        _flavorKey,
         'String',
       );
       final (List<AssetTransformerEntry>? transformers, List<String> transformersErrors) = _parseTransformersSection(yaml[_transformersKey]);

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -795,7 +795,10 @@ class AssetsEntry {
   }
 
   static (List<AssetTransformerEntry>?, List<String> errors) _parseTransformersSection(Object? yaml) {
-    final (List<YamlMap>? yamlObjects, List<String> listErrors) = _validateListNullable<YamlMap>(
+    if (yaml == null) {
+      return (null, <String>[]);
+    }
+    final (List<YamlMap>? yamlObjects, List<String> listErrors) = _validateList<YamlMap>(
       yaml,
       '$_transformersKey list',
       'Map',

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -872,7 +872,7 @@ final class AssetTransformerEntry {
     final (List<String>? args, List<String> argsErrors) = _parseNullableList(yaml['args'], 'args', 'String');
 
     if (argsErrors.isNotEmpty) {
-      return (null, argsErrors.map((String e) => 'In args section of transformer $package: $e').toList());
+      return (null, argsErrors.map((String e) => 'In args section of transformer using package "$package": $e').toList());
     }
 
     return (

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -156,8 +156,7 @@ flutter:
       expect(logger.errorText, contains(
         'Unable to parse assets section.\n'
         'In flavors section of asset "assets/vanilla/": Expected flavors '
-        'list of entry "assets/vanilla/" to be a list of String, but element '
-        'at index 0 was a YamlMap.\n'
+        'to be a list of String, but element at index 0 was a YamlMap.\n'
       ));
     });
   });

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -154,8 +154,10 @@ flutter:
 ''';
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(logger.errorText, contains(
-        'Asset manifest entry is malformed. '
-        'Expected "flavors" entry to be a list of strings.',
+        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'In flavors section of asset "assets/vanilla/": Expected flavors '
+        'list of entry "assets/vanilla/" to be a list of String, but element '
+        'at index 0 was a YamlMap.\n'
       ));
     });
   });

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -154,7 +154,7 @@ flutter:
 ''';
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(logger.errorText, contains(
-        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'Unable to parse assets section.\n'
         'In flavors section of asset "assets/vanilla/": Expected flavors '
         'list of entry "assets/vanilla/" to be a list of String, but element '
         'at index 0 was a YamlMap.\n'

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_transformers_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_transformers_test.dart
@@ -85,7 +85,7 @@ flutter:
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(
         logger.errorText,
-        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'Unable to parse assets section.\n'
         'In transformers section of asset "asset/hello.txt": Expected '
         'transformers list to be a list of Map, but element at index 0 was a String.\n',
       );
@@ -109,7 +109,7 @@ flutter:
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(
         logger.errorText,
-        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'Unable to parse assets section.\n'
         'In transformers section of asset "asset/hello.txt": '
         'Expected "package" to be a String. Found YamlMap instead.\n',
       );
@@ -132,7 +132,7 @@ flutter:
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(
         logger.errorText,
-        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'Unable to parse assets section.\n'
         'In transformers section of asset "asset/hello.txt": Expected "package" to be a '
         'String. Found Null instead.\n',
       );
@@ -156,7 +156,7 @@ flutter:
       FlutterManifest.createFromString(manifest, logger: logger);
       expect(
         logger.errorText,
-        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'Unable to parse assets section.\n'
         'In transformers section of asset "asset/hello.txt": In args section '
         'of transformer my_transformer: Expected args to be a list of String, '
         'but got hello (String).\n',

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_transformers_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_transformers_test.dart
@@ -158,8 +158,8 @@ flutter:
         logger.errorText,
         'Unable to parse assets section.\n'
         'In transformers section of asset "asset/hello.txt": In args section '
-        'of transformer my_transformer: Expected args to be a list of String, '
-        'but got hello (String).\n',
+        'of transformer using package "my_transformer": Expected args to be a '
+        'list of String, but got hello (String).\n',
       );
     });
   });

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_transformers_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_transformers_test.dart
@@ -1,0 +1,166 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
+
+import '../src/common.dart';
+
+void main() {
+  group('parsing of assets section in flutter manifests with asset transformers', () {
+    testWithoutContext('parses an asset with a simple transformation', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: asset/hello.txt
+      transformers:
+        - package: my_package
+  ''';
+      final FlutterManifest? parsedManifest = FlutterManifest.createFromString(manifest, logger: logger);
+
+      expect(parsedManifest!.assets, <AssetsEntry>[
+        AssetsEntry(
+          uri: Uri.parse('asset/hello.txt'),
+          transformers: const <AssetTransformerEntry>[
+            AssetTransformerEntry(package: 'my_package', args: <String>[])
+          ],
+        ),
+      ]);
+
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('parses an asset with a transformation that has args', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: asset/hello.txt
+      transformers:
+        - package: my_package
+          args: ["-e", "--color", "purple"]
+''';
+      final FlutterManifest? parsedManifest = FlutterManifest.createFromString(manifest, logger: logger);
+
+      expect(parsedManifest!.assets, <AssetsEntry>[
+        AssetsEntry(
+          uri: Uri.parse('asset/hello.txt'),
+          transformers: const <AssetTransformerEntry>[
+            AssetTransformerEntry(
+              package: 'my_package',
+              args: <String>['-e', '--color', 'purple'],
+            )
+          ],
+        ),
+      ]);
+      expect(logger.errorText, isEmpty);
+    });
+
+    testWithoutContext('fails when a transformers section is not a list', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: asset/hello.txt
+      transformers:
+        - my_transformer
+  ''';
+      FlutterManifest.createFromString(manifest, logger: logger);
+      expect(
+        logger.errorText,
+        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'In transformers section of asset "asset/hello.txt": Expected '
+        'transformers list to be a list of Map, but element at index 0 was a String.\n',
+      );
+    });
+    testWithoutContext('fails when a transformers section package is not a string', () async {
+      final BufferLogger logger = BufferLogger.test();
+
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: asset/hello.txt
+      transformers:
+        - package:
+            i am a key: i am a value
+  ''';
+      FlutterManifest.createFromString(manifest, logger: logger);
+      expect(
+        logger.errorText,
+        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'In transformers section of asset "asset/hello.txt": '
+        'Expected "package" to be a String. Found YamlMap instead.\n',
+      );
+    });
+
+    testWithoutContext('fails when a transformer is missing the package field', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: asset/hello.txt
+      transformers:
+        - args: ["-e"]
+    ''';
+      FlutterManifest.createFromString(manifest, logger: logger);
+      expect(
+        logger.errorText,
+        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'In transformers section of asset "asset/hello.txt": Expected "package" to be a '
+        'String. Found Null instead.\n',
+      );
+    });
+
+    testWithoutContext('fails when a transformer has args field that is not a list of strings', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String manifest = '''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  uses-material-design: true
+  assets:
+    - path: asset/hello.txt
+      transformers:
+        - package: my_transformer
+          args: hello
+    ''';
+      FlutterManifest.createFromString(manifest, logger: logger);
+      expect(
+        logger.errorText,
+        'Unable to parse the assets section in the pubspec.yaml file.\n'
+        'In transformers section of asset "asset/hello.txt": In args section '
+        'of transformer my_transformer: Expected args to be a list of String, '
+        'but got hello (String).\n',
+      );
+    });
+  });
+}


### PR DESCRIPTION
In service of https://github.com/flutter/flutter/issues/143348.

This PR enables parsing of the pubspec yaml schemes for assets with transformations as described in #143348.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
