### PR TITLE
Ignore implementation_imports in non-lib files

### DIFF
--- a/dev/bots/prepare_package/archive_publisher.dart
+++ b/dev/bots/prepare_package/archive_publisher.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+// ignore: implementation_imports
 import 'package:crypto/src/digest_sink.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as path;

--- a/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
+++ b/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore: implementation_imports
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_driver/src/common/find.dart';
+// ignore: implementation_imports
 import 'package:flutter_test/src/finders.dart';
 
 import 'stub_finder.dart';

--- a/packages/flutter_driver/test/src/web_tests/web_driver_test.dart
+++ b/packages/flutter_driver/test/src/web_tests/web_driver_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_driver/src/common/error.dart';
 import 'package:flutter_driver/src/common/health.dart';
 import 'package:flutter_driver/src/driver/web_driver.dart';
+// ignore: implementation_imports
 import 'package:webdriver/src/common/log.dart';
 
 import '../../common.dart';

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matcher/expect.dart' as matcher;
+// ignore: implementation_imports
 import 'package:matcher/src/expect/async_matcher.dart';
 
 import 'multi_view_testing.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:file/memory.dart';
+// ignore: implementation_imports
 import 'package:file/src/interface/file.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert' show jsonEncode;
 import 'dart:io' show Directory, File;
 
+// ignore: implementation_imports
 import 'package:coverage/src/hitmap.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart' show FileSystem;

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+// ignore: implementation_imports
 import 'package:file/src/interface/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/net.dart';

--- a/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore: implementation_imports
 import 'package:file/src/interface/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -30,6 +30,7 @@ import 'package:flutter_tools/src/run_cold.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
+// ignore: implementation_imports
 import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -27,6 +27,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:test/fake.dart';
+// ignore: implementation_imports
 import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+// ignore: implementation_imports
 import 'package:dds/src/dap/logging.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/debug_adapters/server.dart';

--- a/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore: implementation_imports
 import 'package:file/src/interface/file.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/io.dart';

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -17,6 +17,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:test/test.dart' as test_package show test;
 import 'package:test/test.dart' hide test;
+// ignore: implementation_imports
 import 'package:unified_analytics/src/enums.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/59384

There are libraries outside a `lib/` directory, which violate `implementation_imports`. This PR ignores all such violations.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
