### PR TITLE
[flutter_test] Use defaultTargetPlatform for key events simulation

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -22,8 +22,6 @@ import 'window.dart';
 /// This value must be greater than [kTouchSlop].
 const double kDragSlopDefault = 20.0;
 
-const String _defaultPlatform = kIsWeb ? 'web' : 'android';
-
 // Finds the end index (exclusive) of the span at `startIndex`, or `endIndex` if
 // there are no other spans between `startIndex` and `endIndex`.
 // The InlineSpan protocol doesn't expose the length of the span so we'll
@@ -1957,8 +1955,8 @@ abstract class WidgetController {
   ///
   /// Specify `platform` as one of the platforms allowed in
   /// [platform.Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. Defaults to "web" on web, and "android" everywhere
-  /// else.
+  /// that type of system. If not specified, defaults to "web" on web, and the
+  /// operating system name based on [defaultTargetPlatform] everywhere else.
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -1982,7 +1980,7 @@ abstract class WidgetController {
   ///  - [sendKeyUpEvent] to simulate only a key up event.
   Future<bool> sendKeyEvent(
     LogicalKeyboardKey key, {
-    String platform = _defaultPlatform,
+    String? platform,
     String? character,
     PhysicalKeyboardKey? physicalKey
   }) async {
@@ -1999,8 +1997,8 @@ abstract class WidgetController {
   ///
   /// Specify `platform` as one of the platforms allowed in
   /// [platform.Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. Defaults to "web" on web, and "android" everywhere
-  /// else.
+  /// that type of system. If not specified, defaults to "web" on web, and the
+  /// operating system name based on [defaultTargetPlatform] everywhere else.
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -2021,7 +2019,7 @@ abstract class WidgetController {
   ///  - [sendKeyEvent] to simulate both the key up and key down in the same call.
   Future<bool> sendKeyDownEvent(
     LogicalKeyboardKey key, {
-    String platform = _defaultPlatform,
+    String? platform,
     String? character,
     PhysicalKeyboardKey? physicalKey
   }) async {
@@ -2036,8 +2034,8 @@ abstract class WidgetController {
   ///
   /// Specify `platform` as one of the platforms allowed in
   /// [platform.Platform.operatingSystem] to make the event appear to be from
-  /// that type of system. Defaults to "web" on web, and "android" everywhere
-  /// else. May not be null.
+  /// that type of system. If not specified, defaults to "web" on web, and the
+  /// operating system name based on [defaultTargetPlatform] everywhere else.
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -2052,7 +2050,7 @@ abstract class WidgetController {
   ///  - [sendKeyEvent] to simulate both the key up and key down in the same call.
   Future<bool> sendKeyUpEvent(
       LogicalKeyboardKey key, {
-        String platform = _defaultPlatform,
+        String? platform,
         PhysicalKeyboardKey? physicalKey
       }) async {
     // Internally wrapped in async guard.
@@ -2065,9 +2063,9 @@ abstract class WidgetController {
   /// from a soft keyboard.
   ///
   /// Specify `platform` as one of the platforms allowed in
-  /// [platform.Platform.operatingSystem] to make the event appear to be from that type
-  /// of system. Defaults to "web" on web, and "android" everywhere else. Must not be
-  /// null.
+  /// [platform.Platform.operatingSystem] to make the event appear to be from
+  /// that type of system. If not specified, defaults to "web" on web, and the
+  /// operating system name based on [defaultTargetPlatform] everywhere else.
   ///
   /// Specify the `physicalKey` for the event to override what is included in
   /// the simulated event. If not specified, it uses a default from the US
@@ -2088,7 +2086,7 @@ abstract class WidgetController {
   ///  - [sendKeyEvent] to simulate both the key up and key down in the same call.
   Future<bool> sendKeyRepeatEvent(
       LogicalKeyboardKey key, {
-        String platform = _defaultPlatform,
+        String? platform,
         String? character,
         PhysicalKeyboardKey? physicalKey
       }) async {

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -711,7 +711,7 @@ abstract final class KeyEventSimulator {
   @visibleForTesting
   static KeyDataTransitMode get transitMode => _transitMode;
 
-  static String get _defaultPlatform => kIsWeb ? 'web' : Platform.operatingSystem;
+  static String get _defaultPlatform => kIsWeb ? 'web' : defaultTargetPlatform.name.toLowerCase();
 
   /// Simulates sending a hardware key down event.
   ///
@@ -720,7 +720,8 @@ abstract final class KeyEventSimulator {
   ///
   /// Specify `platform` as one of the platforms allowed in
   /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to the operating system that the test is running on.
+  /// system. Defaults to "web" on web, and the operating system name based on
+  /// [defaultTargetPlatform] everywhere else.
   ///
   /// Keys that are down when the test completes are cleared after each test.
   ///
@@ -767,7 +768,8 @@ abstract final class KeyEventSimulator {
   ///
   /// Specify `platform` as one of the platforms allowed in
   /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to the operating system that the test is running on.
+  /// system. Defaults to "web" on web, and the operating system name based on
+  /// [defaultTargetPlatform] everywhere else.
   ///
   /// Returns true if the key event was handled by the framework.
   ///
@@ -811,7 +813,8 @@ abstract final class KeyEventSimulator {
   ///
   /// Specify `platform` as one of the platforms allowed in
   /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to the operating system that the test is running on.
+  /// system. Defaults to "web" on web, and the operating system name based on
+  /// [defaultTargetPlatform] everywhere else.
   ///
   /// Returns true if the key event was handled by the framework.
   ///
@@ -860,7 +863,8 @@ abstract final class KeyEventSimulator {
 ///
 /// Specify `platform` as one of the platforms allowed in
 /// [Platform.operatingSystem] to make the event appear to be from that type of
-/// system. Defaults to the operating system that the test is running on.
+/// system. Defaults to "web" on web, and the operating system name based on
+/// [defaultTargetPlatform] everywhere else.
 ///
 /// Keys that are down when the test completes are cleared after each test.
 ///
@@ -894,7 +898,8 @@ Future<bool> simulateKeyDownEvent(
 ///
 /// Specify `platform` as one of the platforms allowed in
 /// [Platform.operatingSystem] to make the event appear to be from that type of
-/// system. Defaults to the operating system that the test is running on.
+/// system. Defaults to "web" on web, and the operating system name based on
+/// [defaultTargetPlatform] everywhere else.
 ///
 /// Returns true if the key event was handled by the framework.
 ///
@@ -922,7 +927,8 @@ Future<bool> simulateKeyUpEvent(
 ///
 /// Specify `platform` as one of the platforms allowed in
 /// [Platform.operatingSystem] to make the event appear to be from that type of
-/// system. Defaults to the operating system that the test is running on.
+/// system. Defaults to "web" on web, and the operating system name based on
+/// [defaultTargetPlatform] everywhere else.
 ///
 /// Returns true if the key event was handled by the framework.
 ///


### PR DESCRIPTION
## Description

This PRs changes the default value for the `platform` parameter used to simulate key events.

With this PR, the default value is "web" on web, otherwise it is the operating system name retrieved from `defaultTargetPlatform`.

Previously, for methods in `WidgetController`, it defaulted to “web” on web, and “android” everywhere else. And for methods in `KeyEventSimulator` it defaulted to “web” on web, and the operating system that the test was running on everywhere else. Because the operating system was based on `Platform.operatingSystem`, it usually differed from the target platform the test was running on.

AFAIK, the `platform` parameter is only meaningful for simulating `RawKeyEvent`. Once `RawKeyboard` will be fully removed, the `platform` parameter won’t be needed. 
@gspencergoog  In the meantime, do you think it is worth merging this fix?

## Related Issue

Fixes https://github.com/flutter/flutter/issues/133955

## Tests

Adds one test.

