### PR TITLE
Fix implementation imports outside of lib

### DIFF
--- a/dev/bots/prepare_package/archive_publisher.dart
+++ b/dev/bots/prepare_package/archive_publisher.dart
@@ -4,8 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
-import 'package:crypto/src/digest_sink.dart';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as path;
 import 'package:platform/platform.dart' show LocalPlatform, Platform;
@@ -49,7 +49,7 @@ class ArchivePublisher {
   static String getMetadataFilename(Platform platform) => 'releases_${platform.operatingSystem.toLowerCase()}.json';
 
   Future<String> _getChecksum(File archiveFile) async {
-    final DigestSink digestSink = DigestSink();
+    final AccumulatorSink<Digest> digestSink = AccumulatorSink<Digest>();
     final ByteConversionSink sink = sha256.startChunkedConversion(digestSink);
 
     final Stream<List<int>> stream = archiveFile.openRead();
@@ -57,7 +57,7 @@ class ArchivePublisher {
       sink.add(chunk);
     });
     sink.close();
-    return digestSink.value.toString();
+    return digestSink.events.single.toString();
   }
 
   /// Publish the archive to Google Storage.

--- a/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
+++ b/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_driver/src/common/find.dart';
-import 'package:flutter_test/src/finders.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'stub_finder.dart';
 

--- a/packages/flutter_driver/test/src/web_tests/web_driver_test.dart
+++ b/packages/flutter_driver/test/src/web_tests/web_driver_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter_driver/src/common/error.dart';
 import 'package:flutter_driver/src/common/health.dart';
 import 'package:flutter_driver/src/driver/web_driver.dart';
-import 'package:webdriver/src/common/log.dart';
+import 'package:webdriver/async_io.dart';
 
 import '../../common.dart';
 

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matcher/expect.dart' as matcher;
-import 'package:matcher/src/expect/async_matcher.dart';
+import 'package:matcher/src/expect/async_matcher.dart'; // ignore: implementation_imports
 
 import 'multi_view_testing.dart';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -7,8 +7,8 @@ import 'dart:io' as io;
 import 'dart:typed_data';
 
 import 'package:fake_async/fake_async.dart';
+import 'package:file/file.dart';
 import 'package:file/memory.dart';
-import 'package:file/src/interface/file.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/application_package.dart';

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -5,7 +5,7 @@
 import 'dart:convert' show jsonEncode;
 import 'dart:io' show Directory, File;
 
-import 'package:coverage/src/hitmap.dart';
+import 'package:coverage/coverage.dart' show HitMap;
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart' show FileSystem;
 import 'package:flutter_tools/src/test/coverage_collector.dart';

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:file/src/interface/file_system.dart';
+import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/base/process.dart';

--- a/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:file/src/interface/file_system.dart';
+import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/isolated/native_assets/native_assets.dart';
 import 'package:flutter_tools/src/resident_runner.dart';

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -30,7 +30,7 @@ import 'package:flutter_tools/src/run_cold.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
-import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/enums.dart' show DashEvent; // ignore: implementation_imports
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -30,6 +30,7 @@ import 'package:flutter_tools/src/run_cold.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
+// TODO(goderbauer): Fix this ignore when https://github.com/dart-lang/tools/issues/234 is resolved.
 import 'package:unified_analytics/src/enums.dart' show DashEvent; // ignore: implementation_imports
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -27,7 +27,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:test/fake.dart';
-import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/enums.dart' show DashEvent; // ignore: implementation_imports
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -27,6 +27,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:test/fake.dart';
+// TODO(goderbauer): Fix this ignore when https://github.com/dart-lang/tools/issues/234 is resolved.
 import 'package:unified_analytics/src/enums.dart' show DashEvent; // ignore: implementation_imports
 import 'package:unified_analytics/unified_analytics.dart';
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dds/src/dap/logging.dart';
+import 'package:dds/dap.dart' show Logger;
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/debug_adapters/server.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;

--- a/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:file/src/interface/file.dart';
+import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/io.dart';
 

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -17,6 +17,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:test/test.dart' as test_package show test;
 import 'package:test/test.dart' hide test;
+// TODO(goderbauer): Fix this ignore when https://github.com/dart-lang/tools/issues/234 is resolved.
 import 'package:unified_analytics/src/enums.dart' show DevicePlatform; // ignore: implementation_imports
 import 'package:unified_analytics/unified_analytics.dart';
 

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -17,7 +17,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:test/test.dart' as test_package show test;
 import 'package:test/test.dart' hide test;
-import 'package:unified_analytics/src/enums.dart';
+import 'package:unified_analytics/src/enums.dart' show DevicePlatform; // ignore: implementation_imports
 import 'package:unified_analytics/unified_analytics.dart';
 
 import 'fakes.dart';


### PR DESCRIPTION
Work towards https://github.com/dart-lang/sdk/issues/59384

There are libraries outside a `lib/` directory, which violate `implementation_imports`.

Supersedes https://github.com/flutter/flutter/pull/143560.