### PR TITLE
Try moving our api34 FTL test from physical to virtual

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -515,7 +515,6 @@ targets:
       task_name: abstract_method_smoke_test
       physical_devices: >-
         [
-          "--device", "model=shiba,version=34",
           "--device", "model=panther,version=33",
           "--device", "model=redfin,version=30"
         ]
@@ -530,7 +529,8 @@ targets:
           "--device", "model=Nexus6P,version=25",
           "--device", "model=Nexus6P,version=26",
           "--device", "model=Nexus6P,version=27",
-          "--device", "model=NexusLowRes,version=29"
+          "--device", "model=NexusLowRes,version=29",
+          "--device", "model=MediumPhone.arm,version=34"
         ]
 
   - name: Linux firebase_android_embedding_v2_smoke_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -501,7 +501,7 @@ targets:
       - .ci.yaml
 
   - name: Linux firebase_abstract_method_smoke_test
-    presubmit: false
+    presubmit: true
     recipe: firebaselab/firebaselab
     timeout: 60
     properties:
@@ -534,6 +534,7 @@ targets:
         ]
 
   - name: Linux firebase_android_embedding_v2_smoke_test
+    presubmit: true
     recipe: firebaselab/firebaselab
     timeout: 60
     properties:
@@ -547,7 +548,6 @@ targets:
       task_name: android_embedding_v2_smoke_test
       physical_devices: >-
         [
-          "--device", "model=shiba,version=34",
           "--device", "model=redfin,version=30",
           "--device", "model=griffin,version=24"
         ]
@@ -561,10 +561,12 @@ targets:
           "--device", "model=Nexus6P,version=25",
           "--device", "model=Nexus6P,version=26",
           "--device", "model=Nexus6P,version=27",
-          "--device", "model=NexusLowRes,version=29"
+          "--device", "model=NexusLowRes,version=29",
+          "--device", "model=MediumPhone.arm,version=34"
         ]
 
   - name: Linux firebase_release_smoke_test
+    presubmit: true
     recipe: firebaselab/firebaselab
     timeout: 60
     properties:
@@ -578,7 +580,6 @@ targets:
       task_name: release_smoke_test
       physical_devices: >-
         [
-          "--device", "model=shiba,version=34",
           "--device", "model=redfin,version=30",
           "--device", "model=griffin,version=24"
         ]
@@ -592,7 +593,8 @@ targets:
           "--device", "model=Nexus6P,version=25",
           "--device", "model=Nexus6P,version=26",
           "--device", "model=Nexus6P,version=27",
-          "--device", "model=NexusLowRes,version=29"
+          "--device", "model=NexusLowRes,version=29",
+          "--device", "model=MediumPhone.arm,version=34"
         ]
 
   - name: Linux flutter_packaging_test


### PR DESCRIPTION
If this fails, then either firebase is having problems with all api 34 testing (physical+virtual) (unlikely), or the failure is caused by an engine roll.

If this passes then the issue is with api 34 physical devices (either infra or this is actually device specific)

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
