### PR TITLE
Add an override annotation to the lineTerminator setter in the MemoryStdout fake class

### DIFF
--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -196,6 +196,8 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
   @override
   // ignore: override_on_non_overriding_member
   String get lineTerminator => '\n';
+  @override
+  // ignore: override_on_non_overriding_member
   set lineTerminator(String value) {
     throw UnimplementedError('Setting the line terminator is not supported');
   }


### PR DESCRIPTION
This is required by a new API recently added to Dart.

See https://github.com/flutter/flutter/issues/143614