### PR TITLE
Update Scrollbar widget to use CupertinoScrollbar on macOS

### DIFF
--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -27,8 +27,8 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 ///
 /// {@macro flutter.widgets.Scrollbar}
 ///
-/// Dynamically changes to a [CupertinoScrollbar], an iOS style scrollbar, by
-/// default on the iOS platform.
+/// Dynamically changes to a [CupertinoScrollbar], an Cupertino style scrollbar, by
+/// default on the iOS and macOS platforms.
 ///
 /// The color of the Scrollbar thumb will change when [MaterialState.dragged],
 /// or [MaterialState.hovered] on desktop and web platforms. These stateful
@@ -66,7 +66,7 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 ///  * [RawScrollbar], a basic scrollbar that fades in and out, extended
 ///    by this class to add more animations and behaviors.
 ///  * [ScrollbarTheme], which configures the Scrollbar's appearance.
-///  * [CupertinoScrollbar], an iOS style scrollbar.
+///  * [CupertinoScrollbar], an Cupertino style scrollbar.
 ///  * [ListView], which displays a linear, scrollable list of children.
 ///  * [GridView], which displays a 2 dimensional, scrollable array of children.
 class Scrollbar extends StatelessWidget {
@@ -173,7 +173,9 @@ class Scrollbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (Theme.of(context).platform == TargetPlatform.iOS) {
+    final bool isAppleOS = Theme.of(context).platform == TargetPlatform.iOS ||
+         Theme.of(context).platform == TargetPlatform.macOS;
+    if (isAppleOS) {
       return CupertinoScrollbar(
         thumbVisibility: thumbVisibility ?? false,
         thickness: thickness ?? CupertinoScrollbar.defaultThickness,

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1360,7 +1360,7 @@ void main() {
     expect(scrollbar.controller, isNotNull);
 
     controller.dispose();
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   testWidgets("Scrollbar doesn't show when scroll the inner scrollable widget", (WidgetTester tester) async {
     final GlobalKey key1 = GlobalKey();


### PR DESCRIPTION
*Update Scrollbar widget to use CupertinoScrollbar on macOS*

* Fix #138447

If we are using the CupertinoScrollbar by default on **iOS** then it's a good idea to use it also on **macOS** since both use the Cupertino theme system designed by Apple

[Previous PR](https://github.com/flutter/flutter/pull/138189)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
