### PR TITLE
Add scroll lock when using trackpad on web

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1760,6 +1760,7 @@ mixin _CopyPointerScrollEvent on PointerEvent {
     double? tilt,
     bool? synthesized,
     int? embedderId,
+    Offset? scrollDelta,
   }) {
     return PointerScrollEvent(
       viewId: viewId ?? this.viewId,
@@ -1767,7 +1768,7 @@ mixin _CopyPointerScrollEvent on PointerEvent {
       kind: kind ?? this.kind,
       device: device ?? this.device,
       position: position ?? this.position,
-      scrollDelta: scrollDelta,
+      scrollDelta: scrollDelta ?? this.scrollDelta,
       embedderId: embedderId ?? this.embedderId,
     ).transformed(transform);
   }

--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -66,7 +66,7 @@ class PointerSignalResolver {
         eventTimestamp - (_lastWheelEventTimestamp ?? Duration.zero);
 
     // print(
-    //   'Diff: ${diff.inMilliseconds}; event: ${event.timeStamp}; lastEvent: ${_lastWheelEvent?.timeStamp}',
+    //   'Diff: ${diff.inMilliseconds}; event: ${eventTimestamp}; lastEvent: ${_lastWheelEventTimestamp}',
     // );
     if (diff.inMilliseconds < 100 && _trackpadLastScrollOffset != null) {
       return _trackpadLastScrollOffset!.dx.abs() >
@@ -81,7 +81,7 @@ class PointerSignalResolver {
         eventTimestamp - (_lastWheelEventTimestamp ?? Duration.zero);
 
     // print(
-    //   'Diff: ${diff.inMilliseconds}; event: ${event.timeStamp}; lastEvent: ${_lastWheelEvent?.timeStamp}',
+    //   'Diff: ${diff.inMilliseconds}; event: ${eventTimestamp}; lastEvent: ${_lastWheelEventTimestamp}',
     // );
     if (diff.inMilliseconds < 100 && _trackpadLastScrollOffset != null) {
       return _trackpadLastScrollOffset!.dx.abs() <
@@ -132,7 +132,9 @@ class PointerSignalResolver {
     }
     assert(_isSameEvent(_currentEvent!, event));
 
-    if (event is PointerScrollEvent) {
+    print(event.kind);
+    // TODO(Ichordedionysos): Re-enable check for trackpad once the event.kind is properly exposing trackpad usage.
+    if (event is PointerScrollEvent /*&& event.kind == PointerDeviceKind.trackpad*/) {
       final Duration eventTimestamp = event.timeStamp;
       final Offset eventOffset = event.scrollDelta;
 


### PR DESCRIPTION
_Related PR: https://github.com/flutter/engine/pull/50645 (Depending on where it should be fixed this or the other PR is obsolete)_

-- 

This is an attempt to fix weird scrolling behavior with trackpads on Flutter web.
It's done by looking at the last scroll events and locking the axis to the major axis of the first scroll axis within a series.
The lock resets automatically if no scroll event is received within x amount of time (e.g. 10ms).

Attempts to fix https://github.com/flutter/flutter/issues/143276

Check https://github.com/flutter/flutter/issues/143276#issuecomment-1950566307 for reasons for introducing this change on web and screen recordings before and after.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
