### PR TITLE
Allow `Listenable.merge()` to use any iterable

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -62,10 +62,10 @@ abstract class Listenable {
   /// Return a [Listenable] that triggers when any of the given [Listenable]s
   /// themselves trigger.
   ///
-  /// The list must not be changed after this method has been called. Doing so
-  /// will lead to memory leaks or exceptions.
+  /// [listenables] must not be changed after this method has been called.
+  /// Doing so will lead to memory leaks or exceptions.
   ///
-  /// The list may contain nulls; they are ignored.
+  /// The iterable may contain nulls; they are ignored.
   factory Listenable.merge(Iterable<Listenable?> listenables) = _MergingListenable;
 
   /// Register a closure to be called when the object notifies its listeners.

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -62,7 +62,7 @@ abstract class Listenable {
   /// Return a [Listenable] that triggers when any of the given [Listenable]s
   /// themselves trigger.
   ///
-  /// [listenables] must not be changed after this method has been called.
+  /// Once the factory is called, items must not be added or removed from the iterable.
   /// Doing so will lead to memory leaks or exceptions.
   ///
   /// The iterable may contain nulls; they are ignored.

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -66,7 +66,7 @@ abstract class Listenable {
   /// will lead to memory leaks or exceptions.
   ///
   /// The list may contain nulls; they are ignored.
-  factory Listenable.merge(List<Listenable?> listenables) = _MergingListenable;
+  factory Listenable.merge(Iterable<Listenable?> listenables) = _MergingListenable;
 
   /// Register a closure to be called when the object notifies its listeners.
   void addListener(VoidCallback listener);
@@ -491,7 +491,7 @@ mixin class ChangeNotifier implements Listenable {
 class _MergingListenable extends Listenable {
   _MergingListenable(this._children);
 
-  final List<Listenable?> _children;
+  final Iterable<Listenable?> _children;
 
   @override
   void addListener(VoidCallback listener) {

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -282,7 +282,7 @@ void main() {
     final TestNotifier source3 = TestNotifier();
     final List<String> log = <String>[];
 
-    final Listenable merged = Listenable.merge(<Listenable>{source1, source2});
+    final Listenable merged = Listenable.merge(<Listenable>[source1, source2]);
     void listener1() {
       log.add('listener1');
     }
@@ -311,6 +311,21 @@ void main() {
     source2.notify();
     source3.notify();
     expect(log, <String>['listener1', 'listener2', 'listener1', 'listener2']);
+    log.clear();
+  });
+
+  test('Merging change notifiers supports any iterable', () {
+    final TestNotifier source1 = TestNotifier();
+    final TestNotifier source2 = TestNotifier();
+    final List<String> log = <String>[];
+
+    final Listenable merged = Listenable.merge(<Listenable?>{source1, source2});
+    void listener() => log.add('listener');
+
+    merged.addListener(listener);
+    source1.notify();
+    source2.notify();
+    expect(log, <String>['listener', 'listener']);
     log.clear();
   });
 

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -282,7 +282,7 @@ void main() {
     final TestNotifier source3 = TestNotifier();
     final List<String> log = <String>[];
 
-    final Listenable merged = Listenable.merge(<Listenable>[source1, source2]);
+    final Listenable merged = Listenable.merge(<Listenable>{source1, source2});
     void listener1() {
       log.add('listener1');
     }


### PR DESCRIPTION
This is a very small change that fixes #143664.