### PR TITLE
instead of exiting the tool, print a warning when using --flavor with an incompatible device

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -640,7 +640,11 @@ class RunCommand extends RunCommandBase {
     final bool flavorsSupportedOnEveryDevice = devices!
       .every((Device device) => device.supportsFlavors);
     if (flavor != null && !flavorsSupportedOnEveryDevice) {
-      throwToolExit('--flavor is only supported for Android, macOS, and iOS devices.');
+      globals.printWarning(
+        '--flavor is only supported for Android, macOS, and iOS devices. '
+        'Flavor-related features may not function properly and could '
+        'behave differently in a future release.'
+      );
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -48,11 +48,13 @@ void main() {
   });
 
   group('run', () {
+    late BufferLogger logger;
     late TestDeviceManager testDeviceManager;
     late FileSystem fileSystem;
 
     setUp(() {
-      testDeviceManager = TestDeviceManager(logger: BufferLogger.test());
+      logger = BufferLogger.test();
+      testDeviceManager = TestDeviceManager(logger: logger);
       fileSystem = MemoryFileSystem.test();
     });
 
@@ -65,7 +67,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => BufferLogger.test(),
+      Logger: () => logger,
     });
 
     testUsingContext('does not support --no-sound-null-safety by default', () async {
@@ -89,7 +91,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => BufferLogger.test(),
+      Logger: () => logger,
     });
 
     testUsingContext('supports --no-sound-null-safety with an overridden NonNullSafeBuilds', () async {
@@ -109,7 +111,7 @@ void main() {
     }, overrides: <Type, Generator>{
       DeviceManager: () => testDeviceManager,
       FileSystem: () => fileSystem,
-      Logger: () => BufferLogger.test(),
+      Logger: () => logger,
       NonNullSafeBuilds: () => NonNullSafeBuilds.allowed,
       ProcessManager: () => FakeProcessManager.any(),
     });
@@ -137,7 +139,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => BufferLogger.test(),
+      Logger: () => logger,
     });
 
     testUsingContext('Walks upward looking for a pubspec.yaml and succeeds if found', () async {
@@ -165,7 +167,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => BufferLogger.test(),
+      Logger: () => logger,
     });
 
     testUsingContext('Walks upward looking for a pubspec.yaml and exits if missing', () async {
@@ -185,7 +187,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => BufferLogger.test(),
+      Logger: () => logger,
     });
 
     group('run app', () {
@@ -487,7 +489,7 @@ void main() {
         Cache: () => Cache.test(processManager: FakeProcessManager.any()),
       });
 
-      testUsingContext('fails when --flavor is used with an unsupported target platform', () async {
+      testUsingContext('prints warning when --flavor is used with an unsupported target platform', () async {
         const List<String> runCommand = <String>[
           'run',
           '--no-pub',
@@ -496,24 +498,25 @@ void main() {
           '-d',
           'all',
         ];
-
         // Useful for test readability.
         // ignore: avoid_redundant_argument_values
         final FakeDevice deviceWithoutFlavorSupport = FakeDevice(supportsFlavors: false);
         final FakeDevice deviceWithFlavorSupport = FakeDevice(supportsFlavors: true);
         testDeviceManager.devices = <Device>[deviceWithoutFlavorSupport, deviceWithFlavorSupport];
 
-        await expectLater(
-          () => createTestCommandRunner(RunCommand()).run(runCommand),
-          throwsToolExit(
-            message: '--flavor is only supported for Android, macOS, and iOS devices.',
-          ),
-        );
+        await createTestCommandRunner(TestRunCommandThatOnlyValidates()).run(runCommand);
+
+        expect(logger.warningText, contains(
+          '--flavor is only supported for Android, macOS, and iOS devices. '
+          'Flavor-related features may not function properly and could '
+          'behave differently in a future release.'
+        ));
       }, overrides: <Type, Generator>{
         DeviceManager: () => testDeviceManager,
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
         Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+        Logger: () => logger,
       });
 
       testUsingContext('forwards --uninstall-only to DebuggingOptions', () async {
@@ -678,7 +681,7 @@ void main() {
           ProcessManager: () => FakeProcessManager.any(),
           Usage: () => usage,
           Stdio: () => FakeStdio(),
-          Logger: () => AppRunLogger(parent: BufferLogger.test()),
+          Logger: () => AppRunLogger(parent: logger),
         });
 
         testUsingContext('can disable devtools with --no-devtools', () async {
@@ -706,7 +709,7 @@ void main() {
           ProcessManager: () => FakeProcessManager.any(),
           Usage: () => usage,
           Stdio: () => FakeStdio(),
-          Logger: () => AppRunLogger(parent: BufferLogger.test()),
+          Logger: () => AppRunLogger(parent: logger),
         });
       });
     });
@@ -1015,7 +1018,7 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
-        Logger: () => BufferLogger.test(),
+        Logger: () => logger,
         DeviceManager: () => testDeviceManager,
       });
 
@@ -1036,7 +1039,7 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
-        Logger: () => BufferLogger.test(),
+        Logger: () => logger,
         DeviceManager: () => testDeviceManager,
       });
 
@@ -1060,7 +1063,7 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
-        Logger: () => BufferLogger.test(),
+        Logger: () => logger,
         DeviceManager: () => testDeviceManager,
       });
 
@@ -1080,7 +1083,7 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         ProcessManager: () => FakeProcessManager.any(),
-        Logger: () => BufferLogger.test(),
+        Logger: () => logger,
         DeviceManager: () => testDeviceManager,
       });
     });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/143574 by printing a warning (instead of exiting) when `--flavor` is used with a target platform that doesn't have flavors support.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
