### PR TITLE
Handle FormatException from SkiaGoldClient

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -507,6 +507,13 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
         'SocketException occurred, could not reach Gold. '
           'Switching to FlutterSkippingGoldenFileComparator.',
       );
+    } on FormatException catch (_) {
+      return FlutterSkippingFileComparator(
+        baseDirectory.uri,
+        goldens,
+        'FormatException occurred, could not reach Gold. '
+          'Switching to FlutterSkippingGoldenFileComparator.',
+      );
     }
 
     return FlutterLocalFileComparator(baseDirectory.uri, goldens);

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -1160,6 +1160,16 @@ void main() {
           baseDirectory: fakeDirectory,
         );
         expect(comparator.runtimeType, FlutterSkippingFileComparator);
+
+        fakeSkiaClient.getExpectationForTestThrowable =  const FormatException("Can't reach Gold");
+
+        comparator = await FlutterLocalFileComparator.fromDefaultComparator(
+          platform,
+          goldens: fakeSkiaClient,
+          baseDirectory: fakeDirectory,
+        );
+        expect(comparator.runtimeType, FlutterSkippingFileComparator);
+
         // reset property or it will carry on to other tests
         fakeSkiaClient.getExpectationForTestThrowable = null;
       });


### PR DESCRIPTION
Seen in https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Framework%20Smoke%20Tests/17183/overview closing the engine tree.