### PR TITLE
[flutter_tools] enable wasm compile on beta channel

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -149,7 +149,7 @@ class BuildWebCommand extends BuildSubCommand {
     final List<WebCompilerConfig> compilerConfigs;
     if (boolArg('wasm')) {
       if (!featureFlags.isFlutterWebWasmEnabled) {
-        throwToolExit('Compiling to WebAssembly (wasm) is only available on the master channel.');
+        throwToolExit('Compiling to WebAssembly (wasm) is only available on the beta and master channels.');
       }
       if (stringArg(FlutterOptions.kWebRendererFlag) != argParser.defaultFor(FlutterOptions.kWebRendererFlag)) {
         throwToolExit('"--${FlutterOptions.kWebRendererFlag}" cannot be combined with "--${FlutterOptions.kWebWasmFlag}"');

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -150,6 +150,10 @@ const Feature flutterCustomDevicesFeature = Feature(
 const Feature flutterWebWasm = Feature(
   name: 'WebAssembly compilation from flutter build web',
   environmentOverride: 'FLUTTER_WEB_WASM',
+  beta: FeatureChannelSetting(
+    available: true,
+    enabledByDefault: true,
+  ),
   master: FeatureChannelSetting(
     available: true,
     enabledByDefault: true,

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -83,7 +83,7 @@ void main() {
 
     testWithoutContext('Flutter web wasm only enable on master', () {
       expect(flutterWebWasm.getSettingForChannel('master').enabledByDefault, isTrue);
-      expect(flutterWebWasm.getSettingForChannel('beta').enabledByDefault, isFalse);
+      expect(flutterWebWasm.getSettingForChannel('beta').enabledByDefault, isTrue);
       expect(flutterWebWasm.getSettingForChannel('stable').enabledByDefault, isFalse);
     });
 


### PR DESCRIPTION
Wasm compilation is now available on `master` and `beta` channels.