### PR TITLE
Mention SelectionArea in SelectableText docs

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -151,6 +151,9 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 
 /// A run of selectable text with a single style.
 ///
+/// Consider using [SelectionArea] or [SelectableRegion] instead, which enable
+/// selection on a widget subtree.
+///
 /// The [SelectableText] widget displays a string of text with a single style.
 /// The string might break across multiple lines or might all be displayed on
 /// the same line depending on the layout constraints.
@@ -214,6 +217,8 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 ///
 ///  * [Text], which is the non selectable version of this widget.
 ///  * [TextField], which is the editable version of this widget.
+///  * [SelectionArea], which enables the selection of multiple [Text] widgets
+///    and of other widgets.
 class SelectableText extends StatefulWidget {
   /// Creates a selectable text widget.
   ///

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -152,7 +152,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 /// A run of selectable text with a single style.
 ///
 /// Consider using [SelectionArea] or [SelectableRegion] instead, which enable
-/// selection on a widget subtree.
+/// selection on a widget subtree, including but not limited to [Text] widgets.
 ///
 /// The [SelectableText] widget displays a string of text with a single style.
 /// The string might break across multiple lines or might all be displayed on

--- a/packages/flutter/lib/src/material/selection_area.dart
+++ b/packages/flutter/lib/src/material/selection_area.dart
@@ -35,6 +35,7 @@ import 'theme.dart';
 /// See also:
 ///
 ///  * [SelectableRegion], which provides an overview of the selection system.
+///  * [SelectableText], which enables selection on a single run of text.
 class SelectionArea extends StatefulWidget {
   /// Creates a [SelectionArea].
   ///

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -195,6 +195,7 @@ const double _kSelectableVerticalComparingThreshold = 3.0;
 ///
 ///  * [SelectionArea], which creates a [SelectableRegion] with
 ///    platform-adaptive selection controls.
+///  * [SelectableText], which enables selection on a single run of text.
 ///  * [SelectionHandler], which contains APIs to handle selection events from the
 ///    [SelectableRegion].
 ///  * [Selectable], which provides API to participate in the selection system.


### PR DESCRIPTION
Some users of SelectableText seem to be unaware of SelectionArea/SelectableRegion, and our docs have no references between these very similar widgets. This PR adds references and attempts to nudge users in the direction of SelectionArea/SelectableRegion instead of SelectableText.

@hangyujin @Renzo-Olivares My understanding is that there are a few things that SelectableText can do that SelectableRegion cannot, so for now the plan is to keep it around until it can be totally replaced by SelectableRegion. Is that right? Am I ok to strongly nudge users away from SelectableText?

The main flaw (or feature?) of SelectableText that I'm thinking of is that multiple SelectableTexts show multiple simultaneous selection, which can be seen in [this dartpad](https://dartpad.dev/?id=4238f4fa148727caafd9c7fee5273bd3). Using SelectableText, it's easy to stick two of them somewhere and have this poor experience for your users.

![Screenshot from 2024-02-20 13-48-33](https://github.com/flutter/flutter/assets/389558/576ca585-a7c3-43d9-aa4e-5742c1030e74)


FYI @chunhtai 

Fixes https://github.com/flutter/flutter/issues/119911