### PR TITLE
Disable debug banner to stabilize impeller goldens.

### DIFF
--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2797,6 +2797,7 @@ void main() {
 
   testWidgets('Material2 - SnackBars should be shown above the bottomSheet', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       theme: ThemeData(useMaterial3: false),
       home: const Scaffold(
         bottomSheet: SizedBox(
@@ -3142,6 +3143,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/98205
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: Scaffold(
         body: const Scaffold(),
         floatingActionButton: FloatingActionButton(onPressed: () {}),
@@ -3175,6 +3177,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/98205
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: true),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: Scaffold(
         body: const Scaffold(),
         floatingActionButton: FloatingActionButton(onPressed: () {}),
@@ -3207,6 +3210,7 @@ void main() {
   testWidgets('Floating snackbar can display optional icon', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3239,6 +3243,7 @@ void main() {
   testWidgets('Material2 - Fixed width snackbar can display optional icon', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3266,6 +3271,7 @@ void main() {
   testWidgets('Material3 - Fixed width snackbar can display optional icon', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: true),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3293,6 +3299,7 @@ void main() {
   testWidgets('Material2 - Fixed snackbar can display optional icon without action', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3321,6 +3328,7 @@ void main() {
   testWidgets('Material3 - Fixed snackbar can display optional icon without action', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: true),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3349,6 +3357,7 @@ void main() {
   testWidgets('Material2 - Floating width snackbar can display optional icon without action', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3375,6 +3384,7 @@ void main() {
   testWidgets('Material3 - Floating width snackbar can display optional icon without action', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: true),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3401,6 +3411,7 @@ void main() {
   testWidgets('Material2 - Floating multi-line snackbar with icon is aligned correctly', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3428,6 +3439,7 @@ void main() {
   testWidgets('Material3 - Floating multi-line snackbar with icon is aligned correctly', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: true),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3455,6 +3467,7 @@ void main() {
   testWidgets('Material2 - Floating multi-line snackbar with icon and actionOverflowThreshold=1 is aligned correctly', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: false),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,
@@ -3485,6 +3498,7 @@ void main() {
   testWidgets('Material3 - Floating multi-line snackbar with icon and actionOverflowThreshold=1 is aligned correctly', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(useMaterial3: true),
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       home: const Scaffold(
         bottomSheet: SizedBox(
           width: 200,

--- a/packages/flutter/test/material/value_indicating_slider_test.dart
+++ b/packages/flutter/test/material/value_indicating_slider_test.dart
@@ -405,6 +405,7 @@ Future<void> _buildValueIndicatorStaticSlider(
 }) async {
   await tester.pumpWidget(
     MaterialApp(
+      debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
       theme: ThemeData(useMaterial3: useMaterial3),
       home: Scaffold(
         body: Builder(

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -40,6 +40,7 @@ void main() {
         child: ColorFiltered(
           colorFilter: sepia,
           child: MaterialApp(
+            debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
             title: 'Flutter Demo',
             theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: false),
             home: Scaffold(


### PR DESCRIPTION
Fixes some of https://github.com/flutter/flutter/issues/143616 by disabling the debug banner, which does not appear to be a critical part of the golden.