### PR TITLE
Fix `ExpansionTile` Expanded/Collapsed announcement is interrupted by VoiceOver

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -601,7 +601,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     super.dispose();
   }
 
-  Future<void> _toggleExpansion() async {
+  void _toggleExpansion() {
     final TextDirection textDirection = WidgetsLocalizations.of(context).textDirection;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final String stateHint = _isExpanded ? localizations.expandedHint : localizations.collapsedHint;
@@ -626,11 +626,11 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       // TODO(tahatesser): This is a workaround for VoiceOver interrupting
       // semantic announcements on iOS. https://github.com/flutter/flutter/issues/122101.
-      await Future<void>.delayed(const Duration(seconds: 1), () async {
-        await SemanticsService.announce(stateHint, textDirection);
+      Future<void>.delayed(const Duration(seconds: 1), () {
+        SemanticsService.announce(stateHint, textDirection);
       });
     } else {
-      await SemanticsService.announce(stateHint, textDirection);
+      SemanticsService.announce(stateHint, textDirection);
     }
   }
 

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -572,6 +574,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
 
   bool _isExpanded = false;
   late ExpansionTileController _tileController;
+  Timer? _timer;
 
   @override
   void initState() {
@@ -598,6 +601,8 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   void dispose() {
     _tileController._state = null;
     _animationController.dispose();
+    _timer?.cancel();
+    _timer = null;
     super.dispose();
   }
 
@@ -626,8 +631,11 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       // TODO(tahatesser): This is a workaround for VoiceOver interrupting
       // semantic announcements on iOS. https://github.com/flutter/flutter/issues/122101.
-      Future<void>.delayed(const Duration(seconds: 1), () {
+      _timer?.cancel();
+      _timer = Timer(const Duration(seconds: 1), () {
         SemanticsService.announce(stateHint, textDirection);
+        _timer?.cancel();
+        _timer = null;
       });
     } else {
       SemanticsService.announce(stateHint, textDirection);


### PR DESCRIPTION
fixes [`ExpansionTile` accessibility information doesn't read Expanded/Collapsed (iOS)](https://github.com/flutter/flutter/issues/132264)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        appBar: AppBar(
          title: const Text('ExpansionTile'),
        ),
        body: const ExpansionTile(
          title: Text("Title"),
          children: <Widget>[
            Placeholder(),
          ],
        ),
        floatingActionButton: FloatingActionButton(
          onPressed: () {},
          child: const Icon(Icons.add),
        ),
      ),
    );
  }
}
```

</details>

### Before

https://github.com/flutter/flutter/assets/48603081/542d8392-52dc-4319-92ba-215a7164db49

### After

https://github.com/flutter/flutter/assets/48603081/c9225144-4c12-4e92-bc41-4ff82b370ad7


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
