### PR TITLE
Added filter callback on dropdown menu

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -25,6 +25,12 @@ import 'theme_data.dart';
 // late BuildContext context;
 // late FocusNode myFocusNode;
 
+/// A callback function that returns the list of the items that matches the
+/// current applied filter.
+///
+/// Used by [DropdownMenu.filterCallback].
+typedef FilterCallback<T> = List<DropdownMenuEntry<T>> Function(List<DropdownMenuEntry<T>> entries, String filter);
+
 /// A callback function that returns the index of the item that matches the
 /// current contents of a text field.
 ///
@@ -163,6 +169,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.focusNode,
     this.requestFocusOnTap,
     this.expandedInsets,
+    this.filterCallback,
     this.searchCallback,
     required this.dropdownMenuEntries,
     this.inputFormatters,
@@ -381,6 +388,40 @@ class DropdownMenu<T> extends StatefulWidget {
   ///
   /// Defaults to null.
   final EdgeInsets? expandedInsets;
+
+  /// When [DropdownMenu.enableFilter] is true, this callback is used to
+  /// compute the list of filtered items.
+  ///
+  /// {@tool snippet}
+  ///
+  /// In this example the `filterCallback` returns the items that contains the
+  /// trimmed query.
+  ///
+  /// ```dart
+  /// DropdownMenu<Text>(
+  ///   filterCallback: (List<DropdownMenuEntry<Text>> entries, String filter) {
+  ///     final String trimmedFilter = filter.trim().toLowerCase();
+  ///       if (trimmedFilter.isEmpty) {
+  ///         return entries;
+  ///       }
+  ///
+  ///       return entries
+  ///         .where((DropdownMenuEntry<Text> entry) =>
+  ///           entry.label.toLowerCase().contains(trimmedFilter),
+  ///         )
+  ///         .toList();
+  ///   },
+  ///   dropdownMenuEntries: const <DropdownMenuEntry<Text>>[],
+  /// )
+  /// ```
+  /// {@end-tool}
+  ///
+  /// Defaults to null. If this parameter is null and the
+  /// [DropdownMenu.enableFilter] property is set to true, the default behavior
+  /// will return a filtered list. The filtered list will contain items
+  /// that match the text provided by the input field, with a case-insensitive
+  /// comparison.
+  final FilterCallback<T>? filterCallback;
 
   /// When [DropdownMenu.enableSearch] is true, this callback is used to compute
   /// the index of the search result to be highlighted.
@@ -691,7 +732,11 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     final DropdownMenuThemeData defaults = _DropdownMenuDefaultsM3(context);
 
     if (_enableFilter) {
-      filteredEntries = filter(widget.dropdownMenuEntries, _localTextEditingController!);
+      if (widget.filterCallback != null) {
+        filteredEntries = widget.filterCallback!.call(filteredEntries, _localTextEditingController!.text);
+      } else {
+        filteredEntries = filter(widget.dropdownMenuEntries, _localTextEditingController!);
+      }
     }
 
     if (widget.enableSearch) {

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -173,7 +173,9 @@ class DropdownMenu<T> extends StatefulWidget {
     this.searchCallback,
     required this.dropdownMenuEntries,
     this.inputFormatters,
-  });
+  }) :
+  /// Checks if [enableFilter] is true when [filterCallback] != null
+        assert(filterCallback == null || enableFilter);
 
   /// Determine if the [DropdownMenu] is enabled.
   ///

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -173,8 +173,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.searchCallback,
     required this.dropdownMenuEntries,
     this.inputFormatters,
-  }) :
-        assert(filterCallback == null || enableFilter);
+  }) : assert(filterCallback == null || enableFilter);
 
   /// Determine if the [DropdownMenu] is enabled.
   ///

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -174,7 +174,6 @@ class DropdownMenu<T> extends StatefulWidget {
     required this.dropdownMenuEntries,
     this.inputFormatters,
   }) :
-  /// Checks if [enableFilter] is true when [filterCallback] != null
         assert(filterCallback == null || enableFilter);
 
   /// Determine if the [DropdownMenu] is enabled.
@@ -423,7 +422,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// [DropdownMenu.enableFilter] property is set to true, the default behavior
   /// will return a filtered list. The filtered list will contain items
   /// that match the text provided by the input field, with a case-insensitive
-  /// comparison.
+  /// comparison. When this is not null, `enableFilter` must be set to true.
   final FilterCallback<T>? filterCallback;
 
   /// When [DropdownMenu.enableSearch] is true, this callback is used to compute

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -401,6 +401,7 @@ class DropdownMenu<T> extends StatefulWidget {
   ///
   /// ```dart
   /// DropdownMenu<Text>(
+  ///   enableFilter: true,
   ///   filterCallback: (List<DropdownMenuEntry<Text>> entries, String filter) {
   ///     final String trimmedFilter = filter.trim().toLowerCase();
   ///       if (trimmedFilter.isEmpty) {

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -732,11 +732,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     final DropdownMenuThemeData defaults = _DropdownMenuDefaultsM3(context);
 
     if (_enableFilter) {
-      if (widget.filterCallback != null) {
-        filteredEntries = widget.filterCallback!.call(filteredEntries, _localTextEditingController!.text);
-      } else {
-        filteredEntries = filter(widget.dropdownMenuEntries, _localTextEditingController!);
-      }
+      filteredEntries = widget.filterCallback?.call(filteredEntries, _localTextEditingController!.text)
+        ?? filter(widget.dropdownMenuEntries, _localTextEditingController!);
     }
 
     if (widget.enableSearch) {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1150,7 +1150,7 @@ void main() {
       ),
     ));
 
-    // Open the menu
+    // Open the menu.
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
@@ -1170,6 +1170,28 @@ void main() {
     expect(find.widgetWithText(MenuItemButton, 'Item 3').hitTestable(), findsOneWidget);
     expect(find.widgetWithText(MenuItemButton, 'Item 4').hitTestable(), findsOneWidget);
     expect(find.widgetWithText(MenuItemButton, 'Item 5').hitTestable(), findsOneWidget);
+  });
+
+  testWidgets('Throw assertion error when enable filtering with custom filter callback and enableFilter set on False', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData();
+    final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    expect((){
+      MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          body: DropdownMenu<TestMenu>(
+            requestFocusOnTap: true,
+            filterCallback: (List<DropdownMenuEntry<TestMenu>> entries, String filter) {
+              return entries.where((DropdownMenuEntry<TestMenu> element) => element.label.contains(filter)).toList();
+            },
+            dropdownMenuEntries: menuChildren,
+            controller: controller,
+          ),
+        ),
+      );
+    }, throwsAssertionError);
   });
 
   testWidgets('The controller can access the value in the input field', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1165,6 +1165,7 @@ void main() {
     expect(controller.text, 'Item');
     await tester.pumpAndSettle();
     expect(find.widgetWithText(MenuItemButton, 'Item 0').hitTestable(), findsOneWidget);
+    expect(find.widgetWithText(MenuItemButton, 'Menu 1').hitTestable(), findsNothing);
     expect(find.widgetWithText(MenuItemButton, 'Item 2').hitTestable(), findsOneWidget);
     expect(find.widgetWithText(MenuItemButton, 'Item 3').hitTestable(), findsOneWidget);
     expect(find.widgetWithText(MenuItemButton, 'Item 4').hitTestable(), findsOneWidget);

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -1130,6 +1130,47 @@ void main() {
     }
   });
 
+  testWidgets('Enable filtering with custom filter callback that filter text case sensitive', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData();
+    final TextEditingController controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: themeData,
+      home: Scaffold(
+        body: DropdownMenu<TestMenu>(
+          requestFocusOnTap: true,
+          enableFilter: true,
+          filterCallback: (List<DropdownMenuEntry<TestMenu>> entries, String filter) {
+            return entries.where((DropdownMenuEntry<TestMenu> element) => element.label.contains(filter)).toList();
+          },
+          dropdownMenuEntries: menuChildren,
+          controller: controller,
+        ),
+      ),
+    ));
+
+    // Open the menu
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField).first, 'item');
+    expect(controller.text, 'item');
+    await tester.pumpAndSettle();
+    for (final TestMenu menu in TestMenu.values) {
+      expect(find.widgetWithText(MenuItemButton, menu.label).hitTestable(), findsNothing);
+    }
+
+    await tester.enterText(find.byType(TextField).first, 'Item');
+    expect(controller.text, 'Item');
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(MenuItemButton, 'Item 0').hitTestable(), findsOneWidget);
+    expect(find.widgetWithText(MenuItemButton, 'Item 2').hitTestable(), findsOneWidget);
+    expect(find.widgetWithText(MenuItemButton, 'Item 3').hitTestable(), findsOneWidget);
+    expect(find.widgetWithText(MenuItemButton, 'Item 4').hitTestable(), findsOneWidget);
+    expect(find.widgetWithText(MenuItemButton, 'Item 5').hitTestable(), findsOneWidget);
+  });
+
   testWidgets('The controller can access the value in the input field', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();
     final TextEditingController controller = TextEditingController();


### PR DESCRIPTION
I added a callback on DropDown Menu for filtering options. I needed this feature because I wanted to filtered data using a custom way and that was not possible. For searching there was already a callback that helped, but none for filtering.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
