### PR TITLE
Retry button tap in [FlutterUITests testFlutterViewWarm]

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -73,7 +73,15 @@ static const CGFloat kStandardTimeOut = 60.0;
     XCTAssertTrue(newPageAppeared);
 
     [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeOut]);
+    BOOL countIncremented = [app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeOut];
+    if (!countIncremented) {
+        [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
+        countIncremented = [app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeOut];
+        if (!countIncremented) {
+            os_log(OS_LOG_DEFAULT, "%@", app.debugDescription);
+        }
+    }
+    XCTAssertTrue(countIncremented);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];

--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -75,6 +75,8 @@ static const CGFloat kStandardTimeOut = 60.0;
     [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
     BOOL countIncremented = [app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeOut];
     if (!countIncremented) {
+        // Sometimes, the element doesn't respond to the tap, it seems to be an iOS 17 Simulator issue where the
+        // simulator reboots. Try to tap the element again.
         [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
         countIncremented = [app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeOut];
         if (!countIncremented) {


### PR DESCRIPTION
Attempting to fix https://github.com/flutter/flutter/issues/142125.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
