### PR TITLE
Remove unused drone_dimension field

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -453,8 +453,6 @@ targets:
       firebase_project: main-docs-flutter-prod
       release_ref: refs/heads/master
       release_build: "true"
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux docs_test
     recipe: flutter/flutter_drone
@@ -6018,8 +6016,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "linux"]
-    drone_dimensions:
-      - os=Linux
 
   - name: Mac flutter_packaging
     recipe: packaging/packaging
@@ -6032,9 +6028,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-    drone_dimensions:
-      - os=Mac
-      - cpu=x86
 
 
   - name: Mac_arm64 flutter_packaging
@@ -6048,9 +6041,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-    drone_dimensions:
-      - os=Mac
-      - cpu=arm64
 
   - name: Windows flutter_packaging
     recipe: packaging/packaging
@@ -6064,8 +6054,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "windows"]
-    drone_dimensions:
-      - os=Windows
 
 
   - name: Linux docs_deploy_beta
@@ -6088,8 +6076,6 @@ targets:
       validation: docs_deploy
       validation_name: Docs_deploy
       firebase_project: master-docs-flutter-dev
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux docs_deploy_stable
     recipe: flutter/docs
@@ -6111,5 +6097,3 @@ targets:
       validation: docs_deploy
       validation_name: Docs_deploy
       firebase_project: docs-flutter-dev
-    drone_dimensions:
-      - os=Linux


### PR DESCRIPTION
The drone_dimensions is expected to be defined under property only. The field level definition has never been used.

part of https://github.com/flutter/flutter/issues/143671