### PR TITLE
Add `DataColumn.headingRowAlignment ` for `DataTable`

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -42,6 +42,7 @@ class DataColumn {
     this.numeric = false,
     this.onSort,
     this.mouseCursor,
+    this.mainAxisAlignment,
   });
 
   /// The column heading.
@@ -97,6 +98,17 @@ class DataColumn {
   /// See also:
   ///  * [MaterialStateMouseCursor], which can be used to create a [MouseCursor].
   final MaterialStateProperty<MouseCursor?>? mouseCursor;
+
+  /// Defines the horizontal layout of the [label] and sort indicator in the
+  /// heading row.
+  ///
+  /// If [mainAxisAlignment] value is [MainAxisAlignment.center] and [onSort] is
+  /// not null, then a [SizedBox] with a width of sort arrow icon size and sort
+  /// arrow padding will be placed before the [label] to ensure the label is
+  /// centered in the column.
+  ///
+  /// If null, then defaults to [MainAxisAlignment.start].
+  final MainAxisAlignment? mainAxisAlignment;
 }
 
 /// Row configuration and cell data for a [DataTable].
@@ -830,12 +842,16 @@ class DataTable extends StatelessWidget {
     required bool ascending,
     required MaterialStateProperty<Color?>? overlayColor,
     required MouseCursor? mouseCursor,
+    required MainAxisAlignment mainAxisAlignment,
   }) {
     final ThemeData themeData = Theme.of(context);
     final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
     label = Row(
       textDirection: numeric ? TextDirection.rtl : null,
+      mainAxisAlignment: mainAxisAlignment,
       children: <Widget>[
+        if (mainAxisAlignment == MainAxisAlignment.center && onSort != null)
+          const SizedBox(width: _SortArrowState._arrowIconSize + _sortArrowPadding),
         label,
         if (onSort != null)
           ...<Widget>[
@@ -1117,6 +1133,7 @@ class DataTable extends StatelessWidget {
         ascending: sortAscending,
         overlayColor: effectiveHeadingRowColor,
         mouseCursor: column.mouseCursor?.resolve(headerStates) ?? dataTableTheme.headingCellCursor?.resolve(headerStates),
+        mainAxisAlignment: column.mainAxisAlignment ?? MainAxisAlignment.start,
       );
       rowIndex = 1;
       for (final DataRow row in rows) {

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -42,7 +42,7 @@ class DataColumn {
     this.numeric = false,
     this.onSort,
     this.mouseCursor,
-    this.mainAxisAlignment,
+    this.headingRowAlignment,
   });
 
   /// The column heading.
@@ -102,13 +102,13 @@ class DataColumn {
   /// Defines the horizontal layout of the [label] and sort indicator in the
   /// heading row.
   ///
-  /// If [mainAxisAlignment] value is [MainAxisAlignment.center] and [onSort] is
+  /// If [headingRowAlignment] value is [MainAxisAlignment.center] and [onSort] is
   /// not null, then a [SizedBox] with a width of sort arrow icon size and sort
   /// arrow padding will be placed before the [label] to ensure the label is
   /// centered in the column.
   ///
   /// If null, then defaults to [MainAxisAlignment.start].
-  final MainAxisAlignment? mainAxisAlignment;
+  final MainAxisAlignment? headingRowAlignment;
 }
 
 /// Row configuration and cell data for a [DataTable].
@@ -842,15 +842,15 @@ class DataTable extends StatelessWidget {
     required bool ascending,
     required MaterialStateProperty<Color?>? overlayColor,
     required MouseCursor? mouseCursor,
-    required MainAxisAlignment mainAxisAlignment,
+    required MainAxisAlignment headingRowAlignment,
   }) {
     final ThemeData themeData = Theme.of(context);
     final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
     label = Row(
       textDirection: numeric ? TextDirection.rtl : null,
-      mainAxisAlignment: mainAxisAlignment,
+      mainAxisAlignment: headingRowAlignment,
       children: <Widget>[
-        if (mainAxisAlignment == MainAxisAlignment.center && onSort != null)
+        if (headingRowAlignment == MainAxisAlignment.center && onSort != null)
           const SizedBox(width: _SortArrowState._arrowIconSize + _sortArrowPadding),
         label,
         if (onSort != null)
@@ -1133,7 +1133,7 @@ class DataTable extends StatelessWidget {
         ascending: sortAscending,
         overlayColor: effectiveHeadingRowColor,
         mouseCursor: column.mouseCursor?.resolve(headerStates) ?? dataTableTheme.headingCellCursor?.resolve(headerStates),
-        mainAxisAlignment: column.mainAxisAlignment ?? MainAxisAlignment.start,
+        headingRowAlignment: column.headingRowAlignment ?? dataTableTheme.headingRowAlignment ?? MainAxisAlignment.start,
       );
       rowIndex = 1;
       for (final DataRow row in rows) {

--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -57,6 +57,7 @@ class DataTableThemeData with Diagnosticable {
     this.checkboxHorizontalMargin,
     this.headingCellCursor,
     this.dataRowCursor,
+    this.headingRowAlignment,
   }) : assert(dataRowMinHeight == null || dataRowMaxHeight == null || dataRowMaxHeight >= dataRowMinHeight),
        assert(dataRowHeight == null || (dataRowMinHeight == null && dataRowMaxHeight == null),
          'dataRowHeight ($dataRowHeight) must not be set if dataRowMinHeight ($dataRowMinHeight) or dataRowMaxHeight ($dataRowMaxHeight) are set.'),
@@ -114,6 +115,9 @@ class DataTableThemeData with Diagnosticable {
   /// If specified, overrides the default value of [DataRow.mouseCursor].
   final MaterialStateProperty<MouseCursor?>? dataRowCursor;
 
+  /// If specified, overrides the default value of [DataColumn.headingRowAlignment].
+  final MainAxisAlignment? headingRowAlignment;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   DataTableThemeData copyWith({
@@ -136,6 +140,7 @@ class DataTableThemeData with Diagnosticable {
     double? checkboxHorizontalMargin,
     MaterialStateProperty<MouseCursor?>? headingCellCursor,
     MaterialStateProperty<MouseCursor?>? dataRowCursor,
+    MainAxisAlignment? headingRowAlignment,
   }) {
     assert(dataRowHeight == null || (dataRowMinHeight == null && dataRowMaxHeight == null),
       'dataRowHeight ($dataRowHeight) must not be set if dataRowMinHeight ($dataRowMinHeight) or dataRowMaxHeight ($dataRowMaxHeight) are set.');
@@ -157,6 +162,7 @@ class DataTableThemeData with Diagnosticable {
       checkboxHorizontalMargin: checkboxHorizontalMargin ?? this.checkboxHorizontalMargin,
       headingCellCursor: headingCellCursor ?? this.headingCellCursor,
       dataRowCursor: dataRowCursor ?? this.dataRowCursor,
+      headingRowAlignment: headingRowAlignment ?? this.headingRowAlignment,
     );
   }
 
@@ -182,6 +188,7 @@ class DataTableThemeData with Diagnosticable {
       checkboxHorizontalMargin: lerpDouble(a.checkboxHorizontalMargin, b.checkboxHorizontalMargin, t),
       headingCellCursor: t < 0.5 ? a.headingCellCursor : b.headingCellCursor,
       dataRowCursor: t < 0.5 ? a.dataRowCursor : b.dataRowCursor,
+      headingRowAlignment: t < 0.5 ? a.headingRowAlignment : b.headingRowAlignment,
     );
   }
 
@@ -201,6 +208,7 @@ class DataTableThemeData with Diagnosticable {
     checkboxHorizontalMargin,
     headingCellCursor,
     dataRowCursor,
+    headingRowAlignment,
   );
 
   @override
@@ -225,7 +233,8 @@ class DataTableThemeData with Diagnosticable {
       && other.dividerThickness == dividerThickness
       && other.checkboxHorizontalMargin == checkboxHorizontalMargin
       && other.headingCellCursor == headingCellCursor
-      && other.dataRowCursor == dataRowCursor;
+      && other.dataRowCursor == dataRowCursor
+      && other.headingRowAlignment == headingRowAlignment;
   }
 
   @override
@@ -245,6 +254,7 @@ class DataTableThemeData with Diagnosticable {
     properties.add(DoubleProperty('checkboxHorizontalMargin', checkboxHorizontalMargin, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>?>('headingCellCursor', headingCellCursor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>?>('dataRowCursor', dataRowCursor, defaultValue: null));
+    properties.add(EnumProperty<MainAxisAlignment>('headingRowAlignment', headingRowAlignment, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2368,13 +2368,13 @@ void main() {
   testWidgets('DataColumn label can be centered', (WidgetTester tester) async {
     const double horizontalMargin = 24.0;
 
-    Widget buildTable({ MainAxisAlignment? mainAxisAlignment, bool sortEnabled = false }) {
+    Widget buildTable({ MainAxisAlignment? headingRowAlignment, bool sortEnabled = false }) {
       return MaterialApp(
         home: Material(
           child: DataTable(
             columns: <DataColumn>[
               DataColumn(
-                mainAxisAlignment: mainAxisAlignment,
+                headingRowAlignment: headingRowAlignment,
                 onSort: sortEnabled
                   ? (int columnIndex, bool ascending) { }
                   : null,
@@ -2400,7 +2400,7 @@ void main() {
     expect(headerTopLeft.dx, equals(horizontalMargin));
 
     // Test mainAxisAlignment.center without sort arrow.
-    await tester.pumpWidget(buildTable(mainAxisAlignment: MainAxisAlignment.center));
+    await tester.pumpWidget(buildTable(headingRowAlignment: MainAxisAlignment.center));
 
     Offset headerCenter = tester.getCenter(find.text('Header'));
     expect(headerCenter.dx, equals(400));
@@ -2412,7 +2412,7 @@ void main() {
     expect(headerTopLeft.dx, equals(horizontalMargin));
 
     // Test mainAxisAlignment.center with sort arrow.
-    await tester.pumpWidget(buildTable(mainAxisAlignment: MainAxisAlignment.center, sortEnabled: true));
+    await tester.pumpWidget(buildTable(headingRowAlignment: MainAxisAlignment.center, sortEnabled: true));
 
     headerCenter = tester.getCenter(find.text('Header'));
     expect(headerCenter.dx, equals(400));

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2363,6 +2363,60 @@ void main() {
     final TextStyle? dataTextStyle = _getTextRenderObject(tester, 'Data 1').text.style;
     expect(dataTextStyle, defaultTextStyle.style);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/143340.
+  testWidgets('DataColumn label can be centered', (WidgetTester tester) async {
+    const double horizontalMargin = 24.0;
+
+    Widget buildTable({ MainAxisAlignment? mainAxisAlignment, bool sortEnabled = false }) {
+      return MaterialApp(
+        home: Material(
+          child: DataTable(
+            columns: <DataColumn>[
+              DataColumn(
+                mainAxisAlignment: mainAxisAlignment,
+                onSort: sortEnabled
+                  ? (int columnIndex, bool ascending) { }
+                  : null,
+                label: const Text('Header'),
+              ),
+            ],
+            rows: const <DataRow>[
+              DataRow(
+                cells: <DataCell>[
+                  DataCell(Text('Data')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Test mainAxisAlignment without sort arrow.
+    await tester.pumpWidget(buildTable());
+
+    Offset headerTopLeft = tester.getTopLeft(find.text('Header'));
+    expect(headerTopLeft.dx, equals(horizontalMargin));
+
+    // Test mainAxisAlignment.center without sort arrow.
+    await tester.pumpWidget(buildTable(mainAxisAlignment: MainAxisAlignment.center));
+
+    Offset headerCenter = tester.getCenter(find.text('Header'));
+    expect(headerCenter.dx, equals(400));
+
+    // Test mainAxisAlignment with sort arrow.
+    await tester.pumpWidget(buildTable(sortEnabled: true));
+
+    headerTopLeft = tester.getTopLeft(find.text('Header'));
+    expect(headerTopLeft.dx, equals(horizontalMargin));
+
+    // Test mainAxisAlignment.center with sort arrow.
+    await tester.pumpWidget(buildTable(mainAxisAlignment: MainAxisAlignment.center, sortEnabled: true));
+
+    headerCenter = tester.getCenter(find.text('Header'));
+    expect(headerCenter.dx, equals(400));
+  });
 }
 
 RenderParagraph _getTextRenderObject(WidgetTester tester, String text) {


### PR DESCRIPTION
fixes [[`DataTable`]  Unable to center the label of a DataColumn without side effects](https://github.com/flutter/flutter/issues/143340)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: MaterialApp(
        home: Material(
          child: DataTable(
            columns: <DataColumn>[
              DataColumn(
                headingRowAlignment: MainAxisAlignment.center,
                onSort: (int columnIndex, bool ascending) {},
                label: const Text('Header'),
              ),
            ],
            sortColumnIndex: 0,
            rows: const <DataRow>[
              DataRow(
                cells: <DataCell>[
                  DataCell(Center(child: Text('Data'))),
                ],
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```

</details>


### Center `DataColumn.headingRowAlignment ` without sort arrow
![Screenshot 2024-03-25 at 17 13 05](https://github.com/flutter/flutter/assets/48603081/0c91d279-23e8-40d9-ab86-c08013c73666)



### Center `DataColumn.headingRowAlignment ` with sort arrow

![Screenshot 2024-03-25 at 17 11 54](https://github.com/flutter/flutter/assets/48603081/d042d02a-e7be-4f47-a90c-8a1ee0f7f5f3)



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
