### PR TITLE
Re-enable Impeller goldens blocking.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3458,7 +3458,6 @@ targets:
   - name: Mac framework_tests_impeller
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/143616

Without this these tests only run on postsubmit which means we can't get gold results on PRs.

This was reverted because it landed after an engine change that broke flutter tester. That change has since been reverted.
