### PR TITLE
Update copyDirectory to allow links to not be followed

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -140,9 +140,9 @@ void copyDirectory(
     final String newPath = destDir.fileSystem.path.join(destDir.path, entity.basename);
     if (entity is Link) {
       final Link newLink = destDir.fileSystem.link(newPath);
-      final String target;
-      if (linkToDestinationTarget && !followLinks && entity.targetSync().contains(srcDir.path)) {
-        target = entity.targetSync().replaceFirst(srcDir.path, destDir.path);
+      String target = entity.targetSync();
+      if (linkToDestinationTarget && !followLinks && target.contains(srcDir.path)) {
+        target = target.replaceFirst(srcDir.path, destDir.path);
       } else {
         target = entity.targetSync();
       }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -115,10 +115,6 @@ String getDisplayPath(String fullPath, FileSystem fileSystem) {
 ///
 /// If [followLinks] is true, then working links are reported as directories or
 /// files, depending on what they point to.
-///
-/// If [linkToDestinationTarget] is true, [followLinks] is false, and the symbolic
-/// link target is within the [srcDir], set the target of the copied link to the
-/// corresponding target in the [destDir] rather than the [srcDir].
 void copyDirectory(
   Directory srcDir,
   Directory destDir, {
@@ -126,7 +122,6 @@ void copyDirectory(
   bool Function(Directory)? shouldCopyDirectory,
   void Function(File srcFile, File destFile)? onFileCopied,
   bool followLinks = true,
-  bool linkToDestinationTarget = false,
 }) {
   if (!srcDir.existsSync()) {
     throw Exception('Source directory "${srcDir.path}" does not exist, nothing to copy');
@@ -140,11 +135,7 @@ void copyDirectory(
     final String newPath = destDir.fileSystem.path.join(destDir.path, entity.basename);
     if (entity is Link) {
       final Link newLink = destDir.fileSystem.link(newPath);
-      String target = entity.targetSync();
-      if (linkToDestinationTarget && !followLinks && target.contains(srcDir.path)) {
-        target = target.replaceFirst(srcDir.path, destDir.path);
-      }
-      newLink.createSync(target);
+      newLink.createSync(entity.targetSync());
     } else if (entity is File) {
       final File newFile = destDir.fileSystem.file(newPath);
       if (shouldCopyFile != null && !shouldCopyFile(entity, newFile)) {

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -143,8 +143,6 @@ void copyDirectory(
       String target = entity.targetSync();
       if (linkToDestinationTarget && !followLinks && target.contains(srcDir.path)) {
         target = target.replaceFirst(srcDir.path, destDir.path);
-      } else {
-        target = entity.targetSync();
       }
       newLink.createSync(target);
     } else if (entity is File) {

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -115,6 +115,7 @@ void copyDirectory(
   bool Function(File srcFile, File destFile)? shouldCopyFile,
   bool Function(Directory)? shouldCopyDirectory,
   void Function(File srcFile, File destFile)? onFileCopied,
+  bool followLinks = true,
 }) {
   if (!srcDir.existsSync()) {
     throw Exception('Source directory "${srcDir.path}" does not exist, nothing to copy');
@@ -124,7 +125,7 @@ void copyDirectory(
     destDir.createSync(recursive: true);
   }
 
-  for (final FileSystemEntity entity in srcDir.listSync()) {
+  for (final FileSystemEntity entity in srcDir.listSync(followLinks: followLinks)) {
     final String newPath = destDir.fileSystem.path.join(destDir.path, entity.basename);
     if (entity is Link) {
       final Link newLink = destDir.fileSystem.link(newPath);
@@ -145,6 +146,7 @@ void copyDirectory(
         destDir.fileSystem.directory(newPath),
         shouldCopyFile: shouldCopyFile,
         onFileCopied: onFileCopied,
+        followLinks: followLinks,
       );
     } else {
       throw Exception('${entity.path} is neither File nor Directory, was ${entity.runtimeType}');

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -95,33 +95,34 @@ void main() {
       );
       final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_copy_directory.');
       try {
-        const String sourcePath = 'some/origin';
+        final String sourcePath = io.Platform.isWindows ? r'some\origin' : 'some/origin';
         final Directory sourceDirectory = tempDir.childDirectory(sourcePath)..createSync(recursive: true);
         final File sourceFile1 = sourceDirectory.childFile('some_file.txt')..writeAsStringSync('file 1');
-        sourceDirectory.childLink('absolute_linked.txt').createSync(sourceFile1.path);
+        sourceDirectory.childLink('absolute_linked.txt').createSync(sourceFile1.absolute.path);
         final DateTime writeTime = sourceFile1.lastModifiedSync();
-        final Directory sourceSubDirectory = sourceDirectory.childDirectory('sub_dir/sub_dir_2')..createSync(recursive: true);
+        final Directory sourceSubDirectory = sourceDirectory.childDirectory('dir1').childDirectory('dir2')..createSync(recursive: true);
         sourceSubDirectory.childFile('another_file.txt').writeAsStringSync('file 2');
-        sourceDirectory.childLink('relative_linked_sub_dir').createSync('sub_dir/sub_dir_2');
+        final String subdirectorySourcePath = io.Platform.isWindows ? r'dir1\dir2' : 'dir1/dir2';
+        sourceDirectory.childLink('relative_linked_sub_dir').createSync(subdirectorySourcePath);
         sourceDirectory.childDirectory('empty_directory').createSync(recursive: true);
 
-        const String targetPath = 'some/non-existent/target';
+        final String targetPath = io.Platform.isWindows ? r'some\non-existent\target' : 'some/non-existent/target';
         final Directory targetDirectory = tempDir.childDirectory(targetPath);
 
-        copyDirectory(sourceDirectory, targetDirectory);
+        copyDirectory(sourceDirectory, targetDirectory, followLinks: false);
 
         expect(targetDirectory.existsSync(), true);
         expect(targetDirectory.childFile('some_file.txt').existsSync(), true);
         expect(targetDirectory.childFile('some_file.txt').readAsStringSync(), 'file 1');
         expect(targetDirectory.childFile('absolute_linked.txt').readAsStringSync(), 'file 1');
         expect(targetDirectory.childLink('absolute_linked.txt').existsSync(), false);
-        expect(targetDirectory.childDirectory('sub_dir/sub_dir_2').existsSync(), true);
-        expect(targetDirectory.childFile('sub_dir/sub_dir_2/another_file.txt').existsSync(), true);
-        expect(targetDirectory.childFile('sub_dir/sub_dir_2/another_file.txt').readAsStringSync(), 'file 2');
+        expect(targetDirectory.childDirectory('dir1').childDirectory('dir2').existsSync(), true);
+        expect(targetDirectory.childDirectory('dir1').childDirectory('dir2').childFile('another_file.txt').existsSync(), true);
+        expect(targetDirectory.childDirectory('dir1').childDirectory('dir2').childFile('another_file.txt').readAsStringSync(), 'file 2');
         expect(targetDirectory.childDirectory('relative_linked_sub_dir').existsSync(), true);
         expect(targetDirectory.childLink('relative_linked_sub_dir').existsSync(), false);
-        expect(targetDirectory.childFile('relative_linked_sub_dir/another_file.txt').existsSync(), true);
-        expect(targetDirectory.childFile('relative_linked_sub_dir/another_file.txt').readAsStringSync(), 'file 2');
+        expect(targetDirectory.childDirectory('relative_linked_sub_dir').childFile('another_file.txt').existsSync(), true);
+        expect(targetDirectory.childDirectory('relative_linked_sub_dir').childFile('another_file.txt').readAsStringSync(), 'file 2');
         expect(targetDirectory.childDirectory('empty_directory').existsSync(), true);
 
         // Assert that the copy operation hasn't modified the original file in some way.
@@ -140,17 +141,18 @@ void main() {
       );
       final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_copy_directory.');
       try {
-        const String sourcePath = 'some/origin';
+        final String sourcePath = io.Platform.isWindows ? r'some\origin' : 'some/origin';
         final Directory sourceDirectory = tempDir.childDirectory(sourcePath)..createSync(recursive: true);
         final File sourceFile1 = sourceDirectory.childFile('some_file.txt')..writeAsStringSync('file 1');
         sourceDirectory.childLink('absolute_linked.txt').createSync(sourceFile1.absolute.path);
         final DateTime writeTime = sourceFile1.lastModifiedSync();
-        final Directory sourceSubDirectory = sourceDirectory.childDirectory('sub_dir/sub_dir_2')..createSync(recursive: true);
+        final Directory sourceSubDirectory = sourceDirectory.childDirectory('dir1').childDirectory('dir2')..createSync(recursive: true);
         sourceSubDirectory.childFile('another_file.txt').writeAsStringSync('file 2');
-        sourceDirectory.childLink('relative_linked_sub_dir').createSync('sub_dir/sub_dir_2');
+        final String subdirectorySourcePath = io.Platform.isWindows ? r'dir1\dir2' : 'dir1/dir2';
+        sourceDirectory.childLink('relative_linked_sub_dir').createSync(subdirectorySourcePath);
         sourceDirectory.childDirectory('empty_directory').createSync(recursive: true);
 
-        const String targetPath = 'some/non-existent/target';
+        final String targetPath = io.Platform.isWindows ? r'some\non-existent\target' : 'some/non-existent/target';
         final Directory targetDirectory = tempDir.childDirectory(targetPath);
 
         copyDirectory(sourceDirectory, targetDirectory, followLinks: false);
@@ -164,17 +166,17 @@ void main() {
           targetDirectory.childLink('absolute_linked.txt').targetSync(),
           sourceFile1.absolute.path,
         );
-        expect(targetDirectory.childDirectory('sub_dir/sub_dir_2').existsSync(), true);
-        expect(targetDirectory.childFile('sub_dir/sub_dir_2/another_file.txt').existsSync(), true);
-        expect(targetDirectory.childFile('sub_dir/sub_dir_2/another_file.txt').readAsStringSync(), 'file 2');
+        expect(targetDirectory.childDirectory('dir1').childDirectory('dir2').existsSync(), true);
+        expect(targetDirectory.childDirectory('dir1').childDirectory('dir2').childFile('another_file.txt').existsSync(), true);
+        expect(targetDirectory.childDirectory('dir1').childDirectory('dir2').childFile('another_file.txt').readAsStringSync(), 'file 2');
         expect(targetDirectory.childDirectory('relative_linked_sub_dir').existsSync(), true);
         expect(targetDirectory.childLink('relative_linked_sub_dir').existsSync(), true);
         expect(
           targetDirectory.childLink('relative_linked_sub_dir').targetSync(),
-          'sub_dir/sub_dir_2',
+          subdirectorySourcePath,
         );
-        expect(targetDirectory.childFile('relative_linked_sub_dir/another_file.txt').existsSync(), true);
-        expect(targetDirectory.childFile('relative_linked_sub_dir/another_file.txt').readAsStringSync(), 'file 2');
+        expect(targetDirectory.childDirectory('relative_linked_sub_dir').childFile('another_file.txt').existsSync(), true);
+        expect(targetDirectory.childDirectory('relative_linked_sub_dir').childFile('another_file.txt').readAsStringSync(), 'file 2');
         expect(targetDirectory.childDirectory('empty_directory').existsSync(), true);
 
         // Assert that the copy operation hasn't modified the original file in some way.

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -104,6 +104,8 @@ void main() {
         sourceSubDirectory.childFile('another_file.txt').createSync(recursive: true);
         sourceDirectory.childLink('linked_sub_dir').createSync(sourceSubDirectory.path);
         sourceDirectory.childDirectory('empty_directory').createSync(recursive: true);
+        final File outsideFile = tempDir.childFile('outside/outside_link.txt')..createSync(recursive: true);
+        sourceDirectory.childLink('outside_link.txt').createSync(outsideFile.path);
 
         const String targetPath = 'some/non-existent/target';
         final Directory targetDirectory = tempDir.childDirectory(targetPath);
@@ -122,17 +124,19 @@ void main() {
         expect(targetDirectory.childLink('linked_sub_dir').existsSync(), false);
         expect(targetDirectory.childFile('linked_sub_dir/another_file.txt').existsSync(), true);
         expect(targetDirectory.childDirectory('empty_directory').existsSync(), true);
+        expect(targetDirectory.childFile('outside_link.txt').existsSync(), true);
+        expect(targetDirectory.childLink('outside_link.txt').existsSync(), false);
 
         // Assert that the copy operation hasn't modified the original file in some way.
         expect(sourceDirectory.childFile('some_file.txt').lastModifiedSync(), writeTime);
         // There's still 5 things in the original directory as there were initially.
-        expect(sourceDirectory.listSync().length, 5);
+        expect(sourceDirectory.listSync().length, 6);
       } finally {
         tryToDelete(tempDir);
       }
     });
 
-    testWithoutContext('test directory copy with followLinks: false', () async {
+    testWithoutContext('test directory copy with followLinks: false and linkToDestinationTarget: true', () async {
       final Signals signals = Signals.test();
       final LocalFileSystem fileSystem = LocalFileSystem.test(
         signals: signals,
@@ -148,6 +152,69 @@ void main() {
         sourceSubDirectory.childFile('another_file.txt').createSync(recursive: true);
         sourceDirectory.childLink('linked_sub_dir').createSync(sourceSubDirectory.path);
         sourceDirectory.childDirectory('empty_directory').createSync(recursive: true);
+        final File outsideFile = tempDir.childFile('outside/outside_link.txt')..createSync(recursive: true);
+        sourceDirectory.childLink('outside_link.txt').createSync(outsideFile.path);
+
+        const String targetPath = 'some/non-existent/target';
+        final Directory targetDirectory = tempDir.childDirectory(targetPath);
+
+        copyDirectory(
+          sourceDirectory,
+          targetDirectory,
+          followLinks: false,
+          linkToDestinationTarget: true,
+        );
+
+        expect(targetDirectory.existsSync(), true);
+        expect(targetDirectory.childFile('some_file.txt').existsSync(), true);
+        expect(targetDirectory.childFile('some_file.txt').readAsStringSync(), 'bleh');
+        expect(targetDirectory.childLink('some_link.txt').existsSync(), true);
+        expect(
+          targetDirectory.childLink('some_link.txt').targetSync(),
+          targetDirectory.childFile('some_file.txt').path,
+        );
+        expect(targetDirectory.childDirectory('sub_dir').existsSync(), true);
+        expect(targetDirectory.childFile('sub_dir/another_file.txt').existsSync(), true);
+        expect(targetDirectory.childLink('linked_sub_dir').existsSync(), true);
+        expect(
+          targetDirectory.childLink('linked_sub_dir').targetSync(),
+          targetDirectory.childDirectory('sub_dir').path,
+        );
+        expect(targetDirectory.childFile('linked_sub_dir/another_file.txt').existsSync(), true);
+        expect(targetDirectory.childDirectory('empty_directory').existsSync(), true);
+        expect(targetDirectory.childLink('outside_link.txt').existsSync(), true);
+        expect(
+          targetDirectory.childLink('outside_link.txt').targetSync(),
+          outsideFile.path,
+        );
+
+        // Assert that the copy operation hasn't modified the original file in some way.
+        expect(sourceDirectory.childFile('some_file.txt').lastModifiedSync(), writeTime);
+        // There's still 5 things in the original directory as there were initially.
+        expect(sourceDirectory.listSync().length, 6);
+      } finally {
+        tryToDelete(tempDir);
+      }
+    });
+
+    testWithoutContext('test directory copy with followLinks: false and linkToDestinationTarget: false', () async {
+      final Signals signals = Signals.test();
+      final LocalFileSystem fileSystem = LocalFileSystem.test(
+        signals: signals,
+      );
+      final Directory tempDir = fileSystem.systemTempDirectory.createTempSync('flutter_copy_directory.');
+      try {
+        const String sourcePath = 'some/origin';
+        final Directory sourceDirectory = tempDir.childDirectory(sourcePath)..createSync(recursive: true);
+        final File sourceFile1 = sourceDirectory.childFile('some_file.txt')..writeAsStringSync('bleh');
+        sourceDirectory.childLink('some_link.txt').createSync(sourceFile1.path);
+        final DateTime writeTime = sourceFile1.lastModifiedSync();
+        final Directory sourceSubDirectory = sourceDirectory.childDirectory('sub_dir')..createSync(recursive: true);
+        sourceSubDirectory.childFile('another_file.txt').createSync(recursive: true);
+        sourceDirectory.childLink('linked_sub_dir').createSync(sourceSubDirectory.path);
+        sourceDirectory.childDirectory('empty_directory').createSync(recursive: true);
+        final File outsideFile = tempDir.childFile('outside/outside_link.txt')..createSync(recursive: true);
+        sourceDirectory.childLink('outside_link.txt').createSync(outsideFile.path);
 
         const String targetPath = 'some/non-existent/target';
         final Directory targetDirectory = tempDir.childDirectory(targetPath);
@@ -158,17 +225,29 @@ void main() {
         expect(targetDirectory.childFile('some_file.txt').existsSync(), true);
         expect(targetDirectory.childFile('some_file.txt').readAsStringSync(), 'bleh');
         expect(targetDirectory.childLink('some_link.txt').existsSync(), true);
-        expect(targetDirectory.childFile('some_link.txt').readAsStringSync(), 'bleh');
+        expect(
+          targetDirectory.childLink('some_link.txt').targetSync(),
+          sourceDirectory.childFile('some_file.txt').path,
+        );
         expect(targetDirectory.childDirectory('sub_dir').existsSync(), true);
         expect(targetDirectory.childFile('sub_dir/another_file.txt').existsSync(), true);
         expect(targetDirectory.childLink('linked_sub_dir').existsSync(), true);
+        expect(
+          targetDirectory.childLink('linked_sub_dir').targetSync(),
+          sourceDirectory.childDirectory('sub_dir').path,
+        );
         expect(targetDirectory.childFile('linked_sub_dir/another_file.txt').existsSync(), true);
         expect(targetDirectory.childDirectory('empty_directory').existsSync(), true);
+        expect(targetDirectory.childLink('outside_link.txt').existsSync(), true);
+        expect(
+          targetDirectory.childLink('outside_link.txt').targetSync(),
+          outsideFile.path,
+        );
 
         // Assert that the copy operation hasn't modified the original file in some way.
         expect(sourceDirectory.childFile('some_file.txt').lastModifiedSync(), writeTime);
         // There's still 5 things in the original directory as there were initially.
-        expect(sourceDirectory.listSync().length, 5);
+        expect(sourceDirectory.listSync().length, 6);
       } finally {
         tryToDelete(tempDir);
       }

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -109,7 +109,7 @@ void main() {
         final String targetPath = io.Platform.isWindows ? r'some\non-existent\target' : 'some/non-existent/target';
         final Directory targetDirectory = tempDir.childDirectory(targetPath);
 
-        copyDirectory(sourceDirectory, targetDirectory, followLinks: false);
+        copyDirectory(sourceDirectory, targetDirectory);
 
         expect(targetDirectory.existsSync(), true);
         expect(targetDirectory.childFile('some_file.txt').existsSync(), true);


### PR DESCRIPTION
In other words, copy links within a directory as links rather than copying them as files/directories. 

Fixes https://github.com/flutter/flutter/issues/144032.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
