### PR TITLE
Remove deprecated `backgroundColor` from `ThemeData`

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -372,11 +372,6 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.3.0-0.5.pre.',
     )
     Color? errorColor,
-    @Deprecated(
-      'Use colorScheme.background instead. '
-      'This feature was deprecated after v3.3.0-0.5.pre.',
-    )
-    Color? backgroundColor,
   }) {
     // GENERAL CONFIGURATION
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
@@ -431,7 +426,6 @@ class ThemeData with Diagnosticable {
       scaffoldBackgroundColor ??= colorScheme.background;
       cardColor ??= colorScheme.surface;
       dividerColor ??= colorScheme.outline;
-      backgroundColor ??= colorScheme.background;
       dialogBackgroundColor ??= colorScheme.background;
       indicatorColor ??= onPrimarySurfaceColor;
       errorColor ??= colorScheme.error;
@@ -554,8 +548,6 @@ class ThemeData with Diagnosticable {
 
     // DEPRECATED (newest deprecations at the bottom)
     errorColor ??= Colors.red[700]!;
-    backgroundColor ??= isDark ? Colors.grey[700]! : primarySwatch[200]!;
-
     return ThemeData.raw(
       // For the sanity of the reader, make sure these properties are in the same
       // order in every place that they are separated by section comments (e.g.
@@ -650,7 +642,6 @@ class ThemeData with Diagnosticable {
       tooltipTheme: tooltipTheme,
       // DEPRECATED (newest deprecations at the bottom)
       errorColor: errorColor,
-      backgroundColor: backgroundColor,
     );
   }
 
@@ -762,19 +753,12 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.3.0-0.5.pre.',
     )
     Color? errorColor,
-    @Deprecated(
-      'Use colorScheme.background instead. '
-      'This feature was deprecated after v3.3.0-0.5.pre.',
-    )
-    Color? backgroundColor,
 
   }) : // DEPRECATED (newest deprecations at the bottom)
        // should not be `required`, use getter pattern to avoid breakages.
        _errorColor = errorColor,
-       _backgroundColor = backgroundColor,
         // DEPRECATED (newest deprecations at the bottom)
-       assert(errorColor != null),
-       assert(backgroundColor != null);
+       assert(errorColor != null);
 
   /// Create a [ThemeData] based on the colors in the given [colorScheme] and
   /// text styles of the optional [textTheme].
@@ -821,7 +805,6 @@ class ThemeData with Diagnosticable {
       scaffoldBackgroundColor: colorScheme.background,
       cardColor: colorScheme.surface,
       dividerColor: colorScheme.onSurface.withOpacity(0.12),
-      backgroundColor: colorScheme.background,
       dialogBackgroundColor: colorScheme.background,
       indicatorColor: onPrimarySurfaceColor,
       errorColor: colorScheme.error,
@@ -1442,15 +1425,6 @@ class ThemeData with Diagnosticable {
   Color get errorColor => _errorColor!;
   final Color? _errorColor;
 
-  /// Obsolete property that was unused by the framework.
-  /// Use [ColorScheme.background] instead.
-  @Deprecated(
-    'Use colorScheme.background instead. '
-    'This feature was deprecated after v3.3.0-0.5.pre.',
-  )
-  Color get backgroundColor => _backgroundColor!;
-  final Color? _backgroundColor;
-
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ///
   /// The [brightness] value is applied to the [colorScheme].
@@ -1555,11 +1529,6 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.3.0-0.5.pre.',
     )
     Color? errorColor,
-    @Deprecated(
-      'Use colorScheme.background instead. '
-      'This feature was deprecated after v3.3.0-0.5.pre.',
-    )
-    Color? backgroundColor,
     @Deprecated(
       'Use a ThemeData constructor (.from, .light, or .dark) instead. '
       'These constructors all have a useMaterial3 argument, '
@@ -1666,7 +1635,6 @@ class ThemeData with Diagnosticable {
       tooltipTheme: tooltipTheme ?? this.tooltipTheme,
       // DEPRECATED (newest deprecations at the bottom)
       errorColor: errorColor ?? _errorColor,
-      backgroundColor: backgroundColor ?? _backgroundColor,
     );
   }
 
@@ -1862,7 +1830,6 @@ class ThemeData with Diagnosticable {
       tooltipTheme: TooltipThemeData.lerp(a.tooltipTheme, b.tooltipTheme, t)!,
       // DEPRECATED (newest deprecations at the bottom)
       errorColor: Color.lerp(a.errorColor, b.errorColor, t),
-      backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
     );
   }
 
@@ -1964,8 +1931,7 @@ class ThemeData with Diagnosticable {
         other.toggleButtonsTheme == toggleButtonsTheme &&
         other.tooltipTheme == tooltipTheme &&
         // DEPRECATED (newest deprecations at the bottom)
-        other.errorColor == errorColor &&
-        other.backgroundColor == backgroundColor;
+        other.errorColor == errorColor;
   }
 
   @override
@@ -2066,7 +2032,6 @@ class ThemeData with Diagnosticable {
       tooltipTheme,
       // DEPRECATED (newest deprecations at the bottom)
       errorColor,
-      backgroundColor,
     ];
     return Object.hashAll(values);
   }
@@ -2168,7 +2133,6 @@ class ThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<TooltipThemeData>('tooltipTheme', tooltipTheme, level: DiagnosticLevel.debug));
     // DEPRECATED (newest deprecations at the bottom)
     properties.add(ColorProperty('errorColor', errorColor, defaultValue: defaultData.errorColor, level: DiagnosticLevel.debug));
-    properties.add(ColorProperty('backgroundColor', backgroundColor, defaultValue: defaultData.backgroundColor, level: DiagnosticLevel.debug));
   }
 }
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -637,7 +637,6 @@ void main() {
       buttonTheme: const ButtonThemeData(colorScheme: ColorScheme.dark()),
       toggleButtonsTheme: const ToggleButtonsThemeData(textStyle: TextStyle(color: Colors.black)),
       secondaryHeaderColor: Colors.black,
-      backgroundColor: Colors.black,
       dialogBackgroundColor: Colors.black,
       indicatorColor: Colors.black,
       hintColor: Colors.black,

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -194,7 +194,6 @@ void main() {
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.backgroundColor, theme.colorScheme.background);
     expect(theme.dialogBackgroundColor, theme.colorScheme.background);
     expect(theme.indicatorColor, theme.colorScheme.onPrimary);
     expect(theme.errorColor, theme.colorScheme.error);
@@ -263,7 +262,6 @@ void main() {
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.backgroundColor, theme.colorScheme.background);
     expect(theme.dialogBackgroundColor, theme.colorScheme.background);
     expect(theme.indicatorColor, theme.colorScheme.onSurface);
     expect(theme.errorColor, theme.colorScheme.error);
@@ -327,7 +325,6 @@ void main() {
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.backgroundColor, theme.colorScheme.background);
     expect(theme.dialogBackgroundColor, theme.colorScheme.background);
     expect(theme.indicatorColor, theme.colorScheme.onPrimary);
     expect(theme.errorColor, theme.colorScheme.error);
@@ -392,7 +389,6 @@ void main() {
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.backgroundColor, theme.colorScheme.background);
     expect(theme.dialogBackgroundColor, theme.colorScheme.background);
     expect(theme.indicatorColor, theme.colorScheme.onPrimary);
     expect(theme.errorColor, theme.colorScheme.error);
@@ -456,7 +452,6 @@ void main() {
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.backgroundColor, theme.colorScheme.background);
     expect(theme.dialogBackgroundColor, theme.colorScheme.background);
     expect(theme.indicatorColor, theme.colorScheme.onSurface);
     expect(theme.errorColor, theme.colorScheme.error);
@@ -470,7 +465,6 @@ void main() {
     expect(theme.brightness, equals(Brightness.light));
     expect(theme.primaryColor, equals(lightColors.primary));
     expect(theme.cardColor, equals(lightColors.surface));
-    expect(theme.backgroundColor, equals(lightColors.background));
     expect(theme.canvasColor, equals(lightColors.background));
     expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
     expect(theme.dialogBackgroundColor, equals(lightColors.background));
@@ -486,7 +480,6 @@ void main() {
     // in dark theme's the color used for main components is surface instead of primary
     expect(theme.primaryColor, equals(darkColors.surface));
     expect(theme.cardColor, equals(darkColors.surface));
-    expect(theme.backgroundColor, equals(darkColors.background));
     expect(theme.canvasColor, equals(darkColors.background));
     expect(theme.scaffoldBackgroundColor, equals(darkColors.background));
     expect(theme.dialogBackgroundColor, equals(darkColors.background));
@@ -903,7 +896,6 @@ void main() {
       tooltipTheme: const TooltipThemeData(height: 100),
       // DEPRECATED (newest deprecations at the bottom)
       errorColor: Colors.black,
-      backgroundColor: Colors.black,
     );
 
     final SliderThemeData otherSliderTheme = SliderThemeData.fromPrimaryColors(
@@ -1021,7 +1013,6 @@ void main() {
 
       // DEPRECATED (newest deprecations at the bottom)
       errorColor: Colors.white,
-      backgroundColor: Colors.white,
     );
 
     final ThemeData themeDataCopy = theme.copyWith(
@@ -1120,7 +1111,6 @@ void main() {
 
       // DEPRECATED (newest deprecations at the bottom)
       errorColor: otherTheme.errorColor,
-      backgroundColor: otherTheme.backgroundColor,
     );
 
     // For the sanity of the reader, make sure these properties are in the same
@@ -1220,7 +1210,6 @@ void main() {
 
     // DEPRECATED (newest deprecations at the bottom)
     expect(themeDataCopy.errorColor, equals(otherTheme.errorColor));
-    expect(themeDataCopy.backgroundColor, equals(otherTheme.backgroundColor));
   });
 
   testWidgets('ThemeData.toString has less than 200 characters output', (WidgetTester tester) async {
@@ -1252,7 +1241,6 @@ void main() {
     expect(theme.colorScheme.brightness, equals(Brightness.dark));
     expect(theme.primaryColor, equals(lightColors.primary));
     expect(theme.cardColor, equals(lightColors.surface));
-    expect(theme.backgroundColor, equals(lightColors.background));
     expect(theme.canvasColor, equals(lightColors.background));
     expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
     expect(theme.dialogBackgroundColor, equals(lightColors.background));
@@ -1351,7 +1339,6 @@ void main() {
       'tooltipTheme',
       // DEPRECATED (newest deprecations at the bottom)
       'errorColor',
-      'backgroundColor',
     };
 
     final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();


### PR DESCRIPTION
This PR is to remove deprecated ThemeData.backgroundColor.

These parameters are made obsolete in https://github.com/flutter/flutter/pull/110162.
Part of https://github.com/flutter/flutter/issues/143956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
