### PR TITLE
Remove `bottomAppBarColor` from `ThemeData`

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -280,7 +280,7 @@ class _BottomAppBarDefaultsM2 extends BottomAppBarTheme {
   final BuildContext context;
 
   @override
-  Color? get color => Theme.of(context).bottomAppBarColor;
+  Color? get color => Theme.of(context).brightness == Brightness.dark ? Colors.grey[800]! : Colors.white;
 
   @override
   Color? get surfaceTintColor => Theme.of(context).colorScheme.surfaceTint;

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -94,8 +94,10 @@ class BottomAppBar extends StatefulWidget {
   /// The bottom app bar's background color.
   ///
   /// If this property is null then [BottomAppBarTheme.color] of
-  /// [ThemeData.bottomAppBarTheme] is used. If that's null then
-  /// [ThemeData.bottomAppBarColor] is used.
+  /// [ThemeData.bottomAppBarTheme] is used. If that's null and [ThemeData.useMaterial3]
+  /// is true, the default value is [ColorScheme.surface]; if [ThemeData.useMaterial3]
+  /// is false, then the default value is `Color(0xFF424242)` in dark theme and
+  /// [Colors.white] in light theme.
   final Color? color;
 
   /// The z-coordinate at which to place this bottom app bar relative to its

--- a/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
@@ -39,8 +39,6 @@ class BottomAppBarTheme with Diagnosticable {
   });
 
   /// Overrides the default value for [BottomAppBar.color].
-  ///
-  /// If null, [BottomAppBar] uses [ThemeData.bottomAppBarColor].
   final Color? color;
 
   /// Overrides the default value for [BottomAppBar.elevation].

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -384,11 +384,6 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.3.0-0.5.pre.',
     )
     Color? backgroundColor,
-    @Deprecated(
-      'Use BottomAppBarTheme.color instead. '
-      'This feature was deprecated after v3.3.0-0.6.pre.',
-    )
-    Color? bottomAppBarColor,
   }) {
     // GENERAL CONFIGURATION
     cupertinoOverrideTheme = cupertinoOverrideTheme?.noDefault();
@@ -441,7 +436,6 @@ class ThemeData with Diagnosticable {
       primaryColor ??= primarySurfaceColor;
       canvasColor ??= colorScheme.background;
       scaffoldBackgroundColor ??= colorScheme.background;
-      bottomAppBarColor ??= colorScheme.surface;
       cardColor ??= colorScheme.surface;
       dividerColor ??= colorScheme.outline;
       backgroundColor ??= colorScheme.background;
@@ -569,7 +563,6 @@ class ThemeData with Diagnosticable {
     // DEPRECATED (newest deprecations at the bottom)
     errorColor ??= Colors.red[700]!;
     backgroundColor ??= isDark ? Colors.grey[700]! : primarySwatch[200]!;
-    bottomAppBarColor ??= colorSchemeSeed != null ? colorScheme.surface : isDark ? Colors.grey[800]! : Colors.white;
 
     return ThemeData.raw(
       // For the sanity of the reader, make sure these properties are in the same
@@ -667,7 +660,6 @@ class ThemeData with Diagnosticable {
       toggleableActiveColor: toggleableActiveColor,
       errorColor: errorColor,
       backgroundColor: backgroundColor,
-      bottomAppBarColor: bottomAppBarColor,
     );
   }
 
@@ -791,18 +783,12 @@ class ThemeData with Diagnosticable {
       'This feature was deprecated after v3.3.0-0.5.pre.',
     )
     Color? backgroundColor,
-    @Deprecated(
-      'Use BottomAppBarTheme.color instead. '
-      'This feature was deprecated after v3.3.0-0.6.pre.',
-    )
-    Color? bottomAppBarColor,
 
   }) : // DEPRECATED (newest deprecations at the bottom)
        // should not be `required`, use getter pattern to avoid breakages.
        _toggleableActiveColor = toggleableActiveColor,
        _errorColor = errorColor,
        _backgroundColor = backgroundColor,
-       _bottomAppBarColor = bottomAppBarColor,
        assert(toggleableActiveColor != null),
         // DEPRECATED (newest deprecations at the bottom)
        assert(errorColor != null),
@@ -851,7 +837,6 @@ class ThemeData with Diagnosticable {
       primaryColor: primarySurfaceColor,
       canvasColor: colorScheme.background,
       scaffoldBackgroundColor: colorScheme.background,
-      bottomAppBarColor: colorScheme.surface,
       cardColor: colorScheme.surface,
       dividerColor: colorScheme.onSurface.withOpacity(0.12),
       backgroundColor: colorScheme.background,
@@ -1183,14 +1168,6 @@ class ThemeData with Diagnosticable {
   final VisualDensity visualDensity;
 
   // COLOR
-
-  /// The default color of the [BottomAppBar].
-    @Deprecated(
-      'Use BottomAppBarTheme.color instead. '
-      'This feature was deprecated after v3.3.0-0.6.pre.',
-    )
-  Color get bottomAppBarColor => _bottomAppBarColor!;
-  final Color? _bottomAppBarColor;
 
   /// The default color of [MaterialType.canvas] [Material].
   final Color canvasColor;
@@ -1620,11 +1597,6 @@ class ThemeData with Diagnosticable {
     )
     Color? backgroundColor,
     @Deprecated(
-      'Use BottomAppBarTheme.color instead. '
-      'This feature was deprecated after v3.3.0-0.6.pre.',
-    )
-    Color? bottomAppBarColor,
-    @Deprecated(
       'Use a ThemeData constructor (.from, .light, or .dark) instead. '
       'These constructors all have a useMaterial3 argument, '
       'and they set appropriate default values based on its value. '
@@ -1732,7 +1704,6 @@ class ThemeData with Diagnosticable {
       toggleableActiveColor: toggleableActiveColor ?? _toggleableActiveColor,
       errorColor: errorColor ?? _errorColor,
       backgroundColor: backgroundColor ?? _backgroundColor,
-      bottomAppBarColor: bottomAppBarColor ?? _bottomAppBarColor,
     );
   }
 
@@ -1930,7 +1901,6 @@ class ThemeData with Diagnosticable {
       toggleableActiveColor: Color.lerp(a.toggleableActiveColor, b.toggleableActiveColor, t),
       errorColor: Color.lerp(a.errorColor, b.errorColor, t),
       backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
-      bottomAppBarColor: Color.lerp(a.bottomAppBarColor, b.bottomAppBarColor, t),
     );
   }
 
@@ -2034,8 +2004,7 @@ class ThemeData with Diagnosticable {
         // DEPRECATED (newest deprecations at the bottom)
         other.toggleableActiveColor == toggleableActiveColor &&
         other.errorColor == errorColor &&
-        other.backgroundColor == backgroundColor &&
-        other.bottomAppBarColor == bottomAppBarColor;
+        other.backgroundColor == backgroundColor;
   }
 
   @override
@@ -2138,7 +2107,6 @@ class ThemeData with Diagnosticable {
       toggleableActiveColor,
       errorColor,
       backgroundColor,
-      bottomAppBarColor,
     ];
     return Object.hashAll(values);
   }
@@ -2242,7 +2210,6 @@ class ThemeData with Diagnosticable {
     properties.add(ColorProperty('toggleableActiveColor', toggleableActiveColor, defaultValue: defaultData.toggleableActiveColor, level: DiagnosticLevel.debug));
     properties.add(ColorProperty('errorColor', errorColor, defaultValue: defaultData.errorColor, level: DiagnosticLevel.debug));
     properties.add(ColorProperty('backgroundColor', backgroundColor, defaultValue: defaultData.backgroundColor, level: DiagnosticLevel.debug));
-    properties.add(ColorProperty('bottomAppBarColor', bottomAppBarColor, defaultValue: defaultData.bottomAppBarColor, level: DiagnosticLevel.debug));
   }
 }
 

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -233,7 +233,7 @@ void main() {
         home: Builder(
           builder: (BuildContext context) {
             return Theme(
-              data: Theme.of(context).copyWith(bottomAppBarColor: const Color(0xffffff00)),
+              data: Theme.of(context).copyWith(bottomAppBarTheme: const BottomAppBarTheme(color: Color(0xffffff00))),
               child: const Scaffold(
                 floatingActionButton: FloatingActionButton(
                   onPressed: null,
@@ -259,7 +259,7 @@ void main() {
         home: Builder(
           builder: (BuildContext context) {
             return Theme(
-              data: Theme.of(context).copyWith(bottomAppBarColor: const Color(0xffffff00)),
+              data: Theme.of(context).copyWith(bottomAppBarTheme: const BottomAppBarTheme(color: Color(0xffffff00))),
               child: const Scaffold(
                 floatingActionButton: FloatingActionButton(
                   onPressed: null,
@@ -287,7 +287,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.light(useMaterial3: true).copyWith(
-          bottomAppBarColor: const Color(0xffffff00),
+          bottomAppBarTheme: const BottomAppBarTheme(color: Color(0xffffff00)),
         ),
         home: Builder(
           builder: (BuildContext context) {

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -29,7 +29,6 @@ void main() {
     });
 
     testWidgets('Material2 - BAB color - Widget', (WidgetTester tester) async {
-      const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const Color babColor = Colors.pink;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: babThemeColor);
@@ -38,7 +37,6 @@ void main() {
         theme: ThemeData(
           useMaterial3: false,
           bottomAppBarTheme: theme,
-          bottomAppBarColor: themeColor
         ),
         home: const Scaffold(body: BottomAppBar(color: babColor)),
       ));
@@ -48,7 +46,6 @@ void main() {
     });
 
     testWidgets('Material2 - BAB color - BabTheme', (WidgetTester tester) async {
-      const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: babThemeColor);
 
@@ -56,7 +53,6 @@ void main() {
         theme: ThemeData(
           useMaterial3: false,
           bottomAppBarTheme: theme,
-          bottomAppBarColor: themeColor
         ),
         home: const Scaffold(body: BottomAppBar()),
       ));
@@ -69,7 +65,7 @@ void main() {
       const Color themeColor = Colors.white10;
 
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(useMaterial3: false, bottomAppBarColor: themeColor),
+        theme: ThemeData(useMaterial3: false, bottomAppBarTheme: const BottomAppBarTheme(color: themeColor)),
         home: const Scaffold(body: BottomAppBar()),
       ));
 
@@ -130,7 +126,6 @@ void main() {
     });
 
     testWidgets('Material3 - BAB color - Widget', (WidgetTester tester) async {
-      const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const Color babColor = Colors.pink;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: babThemeColor);
@@ -139,7 +134,6 @@ void main() {
         theme: ThemeData(
           useMaterial3: true,
           bottomAppBarTheme: theme,
-          bottomAppBarColor: themeColor
         ),
         home: const Scaffold(body: BottomAppBar(color: babColor, surfaceTintColor: Colors.transparent)),
       ));
@@ -149,7 +143,6 @@ void main() {
     });
 
     testWidgets('Material3 - BAB color - BabTheme', (WidgetTester tester) async {
-      const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(color: babThemeColor);
 
@@ -157,7 +150,6 @@ void main() {
         theme: ThemeData(
           useMaterial3: true,
           bottomAppBarTheme: theme,
-          bottomAppBarColor: themeColor
         ),
         home: const Scaffold(body: BottomAppBar(surfaceTintColor: Colors.transparent)),
       ));
@@ -204,7 +196,6 @@ void main() {
 
     testWidgets('Material3 - BAB surfaceTintColor - Widget', (WidgetTester tester) async {
       const Color color = Colors.white10; // base color that the surface tint will be applied to
-      const Color themeSurfaceTintColor = Colors.white10;
       const Color babThemeSurfaceTintColor = Colors.black87;
       const Color babSurfaceTintColor = Colors.pink;
       const BottomAppBarTheme theme = BottomAppBarTheme(
@@ -214,7 +205,6 @@ void main() {
         theme: ThemeData(
           useMaterial3: true,
           bottomAppBarTheme: theme,
-          bottomAppBarColor: themeSurfaceTintColor
         ),
         home: const Scaffold(
           body: BottomAppBar(color: color, surfaceTintColor: babSurfaceTintColor)
@@ -227,7 +217,6 @@ void main() {
 
     testWidgets('Material3 - BAB surfaceTintColor - BabTheme', (WidgetTester tester) async {
       const Color color = Colors.blue; // base color that the surface tint will be applied to
-      const Color themeColor = Colors.white10;
       const Color babThemeColor = Colors.black87;
       const BottomAppBarTheme theme = BottomAppBarTheme(
         surfaceTintColor: babThemeColor
@@ -237,7 +226,6 @@ void main() {
         theme: ThemeData(
           useMaterial3: true,
           bottomAppBarTheme: theme,
-          bottomAppBarColor: themeColor
         ),
         home: const Scaffold(body: BottomAppBar(color: color)),
       ));

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -625,7 +625,6 @@ void main() {
       canvasColor: Colors.black,
       shadowColor: Colors.black,
       scaffoldBackgroundColor: Colors.black,
-      bottomAppBarColor: Colors.black,
       cardColor: Colors.black,
       dividerColor: Colors.black,
       focusColor: Colors.black,

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -171,7 +171,6 @@ void main() {
     expect(theme.primaryColor, theme.colorScheme.primary);
     expect(theme.canvasColor, theme.colorScheme.background);
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
-    expect(theme.bottomAppBarColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
     expect(theme.backgroundColor, theme.colorScheme.background);
@@ -220,7 +219,6 @@ void main() {
     expect(theme.primaryColor, theme.colorScheme.surface);
     expect(theme.canvasColor, theme.colorScheme.background);
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
-    expect(theme.bottomAppBarColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
     expect(theme.backgroundColor, theme.colorScheme.background);
@@ -266,7 +264,6 @@ void main() {
     expect(theme.primaryColor, theme.colorScheme.primary);
     expect(theme.canvasColor, theme.colorScheme.background);
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
-    expect(theme.bottomAppBarColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
     expect(theme.backgroundColor, theme.colorScheme.background);
@@ -313,7 +310,6 @@ void main() {
     expect(theme.primaryColor, theme.colorScheme.primary);
     expect(theme.canvasColor, theme.colorScheme.background);
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
-    expect(theme.bottomAppBarColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
     expect(theme.backgroundColor, theme.colorScheme.background);
@@ -360,7 +356,6 @@ void main() {
     expect(theme.primaryColor, theme.colorScheme.surface);
     expect(theme.canvasColor, theme.colorScheme.background);
     expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
-    expect(theme.bottomAppBarColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
     expect(theme.backgroundColor, theme.colorScheme.background);
@@ -812,7 +807,6 @@ void main() {
       toggleableActiveColor: Colors.black,
       errorColor: Colors.black,
       backgroundColor: Colors.black,
-      bottomAppBarColor: Colors.black,
     );
 
     final SliderThemeData otherSliderTheme = SliderThemeData.fromPrimaryColors(
@@ -932,7 +926,6 @@ void main() {
       toggleableActiveColor: Colors.white,
       errorColor: Colors.white,
       backgroundColor: Colors.white,
-      bottomAppBarColor: Colors.white,
     );
 
     final ThemeData themeDataCopy = theme.copyWith(
@@ -1033,7 +1026,6 @@ void main() {
       toggleableActiveColor: otherTheme.toggleableActiveColor,
       errorColor: otherTheme.errorColor,
       backgroundColor: otherTheme.backgroundColor,
-      bottomAppBarColor: otherTheme.bottomAppBarColor,
     );
 
     // For the sanity of the reader, make sure these properties are in the same
@@ -1135,7 +1127,6 @@ void main() {
     expect(themeDataCopy.toggleableActiveColor, equals(otherTheme.toggleableActiveColor));
     expect(themeDataCopy.errorColor, equals(otherTheme.errorColor));
     expect(themeDataCopy.backgroundColor, equals(otherTheme.backgroundColor));
-    expect(themeDataCopy.bottomAppBarColor, equals(otherTheme.bottomAppBarColor));
   });
 
   testWidgets('ThemeData.toString has less than 200 characters output', (WidgetTester tester) async {
@@ -1268,7 +1259,6 @@ void main() {
       'toggleableActiveColor',
       'errorColor',
       'backgroundColor',
-      'bottomAppBarColor',
     };
 
     final DiagnosticPropertiesBuilder properties = DiagnosticPropertiesBuilder();


### PR DESCRIPTION
This PR is to remove deprecated ThemeData.bottomAppBarColor.

These parameters are made obsolete in https://github.com/flutter/flutter/pull/110162.
Part of https://github.com/flutter/flutter/issues/143956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
