### PR TITLE
[flutter_tools] Fix missing stack trace from daemon

### DIFF
--- a/packages/flutter_tools/lib/src/daemon.dart
+++ b/packages/flutter_tools/lib/src/daemon.dart
@@ -340,7 +340,7 @@ class DaemonConnection {
           // This is an error response.
           _logger.printTrace('<- Error response received from daemon, id = $id');
           final Object error = data['error']!;
-          final String stackTrace = data['stackTrace'] as String? ?? '';
+          final String stackTrace = data['trace'] as String? ?? '';
           _outgoingRequestCompleters.remove(id)?.completeError(error, StackTrace.fromString(stackTrace));
         } else {
           _logger.printTrace('<- Response received from daemon, id = $id');

--- a/packages/flutter_tools/test/general.shard/daemon_test.dart
+++ b/packages/flutter_tools/test/general.shard/daemon_test.dart
@@ -173,7 +173,18 @@ void main() {
 
       final String id = message.data['id']! as String;
       daemonStreams.inputs.add(DaemonMessage(<String, dynamic>{'id': id, 'error': 'some_error', 'trace': 'stack trace'}));
-      expect(requestFuture, throwsA('some_error'));
+
+      Object? gotError;
+      StackTrace? gotStackTrace;
+      try {
+        await requestFuture;
+      } on Object catch (error, stackTrace) {
+        gotError = error;
+        gotStackTrace = stackTrace;
+      }
+
+      expect(gotError, 'some_error');
+      expect(gotStackTrace.toString(), 'stack trace');
     });
   });
 


### PR DESCRIPTION
When the daemon throws an exception, the receiving client is unable to surface stack traces from the daemon.

This is because it is sent with the `trace` key here:

https://github.com/flutter/flutter/blob/1e8dd1e4d6d70c5e06525bea3fb164a03d7a6c1d/packages/flutter_tools/lib/src/daemon.dart#L308

But the client tries to read it with the `stackTrace` key here:

https://github.com/flutter/flutter/blob/1e8dd1e4d6d70c5e06525bea3fb164a03d7a6c1d/packages/flutter_tools/lib/src/daemon.dart#L343

Thanks to @mraleph for spotting this!

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

b/326825892

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
