### PR TITLE
Revert "Re-enable Impeller goldens blocking. (#144023)"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3458,6 +3458,7 @@ targets:
   - name: Mac framework_tests_impeller
     recipe: flutter/flutter_drone
     timeout: 60
+    bringup: true
     properties:
       cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-


### PR DESCRIPTION
On the current head some tests (such as test/widgets/shadow_test.dart) are segfaulting in the Impeller Vulkan back end.

This reverts commit 39585e66c11f0dccbf27089155f2bdc4b28f82d2.

See https://github.com/flutter/flutter/issues/144116