### PR TITLE
[web] Make flutter web profile builds always keep wasm symbols

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -196,8 +196,7 @@ class Dart2JSTarget extends Dart2WebTarget {
       throwOnError: true,
       <String>[
         ...sharedCommandOptions,
-        if (buildMode == BuildMode.profile) '--no-minify',
-        ...compilerConfig.toCommandOptions(),
+        ...compilerConfig.toCommandOptions(buildMode),
         '-o',
         outputJSFile.path,
         environment.buildDir.childFile('app.dill').path, // dartfile
@@ -279,7 +278,7 @@ class Dart2WasmTarget extends Dart2WebTarget {
         '-D$dartDefine',
       '--extra-compiler-option=--depfile=${depFile.path}',
 
-      ...compilerConfig.toCommandOptions(),
+      ...compilerConfig.toCommandOptions(buildMode),
       '-o',
       outputWasmFile.path,
       environment.buildDir.childFile('main.dart').path, // dartfile

--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -148,7 +148,7 @@ class WasmCompilerConfig extends WebCompilerConfig {
   CompileTarget get compileTarget => CompileTarget.wasm;
 
   List<String> toCommandOptions(BuildMode buildMode) {
-    final bool stripSymbols = buildMode == BuildMode.release ? stripWasm : false;
+    final bool stripSymbols = buildMode == BuildMode.release && stripWasm;
     return <String>[
       '-O$optimizationLevel',
       '--${stripSymbols ? 'no-' : ''}name-section',

--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../build_info.dart' show BuildMode;
 import '../convert.dart';
 import 'compile.dart';
 
@@ -106,7 +107,8 @@ class JsCompilerConfig extends WebCompilerConfig {
   /// Arguments to use in the full JS compile, but not CFE-only.
   ///
   /// Includes the contents of [toSharedCommandOptions].
-  List<String> toCommandOptions() => <String>[
+  List<String> toCommandOptions(BuildMode buildMode) => <String>[
+        if (buildMode == BuildMode.profile) '--no-minify',
         ...toSharedCommandOptions(),
         '-O$optimizationLevel',
         if (dumpInfo) '--dump-info',
@@ -145,10 +147,11 @@ class WasmCompilerConfig extends WebCompilerConfig {
   @override
   CompileTarget get compileTarget => CompileTarget.wasm;
 
-  List<String> toCommandOptions() {
+  List<String> toCommandOptions(BuildMode buildMode) {
+    final bool stripSymbols = buildMode == BuildMode.release ? stripWasm : false;
     return <String>[
       '-O$optimizationLevel',
-      '--${stripWasm? 'no-' : ''}name-section',
+      '--${stripSymbols ? 'no-' : ''}name-section',
     ];
   }
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -904,53 +904,55 @@ void main() {
     for (int level = 1; level <= 4; level++) {
       for (final bool strip in <bool>[true, false]) {
         for (final List<String> defines in const <List<String>>[<String>[], <String>['FOO=bar', 'BAZ=qux']]) {
-          test('Dart2WasmTarget invokes dart2wasm with renderer=$renderer, -O$level, stripping=$strip, defines=$defines', () => testbed.run(() async {
-            environment.defines[kBuildMode] = 'release';
-            environment.defines[kDartDefines] = encodeDartDefines(defines);
+          for (final String buildMode in const <String>['profile', 'release']) {
+            test('Dart2WasmTarget invokes dart2wasm with renderer=$renderer, -O$level, stripping=$strip, defines=$defines, modeMode=$buildMode', () => testbed.run(() async {
+              environment.defines[kBuildMode] = buildMode;
+              environment.defines[kDartDefines] = encodeDartDefines(defines);
 
-            final File depFile = environment.buildDir.childFile('dart2wasm.d');
+              final File depFile = environment.buildDir.childFile('dart2wasm.d');
 
-            final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
-            processManager.addCommand(FakeCommand(
-              command: <String>[
-                ..._kDart2WasmLinuxArgs,
-                if (renderer == WebRendererMode.skwasm) ...<String>[
-                  '--extra-compiler-option=--import-shared-memory',
-                  '--extra-compiler-option=--shared-memory-max-pages=32768',
+              final File outputJsFile = environment.buildDir.childFile('main.dart.mjs');
+              processManager.addCommand(FakeCommand(
+                command: <String>[
+                  ..._kDart2WasmLinuxArgs,
+                  if (renderer == WebRendererMode.skwasm) ...<String>[
+                    '--extra-compiler-option=--import-shared-memory',
+                    '--extra-compiler-option=--shared-memory-max-pages=32768',
+                  ],
+                  '-Ddart.vm.${buildMode == 'release' ? 'product' : 'profile' }=true',
+                  ...defines.map((String define) => '-D$define'),
+                  if (renderer == WebRendererMode.skwasm) ...<String>[
+                    '-DFLUTTER_WEB_AUTO_DETECT=false',
+                    '-DFLUTTER_WEB_USE_SKIA=false',
+                    '-DFLUTTER_WEB_USE_SKWASM=true',
+                  ],
+                  if (renderer == WebRendererMode.canvaskit) ...<String>[
+                    '-DFLUTTER_WEB_AUTO_DETECT=false',
+                    '-DFLUTTER_WEB_USE_SKIA=true',
+                  ],
+                  '--extra-compiler-option=--depfile=${depFile.absolute.path}',
+                  '-O$level',
+                  if (strip && buildMode == 'release') '--no-name-section' else '--name-section',
+                  '-o',
+                  environment.buildDir.childFile('main.dart.wasm').absolute.path,
+                  environment.buildDir.childFile('main.dart').absolute.path,
                 ],
-                '-Ddart.vm.product=true',
-                ...defines.map((String define) => '-D$define'),
-                if (renderer == WebRendererMode.skwasm) ...<String>[
-                  '-DFLUTTER_WEB_AUTO_DETECT=false',
-                  '-DFLUTTER_WEB_USE_SKIA=false',
-                  '-DFLUTTER_WEB_USE_SKWASM=true',
-                ],
-                if (renderer == WebRendererMode.canvaskit) ...<String>[
-                  '-DFLUTTER_WEB_AUTO_DETECT=false',
-                  '-DFLUTTER_WEB_USE_SKIA=true',
-                ],
-                '--extra-compiler-option=--depfile=${depFile.absolute.path}',
-                '-O$level',
-                if (strip) '--no-name-section' else '--name-section',
-                '-o',
-                environment.buildDir.childFile('main.dart.wasm').absolute.path,
-                environment.buildDir.childFile('main.dart').absolute.path,
-              ],
-              onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo'))
-            );
+                onRun: (_) => outputJsFile..createSync()..writeAsStringSync('foo'))
+              );
 
-            await Dart2WasmTarget(
-              WasmCompilerConfig(
-                optimizationLevel: level,
-                stripWasm: strip,
-                renderer: renderer,
-              )
-            ).build(environment);
+              await Dart2WasmTarget(
+                WasmCompilerConfig(
+                  optimizationLevel: level,
+                  stripWasm: strip,
+                  renderer: renderer,
+                )
+              ).build(environment);
 
-            expect(outputJsFile.existsSync(), isTrue);
-          }, overrides: <Type, Generator>{
+              expect(outputJsFile.existsSync(), isTrue);
+            }, overrides: <Type, Generator>{
             ProcessManager: () => processManager,
           }));
+        }
         }
       }
     }


### PR DESCRIPTION
So far `flutter build web --wasm` was always stripping wasm symbols except if `--no-strip-wasm` is passed.

=> Ensure that in profile mode we also keep the symbols
