### PR TITLE
Implementing iterable methods throughout the repository

### DIFF
--- a/dev/integration_tests/channels/lib/src/test_step.dart
+++ b/dev/integration_tests/channels/lib/src/test_step.dart
@@ -188,12 +188,7 @@ bool _deepEqualsMap(Map<dynamic, dynamic> a, Map<dynamic, dynamic> b) {
   if (a.length != b.length) {
     return false;
   }
-  for (final dynamic key in a.keys) {
-    if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
-      return false;
-    }
-  }
-  return true;
+  return a.keys.every((dynamic key) => b.containsKey(key) && _deepEquals(a[key], b[key]));
 }
 
 bool _deepEqualsPair(Pair a, Pair b) {

--- a/dev/tracing_tests/test/image_cache_tracing_test.dart
+++ b/dev/tracing_tests/test/image_cache_tracing_test.dart
@@ -98,12 +98,7 @@ void _expectTimelineEvents(List<TimelineEvent> events, List<Map<String, dynamic>
 }
 
 bool _mapsEqual(Map<String, dynamic> expectedArgs, Map<String, dynamic> args) {
-  for (final String key in expectedArgs.keys) {
-    if (expectedArgs[key] != args[key]) {
-      return false;
-    }
-  }
-  return true;
+  return expectedArgs.keys.every((String key) => expectedArgs[key] == args[key]);
 }
 
 class TestImageStreamCompleter extends ImageStreamCompleter {

--- a/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
+++ b/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
@@ -135,14 +135,9 @@ class FallbackKeyEventRegistrar {
       if (existing(message)) {
         return true;
       }
-      if (_fallbackNodes.isNotEmpty) {
-        for (final KeyEvent event in message.events) {
-          if (_fallbackNodes.last.onKeyEvent(event)) {
-            return true;
-          }
-        }
-      }
-      return false;
+      return _fallbackNodes.isNotEmpty && message.events.any(
+        (KeyEvent event) => _fallbackNodes.last.onKeyEvent(event),
+      );
     };
   }
 }

--- a/packages/flutter/lib/src/foundation/collections.dart
+++ b/packages/flutter/lib/src/foundation/collections.dart
@@ -26,15 +26,7 @@ bool setEquals<T>(Set<T>? a, Set<T>? b) {
   if (b == null || a.length != b.length) {
     return false;
   }
-  if (identical(a, b)) {
-    return true;
-  }
-  for (final T value in a) {
-    if (!b.contains(value)) {
-      return false;
-    }
-  }
-  return true;
+  return identical(a, b) || a.every((T value) => b.contains(value));
 }
 
 /// Compares two lists for element-by-element equality.
@@ -95,12 +87,7 @@ bool mapEquals<T, U>(Map<T, U>? a, Map<T, U>? b) {
   if (identical(a, b)) {
     return true;
   }
-  for (final T key in a.keys) {
-    if (!b.containsKey(key) || b[key] != a[key]) {
-      return false;
-    }
-  }
-  return true;
+  return a.keys.every((T key) => b.containsKey(key) && a[key] == b[key]);
 }
 
 /// Returns the position of `value` in the `sortedList`, if it exists.

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2308,7 +2308,6 @@ class _MenuBarAnchor extends MenuAnchor {
 }
 
 class _MenuBarAnchorState extends _MenuAnchorState {
-  // If it's a bar, then it's "open" if any of its children are open.
   @override
   bool get _isOpen => _anchorChildren.any((_MenuAnchorState child) => child._isOpen);
 

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2308,16 +2308,9 @@ class _MenuBarAnchor extends MenuAnchor {
 }
 
 class _MenuBarAnchorState extends _MenuAnchorState {
+  // If it's a bar, then it's "open" if any of its children are open.
   @override
-  bool get _isOpen {
-    // If it's a bar, then it's "open" if any of its children are open.
-    for (final _MenuAnchorState child in _anchorChildren) {
-      if (child._isOpen) {
-        return true;
-      }
-    }
-    return false;
-  }
+  bool get _isOpen => _anchorChildren.any((_MenuAnchorState child) => child._isOpen);
 
   @override
   Axis get _orientation => Axis.horizontal;

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -424,12 +424,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   }
 
   bool _isLabel() {
-    for (final Step step in widget.steps) {
-      if (step.label != null) {
-        return true;
-      }
-    }
-    return false;
+    return widget.steps.any((Step step) => step.label != null);
   }
 
   StepStyle? _stepStyle(int index) {

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -316,28 +316,12 @@ class TextSpan extends InlineSpan implements HitTestTarget, MouseTrackerAnnotati
     if (text != null && !visitor(this)) {
       return false;
     }
-    final List<InlineSpan>? children = this.children;
-    if (children != null) {
-      for (final InlineSpan child in children) {
-        if (!child.visitChildren(visitor)) {
-          return false;
-        }
-      }
-    }
-    return true;
+    return children?.every((InlineSpan child) => child.visitChildren(visitor)) ?? true;
   }
 
   @override
   bool visitDirectChildren(InlineSpanVisitor visitor) {
-    final List<InlineSpan>? children = this.children;
-    if (children != null) {
-      for (final InlineSpan child in children) {
-        if (!visitor(child)) {
-          return false;
-        }
-      }
-    }
-    return true;
+    return children?.every((InlineSpan child) => visitor(child)) ?? true;
   }
 
   /// Returns the text span that contains the given position in the text.

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2026,14 +2026,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
   /// until visitor returns false. Returns true if all the visitor calls
   /// returned true, otherwise returns false.
   bool _visitDescendants(SemanticsNodeVisitor visitor) {
-    if (_children != null) {
-      for (final SemanticsNode child in _children!) {
-        if (!visitor(child) || !child._visitDescendants(visitor)) {
-          return false;
-        }
-      }
-    }
-    return true;
+    return _children?.every((SemanticsNode child) => visitor(child) && child._visitDescendants(visitor)) ?? true;
   }
 
   /// The owner for this node (null if unattached).

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -472,15 +472,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
   /// node can't be reached via traversal, not that it can't be focused. It may
   /// still be focused explicitly.
   bool get skipTraversal {
-    if (_skipTraversal) {
-      return true;
-    }
-    for (final FocusNode ancestor in ancestors) {
-      if (!ancestor.descendantsAreTraversable) {
-        return true;
-      }
-    }
-    return false;
+    return _skipTraversal || ancestors.any((FocusNode ancestor) => !ancestor.descendantsAreTraversable);
   }
   bool _skipTraversal;
   set skipTraversal(bool value) {
@@ -525,12 +517,7 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
     if (scope != null && !scope.canRequestFocus) {
       return false;
     }
-    for (final FocusNode ancestor in ancestors) {
-      if (!ancestor.descendantsAreFocusable) {
-        return false;
-      }
-    }
-    return true;
+    return ancestors.every((FocusNode ancestor) => ancestor.descendantsAreFocusable);
   }
 
   bool _canRequestFocus;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5818,12 +5818,7 @@ class _HistoryProperty extends RestorableProperty<Map<String?, List<Object>>?> {
     if (!setEquals(a.keys.toSet(), b.keys.toSet())) {
       return false;
     }
-    for (final String? key in a.keys) {
-      if (!listEquals(a[key], b[key])) {
-        return false;
-      }
-    }
-    return true;
+    return a.keys.every((String? key) => listEquals(a[key], b[key]));
   }
 
   void clear() {

--- a/packages/flutter/lib/src/widgets/shared_app_data.dart
+++ b/packages/flutter/lib/src/widgets/shared_app_data.dart
@@ -189,11 +189,6 @@ class _SharedAppModel extends InheritedModel<Object> {
 
   @override
   bool updateShouldNotifyDependent(_SharedAppModel old, Set<Object> keys) {
-    for (final Object key in keys) {
-      if (data[key] != old.data[key]) {
-        return true;
-      }
-    }
-    return false;
+    return keys.any((Object key) => data[key] != old.data[key]);
   }
 }

--- a/packages/flutter/lib/src/widgets/tap_region.dart
+++ b/packages/flutter/lib/src/widgets/tap_region.dart
@@ -225,14 +225,7 @@ class RenderTapRegionSurface extends RenderProxyBoxWithHitTestBehavior implement
   @override
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     assert(debugHandleEvent(event, entry));
-    assert(() {
-      for (final RenderTapRegion region in _registeredRegions) {
-        if (!region.enabled) {
-          return false;
-        }
-      }
-      return true;
-    }(), 'A RenderTapRegion was registered when it was disabled.');
+    assert(_registeredRegions.every((RenderTapRegion region) => region.enabled), 'A RenderTapRegion was registered when it was disabled.');
 
     if (event is! PointerDownEvent) {
       return;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1762,12 +1762,7 @@ mixin WidgetInspectorService {
       // https://github.com/flutter/flutter/issues/32660 is fixed.
       return !file.contains('packages/flutter/');
     }
-    for (final String directory in _pubRootDirectories!) {
-      if (file.startsWith(directory)) {
-        return true;
-      }
-    }
-    return false;
+    return _pubRootDirectories!.any((String directory) => file.startsWith(directory));
   }
 
   /// Memoized version of [_isLocalCreationLocationImpl].

--- a/packages/flutter/test/services/message_codecs_testing.dart
+++ b/packages/flutter/test/services/message_codecs_testing.dart
@@ -83,13 +83,7 @@ bool deepEqualsList(List<dynamic> valueA, List<dynamic> valueB) {
 }
 
 bool deepEqualsMap(Map<dynamic, dynamic> valueA, Map<dynamic, dynamic> valueB) {
-  if (valueA.length != valueB.length) {
-    return false;
-  }
-  for (final dynamic key in valueA.keys) {
-    if (!valueB.containsKey(key) || !deepEquals(valueA[key], valueB[key])) {
-      return false;
-    }
-  }
-  return true;
+  return valueA.length == valueB.length && valueA.keys.every(
+    (dynamic key) => valueB.containsKey(key) && deepEquals(valueA[key], valueB[key]),
+  );
 }

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1640,15 +1640,9 @@ class _IsMethodCall extends Matcher {
   }
 
   bool _deepEqualsMap(Map<dynamic, dynamic> a, Map<dynamic, dynamic> b) {
-    if (a.length != b.length) {
-      return false;
-    }
-    for (final dynamic key in a.keys) {
-      if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) {
-        return false;
-      }
-    }
-    return true;
+    return a.length == b.length && a.keys.every(
+      (dynamic key) => b.containsKey(key) && _deepEquals(a[key], b[key]),
+    );
   }
 
   @override

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -488,13 +488,5 @@ bool setEquals<T>(Set<T>? a, Set<T>? b) {
   if (b == null || a.length != b.length) {
     return false;
   }
-  if (identical(a, b)) {
-    return true;
-  }
-  for (final T value in a) {
-    if (!b.contains(value)) {
-      return false;
-    }
-  }
-  return true;
+  return identical(a, b) || a.every((T value) => b.contains(value));
 }

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -194,21 +194,11 @@ class AssembleCommand extends FlutterCommand {
   }
 
   bool isDeferredComponentsTargets() {
-    for (final String targetName in argResults!.rest) {
-      if (deferredComponentsTargets.contains(targetName)) {
-        return true;
-      }
-    }
-    return false;
+    return argResults!.rest.any((String targetName) => deferredComponentsTargets.contains(targetName));
   }
 
   bool isDebug() {
-    for (final String targetName in argResults!.rest) {
-      if (targetName.contains('debug')) {
-        return true;
-      }
-    }
-    return false;
+    return argResults!.rest.any((String targetName) => targetName.contains('debug'));
   }
 
   late final Environment _environment = _createEnvironment();

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -101,15 +101,9 @@ class PubDependencies extends ArtifactSet {
       logger: _logger,
       throwOnError: false,
     );
-    if (packageConfig == PackageConfig.empty) {
-      return false;
-    }
-    for (final Package package in packageConfig.packages) {
-      if (!fileSystem.directory(package.root).childFile('pubspec.yaml').existsSync()) {
-        return false;
-      }
-    }
-    return true;
+    return packageConfig != PackageConfig.empty && packageConfig.packages.every(
+      (Package package) => fileSystem.directory(package.root).childFile('pubspec.yaml').existsSync(),
+    );
   }
 
   @override
@@ -809,16 +803,7 @@ class IosUsbArtifacts extends CachedArtifact {
 
   @override
   bool isUpToDateInner(FileSystem fileSystem) {
-    final List<String>? executables =_kExecutables[name];
-    if (executables == null) {
-      return true;
-    }
-    for (final String executable in executables) {
-      if (!location.childFile(executable).existsSync()) {
-        return false;
-      }
-    }
-    return true;
+    return _kExecutables[name]?.every((String executable) => location.childFile(executable).existsSync()) ?? true;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -494,12 +494,7 @@ class XcodeProjectInfo {
   /// regard to case.
   bool hasBuildConfigurationForBuildMode(String buildMode) {
     buildMode = buildMode.toLowerCase();
-    for (final String name in buildConfigurations) {
-      if (name.toLowerCase() == buildMode) {
-        return true;
-      }
-    }
-    return false;
+    return buildConfigurations.any((String name) => name.toLowerCase() == buildMode);
   }
 
   /// Returns unique scheme matching [buildInfo], or null, if there is no unique


### PR DESCRIPTION
This pull request fixes #144156 by taking advantage of the iterable `.any()` and `.every()` methods.  
<br>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes