### PR TITLE
Remove `showTrackOnHover` from `Scrollbar` and `ScrollbarTheme`

### DIFF
--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -95,11 +95,6 @@ class Scrollbar extends StatelessWidget {
     this.notificationPredicate,
     this.interactive,
     this.scrollbarOrientation,
-    @Deprecated(
-      'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after v3.4.0-19.0.pre.',
-    )
-    this.showTrackOnHover,
   });
 
   /// {@macro flutter.widgets.Scrollbar.child}
@@ -128,23 +123,7 @@ class Scrollbar extends StatelessWidget {
   /// If the track visibility is related to the scrollbar's material state,
   /// use the global [ScrollbarThemeData.trackVisibility] or override the
   /// sub-tree's theme data.
-  ///
-  /// Replaces deprecated [showTrackOnHover].
   final bool? trackVisibility;
-
-  /// Controls if the track will show on hover and remain, including during drag.
-  ///
-  /// If this property is null, then [ScrollbarThemeData.showTrackOnHover] of
-  /// [ThemeData.scrollbarTheme] is used. If that is also null, the default value
-  /// is false.
-  ///
-  /// This is deprecated, [trackVisibility] or [ScrollbarThemeData.trackVisibility]
-  /// should be used instead.
-  @Deprecated(
-    'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-    'This feature was deprecated after v3.4.0-19.0.pre.',
-  )
-  final bool? showTrackOnHover;
 
   /// The thickness of the scrollbar in the cross axis of the scrollable.
   ///
@@ -190,7 +169,6 @@ class Scrollbar extends StatelessWidget {
       controller: controller,
       thumbVisibility: thumbVisibility,
       trackVisibility: trackVisibility,
-      showTrackOnHover: showTrackOnHover,
       thickness: thickness,
       radius: radius,
       notificationPredicate: notificationPredicate,
@@ -207,7 +185,6 @@ class _MaterialScrollbar extends RawScrollbar {
     super.controller,
     super.thumbVisibility,
     super.trackVisibility,
-    this.showTrackOnHover,
     super.thickness,
     super.radius,
     ScrollNotificationPredicate? notificationPredicate,
@@ -219,8 +196,6 @@ class _MaterialScrollbar extends RawScrollbar {
          pressDuration: Duration.zero,
          notificationPredicate: notificationPredicate ?? defaultScrollNotificationPredicate,
        );
-
-  final bool? showTrackOnHover;
 
   @override
   _MaterialScrollbarState createState() => _MaterialScrollbarState();
@@ -241,12 +216,8 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   @override
   bool get enableGestures => widget.interactive ?? _scrollbarTheme.interactive ?? !_useAndroidScrollbar;
 
-  bool get _showTrackOnHover => widget.showTrackOnHover ?? _scrollbarTheme.showTrackOnHover ?? false;
 
   MaterialStateProperty<bool> get _trackVisibility => MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-    if (states.contains(MaterialState.hovered) && _showTrackOnHover) {
-      return true;
-    }
     return widget.trackVisibility ?? _scrollbarTheme.trackVisibility?.resolve(states) ?? false;
   });
 

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -45,11 +45,6 @@ class ScrollbarThemeData with Diagnosticable {
     this.mainAxisMargin,
     this.minThumbLength,
     this.interactive,
-    @Deprecated(
-      'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after v3.4.0-19.0.pre.',
-    )
-    this.showTrackOnHover,
   });
 
   /// Overrides the default value of [Scrollbar.thumbVisibility] in all
@@ -66,14 +61,6 @@ class ScrollbarThemeData with Diagnosticable {
   /// Overrides the default value of [Scrollbar.trackVisibility] in all
   /// descendant [Scrollbar] widgets.
   final MaterialStateProperty<bool?>? trackVisibility;
-
-  /// Overrides the default value of [Scrollbar.showTrackOnHover] in all
-  /// descendant [Scrollbar] widgets.
-  @Deprecated(
-    'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-    'This feature was deprecated after v3.4.0-19.0.pre.',
-  )
-  final bool? showTrackOnHover;
 
   /// Overrides the default value of [Scrollbar.interactive] in all
   /// descendant [Scrollbar] widgets.
@@ -92,14 +79,14 @@ class ScrollbarThemeData with Diagnosticable {
   final MaterialStateProperty<Color?>? thumbColor;
 
   /// Overrides the default [Color] of the [Scrollbar] track when
-  /// [showTrackOnHover] is true in all descendant [Scrollbar] widgets.
+  /// [trackVisibility] is true in all descendant [Scrollbar] widgets.
   ///
   /// Resolves in the following states:
   ///  * [MaterialState.hovered] on web and desktop platforms.
   final MaterialStateProperty<Color?>? trackColor;
 
   /// Overrides the default [Color] of the [Scrollbar] track border when
-  /// [showTrackOnHover] is true in all descendant [Scrollbar] widgets.
+  /// [trackVisibility] is true in all descendant [Scrollbar] widgets.
   ///
   /// Resolves in the following states:
   ///  * [MaterialState.hovered] on web and desktop platforms.
@@ -148,17 +135,11 @@ class ScrollbarThemeData with Diagnosticable {
     double? crossAxisMargin,
     double? mainAxisMargin,
     double? minThumbLength,
-    @Deprecated(
-      'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after v3.4.0-19.0.pre.',
-    )
-    bool? showTrackOnHover,
   }) {
     return ScrollbarThemeData(
       thumbVisibility: thumbVisibility ?? this.thumbVisibility,
       thickness: thickness ?? this.thickness,
       trackVisibility: trackVisibility ?? this.trackVisibility,
-      showTrackOnHover: showTrackOnHover ?? this.showTrackOnHover,
       interactive: interactive ?? this.interactive,
       radius: radius ?? this.radius,
       thumbColor: thumbColor ?? this.thumbColor,
@@ -181,7 +162,6 @@ class ScrollbarThemeData with Diagnosticable {
       thumbVisibility: MaterialStateProperty.lerp<bool?>(a?.thumbVisibility, b?.thumbVisibility, t, _lerpBool),
       thickness: MaterialStateProperty.lerp<double?>(a?.thickness, b?.thickness, t, lerpDouble),
       trackVisibility: MaterialStateProperty.lerp<bool?>(a?.trackVisibility, b?.trackVisibility, t, _lerpBool),
-      showTrackOnHover: _lerpBool(a?.showTrackOnHover, b?.showTrackOnHover, t),
       interactive: _lerpBool(a?.interactive, b?.interactive, t),
       radius: Radius.lerp(a?.radius, b?.radius, t),
       thumbColor: MaterialStateProperty.lerp<Color?>(a?.thumbColor, b?.thumbColor, t, Color.lerp),
@@ -198,7 +178,6 @@ class ScrollbarThemeData with Diagnosticable {
     thumbVisibility,
     thickness,
     trackVisibility,
-    showTrackOnHover,
     interactive,
     radius,
     thumbColor,
@@ -221,7 +200,6 @@ class ScrollbarThemeData with Diagnosticable {
       && other.thumbVisibility == thumbVisibility
       && other.thickness == thickness
       && other.trackVisibility == trackVisibility
-      && other.showTrackOnHover == showTrackOnHover
       && other.interactive == interactive
       && other.radius == radius
       && other.thumbColor == thumbColor
@@ -238,7 +216,6 @@ class ScrollbarThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('thumbVisibility', thumbVisibility, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('thickness', thickness, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('trackVisibility', trackVisibility, defaultValue: null));
-    properties.add(DiagnosticsProperty<bool>('showTrackOnHover', showTrackOnHover, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('interactive', interactive, defaultValue: null));
     properties.add(DiagnosticsProperty<Radius>('radius', radius, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('thumbColor', thumbColor, defaultValue: null));

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1020,7 +1020,6 @@ void main() {
           useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(
             thumbVisibility: MaterialStateProperty.all(true),
-            showTrackOnHover: true,
           ),
         ),
         home: const SingleChildScrollView(
@@ -1160,7 +1159,7 @@ void main() {
     }),
   );
 
-  testWidgets('ScrollbarThemeData.trackVisibility replaces showTrackOnHover', (WidgetTester tester) async {
+  testWidgets('ScrollbarThemeData.trackVisibility', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
@@ -1219,69 +1218,6 @@ void main() {
           // Hover color
           color: const Color(0x80000000),
         ),
-    );
-  },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.linux,
-      TargetPlatform.macOS,
-      TargetPlatform.windows,
-    }),
-  );
-
-  testWidgets('Scrollbar showTrackOnHover', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(
-          useMaterial3: false,
-          scrollbarTheme: ScrollbarThemeData(
-            thumbVisibility: MaterialStateProperty.all(true),
-            showTrackOnHover: true,
-          ),
-        ),
-        home: const SingleChildScrollView(
-          child: SizedBox(width: 4000.0, height: 4000.0),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(
-      find.byType(Scrollbar),
-      paints..rrect(
-        rrect: RRect.fromRectAndRadius(
-          getStartingThumbRect(isAndroid: false),
-          _kDefaultThumbRadius,
-        ),
-        color: _kDefaultIdleThumbColor,
-      ),
-    );
-
-    final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
-    await gesture.addPointer();
-    await gesture.moveTo(const Offset(794.0, 5.0));
-    await tester.pump();
-
-    expect(
-      find.byType(Scrollbar),
-      paints
-        ..rect(
-          rect: const Rect.fromLTRB(784.0, 0.0, 800.0, 600.0),
-          color: const Color(0x08000000),
-        )
-        ..line(
-          p1: const Offset(784.0, 0.0),
-          p2: const Offset(784.0, 600.0),
-          strokeWidth: 1.0,
-          color: _kDefaultIdleThumbColor,
-        )
-        ..rrect(
-          rrect: RRect.fromRectAndRadius(
-            // Scrollbar thumb is larger
-            const Rect.fromLTRB(786.0, 0.0, 798.0, 90.0),
-            _kDefaultThumbRadius,
-          ),
-          // Hover color
-          color: const Color(0x80000000),
-      ),
     );
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1020,6 +1020,12 @@ void main() {
           useMaterial3: false,
           scrollbarTheme: ScrollbarThemeData(
             thumbVisibility: MaterialStateProperty.all(true),
+            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.hovered)) {
+                return true;
+              }
+              return false;
+            })
           ),
         ),
         home: const SingleChildScrollView(
@@ -1285,7 +1291,7 @@ void main() {
           ),
           // Hover color
           color: const Color(0x80000000),
-        ),
+      ),
     );
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{
@@ -1294,7 +1300,6 @@ void main() {
       TargetPlatform.windows,
     }),
   );
-
 
   testWidgets('Adaptive scrollbar', (WidgetTester tester) async {
     Widget viewWithScroll(TargetPlatform platform) {

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1227,6 +1227,75 @@ void main() {
     }),
   );
 
+  testWidgets('Scrollbar trackVisibility on hovered', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: ScrollbarThemeData(
+            thumbVisibility: MaterialStateProperty.all(true),
+            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.hovered)) {
+                return true;
+              }
+              return false;
+            }),
+          ),
+        ),
+        home: const SingleChildScrollView(
+          child: SizedBox(width: 4000.0, height: 4000.0),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(
+          getStartingThumbRect(isAndroid: false),
+          _kDefaultThumbRadius,
+        ),
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(794.0, 5.0));
+    await tester.pump();
+
+    expect(
+      find.byType(Scrollbar),
+      paints
+        ..rect(
+          rect: const Rect.fromLTRB(784.0, 0.0, 800.0, 600.0),
+          color: const Color(0x08000000),
+        )
+        ..line(
+          p1: const Offset(784.0, 0.0),
+          p2: const Offset(784.0, 600.0),
+          strokeWidth: 1.0,
+          color: _kDefaultIdleThumbColor,
+        )
+        ..rrect(
+          rrect: RRect.fromRectAndRadius(
+            // Scrollbar thumb is larger
+            const Rect.fromLTRB(786.0, 0.0, 798.0, 90.0),
+            _kDefaultThumbRadius,
+          ),
+          // Hover color
+          color: const Color(0x80000000),
+        ),
+    );
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+    }),
+  );
+
+
   testWidgets('Adaptive scrollbar', (WidgetTester tester) async {
     Widget viewWithScroll(TargetPlatform platform) {
       return _buildBoilerplate(

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -33,7 +33,17 @@ void main() {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(useMaterial3: false),
+        theme: ThemeData(
+          useMaterial3: false,
+          scrollbarTheme: ScrollbarThemeData(
+            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.hovered)) {
+                return true;
+              }
+              return false;
+            })
+          )
+        ),
         home: ScrollConfiguration(
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
@@ -369,6 +379,14 @@ void main() {
       MaterialApp(
         theme: ThemeData(
           colorScheme: const ColorScheme.light(),
+          scrollbarTheme: ScrollbarThemeData(
+            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.hovered)) {
+                return true;
+              }
+              return false;
+            })
+          ),
         ),
         home: ScrollConfiguration(
           behavior: const NoScrollbarBehavior(),
@@ -462,10 +480,20 @@ void main() {
   testWidgets('ThemeData colorScheme is used when no ScrollbarTheme is set', (WidgetTester tester) async {
     (ScrollController, Widget) buildFrame(ThemeData appTheme) {
       final ScrollController scrollController = ScrollController();
+      final ThemeData theme = appTheme.copyWith(
+        scrollbarTheme: ScrollbarThemeData(
+          trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            if (states.contains(MaterialState.hovered)) {
+              return true;
+            }
+            return false;
+          })
+        ),
+      );
       return (
           scrollController,
           MaterialApp(
-            theme: appTheme,
+            theme: theme,
             home: ScrollConfiguration(
               behavior: const NoScrollbarBehavior(),
               child: Scrollbar(
@@ -753,7 +781,12 @@ ScrollbarThemeData _scrollbarTheme({
 }) {
   return ScrollbarThemeData(
     thickness: thickness ?? MaterialStateProperty.resolveWith(_getThickness),
-    trackVisibility: trackVisibility,
+    trackVisibility: trackVisibility ?? MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.hovered)) {
+        return true;
+      }
+      return false;
+    }),
     thumbVisibility: thumbVisibility,
     radius: radius,
     thumbColor: thumbColor ?? MaterialStateProperty.resolveWith(_getThumbColor),

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -38,7 +38,6 @@ void main() {
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
             thumbVisibility: true,
-            showTrackOnHover: true,
             controller: scrollController,
             child: SingleChildScrollView(
               controller: scrollController,
@@ -363,7 +362,6 @@ void main() {
   testWidgets('Scrollbar widget properties take priority over theme', (WidgetTester tester) async {
     const double thickness = 4.0;
     const double edgeMargin = 2.0;
-    const bool showTrackOnHover = true;
     const Radius radius = Radius.circular(3.0);
     final ScrollController scrollController = ScrollController();
 
@@ -377,7 +375,6 @@ void main() {
           child: Scrollbar(
             thickness: thickness,
             thumbVisibility: true,
-            showTrackOnHover: showTrackOnHover,
             radius: radius,
             controller: scrollController,
             child: SingleChildScrollView(
@@ -473,7 +470,6 @@ void main() {
               behavior: const NoScrollbarBehavior(),
               child: Scrollbar(
                 thumbVisibility: true,
-                showTrackOnHover: true,
                 controller: scrollController,
                 child: SingleChildScrollView(
                   controller: scrollController,
@@ -654,7 +650,6 @@ void main() {
           behavior: const NoScrollbarBehavior(),
           child: Scrollbar(
             thumbVisibility: true,
-            showTrackOnHover: true,
             controller: scrollController,
             child: SingleChildScrollView(
               controller: scrollController,
@@ -702,7 +697,6 @@ void main() {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     ScrollbarThemeData(
       thickness: MaterialStateProperty.resolveWith(_getThickness),
-      showTrackOnHover: true,
       thumbVisibility: MaterialStateProperty.resolveWith(_getThumbVisibility),
       radius: const Radius.circular(3.0),
       thumbColor: MaterialStateProperty.resolveWith(_getThumbColor),
@@ -721,7 +715,6 @@ void main() {
     expect(description, <String>[
       "thumbVisibility: Instance of '_MaterialStatePropertyWith<bool?>'",
       "thickness: Instance of '_MaterialStatePropertyWith<double?>'",
-      'showTrackOnHover: true',
       'radius: Radius.circular(3.0)',
       "thumbColor: Instance of '_MaterialStatePropertyWith<Color?>'",
       "trackColor: Instance of '_MaterialStatePropertyWith<Color?>'",
@@ -749,7 +742,6 @@ class NoScrollbarBehavior extends ScrollBehavior {
 ScrollbarThemeData _scrollbarTheme({
   MaterialStateProperty<double?>? thickness,
   MaterialStateProperty<bool?>? trackVisibility,
-  bool showTrackOnHover = true,
   MaterialStateProperty<bool?>? thumbVisibility,
   Radius radius = const Radius.circular(6.0),
   MaterialStateProperty<Color?>? thumbColor,
@@ -762,7 +754,6 @@ ScrollbarThemeData _scrollbarTheme({
   return ScrollbarThemeData(
     thickness: thickness ?? MaterialStateProperty.resolveWith(_getThickness),
     trackVisibility: trackVisibility,
-    showTrackOnHover: showTrackOnHover,
     thumbVisibility: thumbVisibility,
     radius: radius,
     thumbColor: thumbColor ?? MaterialStateProperty.resolveWith(_getThumbColor),


### PR DESCRIPTION
This PR is to remove deprecated `Scrollbar.showTrackOnHover` and `ScrollbarThemeData.showTrackOnHover`.

These parameters are made obsolete in https://github.com/flutter/flutter/pull/111706.
Part of https://github.com/flutter/flutter/issues/143956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.