### PR TITLE
Re-enable Impeller goldens blocking. 

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3459,7 +3459,6 @@ targets:
   - name: Mac framework_tests_impeller
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true
     properties:
       cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-


### PR DESCRIPTION
The issues in flutter/flutter#144115 should be fixed with the removal of the incorrect render pass caching behavior in https://github.com/flutter/engine/pull/50976