### PR TITLE
Reland Activate InkSparkle on CanvasKit

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -391,7 +391,7 @@ class ThemeData with Diagnosticable {
     scrollbarTheme ??= const ScrollbarThemeData();
     visualDensity ??= VisualDensity.defaultDensityForPlatform(platform);
     useMaterial3 ??= true;
-    final bool useInkSparkle = platform == TargetPlatform.android && !kIsWeb;
+    final bool useInkSparkle = platform == TargetPlatform.android && (!kIsWeb || isCanvasKit);
     splashFactory ??= useMaterial3
       ? useInkSparkle ? InkSparkle.splashFactory : InkRipple.splashFactory
       : InkSplash.splashFactory;

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -1514,7 +1514,7 @@ void main() {
       matching: find.byType(InkWell),
     ));
 
-    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && !kIsWeb) {
+    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && (!kIsWeb || isCanvasKit)) {
       expect(buttonInkWell.splashFactory, equals(InkSparkle.splashFactory));
     } else {
       expect(buttonInkWell.splashFactory, equals(InkRipple.splashFactory));

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -1649,7 +1649,7 @@ void main() {
       matching: find.byType(InkWell),
     ));
 
-    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && !kIsWeb) {
+    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && (!kIsWeb || isCanvasKit)) {
       expect(buttonInkWell.splashFactory, equals(InkSparkle.splashFactory));
     } else {
       expect(buttonInkWell.splashFactory, equals(InkRipple.splashFactory));

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/src/foundation/capabilities.dart';
 import 'package:flutter/src/foundation/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -29,7 +30,7 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('InkSparkle default splashFactory paints with drawRect when bounded', (WidgetTester tester) async {
@@ -58,7 +59,7 @@ void main() {
     // ink feature is disposed.
     expect((material as dynamic).debugInkFeatures, isEmpty);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('InkSparkle default splashFactory paints with drawPaint when unbounded', (WidgetTester tester) async {
@@ -81,7 +82,7 @@ void main() {
     final MaterialInkController material = Material.of(tester.element(buttonFinder));
     expect(material, paintsExactlyCountTimes(#drawPaint, 1));
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   /////////////
@@ -91,37 +92,37 @@ void main() {
   testWidgets('Material2 - InkSparkle renders with sparkles when top left of button is tapped', (WidgetTester tester) async {
     await _runTest(tester, 'top_left', 0.2);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('Material3 - InkSparkle renders with sparkles when top left of button is tapped', (WidgetTester tester) async {
     await _runM3Test(tester, 'top_left', 0.2);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('Material2 - InkSparkle renders with sparkles when center of button is tapped', (WidgetTester tester) async {
     await _runTest(tester, 'center', 0.5);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('Material3 - InkSparkle renders with sparkles when center of button is tapped', (WidgetTester tester) async {
     await _runM3Test(tester, 'center', 0.5);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('Material2 - InkSparkle renders with sparkles when bottom right of button is tapped', (WidgetTester tester) async {
     await _runTest(tester, 'bottom_right', 0.8);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 
   testWidgets('Material3 - InkSparkle renders with sparkles when bottom right of button is tapped', (WidgetTester tester) async {
     await _runM3Test(tester, 'bottom_right', 0.8);
   },
-    skip: kIsWeb, // [intended] shaders are not yet supported for web.
+    skip: kIsWeb && !isCanvasKit, // [intended] shaders are not supported for the HTML renderer.
   );
 }
 

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1691,7 +1691,7 @@ void main() {
       matching: find.byType(InkWell),
     ));
 
-    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && !kIsWeb) {
+    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && (!kIsWeb || isCanvasKit)) {
       expect(buttonInkWell.splashFactory, equals(InkSparkle.splashFactory));
     } else {
       expect(buttonInkWell.splashFactory, equals(InkRipple.splashFactory));

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -1468,7 +1468,7 @@ void main() {
       matching: find.byType(InkWell),
     ));
 
-    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && !kIsWeb) {
+    if (debugDefaultTargetPlatformOverride! == TargetPlatform.android && (!kIsWeb || isCanvasKit)) {
       expect(buttonInkWell.splashFactory, equals(InkSparkle.splashFactory));
     } else {
       expect(buttonInkWell.splashFactory, equals(InkRipple.splashFactory));

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -488,7 +488,7 @@ void main() {
 
     switch (debugDefaultTargetPlatformOverride!) {
       case TargetPlatform.android:
-        if (kIsWeb) {
+        if (kIsWeb && !isCanvasKit) {
           expect(theme.splashFactory, equals(InkRipple.splashFactory));
         } else {
           expect(theme.splashFactory, equals(InkSparkle.splashFactory));


### PR DESCRIPTION
## Description

This PR activates the M3 `InkSparkle` splash animation on Android + CanvasKit.
This is a reland for https://github.com/flutter/flutter/pull/138545 which was reverted due to a Flutter Gallery integration test failure.

The failure which lead to the revert was reproducible as described in https://github.com/flutter/flutter/issues/143075.
I'm no more able to reproduce this error locally.
The root issue was probably fixed in https://github.com/flutter/engine/pull/49754.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/138487

## Tests

Updates several existing tests.