### PR TITLE
Use dartpad's main channel for master/main docs

### DIFF
--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -744,7 +744,7 @@ class DartdocGenerator {
     // arguments.
     // Just use "master" for any branch other than the LUCI_BRANCH.
     final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
-    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'master';
+    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'main';
     final List<String> argumentRegExps = <String>[
       r'split=\d+',
       r'run=true',

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -742,14 +742,13 @@ class DartdocGenerator {
 
     // Check a "dartpad" example, any one will do, and check for the correct URL
     // arguments.
-    // Just use "master" for any branch other than the LUCI_BRANCH.
+    // Just use "main" for any branch other than the LUCI_BRANCH.
     final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
     final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'main';
     final List<String> argumentRegExps = <String>[
       r'split=\d+',
       r'run=true',
       r'sample_id=widgets\.Listener\.\d+',
-      'sample_channel=$expectedBranch',
       'channel=$expectedBranch',
     ];
     for (final String argumentRegExp in argumentRegExps) {


### PR DESCRIPTION
Dartpad doesn't have a "master" channel anymore, it got renamed to "main". Sadly, specifying "master" is now falling back to "stable" which breaks some of our examples in the docs that require a more current Flutter version, e.g. https://main-api.flutter.dev/flutter/material/TextButton-class.html