### PR TITLE
Use dartpad's main channel for master/main docs

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -116,7 +116,7 @@ function generate_docs() {
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:
     # https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
-    "$DART" pub global activate snippets 0.4.0
+    "$DART" pub global activate 0.4.2
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into DOC_DIR.

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -116,7 +116,7 @@ function generate_docs() {
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:
     # https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
-    "$DART" pub global activate 0.4.2
+    "$DART" pub global activate snippets 0.4.2
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into DOC_DIR.

--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -13,7 +13,7 @@
         </p>
     </div>
     <iframe class="snippet-dartpad"
-        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}&amp;channel={{channel}}">
+        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;sample_id={{id}}&amp;channel={{channel}}">
     </iframe>
 </div>
 {@end-inject-html}

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -744,7 +744,7 @@ class DartdocGenerator {
     // arguments.
     // Just use "master" for any branch other than the LUCI_BRANCH.
     final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
-    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'master';
+    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'main';
     final List<String> argumentRegExps = <String>[
       r'split=\d+',
       r'run=true',

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -742,14 +742,13 @@ class DartdocGenerator {
 
     // Check a "dartpad" example, any one will do, and check for the correct URL
     // arguments.
-    // Just use "master" for any branch other than the LUCI_BRANCH.
+    // Just use "main" for any branch other than the LUCI_BRANCH.
     final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
     final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'main';
     final List<String> argumentRegExps = <String>[
       r'split=\d+',
       r'run=true',
       r'sample_id=widgets\.Listener\.\d+',
-      'sample_channel=$expectedBranch',
       'channel=$expectedBranch',
     ];
     for (final String argumentRegExp in argumentRegExps) {

--- a/dev/tools/test/create_api_docs_test.dart
+++ b/dev/tools/test/create_api_docs_test.dart
@@ -441,7 +441,7 @@ void main() {
   </code>
 </pre>
 ''');
-            const String queryParams = 'split=1&run=true&sample_id=widgets.Listener.123&sample_channel=master&channel=master';
+            const String queryParams = 'split=1&run=true&sample_id=widgets.Listener.123&channel=main';
             widgetsDir.childFile('Listener-class.html').writeAsStringSync('''
 <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?$queryParams">
 </iframe>


### PR DESCRIPTION
Dartpad doesn't have a "master" channel anymore, it got renamed to "main". Sadly, specifying "master" is now falling back to "stable" which breaks some of our examples in the docs that require a more current Flutter version, e.g. https://main-api.flutter.dev/flutter/material/TextButton-class.html