### PR TITLE
Make daemon server work on ipv6-only machines.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -73,7 +73,7 @@ class DaemonCommand extends FlutterCommand {
         throwToolExit('Invalid port for `--listen-on-tcp-port`: $error');
       }
 
-      await _DaemonServer(
+      await DaemonServer(
         port: port,
         logger: StdoutLogger(
           terminal: globals.terminal,
@@ -100,12 +100,14 @@ class DaemonCommand extends FlutterCommand {
   }
 }
 
-class _DaemonServer {
-  _DaemonServer({
+@visibleForTesting
+class DaemonServer {
+  DaemonServer({
     this.port,
     required this.logger,
     this.notifyingLogger,
-  });
+    @visibleForTesting Future<ServerSocket> Function(InternetAddress address, int port) bind = ServerSocket.bind,
+  }) : _bind = bind;
 
   final int? port;
 
@@ -115,17 +117,19 @@ class _DaemonServer {
   // Logger that sends the message to the other end of daemon connection.
   final NotifyingLogger? notifyingLogger;
 
+  final Future<ServerSocket> Function(InternetAddress address, int port) _bind;
+
   Future<void> run() async {
     ServerSocket? serverSocket;
     try {
-      serverSocket = await ServerSocket.bind(InternetAddress.loopbackIPv4, port!);
+      serverSocket = await _bind(InternetAddress.loopbackIPv4, port!);
     } on SocketException {
       logger.printTrace('Bind on $port failed with IPv4, retrying on IPv6');
     }
 
     // If binding on IPv4 failed, try binding on IPv6.
     // Omit try catch here, let the failure fallthrough.
-    serverSocket ??= await ServerSocket.bind(InternetAddress.loopbackIPv6, port!);
+    serverSocket ??= await _bind(InternetAddress.loopbackIPv6, port!);
 
     logger.printStatus('Daemon server listening on ${serverSocket.port}');
 

--- a/packages/flutter_tools/test/general.shard/commands/daemon_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/daemon_test.dart
@@ -1,0 +1,96 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/commands/daemon.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('binds on ipv4 normally', () async {
+    final FakeServerSocket socket = FakeServerSocket();
+    final BufferLogger logger = BufferLogger.test();
+
+    int bindCalledTimes = 0;
+    final List<Object?> bindAddresses = <Object?>[];
+    final List<int> bindPorts = <int>[];
+
+    final DaemonServer server = DaemonServer(
+      port: 123,
+      logger: logger,
+      bind: (Object? address, int port) async {
+        bindCalledTimes++;
+        bindAddresses.add(address);
+        bindPorts.add(port);
+        return socket;
+      },
+    );
+    await server.run();
+    expect(bindCalledTimes, 1);
+    expect(bindAddresses, <Object?>[InternetAddress.loopbackIPv4]);
+    expect(bindPorts, <int>[123]);
+  });
+
+  testWithoutContext('binds on ipv6 if ipv4 failed normally', () async {
+    final FakeServerSocket socket = FakeServerSocket();
+    final BufferLogger logger = BufferLogger.test();
+
+    int bindCalledTimes = 0;
+    final List<Object?> bindAddresses = <Object?>[];
+    final List<int> bindPorts = <int>[];
+
+    final DaemonServer server = DaemonServer(
+      port: 123,
+      logger: logger,
+      bind: (Object? address, int port) async {
+        bindCalledTimes++;
+        bindAddresses.add(address);
+        bindPorts.add(port);
+        if (address == InternetAddress.loopbackIPv4) {
+          throw const SocketException('fail');
+        }
+        return socket;
+      },
+    );
+    await server.run();
+    expect(bindCalledTimes, 2);
+    expect(bindAddresses, <Object?>[InternetAddress.loopbackIPv4, InternetAddress.loopbackIPv6]);
+    expect(bindPorts, <int>[123, 123]);
+  });
+}
+
+class FakeServerSocket extends Fake implements ServerSocket {
+  FakeServerSocket();
+
+  @override
+  int get port => 1;
+
+  bool closeCalled = false;
+  final StreamController<Socket> controller = StreamController<Socket>();
+
+  @override
+  StreamSubscription<Socket> listen(
+    void Function(Socket event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    // Close the controller immediately for testing purpose.
+    scheduleMicrotask(() {
+      controller.close();
+    });
+    return controller.stream.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+
+  @override
+  Future<ServerSocket> close() async {
+    closeCalled = true;
+    return this;
+  }
+}


### PR DESCRIPTION
Retry binding on ipv6 if binding on ipv4 failed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
