### PR TITLE
Always use local CanvasKit/Skwasm in benchmarks for better hermeticity.

### DIFF
--- a/dev/benchmarks/macrobenchmarks/web/index.html
+++ b/dev/benchmarks/macrobenchmarks/web/index.html
@@ -11,7 +11,11 @@ found in the LICENSE file. -->
 <body>
   <script>
     {{flutter_build_config}}
-    _flutter.loader.load();
+    _flutter.loader.load({
+      config: {
+        canvasKitBaseUrl: '/canvaskit/',
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
We should avoid hitting gstatic in the benchmarks and just use local canvaskit/skwasm instead.