### PR TITLE
Reland "Use dartpad's main channel for master/main docs (#144329)"

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -116,7 +116,7 @@ function generate_docs() {
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:
     # https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
-    "$DART" pub global activate snippets 0.4.0
+    "$DART" pub global activate snippets 0.4.2
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into DOC_DIR.

--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -13,7 +13,7 @@
         </p>
     </div>
     <iframe class="snippet-dartpad"
-        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}&amp;channel={{channel}}">
+        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;sample_id={{id}}&amp;channel={{channel}}">
     </iframe>
 </div>
 {@end-inject-html}

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -742,14 +742,13 @@ class DartdocGenerator {
 
     // Check a "dartpad" example, any one will do, and check for the correct URL
     // arguments.
-    // Just use "master" for any branch other than the LUCI_BRANCH.
+    // Just use "main" for any branch other than the LUCI_BRANCH.
     final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
-    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'master';
+    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'main';
     final List<String> argumentRegExps = <String>[
       r'split=\d+',
       r'run=true',
       r'sample_id=widgets\.Listener\.\d+',
-      'sample_channel=$expectedBranch',
       'channel=$expectedBranch',
     ];
     for (final String argumentRegExp in argumentRegExps) {

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -742,14 +742,15 @@ class DartdocGenerator {
 
     // Check a "dartpad" example, any one will do, and check for the correct URL
     // arguments.
-    // Just use "main" for any branch other than the LUCI_BRANCH.
+    // Just use "main" for any branch other than "stable", just like it is done
+    // in the snippet generator at https://github.com/flutter/assets-for-api-docs/blob/cc56972b8f03552fc5f9f9f1ef309efc6c93d7bc/packages/snippets/lib/src/snippet_generator.dart#L104.
     final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
-    final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'main';
+    final String expectedChannel = luciBranch == 'stable' ? 'stable' : 'main';
     final List<String> argumentRegExps = <String>[
       r'split=\d+',
       r'run=true',
       r'sample_id=widgets\.Listener\.\d+',
-      'channel=$expectedBranch',
+      'channel=$expectedChannel',
     ];
     for (final String argumentRegExp in argumentRegExps) {
       _sanityCheckExample(

--- a/dev/tools/test/create_api_docs_test.dart
+++ b/dev/tools/test/create_api_docs_test.dart
@@ -441,7 +441,7 @@ void main() {
   </code>
 </pre>
 ''');
-            const String queryParams = 'split=1&run=true&sample_id=widgets.Listener.123&sample_channel=master&channel=master';
+            const String queryParams = 'split=1&run=true&sample_id=widgets.Listener.123&channel=main';
             widgetsDir.childFile('Listener-class.html').writeAsStringSync('''
 <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?$queryParams">
 </iframe>


### PR DESCRIPTION
Fix is in the second commit. The logic here went out of sync with the logic in the snippets generator from https://github.com/flutter/assets-for-api-docs, whose version was bumped as part of this change.