### PR TITLE
Fix `showDateRangePicker` is missing `dartpad` tag and cleanup

### DIFF
--- a/examples/api/lib/material/date_picker/show_date_picker.0.dart
+++ b/examples/api/lib/material/date_picker/show_date_picker.0.dart
@@ -13,10 +13,9 @@ class DatePickerApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: ThemeData(useMaterial3: true),
+    return const MaterialApp(
       restorationScopeId: 'app',
-      home: const DatePickerExample(restorationId: 'main'),
+      home: DatePickerExample(restorationId: 'main'),
     );
   }
 }

--- a/examples/api/lib/material/date_picker/show_date_range_picker.0.dart
+++ b/examples/api/lib/material/date_picker/show_date_range_picker.0.dart
@@ -13,10 +13,9 @@ class DatePickerApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      theme: ThemeData(useMaterial3: true),
+    return const MaterialApp(
       restorationScopeId: 'app',
-      home: const DatePickerExample(restorationId: 'main'),
+      home: DatePickerExample(restorationId: 'main'),
     );
   }
 }

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1020,7 +1020,7 @@ class _DatePickerHeader extends StatelessWidget {
 ///
 /// {@macro flutter.widgets.RestorationManager}
 ///
-/// {@tool sample}
+/// {@tool dartpad}
 /// This sample demonstrates how to create a restorable Material date range picker.
 /// This is accomplished by enabling state restoration by specifying
 /// [MaterialApp.restorationScopeId] and using [Navigator.restorablePush] to


### PR DESCRIPTION
fixes [`showDateRangePicker` interactive sample not loading](https://github.com/flutter/flutter/issues/144474)

### Description 

This fixes `showDateRangePicker` example not loading in Dartpad.

Similar fix was made for `showDatePicker` in https://github.com/flutter/flutter/pull/99401

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
