### PR TITLE
refactor: Perform plugin resolution per platform

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1248,15 +1248,14 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
     MacOSPlugin.kConfigKey,
     WindowsPlugin.kConfigKey,
   ];
-  final Map<String, List<PluginInterfaceResolution>> possibleResolutions =
-      <String, List<PluginInterfaceResolution>>{};
-  final Map<String, String> defaultImplementations = <String, String>{};
-  // Generates a key for the maps above.
-  String getResolutionKey({required String platform, required String packageName}) {
-    return '$packageName:$platform';
-  }
+  final List<PluginInterfaceResolution> finalResolution = <PluginInterfaceResolution>[];
+  bool hasResolutionError = false;
 
   for (final String platformKey in platformKeys) {
+    // Key: the plugin name
+    final Map<String, List<Plugin>> possibleResolutions = <String, List<Plugin>>{};
+    final Map<String, String> defaultImplementations = <String, String>{};
+
     for (final Plugin plugin in plugins) {
       final String? defaultImplementation = plugin.defaultPackagePlatforms[platformKey];
       if (plugin.platforms[platformKey] == null && defaultImplementation == null) {
@@ -1271,9 +1270,8 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
           // Skip native inline PluginPlatform implementation
           continue;
         }
-        final String defaultImplementationKey = getResolutionKey(platform: platformKey, packageName: plugin.name);
         if (defaultImplementation != null) {
-          defaultImplementations[defaultImplementationKey] = defaultImplementation;
+          defaultImplementations[plugin.name] = defaultImplementation;
           continue;
         } else {
           // An app-facing package (i.e., one with no 'implements') with an
@@ -1293,7 +1291,7 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
             minFlutterVersion.compareTo(semver.Version(2, 11, 0)) >= 0;
           if (!isDesktop || hasMinVersionForImplementsRequirement) {
             implementsPackage = plugin.name;
-            defaultImplementations[defaultImplementationKey] = plugin.name;
+            defaultImplementations[plugin.name] = plugin.name;
           } else {
             // If it doesn't meet any of the conditions, it isn't eligible for
             // auto-registration.
@@ -1309,63 +1307,63 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
 
       // If it hasn't been skipped, it's a candidate for auto-registration, so
       // add it as a possible resolution.
-      final String resolutionKey = getResolutionKey(platform: platformKey, packageName: implementsPackage);
-      possibleResolutions.putIfAbsent(resolutionKey, () => <PluginInterfaceResolution>[]);
-      possibleResolutions[resolutionKey]!.add(PluginInterfaceResolution(
-        plugin: plugin,
-        platform: platformKey,
-      ));
+      possibleResolutions.putIfAbsent(implementsPackage, () => <Plugin>[]);
+      possibleResolutions[implementsPackage]!.add(plugin);
     }
-  }
 
-  // Now resolve all the possible resolutions to a single option for each
-  // plugin, or throw if that's not possible.
-  bool hasResolutionError = false;
-  final List<PluginInterfaceResolution> finalResolution = <PluginInterfaceResolution>[];
-  for (final MapEntry<String, List<PluginInterfaceResolution>> entry in possibleResolutions.entries) {
-    final List<PluginInterfaceResolution> candidates = entry.value;
-    // If there's only one candidate, use it.
-    if (candidates.length == 1) {
-      finalResolution.add(candidates.first);
-      continue;
-    }
-    // Next, try direct dependencies of the resolving application.
-    final Iterable<PluginInterfaceResolution> directDependencies = candidates.where((PluginInterfaceResolution r) {
-      return r.plugin.isDirectDependency;
-    });
-    if (directDependencies.isNotEmpty) {
-      if (directDependencies.length > 1) {
+    final List<Plugin> pluginResolution = <Plugin>[];
+
+    // Resolve all the possible resolutions to a single option for each plugin, or throw if that's not possible.
+    for (final MapEntry<String, List<Plugin>> entry in possibleResolutions.entries) {
+      final List<Plugin> candidates = entry.value;
+      // If there's only one candidate, use it.
+      if (candidates.length == 1) {
+        pluginResolution.add(candidates.first);
+        continue;
+      }
+      // Next, try direct dependencies of the resolving application.
+      final Iterable<Plugin> directDependencies = candidates.where((Plugin plugin) {
+        return plugin.isDirectDependency;
+      });
+      if (directDependencies.isNotEmpty) {
+        if (directDependencies.length > 1) {
+          globals.printError(
+              'Plugin ${entry.key}:$platformKey has conflicting direct dependency implementations:\n'
+                  '${directDependencies.map((Plugin plugin) => '  ${plugin.name}\n').join()}'
+                  'To fix this issue, remove all but one of these dependencies from pubspec.yaml.\n'
+          );
+          hasResolutionError = true;
+        } else {
+          pluginResolution.add(directDependencies.first);
+        }
+        continue;
+      }
+      // Next, defer to the default implementation if there is one.
+      final String? defaultPackageName = defaultImplementations[entry.key];
+      if (defaultPackageName != null) {
+        final int defaultIndex = candidates
+            .indexWhere((Plugin plugin) => plugin.name == defaultPackageName);
+        if (defaultIndex != -1) {
+          pluginResolution.add(candidates[defaultIndex]);
+          continue;
+        }
+      }
+      // Otherwise, require an explicit choice.
+      if (candidates.length > 1) {
         globals.printError(
-          'Plugin ${entry.key} has conflicting direct dependency implementations:\n'
-          '${directDependencies.map((PluginInterfaceResolution r) => '  ${r.plugin.name}\n').join()}'
-          'To fix this issue, remove all but one of these dependencies from pubspec.yaml.\n'
+            'Plugin ${entry.key}:$platformKey has multiple possible implementations:\n'
+                '${candidates.map((Plugin plugin) => '  ${plugin.name}\n').join()}'
+                'To fix this issue, add one of these dependencies to pubspec.yaml.\n'
         );
         hasResolutionError = true;
-      } else {
-        finalResolution.add(directDependencies.first);
-      }
-      continue;
-    }
-    // Next, defer to the default implementation if there is one.
-    final String? defaultPackageName = defaultImplementations[entry.key];
-    if (defaultPackageName != null) {
-      final int defaultIndex = candidates
-          .indexWhere((PluginInterfaceResolution r) => r.plugin.name == defaultPackageName);
-      if (defaultIndex != -1) {
-        finalResolution.add(candidates[defaultIndex]);
         continue;
       }
     }
-    // Otherwise, require an explicit choice.
-    if (candidates.length > 1) {
-      globals.printError(
-        'Plugin ${entry.key} has multiple possible implementations:\n'
-        '${candidates.map((PluginInterfaceResolution r) => '  ${r.plugin.name}\n').join()}'
-        'To fix this issue, add one of these dependencies to pubspec.yaml.\n'
-      );
-      hasResolutionError = true;
-      continue;
-    }
+
+    finalResolution.addAll(
+      pluginResolution.map((Plugin plugin) =>
+          PluginInterfaceResolution(plugin: plugin, platform: platformKey)),
+    );
   }
   if (hasResolutionError) {
     throwToolExit('Please resolve the plugin implementation selection errors');


### PR DESCRIPTION
Part of #137040 and #80374

`possibleResolutions` and `possibleResolutions` used a key containing the platform and the plugin name via `getResolutionKey`. The global list is not necessary and also confusing. It can be avoided by handling the resolution of plugins per platform. This helps to have a more self-contained plugin resolution. This also is necessary to reuse the plugin resolution logic (per platform) for #137040.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
