### PR TITLE
remove `DevFSContent::isModified`, use `DevFSContent::isModifiedAfter` instead

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -103,6 +103,9 @@ abstract class AssetBundle {
   /// indexed by asset key.
   Map<String, AssetBundleEntry> get entries;
 
+  /// The time at which this bundle was last built.
+  DateTime? get lastBuildTime;
+
   /// The files that were specified under the deferred components assets sections
   /// in a pubspec, indexed by component name and asset key.
   Map<String, Map<String, AssetBundleEntry>> get deferredComponentsEntries;
@@ -178,6 +181,11 @@ class ManifestAssetBundle implements AssetBundle {
   final String _flutterRoot;
   final bool _splitDeferredAssets;
 
+  DateTime? _lastBuildTime;
+
+  @override
+  DateTime? get lastBuildTime => _lastBuildTime;
+
   @override
   final Map<String, AssetBundleEntry> entries = <String, AssetBundleEntry>{};
 
@@ -247,6 +255,7 @@ class ManifestAssetBundle implements AssetBundle {
     TargetPlatform? targetPlatform,
     String? flavor,
   }) async {
+    _lastBuildTime = DateTime.now();
     if (flutterProject == null) {
       try {
         flutterProject = FlutterProject.fromDirectory(_fileSystem.file(manifestPath).parent);

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -698,9 +698,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       .map((AssetBundleEntry asset) => asset.content)
       .whereType<DevFSFileContent>();
     for (final DevFSFileContent entry in files) {
-      // Calling isModified to access file stats first in order for isModifiedAfter
-      // to work.
-      if (entry.isModified && entry.isModifiedAfter(lastModified)) {
+      if (entry.isModifiedAfter(lastModified)) {
         return true;
       }
     }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -615,7 +615,7 @@ class DevFS {
       bundle.entries.forEach((String archivePath, AssetBundleEntry entry) {
         // If the content is backed by a real file, isModified will file stat and return true if
         // it was modified since the last time this was called.
-        if (!entry.content.isModifiedAfter(bundle.lastBuildTime!) || bundleFirstUpload) {
+        if (bundleFirstUpload || !entry.content.isModifiedAfter(bundle.lastBuildTime!)) {
           return;
         }
         // Modified shaders must be recompiled per-target platform.

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1943,12 +1943,3 @@ class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
   @override
   final String name;
 }
-
-class FakeSystemClock extends Fake implements SystemClock {
-  late DateTime currentTime;
-
-  @override
-  DateTime now() {
-    return currentTime;
-  }
-}

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -622,6 +622,24 @@ class FakeStopwatchFactory implements StopwatchFactory {
   }
 }
 
+base class FakeSystemClock extends Fake implements SystemClock {
+  late DateTime currentTime;
+
+  @override
+  DateTime now() {
+    return currentTime;
+  }
+
+  @override
+  DateTime ago(Duration duration) {
+    return currentTime.subtract(duration);
+  }
+
+  DateTime later(Duration duration) {
+    return currentTime.add(duration);
+  }
+}
+
 class FakeFlutterProjectFactory implements FlutterProjectFactory {
   @override
   FlutterProject fromDirectory(Directory directory) {


### PR DESCRIPTION
WIP to improve asset bundling in the flutter tool
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
