### PR TITLE
Fix text color for default CupertinoContextMenuAction

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -89,6 +89,7 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
   TextStyle get _textStyle {
     if (widget.isDefaultAction) {
       return _kActionSheetActionStyle.copyWith(
+        color: CupertinoDynamicColor.resolve(CupertinoColors.label, context),
         fontWeight: FontWeight.w600,
       );
     }

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -10,13 +10,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   // Constants taken from _ContextMenuActionState.
-  const CupertinoDynamicColor kBackgroundColor =
-      CupertinoDynamicColor.withBrightness(
+  const CupertinoDynamicColor kBackgroundColor = CupertinoDynamicColor.withBrightness(
     color: Color(0xFFF1F1F1),
     darkColor: Color(0xFF212122),
   );
-  const CupertinoDynamicColor kBackgroundColorPressed =
-      CupertinoDynamicColor.withBrightness(
+  const CupertinoDynamicColor kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
     color: Color(0xFFDDDDDD),
     darkColor: Color(0xFF3F3F40),
   );
@@ -117,24 +115,33 @@ void main() {
         paints..rect(color: kBackgroundColor.darkColor));
   });
 
-  testWidgets('icon and textStyle colors are correct out of the box',
-      (WidgetTester tester) async {
+  testWidgets('icon and textStyle colors are correct out of the box', (WidgetTester tester) async {
     await tester.pumpWidget(getApp());
     expect(getTextStyle(tester).color, CupertinoColors.label);
     expect(getIcon(tester).color, CupertinoColors.label);
   });
 
-  testWidgets('icon and textStyle colors are correct for destructive actions',
-      (WidgetTester tester) async {
+  testWidgets('icon and textStyle colors are correct for destructive actions', (WidgetTester tester) async {
     await tester.pumpWidget(getApp(isDestructiveAction: true));
     expect(getTextStyle(tester).color, kDestructiveActionColor);
     expect(getIcon(tester).color, kDestructiveActionColor);
   });
 
-  testWidgets('textStyle is correct for defaultAction',
-      (WidgetTester tester) async {
+  testWidgets('textStyle is correct for defaultAction for Brightness.light', (WidgetTester tester) async {
     await tester.pumpWidget(getApp(isDefaultAction: true));
     expect(getTextStyle(tester).fontWeight, kDefaultActionWeight);
+    final Element context = tester.element(find.byType(CupertinoContextMenuAction));
+    // The dynamic color should have been resolved.
+    expect(getTextStyle(tester).color, CupertinoColors.label.resolveFrom(context));
+  });
+
+  testWidgets('textStyle is correct for defaultAction for Brightness.dark', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/144492.
+    await tester.pumpWidget(getApp(isDefaultAction: true, brightness: Brightness.dark));
+    expect(getTextStyle(tester).fontWeight, kDefaultActionWeight);
+    final Element context = tester.element(find.byType(CupertinoContextMenuAction));
+    // The dynamic color should have been resolved.
+    expect(getTextStyle(tester).color, CupertinoColors.label.resolveFrom(context));
   });
 
   testWidgets(


### PR DESCRIPTION
## Description

This PR fix the text color for the default action in a CupertiniContextMenu.
Previously the dynamic color was not resolved which leads to text being blacks when theme brightness was dark.

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-03-04 à 14 58 45](https://github.com/flutter/flutter/assets/840911/6a06715d-b2b8-49e1-b6de-37c03b96b627) |  ![Capture d’écran 2024-03-04 à 15 00 27](https://github.com/flutter/flutter/assets/840911/ed7c71ec-96f2-46ca-a5f6-ba3890732e33) |

## Related Issue

Fixes https://github.com/flutter/flutter/issues/144492.

## Tests

Adds 1 test, updates 1.