### PR TITLE
Fix build mode not propagated in android native asset build

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/native_assets.dart
@@ -314,8 +314,13 @@ class NativeAssets extends Target {
     );
     final int targetAndroidNdkApi =
         int.parse(environment.defines[kMinSdkVersion] ?? minSdkVersion);
+    final String? environmentBuildMode = environment.defines[kBuildMode];
+    if (environmentBuildMode == null) {
+      throw MissingDefineException(kBuildMode, name);
+    }
+    final BuildMode buildMode = BuildMode.fromCliName(environmentBuildMode);
     return buildNativeAssetsAndroid(
-      buildMode: BuildMode.debug,
+      buildMode: buildMode,
       projectUri: projectUri,
       yamlParentDirectory: environment.buildDir.uri,
       fileSystem: fileSystem,

--- a/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/build_system/targets/native_assets_test.dart
@@ -187,7 +187,7 @@ void main() {
         await createPackageConfig(androidEnvironment);
         await fileSystem.file('libfoo.so').create();
 
-        final NativeAssetsBuildRunner buildRunner = FakeNativeAssetsBuildRunner(
+        final FakeNativeAssetsBuildRunner buildRunner = FakeNativeAssetsBuildRunner(
           packagesWithNativeAssetsResult: <Package>[
             Package('foo', androidEnvironment.buildDir.uri)
           ],
@@ -207,6 +207,7 @@ void main() {
           ]),
         );
         await NativeAssets(buildRunner: buildRunner).build(androidEnvironment);
+        expect(buildRunner.lastBuildMode, native_assets_cli.BuildMode.release);
       },
     );
   }

--- a/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
@@ -36,6 +36,7 @@ class FakeNativeAssetsBuildRunner implements NativeAssetsBuildRunner {
   int dryRunInvocations = 0;
   int hasPackageConfigInvocations = 0;
   int packagesWithNativeAssetsInvocations = 0;
+  BuildMode? lastBuildMode;
 
   @override
   Future<native_assets_builder.BuildResult> build({
@@ -49,6 +50,7 @@ class FakeNativeAssetsBuildRunner implements NativeAssetsBuildRunner {
     IOSSdk? targetIOSSdk,
   }) async {
     buildInvocations++;
+    lastBuildMode = buildMode;
     return buildResult;
   }
 


### PR DESCRIPTION
This fixes bug where build mode is hardcoded to debug while building native assets for Android.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
