### PR TITLE
Print warning and exit when iOS device is unpaired

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -267,6 +267,7 @@ class IOSDevice extends Device {
     required this.cpuArchitecture,
     required this.connectionInterface,
     required this.isConnected,
+    required this.isPaired,
     required this.devModeEnabled,
     required this.isCoreDevice,
     String? sdkVersion,
@@ -336,6 +337,11 @@ class IOSDevice extends Device {
   @override
   bool isConnected;
 
+  bool devModeEnabled = false;
+
+  /// Device has trusted this computer and paired.
+  bool isPaired = false;
+
   /// CoreDevice is a device connectivity stack introduced in Xcode 15. Devices
   /// with iOS 17 or greater are CoreDevices.
   final bool isCoreDevice;
@@ -343,8 +349,6 @@ class IOSDevice extends Device {
   final Map<IOSApp?, DeviceLogReader> _logReaders = <IOSApp?, DeviceLogReader>{};
 
   DevicePortForwarder? _portForwarder;
-
-  bool devModeEnabled = false;
 
   @visibleForTesting
   IOSDeployDebugger? iosDeployDebugger;

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -545,11 +545,15 @@ class XCDevice {
         bool devModeEnabled = true;
         bool isConnected = true;
         bool isPaired = true;
-        String? errorMessage;
         final Map<String, Object?>? errorProperties = _errorProperties(device);
         if (errorProperties != null) {
-          errorMessage = _parseErrorMessage(errorProperties);
+          final String? errorMessage = _parseErrorMessage(errorProperties);
           if (errorMessage != null) {
+            if (errorMessage.contains('not paired')) {
+              UsageEvent('device', 'ios-trust-failure', flutterUsage: globals.flutterUsage).send();
+              _analytics.send(Event.appleUsageEvent(workflow: 'device', parameter: 'ios-trust-failure'));
+
+            }
             _logger.printTrace(errorMessage);
           }
 
@@ -562,12 +566,8 @@ class XCDevice {
             isConnected = false;
           }
           // Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)
-          if (errorMessage != null && errorMessage.contains('not paired')) {
-            UsageEvent('device', 'ios-trust-failure', flutterUsage: globals.flutterUsage).send();
-            _analytics.send(Event.appleUsageEvent(workflow: 'device', parameter: 'ios-trust-failure'));
-            if (code == -9) {
-              isPaired = false;
-            }
+          if (code == -9) {
+            isPaired = false;
           }
 
           if (code == 6) {

--- a/packages/flutter_tools/lib/src/runner/target_devices.dart
+++ b/packages/flutter_tools/lib/src/runner/target_devices.dart
@@ -30,6 +30,8 @@ String _noMatchingDeviceMessage(String deviceId) => 'No supported devices found 
     "matching '$deviceId'.";
 String flutterSpecifiedDeviceDevModeDisabled(String deviceName) => 'To use '
     "'$deviceName' for development, enable Developer Mode in Settings → Privacy & Security.";
+String flutterSpecifiedDeviceUnpaired(String deviceName) => "'$deviceName' is not paired. "
+    'Open Xcode and trust this computer when prompted.';
 
 /// This class handles functionality of finding and selecting target devices.
 ///
@@ -494,17 +496,24 @@ class TargetDevicesWithExtendedWirelessDeviceDiscovery extends TargetDevices {
 
       if (specifiedDevices.length == 1) {
         Device? matchedDevice = specifiedDevices.first;
-        // If the only matching device does not have Developer Mode enabled,
-        // print a warning
-        if (matchedDevice is IOSDevice && !matchedDevice.devModeEnabled) {
-          _logger.printStatus(
-              flutterSpecifiedDeviceDevModeDisabled(matchedDevice.name)
-          );
-          return null;
-        }
+        if (matchedDevice is IOSDevice) {
+          // If the only matching device is not paired, print a warning
+          if (!matchedDevice.isPaired) {
+            _logger.printStatus(flutterSpecifiedDeviceUnpaired(matchedDevice.name));
+            return null;
+          }
+          // If the only matching device does not have Developer Mode enabled,
+          // print a warning
+          if (!matchedDevice.devModeEnabled) {
+            _logger.printStatus(
+                flutterSpecifiedDeviceDevModeDisabled(matchedDevice.name)
+            );
+            return null;
+          }
 
-        if (!matchedDevice.isConnected && matchedDevice is IOSDevice) {
-          matchedDevice = await _waitForIOSDeviceToConnect(matchedDevice);
+          if (!matchedDevice.isConnected) {
+            matchedDevice = await _waitForIOSDeviceToConnect(matchedDevice);
+          }
         }
 
         if (matchedDevice != null && matchedDevice.isConnected) {
@@ -512,9 +521,14 @@ class TargetDevicesWithExtendedWirelessDeviceDiscovery extends TargetDevices {
         }
 
       } else {
-        for (final Device device in specifiedDevices) {
+        for (final IOSDevice device in specifiedDevices.whereType<IOSDevice>()) {
+          // Print warning for every matching unpaired device.
+          if (!device.isPaired) {
+            _logger.printStatus(flutterSpecifiedDeviceUnpaired(device.name));
+          }
+
           // Print warning for every matching device that does not have Developer Mode enabled.
-          if (device is IOSDevice && !device.devModeEnabled) {
+          if (!device.devModeEnabled) {
             _logger.printStatus(
                 flutterSpecifiedDeviceDevModeDisabled(device.name)
             );

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -85,6 +85,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );
@@ -106,6 +107,7 @@ void main() {
         cpuArchitecture: DarwinArch.armv7,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );
@@ -128,6 +130,7 @@ void main() {
         sdkVersion: '1.0.0',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).majorSdkVersion, 1);
@@ -146,6 +149,7 @@ void main() {
         sdkVersion: '13.1.1',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).majorSdkVersion, 13);
@@ -164,6 +168,7 @@ void main() {
         sdkVersion: '10',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).majorSdkVersion, 10);
@@ -182,6 +187,7 @@ void main() {
         sdkVersion: '0',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).majorSdkVersion, 0);
@@ -200,6 +206,7 @@ void main() {
         sdkVersion: 'bogus',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).majorSdkVersion, 0);
@@ -221,6 +228,7 @@ void main() {
         sdkVersion: '13.3.1',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).sdkVersion;
@@ -244,6 +252,7 @@ void main() {
         sdkVersion: '13.3.1 (20ADBC)',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).sdkVersion;
@@ -267,6 +276,7 @@ void main() {
         sdkVersion: '16.4.1(a) (20ADBC)',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).sdkVersion;
@@ -290,6 +300,7 @@ void main() {
         sdkVersion: '0',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).sdkVersion;
@@ -312,6 +323,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).sdkVersion;
@@ -332,6 +344,7 @@ void main() {
         sdkVersion: 'bogus',
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       ).sdkVersion;
@@ -354,6 +367,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );
@@ -377,6 +391,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );
@@ -406,6 +421,7 @@ void main() {
               cpuArchitecture: DarwinArch.arm64,
               connectionInterface: DeviceConnectionInterface.attached,
               isConnected: true,
+              isPaired: true,
               devModeEnabled: true,
               isCoreDevice: false,
             );
@@ -501,6 +517,7 @@ void main() {
           cpuArchitecture: DarwinArch.arm64,
           connectionInterface: DeviceConnectionInterface.attached,
           isConnected: true,
+          isPaired: true,
           devModeEnabled: true,
           isCoreDevice: false,
         );
@@ -571,6 +588,7 @@ void main() {
         fileSystem: MemoryFileSystem.test(),
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );
@@ -590,6 +608,7 @@ void main() {
         fileSystem: MemoryFileSystem.test(),
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: true,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );
@@ -889,6 +908,7 @@ void main() {
         fileSystem: MemoryFileSystem.test(),
         connectionInterface: DeviceConnectionInterface.attached,
         isConnected: false,
+        isPaired: true,
         devModeEnabled: true,
         isCoreDevice: false,
       );

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -434,6 +434,7 @@ IOSDevice setUpIOSDevice({
     iProxy: IProxy.test(logger: logger, processManager: processManager),
     connectionInterface: interfaceType ?? DeviceConnectionInterface.attached,
     isConnected: true,
+    isPaired: true,
     devModeEnabled: true,
     isCoreDevice: isCoreDevice,
   );

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -106,6 +106,7 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     iProxy: IProxy.test(logger: logger, processManager: processManager),
     connectionInterface: DeviceConnectionInterface.attached,
     isConnected: true,
+    isPaired: true,
     devModeEnabled: true,
     isCoreDevice: false,
   );

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -869,6 +869,7 @@ IOSDevice setUpIOSDevice({
     cpuArchitecture: DarwinArch.arm64,
     connectionInterface: DeviceConnectionInterface.attached,
     isConnected: true,
+    isPaired: true,
     devModeEnabled: true,
     isCoreDevice: isCoreDevice,
   );

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -1094,6 +1094,7 @@ IOSDevice setUpIOSDevice({
     cpuArchitecture: DarwinArch.arm64,
     connectionInterface: interfaceType,
     isConnected: true,
+    isPaired: true,
     devModeEnabled: true,
     isCoreDevice: isCoreDevice,
   );


### PR DESCRIPTION
Explicitly handle the case where the iOS device is not paired.  On `flutter run` show an error and bail instead of trying and failing to launch on the device.

On this PR:
```
$ flutter run -d 00008110-0009588C2651401E
'iPhone' is not paired. Open Xcode and trust this computer when prompted.
$
```

Fixes https://github.com/flutter/flutter/issues/144447
Closes https://github.com/flutter/flutter/pull/144095

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
