### PR TITLE
Revert "_DefaultTabControllerState should dispose all created TabContoller instances. (#136608)"

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -132,11 +132,8 @@ class TabController extends ChangeNotifier {
   }) : _index = index,
        _previousIndex = previousIndex,
        _animationController = animationController,
-       _animationDuration = animationDuration {
-    if (kFlutterMemoryAllocationsEnabled) {
-      ChangeNotifier.maybeDispatchObjectCreation(this);
-    }
-  }
+       _animationDuration = animationDuration;
+
 
   /// Creates a new [TabController] with `index`, `previousIndex`, `length`, and
   /// `animationDuration` if they are non-null.
@@ -145,10 +142,7 @@ class TabController extends ChangeNotifier {
   ///
   /// When [DefaultTabController.length] is updated, this method is called to
   /// create a new [TabController] without creating a new [AnimationController].
-  ///
-  /// This instance of [TabController] will be disposed and must not be used
-  /// anymore.
-  TabController _copyWithAndDispose({
+  TabController _copyWith({
     required int? index,
     required int? length,
     required int? previousIndex,
@@ -157,20 +151,13 @@ class TabController extends ChangeNotifier {
     if (index != null) {
       _animationController!.value = index.toDouble();
     }
-    final TabController newController = TabController._(
+    return TabController._(
       index: index ?? _index,
       length: length ?? this.length,
       animationController: _animationController,
       previousIndex: previousIndex ?? _previousIndex,
       animationDuration: animationDuration ?? _animationDuration,
     );
-
-    // Nulling _animationController to not dispose it. It will be disposed by
-    // the newly created instance of the TabController.
-    _animationController = null;
-    dispose();
-
-    return newController;
   }
 
   /// An animation whose value represents the current position of the [TabBar]'s
@@ -498,7 +485,7 @@ class _DefaultTabControllerState extends State<DefaultTabController> with Single
         newIndex = math.max(0, widget.length - 1);
         previousIndex = _controller.index;
       }
-      _controller = _controller._copyWithAndDispose(
+      _controller = _controller._copyWith(
         length: widget.length,
         animationDuration: widget.animationDuration,
         index: newIndex,
@@ -507,7 +494,7 @@ class _DefaultTabControllerState extends State<DefaultTabController> with Single
     }
 
     if (oldWidget.animationDuration != widget.animationDuration) {
-      _controller = _controller._copyWithAndDispose(
+      _controller = _controller._copyWith(
         length: widget.length,
         animationDuration: widget.animationDuration,
         index: _controller.index,


### PR DESCRIPTION
This reverts commit 9fa9fd365c9f1d8053cc75da996407abe1537410.

Fixes https://github.com/flutter/flutter/issues/144087.
Fixes https://github.com/flutter/flutter/issues/138588.

This crash has been reported previously from a customer in google3 in https://github.com/flutter/flutter/issues/138588, but we weren't able to track it down. Thankfully, a repro was now provided in https://github.com/flutter/flutter/issues/144087#issuecomment-1968257383 which traced the crash down to a change made in #136608. This PR reverts that change to fix that crash for now. I will post a new PR shortly (edit: https://github.com/flutter/flutter/pull/144627) that will add a test to cover the use case that caused the crash with #136608 to make sure we don't re-introduce the crash in the future.