### PR TITLE
Updated the smiley TextButton example again

### DIFF
--- a/examples/api/test/material/text_button/text_button.0_test.dart
+++ b/examples/api/test/material/text_button/text_button.0_test.dart
@@ -55,8 +55,8 @@ void main() {
     await tester.pumpAndSettle();
 
     final Finder smileyButton = find.byType(TextButton).last;
-    await tester.tap(smileyButton); // Smiley image button
-    await tester.pumpAndSettle();
+    await tester.tap(smileyButton);
+    await tester.pump();
 
     String smileyButtonImageUrl() {
       final AnimatedContainer container = tester.widget<AnimatedContainer>(
@@ -66,11 +66,24 @@ void main() {
       final NetworkImage image = decoration.image!.image as NetworkImage;
       return image.url;
     }
+
     // The smiley button's onPressed method changes the button image
     // for one second to simulate a long action running. The button's
     // image changes while the action is running.
     expect(smileyButtonImageUrl().endsWith('text_button_nhu_end.png'), isTrue);
     await tester.pump(const Duration(seconds: 1));
+    expect(smileyButtonImageUrl().endsWith('text_button_nhu_default.png'), isTrue);
+
+    // Pressing the smiley button while the one second action is
+    // underway starts a new one section action. The button's image
+    // doesn't change until the second action has finished.
+    await tester.tap(smileyButton);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(smileyButtonImageUrl().endsWith('text_button_nhu_end.png'), isTrue);
+    await tester.tap(smileyButton); // Second button press.
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(smileyButtonImageUrl().endsWith('text_button_nhu_end.png'), isTrue);
+    await tester.pump(const Duration(milliseconds: 500));
     expect(smileyButtonImageUrl().endsWith('text_button_nhu_default.png'), isTrue);
 
     await tester.tap(find.byType(Switch).at(0)); // Dark Mode Switch


### PR DESCRIPTION
Improved the smiley image TextButton example a little. Handling the case where the `Future.delayed` object that represents the button's one second long action is superseded by a second button press that triggers a new one-second action. This does complicate the example - just a little - but it's a little more robust. In case someone copy-and-pastes the code.

The TextButton example was recently updated: https://github.com/flutter/flutter/pull/144583
