### PR TITLE
make hot reload reflect changes to asset transformer configurations

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -95,8 +95,6 @@ final class AssetBundleEntry {
   final AssetKind kind;
   final List<AssetTransformerEntry> transformers;
 
-  final DateTime creationTime = DateTime.now();
-
   Future<List<int>> contentsAsBytes() => content.contentsAsBytes();
 
   bool hasEquivalentConfigurationWith(AssetBundleEntry other) {

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -95,16 +95,6 @@ final class AssetBundleEntry {
   final AssetKind kind;
   final List<AssetTransformerEntry> transformers;
 
-  bool _hasModifiedBeenCalled = false;
-  bool get isModified {
-    if (!_hasModifiedBeenCalled) {
-      _hasModifiedBeenCalled = true;
-      content.isModified;
-      return true;
-    }
-    return content.isModified;
-  }
-
   final DateTime creationTime = DateTime.now();
 
   Future<List<int>> contentsAsBytes() => content.contentsAsBytes();

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -14,6 +14,7 @@ import 'base/deferred_component.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/platform.dart';
+import 'base/utils.dart';
 import 'build_info.dart';
 import 'cache.dart';
 import 'convert.dart';
@@ -84,9 +85,8 @@ enum AssetKind {
 
 /// Contains all information about an asset needed by tool the to prepare and
 /// copy an asset file to the build output.
-@immutable
 final class AssetBundleEntry {
-  const AssetBundleEntry(this.content, {
+  AssetBundleEntry(this.content, {
     required this.kind,
     required this.transformers,
   });
@@ -95,7 +95,27 @@ final class AssetBundleEntry {
   final AssetKind kind;
   final List<AssetTransformerEntry> transformers;
 
+  bool _hasModifiedBeenCalled = false;
+  bool get isModified {
+    if (!_hasModifiedBeenCalled) {
+      _hasModifiedBeenCalled = true;
+      content.isModified;
+      return true;
+    }
+    return content.isModified;
+  }
+
+  final DateTime creationTime = DateTime.now();
+
+  bool isModifiedAfter(DateTime dateTime) {
+    return content.isModifiedAfter(dateTime) || creationTime.isAfter(dateTime);
+  }
+
   Future<List<int>> contentsAsBytes() => content.contentsAsBytes();
+
+  bool hasEquivalentConfigurationWith(AssetBundleEntry other) {
+    return listEquals(transformers, other.transformers);
+  }
 }
 
 abstract class AssetBundle {
@@ -425,11 +445,11 @@ class ManifestAssetBundle implements AssetBundle {
         final File variantFile = variant.lookupAssetFile(_fileSystem);
         inputFiles.add(variantFile);
         assert(variantFile.existsSync());
-        entries[variant.entryUri.path] ??= AssetBundleEntry(
+        _setIfConfigurationChanged(entries, variant.entryUri.path, AssetBundleEntry(
           DevFSFileContent(variantFile),
           kind: variant.kind,
           transformers: variant.transformers,
-        );
+        ));
       }
     }
     // Save the contents of each deferred component image, image variant, and font
@@ -459,11 +479,11 @@ class ManifestAssetBundle implements AssetBundle {
         for (final _Asset variant in assetsMap[asset]!) {
           final File variantFile = variant.lookupAssetFile(_fileSystem);
           assert(variantFile.existsSync());
-          deferredComponentsEntries[componentName]![variant.entryUri.path] ??= AssetBundleEntry(
+          _setIfConfigurationChanged(deferredComponentsEntries[componentName]!, variant.entryUri.path, AssetBundleEntry(
             DevFSFileContent(variantFile),
             kind: AssetKind.regular,
             transformers: variant.transformers,
-          );
+          ));
         }
       }
     }
@@ -561,6 +581,13 @@ class ManifestAssetBundle implements AssetBundle {
     }
 
     return true;
+  }
+
+  void _setIfConfigurationChanged(Map<String, AssetBundleEntry> entryMap, String key, AssetBundleEntry entry,) {
+    final AssetBundleEntry? existingEntry = entryMap[key];
+    if (existingEntry == null || !entry.hasEquivalentConfigurationWith(existingEntry)) {
+      entryMap[key] = entry;
+    }
   }
 
   void _setLicenseIfChanged(

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -107,10 +107,6 @@ final class AssetBundleEntry {
 
   final DateTime creationTime = DateTime.now();
 
-  bool isModifiedAfter(DateTime dateTime) {
-    return content.isModifiedAfter(dateTime) || creationTime.isAfter(dateTime);
-  }
-
   Future<List<int>> contentsAsBytes() => content.contentsAsBytes();
 
   bool hasEquivalentConfigurationWith(AssetBundleEntry other) {

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -621,7 +621,7 @@ class DevFS {
       bundle.entries.forEach((String archivePath, AssetBundleEntry entry) {
         // If the content is backed by a real file, isModified will file stat and return true if
         // it was modified since the last time this was called.
-        if (!entry.isModified || bundleFirstUpload) {
+        if (!entry.content.isModified || bundleFirstUpload) {
           return;
         }
         // Modified shaders must be recompiled per-target platform.

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -621,7 +621,7 @@ class DevFS {
       bundle.entries.forEach((String archivePath, AssetBundleEntry entry) {
         // If the content is backed by a real file, isModified will file stat and return true if
         // it was modified since the last time this was called.
-        if (!entry.content.isModified || bundleFirstUpload) {
+        if (!entry.isModified || bundleFirstUpload) {
           return;
         }
         // Modified shaders must be recompiled per-target platform.

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -428,6 +428,73 @@ flutter:
         ),
       );
     });
+
+    testWithoutContext("AssetBundleEntry::isModified is true when an asset's transformers change in between builds", () async {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+
+      fileSystem.file('my-asset.txt').createSync();
+
+      final BufferLogger logger = BufferLogger.test();
+      final FakePlatform platform = FakePlatform();
+      fileSystem.file('.packages').createSync();
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync(r'''
+name: example
+flutter:
+  assets:
+    - path: my-asset.txt
+      transformers:
+        - package: my-transformer-one
+''');
+      final ManifestAssetBundle bundle = ManifestAssetBundle(
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+        flutterRoot: Cache.defaultFlutterRoot(
+          platform: platform,
+          fileSystem: fileSystem,
+          userMessages: UserMessages(),
+        ),
+      );
+
+      await bundle.build(
+        packagesPath: '.packages',
+        flutterProject: FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        ),
+      );
+
+      expect(bundle.entries['my-asset.txt']!.isModified, isTrue);
+
+      await bundle.build(
+        packagesPath: '.packages',
+        flutterProject: FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        ),
+      );
+
+      expect(bundle.entries['my-asset.txt']!.isModified, isFalse);
+
+      fileSystem.file('pubspec.yaml').writeAsStringSync(r'''
+name: example
+flutter:
+  assets:
+    - path: my-asset.txt
+      transformers:
+        - package: my-transformer-one
+        - package: my-transformer-two
+''');
+
+      await bundle.build(
+        packagesPath: '.packages',
+        flutterProject: FlutterProject.fromDirectoryTest(
+          fileSystem.currentDirectory,
+        ),
+      );
+
+      expect(bundle.entries['my-asset.txt']!.isModified, isTrue);
+    });
   });
 
   group('AssetBundle.build (web builds)', () {

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -429,7 +429,7 @@ flutter:
       );
     });
 
-    testWithoutContext("AssetBundleEntry::isModified is true when an asset's transformers change in between builds", () async {
+    testWithoutContext("AssetBundleEntry::content::isModified is true when an asset's transformers change in between builds", () async {
       final FileSystem fileSystem = MemoryFileSystem.test();
 
       fileSystem.file('my-asset.txt').createSync();
@@ -465,7 +465,7 @@ flutter:
         ),
       );
 
-      expect(bundle.entries['my-asset.txt']!.isModified, isTrue);
+      expect(bundle.entries['my-asset.txt']!.content.isModified, isTrue);
 
       await bundle.build(
         packagesPath: '.packages',
@@ -474,7 +474,7 @@ flutter:
         ),
       );
 
-      expect(bundle.entries['my-asset.txt']!.isModified, isFalse);
+      expect(bundle.entries['my-asset.txt']!.content.isModified, isFalse);
 
       fileSystem.file('pubspec.yaml').writeAsStringSync(r'''
 name: example
@@ -493,7 +493,7 @@ flutter:
         ),
       );
 
-      expect(bundle.entries['my-asset.txt']!.isModified, isTrue);
+      expect(bundle.entries['my-asset.txt']!.content.isModified, isTrue);
     });
   });
 


### PR DESCRIPTION
In service of https://github.com/flutter/flutter/issues/143348

This PR makes hot reloads reflect changes to transformer configurations under the `assets` section in pubspec.yaml.
This PR is optimized for ease of implementation, and should not be merged as-is. If it is merged as-is, seriously consider creating a tech debt issue and assigning it to someone to make sure it gets resolved.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
