### PR TITLE
make DevFSContent descendants immutable

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -153,18 +153,11 @@ class DevFSFileContent extends DevFSContent {
 class DevFSByteContent extends DevFSContent {
   DevFSByteContent(this._bytes);
 
-  List<int> _bytes;
-
+  final List<int> _bytes;
+  final DateTime _creationTime = DateTime.now();
   bool _isModified = true;
-  DateTime _modificationTime = DateTime.now();
 
   List<int> get bytes => _bytes;
-
-  set bytes(List<int> value) {
-    _bytes = value;
-    _isModified = true;
-    _modificationTime = DateTime.now();
-  }
 
   /// Return true only once so that the content is written to the device only once.
   @override
@@ -176,7 +169,7 @@ class DevFSByteContent extends DevFSContent {
 
   @override
   bool isModifiedAfter(DateTime time) {
-    return _modificationTime.isAfter(time);
+    return _creationTime.isAfter(time);
   }
 
   @override
@@ -196,19 +189,9 @@ class DevFSStringContent extends DevFSByteContent {
     : _string = string,
       super(utf8.encode(string));
 
-  String _string;
+  final String _string;
 
   String get string => _string;
-
-  set string(String value) {
-    _string = value;
-    super.bytes = utf8.encode(_string);
-  }
-
-  @override
-  set bytes(List<int> value) {
-    string = utf8.decode(value);
-  }
 }
 
 /// A string compressing DevFSContent.
@@ -233,7 +216,7 @@ class DevFSStringCompressingBytesContent extends DevFSContent {
 
   final String _string;
   final ZLibEncoder _compressor;
-  final DateTime _modificationTime = DateTime.now();
+  final DateTime _creationTime = DateTime.now();
 
   bool _isModified = true;
 
@@ -249,7 +232,7 @@ class DevFSStringCompressingBytesContent extends DevFSContent {
 
   @override
   bool isModifiedAfter(DateTime time) {
-    return _modificationTime.isAfter(time);
+    return _creationTime.isAfter(time);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -67,10 +67,6 @@ void main() {
     expect(content.bytes, orderedEquals(<int>[4, 5, 6]));
     expect(content.isModified, isTrue);
     expect(content.isModified, isFalse);
-    content.bytes = <int>[7, 8, 9, 2];
-    expect(content.bytes, orderedEquals(<int>[7, 8, 9, 2]));
-    expect(content.isModified, isTrue);
-    expect(content.isModified, isFalse);
   });
 
   testWithoutContext('DevFSStringContent', () {
@@ -78,16 +74,6 @@ void main() {
 
     expect(content.string, 'some string');
     expect(content.bytes, orderedEquals(utf8.encode('some string')));
-    expect(content.isModified, isTrue);
-    expect(content.isModified, isFalse);
-    content.string = 'another string';
-    expect(content.string, 'another string');
-    expect(content.bytes, orderedEquals(utf8.encode('another string')));
-    expect(content.isModified, isTrue);
-    expect(content.isModified, isFalse);
-    content.bytes = utf8.encode('foo bar');
-    expect(content.string, 'foo bar');
-    expect(content.bytes, orderedEquals(utf8.encode('foo bar')));
     expect(content.isModified, isTrue);
     expect(content.isModified, isFalse);
   });


### PR DESCRIPTION
`DevFSBytesContent` (and it's descendant `DevFSStringContent`) have setters that change the underlying content. These are unused outside of tests, so this PR removes them. Amongst other things, this could help me refactor https://github.com/flutter/flutter/pull/144660 into something that has fewer pitfalls.

This is purely a refactoring.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
