### PR TITLE
Enable asset transformation for `flutter run -d <browser>` and `flutter test`

### DIFF
--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -14,6 +14,7 @@ import 'base/logger.dart';
 import 'build_info.dart';
 import 'build_system/build_system.dart';
 import 'build_system/depfile.dart';
+import 'build_system/tools/asset_transformer.dart';
 import 'build_system/tools/scene_importer.dart';
 import 'build_system/tools/shader_compiler.dart';
 import 'bundle.dart';
@@ -145,6 +146,7 @@ Future<void> writeBundle(
   required FileSystem fileSystem,
   required Artifacts artifacts,
   required Logger logger,
+  required Directory projectDir,
 }) async {
   if (bundleDir.existsSync()) {
     try {
@@ -172,6 +174,12 @@ Future<void> writeBundle(
     artifacts: artifacts,
   );
 
+  final AssetTransformer assetTransformer = AssetTransformer(
+    processManager: processManager,
+    fileSystem: fileSystem,
+    dartBinaryPath: artifacts.getArtifactPath(Artifact.engineDartBinary),
+  );
+
   // Limit number of open files to avoid running out of file descriptors.
   final Pool pool = Pool(64);
   await Future.wait<void>(
@@ -191,7 +199,18 @@ Future<void> writeBundle(
           bool doCopy = true;
           switch (entry.value.kind) {
             case AssetKind.regular:
-              break;
+            if (entry.value.transformers.isNotEmpty) {
+                final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+                  asset: input,
+                  outputPath: file.path,
+                  workingDirectory: projectDir.path,
+                  transformerEntries: entry.value.transformers,
+                );
+                doCopy = false;
+                if (failure != null) {
+                  throwToolExit(failure.message);
+                }
+              }
             case AssetKind.font:
               break;
             case AssetKind.shader:

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -198,18 +198,19 @@ Future<void> writeBundle(
           final File input = devFSContent.file as File;
           bool doCopy = true;
           switch (entry.value.kind) {
-            case AssetKind.regular:
-            if (entry.value.transformers.isNotEmpty) {
-              final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
-                asset: input,
-                outputPath: file.path,
-                workingDirectory: projectDir.path,
-                transformerEntries: entry.value.transformers,
-              );
-              doCopy = false;
-              if (failure != null) {
-                throwToolExit(failure.message);
-              }
+          case AssetKind.regular:
+            if (entry.value.transformers.isEmpty) {
+              break;
+            }
+            final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+              asset: input,
+              outputPath: file.path,
+              workingDirectory: projectDir.path,
+              transformerEntries: entry.value.transformers,
+            );
+            doCopy = false;
+            if (failure != null) {
+              throwToolExit(failure.message);
             }
             case AssetKind.font:
               break;

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -200,17 +200,17 @@ Future<void> writeBundle(
           switch (entry.value.kind) {
             case AssetKind.regular:
             if (entry.value.transformers.isNotEmpty) {
-                final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
-                  asset: input,
-                  outputPath: file.path,
-                  workingDirectory: projectDir.path,
-                  transformerEntries: entry.value.transformers,
-                );
-                doCopy = false;
-                if (failure != null) {
-                  throwToolExit(failure.message);
-                }
+              final AssetTransformationFailure? failure = await assetTransformer.transformAsset(
+                asset: input,
+                outputPath: file.path,
+                workingDirectory: projectDir.path,
+                transformerEntries: entry.value.transformers,
+              );
+              doCopy = false;
+              if (failure != null) {
+                throwToolExit(failure.message);
               }
+            }
             case AssetKind.font:
               break;
             case AssetKind.shader:

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -675,6 +675,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         fileSystem: globals.fs,
         artifacts: globals.artifacts!,
         logger: globals.logger,
+        projectDir: globals.fs.currentDirectory,
       );
     }
   }

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -946,6 +946,7 @@ class WebDevFS implements DevFS {
           fileSystem: globals.fs,
           artifacts: globals.artifacts!,
           logger: globals.logger,
+          projectDir: rootDirectory,
         );
       }
     }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -543,6 +543,7 @@ flutter:
       fileSystem: globals.fs,
       artifacts: globals.artifacts!,
       logger: testLogger,
+      projectDir: globals.fs.currentDirectory
     );
 
     expect(testLogger.warningText, contains('Expected Error Text'));
@@ -668,6 +669,7 @@ flutter:
         fileSystem: globals.fs,
         artifacts: globals.artifacts!,
         logger: testLogger,
+        projectDir: globals.fs.currentDirectory,
       );
 
     }, overrides: <Type, Generator>{
@@ -719,6 +721,7 @@ flutter:
         fileSystem: globals.fs,
         artifacts: globals.artifacts!,
         logger: testLogger,
+        projectDir: globals.fs.currentDirectory,
       );
 
     }, overrides: <Type, Generator>{
@@ -805,6 +808,7 @@ flutter:
         fileSystem: globals.fs,
         artifacts: globals.artifacts!,
         logger: testLogger,
+        projectDir: globals.fs.currentDirectory,
       );
       expect((globals.processManager as FakeProcessManager).hasRemainingExpectations, false);
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -14,18 +14,18 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
-import 'package:flutter_tools/src/bundle.dart';
+import 'package:flutter_tools/src/bundle.dart' hide defaultManifestPath;
 import 'package:flutter_tools/src/bundle_builder.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
+import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/test_build_system.dart';
-import 'devfs_test.dart';
 
 // Tests for BundleBuilder.
 void main() {
@@ -96,7 +96,7 @@ void main() {
         ],
       );
 
-    final FakeBundle bundle = FakeBundle()
+    final FakeAssetBundle bundle = FakeAssetBundle()
       ..entries['my-asset.txt'] = AssetBundleEntry(
         DevFSFileContent(asset),
         kind: AssetKind.regular,
@@ -236,4 +236,9 @@ void main() {
       config: config,
     ), 'build/95b595cca01caa5f0ca0a690339dd7f6.cache.dill.track.dill');
   });
+}
+
+class FakeAssetBundle extends Fake implements AssetBundle {
+  @override
+  final Map<String, AssetBundleEntry> entries = <String, AssetBundleEntry>{};
 }

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -2,19 +2,30 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
+import 'package:args/args.dart';
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/bundle_builder.dart';
+import 'package:flutter_tools/src/devfs.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/test_build_system.dart';
+import 'devfs_test.dart';
 
 // Tests for BundleBuilder.
 void main() {
@@ -44,6 +55,75 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testWithoutContext('writeBundle applies transformations to any assets that have them defined', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    final File asset = fileSystem.file('my-asset.txt')
+      ..createSync()
+      ..writeAsBytesSync(<int>[1, 2, 3]);
+    final Artifacts artifacts = Artifacts.test();
+
+    final FakeProcessManager processManager = FakeProcessManager.list(
+        <FakeCommand>[
+          FakeCommand(
+            command: <Pattern>[
+              artifacts.getArtifactPath(Artifact.engineDartBinary),
+              'run',
+              'increment',
+              '--input=/.tmp_rand0/my-asset.txt-transformOutput0.txt',
+              '--output=/.tmp_rand0/my-asset.txt-transformOutput1.txt'
+            ],
+            onRun: (List<String> command) {
+              final ArgResults argParseResults = (ArgParser()
+                  ..addOption('input', mandatory: true)
+                  ..addOption('output', mandatory: true))
+                .parse(command);
+
+              final File inputFile = fileSystem.file(argParseResults['input']);
+              final File outputFile = fileSystem.file(argParseResults['output']);
+
+              expect(inputFile, exists);
+              outputFile
+                ..createSync()
+                ..writeAsBytesSync(
+                  Uint8List.fromList(
+                    inputFile.readAsBytesSync().map((int b) => b + 1).toList(),
+                  ),
+                );
+            },
+          ),
+        ],
+      );
+
+    final FakeBundle bundle = FakeBundle()
+      ..entries['my-asset.txt'] = AssetBundleEntry(
+        DevFSFileContent(asset),
+        kind: AssetKind.regular,
+        transformers: const <AssetTransformerEntry>[
+          AssetTransformerEntry(package: 'increment', args: <String>[]),
+        ],
+      );
+
+    final Directory bundleDir = fileSystem.directory(
+      getAssetBuildDirectory(Config.test(), fileSystem),
+    );
+
+    await writeBundle(
+      bundleDir,
+      bundle.entries,
+      targetPlatform: TargetPlatform.tester,
+      impellerStatus: ImpellerStatus.platformDefault,
+      processManager: processManager,
+      fileSystem: fileSystem,
+      artifacts: artifacts,
+      logger: BufferLogger.test(),
+      projectDir: fileSystem.currentDirectory,
+    );
+
+    final File outputAssetFile = fileSystem.file('build/flutter_assets/my-asset.txt');
+    expect(outputAssetFile, exists);
+    expect(outputAssetFile.readAsBytesSync(), orderedEquals(<int>[2, 3, 4]));
   });
 
   testUsingContext('Handles build system failure', () {

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -4,15 +4,10 @@
 
 import 'dart:async';
 import 'dart:io' hide Directory, File;
-import 'dart:typed_data';
 
-import 'package:args/args.dart';
 import 'package:dwds/dwds.dart';
 import 'package:fake_async/fake_async.dart';
-import 'package:file/memory.dart';
-import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -21,7 +16,6 @@ import 'package:flutter_tools/src/build_system/tools/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/devfs.dart';
-import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/html_utils.dart';
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
@@ -33,10 +27,7 @@ import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../src/common.dart';
-import '../../src/context.dart';
-import '../../src/fake_process_manager.dart';
 import '../../src/testbed.dart';
-import '../devfs_test.dart';
 
 const List<int> kTransparentImage = <int>[
   0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49,
@@ -1310,116 +1301,6 @@ void main() {
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
   }));
-
-  group('Asset transformation', () {
-    testUsingContext('DevFS re-transforms assets with transformers during update', () async {
-      final File asset = globals.fs.file('my-asset.txt')
-        ..createSync()
-        ..writeAsBytesSync(<int>[1, 2, 3]);
-      final File outputFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
-        ..createSync(recursive: true);
-      outputFile.parent.childFile('a.sources').writeAsStringSync('');
-      outputFile.parent.childFile('a.json').writeAsStringSync('{}');
-      outputFile.parent.childFile('a.map').writeAsStringSync('{}');
-      outputFile.parent.childFile('a.metadata').writeAsStringSync('{}');
-
-      final ResidentCompiler residentCompiler = FakeResidentCompiler()
-        ..output = const CompilerOutput('a', 0, <Uri>[]);
-
-      final WebDevFS devFS = WebDevFS(
-        hostname: 'localhost',
-        port: 0,
-        tlsCertPath: null,
-        tlsCertKeyPath: null,
-        packagesFilePath: '.packages',
-        urlTunneller: null,
-        useSseForDebugProxy: true,
-        useSseForDebugBackend: true,
-        useSseForInjectedClient: true,
-        nullAssertions: true,
-        nativeNullAssertions: true,
-        buildInfo: BuildInfo.debug,
-        enableDwds: false,
-        enableDds: false,
-        entrypoint: Uri.base,
-        testMode: true,
-        expressionCompiler: null,
-        extraHeaders: const <String, String>{},
-        chromiumLauncher: null,
-        nullSafetyMode: NullSafetyMode.unsound,
-        ddcModuleSystem: usesDdcModuleSystem,
-        webRenderer: WebRendererMode.canvaskit,
-        rootDirectory: globals.fs.currentDirectory,
-      );
-      devFS.flutterJs.createSync(recursive: true);
-      devFS.requireJS.createSync(recursive: true);
-      devFS.stackTraceMapper.createSync(recursive: true);
-      await devFS.create();
-
-      final FakeBundle bundle = FakeBundle()
-        ..entries['my-asset.txt'] = AssetBundleEntry(
-          DevFSFileContent(asset),
-          kind: AssetKind.regular,
-          transformers: const <AssetTransformerEntry>[
-            AssetTransformerEntry(package: 'increment', args: <String>[]),
-          ],
-        );
-
-      final UpdateFSReport report = await devFS.update(
-        mainUri: Uri.parse('lib/main.dart'),
-        generator: residentCompiler,
-        dillOutputPath: '',
-        pathToReload: '',
-        trackWidgetCreation: true,
-        invalidatedFiles: <Uri>[],
-        packageConfig: PackageConfig.empty,
-        shaderCompiler: const FakeShaderCompiler(),
-        bundleFirstUpload: true,
-        bundle: bundle,
-      );
-
-      expect(globals.processManager, hasNoRemainingExpectations);
-      expect(report.success, true);
-
-      final File outputAssetFile = globals.fs.file('build/flutter_assets/my-asset.txt');
-      expect(outputAssetFile, exists);
-      expect(outputAssetFile.readAsBytesSync(), orderedEquals(<int>[2, 3, 4]));
-    }, overrides: <Type, Generator>{
-      FileSystem: () => MemoryFileSystem.test(),
-      Artifacts: () => Artifacts.test(),
-      ProcessManager: () => FakeProcessManager.list(
-        <FakeCommand>[
-          FakeCommand(
-            command: <Pattern>[
-              globals.artifacts!.getArtifactPath(Artifact.engineDartBinary),
-              'run',
-              'increment',
-              '--input=/.tmp_rand0/my-asset.txt-transformOutput0.txt',
-              '--output=/.tmp_rand0/my-asset.txt-transformOutput1.txt'
-            ],
-            onRun: (List<String> command) {
-              final ArgResults argParseResults = (ArgParser()
-                  ..addOption('input', mandatory: true)
-                  ..addOption('output', mandatory: true))
-                .parse(command);
-
-              final File inputFile = globals.fs.file(argParseResults['input']);
-              final File outputFile = globals.fs.file(argParseResults['output']);
-
-              expect(inputFile, exists);
-              outputFile
-                ..createSync()
-                ..writeAsBytesSync(
-                  Uint8List.fromList(
-                    inputFile.readAsBytesSync().map((int b) => b + 1).toList(),
-                  ),
-                );
-            },
-          ),
-        ],
-      ),
-    });
-  });
 }
 
 class FakeHttpServer extends Fake implements HttpServer {


### PR DESCRIPTION
Partial implementation of https://github.com/flutter/flutter/issues/143348.

The title says it all. Feel free to experiment with the feature using this project: https://github.com/andrewkolos/asset_transformers_test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
