### PR TITLE
Remove tracing "Frame" in the framework

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -1197,7 +1197,6 @@ mixin SchedulerBinding on BindingBase {
   /// statements printed during a frame from those printed between frames (e.g.
   /// in response to events or timers).
   void handleBeginFrame(Duration? rawTimeStamp) {
-    _frameTimelineTask?.start('Frame');
     _firstRawTimeStampInEpoch ??= rawTimeStamp;
     _currentFrameTimeStamp = _adjustForEpoch(rawTimeStamp ?? _lastRawTimeStamp);
     if (rawTimeStamp != null) {
@@ -1332,7 +1331,6 @@ mixin SchedulerBinding on BindingBase {
       }
     } finally {
       _schedulerPhase = SchedulerPhase.idle;
-      _frameTimelineTask?.finish(); // end the Frame
       assert(() {
         if (debugPrintEndFrameBanner) {
           debugPrint('▀' * _debugBanner!.length);


### PR DESCRIPTION
This PR, together with https://github.com/flutter/engine/pull/51257, moves the tracing of the frame build time from the framework to the engine, resolving the downside of option a in https://github.com/flutter/engine/pull/51186#issuecomment-1977820525 and implementing option b. Please see the link for reason and analysis.


### Landing
The framework PR should be merged first, then the engine PR. Between the gap of the two PRs, the build time benchmark will be missing, but it's fine since it's not a public API.

An alternative option of landing is:
* The engine PR traces with a different name (such as `"Animator::Frame"`), and the framework changes `kBuildFrameEventName` to this name.
  * Downside: This is a larger change and might cause problems to other places that uses this tracing (such as testing).

### Question
* Should I add more tests?
* Should I remove existing tests? Namely
https://github.com/flutter/flutter/blob/a23a9afeda3d2a296bcb848e7f48ad64870cd0bb/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart#L28

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
