### PR TITLE
Copy over source maps from dart2js target when they are enabled.

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -231,6 +231,7 @@ class Dart2JSTarget extends Dart2WebTarget {
   @override
   List<String> get buildFiles => <String>[
     'main.dart.js',
+    if (compilerConfig.sourceMaps) 'main.dart.js.map',
   ];
 }
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -182,6 +182,7 @@ void main() {
     webResources.childFile('foo.txt')
       .writeAsStringSync('A');
     environment.buildDir.childFile('main.dart.js').createSync();
+    environment.buildDir.childFile('main.dart.js.map').createSync();
 
     await WebReleaseBundle(<WebCompilerConfig>[
         const JsCompilerConfig()
@@ -190,6 +191,8 @@ void main() {
     expect(environment.outputDir.childFile('foo.txt')
       .readAsStringSync(), 'A');
     expect(environment.outputDir.childFile('main.dart.js')
+      .existsSync(), true);
+    expect(environment.outputDir.childFile('main.dart.js.map')
       .existsSync(), true);
     expect(environment.outputDir.childDirectory('assets')
       .childFile('AssetManifest.bin.json').existsSync(), true);


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/143703

We need to make sure that when source maps are enabled for the dart2js target, it advertises the sourcemap file as one of its outputs so that the web release bundle can copy it over.