### PR TITLE
Revert "[flutter_test] Change KeyEventSimulator default transit mode (#143847)"

### DIFF
--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -8507,12 +8507,14 @@ void main() {
     expect(controller.selection.extentOffset, 20);
 
     await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     await tester.tapAt(textOffsetToPosition(tester, 23));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 13);
     expect(controller.selection.extentOffset, 23);
 
     await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     await tester.tapAt(textOffsetToPosition(tester, 4));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 13);

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -694,7 +694,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     Finder button0Material = find.descendant(
       of: find.widgetWithText(MenuItemButton, 'Item 0').last,
@@ -705,7 +705,7 @@ void main() {
     expect(item0material.color, themeData.colorScheme.onSurface.withOpacity(0.12));
 
     // Press down key one more time, the highlight should move to the next item.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     final Finder button1Material = find.descendant(
       of: find.widgetWithText(MenuItemButton, 'Menu 1').last,
@@ -735,7 +735,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     Finder button5Material = find.descendant(
       of: find.widgetWithText(MenuItemButton, 'Item 5').last,
@@ -746,7 +746,7 @@ void main() {
     expect(item5material.color, themeData.colorScheme.onSurface.withOpacity(0.12));
 
     // Press up key one more time, the highlight should move up to the item 4.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     final Finder button4Material = find.descendant(
       of: find.widgetWithText(MenuItemButton, 'Item 4').last,
@@ -779,17 +779,17 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Item 0'), findsOneWidget);
 
     // Press down key one more time to the next item.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Menu 1'), findsOneWidget);
 
     // Press down to the next item.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Item 2'), findsOneWidget);
   }, variant: TargetPlatformVariant.desktop());
@@ -810,17 +810,17 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Item 5'), findsOneWidget);
 
     // Press up key one more time to the upper item.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Item 4'), findsOneWidget);
 
     // Press up to the upper item.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
     await tester.pump();
     expect(find.widgetWithText(TextField, 'Item 3'), findsOneWidget);
   }, variant: TargetPlatformVariant.desktop());
@@ -849,7 +849,7 @@ void main() {
     await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     final Finder button0Material = find.descendant(
       of: find.widgetWithText(MenuItemButton, 'Item 0').last,
@@ -859,7 +859,7 @@ void main() {
     expect(item0Material.color, themeData.colorScheme.onSurface.withOpacity(0.12)); // first item can be highlighted as it's enabled.
 
     // Continue to press down key. Item 3 should be highlighted as Menu 1 and Item 2 are both disabled.
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     final Finder button3Material = find.descendant(
       of: find.widgetWithText(MenuItemButton, 'Item 3').last,
@@ -941,7 +941,6 @@ void main() {
 
     // Press up to the upper item (Item 0).
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
-    await simulateKeyUpEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(find.widgetWithText(TextField, 'Item 0'), findsOneWidget);
     final Finder button0Material = find.descendant(
@@ -953,7 +952,6 @@ void main() {
 
     // Continue to move up to the last item (Item 5).
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
-    await simulateKeyUpEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(find.widgetWithText(TextField, 'Item 5'), findsOneWidget);
     final Finder button5Material = find.descendant(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -15933,12 +15933,14 @@ void main() {
     expect(controller.selection.extentOffset, 20);
 
     await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     await tester.tapAt(textOffsetToPosition(tester, 23));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 13);
     expect(controller.selection.extentOffset, 23);
 
     await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     await tester.tapAt(textOffsetToPosition(tester, 4));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 13);

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -30,7 +30,7 @@ void main() {
         await simulateKeyDownEvent(LogicalKeyboardKey.backquote, platform: platform);
         RawKeyboard.instance.removeListener(handleKey);
       }
-    }, variant: KeySimulatorTransitModeVariant.rawKeyData());
+    });
 
     testWidgets('No character is produced for non-printables', (WidgetTester tester) async {
       for (final String platform in <String>['linux', 'android', 'macos', 'fuchsia', 'windows', 'web', 'ios']) {
@@ -41,7 +41,7 @@ void main() {
         await simulateKeyDownEvent(LogicalKeyboardKey.shiftLeft, platform: platform);
         RawKeyboard.instance.removeListener(handleKey);
       }
-    }, variant: KeySimulatorTransitModeVariant.rawKeyData());
+    });
 
     testWidgets('keysPressed is maintained', (WidgetTester tester) async {
       for (final String platform in <String>['linux', 'android', 'macos', 'fuchsia', 'windows', 'ios']) {
@@ -147,10 +147,7 @@ void main() {
           expect(RawKeyboard.instance.keysPressed, isEmpty, reason: 'on $platform');
         }
       }
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // https://github.com/flutter/flutter/issues/61021
-    );
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
     testWidgets('keysPressed is correct when modifier is released before key', (WidgetTester tester) async {
       for (final String platform in <String>['linux', 'android', 'macos', 'fuchsia', 'windows', 'ios']) {
@@ -201,10 +198,7 @@ void main() {
         await simulateKeyUpEvent(LogicalKeyboardKey.keyA, platform: platform, physicalKey: PhysicalKeyboardKey.keyA);
         expect(RawKeyboard.instance.keysPressed, isEmpty, reason: 'on $platform');
       }
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // https://github.com/flutter/flutter/issues/76741
-    );
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/76741
 
     testWidgets('keysPressed modifiers are synchronized with key events on macOS', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -228,10 +222,7 @@ void main() {
           <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a macOS-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is a macOS-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on iOS', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -255,10 +246,7 @@ void main() {
           <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a iOS-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is an iOS-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on Windows', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -282,10 +270,7 @@ void main() {
           <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a Windows-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is a Windows-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on android', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -309,10 +294,7 @@ void main() {
           <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is an Android-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is an Android-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on fuchsia', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -336,10 +318,7 @@ void main() {
           <LogicalKeyboardKey>{LogicalKeyboardKey.shiftLeft, LogicalKeyboardKey.keyA},
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a Fuchsia-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is a Fuchsia-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on Linux GLFW', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -369,10 +348,7 @@ void main() {
           },
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a GLFW-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is a GLFW-specific test.
 
     Future<void> simulateGTKKeyEvent(bool keyDown, int scancode, int keycode, int modifiers) async {
       final Map<String, dynamic> data = <String, dynamic>{
@@ -421,10 +397,7 @@ void main() {
           },
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a GTK-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is a GTK-specific test.
 
     // Regression test for https://github.com/flutter/flutter/issues/114591 .
     //
@@ -441,10 +414,7 @@ void main() {
           },
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a GTK-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is a GTK-specific test.
 
     // Regression test for https://github.com/flutter/flutter/issues/114591 .
     //
@@ -477,10 +447,7 @@ void main() {
           },
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: !isBrowser, // [intended] This is a Browser-specific test.
-    );
+    }, skip: !isBrowser); // [intended] This is a Browser-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on web', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
@@ -605,10 +572,7 @@ void main() {
           },
         ),
       );
-    },
-      variant: KeySimulatorTransitModeVariant.rawKeyData(),
-      skip: isBrowser, // [intended] This is a Android-specific test.
-    );
+    }, skip: isBrowser); // [intended] This is an Android-specific test.
 
     testWidgets('sided modifiers without a side set return all sides on macOS', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -684,7 +684,7 @@ abstract final class KeyEventSimulator {
     return result!;
   }
 
-  static const KeyDataTransitMode _defaultTransitMode = KeyDataTransitMode.keyDataThenRawKeyData;
+  static const KeyDataTransitMode _defaultTransitMode = KeyDataTransitMode.rawKeyData;
 
   // The simulation transit mode for [simulateKeyDownEvent], [simulateKeyUpEvent],
   // and [simulateKeyRepeatEvent].
@@ -693,8 +693,8 @@ abstract final class KeyEventSimulator {
   // and delivered. For detailed introduction, see [KeyDataTransitMode] and
   // its values.
   //
-  // The `_transitMode` defaults to [KeyDataTransitMode.keyDataThenRawKeyData], and can
-  // be overridden with [debugKeyEventSimulatorTransitModeOverride]. In widget tests, it
+  // The `_transitMode` defaults to [KeyDataTransitMode.rawKeyEvent], and can be
+  // overridden with [debugKeyEventSimulatorTransitModeOverride]. In widget tests, it
   // is often set with [KeySimulationModeVariant].
   static KeyDataTransitMode get _transitMode {
     KeyDataTransitMode? result;
@@ -704,12 +704,6 @@ abstract final class KeyEventSimulator {
     }());
     return result ?? _defaultTransitMode;
   }
-
-  /// Returns the transit mode that simulated key events are constructed
-  /// and delivered. For detailed introduction, see [KeyDataTransitMode]
-  /// and its values.
-  @visibleForTesting
-  static KeyDataTransitMode get transitMode => _transitMode;
 
   static String get _defaultPlatform => kIsWeb ? 'web' : defaultTargetPlatform.name.toLowerCase();
 
@@ -976,15 +970,6 @@ class KeySimulatorTransitModeVariant extends TestVariant<KeyDataTransitMode> {
   )
   KeySimulatorTransitModeVariant.keyDataThenRawKeyData()
     : this(<KeyDataTransitMode>{KeyDataTransitMode.keyDataThenRawKeyData});
-
-  /// Creates a [KeySimulatorTransitModeVariant] that only contains
-  /// [KeyDataTransitMode.rawKeyData].
-  @Deprecated(
-    'No longer supported. Transit mode is always key data only. '
-    'This feature was deprecated after v3.18.0-2.0.pre.',
-  )
-  KeySimulatorTransitModeVariant.rawKeyData()
-    : this(<KeyDataTransitMode>{KeyDataTransitMode.rawKeyData});
 
   @override
   final Set<KeyDataTransitMode> values;

--- a/packages/flutter_test/test/event_simulation_test.dart
+++ b/packages/flutter_test/test/event_simulation_test.dart
@@ -37,25 +37,12 @@ Future<void> _shouldThrow<T extends Error>(AsyncValueGetter<void> func) async {
 }
 
 void main() {
-  testWidgets('default transit mode is keyDataThenRawKeyData', (WidgetTester tester) async {
-    expect(KeyEventSimulator.transitMode, KeyDataTransitMode.keyDataThenRawKeyData);
-  });
-
-  testWidgets('debugKeyEventSimulatorTransitModeOverride overrides default transit mode', (WidgetTester tester) async {
-    debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.rawKeyData;
-    expect(KeyEventSimulator.transitMode, KeyDataTransitMode.rawKeyData);
-    // Unsetting debugKeyEventSimulatorTransitModeOverride can't be called in a
-    // tear down callback because TestWidgetsFlutterBinding._verifyInvariants
-    // is called before tear down callbacks.
-    debugKeyEventSimulatorTransitModeOverride = null;
-  });
-
   testWidgets('simulates keyboard events (RawEvent)', (WidgetTester tester) async {
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.rawKeyData;
 
     final List<RawKeyEvent> events = <RawKeyEvent>[];
+
     final FocusNode focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
       RawKeyboardListener(
@@ -93,6 +80,7 @@ void main() {
     }
 
     await tester.pumpWidget(Container());
+    focusNode.dispose();
 
     debugKeyEventSimulatorTransitModeOverride = null;
   });
@@ -101,8 +89,8 @@ void main() {
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
 
     final List<KeyEvent> events = <KeyEvent>[];
+
     final FocusNode focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
       KeyboardListener(
@@ -255,6 +243,7 @@ void main() {
     await tester.idle();
 
     await tester.pumpWidget(Container());
+    focusNode.dispose();
 
     debugKeyEventSimulatorTransitModeOverride = null;
   });
@@ -263,9 +252,8 @@ void main() {
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.rawKeyData;
 
     final List<Object> events = <Object>[];
-    final FocusNode focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
 
+    final FocusNode focusNode = FocusNode();
     await tester.pumpWidget(
       Focus(
         focusNode: focusNode,
@@ -320,9 +308,8 @@ void main() {
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
 
     final List<Object> events = <Object>[];
-    final FocusNode focusNode = FocusNode();
-    addTearDown(focusNode.dispose);
 
+    final FocusNode focusNode = FocusNode();
     await tester.pumpWidget(
       Focus(
         focusNode: focusNode,


### PR DESCRIPTION
This reverts commit 8ade81fb201ae556b31dd6ab6a0b8cdcbf72b99b.

Reason for revert: Causes Google internal tests to fail. See b/328788027

Will attempt re-land once tests are fixed.