### PR TITLE
Rename isAvailableForEnvironment to isForEnvironment (#143176)

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -23,7 +23,12 @@ export 'skia_client.dart';
 //   /packages/flutter/test/widgets/basic_test.dart
 
 const String _kFlutterRootKey = 'FLUTTER_ROOT';
-final RegExp _kMainBranch = RegExp(r'master|main');
+
+bool _isMainBranch(String? branch) {
+  return branch == 'main'
+      || branch == 'master';
+}
+
 
 /// Main method that can be used in a `flutter_test_config.dart` file to set
 /// [goldenFileComparator] to an instance of [FlutterGoldenFileComparator] that
@@ -33,11 +38,11 @@ final RegExp _kMainBranch = RegExp(r'master|main');
 /// When set, the `namePrefix` is prepended to the names of all gold images.
 Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePrefix}) async {
   const Platform platform = LocalPlatform();
-  if (FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform)) {
+  if (FlutterPostSubmitFileComparator.isForEnvironment(platform)) {
     goldenFileComparator = await FlutterPostSubmitFileComparator.fromDefaultComparator(platform, namePrefix: namePrefix);
-  } else if (FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform)) {
+  } else if (FlutterPreSubmitFileComparator.isForEnvironment(platform)) {
     goldenFileComparator = await FlutterPreSubmitFileComparator.fromDefaultComparator(platform, namePrefix: namePrefix);
-  } else if (FlutterSkippingFileComparator.isAvailableForEnvironment(platform)) {
+  } else if (FlutterSkippingFileComparator.isForEnvironment(platform)) {
     goldenFileComparator = FlutterSkippingFileComparator.fromDefaultComparator(
       'Golden file testing is not executed on Cirrus, or LUCI environments outside of flutter/flutter.',
         namePrefix: namePrefix
@@ -259,13 +264,13 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
 
   /// Decides based on the current environment if goldens tests should be
   /// executed through Skia Gold.
-  static bool isAvailableForEnvironment(Platform platform) {
+  static bool isForEnvironment(Platform platform) {
     final bool luciPostSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')
       // Luci tryjob environments contain this value to inform the [FlutterPreSubmitComparator].
       && !platform.environment.containsKey('GOLD_TRYJOB')
       // Only run on main branch.
-      && _kMainBranch.hasMatch(platform.environment['GIT_BRANCH'] ?? '');
+      && _isMainBranch(platform.environment['GIT_BRANCH']);
 
     return luciPostSubmit;
   }
@@ -349,12 +354,12 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
 
   /// Decides based on the current environment if goldens tests should be
   /// executed as pre-submit tests with Skia Gold.
-  static bool isAvailableForEnvironment(Platform platform) {
+  static bool isForEnvironment(Platform platform) {
     final bool luciPreSubmit = platform.environment.containsKey('SWARMING_TASK_ID')
       && platform.environment.containsKey('GOLDCTL')
       && platform.environment.containsKey('GOLD_TRYJOB')
       // Only run on the main branch
-      && _kMainBranch.hasMatch(platform.environment['GIT_BRANCH'] ?? '');
+      && _isMainBranch(platform.environment['GIT_BRANCH']);
     return luciPreSubmit;
   }
 }
@@ -420,12 +425,12 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
   ///
   /// If we are in a CI environment, LUCI or Cirrus, but are not using the other
   /// comparators, we skip.
-  static bool isAvailableForEnvironment(Platform platform) {
+  static bool isForEnvironment(Platform platform) {
     return (platform.environment.containsKey('SWARMING_TASK_ID')
       // Some builds are still being run on Cirrus, we should skip these.
       || platform.environment.containsKey('CIRRUS_CI'))
       // If we are in CI, skip on branches that are not main.
-      && !_kMainBranch.hasMatch(platform.environment['GIT_BRANCH'] ?? '');
+      && !_isMainBranch(platform.environment['GIT_BRANCH']);
   }
 }
 
@@ -435,7 +440,7 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
 /// This comparator utilizes the [SkiaGoldClient] to request baseline images for
 /// the given device under test for comparison. This comparator is initialized
 /// when conditions for all other [FlutterGoldenFileComparators] have not been
-/// met, see the `isAvailableForEnvironment` method for each one listed below.
+/// met, see the `isForEnvironment` method for each one listed below.
 ///
 /// The [FlutterLocalFileComparator] is intended to run on local machines and
 /// serve as a smoke test during development. As such, it will not be able to

--- a/packages/flutter_goldens/test/comparator_selection_test.dart
+++ b/packages/flutter_goldens/test/comparator_selection_test.dart
@@ -39,13 +39,13 @@ _Comparator _testRecommendations({
     },
     operatingSystem: os,
   );
-  if (FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform)) {
+  if (FlutterPostSubmitFileComparator.isForEnvironment(platform)) {
     return _Comparator.post;
   }
-  if (FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform)) {
+  if (FlutterPreSubmitFileComparator.isForEnvironment(platform)) {
     return _Comparator.pre;
   }
-  if (FlutterSkippingFileComparator.isAvailableForEnvironment(platform)) {
+  if (FlutterSkippingFileComparator.isForEnvironment(platform)) {
     return _Comparator.skip;
   }
   return _Comparator.local;
@@ -164,5 +164,12 @@ void main() {
     // On Cirrus (with Gold and not on Luci), we skip regardless.
     expect(_testRecommendations(os: 'linux', hasCirrus: true, hasGold: true, hasFlutterRoot: true), _Comparator.local); // TODO(ianh): this should be skip
     expect(_testRecommendations(os: 'linux', hasCirrus: true, hasGold: true, hasFlutterRoot: true, hasTryJob: true), _Comparator.local); // TODO(ianh): this should be skip
+  });
+
+  test('Branch names', () {
+    expect(_testRecommendations(hasLuci: true, hasGold: true, hasFlutterRoot: true), _Comparator.post);
+    expect(_testRecommendations(branch: 'master', hasLuci: true, hasGold: true, hasFlutterRoot: true), _Comparator.post);
+    expect(_testRecommendations(branch: 'the_master_of_justice', hasLuci: true, hasGold: true, hasFlutterRoot: true), _Comparator.skip);
+    expect(_testRecommendations(branch: 'maintain_accuracy', hasLuci: true, hasGold: true, hasFlutterRoot: true), _Comparator.skip);
   });
 }

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -725,7 +725,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -741,7 +741,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -757,7 +757,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -773,7 +773,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -787,7 +787,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -803,7 +803,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -820,7 +820,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -893,7 +893,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -910,7 +910,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -927,7 +927,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -944,7 +944,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -957,7 +957,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -972,7 +972,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -987,7 +987,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPreSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPreSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -1004,7 +1004,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterPostSubmitFileComparator.isAvailableForEnvironment(platform),
+            FlutterPostSubmitFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });
@@ -1025,7 +1025,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            FlutterSkippingFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -1041,7 +1041,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            FlutterSkippingFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -1055,7 +1055,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            FlutterSkippingFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -1069,7 +1069,7 @@ void main() {
             operatingSystem: 'macos'
           );
           expect(
-            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            FlutterSkippingFileComparator.isForEnvironment(platform),
             isTrue,
           );
         });
@@ -1082,7 +1082,7 @@ void main() {
             operatingSystem: 'macos',
           );
           expect(
-            FlutterSkippingFileComparator.isAvailableForEnvironment(platform),
+            FlutterSkippingFileComparator.isForEnvironment(platform),
             isFalse,
           );
         });


### PR DESCRIPTION
This is part 4 of a broken down version of the #140101 refactor.

This PR renames isAvailableForEnvironment to isForEnvironment and replaces a regular expression with a simple function. (The latter will change the behaviour for people with branch names like `mainly_refactors` or `chess_master_experiment` or whatever, but I'm pretty sure the old behaviour was not intended.)

----

This is a reland of https://github.com/flutter/flutter/pull/143176 which was speculatively reverted in https://github.com/flutter/flutter/pull/144855 but turned out not to be the cause of the tree redness.