### PR TITLE
Feature: Add AnimatedList with separators

### DIFF
--- a/examples/api/lib/widgets/animated_list/animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list.0.dart
@@ -66,7 +66,8 @@ class _AnimatedListSampleState extends State<AnimatedListSample> {
   // Insert the "next item" into the list model.
   void _insert() {
     final int index = _selectedItem == null ? _list.length : _list.indexOf(_selectedItem!);
-    _list.insert(index, _nextItem++);
+    _list.insert(index, _nextItem);
+    _nextItem++;
   }
 
   // Remove the selected item from the list model.

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -30,7 +30,6 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
       listKey: _listKey,
       initialItems: <int>[0, 1, 2],
       removedItemBuilder: _buildRemovedItem,
-      removedSeparatorBuilder: _buildRemovedSeparator,
     );
     _nextItem = 3;
   }
@@ -75,7 +74,7 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
   // Build a separator for items that have been removed from the list.
   /// The widget will be used by the [AnimatedListSeparatedState.removeSeparatedItem] method's
   /// `separatorBuilder` parameter.
-  Widget _buildRemovedSeparator(int item, BuildContext context, Animation<double> animation) => SizeTransition(
+  Widget _buildRemovedSeparator(BuildContext context, int item, Animation<double> animation) => SizeTransition(
                 sizeFactor: animation,
                 child: ItemSeparator(
                   animation: animation,
@@ -126,6 +125,7 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
             initialItemCount: _list.length,
             itemBuilder: _buildItem,
             separatorBuilder: _buildSeparator,
+            removeSeparatorBuilder: _buildRemovedSeparator,
           ),
         ),
       ),
@@ -148,13 +148,11 @@ class ListModel<E> {
   ListModel({
     required this.listKey,
     required this.removedItemBuilder,
-    required this.removedSeparatorBuilder,
     Iterable<E>? initialItems,
   }) : _items = List<E>.from(initialItems ?? <E>[]);
 
   final GlobalKey<AnimatedListSeparatedState> listKey;
   final RemovedItemBuilder<E> removedItemBuilder;
-  final RemovedItemBuilder<E> removedSeparatorBuilder;
   final List<E> _items;
 
   AnimatedListSeparatedState? get _animatedListSeparated => listKey.currentState;
@@ -167,16 +165,10 @@ class ListModel<E> {
   E removeAt(int index) {
     final E removedItem = _items.removeAt(index);
     if (removedItem != null) {
-      final bool isLastItem = index == length;
-      // If the removed item is the last item in the list, the separator of the preceding item is removed.
-      final E itemOfRemovedSeparator = isLastItem && length > 0 ? _items[index - 1] : removedItem;
       _animatedListSeparated!.removeItem(
         index,
         (BuildContext context, Animation<double> animation) {
           return removedItemBuilder(removedItem, context, animation);
-        },
-        (BuildContext context, Animation<double> animation) {
-          return removedSeparatorBuilder(itemOfRemovedSeparator, context, animation);
         },
       );
     }

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -18,7 +18,7 @@ class AnimatedListSeparatedSample extends StatefulWidget {
 }
 
 class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSample> {
-  final GlobalKey<AnimatedListSeparatedState> _listKey = GlobalKey<AnimatedListSeparatedState>();
+  final GlobalKey<AnimatedListState> _listKey = GlobalKey<AnimatedListState>();
   late ListModel<int> _list;
   int? _selectedItem;
   late int _nextItem; // The next item inserted when the user presses the '+' button.
@@ -120,12 +120,12 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
         ),
         body: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: AnimatedListSeparated(
+          child: AnimatedList.separated(
             key: _listKey,
             initialItemCount: _list.length,
             itemBuilder: _buildItem,
             separatorBuilder: _buildSeparator,
-            removeSeparatorBuilder: _buildRemovedSeparator,
+            removedSeparatorBuilder: _buildRemovedSeparator,
           ),
         ),
       ),
@@ -151,11 +151,11 @@ class ListModel<E> {
     Iterable<E>? initialItems,
   }) : _items = List<E>.from(initialItems ?? <E>[]);
 
-  final GlobalKey<AnimatedListSeparatedState> listKey;
+  final GlobalKey<AnimatedListState> listKey;
   final RemovedItemBuilder<E> removedItemBuilder;
   final List<E> _items;
 
-  AnimatedListSeparatedState? get _animatedListSeparated => listKey.currentState;
+  AnimatedListState? get _animatedListSeparated => listKey.currentState;
 
   void insert(int index, E item) {
     _items.insert(index, item);

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -83,12 +83,12 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
   /// have been removed from the list model by the time this builder is called.
   Widget _buildRemovedSeparator(BuildContext context, int index, Animation<double> animation) {
     return SizeTransition(
-                sizeFactor: animation,
-                child: ItemSeparator(
-                  animation: animation,
-                  item: null,
-                )
-              );
+      sizeFactor: animation,
+      child: ItemSeparator(
+        animation: animation,
+        item: null,
+      )
+    );
   }
 
   // Insert the "next item" into the list model.

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -79,7 +79,7 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
   /// via the [AnimatedList.removedSeparatorBuilder] parameter and used
   /// in the [AnimatedListState.removeItem] method.
   ///
-  /// Note that the item parameter is null, because the corresponding item will
+  /// The item parameter is null, because the corresponding item will
   /// have been removed from the list model by the time this builder is called.
   Widget _buildRemovedSeparator(BuildContext context, int index, Animation<double> animation) => SizeTransition(
                 sizeFactor: animation,

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -75,7 +75,7 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
   // Build a separator for items that have been removed from the list.
   /// The widget will be used by the [AnimatedListSeparatedState.removeSeparatedItem] method's
   /// `separatorBuilder` parameter.
-  Widget _buildRemovedSeparator(int item , BuildContext context, Animation<double> animation) => SizeTransition(
+  Widget _buildRemovedSeparator(int item, BuildContext context, Animation<double> animation) => SizeTransition(
                 sizeFactor: animation,
                 child: ItemSeparator(
                   animation: animation,
@@ -86,7 +86,8 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
   // Insert the "next item" into the list model.
   void _insert() {
     final int index = _selectedItem == null ? _list.length : _list.indexOf(_selectedItem!);
-    _list.insert(index, _nextItem++);
+    _list.insert(index, _nextItem);
+    _nextItem++;
   }
 
   // Remove the selected item from the list model.

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -81,13 +81,15 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
   ///
   /// The item parameter is null, because the corresponding item will
   /// have been removed from the list model by the time this builder is called.
-  Widget _buildRemovedSeparator(BuildContext context, int index, Animation<double> animation) => SizeTransition(
+  Widget _buildRemovedSeparator(BuildContext context, int index, Animation<double> animation) {
+    return SizeTransition(
                 sizeFactor: animation,
                 child: ItemSeparator(
                   animation: animation,
                   item: null,
                 )
               );
+  }
 
   // Insert the "next item" into the list model.
   void _insert() {

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -1,0 +1,274 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [AnimatedListSeparated].
+
+void main() {
+  runApp(const AnimatedListSeparatedSample());
+}
+
+class AnimatedListSeparatedSample extends StatefulWidget {
+  const AnimatedListSeparatedSample({super.key});
+
+  @override
+  State<AnimatedListSeparatedSample> createState() => _AnimatedListSeparatedSampleState();
+}
+
+class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSample> {
+  final GlobalKey<AnimatedListSeparatedState> _listKey = GlobalKey<AnimatedListSeparatedState>();
+  late ListModel<int> _list;
+  int? _selectedItem;
+  late int _nextItem; // The next item inserted when the user presses the '+' button.
+
+  @override
+  void initState() {
+    super.initState();
+    _list = ListModel<int>(
+      listKey: _listKey,
+      initialItems: <int>[0, 1, 2],
+      removedItemBuilder: _buildRemovedItem,
+      removedSeparatorBuilder: _buildRemovedSeparator,
+    );
+    _nextItem = 3;
+  }
+
+  // Used to build list items that haven't been removed.
+  Widget _buildItem(BuildContext context, int index, Animation<double> animation) {
+    return CardItem(
+      animation: animation,
+      item: _list[index],
+      selected: _selectedItem == _list[index],
+      onTap: () {
+        setState(() {
+          _selectedItem = _selectedItem == _list[index] ? null : _list[index];
+        });
+      },
+    );
+  }
+
+  // Used to build separators that haven't been removed.
+  Widget _buildSeparator(BuildContext context, int index, Animation<double> animation) {
+    return ItemSeparator(
+      animation: animation,
+      item: _list[index],
+    );
+  }
+
+  /// The builder function used to build items that have been removed.
+  ///
+  /// Used to build an item after it has been removed from the list. This method
+  /// is needed because a removed item remains visible until its animation has
+  /// completed (even though it's gone as far as this ListModel is concerned).
+  /// The widget will be used by the [AnimatedListSeparatedState.removeSeparatedItem] method's
+  /// `itemBuilder` parameter.
+  Widget _buildRemovedItem(int item, BuildContext context, Animation<double> animation) {
+    return CardItem(
+      animation: animation,
+      item: item,
+      // No gesture detector here: we don't want removed items to be interactive.
+    );
+  }
+
+  // Build a separator for items that have been removed from the list.
+  /// The widget will be used by the [AnimatedListSeparatedState.removeSeparatedItem] method's
+  /// `separatorBuilder` parameter.
+  Widget _buildRemovedSeparator(int item , BuildContext context, Animation<double> animation) => SizeTransition(
+                sizeFactor: animation,
+                child: ItemSeparator(
+                  animation: animation,
+                  item: item,
+                )
+              );
+
+  // Insert the "next item" into the list model.
+  void _insert() {
+    final int index = _selectedItem == null ? _list.length : _list.indexOf(_selectedItem!);
+    _list.insert(index, _nextItem++);
+  }
+
+  // Remove the selected item from the list model.
+  void _remove() {
+    if (_selectedItem != null) {
+      _list.removeAt(_list.indexOf(_selectedItem!));
+      setState(() {
+        _selectedItem = null;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('AnimatedListSeparated'),
+          actions: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.add_circle),
+              onPressed: _insert,
+              tooltip: 'insert a new item',
+            ),
+            IconButton(
+              icon: const Icon(Icons.remove_circle),
+              onPressed: _remove,
+              tooltip: 'remove the selected item',
+            ),
+          ],
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: AnimatedListSeparated(
+            key: _listKey,
+            initialItemCount: _list.length,
+            itemBuilder: _buildItem,
+            separatorBuilder: _buildSeparator,
+            ),
+          ),
+      ),
+    );
+  }
+}
+
+typedef RemovedItemBuilder<T> = Widget Function(T item, BuildContext context, Animation<double> animation);
+
+/// Keeps a Dart [List] in sync with an [AnimatedListSeparated].
+///
+/// The [insert] and [removeAt] methods apply to both the internal list and
+/// the animated list that belongs to [listKey].
+///
+/// This class only exposes as much of the Dart List API as is needed by the
+/// sample app. More list methods are easily added, however methods that
+/// mutate the list must make the same changes to the animated list in terms
+/// of [AnimatedListSeparatedState.insertItem] and [AnimatedListSeparatedState.removeSeparatedItem].
+class ListModel<E> {
+  ListModel({
+    required this.listKey,
+    required this.removedItemBuilder,
+    required this.removedSeparatorBuilder,
+    Iterable<E>? initialItems,
+  }) : _items = List<E>.from(initialItems ?? <E>[]);
+
+  final GlobalKey<AnimatedListSeparatedState> listKey;
+  final RemovedItemBuilder<E> removedItemBuilder;
+  final RemovedItemBuilder<E> removedSeparatorBuilder;
+  final List<E> _items;
+
+  AnimatedListSeparatedState? get _animatedListSeparated => listKey.currentState;
+
+  void insert(int index, E item) {
+    _items.insert(index, item);
+    _animatedListSeparated!.insertItem(index);
+  }
+
+  E removeAt(int index) {
+    final E removedItem = _items.removeAt(index);
+    if (removedItem != null) {
+      final bool isLastItem = index == length;
+      // If the removed item is the last item in the list, the separator of the preceding item is removed.
+      final E itemOfRemovedSeparator = isLastItem && length > 0 ? _items[index - 1] : removedItem;
+      _animatedListSeparated!.removeSeparatedItem(
+        index,
+        (BuildContext context, Animation<double> animation) {
+          return removedItemBuilder(removedItem, context, animation);
+        },
+        (BuildContext context, Animation<double> animation) {
+          return removedSeparatorBuilder(itemOfRemovedSeparator, context, animation);
+        },
+      );
+    }
+    return removedItem;
+  }
+
+  int get length => _items.length;
+
+  E operator [](int index) => _items[index];
+
+  int indexOf(E item) => _items.indexOf(item);
+}
+
+/// Displays its integer item as 'item N' on a Card whose color is based on
+/// the item's value.
+///
+/// The text is displayed in bright green if [selected] is
+/// true. This widget's height is based on the [animation] parameter, it
+/// varies from 0 to 80 as the animation varies from 0.0 to 1.0.
+class CardItem extends StatelessWidget {
+  const CardItem({
+    super.key,
+    this.onTap,
+    this.selected = false,
+    required this.animation,
+    required this.item,
+  }) : assert(item >= 0);
+
+  final Animation<double> animation;
+  final VoidCallback? onTap;
+  final int item;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    TextStyle textStyle = Theme.of(context).textTheme.headlineMedium!;
+    if (selected) {
+      textStyle = textStyle.copyWith(color: Colors.lightGreenAccent[400]);
+    }
+    return Padding(
+      padding: const EdgeInsets.all(2.0),
+      child: SizeTransition(
+        sizeFactor: animation,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: SizedBox(
+            height: 80.0,
+            child: Card(
+              color: Colors.primaries[item % Colors.primaries.length],
+              child: Center(
+                child: Text('Item $item', style: textStyle),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Displays its integer item as 'separator N' on a Card whose color is based on
+/// the corresponding item's value.
+///
+/// This widget's height is based on the [animation] parameter, it
+/// varies from 0 to 40 as the animation varies from 0.0 to 1.0.
+class ItemSeparator extends StatelessWidget {
+  const ItemSeparator({
+    super.key,
+    required this.animation,
+    required this.item,
+  }) : assert(item >= 0);
+
+  final Animation<double> animation;
+  final int item;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle textStyle = Theme.of(context).textTheme.headlineSmall!;
+    return Padding(
+      padding: const EdgeInsets.all(2.0),
+      child: SizeTransition(
+        sizeFactor: animation,
+        child: SizedBox(
+          height: 40.0,
+          child: Card(
+            color: Colors.primaries[item % Colors.primaries.length],
+            child: Center(
+              child: Text('Separator $item', style: textStyle),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -170,7 +170,7 @@ class ListModel<E> {
       final bool isLastItem = index == length;
       // If the removed item is the last item in the list, the separator of the preceding item is removed.
       final E itemOfRemovedSeparator = isLastItem && length > 0 ? _items[index - 1] : removedItem;
-      _animatedListSeparated!.removeSeparatedItem(
+      _animatedListSeparated!.removeItem(
         index,
         (BuildContext context, Animation<double> animation) {
           return removedItemBuilder(removedItem, context, animation);

--- a/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list_separated.0.dart
@@ -125,8 +125,8 @@ class _AnimatedListSeparatedSampleState extends State<AnimatedListSeparatedSampl
             initialItemCount: _list.length,
             itemBuilder: _buildItem,
             separatorBuilder: _buildSeparator,
-            ),
           ),
+        ),
       ),
     );
   }

--- a/examples/api/test/widgets/animated_list/animated_list_separated.0_test.dart
+++ b/examples/api/test/widgets/animated_list/animated_list_separated.0_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/animated_list/animated_list_separated.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Items can be selected, added, and removed from AnimatedListSeparated',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.AnimatedListSeparatedSample());
+
+      expect(find.text('Item 0'), findsOneWidget);
+      expect(find.text('Separator 0'), findsOneWidget);
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Separator 1'), findsOneWidget);
+      expect(find.text('Item 2'), findsOneWidget);
+
+      // Add an item at the end of the list
+      await tester.tap(find.byIcon(Icons.add_circle));
+      await tester.pumpAndSettle();
+      expect(find.text('Separator 2'), findsOneWidget);
+      expect(find.text('Item 3'), findsOneWidget);
+
+      // Select Item 1.
+      await tester.tap(find.text('Item 1'));
+      await tester.pumpAndSettle();
+
+      // Add item at the top of the list
+      await tester.tap(find.byIcon(Icons.add_circle));
+      await tester.pumpAndSettle();
+      expect(find.text('Item 4'), findsOneWidget);
+      // Contrary to the behavior for insertion at other places,
+      // the Separator for the last item of the list will be added
+      // before that item instead of after it.
+      expect(find.text('Separator 4'), findsOneWidget);
+
+      // Remove selected item.
+      await tester.tap(find.byIcon(Icons.remove_circle));
+
+      // Item animation is not completed.
+      await tester.pump();
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Separator 1'), findsOneWidget);
+
+      // When the animation completes, Item 1 disappears.
+      await tester.pumpAndSettle();
+      expect(find.text('Item 1'), findsNothing);
+      expect(find.text('Separator 1'), findsNothing);
+    },
+  );
+}

--- a/examples/api/test/widgets/animated_list/animated_list_separated.0_test.dart
+++ b/examples/api/test/widgets/animated_list/animated_list_separated.0_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets(
-    'Items can be selected, added, and removed from AnimatedListSeparated',
+    'Items can be selected, added, and removed from AnimatedList.separated',
     (WidgetTester tester) async {
       await tester.pumpWidget(const example.AnimatedListSeparatedSample());
 
@@ -43,12 +43,14 @@ void main() {
       // Item animation is not completed.
       await tester.pump();
       expect(find.text('Item 1'), findsOneWidget);
-      expect(find.text('Separator 1'), findsOneWidget);
+      expect(find.text('Separator 1'), findsNothing);
+      expect(find.text('Removing separator'), findsOneWidget);
 
       // When the animation completes, Item 1 disappears.
       await tester.pumpAndSettle();
       expect(find.text('Item 1'), findsNothing);
       expect(find.text('Separator 1'), findsNothing);
+      expect(find.text('Removing separator'), findsNothing);
     },
   );
 }

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -148,7 +148,7 @@ class AnimatedList extends _AnimatedScrollView {
   AnimatedList.separated({
     super.key,
     required AnimatedItemBuilder itemBuilder,
-    required AnimatedSeparatorBuilder separatorBuilder,
+    required AnimatedItemBuilder separatorBuilder,
     required super.removedSeparatorBuilder,
     int initialItemCount = 0,
     super.scrollDirection = Axis.vertical,
@@ -245,20 +245,6 @@ class AnimatedList extends _AnimatedScrollView {
   @override
   AnimatedListState createState() => AnimatedListState();
 }
-
-/// Signature for the builder callback used by [AnimatedList.separated] to
-/// build its animated separators.
-///
-/// The [context] argument is the build context where the widget will be
-/// created, the [index] is the index of the item of the separator to be built,
-/// and the [animation] is an [Animation] that should be used to animate an entry
-/// transition for the widget that is built.
-///
-/// See also:
-///
-/// * [AnimatedRemovedItemBuilder], a builder that is used for removing items with
-///   animations instead of adding them.
-typedef AnimatedSeparatorBuilder = Widget Function(BuildContext context, int index, Animation<double> animation);
 
 /// The [AnimatedListState] for [AnimatedList], a scrolling list container that
 /// animates items when they are inserted or removed.
@@ -855,13 +841,15 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   }
 }
 
-/// Signature for the builder callback used by [AnimatedList] & [AnimatedGrid] to
-/// build their animated children.
+/// Signature for the builder callback used by [AnimatedList], [AnimatedList.separated]
+/// & [AnimatedGrid] to build their animated children.
+/// [AnimatedList.separated] also uses this signature to build its separators.
 ///
 /// The [context] argument is the build context where the widget will be
 /// created, the [index] is the index of the item to be built, and the
 /// [animation] is an [Animation] that should be used to animate an entry
-/// transition for the widget that is built.
+/// transition for the widget that is built. When used in [AnimatedList.separated],
+/// the [index] is the index of the corresponding item of the separator to be built.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -688,6 +688,8 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       final int itemIndex = _computeItemIndex(index);
       _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
       if (_itemsCount > 1) {
+        // Because `insertItem` moves the items after the index, we need to insert the separator
+        // at the same index as the item. If there is only one item, we don't need to insert a separator.
         _sliverAnimatedMultiBoxKey.currentState!.insertItem(itemIndex, duration: duration);
       }
     }

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -149,7 +149,7 @@ class AnimatedList extends _AnimatedScrollView {
     super.key,
     required AnimatedItemBuilder itemBuilder,
     required AnimatedItemBuilder separatorBuilder,
-    required super.removedSeparatorBuilder,
+    required AnimatedItemBuilder super.removedSeparatorBuilder,
     int initialItemCount = 0,
     super.scrollDirection = Axis.vertical,
     super.reverse = false,

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -569,7 +569,7 @@ abstract class _AnimatedScrollView extends StatefulWidget {
   /// Implementations of this callback should assume that
   /// `removeItem` removes an item immediately.
   /// {@endtemplate}
-  final AnimatedRemovedSeparatorBuilder? removedSeparatorBuilder;
+  final AnimatedItemBuilder? removedSeparatorBuilder;
 
   /// {@template flutter.widgets.AnimatedScrollView.initialItemCount}
   /// The number of items the [AnimatedList] or [AnimatedGrid] will start with.
@@ -716,7 +716,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
   ///     [builder] argument.
   void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
-    final AnimatedRemovedSeparatorBuilder? removedSeparatorBuilder = widget.removedSeparatorBuilder;
+    final AnimatedItemBuilder? removedSeparatorBuilder = widget.removedSeparatorBuilder;
     if (removedSeparatorBuilder == null) {
       // There are no separators. Remove only the item.
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
@@ -755,7 +755,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
   ///     [builder] argument.
   void removeAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
-    final AnimatedRemovedSeparatorBuilder? removedSeparatorBuilder = widget.removedSeparatorBuilder;
+    final AnimatedItemBuilder? removedSeparatorBuilder = widget.removedSeparatorBuilder;
     if (removedSeparatorBuilder == null) {
       // There are no separators. We can remove all items with the same builder.
       _sliverAnimatedMultiBoxKey.currentState!.removeAllItems(builder, duration: duration);
@@ -793,7 +793,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
   // Helper method to create an [AnimatedRemovedItemBuilder]
   // from an [AnimatedRemovedSeparatorBuilder] for given [index].
-  AnimatedRemovedItemBuilder _toRemovedItemBuilder(AnimatedRemovedSeparatorBuilder builder, int index) {
+  AnimatedRemovedItemBuilder _toRemovedItemBuilder(AnimatedItemBuilder builder, int index) {
     return (BuildContext context, Animation<double> animation) {
       return builder(context, index, animation);
     };
@@ -843,13 +843,18 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
 /// Signature for the builder callback used by [AnimatedList], [AnimatedList.separated]
 /// & [AnimatedGrid] to build their animated children.
-/// [AnimatedList.separated] also uses this signature to build its separators.
+/// This signature is also used by [AnimatedList.separated] to build its separators and
+/// to animate their exit transition after their corresponding item has been removed.
 ///
 /// The [context] argument is the build context where the widget will be
 /// created, the [index] is the index of the item to be built, and the
 /// [animation] is an [Animation] that should be used to animate an entry
-/// transition for the widget that is built. When used in [AnimatedList.separated],
-/// the [index] is the index of the corresponding item of the separator to be built.
+/// transition for the widget that is built.
+///
+/// For [AnimatedList.separated], the [index] is the index
+/// of the corresponding item of the separator that is built or removed.
+/// For [AnimatedList.separated] `removedSeparatorBuilder`, the [animation] should be used
+/// to animate an exit transition for the widget that is built.
 ///
 /// See also:
 ///
@@ -870,20 +875,6 @@ typedef AnimatedItemBuilder = Widget Function(BuildContext context, int index, A
 /// * [AnimatedItemBuilder], a builder that is for adding items with animations
 ///   instead of removing them.
 typedef AnimatedRemovedItemBuilder = Widget Function(BuildContext context, Animation<double> animation);
-
-/// Signature for the builder callback used in [AnimatedList.separated]
-/// to animate its separators after they have been removed.
-///
-/// The [context] argument is the build context where the widget will be
-/// created, the [index] is the index of the corresponding item of the separator
-/// that is removed, and the [animation] is an [Animation] that should be used to
-/// animate an exit transition for the widget that is built.
-///
-/// See also:
-///
-/// * [AnimatedItemBuilder], a builder that is for adding items with animations
-///   instead of removing them.
-typedef AnimatedRemovedSeparatorBuilder = Widget Function(BuildContext context, int index, Animation<double> animation);
 
 // The default insert/remove animation duration.
 const Duration _kDuration = Duration(milliseconds: 300);

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -553,7 +553,7 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
   ///
   /// This method's semantics are the same as Dart's [List.clear] method: it
   /// removes all the items in the list.
-  void removeAllSeparatedItems(
+  void removeAllItems(
     AnimatedRemovedItemBuilder itemBuilder,
     AnimatedRemovedItemBuilder separatorBuilder, {
     Duration duration = _kDuration,

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -537,6 +537,8 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
     super.internalRemoveItem(itemIndex, itemBuilder, duration: duration);
     if (_itemsCount > 1) {
       if (itemIndex == _itemsCount - 1) {
+      // Removing from the end of the list, so the separator to remove
+      // is the one at `last index` - 1.
         super.internalRemoveItem(itemIndex - 1, separatorBuilder, duration: duration);
       } else {
         super.internalRemoveItem(itemIndex, separatorBuilder, duration: duration);

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -560,7 +560,7 @@ abstract class _AnimatedScrollView extends StatefulWidget {
   ///
   /// Separators are only built when they're scrolled into view.
   ///
-  /// The [AnimatedRemovedSeparatorBuilder] index parameter indicates the
+  /// The [AnimatedItemBuilder] index parameter indicates the
   /// separator's corresponding item's position in the scroll view. The value
   /// of the index parameter will be between 0 and [initialItemCount] plus the
   /// total number of items that have been inserted with [AnimatedListState.insertItem]
@@ -792,7 +792,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   }
 
   // Helper method to create an [AnimatedRemovedItemBuilder]
-  // from an [AnimatedRemovedSeparatorBuilder] for given [index].
+  // from an [AnimatedItemBuilder] for given [index].
   AnimatedRemovedItemBuilder _toRemovedItemBuilder(AnimatedItemBuilder builder, int index) {
     return (BuildContext context, Animation<double> animation) {
       return builder(context, index, animation);

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -319,12 +319,12 @@ class AnimatedListSeparated extends _AnimatedScrollView {
         throw FlutterError.fromParts(<DiagnosticsNode>[
           ErrorSummary('AnimatedListSeparated.of() called with a context that does not contain an AnimatedListSeparated.'),
           ErrorDescription(
-            'No AnimatedListSeparated ancestor could be found starting'
-            ' from the context that was passed to AnimatedListSeparated.of().',
+            'No AnimatedListSeparated ancestor could be found starting '
+            'from the context that was passed to AnimatedListSeparated.of().',
           ),
           ErrorHint(
-            'This can happen when the context provided is from the same StatefulWidget'
-            ' that built the AnimatedListSeparated.',
+            'This can happen when the context provided is from the same StatefulWidget '
+            'that built the AnimatedListSeparated.',
           ),
           context.describeElement('The context used was'),
         ]);

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -319,13 +319,12 @@ class AnimatedListSeparated extends _AnimatedScrollView {
         throw FlutterError.fromParts(<DiagnosticsNode>[
           ErrorSummary('AnimatedListSeparated.of() called with a context that does not contain an AnimatedListSeparated.'),
           ErrorDescription(
-            'No AnimatedListSeparated ancestor could be found starting from the context that was passed to AnimatedListSeparated.of().',
+            'No AnimatedListSeparated ancestor could be found starting'
+            ' from the context that was passed to AnimatedListSeparated.of().',
           ),
           ErrorHint(
-            'This can happen when the context provided is from the same StatefulWidget that '
-                'built the AnimatedListSeparated. Please see the AnimatedListSeparated documentation for examples '
-                'of how to refer to an AnimatedListSeparatedState object:\n'
-                '  https://api.flutter.dev/flutter/widgets/AnimatedListSeparatedState-class.html',
+            'This can happen when the context provided is from the same StatefulWidget'
+            ' that built the AnimatedListSeparated.',
           ),
           context.describeElement('The context used was'),
         ]);

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -248,9 +248,9 @@ class AnimatedListState extends _AnimatedScrollViewState<AnimatedList> {
 ///           color: Colors.amber,
 ///           child: Center(child: Text('$index')),
 ///         );
-///       }
+///       },
 ///       separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
-///         return Divider();
+///         return const Divider();
 ///       }
 ///     ),
 ///   );

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -125,7 +125,7 @@ class AnimatedList extends _AnimatedScrollView {
   ///       },
   ///       separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
   ///         return const Divider();
-  ///       }
+  ///       },
   ///       removedSeparatorBuilder: (BuildContext context, int index, Animation<double> animation) {
   ///         return const Divider();
   ///       }

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -538,11 +538,10 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
   int _computeItemIndex(int index) {
     if (index == 0) {
       return index;
-    } else {
-      final int indexSeparated = index * 2 - 1;
-      final bool isNewLastIndex = indexSeparated == _itemsCount;
-      return isNewLastIndex ? indexSeparated : indexSeparated + 1;
     }
+    final int indexSeparated = index * 2 - 1;
+    final bool isNewLastIndex = indexSeparated == _itemsCount;
+    return isNewLastIndex ? indexSeparated : indexSeparated + 1;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -843,6 +843,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
 
 /// Signature for the builder callback used by [AnimatedList], [AnimatedList.separated]
 /// & [AnimatedGrid] to build their animated children.
+///
 /// This signature is also used by [AnimatedList.separated] to build its separators and
 /// to animate their exit transition after their corresponding item has been removed.
 ///

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -431,12 +431,12 @@ class AnimatedListSeparated extends _AnimatedScrollView {
 /// and [AnimatedListSeparated.separatorBuilder] whenever
 /// the item's and separator's widgets are needed.
 ///
-/// When an item is removed with [removeSeparatedItem] its animation
+/// When an item is removed with [removeItem] its animation
 /// as well as that of its corresponding separator are reversed.
 /// The removed item's animation is passed to
-/// the [removeSeparatedItem] itemBuilder parameter.
+/// the [removeItem] itemBuilder parameter.
 /// The corresponding separator's animation is passed
-/// to the [removeSeparatedItem] separatorBuilder parameter.
+/// to the [removeItem] separatorBuilder parameter.
 ///
 /// An app that needs to insert or remove items in response to an event
 /// can refer to the [AnimatedListSeparated]'s state with a global key:

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -211,6 +211,342 @@ class AnimatedListState extends _AnimatedScrollViewState<AnimatedList> {
   }
 }
 
+/// A scrolling container that animates items with separators when they are inserted or removed.
+///
+/// This widget's [AnimatedListSeparatedState] can be used to dynamically insert or
+/// remove items. To refer to the [AnimatedListSeparatedState] either provide a
+/// [GlobalKey] or use the static [of] method from an item's input callback.
+///
+/// This widget is similar to one created by [ListView.separated].
+///
+/// {@tool dartpad}
+/// This sample application uses an [AnimatedListSeparated] to create an effect when
+/// items are removed or added to the list.
+///
+/// ** See code in examples/api/lib/widgets/animated_list/animated_list_separated.0.dart **
+/// {@end-tool}
+///
+/// By default, [AnimatedListSeparated] will automatically pad the limits of the
+/// list's scrollable to avoid partial obstructions indicated by
+/// [MediaQuery]'s padding. To avoid this behavior, override with a
+/// zero [padding] property.
+///
+/// {@tool snippet}
+/// The following example demonstrates how to override the default top and
+/// bottom padding using [MediaQuery.removePadding].
+///
+/// ```dart
+/// Widget myWidget(BuildContext context) {
+///   return MediaQuery.removePadding(
+///     context: context,
+///     removeTop: true,
+///     removeBottom: true,
+///     child: AnimatedListSeparated(
+///       initialItemCount: 50,
+///       itemBuilder: (BuildContext context, int index, Animation<double> animation) {
+///         return Card(
+///           color: Colors.amber,
+///           child: Center(child: Text('$index')),
+///         );
+///       }
+///       separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
+///         return Divider();
+///       }
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [SliverAnimatedList], a sliver that animates items when they are inserted
+///    or removed from a list.
+///  * [SliverAnimatedGrid], a sliver which animates items when they are
+///    inserted or removed from a grid.
+///  * [AnimatedGrid], a non-sliver scrolling container that animates items when
+///    they are inserted or removed in a grid.
+class AnimatedListSeparated extends _AnimatedScrollView {
+  /// Creates a scrolling container that animates items with separators when
+  /// they are inserted or removed.
+  AnimatedListSeparated({
+    super.key,
+    required AnimatedItemBuilder itemBuilder,
+    required AnimatedItemBuilder separatorBuilder,
+    int initialItemCount = 0,
+    super.scrollDirection = Axis.vertical,
+    super.reverse = false,
+    super.controller,
+    super.primary,
+    super.physics,
+    super.shrinkWrap = false,
+    super.padding,
+    super.clipBehavior = Clip.hardEdge,
+  }) : assert(initialItemCount >= 0),
+       super(
+         initialItemCount: _computeChildCountWithSeparators(initialItemCount),
+         itemBuilder: (BuildContext context, int index, Animation<double> animation) {
+           final int itemIndex = index ~/ 2;
+           if (index.isEven) {
+             return itemBuilder(context, itemIndex, animation);
+           }
+           return separatorBuilder(context, itemIndex, animation);
+         },
+       );
+
+  /// The state from the closest instance of this class that encloses the given
+  /// context.
+  ///
+  /// This method is typically used by [AnimatedListSeparated] item widgets that insert
+  /// or remove items in response to user input.
+  ///
+  /// If no [AnimatedListSeparated] surrounds the context given, then this function will
+  /// assert in debug mode and throw an exception in release mode.
+  ///
+  /// This method can be expensive (it walks the element tree).
+  ///
+  /// This method does not create a dependency, and so will not cause rebuilding
+  /// when the state changes.
+  ///
+  /// See also:
+  ///
+  ///  * [maybeOf], a similar function that will return null if no
+  ///    [AnimatedListSeparated] ancestor is found.
+  static AnimatedListSeparatedState of(BuildContext context) {
+    final AnimatedListSeparatedState? result = AnimatedListSeparated.maybeOf(context);
+    assert(() {
+      if (result == null) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          ErrorSummary('AnimatedListSeparated.of() called with a context that does not contain an AnimatedListSeparated.'),
+          ErrorDescription(
+            'No AnimatedListSeparated ancestor could be found starting from the context that was passed to AnimatedListSeparated.of().',
+          ),
+          ErrorHint(
+            'This can happen when the context provided is from the same StatefulWidget that '
+                'built the AnimatedListSeparated. Please see the AnimatedListSeparated documentation for examples '
+                'of how to refer to an AnimatedListSeparatedState object:\n'
+                '  https://api.flutter.dev/flutter/widgets/AnimatedListSeparatedState-class.html',
+          ),
+          context.describeElement('The context used was'),
+        ]);
+      }
+      return true;
+    }());
+    return result!;
+  }
+
+  /// The [AnimatedListSeparatedState] from the closest instance
+  /// of [AnimatedListSeparated] that encloses the given context.
+  ///
+  /// This method is typically used by [AnimatedListSeparated] item widgets
+  /// that insert or remove items in response to user input.
+  ///
+  /// If no [AnimatedListSeparated] surrounds the context given,
+  /// then this function will return null.
+  ///
+  /// This method can be expensive (it walks the element tree).
+  ///
+  /// This method does not create a dependency, and so will not cause rebuilding
+  /// when the state changes.
+  ///
+  /// See also:
+  ///
+  ///  * [of], a similar function that will throw if no [AnimatedListSeparated] ancestor
+  ///    is found.
+  static AnimatedListSeparatedState? maybeOf(BuildContext context) {
+    return context.findAncestorStateOfType<AnimatedListSeparatedState>();
+  }
+
+  @override
+  AnimatedListSeparatedState createState() => AnimatedListSeparatedState();
+
+  // Helper method to compute the actual child count when taking separators into account.
+  static int _computeChildCountWithSeparators(int itemCount) {
+    if (itemCount == 0) {
+      return 0;
+    }
+    return itemCount * 2 - 1;
+  }
+}
+
+/// The [AnimatedListSeparatedState] for [AnimatedListSeparated],
+/// a scrolling list container that animates items with separators when they are
+/// inserted or removed.
+///
+/// When an item is inserted with [insertItem] an animation begins running.
+/// The animation is passed to [AnimatedListSeparated.itemBuilder]
+/// and [AnimatedListSeparated.separatorBuilder] whenever the item's
+/// and separator's widgets are needed.
+///
+/// When multiple items are inserted with [insertAllItems] an animation begins running.
+/// The animation is passed to [AnimatedListSeparated.itemBuilder]
+/// and [AnimatedListSeparated.separatorBuilder] whenever
+/// the item's and separator's widgets are needed.
+///
+/// When an item is removed with [removeSeparatedItem] its animation
+/// as well as that of its corresponding separator are reversed.
+/// The removed item's animation is passed to
+/// the [removeSeparatedItem] itemBuilder parameter.
+/// The corresponding separator's animation is passed
+/// to the [removeSeparatedItem] separatorBuilder parameter.
+///
+/// An app that needs to insert or remove items in response to an event
+/// can refer to the [AnimatedListSeparated]'s state with a global key:
+///
+/// ```dart
+/// // (e.g. in a stateful widget)
+/// GlobalKey<AnimatedListSeparatedState> listKey = GlobalKey<AnimatedListSeparatedState>();
+///
+/// // ...
+///
+/// @override
+/// Widget build(BuildContext context) {
+///   return AnimatedListSeparated(
+///     key: listKey,
+///     itemBuilder: (BuildContext context, int index, Animation<double> animation) {
+///       return const Placeholder();
+///     },
+///     separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
+///       return const Placeholder();
+///     },
+///   );
+/// }
+///
+/// // ...
+///
+/// void _updateList() {
+///   // adds "123" to the AnimatedListSeparated
+///   listKey.currentState!.insertItem(123);
+/// }
+/// ```
+///
+/// [AnimatedListSeparated] item input handlers can also refer to their [AnimatedListSeparatedState]
+/// with the static [AnimatedListSeparated.of] method.
+class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSeparated> {
+
+  @override
+  Widget build(BuildContext context) {
+    return _wrap(
+      SliverAnimatedList(
+        key: _sliverAnimatedMultiBoxKey,
+        itemBuilder: widget.itemBuilder,
+        initialItemCount: widget.initialItemCount,
+      ),
+      widget.scrollDirection,
+    );
+  }
+
+  /// Insert an item at [index] with a corresponding separator
+  /// and start an animation that will be passed to
+  /// [AnimatedListSeparated.itemBuilder] and [AnimatedListSeparated.separatorBuilder]
+  /// when the item is visible.
+  ///
+  /// This method's semantics are the same as Dart's [List.insert] method: it
+  /// increases the length of the list of items by one and shifts
+  /// all items at or after [index] towards the end of the list of items.
+  @override
+  void insertItem(int index, { Duration duration = _kDuration }) {
+      final int itemIndex = _computeItemIndex(index);
+      super.insertItem(itemIndex, duration: duration);
+      if (_itemsCount > 1) {
+        super.insertItem(itemIndex, duration: duration);
+      }
+  }
+
+  /// Insert multiple items at [index] with corresponding separators
+  /// and start an animation that will be passed to
+  /// [AnimatedListSeparated.itemBuilder] and [AnimatedListSeparated.separatorBuilder]
+  /// when the items are visible.
+  @override
+  void insertAllItems(int index, int length, { Duration duration = _kDuration, bool isAsync = false }) {
+    final int itemIndex = _computeItemIndex(index);
+    final int lengthWithSeparators = _itemsCount == 0 ? length * 2 - 1 : length * 2;
+    super.insertAllItems(itemIndex, lengthWithSeparators, duration: duration, isAsync: isAsync);
+  }
+
+  /// This method is not supported by [AnimatedListSeparatedState]. Use [removeSeparatedItem] instead.
+  @override
+  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    throw Exception('Separated list items can not be removed with this method. Use removeSeparatedItem instead.');
+  }
+
+  /// This method is not supported by [AnimatedListSeparatedState]. Use [removeAllSeparatedItems] instead.
+  @override
+  void removeAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    throw Exception('Separated list items can not be removed with this method. Use removeAllSeparatedItems instead.');
+  }
+
+  /// Remove the item at [index] with its corresponding separator
+  /// and start an animation that will be passed to
+  /// [itemBuilder] and [separatorBuilder] when the item is visible.
+  ///
+  /// Items are removed immediately. After an item has been removed, its index
+  /// will no longer be passed to the [AnimatedListSeparated.itemBuilder].
+  /// However, the item will still appear for [duration] and during that time
+  /// [itemBuilder] must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.remove] method: it
+  /// decreases the length of items by one and shifts all items at or before
+  /// `index` towards the beginning of the list of items.
+  ///
+  /// See also:
+  ///
+  ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
+  ///     [itemBuilder] and [separatorBuilder] arguments.
+  void removeSeparatedItem(
+    int index,
+    AnimatedRemovedItemBuilder itemBuilder,
+    AnimatedRemovedItemBuilder separatorBuilder, {
+    Duration duration = _kDuration,
+  }) {
+    final int itemIndex = _computeItemIndex(index);
+    super.removeItem(itemIndex, itemBuilder, duration: duration);
+    if (_itemsCount > 1) {
+      if (itemIndex == _itemsCount - 1) {
+        super.removeItem(itemIndex - 1, separatorBuilder, duration: duration);
+      } else {
+        super.removeItem(itemIndex, separatorBuilder, duration: duration);
+      }
+    }
+  }
+
+  /// Remove all the items and corresponding separators and start an animation that will be passed to
+  /// [itemBuilder] and [separatorBuilder] when the items are visible.
+  ///
+  /// Items are removed immediately. However, the
+  /// items will still appear for [duration], and during that time
+  /// [itemBuilder] must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.clear] method: it
+  /// removes all the items in the list.
+  void removeAllSeparatedItems(
+    AnimatedRemovedItemBuilder itemBuilder,
+    AnimatedRemovedItemBuilder separatorBuilder, {
+    Duration duration = _kDuration,
+  }) {
+    for (int itemIndex = _itemsCount - 1; itemIndex >= 0 ; itemIndex--) {
+      if (itemIndex.isEven) {
+        super.removeItem(itemIndex, itemBuilder, duration: duration);
+      } else {
+        super.removeItem(itemIndex, separatorBuilder, duration: duration);
+      }
+    }
+  }
+
+  int get _itemsCount => _sliverAnimatedMultiBoxKey.currentState!._itemsCount;
+
+  // Helper method to compute the index for the separated item considering the added separators.
+  int _computeItemIndex(int index) {
+    if (index == 0) {
+      return index;
+    } else {
+      final int indexSeparated = index * 2 - 1;
+      final bool isNewLastIndex = indexSeparated == _itemsCount;
+      return isNewLastIndex ? indexSeparated : indexSeparated + 1;
+    }
+  }
+}
+
 /// A scrolling container that animates items when they are inserted into or removed from a grid.
 /// in a grid.
 ///

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -732,15 +732,19 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
     final AnimatedRemovedSeparatorBuilder? removedSeparatorBuilder = widget.removedSeparatorBuilder;
     if (removedSeparatorBuilder == null) {
+      // There are no separators. Remove only the item.
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
     } else {
       final int itemIndex = _computeItemIndex(index);
+      // Remove the item
       _sliverAnimatedMultiBoxKey.currentState!.removeItem(itemIndex, builder, duration: duration);
       if (_itemsCount > 1) {
         if (itemIndex == _itemsCount - 1) {
-          // Removing from the end of the list, so the separator to remove is the one at `last index` - 1.
+          // The item was removed from the end of the list, so the separator to remove is the one at `last index` - 1.
           _sliverAnimatedMultiBoxKey.currentState!.removeItem(itemIndex - 1, _toRemovedItemBuilder(removedSeparatorBuilder, index - 1), duration: duration);
         } else {
+          // The item was removed from the middle or beginning of the list,
+          // so the corresponding separator took its place and needs to be removed at `itemIndex`.
           _sliverAnimatedMultiBoxKey.currentState!.removeItem(itemIndex, _toRemovedItemBuilder(removedSeparatorBuilder, index), duration: duration);
         }
       }

--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -209,6 +209,55 @@ class AnimatedListState extends _AnimatedScrollViewState<AnimatedList> {
       widget.scrollDirection,
     );
   }
+
+  /// Insert an item at [index] and start an animation that will be passed
+  /// to [AnimatedList.itemBuilder] when the item is visible.
+  ///
+  /// This method's semantics are the same as Dart's [List.insert] method: it
+  /// increases the length of the list of items by one and shifts
+  /// all items at or after [index] towards the end of the list of items.
+  void insertItem(int index, { Duration duration = _kDuration }) {
+    super.internalInsertItem(index, duration: duration);
+  }
+
+  /// Insert multiple items at [index] and start an animation that will be passed
+  /// to [AnimatedList.itemBuilder] when the items are visible.
+  void insertAllItems(int index, int length, { Duration duration = _kDuration, bool isAsync = false }) {
+    super.internalInsertAllItems(index, length, duration: duration, isAsync: isAsync);
+  }
+
+  /// Remove the item at `index` and start an animation that will be passed to
+  /// `builder` when the item is visible.
+  ///
+  /// Items are removed immediately. After an item has been removed, its index
+  /// will no longer be passed to the `itemBuilder`. However, the
+  /// item will still appear for `duration` and during that time
+  /// `builder` must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.remove] method: it
+  /// decreases the length of items by one and shifts all items at or before
+  /// `index` towards the beginning of the list of items.
+  ///
+  /// See also:
+  ///
+  ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
+  ///     `builder` argument.
+  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    super.internalRemoveItem(index, builder, duration: duration);
+  }
+
+  /// Remove all the items and start an animation that will be passed to
+  /// `builder` when the items are visible.
+  ///
+  /// Items are removed immediately. However, the
+  /// items will still appear for `duration`, and during that time
+  /// `builder` must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.clear] method: it
+  /// removes all the items in the list.
+  void removeAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    super.internalRemoveAllItems(builder, duration: duration);
+  }
 }
 
 /// A scrolling container that animates items with separators when they are inserted or removed.
@@ -443,12 +492,11 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
   /// This method's semantics are the same as Dart's [List.insert] method: it
   /// increases the length of the list of items by one and shifts
   /// all items at or after [index] towards the end of the list of items.
-  @override
   void insertItem(int index, { Duration duration = _kDuration }) {
       final int itemIndex = _computeItemIndex(index);
-      super.insertItem(itemIndex, duration: duration);
+      super.internalInsertItem(itemIndex, duration: duration);
       if (_itemsCount > 1) {
-        super.insertItem(itemIndex, duration: duration);
+        super.internalInsertItem(itemIndex, duration: duration);
       }
   }
 
@@ -456,23 +504,10 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
   /// and start an animation that will be passed to
   /// [AnimatedListSeparated.itemBuilder] and [AnimatedListSeparated.separatorBuilder]
   /// when the items are visible.
-  @override
   void insertAllItems(int index, int length, { Duration duration = _kDuration, bool isAsync = false }) {
     final int itemIndex = _computeItemIndex(index);
     final int lengthWithSeparators = _itemsCount == 0 ? length * 2 - 1 : length * 2;
-    super.insertAllItems(itemIndex, lengthWithSeparators, duration: duration, isAsync: isAsync);
-  }
-
-  /// This method is not supported by [AnimatedListSeparatedState]. Use [removeSeparatedItem] instead.
-  @override
-  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
-    throw Exception('Separated list items can not be removed with this method. Use removeSeparatedItem instead.');
-  }
-
-  /// This method is not supported by [AnimatedListSeparatedState]. Use [removeAllSeparatedItems] instead.
-  @override
-  void removeAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
-    throw Exception('Separated list items can not be removed with this method. Use removeAllSeparatedItems instead.');
+    super.internalInsertAllItems(itemIndex, lengthWithSeparators, duration: duration, isAsync: isAsync);
   }
 
   /// Remove the item at [index] with its corresponding separator
@@ -492,19 +527,19 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
   ///
   ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
   ///     [itemBuilder] and [separatorBuilder] arguments.
-  void removeSeparatedItem(
+  void removeItem(
     int index,
     AnimatedRemovedItemBuilder itemBuilder,
     AnimatedRemovedItemBuilder separatorBuilder, {
     Duration duration = _kDuration,
   }) {
     final int itemIndex = _computeItemIndex(index);
-    super.removeItem(itemIndex, itemBuilder, duration: duration);
+    super.internalRemoveItem(itemIndex, itemBuilder, duration: duration);
     if (_itemsCount > 1) {
       if (itemIndex == _itemsCount - 1) {
-        super.removeItem(itemIndex - 1, separatorBuilder, duration: duration);
+        super.internalRemoveItem(itemIndex - 1, separatorBuilder, duration: duration);
       } else {
-        super.removeItem(itemIndex, separatorBuilder, duration: duration);
+        super.internalRemoveItem(itemIndex, separatorBuilder, duration: duration);
       }
     }
   }
@@ -525,9 +560,9 @@ class AnimatedListSeparatedState extends _AnimatedScrollViewState<AnimatedListSe
   }) {
     for (int itemIndex = _itemsCount - 1; itemIndex >= 0 ; itemIndex--) {
       if (itemIndex.isEven) {
-        super.removeItem(itemIndex, itemBuilder, duration: duration);
+        super.internalRemoveItem(itemIndex, itemBuilder, duration: duration);
       } else {
-        super.removeItem(itemIndex, separatorBuilder, duration: duration);
+        super.internalRemoveItem(itemIndex, separatorBuilder, duration: duration);
       }
     }
   }
@@ -753,6 +788,55 @@ class AnimatedGridState extends _AnimatedScrollViewState<AnimatedGrid> {
       widget.scrollDirection,
     );
   }
+
+  /// Insert an item at [index] and start an animation that will be passed
+  /// to [AnimatedGrid.itemBuilder] when the item is visible.
+  ///
+  /// This method's semantics are the same as Dart's [List.insert] method: it
+  /// increases the length of the list of items by one and shifts
+  /// all items at or after [index] towards the end of the list of items.
+  void insertItem(int index, { Duration duration = _kDuration }) {
+    super.internalInsertItem(index, duration: duration);
+  }
+
+  /// Insert multiple items at [index] and start an animation that will be passed
+  /// to [AnimatedGrid.itemBuilder] when the items are visible.
+  void insertAllItems(int index, int length, { Duration duration = _kDuration, bool isAsync = false }) {
+    super.internalInsertAllItems(index, length, duration: duration, isAsync: isAsync);
+  }
+
+  /// Remove the item at `index` and start an animation that will be passed to
+  /// `builder` when the item is visible.
+  ///
+  /// Items are removed immediately. After an item has been removed, its index
+  /// will no longer be passed to the `itemBuilder`. However, the
+  /// item will still appear for `duration` and during that time
+  /// `builder` must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.remove] method: it
+  /// decreases the length of items by one and shifts all items at or before
+  /// `index` towards the beginning of the list of items.
+  ///
+  /// See also:
+  ///
+  ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
+  ///     `builder` argument.
+  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    super.internalRemoveItem(index, builder, duration: duration);
+  }
+
+  /// Remove all the items and start an animation that will be passed to
+  /// `builder` when the items are visible.
+  ///
+  /// Items are removed immediately. However, the
+  /// items will still appear for `duration`, and during that time
+  /// `builder` must construct its widget as needed.
+  ///
+  /// This method's semantics are the same as Dart's [List.clear] method: it
+  /// removes all the items in the list.
+  void removeAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+    super.internalRemoveAllItems(builder, duration: duration);
+  }
 }
 
 abstract class _AnimatedScrollView extends StatefulWidget {
@@ -883,14 +967,16 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   /// This method's semantics are the same as Dart's [List.insert] method: it
   /// increases the length of the list of items by one and shifts
   /// all items at or after [index] towards the end of the list of items.
-  void insertItem(int index, { Duration duration = _kDuration }) {
+  @protected
+  void internalInsertItem(int index, { Duration duration = _kDuration }) {
     _sliverAnimatedMultiBoxKey.currentState!.insertItem(index, duration: duration);
   }
 
   /// Insert multiple items at [index] and start an animation that will be passed
   /// to [AnimatedGrid.itemBuilder] or [AnimatedList.itemBuilder] when the items
   /// are visible.
-  void insertAllItems(int index, int length, { Duration duration = _kDuration, bool isAsync = false }) {
+  @protected
+  void internalInsertAllItems(int index, int length, { Duration duration = _kDuration, bool isAsync = false }) {
     _sliverAnimatedMultiBoxKey.currentState!.insertAllItems(index, length, duration: duration);
   }
 
@@ -910,7 +996,8 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   ///
   ///   * [AnimatedRemovedItemBuilder], which describes the arguments to the
   ///     `builder` argument.
-  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+  @protected
+  void internalRemoveItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
     _sliverAnimatedMultiBoxKey.currentState!.removeItem(index, builder, duration: duration);
   }
 
@@ -923,7 +1010,8 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
   ///
   /// This method's semantics are the same as Dart's [List.clear] method: it
   /// removes all the items in the list.
-  void removeAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+  @protected
+  void internalRemoveAllItems(AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
     _sliverAnimatedMultiBoxKey.currentState!.removeAllItems(builder, duration: duration);
   }
 

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -710,20 +710,14 @@ void main() {
         ),
       );
     }
+
     Widget itemRemovalBuilder(BuildContext context, int? index, Animation<double> animation) {
-        final String text = index != null ? 'removing item $index' : 'removing item';
-        return  SizedBox(
-          height: 100.0,
-          child: Center(child: Text(text)),
-        );
-      }
-    Widget separatorRemovalBuilder(BuildContext context, int? index, Animation<double> animation) {
-        final String text = index != null ? 'removing separator after item $index' : 'removing separator';
-        return SizedBox(
-          height: 100.0,
-          child: Center(child: Text(text)),
-        );
-      }
+      final String text = index != null ? 'removing item $index' : 'removing item';
+      return  SizedBox(
+        height: 100.0,
+        child: Center(child: Text(text)),
+      );
+    }
 
     AnimatedRemovedItemBuilder itemRemovalBuilderWrapper({int? index}) {
       return (BuildContext context, Animation<double> animation) {
@@ -731,11 +725,13 @@ void main() {
       };
     }
 
-    AnimatedRemovedItemBuilder separatorRemovalBuilderWrapper({int? index}) {
-      return (BuildContext context, Animation<double> animation) {
-        return separatorRemovalBuilder(context, index, animation);
-      };
+    Widget separatorRemovalBuilder(BuildContext context, int index, Animation<double> animation) {
+      return SizedBox(
+        height: 100.0,
+        child: Center(child: Text('removing separator after item $index')),
+      );
     }
+
 
     List<Text> getItemsSeparatorsTexts(WidgetTester tester) {
       final Finder itemsSeparators = find.descendant(of: find.byType(SliverAnimatedList), matching: find.byType(Text));
@@ -752,6 +748,7 @@ void main() {
           initialItemCount: 2,
           itemBuilder: builder,
           separatorBuilder: separatorBuilder,
+          removeSeparatorBuilder: separatorRemovalBuilder,
         ),
       ),
     );
@@ -834,7 +831,6 @@ void main() {
     listKey.currentState!.removeItem(
       0,
       itemRemovalBuilderWrapper(index: 0),
-      separatorRemovalBuilderWrapper(index: 0),
       duration: const Duration(milliseconds: 100),
     );
     await tester.pump();
@@ -869,9 +865,6 @@ void main() {
     listKey.currentState!.removeItem(
       3,
       itemRemovalBuilderWrapper(index: 3),
-      // Removing from the end of the list, so the separator to remove
-      // is the one at `last index` - 1: 3 - 1 = 2.
-      separatorRemovalBuilderWrapper(index: 2),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -894,7 +887,6 @@ void main() {
     listKey.currentState!.removeItem(
       1,
       itemRemovalBuilderWrapper(index: 1),
-      separatorRemovalBuilderWrapper(index: 1),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -923,7 +915,6 @@ void main() {
       () => listKey.currentState!.removeItem(
         -1,
       itemRemovalBuilderWrapper(index: -1),
-      separatorRemovalBuilderWrapper(index: -1),
         duration: const Duration(milliseconds: 100),
       ),
       throwsAssertionError,
@@ -934,7 +925,6 @@ void main() {
       () => listKey.currentState!.removeItem(
         42,
       itemRemovalBuilderWrapper(index: 42),
-      separatorRemovalBuilderWrapper(index: 42),
         duration: const Duration(milliseconds: 100),
       ),
       throwsAssertionError,
@@ -1038,7 +1028,6 @@ void main() {
     // removeAllItems - Remove all items from list with multiple items
     listKey.currentState!.removeAllItems(
       itemRemovalBuilderWrapper(),
-      separatorRemovalBuilderWrapper(),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1048,19 +1037,19 @@ void main() {
 
     expect(itemsSeparatorsTexts.length, 15);
     expect(itemsSeparatorsTexts[0].data, 'removing item');
-    expect(itemsSeparatorsTexts[1].data, 'removing separator');
+    expect(itemsSeparatorsTexts[1].data, 'removing separator after item 0');
     expect(itemsSeparatorsTexts[2].data, 'removing item');
-    expect(itemsSeparatorsTexts[3].data, 'removing separator');
+    expect(itemsSeparatorsTexts[3].data, 'removing separator after item 1');
     expect(itemsSeparatorsTexts[4].data, 'removing item');
-    expect(itemsSeparatorsTexts[5].data, 'removing separator');
+    expect(itemsSeparatorsTexts[5].data, 'removing separator after item 2');
     expect(itemsSeparatorsTexts[6].data, 'removing item');
-    expect(itemsSeparatorsTexts[7].data, 'removing separator');
+    expect(itemsSeparatorsTexts[7].data, 'removing separator after item 3');
     expect(itemsSeparatorsTexts[8].data, 'removing item');
-    expect(itemsSeparatorsTexts[9].data, 'removing separator');
+    expect(itemsSeparatorsTexts[9].data, 'removing separator after item 4');
     expect(itemsSeparatorsTexts[10].data, 'removing item');
-    expect(itemsSeparatorsTexts[11].data, 'removing separator');
+    expect(itemsSeparatorsTexts[11].data, 'removing separator after item 5');
     expect(itemsSeparatorsTexts[12].data, 'removing item');
-    expect(itemsSeparatorsTexts[13].data, 'removing separator');
+    expect(itemsSeparatorsTexts[13].data, 'removing separator after item 6');
     expect(itemsSeparatorsTexts[14].data, 'removing item');
 
     await tester.pumpAndSettle();
@@ -1070,7 +1059,6 @@ void main() {
       () => listKey.currentState!.removeItem(
         0,
         itemRemovalBuilderWrapper(index: 0),
-        separatorRemovalBuilderWrapper(index: 0),
         duration: const Duration(milliseconds: 100),
       ),
       throwsAssertionError,
@@ -1091,7 +1079,6 @@ void main() {
     listKey.currentState!.removeItem(
       0,
       itemRemovalBuilderWrapper(index: 0),
-      separatorRemovalBuilderWrapper(index: 0),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1111,7 +1098,6 @@ void main() {
     // removeAllItems - Remove all items from empty list
     listKey.currentState!.removeAllItems(
       itemRemovalBuilderWrapper(),
-      separatorRemovalBuilderWrapper(),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1136,7 +1122,6 @@ void main() {
     // Test
     listKey.currentState!.removeAllItems(
       itemRemovalBuilderWrapper(),
-      separatorRemovalBuilderWrapper(),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1222,6 +1207,10 @@ void main() {
               return const Placeholder();
             },
             separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
+              innerMediaQueryPaddingSeparator = MediaQuery.paddingOf(context);
+              return const Placeholder();
+            },
+            removeSeparatorBuilder: (BuildContext context, int index, Animation<double> animation) {
               innerMediaQueryPaddingSeparator = MediaQuery.paddingOf(context);
               return const Placeholder();
             },

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -738,17 +738,17 @@ void main() {
       return itemsSeparators.allCandidates.map((Element e) => e.widget).whereType<Text>().toList();
     }
 
-    final GlobalKey<AnimatedListSeparatedState> listKey = GlobalKey<AnimatedListSeparatedState>();
+    final GlobalKey<AnimatedListState> listKey = GlobalKey<AnimatedListState>();
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: AnimatedListSeparated(
+        child: AnimatedList.separated(
           key: listKey,
           initialItemCount: 2,
           itemBuilder: builder,
           separatorBuilder: separatorBuilder,
-          removeSeparatorBuilder: separatorRemovalBuilder,
+          removedSeparatorBuilder: separatorRemovalBuilder,
         ),
       ),
     );
@@ -1148,93 +1148,6 @@ void main() {
     expect(itemsSeparatorsTexts[0].data, 'item 0');
     expect(itemsSeparatorsTexts[1].data, 'separator after item 0');
     expect(itemsSeparatorsTexts[2].data, 'item 1');
-  });
-
-  testWidgets(
-    'AnimatedListSeparated.of() and maybeOf called with a context that does not contain AnimatedListSeparated',
-    (WidgetTester tester) async {
-      final GlobalKey key = GlobalKey();
-      await tester.pumpWidget(Container(key: key));
-      late FlutterError error;
-      expect(AnimatedListSeparated.maybeOf(key.currentContext!), isNull);
-      try {
-        AnimatedListSeparated.of(key.currentContext!);
-      } on FlutterError catch (e) {
-        error = e;
-      }
-      expect(error.diagnostics.length, 4);
-      expect(error.diagnostics[2].level, DiagnosticLevel.hint);
-      expect(
-        error.diagnostics[2].toStringDeep(),
-        equalsIgnoringHashCodes(
-          'This can happen when the context provided is from the same\n'
-          'StatefulWidget that built the AnimatedListSeparated.\n'
-        ),
-      );
-      expect(error.diagnostics[3], isA<DiagnosticsProperty<Element>>());
-      expect(
-        error.toStringDeep(),
-        equalsIgnoringHashCodes(
-          'FlutterError\n'
-          '   AnimatedListSeparated.of() called with a context that does not\n'
-          '   contain an AnimatedListSeparated.\n'
-          '   No AnimatedListSeparated ancestor could be found starting from\n'
-          '   the context that was passed to AnimatedListSeparated.of().\n'
-          '   This can happen when the context provided is from the same\n'
-          '   StatefulWidget that built the AnimatedListSeparated.\n'
-          '   The context used was:\n'
-          '     Container-[GlobalKey#32cc6]\n',
-        ),
-      );
-    },
-  );
-
-  testWidgets('AnimatedListSeparated applies MediaQuery padding', (WidgetTester tester) async {
-    const EdgeInsets padding = EdgeInsets.all(30.0);
-    EdgeInsets? innerMediaQueryPaddingItem;
-    EdgeInsets? innerMediaQueryPaddingSeparator;
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(
-            padding: EdgeInsets.all(30.0),
-          ),
-          child: AnimatedListSeparated(
-            initialItemCount: 3,
-            itemBuilder: (BuildContext context, int index, Animation<double> animation) {
-              innerMediaQueryPaddingItem = MediaQuery.paddingOf(context);
-              return const Placeholder();
-            },
-            separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
-              innerMediaQueryPaddingSeparator = MediaQuery.paddingOf(context);
-              return const Placeholder();
-            },
-            removeSeparatorBuilder: (BuildContext context, int index, Animation<double> animation) {
-              innerMediaQueryPaddingSeparator = MediaQuery.paddingOf(context);
-              return const Placeholder();
-            },
-          ),
-        ),
-      ),
-    );
-    final Offset topLeft = tester.getTopLeft(find.byType(Placeholder).first);
-    // Automatically apply the top padding into sliver.
-    expect(topLeft, Offset(0.0, padding.top));
-
-    // Scroll to the bottom.
-    await tester.drag(find.byType(AnimatedListSeparated), const Offset(0.0, -1000.0));
-    await tester.pumpAndSettle();
-
-    final Offset bottomLeft = tester.getBottomLeft(find.byType(Placeholder).last);
-    // Automatically apply the bottom padding into sliver.
-    expect(bottomLeft, Offset(0.0, 660.0 - padding.bottom));
-
-    // Verify that the left/right padding is not applied to the item.
-    expect(innerMediaQueryPaddingItem, const EdgeInsets.symmetric(horizontal: 30.0));
-
-    // Verify that the left/right padding is not applied to the separator.
-    expect(innerMediaQueryPaddingSeparator, const EdgeInsets.symmetric(horizontal: 30.0));
   });
 }
 

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -710,18 +710,32 @@ void main() {
         ),
       );
     }
-    Widget itemRemovalBuilder(BuildContext context, Animation<double> animation) {
-        return const SizedBox(
+    Widget itemRemovalBuilder(BuildContext context, int? index, Animation<double> animation) {
+        final String text = index != null ? 'removing item $index' : 'removing item';
+        return  SizedBox(
           height: 100.0,
-          child: Center(child: Text('removing item')),
+          child: Center(child: Text(text)),
         );
       }
-    Widget separatorRemovalBuilder(BuildContext context, Animation<double> animation) {
-        return const SizedBox(
+    Widget separatorRemovalBuilder(BuildContext context, int? index, Animation<double> animation) {
+        final String text = index != null ? 'removing separator after item $index' : 'removing separator';
+        return SizedBox(
           height: 100.0,
-          child: Center(child: Text('removing separator')),
+          child: Center(child: Text(text)),
         );
       }
+
+    AnimatedRemovedItemBuilder itemRemovalBuilderWrapper({int? index}) {
+      return (BuildContext context, Animation<double> animation) {
+        return itemRemovalBuilder(context, index, animation);
+      };
+    }
+
+    AnimatedRemovedItemBuilder separatorRemovalBuilderWrapper({int? index}) {
+      return (BuildContext context, Animation<double> animation) {
+        return separatorRemovalBuilder(context, index, animation);
+      };
+    }
 
     List<Text> getItemsSeparatorsTexts(WidgetTester tester) {
       final Finder itemsSeparators = find.descendant(of: find.byType(SliverAnimatedList), matching: find.byType(Text));
@@ -819,8 +833,8 @@ void main() {
     // removeItem - Remove at beginning of list
     listKey.currentState!.removeItem(
       0,
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(index: 0),
+      separatorRemovalBuilderWrapper(index: 0),
       duration: const Duration(milliseconds: 100),
     );
     await tester.pump();
@@ -828,8 +842,8 @@ void main() {
     itemsSeparatorsTexts = getItemsSeparatorsTexts(tester);
 
     expect(itemsSeparatorsTexts.length, 9);
-    expect(itemsSeparatorsTexts[0].data, 'removing item');
-    expect(itemsSeparatorsTexts[1].data, 'removing separator');
+    expect(itemsSeparatorsTexts[0].data, 'removing item 0');
+    expect(itemsSeparatorsTexts[1].data, 'removing separator after item 0');
     expect(itemsSeparatorsTexts[2].data, 'item 0');
     expect(itemsSeparatorsTexts[3].data, 'separator after item 0');
     expect(itemsSeparatorsTexts[4].data, 'item 1');
@@ -854,8 +868,10 @@ void main() {
     // removeItem - Remove at end of list
     listKey.currentState!.removeItem(
       3,
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(index: 3),
+      // Removing from the end of the list, so the separator to remove
+      // is the one at `last index` - 1: 3 - 1 = 2.
+      separatorRemovalBuilderWrapper(index: 2),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -869,16 +885,16 @@ void main() {
     expect(itemsSeparatorsTexts[2].data, 'item 1');
     expect(itemsSeparatorsTexts[3].data, 'separator after item 1');
     expect(itemsSeparatorsTexts[4].data, 'item 2');
-    expect(itemsSeparatorsTexts[5].data, 'removing separator');
-    expect(itemsSeparatorsTexts[6].data, 'removing item');
+    expect(itemsSeparatorsTexts[5].data, 'removing separator after item 2');
+    expect(itemsSeparatorsTexts[6].data, 'removing item 3');
 
     await tester.pumpAndSettle();
 
     // removeItem - Remove in middle of list
     listKey.currentState!.removeItem(
       1,
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(index: 1),
+      separatorRemovalBuilderWrapper(index: 1),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -889,8 +905,8 @@ void main() {
     expect(itemsSeparatorsTexts.length, 5);
     expect(itemsSeparatorsTexts[0].data, 'item 0');
     expect(itemsSeparatorsTexts[1].data, 'separator after item 0');
-    expect(itemsSeparatorsTexts[2].data, 'removing item');
-    expect(itemsSeparatorsTexts[3].data, 'removing separator');
+    expect(itemsSeparatorsTexts[2].data, 'removing item 1');
+    expect(itemsSeparatorsTexts[3].data, 'removing separator after item 1');
     expect(itemsSeparatorsTexts[4].data, 'item 1');
 
     await tester.pumpAndSettle();
@@ -906,8 +922,8 @@ void main() {
     expect(
       () => listKey.currentState!.removeItem(
         -1,
-        itemRemovalBuilder,
-        separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(index: -1),
+      separatorRemovalBuilderWrapper(index: -1),
         duration: const Duration(milliseconds: 100),
       ),
       throwsAssertionError,
@@ -917,8 +933,8 @@ void main() {
     expect(
       () => listKey.currentState!.removeItem(
         42,
-        itemRemovalBuilder,
-        separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(index: 42),
+      separatorRemovalBuilderWrapper(index: 42),
         duration: const Duration(milliseconds: 100),
       ),
       throwsAssertionError,
@@ -1021,8 +1037,8 @@ void main() {
 
     // removeAllItems - Remove all items from list with multiple items
     listKey.currentState!.removeAllItems(
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(),
+      separatorRemovalBuilderWrapper(),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1053,8 +1069,8 @@ void main() {
     expect(
       () => listKey.currentState!.removeItem(
         0,
-        itemRemovalBuilder,
-        separatorRemovalBuilder,
+        itemRemovalBuilderWrapper(index: 0),
+        separatorRemovalBuilderWrapper(index: 0),
         duration: const Duration(milliseconds: 100),
       ),
       throwsAssertionError,
@@ -1074,8 +1090,8 @@ void main() {
     // Test
     listKey.currentState!.removeItem(
       0,
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(index: 0),
+      separatorRemovalBuilderWrapper(index: 0),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1084,7 +1100,7 @@ void main() {
     itemsSeparatorsTexts = getItemsSeparatorsTexts(tester);
 
     expect(itemsSeparatorsTexts.length, 1);
-    expect(itemsSeparatorsTexts[0].data, 'removing item');
+    expect(itemsSeparatorsTexts[0].data, 'removing item 0');
 
     await tester.pumpAndSettle();
 
@@ -1094,8 +1110,8 @@ void main() {
 
     // removeAllItems - Remove all items from empty list
     listKey.currentState!.removeAllItems(
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(),
+      separatorRemovalBuilderWrapper(),
       duration: const Duration(milliseconds: 100),
     );
 
@@ -1119,8 +1135,8 @@ void main() {
 
     // Test
     listKey.currentState!.removeAllItems(
-      itemRemovalBuilder,
-      separatorRemovalBuilder,
+      itemRemovalBuilderWrapper(),
+      separatorRemovalBuilderWrapper(),
       duration: const Duration(milliseconds: 100),
     );
 

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -689,7 +689,7 @@ void main() {
     expect(innerMediaQueryPadding, const EdgeInsets.symmetric(horizontal: 30.0));
   });
 
-  testWidgets('AnimatedListSeparated', (WidgetTester tester) async {
+  testWidgets('AnimatedList.separated', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(600, 1800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -719,6 +719,9 @@ void main() {
       );
     }
 
+    // Helper function to wrap itemRemovalBuilder with index
+    // to allow testing removal of an item at the expected index.
+    // Null index is necessary for removeAllItems.
     AnimatedRemovedItemBuilder itemRemovalBuilderWrapper({int? index}) {
       return (BuildContext context, Animation<double> animation) {
         return itemRemovalBuilder(context, index, animation);


### PR DESCRIPTION
This PR adds `AnimatedList.separated`. A widget like an AnimatedList with animated separators. `animated_list_separated.0.dart` extends `animated_list.0.dart` to work with `AnimatedList.separated`

Related issue: https://github.com/flutter/flutter/issues/48226

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
