### PR TITLE
Make WidgetTester.pageBack work with localised app

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -5,9 +5,8 @@
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart' show BackButton, BackButtonIcon, Tooltip;
+import 'package:flutter/material.dart' show BackButtonIcon, Tooltip;
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import 'binding.dart';
 import 'tree_traversal.dart';
@@ -505,16 +504,23 @@ class CommonFinders {
 
   /// Makes an effort to find a back button widget.
   ///
-  /// This finder is used by [WidgetTester.pageBack].
+  /// This finder looks for a [BackButtonIcon] or a [CupertinoNavigationBarBackButton]
+  /// which are typically available as back button in app bars.
+  ///
+  /// This is useful to find a tappable widget to navigate back to the previous route.
   ///
   /// ## Sample code
   ///
   /// ```dart
   /// expect(find.backButton(), findsOneWidget);
+  /// await tester.tap(find.backButton());
   /// ```
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
+  ///
+  /// See also:
+  /// * [WidgetTester.pageBack] which tries to tap a back button.
   Finder backButton({ bool skipOffstage = true }) {
     Finder backButton = find.byType(BackButtonIcon, skipOffstage: skipOffstage);
     if (backButton.evaluate().isEmpty) {

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -4,7 +4,8 @@
 
 import 'dart:ui';
 
-import 'package:flutter/material.dart' show Tooltip;
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart' show BackButton, BackButtonIcon, Tooltip;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -500,6 +501,26 @@ class CommonFinders {
       },
       skipOffstage: skipOffstage,
     );
+  }
+
+  /// Makes an effort to find a back button widget.
+  ///
+  /// This finder is used by [WidgetTester.pageBack].
+  ///
+  /// ## Sample code
+  ///
+  /// ```dart
+  /// expect(find.backButton(), findsOneWidget);
+  /// ```
+  ///
+  /// If the `skipOffstage` argument is true (the default), then this skips
+  /// nodes that are [Offstage] or that are from inactive [Route]s.
+  Finder backButton({ bool skipOffstage = true }) {
+    Finder backButton = find.byType(BackButtonIcon, skipOffstage: skipOffstage);
+    if (backButton.evaluate().isEmpty) {
+      backButton = find.byType(CupertinoNavigationBarBackButton, skipOffstage: skipOffstage);
+    }
+    return backButton;
   }
 }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' show Tooltip;
+import 'package:flutter/material.dart' show BackButton, MaterialLocalizations, Tooltip;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -1165,7 +1165,17 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// Will throw an error if there is no back button in the page.
   Future<void> pageBack() async {
     return TestAsyncUtils.guard<void>(() async {
-      Finder backButton = find.byTooltip('Back');
+      Finder backButton = find.byType(BackButton);
+      if (backButton.evaluate().isEmpty) {
+        backButton = find.byElementPredicate((Element element) {
+          if (element.widget case final Tooltip tooltip) {
+            final MaterialLocalizations localizations = MaterialLocalizations.of(element);
+            return tooltip.message == localizations.backButtonTooltip;
+          }
+          return false;
+        });
+      }
+
       if (backButton.evaluate().isEmpty) {
         backButton = find.byType(CupertinoNavigationBarBackButton);
       }

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' show BackButton, MaterialLocalizations, Tooltip;
+import 'package:flutter/material.dart' show Tooltip;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -1163,22 +1163,12 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// a [CupertinoPageScaffold].
   ///
   /// Will throw an error if there is no back button in the page.
+  ///
+  /// See also:
+  ///   * [CommonFinders.backButton] that is used to find the back button.
   Future<void> pageBack() async {
     return TestAsyncUtils.guard<void>(() async {
-      Finder backButton = find.byType(BackButton);
-      if (backButton.evaluate().isEmpty) {
-        backButton = find.byElementPredicate((Element element) {
-          if (element.widget case final Tooltip tooltip) {
-            final MaterialLocalizations localizations = MaterialLocalizations.of(element);
-            return tooltip.message == localizations.backButtonTooltip;
-          }
-          return false;
-        });
-      }
-
-      if (backButton.evaluate().isEmpty) {
-        backButton = find.byType(CupertinoNavigationBarBackButton);
-      }
+      final Finder backButton = find.backButton();
 
       expectSync(backButton, findsOneWidget, reason: 'One back button expected on screen');
 

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1349,6 +1350,51 @@ void main() {
         expect(finder.hasFound, true);
         expect(finder.found, orderedEquals(expected));
       });
+    });
+  });
+
+  group('find.backButton', () {
+    testWidgets('finds BackButton', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            appBar: AppBar(leading: const BackButton()),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.backButton(), findsOneWidget);
+    });
+
+    testWidgets('finds CupertinoNavigationBarBackButton', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return CupertinoButton(
+                  child: const Text('Next'),
+                  onPressed: () {
+                    Navigator.push<void>(context, CupertinoPageRoute<void>(
+                      builder: (BuildContext context) {
+                        return CupertinoPageScaffold(
+                          navigationBar: const CupertinoNavigationBar(
+                            middle: Text('Page 2'),
+                          ),
+                          child: Container(),
+                        );
+                      },
+                    ));
+                  },
+                );
+              } ,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      expect(find.backButton(), findsOneWidget);
     });
   });
 }

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -256,7 +256,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
 
       expect(find.byTooltip('Back'), findsNothing);
-      expect(find.byType(BackButton), findsOneWidget);
+      expect(find.backButton(), findsOneWidget);
       expect(find.byTooltip('Custom_Back'), findsOneWidget);
 
       await tester.pageBack();
@@ -270,9 +270,6 @@ void main() {
     testWidgets('successfully taps localized custom back buttons', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
-            _CustomLocalizationsDelegate(),
-          ],
           home: Center(
             child: Builder(
               builder: (BuildContext context) {
@@ -284,8 +281,8 @@ void main() {
                         return Scaffold(
                           appBar: AppBar(
                             leading: IconButton(
-                              icon: const Icon(Icons.arrow_back_ios),
-                              tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+                              icon: const BackButtonIcon(),
+                              tooltip: 'Custom_Back',
                               onPressed: () => Navigator.maybePop(context),
                             ),
                             title: const Text('Page 2'),
@@ -306,9 +303,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(find.byTooltip('Back'), findsNothing);
-      expect(find.byType(BackButton), findsNothing);
-      expect(find.byTooltip('Custom_Back'), findsOneWidget);
+      expect(find.backButton(), findsOneWidget);
 
       await tester.pageBack();
       await tester.pump();

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -220,6 +220,103 @@ void main() {
       expect(find.text('Next'), findsOneWidget);
       expect(find.text('Page 2'), findsNothing);
     });
+
+    testWidgets('successfully taps localized material back buttons', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+            _CustomLocalizationsDelegate(),
+          ],
+          home: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  child: const Text('Next'),
+                  onPressed: () {
+                    Navigator.push<void>(context, MaterialPageRoute<void>(
+                      builder: (BuildContext context) {
+                        return Scaffold(
+                          appBar: AppBar(
+                            title: const Text('Page 2'),
+                          ),
+                        );
+                      },
+                    ));
+                  },
+                );
+              } ,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.tap(find.text('Next'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byTooltip('Back'), findsNothing);
+      expect(find.byType(BackButton), findsOneWidget);
+      expect(find.byTooltip('Custom_Back'), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Next'), findsOneWidget);
+      expect(find.text('Page 2'), findsNothing);
+    });
+
+    testWidgets('successfully taps localized custom back buttons', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+            _CustomLocalizationsDelegate(),
+          ],
+          home: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  child: const Text('Next'),
+                  onPressed: () {
+                    Navigator.push<void>(context, MaterialPageRoute<void>(
+                      builder: (BuildContext context) {
+                        return Scaffold(
+                          appBar: AppBar(
+                            leading: IconButton(
+                              icon: const Icon(Icons.arrow_back_ios),
+                              tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+                              onPressed: () => Navigator.maybePop(context),
+                            ),
+                            title: const Text('Page 2'),
+                          ),
+                        );
+                      },
+                    ));
+                  },
+                );
+              } ,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.tap(find.text('Next'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.byTooltip('Back'), findsNothing);
+      expect(find.byType(BackButton), findsNothing);
+      expect(find.byTooltip('Custom_Back'), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Next'), findsOneWidget);
+      expect(find.text('Page 2'), findsNothing);
+    });
   });
 
   testWidgets('hasRunningAnimations control test', (WidgetTester tester) async {
@@ -763,4 +860,24 @@ class _AlwaysRepaint extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     onPaint();
   }
+}
+
+class _CustomLocalizationsDelegate
+    extends LocalizationsDelegate<MaterialLocalizations> {
+  const _CustomLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => true;
+
+  @override
+  Future<MaterialLocalizations> load(Locale locale) async =>
+      _CustomMaterialLocalizations();
+
+  @override
+  bool shouldReload(_CustomLocalizationsDelegate old) => false;
+}
+
+class _CustomMaterialLocalizations extends DefaultMaterialLocalizations {
+  @override
+  String get backButtonTooltip => 'Custom_Back';
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/51121

Make WidgetTester.pageBack work with localised app. Previously the tooltip "Back" was hardcoded in the `WidgetTester.pageBack` utility method.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
