### PR TITLE
Fix typing to unblock pub roll

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -306,7 +306,7 @@ class TimeseriesVisualization {
     drawLine(0, _normalized(_stats.average), _screenWidth, _normalized(_stats.average));
 
     // Draw a horizontal dashed line corresponding to the outlier cut off.
-    _ctx.setLineDash(<JSAny?>[5.toJS, 5.toJS].toJS);
+    _ctx.setLineDash(<JSNumber>[5.toJS, 5.toJS].toJS);
     drawLine(0, _normalized(_stats.outlierCutOff), _screenWidth, _normalized(_stats.outlierCutOff));
 
     // Draw a light red band that shows the noise (1 stddev in each direction).


### PR DESCRIPTION
The pub roller is blocked on

```
  error â�¢ The argument type 'JSArray<JSAny?>' can't be assigned to the parameter type 'JSArray<JSNumber>'.  â�¢ dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart:309:22 â�¢ argument_type_not_assignable
```

See https://github.com/flutter/flutter/pull/144852.

The fixes the typing so the next pub roll can (hopefully) succeed.