### PR TITLE
Update gold validator to check for regression in flutter-gold check

### DIFF
--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -748,7 +748,7 @@ void main() {
     // golden file can be approved at any time.
     await tester.pumpWidget(RepaintBoundary(
       child: Container(
-        color: const Color(0x20240125),
+        color: const Color(0xFFF40125),
       ),
     ));
 


### PR DESCRIPTION
There were some recent change in flutter/cocoon. Check that the bot warns and holds up the PR as expected.

