### PR TITLE
Reland "Add a microbenchmark for text intrinsic height layout (#145007)"

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/layout/text_intrinsic_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/layout/text_intrinsic_bench.dart
@@ -1,0 +1,62 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../common.dart';
+
+const Duration kBenchmarkTime = Duration(seconds: 15);
+
+// Use an Align to loosen the constraints.
+final Widget intrinsicTextHeight = Align(
+  child: IntrinsicHeight(
+    child: Text('A' * 100),
+  ),
+);
+
+Future<void> main() async {
+  assert(false, "Don't run benchmarks in debug mode! Use 'flutter run --release'.");
+
+  // We control the framePolicy below to prevent us from scheduling frames in
+  // the engine, so that the engine does not interfere with our timings.
+  final LiveTestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as LiveTestWidgetsFlutterBinding;
+
+  final Stopwatch watch = Stopwatch();
+  int iterations = 0;
+
+  await benchmarkWidgets((WidgetTester tester) async {
+    runApp(intrinsicTextHeight);
+
+    final TestViewConfiguration big = TestViewConfiguration.fromView(
+      size: const Size(360.0, 640.0),
+      view: tester.view,
+    );
+    final TestViewConfiguration small = TestViewConfiguration.fromView(
+      size: const Size(100.0, 640.0),
+      view: tester.view,
+    );
+    final RenderView renderView = WidgetsBinding.instance.renderViews.single;
+    binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmark;
+
+    watch.start();
+    while (watch.elapsed < kBenchmarkTime) {
+      renderView.configuration = iterations.isEven ? big : small;
+      await tester.pumpBenchmark(Duration(milliseconds: iterations * 16));
+      iterations += 1;
+    }
+    watch.stop();
+  });
+
+
+  final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+  printer.addResult(
+    description: 'Text intrinsic height',
+    value: watch.elapsedMicroseconds / iterations,
+    unit: 'µs per iteration',
+    name: 'text_intrinsic_height_iteration',
+  );
+  printer.printToStdout();
+}

--- a/dev/benchmarks/microbenchmarks/lib/layout/text_intrinsic_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/layout/text_intrinsic_bench.dart
@@ -11,9 +11,12 @@ import '../common.dart';
 const Duration kBenchmarkTime = Duration(seconds: 15);
 
 // Use an Align to loosen the constraints.
-final Widget intrinsicTextHeight = Align(
-  child: IntrinsicHeight(
-    child: Text('A' * 100),
+final Widget intrinsicTextHeight = Directionality(
+  textDirection: TextDirection.ltr,
+  child: Align(
+    child: IntrinsicHeight(
+      child: Text('A' * 100),
+    ),
   ),
 );
 
@@ -29,6 +32,8 @@ Future<void> main() async {
 
   await benchmarkWidgets((WidgetTester tester) async {
     runApp(intrinsicTextHeight);
+    // Wait for the UI to stabilize.
+    await tester.pump(const Duration(seconds: 1));
 
     final TestViewConfiguration big = TestViewConfiguration.fromView(
       size: const Size(360.0, 640.0),

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -74,6 +74,7 @@ TaskFunction createMicrobenchmarkTask({
       ...await runMicrobench('lib/stocks/build_bench.dart'),
       ...await runMicrobench('lib/stocks/layout_bench.dart'),
       ...await runMicrobench('lib/ui/image_bench.dart'),
+      ...await runMicrobench('lib/layout/text_intrinsic_bench.dart'),
     };
 
     return TaskResult.success(allResults,


### PR DESCRIPTION
Add the missing `Directionality` widget and `await test.pump()` call: commit: https://github.com/flutter/flutter/commit/0fd7712fa72449d35b73d108884b5aeb97b3298a

Without the `pump` 1s, it sometimes schedules multiple `handleBeginFrame`s and `handleDrawFrame`s.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
