### PR TITLE
Mark Mac_arm64_ios module_test_ios not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3697,7 +3697,6 @@ targets:
   - name: Mac_arm64_ios module_test_ios # Must be run on devicelab bot for codesigning https://github.com/flutter/flutter/issues/112033
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # dependency issue: https://github.com/flutter/flutter/issues/144860
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Revert https://github.com/flutter/flutter/pull/144861

https://github.com/flutter/flutter/issues/144860 was resolved by https://github.com/openid/AppAuth-iOS/pull/825

I'm just going to mark this as unflaky instead of waiting for the bot.