### PR TITLE
Update proxied devices to handle connection interface and diagnostics.

### DIFF
--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -586,6 +586,27 @@ enum DeviceConnectionInterface {
   wireless,
 }
 
+/// Returns the `DeviceConnectionInterface` enum based on its string name.
+DeviceConnectionInterface getDeviceConnectionInterfaceForName(String name) {
+  switch (name) {
+    case 'attached':
+      return DeviceConnectionInterface.attached;
+    case 'wireless':
+      return DeviceConnectionInterface.wireless;
+  }
+  throw Exception('Unsupported DeviceConnectionInterface name "$name"');
+}
+
+/// Returns a `DeviceConnectionInterface`'s string name.
+String getNameForDeviceConnectionInterface(DeviceConnectionInterface connectionInterface) {
+  switch (connectionInterface) {
+    case DeviceConnectionInterface.attached:
+      return 'attached';
+    case DeviceConnectionInterface.wireless:
+      return 'wireless';
+  }
+}
+
 /// A device is a physical hardware that can run a Flutter application.
 ///
 /// This may correspond to a connected iOS or Android device, or represent

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -459,6 +459,8 @@ void main() {
             'ephemeral': false,
             'emulatorId': 'device',
             'sdk': 'Android 12',
+            'isConnected': true,
+            'connectionInterface': 'attached',
             'capabilities': <String, Object?>{
               'hotReload': true,
               'hotRestart': true,
@@ -479,6 +481,8 @@ void main() {
             'ephemeral': false,
             'emulatorId': null,
             'sdk': 'preview',
+            'isConnected': true,
+            'connectionInterface': 'attached',
             'capabilities': <String, Object?>{
               'hotReload': true,
               'hotRestart': true,
@@ -723,6 +727,31 @@ void main() {
       expect(stopResponse.data['id'], 1);
       expect(stopResponse.data['error'], isNull);
       expect(device.dds.shutdownCalled, true);
+    });
+
+    testUsingContext('device.getDiagnostics returns correct value', () async {
+      daemon = Daemon(
+        daemonConnection,
+        notifyingLogger: notifyingLogger,
+      );
+      final FakePollingDeviceDiscovery discoverer1 = FakePollingDeviceDiscovery();
+      discoverer1.diagnostics = <String>['fake diagnostic 1', 'fake diagnostic 2'];
+      final FakePollingDeviceDiscovery discoverer2 = FakePollingDeviceDiscovery();
+      discoverer2.diagnostics = <String>['fake diagnostic 3', 'fake diagnostic 4'];
+      daemon.deviceDomain.addDeviceDiscoverer(discoverer1);
+      daemon.deviceDomain.addDeviceDiscoverer(discoverer2);
+      daemonStreams.inputs.add(DaemonMessage(<String, Object?>{
+        'id': 0,
+        'method': 'device.getDiagnostics',
+      }));
+      final DaemonMessage response = await daemonStreams.outputs.stream.firstWhere(_notEvent);
+      expect(response.data['id'], 0);
+      expect(response.data['result'], <String>[
+        'fake diagnostic 1',
+        'fake diagnostic 2',
+        'fake diagnostic 3',
+        'fake diagnostic 4',
+      ]);
     });
 
     testUsingContext('emulator.launch without an emulatorId should report an error', () async {
@@ -1127,6 +1156,9 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   final bool isConnected = true;
+
+  @override
+  final DeviceConnectionInterface connectionInterface = DeviceConnectionInterface.attached;
 
   @override
   Future<String> get sdkNameAndVersion async => 'Android 12';

--- a/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
@@ -275,6 +275,9 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   bool get isConnected => true;
 
   @override
+  final DeviceConnectionInterface connectionInterface = DeviceConnectionInterface.attached;
+
+  @override
   Future<String> get sdkNameAndVersion async => 'Android 12';
 
   @override

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -269,6 +269,11 @@ class FakePollingDeviceDiscovery extends PollingDeviceDiscovery {
 
   @override
   List<String> wellKnownIds = <String>[];
+
+  List<String> diagnostics = <String>[];
+
+  @override
+  Future<List<String>> getDiagnostics() => Future<List<String>>.value(diagnostics);
 }
 
 /// A fake implementation of the [DeviceLogReader].


### PR DESCRIPTION
Also improve the performance of daemon device discovery by parallelizing the calls.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
