### PR TITLE
[Impeller] remove unstable debug checked banner for zoom test.

### DIFF
--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -292,6 +292,7 @@ void main() {
       RepaintBoundary(
         key: key,
         child: MaterialApp(
+          debugShowCheckedModeBanner: false, // https://github.com/flutter/flutter/issues/143616
           theme: ThemeData(useMaterial3: true),
           onGenerateRoute: (RouteSettings settings) {
             return MaterialPageRoute<void>(


### PR DESCRIPTION
These tests have been flaky for impeller since it has rotated text.