### PR TITLE
Reduce Windows_arm64 plugin_test_windows test timeout

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5327,7 +5327,6 @@ targets:
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
-    test_timeout_secs: "900"
     properties:
       dependencies: >-
         [
@@ -5336,6 +5335,7 @@ targets:
       tags: >
         ["devicelab", "hostonly", "windows", "arm64"]
       task_name: plugin_test_windows
+      test_timeout_secs: "900"
     runIf:
       - dev/**
       - packages/flutter_tools/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5335,7 +5335,7 @@ targets:
       tags: >
         ["devicelab", "hostonly", "windows", "arm64"]
       task_name: plugin_test_windows
-      test_timeout_secs: "900"
+      test_timeout_secs: "900" # 15 minutes
     runIf:
       - dev/**
       - packages/flutter_tools/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5327,6 +5327,7 @@ targets:
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
+    test_timeout_secs: "900"
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
Windows Defender sometimes kills the `Windows_arm64 plugin_test_windows` test process, causing the test to hang until it times out after 30 minutes. This reduces the test timeout to 900 seconds (15 minutes) to recover from this scenario faster.

Test timeout duration was chosen by looking at successful duration percentiles in the last 100 days:

duration_seconds_p90 | duration_seconds_p99 | duration_seconds_max
-- | -- | --
532 | 545 | 576

BigQuery SQL:

```sql
WITH
  successful_steps AS (
    SELECT
      b.id,
      TIMESTAMP_DIFF(s.end_time, s.start_time, SECOND) AS duration_seconds,
    FROM cr-buildbucket.flutter.builds AS b, UNNEST(steps) AS s
    WHERE
      create_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 100 DAY)
      AND regexp_substr(input.gitiles_commit.project, '[^\\/]+$') = 'flutter'
      AND builder.project || '/' || builder.bucket || '/' || builder.builder
        = 'flutter/prod/Windows_arm64 plugin_test_windows'
      AND name = 'run plugin_test_windows'
      AND s.status = 'SUCCESS'
  )
SELECT
  percentiles[offset(90)] AS duration_seconds_p90,
  percentiles[offset(99)] AS duration_seconds_p99,
  duration_seconds_max
FROM (
  SELECT
    APPROX_QUANTILES(duration_seconds, 100) AS percentiles,
    MAX(duration_minutes) AS duration_seconds_max
  FROM successful_steps
);
```

`test_timeout_secs` is documented here: https://github.com/flutter/cocoon/blob/main/CI_YAML.md

Part of https://github.com/flutter/flutter/issues/145072

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
