### PR TITLE
Remove autofocus from the a11y_assessments app

### DIFF
--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -8,12 +8,6 @@ import 'package:flutter/rendering.dart';
 
 import 'use_cases/use_cases.dart';
 
-// TODO(yjbanov): https://github.com/flutter/flutter/issues/83809
-//                Currently this app (as most Flutter Web apps) relies on the
-//                `autofocus` property to guide the a11y focus when navigating
-//                across routes (screen transitions, dialogs, etc). We may want
-//                to revisit this after we figure out a long-term story for a11y
-//                focus. See also https://github.com/flutter/flutter/issues/97747
 void main() {
   runApp(const App());
   if (kIsWeb) {
@@ -66,7 +60,6 @@ class HomePageState extends State<HomePage> {
       child: Builder(
           builder: (BuildContext context) {
             return TextButton(
-              autofocus: index == 0,
               key: Key(useCase.name),
               onPressed: () => Navigator.of(context).pushNamed(useCase.route),
               child: Text(useCase.name),

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -35,7 +35,6 @@ class _MainWidgetState extends State<_MainWidget> {
   static Widget _fieldViewBuilder(BuildContext context, TextEditingController textEditingController, FocusNode focusNode, VoidCallback onFieldSubmitted) {
     return TextFormField(
       focusNode: focusNode,
-      autofocus: true,
       controller: textEditingController,
       onFieldSubmitted: (String value) {
         onFieldSubmitted();

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -33,7 +33,6 @@ class _MainWidgetState extends State<_MainWidget> {
       body: ListView(
         children: <Widget>[
           CheckboxListTile(
-            autofocus: true,
             value: _checked,
             onChanged: (bool? value) {
               setState(() {

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -36,7 +36,6 @@ class _MainWidgetState extends State<_MainWidget> {
       ),
       body: Center(
         child: TextButton(
-          autofocus: true,
           onPressed: () => showDatePicker(
             context: context,
             initialEntryMode: DatePickerEntryMode.calendarOnly,

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -29,7 +29,6 @@ class _MainWidget extends StatelessWidget {
       ),
       body: Center(
         child: TextButton(
-          autofocus: true,
           onPressed: () => showDialog<String>(
             context: context,
             builder: (BuildContext context) => Dialog(
@@ -44,14 +43,12 @@ class _MainWidget extends StatelessWidget {
                     Row(
                       children: <Widget>[
                         TextButton(
-                          autofocus: true,
                           onPressed: () {
                             Navigator.pop(context);
                           },
                           child: const Text('OK'),
                         ),
                         TextButton(
-                          autofocus: true,
                           onPressed: () {
                             Navigator.pop(context);
                           },

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -64,7 +64,6 @@ class MainWidgetState extends State<MainWidget> {
       ),
       body: Center(
         child: ElevatedButton(
-          autofocus: true,
           onPressed: onPress,
           child: const Text('Show a MaterialBanner'),
         ),

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -37,7 +37,6 @@ class MainWidgetState extends State<MainWidget> {
       ),
       body: Center(
         child: Slider(
-          autofocus: true,
           value: currentSliderValue,
           max: 100,
           divisions: 5,

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -32,7 +32,6 @@ class _MainWidget extends StatelessWidget {
         children: <Widget>[
           const TextField(
             key: Key('enabled text field'),
-            autofocus: true,
             decoration: InputDecoration(
               labelText: 'Email',
               suffixText: '@gmail.com',

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -32,7 +32,6 @@ class _MainWidget extends StatelessWidget {
         children: const <Widget>[
           TextField(
             key: Key('enabled password'),
-            autofocus: true,
             decoration: InputDecoration(
               labelText: 'Password',
               hintText: 'Enter your password',


### PR DESCRIPTION
As of https://github.com/flutter/engine/pull/47727 the web engine is able to find a default widget to focus on when a new route it pushed. The mobile engine already did that for some time. So `autofocus` is no longer necessary.