### PR TITLE
Asserts if a `TextPainter` gets disposed more than once

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -1659,6 +1659,7 @@ class TextPainter {
   ///
   /// After disposal this painter is unusable.
   void dispose() {
+    assert(!debugDisposed);
     assert(() {
       _disposed = true;
       return true;

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -109,9 +109,10 @@ mixin DebugOverflowIndicatorMixin on RenderObject {
     );
   static final Paint _labelBackgroundPaint = Paint()..color = const Color(0xFFFFFFFF);
 
-  final List<TextPainter> _indicatorLabel = List<TextPainter>.filled(
+  final List<TextPainter> _indicatorLabel = List<TextPainter>.generate(
     _OverflowSide.values.length,
-    TextPainter(textDirection: TextDirection.ltr), // This label is in English.
+    (int i) => TextPainter(textDirection: TextDirection.ltr), // This label is in English.
+    growable: false,
   );
 
   @override

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1429,6 +1429,12 @@ void main() {
     expect(painter.debugDisposed, true);
   });
 
+  test('TextPainter - asserts if disposed more than once', () {
+    final TextPainter painter = TextPainter()..dispose();
+    expect(painter.debugDisposed, isTrue);
+    expect(painter.dispose, throwsAssertionError);
+  });
+
   test('TextPainter computeWidth', () {
     const InlineSpan text = TextSpan(text: 'foobar');
     final TextPainter painter = TextPainter(text: text, textDirection: TextDirection.ltr);


### PR DESCRIPTION
The overflow indicator was sharing the same `TextPainter`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
