### PR TITLE
Activate shortcuts based on NumLock state

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -142,13 +142,13 @@ class KeySet<T extends KeyboardKey> {
   }
 }
 
-/// Determines how the state of the NumLock key is used to accept a shortcut.
-enum NumLockPolicy {
-  /// The NumLock key state is not used to determine [SingleActivator.accepts] result.
+/// Determines how the state of a lock key is used to accept a shortcut.
+enum LockState {
+  /// The lock key state is not used to determine [SingleActivator.accepts] result.
   ignored,
-  /// The NumLock key must be locked to trigger the shortcut.
+  /// The lock key must be locked to trigger the shortcut.
   locked,
-  /// The NumLock key must be unlocked to trigger the shortcut.
+  /// The lock key must be unlocked to trigger the shortcut.
   unlocked,
 }
 
@@ -440,7 +440,7 @@ class SingleActivator with Diagnosticable, MenuSerializableShortcut implements S
     this.shift = false,
     this.alt = false,
     this.meta = false,
-    this.numLockPolicy = NumLockPolicy.ignored,
+    this.numLock = LockState.ignored,
     this.includeRepeats = true,
   }) : // The enumerated check with `identical` is cumbersome but the only way
        // since const constructors can not call functions such as `==` or
@@ -519,15 +519,15 @@ class SingleActivator with Diagnosticable, MenuSerializableShortcut implements S
   /// Whether the NumLock key state should be checked for [trigger] to activate
   /// the shortcut.
   ///
-  /// It defaults to [NumLockPolicy.ignored], meaning the NumLock state is ignored
+  /// It defaults to [LockState.ignored], meaning the NumLock state is ignored
   /// when the event is received in order to activate the shortcut.
-  /// If it's [NumLockPolicy.locked], then the NumLock key must be locked.
-  /// If it's [NumLockPolicy.unlocked], then the NumLock key must be unlocked.
+  /// If it's [LockState.locked], then the NumLock key must be locked.
+  /// If it's [LockState.unlocked], then the NumLock key must be unlocked.
   ///
   /// See also:
   ///
   ///  * [LogicalKeyboardKey.numLock].
-  final NumLockPolicy numLockPolicy;
+  final LockState numLock;
 
   /// Whether this activator accepts repeat events of the [trigger] key.
   ///
@@ -550,10 +550,10 @@ class SingleActivator with Diagnosticable, MenuSerializableShortcut implements S
   }
 
   bool _shouldAcceptNumLock(HardwareKeyboard state) {
-    return switch (numLockPolicy) {
-      NumLockPolicy.ignored => true,
-      NumLockPolicy.locked => state.lockModesEnabled.contains(KeyboardLockMode.numLock),
-      NumLockPolicy.unlocked => !state.lockModesEnabled.contains(KeyboardLockMode.numLock),
+    return switch (numLock) {
+      LockState.ignored => true,
+      LockState.locked => state.lockModesEnabled.contains(KeyboardLockMode.numLock),
+      LockState.unlocked => !state.lockModesEnabled.contains(KeyboardLockMode.numLock),
     };
   }
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -474,7 +474,7 @@ void main() {
 
       const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.keyA, control: true);
 
-     await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
       expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isTrue);
       await tester.sendKeyRepeatEvent(LogicalKeyboardKey.keyA);
@@ -495,6 +495,111 @@ void main() {
       expect(ShortcutActivator.isActivatedBy(noRepeatSingleActivator, events.last), isFalse);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
       expect(ShortcutActivator.isActivatedBy(noRepeatSingleActivator, events.last), isFalse);
+    });
+
+    testWidgets('NumLockPolicy.locked works as expected', (WidgetTester tester) async {
+      // Collect some key events to use for testing.
+      final List<KeyEvent> events = <KeyEvent>[];
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          onKeyEvent: (FocusNode node, KeyEvent event) {
+            events.add(event);
+            return KeyEventResult.ignored;
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4, numLockPolicy: NumLockPolicy.locked);
+
+      // Lock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isTrue);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.numpad4);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isTrue);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
+
+      // Unlock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isFalse);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.numpad4);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isFalse);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
+    });
+
+    testWidgets('NumLockPolicy.unlocked works as expected', (WidgetTester tester) async {
+      // Collect some key events to use for testing.
+      final List<KeyEvent> events = <KeyEvent>[];
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          onKeyEvent: (FocusNode node, KeyEvent event) {
+            events.add(event);
+            return KeyEventResult.ignored;
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4, numLockPolicy: NumLockPolicy.unlocked);
+
+      // Lock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isTrue);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.numpad4);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isFalse);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
+
+      // Unlock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isFalse);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.numpad4);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isTrue);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
+    });
+
+    testWidgets('NumLockPolicy.ignored works as expected', (WidgetTester tester) async {
+      // Collect some key events to use for testing.
+      final List<KeyEvent> events = <KeyEvent>[];
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          onKeyEvent: (FocusNode node, KeyEvent event) {
+            events.add(event);
+            return KeyEventResult.ignored;
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4);
+
+      // Lock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isTrue);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.numpad4);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isTrue);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
+
+      // Unlock NumLock.
+      await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
+      expect(HardwareKeyboard.instance.lockModesEnabled.contains(KeyboardLockMode.numLock), isFalse);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.numpad4);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events.last), isTrue);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
     });
 
     group('diagnostics.', () {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -497,7 +497,7 @@ void main() {
       expect(ShortcutActivator.isActivatedBy(noRepeatSingleActivator, events.last), isFalse);
     });
 
-    testWidgets('NumLockPolicy.locked works as expected', (WidgetTester tester) async {
+    testWidgets('numLock works as expected when set to LockState.locked', (WidgetTester tester) async {
       // Collect some key events to use for testing.
       final List<KeyEvent> events = <KeyEvent>[];
       await tester.pumpWidget(
@@ -511,7 +511,7 @@ void main() {
         ),
       );
 
-      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4, numLockPolicy: NumLockPolicy.locked);
+      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4, numLock: LockState.locked);
 
       // Lock NumLock.
       await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
@@ -532,7 +532,7 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
     });
 
-    testWidgets('NumLockPolicy.unlocked works as expected', (WidgetTester tester) async {
+    testWidgets('numLock works as expected when set to LockState.unlocked', (WidgetTester tester) async {
       // Collect some key events to use for testing.
       final List<KeyEvent> events = <KeyEvent>[];
       await tester.pumpWidget(
@@ -546,7 +546,7 @@ void main() {
         ),
       );
 
-      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4, numLockPolicy: NumLockPolicy.unlocked);
+      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.numpad4, numLock: LockState.unlocked);
 
       // Lock NumLock.
       await tester.sendKeyEvent(LogicalKeyboardKey.numLock);
@@ -567,7 +567,7 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.numpad4);
     });
 
-    testWidgets('NumLockPolicy.ignored works as expected', (WidgetTester tester) async {
+    testWidgets('numLock works as expected when set to LockState.ignored', (WidgetTester tester) async {
       // Collect some key events to use for testing.
       final List<KeyEvent> events = <KeyEvent>[];
       await tester.pumpWidget(


### PR DESCRIPTION
## Description

The PR updates `SingleActivator` in order to add a parameter for specifying that a shortcut depends on <kbd>NumLock</kbd> key state. 

Somewhat similarly to what is possible with common modifiers expect that a boolean is not enough in this case because: by default, a shortcut should ignore the <kbd>NumLock</kbd> state and it should be possible to define shortcuts that require <kbd>NumLock</kbd> to be locked and other that require it to be unlocked.

@gspencergoog I considered defining a new `ShortcutActivator` implementation for this, but I thinks that adding the feature directly to `SingleActivator` results in a cleaner API.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/145144
Preparation for https://github.com/flutter/flutter/issues/144936

## Tests

Adds 3 tests.