### PR TITLE
Add a `minTileHeight` to ListTile widget so its height can be customized to less than the default height.

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -251,6 +251,7 @@ class ExpansionTile extends StatefulWidget {
     this.controller,
     this.dense,
     this.visualDensity,
+    this.minTileHeight,
     this.enableFeedback = true,
     this.enabled = true,
     this.expansionAnimationStyle,
@@ -508,6 +509,9 @@ class ExpansionTile extends StatefulWidget {
   /// {@macro flutter.material.themedata.visualDensity}
   final VisualDensity? visualDensity;
 
+  /// {@macro flutter.material.ListTile.minTileHeight}
+  final double? minTileHeight;
+
   /// {@macro flutter.material.ListTile.enableFeedback}
   final bool? enableFeedback;
 
@@ -710,6 +714,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
                 title: widget.title,
                 subtitle: widget.subtitle,
                 trailing: widget.trailing ?? _buildTrailingIcon(context),
+                minTileHeight: widget.minTileHeight,
               ),
             ),
           ),

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -674,10 +674,9 @@ class ListTile extends StatelessWidget {
   /// The minimum height allocated for the [ListTile] widget.
   ///
   /// If this is null, default tile heights are 56.0, 72.0, and 88.0 for one,
-  /// two, and three lines of text respectively. If 'isDensity' is true, these
-  ///  defaults are changed to 48.0, 64.0, and 76.0. A visual density value or
-  ///  a large title will also adjust the default tile heights.
-  ///
+  /// two, and three lines of text respectively. If [isDensity] is true, these
+  /// defaults are changed to 48.0, 64.0, and 76.0. A visual density value or
+  /// a large title will also adjust the default tile heights.
   /// {@endtemplate}
   final double? minTileHeight;
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -364,6 +364,7 @@ class ListTile extends StatelessWidget {
     this.horizontalTitleGap,
     this.minVerticalPadding,
     this.minLeadingWidth,
+    this.minTileHeight,
     this.titleAlignment,
   }) : assert(!isThreeLine || subtitle != null);
 
@@ -669,6 +670,11 @@ class ListTile extends StatelessWidget {
   /// that is also null, then a default value of 40 is used.
   final double? minLeadingWidth;
 
+  /// The minimum height allocated for the [ListTile] widget.
+  ///
+  /// If null, then the value is caculated in _defaultTileHeight function.
+  final double? minTileHeight;
+
   /// Defines how [ListTile.leading] and [ListTile.trailing] are
   /// vertically aligned relative to the [ListTile]'s titles
   /// ([ListTile.title] and [ListTile.subtitle]).
@@ -884,6 +890,7 @@ class ListTile extends StatelessWidget {
                   horizontalTitleGap: horizontalTitleGap ?? tileTheme.horizontalTitleGap ?? 16,
                   minVerticalPadding: minVerticalPadding ?? tileTheme.minVerticalPadding ?? defaults.minVerticalPadding!,
                   minLeadingWidth: minLeadingWidth ?? tileTheme.minLeadingWidth ?? defaults.minLeadingWidth!,
+                  minTileHeight: minTileHeight,
                   titleAlignment: effectiveTitleAlignment,
                 ),
               ),
@@ -978,6 +985,7 @@ class _ListTile extends SlottedMultiChildRenderObjectWidget<_ListTileSlot, Rende
     required this.horizontalTitleGap,
     required this.minVerticalPadding,
     required this.minLeadingWidth,
+    this.minTileHeight,
     this.subtitleBaselineType,
     required this.titleAlignment,
   });
@@ -995,6 +1003,7 @@ class _ListTile extends SlottedMultiChildRenderObjectWidget<_ListTileSlot, Rende
   final double horizontalTitleGap;
   final double minVerticalPadding;
   final double minLeadingWidth;
+  final double? minTileHeight;
   final ListTileTitleAlignment titleAlignment;
 
   @override
@@ -1022,6 +1031,7 @@ class _ListTile extends SlottedMultiChildRenderObjectWidget<_ListTileSlot, Rende
       horizontalTitleGap: horizontalTitleGap,
       minVerticalPadding: minVerticalPadding,
       minLeadingWidth: minLeadingWidth,
+      minTileHeight: minTileHeight,
       titleAlignment: titleAlignment,
     );
   }
@@ -1037,6 +1047,7 @@ class _ListTile extends SlottedMultiChildRenderObjectWidget<_ListTileSlot, Rende
       ..subtitleBaselineType = subtitleBaselineType
       ..horizontalTitleGap = horizontalTitleGap
       ..minLeadingWidth = minLeadingWidth
+      ..minTileHeight = minTileHeight
       ..minVerticalPadding = minVerticalPadding
       ..titleAlignment = titleAlignment;
   }
@@ -1053,7 +1064,8 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
     required double horizontalTitleGap,
     required double minVerticalPadding,
     required double minLeadingWidth,
-    required ListTileTitleAlignment titleAlignment,
+    double? minTileHeight,
+    required ListTileTitleAlignment titleAlignment
   }) : _isDense = isDense,
        _visualDensity = visualDensity,
        _isThreeLine = isThreeLine,
@@ -1063,6 +1075,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
        _horizontalTitleGap = horizontalTitleGap,
        _minVerticalPadding = minVerticalPadding,
        _minLeadingWidth = minLeadingWidth,
+       _minTileHeight = minTileHeight,
        _titleAlignment = titleAlignment;
 
   RenderBox? get leading => childForSlot(_ListTileSlot.leading);
@@ -1179,6 +1192,16 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
     markNeedsLayout();
   }
 
+  double? _minTileHeight;
+  double? get minTileHeight => _minTileHeight;
+  set minTileHeight(double? value) {
+    if (_minTileHeight == value) {
+      return;
+    }
+    _minTileHeight = value;
+    markNeedsLayout();
+  }
+
   ListTileTitleAlignment get titleAlignment => _titleAlignment;
   ListTileTitleAlignment _titleAlignment;
   set titleAlignment(ListTileTitleAlignment value) {
@@ -1238,7 +1261,7 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
   @override
   double computeMinIntrinsicHeight(double width) {
     return math.max(
-      _defaultTileHeight,
+      minTileHeight ?? _defaultTileHeight,
       title!.getMinIntrinsicHeight(width) + (subtitle?.getMinIntrinsicHeight(width) ?? 0.0),
     );
   }
@@ -1345,19 +1368,17 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
       assert(isOneLine);
     }
 
-    final double defaultTileHeight = _defaultTileHeight;
-
     double tileHeight;
     double titleY;
     double? subtitleY;
     if (!hasSubtitle) {
-      tileHeight = math.max(defaultTileHeight, titleSize.height + 2.0 * _minVerticalPadding);
+      tileHeight = math.max(minTileHeight?? _defaultTileHeight, titleSize.height + 2.0 * _minVerticalPadding);
       titleY = (tileHeight - titleSize.height) / 2.0;
     } else {
       assert(subtitleBaselineType != null);
       titleY = titleBaseline! - _boxBaseline(title!, titleBaselineType)!;
       subtitleY = subtitleBaseline! - _boxBaseline(subtitle!, subtitleBaselineType!)! + visualDensity.vertical * 2.0;
-      tileHeight = defaultTileHeight;
+      tileHeight = minTileHeight?? _defaultTileHeight;
 
       // If the title and subtitle overlap, move the title upwards by half
       // the overlap and the subtitle down by the same amount, and adjust

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -890,7 +890,7 @@ class ListTile extends StatelessWidget {
                   horizontalTitleGap: horizontalTitleGap ?? tileTheme.horizontalTitleGap ?? 16,
                   minVerticalPadding: minVerticalPadding ?? tileTheme.minVerticalPadding ?? defaults.minVerticalPadding!,
                   minLeadingWidth: minLeadingWidth ?? tileTheme.minLeadingWidth ?? defaults.minLeadingWidth!,
-                  minTileHeight: minTileHeight,
+                  minTileHeight: minTileHeight ?? tileTheme.minTileHeight,
                   titleAlignment: effectiveTitleAlignment,
                 ),
               ),

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -674,7 +674,7 @@ class ListTile extends StatelessWidget {
   /// The minimum height allocated for the [ListTile] widget.
   ///
   /// If this is null, default tile heights are 56.0, 72.0, and 88.0 for one,
-  /// two, and three lines of text respectively. If [isDensity] is true, these
+  /// two, and three lines of text respectively. If `isDense` is true, these
   /// defaults are changed to 48.0, 64.0, and 76.0. A visual density value or
   /// a large title will also adjust the default tile heights.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -670,9 +670,15 @@ class ListTile extends StatelessWidget {
   /// that is also null, then a default value of 40 is used.
   final double? minLeadingWidth;
 
+  /// {@template flutter.material.ListTile.minTileHeight}
   /// The minimum height allocated for the [ListTile] widget.
   ///
-  /// If null, then the value is caculated in _defaultTileHeight function.
+  /// If this is null, default tile heights are 56.0, 72.0, and 88.0 for one,
+  /// two, and three lines of text respectively. If 'isDensity' is true, these
+  ///  defaults are changed to 48.0, 64.0, and 76.0. A visual density value or
+  ///  a large title will also adjust the default tile heights.
+  ///
+  /// {@endtemplate}
   final double? minTileHeight;
 
   /// Defines how [ListTile.leading] and [ListTile.trailing] are

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1372,13 +1372,13 @@ class _RenderListTile extends RenderBox with SlottedContainerRenderObjectMixin<_
     double titleY;
     double? subtitleY;
     if (!hasSubtitle) {
-      tileHeight = math.max(minTileHeight?? _defaultTileHeight, titleSize.height + 2.0 * _minVerticalPadding);
+      tileHeight = math.max(minTileHeight ?? _defaultTileHeight, titleSize.height + 2.0 * _minVerticalPadding);
       titleY = (tileHeight - titleSize.height) / 2.0;
     } else {
       assert(subtitleBaselineType != null);
       titleY = titleBaseline! - _boxBaseline(title!, titleBaselineType)!;
       subtitleY = subtitleBaseline! - _boxBaseline(subtitle!, subtitleBaselineType!)! + visualDensity.vertical * 2.0;
-      tileHeight = minTileHeight?? _defaultTileHeight;
+      tileHeight = minTileHeight ?? _defaultTileHeight;
 
       // If the title and subtitle overlap, move the title upwards by half
       // the overlap and the subtitle down by the same amount, and adjust

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -385,7 +385,7 @@ class ListTileTheme extends InheritedTheme {
       horizontalTitleGap: _horizontalTitleGap,
       minVerticalPadding: _minVerticalPadding,
       minLeadingWidth: _minLeadingWidth,
-      minTileHeight:_minTileHeight,
+      minTileHeight: _minTileHeight,
     );
   }
 

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -317,7 +317,6 @@ class ListTileTheme extends InheritedTheme {
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
-    double? minTileHeight,
     required super.child,
   }) : assert(
          data == null ||
@@ -332,8 +331,7 @@ class ListTileTheme extends InheritedTheme {
           mouseCursor ??
           horizontalTitleGap ??
           minVerticalPadding ??
-          minLeadingWidth ??
-          minTileHeight) == null),
+          minLeadingWidth) == null),
        _data = data,
        _dense = dense,
        _shape = shape,
@@ -348,8 +346,7 @@ class ListTileTheme extends InheritedTheme {
        _mouseCursor = mouseCursor,
        _horizontalTitleGap = horizontalTitleGap,
        _minVerticalPadding = minVerticalPadding,
-       _minLeadingWidth = minLeadingWidth,
-       _minTileHeight = minTileHeight;
+       _minLeadingWidth = minLeadingWidth;
 
   final ListTileThemeData? _data;
   final bool? _dense;
@@ -364,7 +361,6 @@ class ListTileTheme extends InheritedTheme {
   final double? _horizontalTitleGap;
   final double? _minVerticalPadding;
   final double? _minLeadingWidth;
-  final double? _minTileHeight;
   final bool? _enableFeedback;
   final MaterialStateProperty<MouseCursor?>? _mouseCursor;
 
@@ -385,7 +381,6 @@ class ListTileTheme extends InheritedTheme {
       horizontalTitleGap: _horizontalTitleGap,
       minVerticalPadding: _minVerticalPadding,
       minLeadingWidth: _minLeadingWidth,
-      minTileHeight: _minTileHeight,
     );
   }
 
@@ -460,12 +455,6 @@ class ListTileTheme extends InheritedTheme {
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.minLeadingWidth] property instead.
   double? get minLeadingWidth => _data != null ? _data.minLeadingWidth : _minLeadingWidth;
-
-  /// Overrides the default value of [ListTile.minTileHeight].
-  ///
-  /// This property is obsolete: please use the [data]
-  /// [ListTileThemeData.minTileHeight] property instead.
-  double? get minTileHeight => _data != null ? _data.minTileHeight : _minTileHeight;
 
   /// Overrides the default value of [ListTile.enableFeedback].
   ///
@@ -565,7 +554,6 @@ class ListTileTheme extends InheritedTheme {
         horizontalTitleGap: horizontalTitleGap,
         minVerticalPadding: minVerticalPadding,
         minLeadingWidth: minLeadingWidth,
-        minTileHeight: minTileHeight,
       ),
       child: child,
     );

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -63,6 +63,7 @@ class ListTileThemeData with Diagnosticable {
     this.enableFeedback,
     this.mouseCursor,
     this.visualDensity,
+    this.minTileHeight,
     this.titleAlignment,
   });
 
@@ -111,6 +112,9 @@ class ListTileThemeData with Diagnosticable {
   /// Overrides the default value of [ListTile.minLeadingWidth].
   final double? minLeadingWidth;
 
+  /// Overrides the default value of [ListTile.minTileHeight].
+  final double? minTileHeight;
+
   /// Overrides the default value of [ListTile.enableFeedback].
   final bool? enableFeedback;
 
@@ -141,6 +145,7 @@ class ListTileThemeData with Diagnosticable {
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
+    double? minTileHeight,
     bool? enableFeedback,
     MaterialStateProperty<MouseCursor?>? mouseCursor,
     bool? isThreeLine,
@@ -163,6 +168,7 @@ class ListTileThemeData with Diagnosticable {
       horizontalTitleGap: horizontalTitleGap ?? this.horizontalTitleGap,
       minVerticalPadding: minVerticalPadding ?? this.minVerticalPadding,
       minLeadingWidth: minLeadingWidth ?? this.minLeadingWidth,
+      minTileHeight: minTileHeight ?? this.minTileHeight,
       enableFeedback: enableFeedback ?? this.enableFeedback,
       mouseCursor: mouseCursor ?? this.mouseCursor,
       visualDensity: visualDensity ?? this.visualDensity,
@@ -191,6 +197,7 @@ class ListTileThemeData with Diagnosticable {
       horizontalTitleGap: lerpDouble(a?.horizontalTitleGap, b?.horizontalTitleGap, t),
       minVerticalPadding: lerpDouble(a?.minVerticalPadding, b?.minVerticalPadding, t),
       minLeadingWidth: lerpDouble(a?.minLeadingWidth, b?.minLeadingWidth, t),
+      minTileHeight: lerpDouble(a?.minTileHeight, b?.minTileHeight, t),
       enableFeedback: t < 0.5 ? a?.enableFeedback : b?.enableFeedback,
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
       visualDensity: t < 0.5 ? a?.visualDensity : b?.visualDensity,
@@ -215,6 +222,7 @@ class ListTileThemeData with Diagnosticable {
     horizontalTitleGap,
     minVerticalPadding,
     minLeadingWidth,
+    minTileHeight,
     enableFeedback,
     mouseCursor,
     visualDensity,
@@ -245,6 +253,7 @@ class ListTileThemeData with Diagnosticable {
       && other.horizontalTitleGap == horizontalTitleGap
       && other.minVerticalPadding == minVerticalPadding
       && other.minLeadingWidth == minLeadingWidth
+      && other.minTileHeight == minTileHeight
       && other.enableFeedback == enableFeedback
       && other.mouseCursor == mouseCursor
       && other.visualDensity == visualDensity
@@ -269,6 +278,7 @@ class ListTileThemeData with Diagnosticable {
     properties.add(DoubleProperty('horizontalTitleGap', horizontalTitleGap, defaultValue: null));
     properties.add(DoubleProperty('minVerticalPadding', minVerticalPadding, defaultValue: null));
     properties.add(DoubleProperty('minLeadingWidth', minLeadingWidth, defaultValue: null));
+    properties.add(DoubleProperty('minTileHeight', minTileHeight, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('enableFeedback', enableFeedback, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('mouseCursor', mouseCursor, defaultValue: null));
     properties.add(DiagnosticsProperty<VisualDensity>('visualDensity', visualDensity, defaultValue: null));
@@ -307,6 +317,7 @@ class ListTileTheme extends InheritedTheme {
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
+    double? minTileHeight,
     required super.child,
   }) : assert(
          data == null ||
@@ -321,7 +332,8 @@ class ListTileTheme extends InheritedTheme {
           mouseCursor ??
           horizontalTitleGap ??
           minVerticalPadding ??
-          minLeadingWidth) == null),
+          minLeadingWidth ??
+          minTileHeight) == null),
        _data = data,
        _dense = dense,
        _shape = shape,
@@ -336,7 +348,8 @@ class ListTileTheme extends InheritedTheme {
        _mouseCursor = mouseCursor,
        _horizontalTitleGap = horizontalTitleGap,
        _minVerticalPadding = minVerticalPadding,
-       _minLeadingWidth = minLeadingWidth;
+       _minLeadingWidth = minLeadingWidth,
+       _minTileHeight = minTileHeight;
 
   final ListTileThemeData? _data;
   final bool? _dense;
@@ -351,6 +364,7 @@ class ListTileTheme extends InheritedTheme {
   final double? _horizontalTitleGap;
   final double? _minVerticalPadding;
   final double? _minLeadingWidth;
+  final double? _minTileHeight;
   final bool? _enableFeedback;
   final MaterialStateProperty<MouseCursor?>? _mouseCursor;
 
@@ -371,6 +385,7 @@ class ListTileTheme extends InheritedTheme {
       horizontalTitleGap: _horizontalTitleGap,
       minVerticalPadding: _minVerticalPadding,
       minLeadingWidth: _minLeadingWidth,
+      minTileHeight:_minTileHeight,
     );
   }
 
@@ -446,6 +461,12 @@ class ListTileTheme extends InheritedTheme {
   /// [ListTileThemeData.minLeadingWidth] property instead.
   double? get minLeadingWidth => _data != null ? _data.minLeadingWidth : _minLeadingWidth;
 
+  /// Overrides the default value of [ListTile.minTileHeight].
+  ///
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.minTileHeight] property instead.
+  double? get minTileHeight => _data != null ? _data.minTileHeight : _minTileHeight;
+
   /// Overrides the default value of [ListTile.enableFeedback].
   ///
   /// This property is obsolete: please use the [data]
@@ -488,6 +509,7 @@ class ListTileTheme extends InheritedTheme {
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
+    double? minTileHeight,
     ListTileTitleAlignment? titleAlignment,
     MaterialStateProperty<MouseCursor?>? mouseCursor,
     VisualDensity? visualDensity,
@@ -515,6 +537,7 @@ class ListTileTheme extends InheritedTheme {
             horizontalTitleGap: horizontalTitleGap ?? parent.horizontalTitleGap,
             minVerticalPadding: minVerticalPadding ?? parent.minVerticalPadding,
             minLeadingWidth: minLeadingWidth ?? parent.minLeadingWidth,
+            minTileHeight: minTileHeight ?? parent.minTileHeight,
             titleAlignment: titleAlignment ?? parent.titleAlignment,
             mouseCursor: mouseCursor ?? parent.mouseCursor,
             visualDensity: visualDensity ?? parent.visualDensity,
@@ -542,6 +565,7 @@ class ListTileTheme extends InheritedTheme {
         horizontalTitleGap: horizontalTitleGap,
         minVerticalPadding: minVerticalPadding,
         minLeadingWidth: minLeadingWidth,
+        minTileHeight: minTileHeight,
       ),
       child: child,
     );

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1802,6 +1802,36 @@ void main() {
     expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 56.0));
     expect(right('title'), 708.0);
   });
+  testWidgets('ListTile minTileHeight', (WidgetTester tester) async {
+    Widget buildFrame(TextDirection textDirection, { double? minTileHeight, }) {
+      return MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: textDirection,
+          child: Material(
+            child: Container(
+              alignment: Alignment.topLeft,
+              child: ListTile(
+                minTileHeight: minTileHeight,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Default list tile with height = 56.0
+    await tester.pumpWidget(buildFrame(TextDirection.ltr));
+    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 56.0));
+
+    // Set list tile height = 30.0
+    await tester.pumpWidget(buildFrame(TextDirection.ltr, minTileHeight: 30));
+    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 30.0));
+
+    // Set list tile height = 60.0
+    await tester.pumpWidget(buildFrame(TextDirection.ltr, minTileHeight: 60));
+    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 60.0));
+  });
 
   testWidgets('colors are applied to leading and trailing text widgets', (WidgetTester tester) async {
     final Key leadingKey = UniqueKey();

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -167,7 +167,6 @@ void main() {
             horizontalTitleGap: 200,
             minVerticalPadding: 300,
             minLeadingWidth: 400,
-            minTileHeight: 30,
             enableFeedback: true,
             mouseCursor: MaterialStateMouseCursor.clickable,
             child: Center(
@@ -195,7 +194,6 @@ void main() {
     expect(theme.horizontalTitleGap, 200);
     expect(theme.minVerticalPadding, 300);
     expect(theme.minLeadingWidth, 400);
-    expect(theme.minTileHeight, 30);
     expect(theme.enableFeedback, true);
     expect(theme.mouseCursor, MaterialStateMouseCursor.clickable);
   });

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -72,6 +72,7 @@ void main() {
     expect(themeData.horizontalTitleGap, null);
     expect(themeData.minVerticalPadding, null);
     expect(themeData.minLeadingWidth, null);
+    expect(themeData.minTileHeight, null);
     expect(themeData.enableFeedback, null);
     expect(themeData.mouseCursor, null);
     expect(themeData.visualDensity, null);
@@ -108,6 +109,7 @@ void main() {
       horizontalTitleGap: 200,
       minVerticalPadding: 300,
       minLeadingWidth: 400,
+      minTileHeight: 30,
       enableFeedback: true,
       mouseCursor: MaterialStateMouseCursor.clickable,
       visualDensity: VisualDensity.comfortable,
@@ -137,6 +139,7 @@ void main() {
         'horizontalTitleGap: 200.0',
         'minVerticalPadding: 300.0',
         'minLeadingWidth: 400.0',
+        'minTileHeight: 30.0',
         'enableFeedback: true',
         'mouseCursor: MaterialStateMouseCursor(clickable)',
         'visualDensity: VisualDensity#00000(h: -1.0, v: -1.0)(horizontal: -1.0, vertical: -1.0)',
@@ -164,6 +167,7 @@ void main() {
             horizontalTitleGap: 200,
             minVerticalPadding: 300,
             minLeadingWidth: 400,
+            minTileHeight: 30,
             enableFeedback: true,
             mouseCursor: MaterialStateMouseCursor.clickable,
             child: Center(
@@ -191,6 +195,7 @@ void main() {
     expect(theme.horizontalTitleGap, 200);
     expect(theme.minVerticalPadding, 300);
     expect(theme.minLeadingWidth, 400);
+    expect(theme.minTileHeight, 30);
     expect(theme.enableFeedback, true);
     expect(theme.mouseCursor, MaterialStateMouseCursor.clickable);
   });
@@ -916,6 +921,7 @@ void main() {
       horizontalTitleGap: 200,
       minVerticalPadding: 300,
       minLeadingWidth: 400,
+      minTileHeight: 30,
       enableFeedback: true,
       titleAlignment: ListTileTitleAlignment.bottom,
     );
@@ -936,6 +942,7 @@ void main() {
       horizontalTitleGap: 600,
       minVerticalPadding: 700,
       minLeadingWidth: 800,
+      minTileHeight: 80,
       enableFeedback: false,
       titleAlignment: ListTileTitleAlignment.top,
     );
@@ -955,6 +962,7 @@ void main() {
     expect(copy.horizontalTitleGap, 600);
     expect(copy.minVerticalPadding, 700);
     expect(copy.minLeadingWidth, 800);
+    expect(copy.minTileHeight, 80);
     expect(copy.enableFeedback, false);
     expect(copy.titleAlignment, ListTileTitleAlignment.top);
   });
@@ -1015,6 +1023,7 @@ void main() {
             horizontalTitleGap: 200,
             minVerticalPadding: 300,
             minLeadingWidth: 400,
+            minTileHeight: 30,
             enableFeedback: true,
             titleAlignment: ListTileTitleAlignment.bottom,
             mouseCursor: MaterialStateMouseCursor.textable,
@@ -1041,6 +1050,7 @@ void main() {
                   horizontalTitleGap: 600,
                   minVerticalPadding: 700,
                   minLeadingWidth: 800,
+                  minTileHeight: 80,
                   enableFeedback: false,
                   titleAlignment: ListTileTitleAlignment.top,
                   mouseCursor: MaterialStateMouseCursor.clickable,
@@ -1071,6 +1081,7 @@ void main() {
     expect(theme.horizontalTitleGap, 600);
     expect(theme.minVerticalPadding, 700);
     expect(theme.minLeadingWidth, 800);
+    expect(theme.minTileHeight, 80);
     expect(theme.enableFeedback, false);
     expect(theme.titleAlignment, ListTileTitleAlignment.top);
     expect(theme.mouseCursor, MaterialStateMouseCursor.clickable);


### PR DESCRIPTION

fixes: https://github.com/flutter/flutter/issues/145369


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
