### PR TITLE
Add flutter_goldens README

### DIFF
--- a/packages/flutter_goldens/README.md
+++ b/packages/flutter_goldens/README.md
@@ -1,0 +1,9 @@
+This package is an internal implementation detail for our testing
+infrastructure. It enables the framework to use the Skia Gold
+infrastructure for tracking golden image tests.
+
+See also:
+￼
+ * https://skia.org/docs/dev/testing/skiagold/
+ * https://flutter-gold.skia.org/
+ * https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter


### PR DESCRIPTION
This is part 5 of a broken down version of the #140101 refactor.

This PR adds a README to flutter_goldens with breadcrumbs to other sources of documentation.