### PR TITLE
Fix `BorderSide.none` requiring explicit transparent color for `UnderlineInputBorder`

### DIFF
--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -243,6 +243,10 @@ class UnderlineInputBorder extends InputBorder {
     double gapPercentage = 0.0,
     TextDirection? textDirection,
   }) {
+    if (borderSide.style == BorderStyle.none) {
+      return;
+    }
+
     if (borderRadius.bottomLeft != Radius.zero || borderRadius.bottomRight != Radius.zero) {
       // This prevents the border from leaking the color due to anti-aliasing rounding errors.
       final BorderRadius updatedBorderRadius = BorderRadius.only(

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -8951,4 +8951,26 @@ void main() {
       expect(tester.renderObject<RenderBox>(find.text('COUNTER')).size, Size.zero);
     });
   });
+
+  testWidgets('UnderlineInputBorder with BorderStyle.none should not show anything', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/143746
+    const InputDecoration decoration = InputDecoration(
+      enabledBorder: UnderlineInputBorder(
+        borderSide: BorderSide(style: BorderStyle.none),
+        borderRadius: BorderRadius.all(Radius.circular(4)),
+      ),
+    );
+
+    await tester.pumpWidget(
+      Center(
+        child: buildInputDecorator(
+          decoration: decoration,
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject(find.byType(InputDecorator));
+
+    expect(box, isNot(paints..drrect()));
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -8961,16 +8961,8 @@ void main() {
       ),
     );
 
-    await tester.pumpWidget(
-      Center(
-        child: buildInputDecorator(
-          decoration: decoration,
-        ),
-      ),
-    );
-
+    await tester.pumpWidget(buildInputDecorator(decoration: decoration));
     final RenderBox box = tester.renderObject(find.byType(InputDecorator));
-
     expect(box, isNot(paints..drrect()));
   });
 }


### PR DESCRIPTION
Fix could have been "paint transparent when Border none" but, following other Borders, we will just not paint anything.

Fix https://github.com/flutter/flutter/issues/143746