### PR TITLE
Add --no-dds to Mac_arm64_ios version of hot_mode_dev_cycle_ios__benchmark

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4673,6 +4673,7 @@ targets:
 
   - name: Mac_arm64_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4673,7 +4673,6 @@ targets:
 
   - name: Mac_arm64_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
-    presubmit: false
     bringup: true
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4679,7 +4679,8 @@ targets:
     properties:
       tags: >
         ["devicelab", "ios", "mac"]
-      task_name: hot_mode_dev_cycle_ios__benchmark
+      # TODO(vashworth): Use "hot_mode_dev_cycle_ios__benchmark" once https://github.com/flutter/flutter/issues/142305 is fixed.
+      task_name: hot_mode_dev_cycle_ios__benchmark_no_dds
 
   - name: Mac_x64 hot_mode_dev_cycle_ios_simulator
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4673,6 +4673,8 @@ targets:
 
   - name: Mac_arm64_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4673,8 +4673,6 @@ targets:
 
   - name: Mac_arm64_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
-    presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -184,6 +184,8 @@
 /dev/devicelab/bin/tasks/fullscreen_textfield_perf_ios__e2e_summary.dart @vashworth @flutter/engine
 /dev/devicelab/bin/tasks/hello_world_ios__compile.dart @jmagman @flutter/engine
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__benchmark.dart @vashworth @flutter/tool
+# TODO(vashworth): Remove once https://github.com/flutter/flutter/issues/142305 is fixed.
+/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__benchmark_no_dds.dart @vashworth @flutter/tool
 /dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf_ios__timeline_summary.dart @hellohuanlin @flutter/engine
 /dev/devicelab/bin/tasks/integration_test_test_ios.dart @jmagman @flutter/engine
 /dev/devicelab/bin/tasks/integration_ui_ios_driver.dart @vashworth @flutter/tool

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__benchmark_no_dds.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios__benchmark_no_dds.dart
@@ -1,0 +1,15 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+
+Future<void> main() async {
+  // TODO(vashworth): Remove once https://github.com/flutter/flutter/issues/142305 is fixed.
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  await task(createHotModeTest(
+    additionalOptions: <String>['--no-dds'],
+  ));
+}

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -23,6 +23,7 @@ const String kReplacementLine = 'fontSize: (orientation == Orientation.portrait)
 TaskFunction createHotModeTest({
   String? deviceIdOverride,
   bool checkAppRunningOnLocalDevice = false,
+  List<String>? additionalOptions,
 }) {
   // This file is modified during the test and needs to be restored at the end.
   final File flutterFrameworkSource = file(path.join(
@@ -47,6 +48,7 @@ TaskFunction createHotModeTest({
       '--no-publish-port',
       '--verbose',
       '--uninstall-first',
+      if (additionalOptions != null) ...additionalOptions,
     ];
     int hotReloadCount = 0;
     late Map<String, dynamic> smallReloadData;


### PR DESCRIPTION
Attempting to debug https://github.com/flutter/flutter/issues/142305.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
