### PR TITLE
Add the createDependency parameter to ModalRoute.of

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4760,6 +4760,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   /// Returns `true` if [dependOnInheritedElement] was previously called with [ancestor].
   @protected
+  @visibleForTesting
   bool doesDependOnInheritedElement(InheritedElement ancestor) =>
       _dependencies != null && _dependencies!.contains(ancestor);
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1044,10 +1044,10 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   @optionalTypeArgs
   static ModalRoute<T>? of<T extends Object?>(
     BuildContext context, {
-    bool listen = true,
+    bool createDependency = true,
   }) {
     _ModalScopeStatus? widget;
-    if (listen) {
+    if (createDependency) {
       widget = context.dependOnInheritedWidgetOfExactType<_ModalScopeStatus>();
     } else {
       widget = context

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1059,6 +1059,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
 
   /// Obtains the element corresponding to the nearest widget of
   /// [_ModalScopeStatus] within the given [context].
+  @protected
   @visibleForTesting
   static InheritedElement? scopeStatusAncestor(BuildContext context) {
     return context.getElementForInheritedWidgetOfExactType<_ModalScopeStatus>();

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1042,9 +1042,26 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// The given [BuildContext] will be rebuilt if the state of the route changes
   /// while it is visible (specifically, if [isCurrent] or [canPop] change value).
   @optionalTypeArgs
-  static ModalRoute<T>? of<T extends Object?>(BuildContext context) {
-    final _ModalScopeStatus? widget = context.dependOnInheritedWidgetOfExactType<_ModalScopeStatus>();
+  static ModalRoute<T>? of<T extends Object?>(
+    BuildContext context, {
+    bool listen = true,
+  }) {
+    _ModalScopeStatus? widget;
+    if (listen) {
+      widget = context.dependOnInheritedWidgetOfExactType<_ModalScopeStatus>();
+    } else {
+      widget = context
+          .getElementForInheritedWidgetOfExactType<_ModalScopeStatus>()
+          ?.widget as _ModalScopeStatus?;
+    }
     return widget?.route as ModalRoute<T>?;
+  }
+
+  /// Obtains the element corresponding to the nearest widget of
+  /// [_ModalScopeStatus] within the given [context].
+  @visibleForTesting
+  static InheritedElement? scopeStatusAncestor(BuildContext context) {
+    return context.getElementForInheritedWidgetOfExactType<_ModalScopeStatus>();
   }
 
   /// Schedule a call to [buildTransitions].

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1942,6 +1942,27 @@ void main() {
     expect(parentRoute, isA<MaterialPageRoute<void>>());
   });
 
+  testWidgets('ModalRoute.of works for listen parameter',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Text('home'),
+    ));
+    final Element context = tester.element(find.text('home'));
+
+    final InheritedElement? ancestor = ModalRoute.scopeStatusAncestor(context);
+    expect(ancestor, isNotNull);
+
+    final ModalRoute<void>? routeWithoutListen = ModalRoute.of<void>(
+      context,
+      listen: false,
+    );
+    expect(routeWithoutListen, isNotNull);
+    expect(context.doesDependOnInheritedElement(ancestor!), false);
+    final ModalRoute<void>? routeWithListen = ModalRoute.of<void>(context);
+    expect(routeWithListen, isNotNull);
+    expect(context.doesDependOnInheritedElement(ancestor), true);
+  });
+
   testWidgets('RawDialogRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1942,7 +1942,7 @@ void main() {
     expect(parentRoute, isA<MaterialPageRoute<void>>());
   });
 
-  testWidgets('ModalRoute.of works for listen parameter',
+  testWidgets('ModalRoute.of works for createDependency parameter',
       (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Text('home'),
@@ -1952,14 +1952,15 @@ void main() {
     final InheritedElement? ancestor = ModalRoute.scopeStatusAncestor(context);
     expect(ancestor, isNotNull);
 
-    final ModalRoute<void>? routeWithoutListen = ModalRoute.of<void>(
+    final ModalRoute<void>? routeWithoutCreateDependency = ModalRoute.of<void>(
       context,
-      listen: false,
+      createDependency: false,
     );
-    expect(routeWithoutListen, isNotNull);
+    expect(routeWithoutCreateDependency, isNotNull);
     expect(context.doesDependOnInheritedElement(ancestor!), false);
-    final ModalRoute<void>? routeWithListen = ModalRoute.of<void>(context);
-    expect(routeWithListen, isNotNull);
+    final ModalRoute<void>? routeWithCreateDependency =
+        ModalRoute.of<void>(context);
+    expect(routeWithCreateDependency, isNotNull);
     expect(context.doesDependOnInheritedElement(ancestor), true);
   });
 


### PR DESCRIPTION
Added `createDependency` parameter to `ModalRoute.of`, which allows developer to freely choose to use `dependOnInheritedWidgetOfExactType` or `getElementForInheritedWidgetOfExactType` to obtain `ModalRoute`.

Releated issue:
- https://github.com/flutter/flutter/issues/145387
- https://github.com/flutter/flutter/issues/145136

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
