### PR TITLE
2DScrollView - Fix drag when one axis does not have enough content

### DIFF
--- a/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
@@ -580,5 +580,297 @@ void main() {
       expect(horizontalController.position.activity!.velocity, 0.0);
       expect(verticalController.position.activity!.velocity, 0.0);
     });
+
+    group('Can drag horizontally when there is not enough vertical content', () {
+      testWidgets('DiagonalDragBehavior.free', (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/144982
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SimpleBuilderTableView(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              diagonalDragBehavior: DiagonalDragBehavior.free,
+              delegate: TwoDimensionalChildBuilderDelegate(
+                maxXIndex: 20,
+                maxYIndex: 1,
+                builder: _testChildBuilder,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        expect(verticalController.position.maxScrollExtent, 0.0);
+        expect(horizontalController.position.maxScrollExtent, 3400.0);
+        // Fling vertically, nothing should happen.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(0.0, -200.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        // Fling horizontally, the horizontal position should change.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(-200.0, 0.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, greaterThan(840.0));
+      });
+
+      testWidgets('DiagonalDragBehavior.weightedEvent', (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/144982
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SimpleBuilderTableView(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              diagonalDragBehavior: DiagonalDragBehavior.weightedEvent,
+              delegate: TwoDimensionalChildBuilderDelegate(
+                maxXIndex: 20,
+                maxYIndex: 1,
+                builder: _testChildBuilder,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        expect(verticalController.position.maxScrollExtent, 0.0);
+        expect(horizontalController.position.maxScrollExtent, 3400.0);
+        // Fling vertically, nothing should happen.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(0.0, -200.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        // Fling horizontally, the horizontal position should change.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(-200.0, 0.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, greaterThan(840.0));
+      });
+
+      testWidgets('DiagonalDragBehavior.weightedContinuous', (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/144982
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SimpleBuilderTableView(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              diagonalDragBehavior: DiagonalDragBehavior.weightedContinuous,
+              delegate: TwoDimensionalChildBuilderDelegate(
+                maxXIndex: 20,
+                maxYIndex: 1,
+                builder: _testChildBuilder,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        expect(verticalController.position.maxScrollExtent, 0.0);
+        expect(horizontalController.position.maxScrollExtent, 3400.0);
+        // Fling vertically, nothing should happen.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(0.0, -200.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        // Fling horizontally, the horizontal position should change.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(-200.0, 0.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, greaterThan(840.0));
+      });
+    });
+
+    group('Can drag vertically when there is not enough horizontal content', () {
+      testWidgets('DiagonalDragBehavior.free', (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/144982
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SimpleBuilderTableView(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              diagonalDragBehavior: DiagonalDragBehavior.free,
+              delegate: TwoDimensionalChildBuilderDelegate(
+                maxXIndex: 1,
+                maxYIndex: 20,
+                builder: _testChildBuilder,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        expect(verticalController.position.maxScrollExtent, 3600.0);
+        expect(horizontalController.position.maxScrollExtent, 0.0);
+        // Fling horizontally, nothing should happen.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(-200.0, 0.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        // Fling vertically, the vertical position should change.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(0.0, -200.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, greaterThan(840.0));
+        expect(horizontalController.position.pixels, 0.0);
+      });
+
+      testWidgets('DiagonalDragBehavior.weightedEvent', (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/144982
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SimpleBuilderTableView(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              diagonalDragBehavior: DiagonalDragBehavior.weightedEvent,
+              delegate: TwoDimensionalChildBuilderDelegate(
+                maxXIndex: 1,
+                maxYIndex: 20,
+                builder: _testChildBuilder,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        expect(verticalController.position.maxScrollExtent, 3600.0);
+        expect(horizontalController.position.maxScrollExtent, 0.0);
+        // Fling horizontally, nothing should happen.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(-200.0, 0.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        // Fling vertically, the vertical position should change.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(0.0, -200.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, greaterThan(840.0));
+        expect(horizontalController.position.pixels, 0.0);
+      });
+
+      testWidgets('DiagonalDragBehavior.weightedContinuous', (WidgetTester tester) async {
+        // Regression test for https://github.com/flutter/flutter/issues/144982
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: SimpleBuilderTableView(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              diagonalDragBehavior: DiagonalDragBehavior.weightedContinuous,
+              delegate: TwoDimensionalChildBuilderDelegate(
+                maxXIndex: 1,
+                maxYIndex: 20,
+                builder: _testChildBuilder,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        expect(verticalController.position.maxScrollExtent, 3600.0);
+        expect(horizontalController.position.maxScrollExtent, 0.0);
+        // Fling horizontally, nothing should happen.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(-200.0, 0.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, 0.0);
+        expect(horizontalController.position.pixels, 0.0);
+        // Fling vertically, the vertical position should change.
+        await tester.fling(
+          find.byType(TwoDimensionalScrollable),
+          const Offset(0.0, -200.0),
+          2000.0,
+        );
+        await tester.pumpAndSettle();
+        expect(verticalController.position.pixels, greaterThan(840.0));
+        expect(horizontalController.position.pixels, 0.0);
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/144982
For reference, may have to do with #138442 when we reworked the gesture handling. The adjustments to the comments here were certainly from #138442 not updating them. Confused myself for a minute or two. 🙃 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
