### PR TITLE
Fix SliverMainAxisGroup layout in reverse

### DIFF
--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -32,9 +32,16 @@ void main() {
     expect(controller.offset, 0);
 
     expect(find.text('Group 0 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 0')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 300.0),
+    );
     expect(find.text('Group 0 Tile 1'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 1')),
+      const Rect.fromLTRB(0.0, 300.0, 300.0, 600.0),
+    );
     expect(find.text('Group 0 Tile 2'), findsNothing);
-
     expect(find.text('Group 1 Tile 0'), findsNothing);
 
     const double scrollOffset = 19 * 300.0;
@@ -44,7 +51,15 @@ void main() {
     expect(controller.offset, scrollOffset);
     expect(find.text('Group 0 Tile 18'), findsNothing);
     expect(find.text('Group 0 Tile 19'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 19')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 300.0),
+    );
     expect(find.text('Group 1 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 1 Tile 0')),
+      const Rect.fromLTRB(0.0, 300.0, 300.0, 500.0),
+    );
 
     final List<RenderSliverList> renderSlivers = tester.renderObjectList<RenderSliverList>(find.byType(SliverList)).toList();
     final RenderSliverList first = renderSlivers[0];
@@ -85,9 +100,16 @@ void main() {
     expect(controller.offset, 0);
 
     expect(find.text('Group 0 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 0')),
+      const Rect.fromLTRB(0.0, 300.0, 300.0, 600.0),
+    );
     expect(find.text('Group 0 Tile 1'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 1')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 300.0),
+    );
     expect(find.text('Group 0 Tile 2'), findsNothing);
-
     expect(find.text('Group 1 Tile 0'), findsNothing);
 
     const double scrollOffset = 19 * 300.0;
@@ -97,7 +119,15 @@ void main() {
     expect(controller.offset, scrollOffset);
     expect(find.text('Group 0 Tile 18'), findsNothing);
     expect(find.text('Group 0 Tile 19'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 19')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 300.0),
+    );
     expect(find.text('Group 1 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 1 Tile 0')),
+      const Rect.fromLTRB(0.0, 400.0, 300.0, 600.0),
+    );
 
     final List<RenderSliverList> renderSlivers = tester.renderObjectList<RenderSliverList>(find.byType(SliverList)).toList();
     final RenderSliverList first = renderSlivers[0];
@@ -138,8 +168,11 @@ void main() {
     expect(controller.offset, 0);
 
     expect(find.text('Group 0 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 0')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 600.0),
+    );
     expect(find.text('Group 0 Tile 1'), findsNothing);
-
     expect(find.text('Group 1 Tile 0'), findsNothing);
 
     const double scrollOffset = 19 * 300.0;
@@ -149,6 +182,10 @@ void main() {
     expect(controller.offset, scrollOffset);
     expect(find.text('Group 0 Tile 18'), findsNothing);
     expect(find.text('Group 0 Tile 19'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 19')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 600.0),
+    );
     expect(find.text('Group 1 Tile 0'), findsNothing);
 
     const double scrollOffset2 = 20 * 300.0;
@@ -156,6 +193,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Group 0 Tile 19'), findsNothing);
     expect(find.text('Group 1 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 1 Tile 0')),
+      const Rect.fromLTRB(0.0, 0.0, 200.0, 600.0),
+    );
 
     final List<RenderSliverList> renderSlivers = tester.renderObjectList<RenderSliverList>(find.byType(SliverList)).toList();
     final RenderSliverList first = renderSlivers[0];
@@ -197,8 +238,11 @@ void main() {
     expect(controller.offset, 0);
 
     expect(find.text('Group 0 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 0')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 600.0),
+    );
     expect(find.text('Group 0 Tile 1'), findsNothing);
-
     expect(find.text('Group 1 Tile 0'), findsNothing);
 
     const double scrollOffset = 19 * 300.0;
@@ -208,6 +252,10 @@ void main() {
     expect(controller.offset, scrollOffset);
     expect(find.text('Group 0 Tile 18'), findsNothing);
     expect(find.text('Group 0 Tile 19'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 0 Tile 19')),
+      const Rect.fromLTRB(0.0, 0.0, 300.0, 600.0),
+    );
     expect(find.text('Group 1 Tile 0'), findsNothing);
 
     const double scrollOffset2 = 20 * 300.0;
@@ -215,6 +263,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Group 0 Tile 19'), findsNothing);
     expect(find.text('Group 1 Tile 0'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('Group 1 Tile 0')),
+      const Rect.fromLTRB(100.0, 0.0, 300.0, 600.0),
+    );
 
     final List<RenderSliverList> renderSlivers = tester.renderObjectList<RenderSliverList>(find.byType(SliverList)).toList();
     final RenderSliverList first = renderSlivers[0];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/145068

The original tests for SliverMainAxisGroup did not actually check where the child was painted (#126596).

Followed the same pattern in RenderSliverMultiBoxAdaptor:

https://github.com/flutter/flutter/blob/11c034f0371eb28576d41a0c218ccae6b38e7702/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart#L666

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
