### PR TITLE
`SearchAnchor` doesn't hide custom `viewTrailing` when input text is empty

### DIFF
--- a/packages/flutter/lib/src/material/search_anchor.dart
+++ b/packages/flutter/lib/src/material/search_anchor.dart
@@ -811,7 +811,7 @@ class _ViewContentState extends State<_ViewContent> {
     );
 
     final List<Widget> defaultTrailing = <Widget>[
-      if (_controller.text.isNotEmpty) IconButton(
+      IconButton(
         icon: const Icon(Icons.close),
         tooltip: MaterialLocalizations.of(context).clearButtonTooltip,
         onPressed: () {
@@ -901,7 +901,7 @@ class _ViewContentState extends State<_ViewContent> {
                             autoFocus: true,
                             constraints: headerConstraints ?? (widget.showFullScreenView ? BoxConstraints(minHeight: _SearchViewDefaultsM3.fullScreenBarHeight) : null),
                             leading: widget.viewLeading ?? defaultLeading,
-                            trailing: widget.viewTrailing ?? defaultTrailing,
+                            trailing: _controller.text.isNotEmpty ? (widget.viewTrailing ?? defaultTrailing) : null,
                             hintText: widget.viewHintText,
                             backgroundColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
                             overlayColor: const MaterialStatePropertyAll<Color>(Colors.transparent),

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -1448,6 +1448,9 @@ void main() {
     await tester.pumpWidget(buildAnchor(viewTrailing: <Widget>[const Icon(Icons.history)]));
     await tester.tap(find.widgetWithIcon(IconButton, Icons.search));
     await tester.pumpAndSettle();
+    // Icon button with history icon is shown when input is not empty.
+    await tester.enterText(findTextField(), 'a');
+    await tester.pump();
     expect(find.byIcon(Icons.close), findsNothing);
     expect(find.byIcon(Icons.history), findsOneWidget);
   });
@@ -3088,6 +3091,44 @@ void main() {
     await tester.enterText(findTextField(), '');
     await tester.pump();
     expect(find.widgetWithIcon(IconButton, Icons.close), findsNothing);
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/144939.
+  testWidgets('SearchAnchor hides custom viewTrailing when input text is empty', (WidgetTester tester) async {
+    Widget buildAnchor({Iterable<Widget>? viewTrailing}) {
+      return MaterialApp(
+        home: Material(
+          child: SearchAnchor(
+            viewTrailing: viewTrailing,
+            builder: (BuildContext context, SearchController controller) {
+              return IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: controller.openView,
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildAnchor(viewTrailing: <Widget>[const Icon(Icons.delete)]));
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.search));
+    await tester.pumpAndSettle();
+    // Icon button with delete icon is not shown when input is empty.
+    expect(find.widgetWithIcon(IconButton, Icons.delete), findsNothing);
+
+    // Icon button with delete icon is shown when input is not empty.
+    await tester.enterText(findTextField(), 'a');
+    await tester.pump();
+    expect(find.byIcon(Icons.delete), findsOneWidget);
+
+    // Clear the input text to hide the icon button.
+    await tester.enterText(findTextField(), '');
+    await tester.pump();
+    expect(find.byIcon(Icons.delete), findsNothing);
   });
 }
 


### PR DESCRIPTION
fixes [SearchAnchor doesn't update trailing icons](https://github.com/flutter/flutter/issues/144939)

### Code sample
```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Material(
        child: SearchAnchor(
          viewTrailing: const <Widget>[Icon(Icons.delete)],
          builder: (BuildContext context, SearchController controller) {
            return Center(
              child: Builder(
                builder: (context) {
                  return IconButton(
                    icon: const Icon(Icons.search),
                    onPressed: () {
                      controller.openView();
                    },
                  );
                }
              ),
            );
          },
          suggestionsBuilder:
              (BuildContext context, SearchController controller) {
            return <Widget>[];
          },
        ),
      ),
    );
  }
}
```

### Before
![after](https://github.com/flutter/flutter/assets/48603081/d44adfe5-f352-461f-ba00-6e8ea8557163)

### After
![before](https://github.com/flutter/flutter/assets/48603081/9a93f8f7-ea9e-465c-9c87-23812508242c)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
