### PR TITLE
Add workaround for bug adding unicode strings to test reports.

### DIFF
--- a/dev/bots/tool_subsharding.dart
+++ b/dev/bots/tool_subsharding.dart
@@ -55,7 +55,7 @@ class TestFileReporterResults {
       /// all the additional content at the beginning of the line until it finds the
       /// first opening curly bracket.
       // TODO(godofredoc): remove when https://github.com/flutter/flutter/issues/145553 is fixed.
-      final String sanitizedMetric = metric.replaceAll(RegExp(r'$.+{'), '{');
+      final String sanitizedMetric = metric.replaceAll(RegExp(r'$.*{'), '{');
       final Map<String, Object?> entry = json.decode(sanitizedMetric) as Map<String, Object?>;
       if (entry.containsKey('suite')) {
         final Map<String, Object?> suite = entry['suite']! as Map<String, Object?>;

--- a/dev/bots/tool_subsharding.dart
+++ b/dev/bots/tool_subsharding.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:developer';
 import 'dart:io';
 
 class TestSpecs {
@@ -49,7 +50,13 @@ class TestFileReporterResults {
     final List<String> errors = <String>[];
 
     for (final String metric in metrics.readAsLinesSync()) {
-      final Map<String, Object?> entry = json.decode(metric) as Map<String, Object?>;
+      /// Using print within a test adds the printed content to the json file report
+      /// as \u0000 making the file parsing step fail. The content of the json file
+      /// is expected to be a json dictionary per line and the following line removes
+      /// all the additional content at the beginning of the line until it finds the
+      /// first opening curly bracket.
+      final String sanitizedMetric = metric.replaceAll(RegExp(r'$.+{'), '{');
+      final Map<String, Object?> entry = json.decode(sanitizedMetric) as Map<String, Object?>;
       if (entry.containsKey('suite')) {
         final Map<String, Object?> suite = entry['suite']! as Map<String, Object?>;
         addTestSpec(suite, entry['time']! as int, testSpecs);

--- a/dev/bots/tool_subsharding.dart
+++ b/dev/bots/tool_subsharding.dart
@@ -54,6 +54,7 @@ class TestFileReporterResults {
       /// is expected to be a json dictionary per line and the following line removes
       /// all the additional content at the beginning of the line until it finds the
       /// first opening curly bracket.
+      // TODO(godofredoc): remove when https://github.com/flutter/flutter/issues/145553 is fixed.
       final String sanitizedMetric = metric.replaceAll(RegExp(r'$.+{'), '{');
       final Map<String, Object?> entry = json.decode(sanitizedMetric) as Map<String, Object?>;
       if (entry.containsKey('suite')) {

--- a/dev/bots/tool_subsharding.dart
+++ b/dev/bots/tool_subsharding.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:io';
 
 class TestSpecs {


### PR DESCRIPTION
When print is used inside tests its content is added to the test report as a string of unicode \u0000 making the test reporting parser fail. This PR cleans removes non json content every line of the report.

Bug: https://github.com/flutter/flutter/issues/145553

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
