### PR TITLE
Fix vertical `Stepper` draws connector on the last step

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -791,7 +791,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             width: _stepIconWidth ?? _kStepSize,
             child: Center(
               child: SizedBox(
-                width: widget.connectorThickness ?? 1.0,
+                width: !_isLast(index) ? (widget.connectorThickness ?? 1.0) : 0.0,
                 child: Container(
                   color: _connectorColor(widget.steps[index].isActive),
                 ),

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -1689,6 +1689,37 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     expect(mergedStyle.gradient, stepStyle.gradient);
     expect(mergedStyle.indexStyle, stepStyle.indexStyle);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/144376.
+  testWidgets('Vertical Stepper does not draw connector on the last step', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Stepper(
+            currentStep: 1,
+              steps: const <Step>[
+                Step(
+                  title: Text('step1'),
+                  content: Text('step1 content'),
+                ),
+                Step(
+                  title: Text('step2'),
+                  content: Text('step2 content'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      )
+    );
+
+    final SizedBox lastConnector = tester.widget<SizedBox>(
+      find.descendant(of: find.byType(PositionedDirectional),
+      matching: find.byType(SizedBox).last,
+    ));
+    expect(lastConnector.width, equals(0.0));
+  });
 }
 
 class _TappableColorWidget extends StatefulWidget {


### PR DESCRIPTION
fixes [Vertical stepper shows line after last step](https://github.com/flutter/flutter/issues/144376)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        body: Center(
          child: Stepper(
            currentStep: 1,
            steps: const <Step>[
              Step(
                title: Text("Step 1"),
                content: Text("Content 1"),
              ),
              Step(
                title: Text("Step 2"),
                content: Text("Content 2"),
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```

</details>

### Before

![Screenshot 2024-03-25 at 18 36 32](https://github.com/flutter/flutter/assets/48603081/af859a88-7ec8-4432-8eec-f8eb72706b57)

### After
![Screenshot 2024-03-25 at 18 36 24](https://github.com/flutter/flutter/assets/48603081/994325b2-4bd4-44ef-9473-245d3492faf7)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
