### PR TITLE
Remove trailing commas in android dependency version checking gradle plugin

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -115,7 +115,7 @@ class DependencyVersionChecker {
             } else {
                 project.logger.error(
                     "Warning: unable to detect project AGP version. Skipping " +
-                        "version checking. \nThis may be because you have applied AGP after the Flutter Gradle Plugin.",
+                        "version checking. \nThis may be because you have applied AGP after the Flutter Gradle Plugin."
                 )
             }
 
@@ -125,7 +125,7 @@ class DependencyVersionChecker {
             } else {
                 project.logger.error(
                     "Warning: unable to detect project KGP version. Skipping " +
-                        "version checking. \nThis may be because you have applied KGP after the Flutter Gradle Plugin.",
+                        "version checking. \nThis may be because you have applied KGP after the Flutter Gradle Plugin."
                 )
             }
         }
@@ -154,9 +154,9 @@ class DependencyVersionChecker {
                 agpVersion =
                     Version.fromString(
                         project.plugins.getPlugin(agpPluginName)::class.java.classLoader.loadClass(
-                            com.android.Version::class.java.name,
+                            com.android.Version::class.java.name
                         ).fields.find { it.name == agpVersionFieldName }!!
-                            .get(null) as String,
+                            .get(null) as String
                     )
             } catch (ignored: ClassNotFoundException) {
                 // Use deprecated Version class as it exists in older AGP (com.android.Version) does
@@ -164,9 +164,9 @@ class DependencyVersionChecker {
                 agpVersion =
                     Version.fromString(
                         project.plugins.getPlugin(agpPluginName)::class.java.classLoader.loadClass(
-                            com.android.builder.model.Version::class.java.name,
+                            com.android.builder.model.Version::class.java.name
                         ).fields.find { it.name == agpVersionFieldName }!!
-                            .get(null) as String,
+                            .get(null) as String
                     )
             }
             return agpVersion
@@ -200,7 +200,7 @@ class DependencyVersionChecker {
             dependencyName: String,
             versionString: String,
             errorVersion: String,
-            potentialFix: String,
+            potentialFix: String
         ): String {
             return "Error: Your project's $dependencyName version ($versionString) is lower " +
                 "than Flutter's minimum supported version of $errorVersion. Please upgrade " +
@@ -213,7 +213,7 @@ class DependencyVersionChecker {
             dependencyName: String,
             versionString: String,
             warnVersion: String,
-            potentialFix: String,
+            potentialFix: String
         ): String {
             return "Warning: Flutter support for your project's $dependencyName version " +
                 "($versionString) will soon be dropped. Please upgrade your $dependencyName " +
@@ -224,7 +224,7 @@ class DependencyVersionChecker {
 
         fun checkGradleVersion(
             version: Version,
-            project: Project,
+            project: Project
         ) {
             if (version < errorGradleVersion) {
                 val errorMessage: String =
@@ -232,7 +232,7 @@ class DependencyVersionChecker {
                         GRADLE_NAME,
                         version.toString(),
                         errorGradleVersion.toString(),
-                        getPotentialGradleFix(project.getRootDir().getPath()),
+                        getPotentialGradleFix(project.getRootDir().getPath())
                     )
                 throw GradleException(errorMessage)
             } else if (version < warnGradleVersion) {
@@ -241,7 +241,7 @@ class DependencyVersionChecker {
                         GRADLE_NAME,
                         version.toString(),
                         warnGradleVersion.toString(),
-                        getPotentialGradleFix(project.getRootDir().getPath()),
+                        getPotentialGradleFix(project.getRootDir().getPath())
                     )
                 project.logger.error(warnMessage)
             }
@@ -249,7 +249,7 @@ class DependencyVersionChecker {
 
         fun checkJavaVersion(
             version: JavaVersion,
-            project: Project,
+            project: Project
         ) {
             if (version < errorJavaVersion) {
                 val errorMessage: String =
@@ -257,7 +257,7 @@ class DependencyVersionChecker {
                         JAVA_NAME,
                         version.toString(),
                         errorJavaVersion.toString(),
-                        POTENTIAL_JAVA_FIX,
+                        POTENTIAL_JAVA_FIX
                     )
                 throw GradleException(errorMessage)
             } else if (version < warnJavaVersion) {
@@ -266,7 +266,7 @@ class DependencyVersionChecker {
                         JAVA_NAME,
                         version.toString(),
                         warnJavaVersion.toString(),
-                        POTENTIAL_JAVA_FIX,
+                        POTENTIAL_JAVA_FIX
                     )
                 project.logger.error(warnMessage)
             }
@@ -274,7 +274,7 @@ class DependencyVersionChecker {
 
         fun checkAGPVersion(
             version: Version,
-            project: Project,
+            project: Project
         ) {
             if (version < errorAGPVersion) {
                 val errorMessage: String =
@@ -282,7 +282,7 @@ class DependencyVersionChecker {
                         AGP_NAME,
                         version.toString(),
                         errorAGPVersion.toString(),
-                        getPotentialAGPFix(project.getRootDir().getPath()),
+                        getPotentialAGPFix(project.getRootDir().getPath())
                     )
                 throw GradleException(errorMessage)
             } else if (version < warnAGPVersion) {
@@ -291,7 +291,7 @@ class DependencyVersionChecker {
                         AGP_NAME,
                         version.toString(),
                         warnAGPVersion.toString(),
-                        getPotentialAGPFix(project.getRootDir().getPath()),
+                        getPotentialAGPFix(project.getRootDir().getPath())
                     )
                 project.logger.error(warnMessage)
             }
@@ -299,7 +299,7 @@ class DependencyVersionChecker {
 
         fun checkKGPVersion(
             version: Version,
-            project: Project,
+            project: Project
         ) {
             if (version < errorKGPVersion) {
                 val errorMessage: String =
@@ -307,7 +307,7 @@ class DependencyVersionChecker {
                         KGP_NAME,
                         version.toString(),
                         errorKGPVersion.toString(),
-                        getPotentialKGPFix(project.getRootDir().getPath()),
+                        getPotentialKGPFix(project.getRootDir().getPath())
                     )
                 throw GradleException(errorMessage)
             } else if (version < warnKGPVersion) {
@@ -316,7 +316,7 @@ class DependencyVersionChecker {
                         KGP_NAME,
                         version.toString(),
                         warnKGPVersion.toString(),
-                        getPotentialKGPFix(project.getRootDir().getPath()),
+                        getPotentialKGPFix(project.getRootDir().getPath())
                     )
                 project.logger.error(warnMessage)
             }
@@ -336,7 +336,7 @@ class Version(val major: Int, val minor: Int, val patch: Int) : Comparable<Versi
             return Version(
                 major = convertedToNumbers.getOrElse(0, { 0 }),
                 minor = convertedToNumbers.getOrElse(1, { 0 }),
-                patch = convertedToNumbers.getOrElse(2, { 0 }),
+                patch = convertedToNumbers.getOrElse(2, { 0 })
             )
         }
     }


### PR DESCRIPTION
Apparently old versions of kotlin (pre 1.4) don't allow trailing commas.

Example logs: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8752506486861217537/+/u/Run_package_tests/build_all_packages_for_Android_-_legacy_version/stdout 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
