### PR TITLE
Be tolerant of backticks around directory name in `pub` output.

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -218,9 +218,11 @@ void main() {
 
       expect(mockStdio.stdout.writes.map(utf8.decode),
         allOf(
-          contains(matches(RegExp(r'Resolving dependencies in .+flutter_project\.\.\.'))),
+          // The output of pub changed, adding backticks around the directory name.
+          // These regexes are tolerant of the backticks being present or absent.
+          contains(matches(RegExp(r'Resolving dependencies in .+flutter_project`?\.\.\.'))),
           contains(matches(RegExp(r'\+ flutter 0\.0\.0 from sdk flutter'))),
-          contains(matches(RegExp(r'Changed \d+ dependencies in .+flutter_project!'))),
+          contains(matches(RegExp(r'Changed \d+ dependencies in .+flutter_project`?!'))),
         ),
       );
 


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/145766

The output of the pub command changed slightly with this change: https://dart.googlesource.com/pub/+/2179b765aa9071386be02d408b3c3caa82af98f5

Update the tests to be tolerant of the directory path being surrounded by backticks (or not) so that we are compatible with the current and upcoming implementation.