### PR TITLE
Test Gold stdout message

### DIFF
--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -750,7 +750,7 @@ void main() {
     // golden file can be approved at any time.
     await tester.pumpWidget(RepaintBoundary(
       child: Container(
-        color: const Color(0xFFF40125),
+        color: const Color(0xFAAAA125),
       ),
     ));
 

--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -355,8 +355,9 @@ class SkiaGoldClient {
 
     final String/*!*/ resultStdout = result.stdout.toString();
     if (result.exitCode != 0) {
-      print('*****');
       print(resultStdout);
+      // Throw for good measure so we know when our error message is ready
+      throw SkiaException('Quick-search');
     }
     if (result.exitCode != 0 &&
       !(resultStdout.contains('Untriaged') || resultStdout.contains('negative image'))) {

--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -354,6 +354,10 @@ class SkiaGoldClient {
     final io.ProcessResult result = await process.run(imgtestCommand);
 
     final String/*!*/ resultStdout = result.stdout.toString();
+    if (result.exitCode != 0) {
+      print('*****');
+      print(resultStdout);
+    }
     if (result.exitCode != 0 &&
       !(resultStdout.contains('Untriaged') || resultStdout.contains('negative image'))) {
       String? resultContents;


### PR DESCRIPTION
Do not merge - testing if Gold's error message distinguishes between untriaged or negative images.
We expect here that it will only say untriaged. If the error message contains 'negative' then https://github.com/flutter/engine/pull/51685 may not work as expected.
If it does though, we should be sure to make the same change in the framework.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
