### PR TITLE
Generate test metrics consistently.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1687,7 +1687,9 @@ Future<void> runFlutterWebTest(
       'FLUTTER_WEB': 'true',
     },
   );
-  // Delete metrics file.
+  // metriciFile is a transitional file that needs to be deleted once it is parsed.
+  // TODO(godofredoc): Ensure metricFile is parsed and aggregated before deleting.
+  // https://github.com/flutter/flutter/issues/146003
   metricFile.deleteSync();
 }
 
@@ -1795,7 +1797,9 @@ Future<void> _runDartTest(String workingDirectory, {
     }
   }
 
-  // Delete metrics file.
+  // metriciFile is a transitional file that needs to be deleted once it is parsed.
+  // TODO(godofredoc): Ensure metricFile is parsed and aggregated before deleting.
+  // https://github.com/flutter/flutter/issues/146003
   metricFile.deleteSync();
 }
 
@@ -1863,7 +1867,9 @@ Future<void> _runFlutterTest(String workingDirectory, {
     environment: environment,
   );
 
-  // Delete metrics file.
+  // metriciFile is a transitional file that needs to be deleted once it is parsed.
+  // TODO(godofredoc): Ensure metricFile is parsed and aggregated before deleting.
+  // https://github.com/flutter/flutter/issues/146003
   metricFile.deleteSync();
 
   if (outputChecker != null) {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1665,11 +1665,15 @@ Future<void> runFlutterWebTest(
   List<String> tests,
   bool useWasm,
 ) async {
+  const LocalFileSystem fileSystem = LocalFileSystem();
+  final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
+  final File metricFile = fileSystem.file(path.join(fileSystem.systemTempDirectory.path, 'metrics_$suffix.json'));
   await runCommand(
     flutter,
     <String>[
       'test',
       '--reporter=expanded',
+      '--file-reporter=json:${metricFile.path}',
       '-v',
       '--platform=chrome',
       if (useWasm) '--wasm',
@@ -1683,6 +1687,8 @@ Future<void> runFlutterWebTest(
       'FLUTTER_WEB': 'true',
     },
   );
+  // Delete metrics file.
+  metricFile.deleteSync();
 }
 
 
@@ -1724,7 +1730,8 @@ Future<void> _runDartTest(String workingDirectory, {
   }
 
   const LocalFileSystem fileSystem = LocalFileSystem();
-  final File metricFile = fileSystem.file(path.join(flutterRoot, 'metrics.json'));
+  final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
+  final File metricFile = fileSystem.file(path.join(fileSystem.systemTempDirectory.path, 'metrics_$suffix.json'));
   final List<String> args = <String>[
     'run',
     'test',
@@ -1787,6 +1794,9 @@ Future<void> _runDartTest(String workingDirectory, {
       print('Failed to generate metrics: $e');
     }
   }
+
+  // Delete metrics file.
+  metricFile.deleteSync();
 }
 
 Future<void> _runFlutterTest(String workingDirectory, {
@@ -1809,9 +1819,13 @@ Future<void> _runFlutterTest(String workingDirectory, {
     tags.addAll(<String>['-t', 'reduced-test-set']);
   }
 
+  const LocalFileSystem fileSystem = LocalFileSystem();
+  final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
+  final File metricFile = fileSystem.file(path.join(fileSystem.systemTempDirectory.path, 'metrics_$suffix.json'));
   final List<String> args = <String>[
     'test',
     '--reporter=expanded',
+    '--file-reporter=json:${metricFile.path}',
     if (shuffleTests && !_isRandomizationOff) '--test-randomize-ordering-seed=$shuffleSeed',
     if (fatalWarnings) '--fatal-warnings',
     ...options,
@@ -1848,6 +1862,9 @@ Future<void> _runFlutterTest(String workingDirectory, {
     outputMode: outputMode,
     environment: environment,
   );
+
+  // Delete metrics file.
+  metricFile.deleteSync();
 
   if (outputChecker != null) {
     final String? message = outputChecker(result);

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1667,7 +1667,7 @@ Future<void> runFlutterWebTest(
 ) async {
   const LocalFileSystem fileSystem = LocalFileSystem();
   final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
-  final File metricFile = fileSystem.file(path.join(fileSystem.systemTempDirectory.path, 'metrics_$suffix.json'));
+  final File metricFile = fileSystem.systemTempDirectory.childFile('metrics_$suffix.json');
   await runCommand(
     flutter,
     <String>[
@@ -1731,7 +1731,7 @@ Future<void> _runDartTest(String workingDirectory, {
 
   const LocalFileSystem fileSystem = LocalFileSystem();
   final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
-  final File metricFile = fileSystem.file(path.join(fileSystem.systemTempDirectory.path, 'metrics_$suffix.json'));
+  final File metricFile = fileSystem.systemTempDirectory.childFile('metrics_$suffix.json');
   final List<String> args = <String>[
     'run',
     'test',
@@ -1821,7 +1821,7 @@ Future<void> _runFlutterTest(String workingDirectory, {
 
   const LocalFileSystem fileSystem = LocalFileSystem();
   final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
-  final File metricFile = fileSystem.file(path.join(fileSystem.systemTempDirectory.path, 'metrics_$suffix.json'));
+  final File metricFile = fileSystem.systemTempDirectory.childFile('metrics_$suffix.json');
   final List<String> args = <String>[
     'test',
     '--reporter=expanded',


### PR DESCRIPTION
Starts creating metric files consistently for web, dart and flutter runners. It also starts creating the files in the temp folder instead of the checkout one.

Bug: https://github.com/flutter/flutter/issues/145793

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
