### PR TITLE
`WidgetState` mapping

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -18,9 +18,9 @@ import 'package:flutter/services.dart';
 /// one of its values, based on the first key that [isSatisfiedBy]
 /// the current set of states.
 ///
-/// {@macro flutter.widgets.WidgetStateProperty.WidgetStateMap}
+/// {@macro flutter.widgets.WidgetStateMap}
 abstract interface class WidgetStatesConstraint {
-  /// Whether the current [states] satisfy this object's criteria.
+  /// Whether the provided [states] satisfy this object's criteria.
   ///
   /// If the constraint is a single [WidgetState] object,
   /// it's satisfied by the set if the set contains the object.
@@ -703,6 +703,8 @@ abstract class WidgetStateProperty<T> {
   /// the method throws an [ArgumentError].
   ///
   /// {@macro flutter.widgets.WidgetState.any}
+  ///
+  /// {@macro flutter.widgets.WidgetStateMap}
   const factory WidgetStateProperty.fromMap(WidgetStateMap<T> map) = _WidgetStateMapper<T>;
 
   /// Resolves the value for the given set of states if `value` is a
@@ -783,10 +785,11 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// A [Map] used to resolve to a single value of type `T` based on
 /// the current set of Widget states.
 ///
-/// {@template flutter.widgets.WidgetStateProperty.WidgetStateMap}
+/// {@template flutter.widgets.WidgetStateMap}
 /// Example:
 ///
 /// ```dart
+/// // This WidgetStateMap<Color?> resolves to null if no keys match.
 /// WidgetStateProperty<Color?>.fromMap(<WidgetStatesConstraint, Color?>{
 ///   WidgetState.error: Colors.red,
 ///   WidgetState.hovered & WidgetState.focused: Colors.blueAccent,

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -13,26 +13,26 @@ import 'package:flutter/services.dart';
 /// This class allows [WidgetState] enum values to be combined
 /// using [WidgetStateOperators].
 ///
-/// A [Map] with [WidgetStateMapKey] objects as keys can be used
+/// A [Map] with [WidgetStatesConstraint] objects as keys can be used
 /// in the [WidgetStateProperty.fromMap] constructor to resolve to
 /// one of its values, based on the first key that [isSatisfiedBy]
 /// the current set of states.
 ///
 /// {@macro flutter.widgets.WidgetStateProperty.WidgetStateMap}
-abstract interface class WidgetStateMapKey {
-  /// Whether this key should apply, given the current [states].
+abstract interface class WidgetStatesConstraint {
+  /// Whether the current [states] satisfy this object's criteria.
   ///
-  /// If the key is a single [WidgetState] object, it's satisfied by the set
-  /// if the set contains the object.
+  /// If the constraint is a single [WidgetState] object,
+  /// it's satisfied by the set if the set contains the object.
   ///
-  /// The key could also be created using one or more operators, for example:
+  /// The constraint can also be created using one or more operators, for example:
   ///
-  /// {@template flutter.widgets.WidgetStateMapKey.isSatisfiedBy}
+  /// {@template flutter.widgets.WidgetStatesConstraint.isSatisfiedBy}
   /// ```dart
-  /// final WidgetStateMapKey mapKey = WidgetState.focused | WidgetState.hovered;
+  /// final WidgetStatesConstraint constraint = WidgetState.focused | WidgetState.hovered;
   /// ```
   ///
-  /// In the above case, `mapKey.isSatisfiedBy(states)` is equivalent to:
+  /// In the above case, `constraint.isSatisfiedBy(states)` is equivalent to:
   ///
   /// ```dart
   /// states.contains(WidgetState.focused) || states.contains(WidgetState.hovered);
@@ -42,7 +42,7 @@ abstract interface class WidgetStateMapKey {
 }
 
 // A private class, used in [WidgetStateOperators].
-class _WidgetStateOperation implements WidgetStateMapKey {
+class _WidgetStateOperation implements WidgetStatesConstraint {
   const _WidgetStateOperation(this._isSatisfiedBy);
 
   final bool Function(Set<WidgetState> states) _isSatisfiedBy;
@@ -56,28 +56,28 @@ class _WidgetStateOperation implements WidgetStateMapKey {
 ///
 /// Example:
 ///
-/// {@macro flutter.widgets.WidgetStateMapKey.isSatisfiedBy}
+/// {@macro flutter.widgets.WidgetStatesConstraint.isSatisfiedBy}
 ///
-/// Since enums can't extend other classes, [WidgetState] instead
-/// `implements` the [WidgetStateMapKey] interface. This `extension` ensures
-/// that the operators can be used without being directly inherited.
-extension WidgetStateOperators on WidgetStateMapKey {
-  /// Combines two [WidgetStateMapKey] values using logical "and".
-  WidgetStateMapKey operator &(WidgetStateMapKey other) {
+/// Since enums can't extend other classes, [WidgetState] instead `implements`
+/// the [WidgetStatesConstraint] interface. This `extension` ensures that
+/// the operators can be used without being directly inherited.
+extension WidgetStateOperators on WidgetStatesConstraint {
+  /// Combines two [WidgetStatesConstraint] values using logical "and".
+  WidgetStatesConstraint operator &(WidgetStatesConstraint other) {
     return _WidgetStateOperation(
       (Set<WidgetState> states) => isSatisfiedBy(states) && other.isSatisfiedBy(states),
     );
   }
 
-  /// Combines two [WidgetStateMapKey] values using logical "or".
-  WidgetStateMapKey operator |(WidgetStateMapKey other) {
+  /// Combines two [WidgetStatesConstraint] values using logical "or".
+  WidgetStatesConstraint operator |(WidgetStatesConstraint other) {
     return _WidgetStateOperation(
       (Set<WidgetState> states) => isSatisfiedBy(states) || other.isSatisfiedBy(states),
     );
   }
 
-  /// Takes a [WidgetStateMapKey] and applies the logical "not".
-  WidgetStateMapKey operator ~() {
+  /// Takes a [WidgetStatesConstraint] and applies the logical "not".
+  WidgetStatesConstraint operator ~() {
     return _WidgetStateOperation(
       (Set<WidgetState> states) => !isSatisfiedBy(states),
     );
@@ -85,7 +85,7 @@ extension WidgetStateOperators on WidgetStateMapKey {
 }
 
 // A private class, used to create [WidgetState.any].
-class _AlwaysMatch implements WidgetStateMapKey {
+class _AlwaysMatch implements WidgetStatesConstraint {
   const _AlwaysMatch();
 
   @override
@@ -122,7 +122,7 @@ class _AlwaysMatch implements WidgetStateMapKey {
 ///    `WidgetStateProperty` which is used in APIs that need to accept either
 ///    a [TextStyle] or a [WidgetStateProperty<TextStyle>].
 /// {@endtemplate}
-enum WidgetState implements WidgetStateMapKey {
+enum WidgetState implements WidgetStatesConstraint {
   /// The state when the user drags their mouse cursor over the given widget.
   ///
   /// See: https://material.io/design/interaction/states.html#hover.
@@ -175,10 +175,11 @@ enum WidgetState implements WidgetStateMapKey {
   error;
 
   /// {@template flutter.widgets.WidgetState.any}
-  /// To prevent a situation where no [WidgetStateMapKey]s are satisfied by
-  /// a given set of states, consier adding [WidgetState.any] as the final key.
+  /// To prevent a situation where each [WidgetStatesConstraint]
+  /// isn't satisfied by the given set of states, consier adding
+  /// [WidgetState.any] as the final [WidgetStateMap] key.
   /// {@endtemplate}
-  static const WidgetStateMapKey any = _AlwaysMatch();
+  static const WidgetStatesConstraint any = _AlwaysMatch();
 
   @override
   bool isSatisfiedBy(Set<WidgetState> states) => states.contains(this);
@@ -475,7 +476,7 @@ abstract class WidgetStateBorderSide extends BorderSide implements WidgetStatePr
   /// ```dart
   /// const Chip(
   ///   label: Text('Transceiver'),
-  ///   side: WidgetStateBorderSide.fromMap(<WidgetStateMapKey, BorderSide?>{
+  ///   side: WidgetStateBorderSide.fromMap(<WidgetStatesConstraint, BorderSide?>{
   ///     WidgetState.selected: BorderSide(color: Colors.red),
   ///     // returns null if not selected, deferring to default theme/widget value.
   ///   }),
@@ -786,7 +787,7 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// Example:
 ///
 /// ```dart
-/// WidgetStateProperty<Color?>.fromMap(<WidgetStateMapKey, Color?>{
+/// WidgetStateProperty<Color?>.fromMap(<WidgetStatesConstraint, Color?>{
 ///   WidgetState.error: Colors.red,
 ///   WidgetState.hovered & WidgetState.focused: Colors.blueAccent,
 ///   WidgetState.focused: Colors.blue,
@@ -814,10 +815,10 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// that there's a match:
 ///
 /// ```dart
-/// final WidgetStateMapKey selectedError = WidgetState.selected & WidgetState.error;
+/// final WidgetStatesConstraint selectedError = WidgetState.selected & WidgetState.error;
 ///
 /// final WidgetStateProperty<Color> color = WidgetStateProperty<Color>.fromMap(
-///   <WidgetStateMapKey, Color>{
+///   <WidgetStatesConstraint, Color>{
 ///     selectedError & WidgetState.hovered: Colors.redAccent,
 ///     selectedError: Colors.red,
 ///     WidgetState.any: Colors.black,
@@ -838,7 +839,7 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// );
 /// ```
 /// {@endtemplate}
-typedef WidgetStateMap<T> = Map<WidgetStateMapKey, T>;
+typedef WidgetStateMap<T> = Map<WidgetStatesConstraint, T>;
 
 // A private class, used to create the [WidgetStateProperty.fromMap] constructor.
 class _WidgetStateMapper<T> implements WidgetStateProperty<T> {
@@ -848,7 +849,7 @@ class _WidgetStateMapper<T> implements WidgetStateProperty<T> {
 
   @override
   T resolve(Set<WidgetState> states) {
-    for (final MapEntry<WidgetStateMapKey, T> entry in map.entries) {
+    for (final MapEntry<WidgetStatesConstraint, T> entry in map.entries) {
       if (entry.key.isSatisfiedBy(states)) {
         return entry.value;
       }

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -15,7 +15,7 @@ import 'package:flutter/services.dart';
 ///
 /// A [Map] with [WidgetStateMapKey] objects as keys can be used
 /// in the [WidgetStateProperty.fromMap] constructor to resolve to
-/// one of its values, based on the first key that [matchesSet]
+/// one of its values, based on the first key that [isSatisfiedBy]
 /// the current set of states.
 ///
 /// {@macro flutter.widgets.WidgetStateProperty.WidgetStateMap}
@@ -38,7 +38,7 @@ abstract interface class WidgetStateMapKey {
   /// states.contains(WidgetState.focused) || states.contains(WidgetState.hovered);
   /// ```
   /// {@endtemplate}
-  bool matchesSet(Set<WidgetState> states);
+  bool isSatisfiedBy(Set<WidgetState> states);
 }
 
 // A private class, used in [WidgetStateOperators].
@@ -48,7 +48,7 @@ class _WidgetStateOperation implements WidgetStateMapKey {
   final bool Function(Set<WidgetState> states) _isSatisfiedBy;
 
   @override
-  bool matchesSet(Set<WidgetState> states) => _isSatisfiedBy(states);
+  bool isSatisfiedBy(Set<WidgetState> states) => _isSatisfiedBy(states);
 }
 
 /// These operators can be used inside a [WidgetStateMap] to combine states
@@ -65,21 +65,21 @@ extension WidgetStateOperators on WidgetStateMapKey {
   /// Combines two [WidgetStateMapKey] values using logical "and".
   WidgetStateMapKey operator &(WidgetStateMapKey other) {
     return _WidgetStateOperation(
-      (Set<WidgetState> states) => matchesSet(states) && other.matchesSet(states),
+      (Set<WidgetState> states) => isSatisfiedBy(states) && other.isSatisfiedBy(states),
     );
   }
 
   /// Combines two [WidgetStateMapKey] values using logical "or".
   WidgetStateMapKey operator |(WidgetStateMapKey other) {
     return _WidgetStateOperation(
-      (Set<WidgetState> states) => matchesSet(states) || other.matchesSet(states),
+      (Set<WidgetState> states) => isSatisfiedBy(states) || other.isSatisfiedBy(states),
     );
   }
 
   /// Takes a [WidgetStateMapKey] and applies the logical "not".
   WidgetStateMapKey operator ~() {
     return _WidgetStateOperation(
-      (Set<WidgetState> states) => !matchesSet(states),
+      (Set<WidgetState> states) => !isSatisfiedBy(states),
     );
   }
 }
@@ -89,7 +89,7 @@ class _AlwaysMatch implements WidgetStateMapKey {
   const _AlwaysMatch();
 
   @override
-  bool matchesSet(Set<WidgetState> states) => true;
+  bool isSatisfiedBy(Set<WidgetState> states) => true;
 }
 
 /// Interactive states that some of the widgets can take on when receiving input
@@ -181,7 +181,7 @@ enum WidgetState implements WidgetStateMapKey {
   static const WidgetStateMapKey any = _AlwaysMatch();
 
   @override
-  bool matchesSet(Set<WidgetState> states) => states.contains(this);
+  bool isSatisfiedBy(Set<WidgetState> states) => states.contains(this);
 }
 
 /// Signature for the function that returns a value of type `T` based on a given
@@ -263,7 +263,7 @@ abstract class WidgetStateColor extends Color implements WidgetStateProperty<Col
   /// [Set] of [WidgetState]s will be selected.
   ///
   /// {@macro flutter.widgets.WidgetState.any}
-  factory WidgetStateColor.map(WidgetStateMap<Color> map) = _WidgetStateColorMapper;
+  factory WidgetStateColor.fromMap(WidgetStateMap<Color> map) = _WidgetStateColorMapper;
 
   /// Returns a [Color] that's to be used when a component is in the specified
   /// state.
@@ -475,7 +475,7 @@ abstract class WidgetStateBorderSide extends BorderSide implements WidgetStatePr
   /// ```dart
   /// const Chip(
   ///   label: Text('Transceiver'),
-  ///   side: WidgetStateBorderSide.map(<WidgetStateMapKey, BorderSide?>{
+  ///   side: WidgetStateBorderSide.fromMap(<WidgetStateMapKey, BorderSide?>{
   ///     WidgetState.selected: BorderSide(color: Colors.red),
   ///     // returns null if not selected, deferring to default theme/widget value.
   ///   }),
@@ -483,7 +483,7 @@ abstract class WidgetStateBorderSide extends BorderSide implements WidgetStatePr
   /// ```
   ///
   /// {@macro flutter.widgets.WidgetState.any}
-  const factory WidgetStateBorderSide.map(WidgetStateMap<BorderSide?> map) = _WidgetBorderSideMapper;
+  const factory WidgetStateBorderSide.fromMap(WidgetStateMap<BorderSide?> map) = _WidgetBorderSideMapper;
 
   /// Returns a [BorderSide] that's to be used when a Widget is in the
   /// specified state. Return null to defer to the default value of the
@@ -598,7 +598,7 @@ abstract class WidgetStateOutlinedBorder extends OutlinedBorder implements Widge
 ///   1. Create a subclass of [WidgetStateTextStyle] and implement the abstract `resolve` method.
 ///   2. Use [WidgetStateTextStyle.resolveWith] and pass in a callback that
 ///      will be used to resolve the color in the given states.
-///   3. Use [WidgetStateTextStyle.map] to assign a style using a [WidgetStateMap].
+///   3. Use [WidgetStateTextStyle.fromMap] to assign a style using a [WidgetStateMap].
 ///
 /// If a [WidgetStateTextStyle] is used for a property or a parameter that doesn't
 /// support resolving [WidgetStateProperty<TextStyle>]s, then its default color
@@ -635,7 +635,7 @@ abstract class WidgetStateTextStyle extends TextStyle implements WidgetStateProp
   /// [Set] of [WidgetState]s will be selected.
   ///
   /// {@macro flutter.widgets.WidgetState.any}
-  const factory WidgetStateTextStyle.map(WidgetStateMap<TextStyle> map) = _WidgetTextStyleMapper;
+  const factory WidgetStateTextStyle.fromMap(WidgetStateMap<TextStyle> map) = _WidgetTextStyleMapper;
 
   /// Returns a [TextStyle] that's to be used when a component is in the
   /// specified state.
@@ -702,7 +702,7 @@ abstract class WidgetStateProperty<T> {
   /// the method throws an [ArgumentError].
   ///
   /// {@macro flutter.widgets.WidgetState.any}
-  const factory WidgetStateProperty.map(WidgetStateMap<T> map) = _WidgetStateMapper<T>;
+  const factory WidgetStateProperty.fromMap(WidgetStateMap<T> map) = _WidgetStateMapper<T>;
 
   /// Resolves the value for the given set of states if `value` is a
   /// [WidgetStateProperty], otherwise returns the value itself.
@@ -786,7 +786,7 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// Example:
 ///
 /// ```dart
-/// WidgetStateProperty<Color?>.map(<WidgetStateMapKey, Color?>{
+/// WidgetStateProperty<Color?>.fromMap(<WidgetStateMapKey, Color?>{
 ///   WidgetState.error: Colors.red,
 ///   WidgetState.hovered & WidgetState.focused: Colors.blueAccent,
 ///   WidgetState.focused: Colors.blue,
@@ -816,7 +816,7 @@ class _WidgetStatePropertyWith<T> implements WidgetStateProperty<T> {
 /// ```dart
 /// final WidgetStateMapKey selectedError = WidgetState.selected & WidgetState.error;
 ///
-/// final WidgetStateProperty<Color> color = WidgetStateProperty<Color>.map(
+/// final WidgetStateProperty<Color> color = WidgetStateProperty<Color>.fromMap(
 ///   <WidgetStateMapKey, Color>{
 ///     selectedError & WidgetState.hovered: Colors.redAccent,
 ///     selectedError: Colors.red,
@@ -849,7 +849,7 @@ class _WidgetStateMapper<T> implements WidgetStateProperty<T> {
   @override
   T resolve(Set<WidgetState> states) {
     for (final MapEntry<WidgetStateMapKey, T> entry in map.entries) {
-      if (entry.key.matchesSet(states)) {
+      if (entry.key.isSatisfiedBy(states)) {
         return entry.value;
       }
     }
@@ -861,7 +861,7 @@ class _WidgetStateMapper<T> implements WidgetStateProperty<T> {
         'The current set of material states is $states.\n'
         'None of the provided map keys matched this set, '
         'and the type "$T" is non-nullable.\n'
-        'Consider using "WidgetStateProperty<$T?>.map()", '
+        'Consider using "WidgetStateProperty<$T?>.fromMap()", '
         'or adding the "WidgetState.any" key to this map.',
       );
     }

--- a/packages/flutter/test/widgets/widget_state_property_test.dart
+++ b/packages/flutter/test/widgets/widget_state_property_test.dart
@@ -20,6 +20,23 @@ void main() {
     expect(value.resolve(<WidgetState>{WidgetState.error}), WidgetState.error);
   });
 
+  test('WidgetStateProperty.map()', () {
+    final WidgetStateMapKey active = WidgetState.hovered | WidgetState.focused | WidgetState.pressed;
+    final WidgetStateProperty<String?> value = WidgetStateProperty<String?>.map(
+      <WidgetStateMapKey, String?>{
+        active & WidgetState.error: 'active error',
+        WidgetState.disabled | WidgetState.error: 'kinda sus',
+        ~(WidgetState.dragged | WidgetState.selected) & ~active: 'this is boring',
+        active: 'active',
+      },
+    );
+    expect(value.resolve(<WidgetState>{WidgetState.focused, WidgetState.error}), 'active error');
+    expect(value.resolve(<WidgetState>{WidgetState.scrolledUnder}), 'this is boring');
+    expect(value.resolve(<WidgetState>{WidgetState.disabled}), 'kinda sus');
+    expect(value.resolve(<WidgetState>{WidgetState.hovered}), 'active');
+    expect(value.resolve(<WidgetState>{WidgetState.dragged}),  null);
+  });
+
   test('WidgetStateProperty.all()', () {
     final WidgetStateProperty<int> value = WidgetStateProperty.all<int>(123);
     expect(value.resolve(<WidgetState>{WidgetState.hovered}), 123);

--- a/packages/flutter/test/widgets/widget_state_property_test.dart
+++ b/packages/flutter/test/widgets/widget_state_property_test.dart
@@ -22,7 +22,7 @@ void main() {
 
   test('WidgetStateProperty.map()', () {
     final WidgetStateMapKey active = WidgetState.hovered | WidgetState.focused | WidgetState.pressed;
-    final WidgetStateProperty<String?> value = WidgetStateProperty<String?>.map(
+    final WidgetStateProperty<String?> value = WidgetStateProperty<String?>.fromMap(
       <WidgetStateMapKey, String?>{
         active & WidgetState.error: 'active error',
         WidgetState.disabled | WidgetState.error: 'kinda sus',

--- a/packages/flutter/test/widgets/widget_state_property_test.dart
+++ b/packages/flutter/test/widgets/widget_state_property_test.dart
@@ -21,9 +21,9 @@ void main() {
   });
 
   test('WidgetStateProperty.map()', () {
-    final WidgetStateMapKey active = WidgetState.hovered | WidgetState.focused | WidgetState.pressed;
+    final WidgetStatesConstraint active = WidgetState.hovered | WidgetState.focused | WidgetState.pressed;
     final WidgetStateProperty<String?> value = WidgetStateProperty<String?>.fromMap(
-      <WidgetStateMapKey, String?>{
+      <WidgetStatesConstraint, String?>{
         active & WidgetState.error: 'active error',
         WidgetState.disabled | WidgetState.error: 'kinda sus',
         ~(WidgetState.dragged | WidgetState.selected) & ~active: 'this is boring',


### PR DESCRIPTION
This pull request implements [enhanced enum](https://dart.dev/language/enums#declaring-enhanced-enums) features for the new `WidgetState` enum, in order to improve the developer experience when creating and using `WidgetStateProperty` objects.

`WidgetState` now has a `.matchesSet()` method:

```dart
// identical to "states.contains(WidgetState.error)"
final bool hasError = WidgetState.error.isSatisfiedBy(states);
```

This addition allows for wide variety of `WidgetStateProperty` objects to be constructed in a simple manner.

<br><br>

```dart
// before
final style = MaterialStateTextStyle.resolveWith((states) {
  if (states.contains(MaterialState.error)) {
    return const TextStyle(color: Colors.red);
  } else if (states.contains(MaterialState.focused)) {
    return const TextStyle(color: Colors.blue);
  }
  return const TextStyle(color: Colors.black);
});


// after
const style = WidgetStateTextStyle.fromMap({
  WidgetState.error:   TextStyle(color: Colors.red),
  WidgetState.focused: TextStyle(color: Colors.blue),
  WidgetState.any:     TextStyle(color: Colors.black),
});
```

```dart
// before
final color = MaterialStateProperty.resolveWith((states) {
  if (states.contains(MaterialState.focused)) {
    return Colors.blue;
  } else if (!states.contains(MaterialState.disabled)) {
    return Colors.black;
  }
  return null;
});


// after
final color = WidgetStateProperty<Color?>.fromMap({
  WidgetState.focused:   Colors.blue,
  ~WidgetState.disabled: Colors.black,
});
```

```dart
// before
const activeStates = [MaterialState.selected, MaterialState.focused, MaterialState.scrolledUnder];

final color = MaterialStateColor.resolveWith((states) {
  if (activeStates.any(states.contains)) {
    if (states.contains(MaterialState.hovered) {
      return Colors.blueAccent;
    }
    return Colors.blue;
  }
  return Colors.black;
});


// after
final active = WidgetState.selected | WidgetState.focused | WidgetState.scrolledUnder;

final color = WidgetStateColor.fromMap({
  active & WidgetState.hovered: Colors.blueAccent,
  active:  Colors.blue,
  ~active: Colors.black,
});
```

<br>

(fixes #146042, and also fixes #143488)