### PR TITLE
Fix border color is wrong for a focused and hovered TextField

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -4703,19 +4703,19 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
       return BorderSide(color: _colors.onSurface.withOpacity(0.38));
     }
     if (states.contains(MaterialState.error)) {
-      if (states.contains(MaterialState.hovered)) {
-        return BorderSide(color: _colors.onErrorContainer);
-      }
       if (states.contains(MaterialState.focused)) {
         return BorderSide(color: _colors.error, width: 2.0);
       }
+      if (states.contains(MaterialState.hovered)) {
+        return BorderSide(color: _colors.onErrorContainer);
+      }
       return BorderSide(color: _colors.error);
-    }
-    if (states.contains(MaterialState.hovered)) {
-      return BorderSide(color: _colors.onSurface);
     }
     if (states.contains(MaterialState.focused)) {
       return BorderSide(color: _colors.primary, width: 2.0);
+    }
+    if (states.contains(MaterialState.hovered)) {
+      return BorderSide(color: _colors.onSurface);
     }
     return BorderSide(color: _colors.onSurfaceVariant);
     });
@@ -4726,19 +4726,19 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
       return BorderSide(color: _colors.onSurface.withOpacity(0.12));
     }
     if (states.contains(MaterialState.error)) {
-      if (states.contains(MaterialState.hovered)) {
-        return BorderSide(color: _colors.onErrorContainer);
-      }
       if (states.contains(MaterialState.focused)) {
         return BorderSide(color: _colors.error, width: 2.0);
       }
+      if (states.contains(MaterialState.hovered)) {
+        return BorderSide(color: _colors.onErrorContainer);
+      }
       return BorderSide(color: _colors.error);
-    }
-    if (states.contains(MaterialState.hovered)) {
-      return BorderSide(color: _colors.onSurface);
     }
     if (states.contains(MaterialState.focused)) {
       return BorderSide(color: _colors.primary, width: 2.0);
+    }
+    if (states.contains(MaterialState.hovered)) {
+      return BorderSide(color: _colors.onSurface);
     }
     return BorderSide(color: _colors.outline);
   });

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -544,6 +544,25 @@ void main() {
           expect(getBorderColor(tester), theme.colorScheme.primary);
           expect(getBorderWeight(tester), 2.0);
         });
+
+        testWidgets('active indicator has correct weight and color when focused and hovered', (WidgetTester tester) async {
+          // Regression test for https://github.com/flutter/flutter/issues/145897.
+          await tester.pumpWidget(
+            buildInputDecorator(
+              isFocused: true,
+              isHovering: true,
+              decoration: const InputDecoration(
+                filled: true,
+                labelText: labelText,
+                helperText: helperText,
+              ),
+            ),
+          );
+
+          final ThemeData theme = Theme.of(tester.element(findDecorator()));
+          expect(getBorderColor(tester), theme.colorScheme.primary);
+          expect(getBorderWeight(tester), 2.0);
+        });
       });
 
       group('when field is in error', () {
@@ -634,6 +653,25 @@ void main() {
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           expect(getBorderColor(tester), theme.colorScheme.onErrorContainer);
           expect(getBorderWeight(tester), 1.0);
+        });
+
+        testWidgets('active indicator has correct weight and color when focused and hovered', (WidgetTester tester) async {
+          // Regression test for https://github.com/flutter/flutter/issues/145897.
+          await tester.pumpWidget(
+            buildInputDecorator(
+              isFocused: true,
+              isHovering: true,
+              decoration: const InputDecoration(
+                filled: true,
+                labelText: labelText,
+                errorText: errorText,
+              ),
+            ),
+          );
+
+          final ThemeData theme = Theme.of(tester.element(findDecorator()));
+          expect(getBorderColor(tester), theme.colorScheme.error);
+          expect(getBorderWeight(tester), 2.0);
         });
       });
 
@@ -872,6 +910,25 @@ void main() {
           expect(getBorderColor(tester), theme.colorScheme.primary);
           expect(getBorderWeight(tester), 2.0);
         });
+
+        testWidgets('outline has correct weight and color when focused and hovered', (WidgetTester tester) async {
+          // Regression test for https://github.com/flutter/flutter/issues/145897.
+          await tester.pumpWidget(
+            buildInputDecorator(
+              isFocused: true,
+              isHovering: true,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: labelText,
+                helperText: helperText,
+              ),
+            ),
+          );
+
+          final ThemeData theme = Theme.of(tester.element(findDecorator()));
+          expect(getBorderColor(tester), theme.colorScheme.primary);
+          expect(getBorderWeight(tester), 2.0);
+        });
       });
 
       group('when field is in error', () {
@@ -958,6 +1015,25 @@ void main() {
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
           expect(getBorderColor(tester), theme.colorScheme.onErrorContainer);
           expect(getBorderWeight(tester), 1.0);
+        });
+
+        testWidgets('outline has correct weight and color when focused and hovered', (WidgetTester tester) async {
+          // Regression test for https://github.com/flutter/flutter/issues/145897.
+          await tester.pumpWidget(
+            buildInputDecorator(
+              isFocused: true,
+              isHovering: true,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: labelText,
+                errorText: errorText,
+              ),
+            ),
+          );
+
+          final ThemeData theme = Theme.of(tester.element(findDecorator()));
+          expect(getBorderColor(tester), theme.colorScheme.error);
+          expect(getBorderWeight(tester), 2.0);
         });
       });
 


### PR DESCRIPTION
## Description

This PRs fixes the active indicator color for a filled text field and the border color for an outlined text field.
Previously, when a text field was focused and hovered, the hover color was used. With this PR the focus color is used.

Screenshots for a focused and hovered text field:

| Before | After |
|--------|--------|
| ![image](https://github.com/flutter/flutter/assets/840911/aeca2b25-e28b-4609-bd47-9d72b3cfb80d) | ![image](https://github.com/flutter/flutter/assets/840911/f4331178-8f1e-4cb8-a93f-7052a6770af7)| 


</details> 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/145897

## Tests

Adds 4 tests.
