### PR TITLE
Add `DropdownMenu` cursor behavior sample

### DIFF
--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
@@ -128,7 +128,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                   return DropdownMenuEntry<String>(value: value, label: value);
                 }).toList(),
               ),
-              const Text('Defeered cursor is shown when hovering over the DropdownMenu.'),
+              const Text('Default cursor is shown when hovering over the DropdownMenu.'),
             ],
           ),
         ),
@@ -159,7 +159,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                   return DropdownMenuEntry<String>(value: value, label: value);
                 }).toList(),
               ),
-              const Text('Defeered cursor is shown when hovering over the DropdownMenu.'),
+              const Text('Default cursor is shown when hovering over the DropdownMenu.'),
             ],
           ),
         ),

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart
@@ -1,0 +1,169 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [DropdownMenu].
+
+const List<String> list = <String>['One', 'Two', 'Three', 'Four'];
+
+void main() => runApp(const DropdownMenuApp());
+
+class DropdownMenuApp extends StatelessWidget {
+  const DropdownMenuApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('DropdownMenu Sample')),
+        body: const Center(
+          child: DropdownMenuExample(),
+        ),
+      ),
+    );
+  }
+}
+
+class DropdownMenuExample extends StatefulWidget {
+  const DropdownMenuExample({super.key});
+
+  @override
+  State<DropdownMenuExample> createState() => _DropdownMenuExampleState();
+}
+
+class _DropdownMenuExampleState extends State<DropdownMenuExample> {
+  String dropdownValue = list.first;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return ListView(
+      children: <Widget>[
+        ListTile(
+          tileColor: colorScheme.primaryContainer,
+          title: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('enabled: true'),
+              Text('requestFocusOnTap: true'),
+            ],
+          ),
+          subtitle: Column(
+            children: <Widget>[
+              DropdownMenu<String>(
+                requestFocusOnTap: true,
+                initialSelection: list.first,
+                expandedInsets: EdgeInsets.zero,
+                onSelected: (String? value) {
+                  setState(() {
+                    dropdownValue = value!;
+                  });
+                },
+                dropdownMenuEntries:
+                    list.map<DropdownMenuEntry<String>>((String value) {
+                  return DropdownMenuEntry<String>(value: value, label: value);
+                }).toList(),
+              ),
+              const Text('Text cursor is shown when hovering over the DropdownMenu.'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        ListTile(
+          tileColor: colorScheme.primaryContainer,
+          title: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('enabled: true'),
+              Text('requestFocusOnTap: false'),
+            ],
+          ),
+          subtitle: Column(
+            children: <Widget>[
+              DropdownMenu<String>(
+                requestFocusOnTap: false,
+                initialSelection: list.first,
+                expandedInsets: EdgeInsets.zero,
+                onSelected: (String? value) {
+                  setState(() {
+                    dropdownValue = value!;
+                  });
+                },
+                dropdownMenuEntries:
+                    list.map<DropdownMenuEntry<String>>((String value) {
+                  return DropdownMenuEntry<String>(value: value, label: value);
+                }).toList(),
+              ),
+              const Text('Clickable cursor is shown when hovering over the DropdownMenu.'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        ListTile(
+          tileColor: colorScheme.onInverseSurface,
+          title: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('enabled: false'),
+              Text('requestFocusOnTap: true'),
+            ],
+          ),
+          subtitle: Column(
+            children: <Widget>[
+              DropdownMenu<String>(
+                enabled: false,
+                requestFocusOnTap: true,
+                initialSelection: list.first,
+                expandedInsets: EdgeInsets.zero,
+                onSelected: (String? value) {
+                  setState(() {
+                    dropdownValue = value!;
+                  });
+                },
+                dropdownMenuEntries:
+                    list.map<DropdownMenuEntry<String>>((String value) {
+                  return DropdownMenuEntry<String>(value: value, label: value);
+                }).toList(),
+              ),
+              const Text('Defeered cursor is shown when hovering over the DropdownMenu.'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        ListTile(
+          tileColor: colorScheme.onInverseSurface,
+          title: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('enabled: false'),
+              Text('requestFocusOnTap: false'),
+            ],
+          ),
+          subtitle: Column(
+            children: <Widget>[
+              DropdownMenu<String>(
+                enabled: false,
+                requestFocusOnTap: false,
+                initialSelection: list.first,
+                expandedInsets: EdgeInsets.zero,
+                onSelected: (String? value) {
+                  setState(() {
+                    dropdownValue = value!;
+                  });
+                },
+                dropdownMenuEntries:
+                    list.map<DropdownMenuEntry<String>>((String value) {
+                  return DropdownMenuEntry<String>(value: value, label: value);
+                }).toList(),
+              ),
+              const Text('Defeered cursor is shown when hovering over the DropdownMenu.'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/api/test/material/dropdown_menu/dropdown_menu.2_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.2_test.dart
@@ -19,29 +19,25 @@ void main() {
       return find.byType(TextField).at(index);
     }
 
-    // Hover over the enabled and requestFocusOnTap set to true text field.
+    // Hover over the "enabled and requestFocusOnTap set to true" text field.
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
     await gesture.moveTo(tester.getCenter(textFieldFinder(0)));
 
-    // The cursor should be a text cursor.
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
 
-    // Hover over the enabled and requestFocusOnTap set to false text field.
+    // Hover over the "enabled and requestFocusOnTap set to false" text field.
     await gesture.moveTo(tester.getCenter(textFieldFinder(1)));
 
-    // The cursor should be a text cursor.
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.click);
 
-    // Hover over the disabled and requestFocusOnTap set to true text field.
+    // Hover over the "disabled and requestFocusOnTap set to true" text field.
     await gesture.moveTo(tester.getCenter(textFieldFinder(2)));
 
-    // The cursor should be defer.
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
 
-    // Hover over the disabled and requestFocusOnTap set to false text field.
-    await gesture.moveTo(tester.getCenter(textFieldFinder(3)));
+    // Hover over the "disabled and requestFocusOnTap set to false" text field.
+   await gesture.moveTo(tester.getCenter(textFieldFinder(3)));
 
-    // The cursor should be defer.
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
   });
 }

--- a/examples/api/test/material/dropdown_menu/dropdown_menu.2_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.2_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_api_samples/material/dropdown_menu/dropdown_menu.2.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DropdownMenu cursor behavoir', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.DropdownMenuApp(),
+    );
+
+    Finder textFieldFinder(int index) {
+      return find.byType(TextField).at(index);
+    }
+
+    // Hover over the enabled and requestFocusOnTap set to true text field.
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.moveTo(tester.getCenter(textFieldFinder(0)));
+
+    // The cursor should be a text cursor.
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+
+    // Hover over the enabled and requestFocusOnTap set to false text field.
+    await gesture.moveTo(tester.getCenter(textFieldFinder(1)));
+
+    // The cursor should be a text cursor.
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.click);
+
+    // Hover over the disabled and requestFocusOnTap set to true text field.
+    await gesture.moveTo(tester.getCenter(textFieldFinder(2)));
+
+    // The cursor should be defer.
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+
+    // Hover over the disabled and requestFocusOnTap set to false text field.
+    await gesture.moveTo(tester.getCenter(textFieldFinder(3)));
+
+    // The cursor should be defer.
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+  });
+}

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -170,6 +170,13 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Determine if the [DropdownMenu] is enabled.
   ///
   /// Defaults to true.
+  ///
+  /// {@tool dartpad}
+  /// This sample demonstrates the cursor behavior when hovering over the text field
+  /// using the [enabled] and [requestFocusOnTap] properties.
+  ///
+  /// ** See code in examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart **
+  /// {@end-tool}
   final bool enabled;
 
   /// Determine the width of the [DropdownMenu].
@@ -338,6 +345,13 @@ class DropdownMenu<T> extends StatefulWidget {
   ///    focus when activated.
   ///
   /// Set this to true or false explicitly to override the default behavior.
+  ///
+  /// {@tool dartpad}
+  /// This sample demonstrates the cursor behavior when hovering over the text field
+  /// using the [enabled] and [requestFocusOnTap] properties.
+  ///
+  /// ** See code in examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart **
+  /// {@end-tool}
   final bool? requestFocusOnTap;
 
   /// Descriptions of the menu items in the [DropdownMenu].

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -172,8 +172,8 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Defaults to true.
   ///
   /// {@tool dartpad}
-  /// This sample demonstrates the cursor behavior when hovering over the text field
-  /// using the [enabled] and [requestFocusOnTap] properties.
+  /// This sample demonstrates how the [enabled] and [requestFocusOnTap] properties
+  /// affect the textfield's hover cursor.
   ///
   /// ** See code in examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart **
   /// {@end-tool}
@@ -347,8 +347,8 @@ class DropdownMenu<T> extends StatefulWidget {
   /// Set this to true or false explicitly to override the default behavior.
   ///
   /// {@tool dartpad}
-  /// This sample demonstrates the cursor behavior when hovering over the text field
-  /// using the [enabled] and [requestFocusOnTap] properties.
+  /// This sample demonstrates how the [enabled] and [requestFocusOnTap] properties
+  /// affect the textfield's hover cursor.
   ///
   /// ** See code in examples/api/lib/material/dropdown_menu/dropdown_menu.2.dart **
   /// {@end-tool}


### PR DESCRIPTION
fixes [Add `DropdownMenu` cursor behavior sample to  `DropdownMenu.enabled` & `DropdownMenu.requestFocusOnTap`  docs](https://github.com/flutter/flutter/issues/146131)

### Preview
![Screenshot 2024-04-02 at 17 12 43](https://github.com/flutter/flutter/assets/48603081/33865ca0-d48d-4651-9c83-9bdcd6369cb8)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
