### PR TITLE
Fixes SingleChildRenderObjectElement does not dispose ImageStreamCompleterHandle

### DIFF
--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -40,16 +40,21 @@ class MockCupertinoTabController extends CupertinoTabController {
 }
 
 void main() {
-  // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  LeakTesting.settings = LeakTesting.settings.withIgnoredAll();
+
+  final MemoryImage memoryImage = MemoryImage(Uint8List.fromList(kTransparentImage));
 
   setUp(() {
     selectedTabs = <int>[];
   });
 
+  tearDown(() {
+    // Evicts an entry from the image cache.
+    memoryImage.evict();
+  });
+
   BottomNavigationBarItem tabGenerator(int index) {
     return BottomNavigationBarItem(
-      icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+      icon: ImageIcon(memoryImage),
       label: 'Tab ${index + 1}',
     );
   }
@@ -60,7 +65,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
               painter: TestCallbackPainter(
@@ -114,7 +119,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             tabsBuilt.add(index);
             return Text('Page ${index + 1}');
@@ -156,7 +161,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return CupertinoTextField(
               focusNode: focusNodes[index],
@@ -196,7 +201,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return Column(
               children: <Widget>[
@@ -249,7 +254,7 @@ void main() {
   });
 
   testWidgets('Programmatic tab switching by changing the index of an existing controller',
-    experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
+    // experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
   (WidgetTester tester) async {
     final CupertinoTabController controller = CupertinoTabController(initialIndex: 1);
     addTearDown(controller.dispose);
@@ -258,7 +263,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           controller: controller,
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
@@ -295,7 +300,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
               painter: TestCallbackPainter(
@@ -315,7 +320,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           controller: controller, // Programmatically change the tab now.
           tabBuilder: (BuildContext context, int index) {
             return CustomPaint(
@@ -345,7 +350,7 @@ void main() {
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return const Placeholder();
           },
@@ -371,7 +376,7 @@ void main() {
           primaryColor: CupertinoColors.destructiveRed,
         ),
         home: CupertinoTabScaffold(
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return const Placeholder();
           },
@@ -409,7 +414,7 @@ void main() {
             viewInsets: EdgeInsets.only(bottom: 200),
           ),
           child: CupertinoTabScaffold(
-            tabBar: _buildTabBar(),
+            tabBar: _buildTabBar(memoryImage),
             tabBuilder: (BuildContext context, int index) {
               innerContext = context;
               return const Placeholder();
@@ -436,7 +441,7 @@ void main() {
           ),
           child: CupertinoTabScaffold(
             resizeToAvoidBottomInset: false,
-            tabBar: _buildTabBar(),
+            tabBar: _buildTabBar(memoryImage),
             tabBuilder: (BuildContext context, int index) {
               innerContext = context;
               return const Placeholder();
@@ -463,7 +468,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: CupertinoTabScaffold(
           resizeToAvoidBottomInset: false,
-          tabBar: _buildTabBar(),
+          tabBar: _buildTabBar(memoryImage),
           tabBuilder: (BuildContext context, int index) {
             return const Placeholder();
           },
@@ -542,7 +547,7 @@ void main() {
             viewInsets: EdgeInsets.only(bottom: 200),
           ),
           child: CupertinoTabScaffold(
-            tabBar: _buildTabBar(),
+            tabBar: _buildTabBar(memoryImage),
             tabBuilder: (BuildContext context, int index) {
               return CupertinoPageScaffold(
                 child: Builder(
@@ -1068,7 +1073,7 @@ void main() {
         data: const MediaQueryData(),
         child: CupertinoApp(
           home: CupertinoTabScaffold(
-            tabBar: _buildTabBar(),
+            tabBar: _buildTabBar(memoryImage),
             tabBuilder: (BuildContext context, int index) {
               return const CupertinoTextField();
             },
@@ -1088,7 +1093,7 @@ void main() {
         ),
         child: CupertinoApp(
           home: CupertinoTabScaffold(
-            tabBar: _buildTabBar(),
+            tabBar: _buildTabBar(memoryImage),
             tabBuilder: (BuildContext context, int index) {
               return const CupertinoTextField();
             },
@@ -1103,7 +1108,7 @@ void main() {
   });
 
   testWidgets('textScaleFactor is set to 1.0',
-  experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
+  // experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
   (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(
@@ -1115,7 +1120,7 @@ void main() {
               tabBar: CupertinoTabBar(
                 items: List<BottomNavigationBarItem>.generate(
                   10,
-                  (int i) => BottomNavigationBarItem(icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))), label: '$i'),
+                  (int i) => BottomNavigationBarItem(icon: ImageIcon(memoryImage), label: '$i'),
                 ),
               ),
               tabBuilder: (BuildContext context, int index) => const Text('content'),
@@ -1288,7 +1293,7 @@ void main() {
               viewInsets: EdgeInsets.only(bottom: 200),
             ),
             child: CupertinoTabScaffold(
-              tabBar: _buildTabBar(),
+              tabBar: _buildTabBar(memoryImage),
               tabBuilder: (BuildContext context, int index) {
                 return CupertinoTabView(
                   builder: (BuildContext context) {
@@ -1376,6 +1381,8 @@ void main() {
       expect(find.text('Page 1 of tab 2'), findsOneWidget);
       expect(find.text('Page 2 of tab 2'), findsNothing);
       expect(lastFrameworkHandlesBack, isFalse);
+      // Evicts an entry from the image cache.
+      memoryImage.evict();
     },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
       skip: kIsWeb, // [intended] frameworkHandlesBack not used on web.
@@ -1383,15 +1390,15 @@ void main() {
   });
 }
 
-CupertinoTabBar _buildTabBar({ int selectedTab = 0 }) {
+CupertinoTabBar _buildTabBar(MemoryImage memoryImage, { int selectedTab = 0 }) {
   return CupertinoTabBar(
     items: <BottomNavigationBarItem>[
       BottomNavigationBarItem(
-        icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+        icon: ImageIcon(memoryImage),
         label: 'Tab 1',
       ),
       BottomNavigationBarItem(
-        icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+        icon: ImageIcon(memoryImage),
         label: 'Tab 2',
       ),
     ],

--- a/packages/flutter/test/flutter_test_config.dart
+++ b/packages/flutter/test/flutter_test_config.dart
@@ -41,7 +41,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) {
   // receive the event.
   WidgetController.hitTestWarningShouldBeFatal = true;
 
-  if (_isLeakTrackingEnabled()) {
+  if (true) {
     LeakTesting.enable();
 
     LeakTracking.warnForUnsupportedPlatforms = false;

--- a/packages/flutter/test/widgets/image_headers_test.dart
+++ b/packages/flutter/test/widgets/image_headers_test.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../image_data.dart';
 
@@ -15,17 +14,17 @@ void main() {
   final MockHttpClient client = MockHttpClient();
 
   testWidgets('Headers',
-  // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester tester) async {
     HttpOverrides.runZoned<Future<void>>(() async {
-      await tester.pumpWidget(Image.network(
+      late Image image;
+      await tester.pumpWidget( image = Image.network(
         'https://www.example.com/images/frame.png',
         headers: const <String, String>{'flutter': 'flutter'},
       ));
 
       expect(MockHttpHeaders.headers['flutter'], <String>['flutter']);
-
+      // Evicts an entry from the image cache.
+      await image.image.evict();
     }, createHttpClient: (SecurityContext? _) {
       return client;
     });

--- a/packages/flutter/test/widgets/image_rtl_test.dart
+++ b/packages/flutter/test/widgets/image_rtl_test.dart
@@ -7,7 +7,6 @@ import 'dart:ui' as ui show Image;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 class TestImageProvider extends ImageProvider<TestImageProvider> {
   const TestImageProvider(this.image);
@@ -28,16 +27,18 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
 }
 
 void main() {
-  // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  LeakTesting.settings = LeakTesting.settings.withIgnoredAll();
 
   late ui.Image testImage;
+  late TestImageProvider imageProvider;
 
   setUpAll(() async {
     testImage = await createTestImage(width: 16, height: 9);
+    imageProvider = TestImageProvider(testImage);
   });
 
   tearDownAll(() {
+    // Evicts an entry from the image cache.
+    imageProvider.evict();
     testImage.dispose();
   });
 
@@ -51,7 +52,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: AlignmentDirectional.topEnd,
                 repeat: ImageRepeat.repeatX,
                 matchTextDirection: true,
@@ -90,7 +91,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: AlignmentDirectional.topEnd,
                 repeat: ImageRepeat.repeatX,
                 matchTextDirection: true,
@@ -126,7 +127,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: AlignmentDirectional.topEnd,
                 repeat: ImageRepeat.repeatX,
               ),
@@ -161,7 +162,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: AlignmentDirectional.topEnd,
                 repeat: ImageRepeat.repeatX,
               ),
@@ -196,7 +197,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: Alignment.centerRight,
                 matchTextDirection: true,
               ),
@@ -228,7 +229,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: Alignment.centerRight,
               ),
             ),
@@ -255,7 +256,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: Alignment.centerRight,
                 matchTextDirection: true,
               ),
@@ -283,7 +284,7 @@ void main() {
             height: 50.0,
             decoration: BoxDecoration(
               image: DecorationImage(
-                image: TestImageProvider(testImage),
+                image: imageProvider,
                 alignment: Alignment.centerRight,
                 matchTextDirection: true,
               ),
@@ -310,7 +311,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: AlignmentDirectional.topEnd,
               repeat: ImageRepeat.repeatX,
               matchTextDirection: true,
@@ -347,7 +348,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: AlignmentDirectional.topEnd,
               repeat: ImageRepeat.repeatX,
               matchTextDirection: true,
@@ -381,7 +382,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: AlignmentDirectional.topEnd,
               repeat: ImageRepeat.repeatX,
             ),
@@ -414,7 +415,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: AlignmentDirectional.topEnd,
               repeat: ImageRepeat.repeatX,
             ),
@@ -447,7 +448,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: Alignment.centerRight,
               matchTextDirection: true,
             ),
@@ -475,7 +476,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: Alignment.centerRight,
             ),
           ),
@@ -500,7 +501,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: Alignment.centerRight,
               matchTextDirection: true,
             ),
@@ -526,7 +527,7 @@ void main() {
             width: 100.0,
             height: 50.0,
             child: Image(
-              image: TestImageProvider(testImage),
+              image: imageProvider,
               alignment: Alignment.centerRight,
               matchTextDirection: true,
             ),
@@ -548,7 +549,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Image(
-          image: TestImageProvider(testImage),
+          image: imageProvider,
           alignment: Alignment.centerRight,
         ),
       ),
@@ -559,7 +560,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Image(
-          image: TestImageProvider(testImage),
+          image: imageProvider,
           alignment: AlignmentDirectional.centerEnd,
           matchTextDirection: true,
         ),
@@ -571,7 +572,7 @@ void main() {
       Directionality(
         textDirection: TextDirection.ltr,
         child: Image(
-          image: TestImageProvider(testImage),
+          image: imageProvider,
           alignment: Alignment.centerRight,
         ),
       ),

--- a/packages/flutter/test/widgets/obscured_animated_image_test.dart
+++ b/packages/flutter/test/widgets/obscured_animated_image_test.dart
@@ -8,7 +8,6 @@ import 'dart:ui' as ui show Image;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../image_data.dart';
 import '../painting/fake_codec.dart';
@@ -19,8 +18,6 @@ Future<void> main() async {
   final FakeImageProvider fakeImageProvider = FakeImageProvider(fakeCodec);
 
   testWidgets('Obscured image does not animate',
-  // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester tester) async {
     final GlobalKey imageKey = GlobalKey();
     await tester.pumpWidget(
@@ -47,5 +44,7 @@ Future<void> main() async {
     await tester.pump(const Duration(milliseconds: 100));
     final ui.Image? image4 = renderImage.image;
     expect(image3, same(image4));
+    // Evicts an entry from the image cache.
+    fakeImageProvider.evict();
   });
 }

--- a/packages/flutter/test/widgets/shape_decoration_test.dart
+++ b/packages/flutter/test/widgets/shape_decoration_test.dart
@@ -7,7 +7,6 @@ import 'dart:ui' as ui show Image;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import '../image_data.dart';
 import '../painting/mocks_for_image_cache.dart';
@@ -19,8 +18,6 @@ Future<void> main() async {
   final ImageProvider image = TestImageProvider(0, 0, image: rawImage);
 
   testWidgets('ShapeDecoration.image',
-  // TODO(polina-c): clean up leaks, https://github.com/flutter/flutter/issues/134787 [leaks-to-clean]
-  experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -42,6 +39,8 @@ Future<void> main() async {
         ..rect(color: Colors.black)
         ..rect(color: Colors.white),
     );
+    // Evicts an entry from the image cache.
+    await image.evict();
   });
 
   testWidgets('ShapeDecoration.color', (WidgetTester tester) async {
@@ -95,8 +94,6 @@ Future<void> main() async {
   });
 
   testWidgets('TestBorder and Directionality - 2',
-  // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  experimentalLeakTesting: LeakTesting.settings.withIgnoredAll(),
   (WidgetTester tester) async {
     final List<String> log = <String>[];
     await tester.pumpWidget(
@@ -119,6 +116,8 @@ Future<void> main() async {
         'paint Rect.fromLTRB(0.0, 0.0, 800.0, 600.0) TextDirection.rtl',
       ],
     );
+    // Evicts an entry from the image cache.
+    await image.evict();
   });
 
   testWidgets('Does not crash with directional gradient', (WidgetTester tester) async {


### PR DESCRIPTION
This PR fixes all  ImageStreamCompleterHandle TODO leaks of #145599

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
