### PR TITLE
Support `flutter run --wasm` and `flutter drive --wasm`.

### DIFF
--- a/dev/bots/suite_runners/run_web_long_running_tests.dart
+++ b/dev/bots/suite_runners/run_web_long_running_tests.dart
@@ -32,6 +32,7 @@ Future<void> webLongRunningTestsRunner(String flutterRoot) async {
         target: path.join('test_driver', 'failure.dart'),
         buildMode: buildMode,
         renderer: 'canvaskit',
+        wasm: false,
         // This test intentionally fails and prints stack traces in the browser
         // logs. To avoid confusion, silence browser output.
         silenceBrowserOutput: true,
@@ -42,6 +43,7 @@ Future<void> webLongRunningTestsRunner(String flutterRoot) async {
         driver: path.join('test_driver', 'integration_test.dart'),
         buildMode: buildMode,
         renderer: 'canvaskit',
+        wasm: false,
         expectWriteResponseFile: true,
         expectResponseFileContent: 'null',
       ),
@@ -51,6 +53,7 @@ Future<void> webLongRunningTestsRunner(String flutterRoot) async {
         driver: path.join('test_driver', 'extended_integration_test.dart'),
         buildMode: buildMode,
         renderer: 'canvaskit',
+        wasm: false,
         expectWriteResponseFile: true,
         expectResponseFileContent: '''
 {
@@ -97,6 +100,7 @@ Future<void> webLongRunningTestsRunner(String flutterRoot) async {
     () => _runWebE2eTest('capabilities_integration_canvaskit', buildMode: 'debug', renderer: 'auto'),
     () => _runWebE2eTest('capabilities_integration_canvaskit', buildMode: 'profile', renderer: 'canvaskit'),
     () => _runWebE2eTest('capabilities_integration_html', buildMode: 'release', renderer: 'html'),
+    () => _runWebE2eTest('capabilities_integration_skwasm', buildMode: 'release', renderer: 'skwasm', wasm: true),
 
     // This test doesn't do anything interesting w.r.t. rendering, so we don't run the full build mode x renderer matrix.
     // CacheWidth and CacheHeight are only currently supported in CanvasKit mode, so we don't run the test in HTML mode.
@@ -110,6 +114,7 @@ Future<void> webLongRunningTestsRunner(String flutterRoot) async {
       target: 'test_driver/smoke_web_engine.dart',
       buildMode: 'profile',
       renderer: 'auto',
+      wasm: false,
     ),
     () => _runGalleryE2eWebTest('debug'),
     () => _runGalleryE2eWebTest('debug', canvasKit: true),
@@ -192,12 +197,14 @@ Future<void> _runWebE2eTest(
   String name, {
   required String buildMode,
   required String renderer,
+  bool wasm = false,
 }) async {
   await _runFlutterDriverWebTest(
     target: path.join('test_driver', '$name.dart'),
     buildMode: buildMode,
     renderer: renderer,
     testAppDirectory: path.join(flutterRoot, 'dev', 'integration_tests', 'web_e2e_tests'),
+    wasm: wasm,
   );
 }
 
@@ -206,6 +213,7 @@ Future<void> _runFlutterDriverWebTest({
   required String buildMode,
   required String renderer,
   required String testAppDirectory,
+  required bool wasm,
   String? driver,
   bool expectFailure = false,
   bool silenceBrowserOutput = false,
@@ -235,6 +243,7 @@ Future<void> _runFlutterDriverWebTest({
       'web-server',
       '--$buildMode',
       '--web-renderer=$renderer',
+      if (wasm) '--wasm',
     ],
     expectNonZeroExit: expectFailure,
     workingDirectory: testAppDirectory,

--- a/dev/bots/suite_runners/run_web_long_running_tests.dart
+++ b/dev/bots/suite_runners/run_web_long_running_tests.dart
@@ -49,6 +49,16 @@ Future<void> webLongRunningTestsRunner(String flutterRoot) async {
       ),
       () => _runFlutterDriverWebTest(
         testAppDirectory: path.join('packages', 'integration_test', 'example'),
+        target: path.join('integration_test', 'example_test.dart'),
+        driver: path.join('test_driver', 'integration_test.dart'),
+        buildMode: buildMode,
+        renderer: 'skwasm',
+        wasm: true,
+        expectWriteResponseFile: true,
+        expectResponseFileContent: 'null',
+      ),
+      () => _runFlutterDriverWebTest(
+        testAppDirectory: path.join('packages', 'integration_test', 'example'),
         target: path.join('integration_test', 'extended_test.dart'),
         driver: path.join('test_driver', 'extended_integration_test.dart'),
         buildMode: buildMode,

--- a/dev/integration_tests/non_nullable/web/flutter_bootstrap.js
+++ b/dev/integration_tests/non_nullable/web/flutter_bootstrap.js
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+{{flutter_js}}
+{{flutter_build_config}}
+_flutter.loader.load({
+  config: {
+    // Use the local CanvasKit bundle instead of the CDN to reduce test flakiness.
+    canvasKitBaseUrl: "/canvaskit/",
+  },
+});

--- a/dev/integration_tests/non_nullable/web/index.html
+++ b/dev/integration_tests/non_nullable/web/index.html
@@ -22,16 +22,6 @@ found in the LICENSE file. -->
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
-  <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
-    }
-  </script>
-  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/dev/integration_tests/web_compile_tests/web/flutter_bootstrap.js
+++ b/dev/integration_tests/web_compile_tests/web/flutter_bootstrap.js
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+{{flutter_js}}
+{{flutter_build_config}}
+_flutter.loader.load({
+  config: {
+    // Use the local CanvasKit bundle instead of the CDN to reduce test flakiness.
+    canvasKitBaseUrl: "/canvaskit/",
+  },
+});

--- a/dev/integration_tests/web_compile_tests/web/index.html
+++ b/dev/integration_tests/web_compile_tests/web/index.html
@@ -7,6 +7,6 @@ found in the LICENSE file. -->
         <title>Hello, World</title>
     </head>
     <body>
-        <script src="main.dart.js"></script>
+        <script src="flutter_bootstrap.js" async></script>
     </body>
 </html>

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_canvaskit.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_canvaskit.dart
@@ -11,6 +11,8 @@ void main() {
 
   testWidgets('isCanvasKit returns true in CanvasKit mode', (WidgetTester tester) async {
     await tester.pumpAndSettle();
-    expect(isCanvasKit, true);
+    expect(isCanvasKit, false);
+    expect(isSkwasm, false);
+    expect(isSkiaWeb, true);
   });
 }

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_canvaskit.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_canvaskit.dart
@@ -11,7 +11,7 @@ void main() {
 
   testWidgets('isCanvasKit returns true in CanvasKit mode', (WidgetTester tester) async {
     await tester.pumpAndSettle();
-    expect(isCanvasKit, false);
+    expect(isCanvasKit, true);
     expect(isSkwasm, false);
     expect(isSkiaWeb, true);
   });

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_html.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_html.dart
@@ -8,7 +8,7 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('isCanvasKit returns false in HTML mode', (WidgetTester tester) async {
+  testWidgets('capabilities are set properly in HTML mode', (WidgetTester tester) async {
     await tester.pumpAndSettle();
     expect(isCanvasKit, false);
     expect(isSkwasm, false);

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_html.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_html.dart
@@ -11,5 +11,7 @@ void main() {
   testWidgets('isCanvasKit returns false in HTML mode', (WidgetTester tester) async {
     await tester.pumpAndSettle();
     expect(isCanvasKit, false);
+    expect(isSkwasm, false);
+    expect(isSkiaWeb, false);
   });
 }

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm.dart
@@ -9,7 +9,7 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('isCanvaskit returns false in Skwasm mode', (WidgetTester tester) async {
+  testWidgets('capabilities are set properly in Skwasm mode', (WidgetTester tester) async {
     await tester.pumpAndSettle();
     expect(isCanvasKit, false);
     expect(isSkwasm, true);

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm.dart
@@ -12,7 +12,7 @@ void main() {
   testWidgets('isCanvaskit returns false in Skwasm mode', (WidgetTester tester) async {
     await tester.pumpAndSettle();
     expect(isCanvasKit, false);
-
-    expect(const bool.fromEnvironment('dart.library.ffi'), true);
+    expect(isSkwasm, true);
+    expect(isSkiaWeb, true);
   });
 }

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm.dart
@@ -1,0 +1,18 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('isCanvaskit returns false in Skwasm mode', (WidgetTester tester) async {
+    await tester.pumpAndSettle();
+    expect(isCanvasKit, false);
+
+    expect(const bool.fromEnvironment('dart.library.ffi'), true);
+  });
+}

--- a/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm_test.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/capabilities_integration_skwasm_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart' as test;
+
+Future<void> main() async => test.integrationDriver();

--- a/examples/hello_world/web/flutter_bootstrap.js
+++ b/examples/hello_world/web/flutter_bootstrap.js
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+{{flutter_js}}
+{{flutter_build_config}}
+_flutter.loader.load({
+  config: {
+    // Use the local CanvasKit bundle instead of the CDN to reduce test flakiness.
+    canvasKitBaseUrl: "/canvaskit/",
+  },
+});

--- a/examples/hello_world/web/index.html
+++ b/examples/hello_world/web/index.html
@@ -7,6 +7,6 @@ found in the LICENSE file. -->
         <title>Hello, World</title>
     </head>
     <body>
-        <script src="main.dart.js"></script>
+        <script src="flutter_bootstrap.js" async></script>
     </body>
 </html>

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -64,7 +64,7 @@ class BuildWebCommand extends BuildSubCommand {
       help:
           'Sets the optimization level used for Dart compilation to JavaScript/Wasm.',
       defaultsTo: '${WebCompilerConfig.kDefaultOptimizationLevel}',
-      allowed: const <String>['1', '2', '3', '4'],
+      allowed: const <String>['0', '1', '2', '3', '4'],
     );
 
     //

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -30,6 +30,7 @@ import '../runner/flutter_command_runner.dart';
 import '../tracing.dart';
 import '../vmservice.dart';
 import '../web/compile.dart';
+import '../web/web_constants.dart';
 import '../web/web_runner.dart';
 import 'daemon.dart';
 
@@ -179,7 +180,13 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         hide: !verboseHelp,
         help: 'Uninstall previous versions of the app on the device '
               'before reinstalling. Currently only supported on iOS.',
-    );
+      )
+      ..addFlag(
+        FlutterOptions.kWebWasmFlag,
+        help: 'Compile to WebAssembly rather than JavaScript.\n$kWasmMoreInfo',
+        negatable: false,
+      );
+;
     usesWebOptions(verboseHelp: verboseHelp);
     usesTargetOption();
     usesPortOptions(verboseHelp: verboseHelp);
@@ -264,6 +271,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webBrowserFlags: webBrowserFlags,
         webHeaders: webHeaders,
         webRenderer: webRenderer,
+        webUseWasm: boolArg(FlutterOptions.kWebWasmFlag),
         enableImpeller: enableImpeller,
         enableVulkanValidation: enableVulkanValidation,
         uninstallFirst: uninstallFirst,
@@ -314,6 +322,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
         webHeaders: webHeaders,
         webRenderer: webRenderer,
+        webUseWasm: boolArg(FlutterOptions.kWebWasmFlag),
         vmserviceOutFile: stringArg('vmservice-out-file'),
         fastStart: argParser.options.containsKey('fast-start')
           && boolArg('fast-start')

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -237,10 +237,14 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
 
   WebRendererMode get webRenderer {
     final String? webRendererString = stringArg('web-renderer');
-    if (webRendererString == null) {
-      return useWasm ? WebRendererMode.skwasm : WebRendererMode.auto;
+    final WebRendererMode mode = webRendererString != null
+      ? WebRendererMode.values.byName(webRendererString)
+      : WebRendererMode.auto;
+    if (mode == WebRendererMode.auto && useWasm) {
+      // Wasm defaults to skwasm
+      return WebRendererMode.skwasm;
     }
-    return WebRendererMode.values.byName(webRendererString);
+    return mode;
   }
 
   /// Create a debugging options instance for the current `run` or `drive` invocation.

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -186,7 +186,6 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         help: 'Compile to WebAssembly rather than JavaScript.\n$kWasmMoreInfo',
         negatable: false,
       );
-;
     usesWebOptions(verboseHelp: verboseHelp);
     usesTargetOption();
     usesPortOptions(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -235,17 +235,10 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
 
   bool get useWasm => boolArg(FlutterOptions.kWebWasmFlag);
 
-  WebRendererMode get webRenderer {
-    final String? webRendererString = stringArg('web-renderer');
-    final WebRendererMode mode = webRendererString != null
-      ? WebRendererMode.values.byName(webRendererString)
-      : WebRendererMode.auto;
-    if (mode == WebRendererMode.auto && useWasm) {
-      // Wasm defaults to skwasm
-      return WebRendererMode.skwasm;
-    }
-    return mode;
-  }
+  WebRendererMode get webRenderer => WebRendererMode.fromCliOption(
+    stringArg(FlutterOptions.kWebRendererFlag),
+    useWasm: useWasm
+  );
 
   /// Create a debugging options instance for the current `run` or `drive` invocation.
   @visibleForTesting

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -330,17 +330,10 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     return super.verifyThenRunCommand(commandPath);
   }
 
-  WebRendererMode get webRenderer {
-    final String? webRendererString = stringArg('web-renderer');
-    final WebRendererMode mode = webRendererString != null
-      ? WebRendererMode.values.byName(webRendererString)
-      : WebRendererMode.auto;
-    if (mode == WebRendererMode.auto && useWasm) {
-      // Wasm defaults to skwasm
-      return WebRendererMode.skwasm;
-    }
-    return mode;
-  }
+  WebRendererMode get webRenderer => WebRendererMode.fromCliOption(
+    stringArg(FlutterOptions.kWebRendererFlag),
+    useWasm: useWasm
+  );
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -330,6 +330,14 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     return super.verifyThenRunCommand(commandPath);
   }
 
+  WebRendererMode get webRenderer {
+    final String? webRendererString = stringArg('web-renderer');
+    if (webRendererString == null) {
+      return useWasm ? WebRendererMode.skwasm : WebRendererMode.auto;
+    }
+    return WebRendererMode.values.byName(webRendererString);
+  }
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     if (!globals.fs.isFileSync('pubspec.yaml')) {
@@ -388,10 +396,6 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       );
     }
 
-    final String? webRendererString = stringArg('web-renderer');
-    final WebRendererMode webRenderer = (webRendererString != null)
-        ? WebRendererMode.values.byName(webRendererString)
-        : WebRendererMode.auto;
     final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(
       buildInfo,
       startPaused: startPaused,
@@ -510,6 +514,10 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
 
     if (!isWeb && useWasm) {
       throwToolExit('--wasm is only supported on the web platform');
+    }
+
+    if (webRenderer == WebRendererMode.skwasm && !useWasm) {
+      throwToolExit('Skwasm renderer requires --wasm');
     }
 
     Device? integrationTestDevice;

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -405,6 +405,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       enableImpeller: ImpellerStatus.fromBool(argResults!['enable-impeller'] as bool?),
       debugLogsDirectoryPath: debugLogsDirectoryPath,
       webRenderer: webRenderer,
+      webUseWasm: useWasm,
     );
 
     String? testAssetDirectory;
@@ -589,7 +590,6 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         testAssetDirectory: testAssetDirectory,
         flutterProject: flutterProject,
         web: isWeb,
-        useWasm: useWasm,
         randomSeed: stringArg('test-randomize-ordering-seed'),
         reporter: stringArg('reporter'),
         fileReporter: stringArg('file-reporter'),

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -332,10 +332,14 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
 
   WebRendererMode get webRenderer {
     final String? webRendererString = stringArg('web-renderer');
-    if (webRendererString == null) {
-      return useWasm ? WebRendererMode.skwasm : WebRendererMode.auto;
+    final WebRendererMode mode = webRendererString != null
+      ? WebRendererMode.values.byName(webRendererString)
+      : WebRendererMode.auto;
+    if (mode == WebRendererMode.auto && useWasm) {
+      // Wasm defaults to skwasm
+      return WebRendererMode.skwasm;
     }
-    return WebRendererMode.values.byName(webRendererString);
+    return mode;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -994,6 +994,7 @@ class DebuggingOptions {
     this.webHeaders = const <String, String>{},
     this.webLaunchUrl,
     this.webRenderer = WebRendererMode.auto,
+    this.webUseWasm = false,
     this.vmserviceOutFile,
     this.fastStart = false,
     this.nullAssertions = false,
@@ -1024,6 +1025,7 @@ class DebuggingOptions {
       this.webLaunchUrl,
       this.webHeaders = const <String, String>{},
       this.webRenderer = WebRendererMode.auto,
+      this.webUseWasm = false,
       this.cacheSkSL = false,
       this.traceAllowlist,
       this.enableImpeller = ImpellerStatus.platformDefault,
@@ -1104,6 +1106,7 @@ class DebuggingOptions {
     required this.webHeaders,
     required this.webLaunchUrl,
     required this.webRenderer,
+    required this.webUseWasm,
     required this.vmserviceOutFile,
     required this.fastStart,
     required this.nullAssertions,
@@ -1190,6 +1193,9 @@ class DebuggingOptions {
 
   /// Which web renderer to use for the debugging session
   final WebRendererMode webRenderer;
+
+  /// Whether to compile to webassembly
+  final bool webUseWasm;
 
   /// A file where the VM Service URL should be written after the application is started.
   final String? vmserviceOutFile;
@@ -1300,6 +1306,7 @@ class DebuggingOptions {
     'webLaunchUrl': webLaunchUrl,
     'webHeaders': webHeaders,
     'webRenderer': webRenderer.name,
+    'webUseWasm': webUseWasm,
     'vmserviceOutFile': vmserviceOutFile,
     'fastStart': fastStart,
     'nullAssertions': nullAssertions,
@@ -1356,6 +1363,7 @@ class DebuggingOptions {
       webHeaders: (json['webHeaders']! as Map<dynamic, dynamic>).cast<String, String>(),
       webLaunchUrl: json['webLaunchUrl'] as String?,
       webRenderer: WebRendererMode.values.byName(json['webRenderer']! as String),
+      webUseWasm: json['webUseWasm']! as bool,
       vmserviceOutFile: json['vmserviceOutFile'] as String?,
       fastStart: json['fastStart']! as bool,
       nullAssertions: json['nullAssertions']! as bool,

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -79,6 +79,7 @@ class WebDriverService extends DriverService {
           port: debuggingOptions.port,
           hostname: debuggingOptions.hostname,
           webRenderer: debuggingOptions.webRenderer,
+          webUseWasm: debuggingOptions.webUseWasm
         )
         : DebuggingOptions.enabled(
           buildInfo,
@@ -86,6 +87,7 @@ class WebDriverService extends DriverService {
           hostname: debuggingOptions.hostname,
           disablePortPublication: debuggingOptions.disablePortPublication,
           webRenderer: debuggingOptions.webRenderer,
+          webUseWasm: debuggingOptions.webUseWasm,
         ),
       stayResident: true,
       flutterProject: FlutterProject.current(),

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -120,7 +120,6 @@ class WebAssetServer implements AssetReader {
     this._nullSafetyMode,
     this._ddcModuleSystem, {
     required this.webRenderer,
-    required this.isWasm,
   }) : basePath = _getWebTemplate('index.html', _kDefaultIndex).getBaseHref();
 
   // Fallback to "application/octet-stream" on null which
@@ -234,7 +233,6 @@ class WebAssetServer implements AssetReader {
       nullSafetyMode,
       ddcModuleSystem,
       webRenderer: webRenderer,
-      isWasm: isWasm,
     );
     if (testMode) {
       return server;
@@ -531,24 +529,16 @@ class WebAssetServer implements AssetReader {
   /// Determines what rendering backed to use.
   final WebRendererMode webRenderer;
 
-  /// Whether the build we are hosting is compiled to wasm.
-  final bool isWasm;
-
   String get _buildConfigString {
-    final Map<String, dynamic> build = isWasm
-      ? <String, dynamic>{
-        'compileTarget': 'dart2wasm',
-        'renderer': webRenderer.name,
-        'mainWasmPath': 'main.dart.wasm',
-        'jsSupportRuntimePath': 'main.dart.mjs',
-      } : <String, dynamic>{
-        'compileTarget': 'dartdevc',
-        'renderer': webRenderer.name,
-        'mainJsPath': 'main.dart.js',
-      };
     final Map<String, dynamic> buildConfig = <String, dynamic>{
       'engineRevision': globals.flutterVersion.engineRevision,
-      'builds': <dynamic>[build],
+      'builds': <dynamic>[
+        <String, dynamic>{
+          'compileTarget': 'dartdevc',
+          'renderer': webRenderer.name,
+          'mainJsPath': 'main.dart.js',
+        },
+      ],
     };
     return '''
 if (!window._flutter) {

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -134,9 +134,9 @@ class ResidentWebRunner extends ResidentRunner {
   // and platform initialization.
   Directory? _generatedEntrypointDirectory;
 
-  // Only the debug builds of the web support the service protocol.
+  // Only non-wasm debug builds of the web support the service protocol.
   @override
-  bool get supportsServiceProtocol => isRunningDebug && deviceIsDebuggable;
+  bool get supportsServiceProtocol => !debuggingOptions.webUseWasm && isRunningDebug && deviceIsDebuggable;
 
   @override
   bool get debuggingEnabled => isRunningDebug && deviceIsDebuggable;

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -311,13 +311,14 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           nativeNullAssertions: debuggingOptions.nativeNullAssertions,
           ddcModuleSystem: debuggingOptions.buildInfo.ddcModuleFormat == DdcModuleFormat.ddc,
           webRenderer: debuggingOptions.webRenderer,
+          isWasm: debuggingOptions.webUseWasm,
           rootDirectory: fileSystem.directory(projectRootPath),
         );
         Uri url = await device!.devFS!.create();
         if (debuggingOptions.tlsCertKeyPath != null && debuggingOptions.tlsCertPath != null) {
           url = url.replace(scheme: 'https');
         }
-        if (debuggingOptions.buildInfo.isDebug) {
+        if (debuggingOptions.buildInfo.isDebug && !debuggingOptions.webUseWasm) {
           await runSourceGenerators();
           final UpdateFSReport report = await _updateDevFS(fullRestart: true);
           if (!report.success) {
@@ -342,12 +343,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
             target,
             debuggingOptions.buildInfo,
             ServiceWorkerStrategy.none,
-            compilerConfigs: <WebCompilerConfig>[
-              JsCompilerConfig.run(
-                nativeNullAssertions: debuggingOptions.nativeNullAssertions,
-                renderer: debuggingOptions.webRenderer,
-              )
-            ]
+            compilerConfigs: <WebCompilerConfig>[_compilerConfig],
           );
         }
         await device!.device!.startApp(
@@ -386,6 +382,17 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     }
   }
 
+  WebCompilerConfig get _compilerConfig => (debuggingOptions.webUseWasm)
+    ? WasmCompilerConfig(
+        optimizationLevel: 0,
+        stripWasm: false,
+        renderer: debuggingOptions.webRenderer
+      )
+    : JsCompilerConfig.run(
+        nativeNullAssertions: debuggingOptions.nativeNullAssertions,
+        renderer: debuggingOptions.webRenderer,
+      );
+
   @override
   Future<OperationResult> restart({
     bool fullRestart = false,
@@ -399,7 +406,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
       progressId: 'hot.restart',
     );
 
-    if (debuggingOptions.buildInfo.isDebug) {
+    if (debuggingOptions.buildInfo.isDebug && !debuggingOptions.webUseWasm) {
       await runSourceGenerators();
       // Full restart is always false for web, since the extra recompile is wasteful.
       final UpdateFSReport report = await _updateDevFS();
@@ -426,12 +433,7 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
           target,
           debuggingOptions.buildInfo,
           ServiceWorkerStrategy.none,
-          compilerConfigs: <WebCompilerConfig>[
-            JsCompilerConfig.run(
-              nativeNullAssertions: debuggingOptions.nativeNullAssertions,
-              renderer: debuggingOptions.webRenderer,
-            )
-          ],
+          compilerConfigs: <WebCompilerConfig>[_compilerConfig],
         );
       } on ToolExit {
         return OperationResult(1, 'Failed to recompile application.');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1181,10 +1181,10 @@ abstract class ResidentRunner extends ResidentHandlers {
   bool get debuggingEnabled => debuggingOptions.debuggingEnabled;
 
   @override
-  bool get isRunningDebug => debuggingOptions.buildInfo.isDebug;
+  bool get isRunningDebug => !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isDebug;
 
   @override
-  bool get isRunningProfile => debuggingOptions.buildInfo.isProfile;
+  bool get isRunningProfile => !debuggingOptions.webUseWasm && debuggingOptions.buildInfo.isProfile;
 
   @override
   bool get isRunningRelease => debuggingOptions.buildInfo.isRelease;

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -52,7 +52,6 @@ abstract class FlutterTestRunner {
     String? icudtlPath,
     Directory? coverageDirectory,
     bool web = false,
-    bool useWasm = false,
     String? randomSeed,
     String? reporter,
     String? fileReporter,
@@ -118,7 +117,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     String? icudtlPath,
     Directory? coverageDirectory,
     bool web = false,
-    bool useWasm = false,
     String? randomSeed,
     String? reporter,
     String? fileReporter,
@@ -188,7 +186,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         testFiles: testFiles.map((Uri uri) => uri.toFilePath()).toList(),
         buildInfo: debuggingOptions.buildInfo,
         webRenderer: debuggingOptions.webRenderer,
-        useWasm: useWasm,
+        useWasm: debuggingOptions.webUseWasm,
       );
       testArgs
         ..add('--platform=chrome')
@@ -221,7 +219,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
             ),
             testTimeRecorder: testTimeRecorder,
             webRenderer: debuggingOptions.webRenderer,
-            useWasm: useWasm,
+            useWasm: debuggingOptions.webUseWasm,
           );
         },
       );

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -184,6 +184,17 @@ enum WebRendererMode implements CliEnum {
   /// Always use skwasm.
   skwasm;
 
+  factory WebRendererMode.fromCliOption(String? webRendererString, {required bool useWasm}) {
+    final WebRendererMode mode = webRendererString != null
+      ? WebRendererMode.values.byName(webRendererString)
+      : WebRendererMode.auto;
+    if (mode == WebRendererMode.auto && useWasm) {
+      // Wasm defaults to skwasm
+      return WebRendererMode.skwasm;
+    }
+    return mode;
+  }
+
   @override
   String get cliName => snakeCase(name, '-');
 

--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -22,7 +22,7 @@ sealed class WebCompilerConfig {
 
   /// The compiler optimization level.
   ///
-  /// Valid values are O1 (lowest, profile default) to O4 (highest, release default).
+  /// Valid values are O0 (lowest, debug default) to O4 (highest, release default).
   final int optimizationLevel;
 
   /// Returns which target this compiler outputs (js or wasm)

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -986,6 +986,36 @@ void main() {
         DeviceManager: () => testDeviceManager,
       });
 
+      testUsingContext('throws a ToolExit when using --wasm on a non-web platform', () async {
+        final RunCommand command = RunCommand();
+        await expectLater(
+          () => createTestCommandRunner(command).run(<String>[
+            'run',
+            '--no-pub',
+            '--wasm',
+          ]), throwsToolExit(message: '--wasm is only supported on the web platform'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      });
+
+      testUsingContext('throws a ToolExit when using the skwasm renderer without --wasm', () async {
+        final RunCommand command = RunCommand();
+        await expectLater(
+          () => createTestCommandRunner(command).run(<String>[
+            'run',
+            '--no-pub',
+            '--web-renderer=skwasm',
+          ]), throwsToolExit(message: 'Skwasm renderer requires --wasm'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
+      });
+
       testUsingContext('accepts headers with commas in them', () async {
         final RunCommand command = RunCommand();
         await expectLater(

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -29,6 +29,7 @@ import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/vmservice.dart';
+import 'package:flutter_tools/src/web/compile.dart';
 import 'package:test/fake.dart';
 import 'package:unified_analytics/unified_analytics.dart' as analytics;
 import 'package:vm_service/vm_service.dart';
@@ -1194,6 +1195,24 @@ void main() {
     expect(options.skiaDeterministicRendering, true);
     expect(options.usingCISystem, true);
     expect(options.debugLogsDirectoryPath, 'path/to/logs');
+  }, overrides: <Type, Generator>{
+    Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('wasm mode selects skwasm renderer by default', () async {
+    final RunCommand command = RunCommand();
+    await expectLater(() => createTestCommandRunner(command).run(<String>[
+      'run',
+      '-d chrome',
+      '--wasm',
+    ]), throwsToolExit());
+
+    final DebuggingOptions options = await command.createDebuggingOptions(false);
+
+    expect(options.webUseWasm, true);
+    expect(options.webRenderer, WebRendererMode.skwasm);
   }, overrides: <Type, Generator>{
     Cache: () => Cache.test(processManager: FakeProcessManager.any()),
     FileSystem: () => MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -1348,6 +1348,24 @@ dev_dependencies:
       FileSystem: () => fs,
       ProcessManager: () => FakeProcessManager.any(),
     });
+
+    testUsingContext('Web renderer defaults to Skwasm when using wasm', () async {
+      final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+      final TestCommand testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+        '--platform=chrome',
+        '--wasm',
+      ]);
+      expect(testRunner.lastDebuggingOptionsValue.webRenderer, WebRendererMode.skwasm);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_ddc_modules_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_ddc_modules_test.dart
@@ -137,6 +137,7 @@ void main() {
             flutterRoot: null, // ignore: avoid_redundant_argument_values
             platform: FakePlatform(),
             webBuildDirectory: null, // ignore: avoid_redundant_argument_values
+            needsCoopCoep: false,
           );
         },
         overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_ddc_modules_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_ddc_modules_test.dart
@@ -927,6 +927,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.unsound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.html,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1063,6 +1064,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.sound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.html,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1199,6 +1201,7 @@ void main() {
                 nullSafetyMode: NullSafetyMode.sound,
                 ddcModuleSystem: usesDdcModuleSystem,
                 webRenderer: WebRendererMode.canvaskit,
+                isWasm: false,
                 rootDirectory: globals.fs.currentDirectory,
               );
               webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1272,6 +1275,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.sound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.canvaskit,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1321,6 +1325,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.sound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.canvaskit,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1372,6 +1377,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.sound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.auto,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1425,6 +1431,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.unsound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.canvaskit,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);
@@ -1463,6 +1470,7 @@ void main() {
         const <String, String>{},
         NullSafetyMode.unsound,
         webRenderer: WebRendererMode.canvaskit,
+        isWasm: false,
         testMode: true);
 
     expect(webAssetServer.defaultResponseHeaders['x-frame-options'], null);
@@ -1496,6 +1504,7 @@ void main() {
         },
         NullSafetyMode.unsound,
         webRenderer: WebRendererMode.canvaskit,
+        isWasm: false,
         testMode: true);
 
     expect(webAssetServer.defaultResponseHeaders[extraHeaderKey],
@@ -1596,6 +1605,7 @@ void main() {
               nullSafetyMode: NullSafetyMode.unsound,
               ddcModuleSystem: usesDdcModuleSystem,
               webRenderer: WebRendererMode.canvaskit,
+              isWasm: false,
               rootDirectory: globals.fs.currentDirectory,
             );
             webDevFS.ddcModuleLoaderJS.createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -76,6 +76,7 @@ void main() {
         flutterRoot: null,
         platform: FakePlatform(),
         webBuildDirectory: null,
+        needsCoopCoep: false,
       );
     }, overrides: <Type, Generator>{
       Logger: () => logger,

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -715,6 +715,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.unsound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.html,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);
@@ -827,6 +828,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.sound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.html,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);
@@ -945,6 +947,7 @@ void main() {
         nullSafetyMode: NullSafetyMode.sound,
         ddcModuleSystem: usesDdcModuleSystem,
         webRenderer: WebRendererMode.canvaskit,
+        isWasm: false,
         rootDirectory: globals.fs.currentDirectory,
       );
       webDevFS.requireJS.createSync(recursive: true);
@@ -1009,6 +1012,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.sound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.canvaskit,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);
@@ -1057,6 +1061,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.sound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.canvaskit,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);
@@ -1106,6 +1111,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.sound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.auto,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);
@@ -1156,6 +1162,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.unsound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.canvaskit,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);
@@ -1194,6 +1201,7 @@ void main() {
       const <String, String>{},
       NullSafetyMode.unsound,
       webRenderer: WebRendererMode.canvaskit,
+      isWasm: false,
       testMode: true
     );
 
@@ -1228,6 +1236,7 @@ void main() {
       },
       NullSafetyMode.unsound,
       webRenderer: WebRendererMode.canvaskit,
+      isWasm: false,
       testMode: true
     );
 
@@ -1310,6 +1319,7 @@ void main() {
       nullSafetyMode: NullSafetyMode.unsound,
       ddcModuleSystem: usesDdcModuleSystem,
       webRenderer: WebRendererMode.canvaskit,
+      isWasm: false,
       rootDirectory: globals.fs.currentDirectory,
     );
     webDevFS.requireJS.createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -136,4 +136,44 @@ void main() {
 
     expect(response.statusCode, HttpStatus.ok);
   });
+
+  testWithoutContext('release asset server serves html content with COOP/COEP headers when specified', () async {
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base,
+      fileSystem: fileSystem,
+      platform: platform,
+      flutterRoot: '/flutter',
+      webBuildDirectory: 'build/web',
+      needsCoopCoep: true,
+    );
+    fileSystem.file('build/web/index.html')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('<html></html>');
+    final Response response = await assetServer
+      .handle(Request('GET', Uri.parse('http://localhost:8080/index.html')));
+
+    expect(response.statusCode, HttpStatus.ok);
+    final Map<String, String> headers = response.headers;
+    expect(headers['Cross-Origin-Opener-Policy'], 'same-origin');
+    expect(headers['Cross-Origin-Embedder-Policy'], 'require-corp');
+  });
+
+  testWithoutContext('release asset server serves html content without COOP/COEP headers when specified', () async {
+    final ReleaseAssetServer assetServer = ReleaseAssetServer(Uri.base,
+      fileSystem: fileSystem,
+      platform: platform,
+      flutterRoot: '/flutter',
+      webBuildDirectory: 'build/web',
+      needsCoopCoep: false,
+    );
+    fileSystem.file('build/web/index.html')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('<html></html>');
+    final Response response = await assetServer
+      .handle(Request('GET', Uri.parse('http://localhost:8080/index.html')));
+
+    expect(response.statusCode, HttpStatus.ok);
+    final Map<String, String> headers = response.headers;
+    expect(headers.containsKey('Cross-Origin-Opener-Policy'), false);
+    expect(headers.containsKey('Cross-Origin-Embedder-Policy'), false);
+  });
 }

--- a/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_asset_server_test.dart
@@ -49,6 +49,7 @@ void main() {
       platform: platform,
       flutterRoot: '/flutter',
       webBuildDirectory: 'build/web',
+      needsCoopCoep: false,
     );
     fileSystem.file('build/web/assets/foo.png')
       ..createSync(recursive: true)
@@ -68,6 +69,7 @@ void main() {
       platform: platform,
       flutterRoot: '/flutter',
       webBuildDirectory: 'build/web',
+      needsCoopCoep: false,
     );
     fileSystem.file('build/web/assets/foo.js')
       ..createSync(recursive: true)
@@ -87,6 +89,7 @@ void main() {
       platform: platform,
       flutterRoot: '/flutter',
       webBuildDirectory: 'build/web',
+      needsCoopCoep: false,
     );
     fileSystem.file('build/web/assets/foo.html')
       ..createSync(recursive: true)
@@ -106,6 +109,7 @@ void main() {
       platform: platform,
       flutterRoot: '/flutter',
       webBuildDirectory: 'build/web',
+      needsCoopCoep: false,
     );
     fileSystem.file('flutter/bar.dart')
       ..createSync(recursive: true)
@@ -122,6 +126,7 @@ void main() {
       platform: platform,
       flutterRoot: '/flutter',
       webBuildDirectory: 'build/web',
+      needsCoopCoep: false,
     );
     fileSystem.file('bar.dart')
       ..createSync(recursive: true)

--- a/packages/integration_test/example/web/flutter_bootstrap.js
+++ b/packages/integration_test/example/web/flutter_bootstrap.js
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+{{flutter_js}}
+{{flutter_build_config}}
+_flutter.loader.load({
+  config: {
+    // Use the local CanvasKit bundle instead of the CDN to reduce test flakiness.
+    canvasKitBaseUrl: "/canvaskit/",
+  },
+});

--- a/packages/integration_test/example/web/index.html
+++ b/packages/integration_test/example/web/index.html
@@ -21,16 +21,6 @@ found in the LICENSE file. -->
   <link rel="manifest" href="/manifest.json">
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
-  <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('/flutter_service_worker.js');
-      });
-    }
-  </script>
-  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
This adds support for adding the `--wasm` flag to `flutter run` and `flutter drive`
* Emits errors if you attempt to use the skwasm renderer without the `--wasm` flag
* Emits errors if you try to use `--wasm` when not using a web device
* Uses the skwasm renderer by default if you pass `--wasm` and no `--web-renderer`