### PR TITLE
[tools] Fix `--template=plugin_ffi` formatting

### DIFF
--- a/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
@@ -43,8 +43,7 @@ class {{pluginDartClass}}Bindings {
   }
 
   late final _sumPtr =
-      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int, ffi.Int)>>(
-          'sum');
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int, ffi.Int)>>('sum');
   late final _sum = _sumPtr.asFunction<int Function(int, int)>();
 
   /// A longer lived native function, which occupies the thread calling it.


### PR DESCRIPTION
It looks like the formatter was updated.

We have a test running on the FFIgen repo that checks that rerunning the generated bindings with FFIgen generates identical bindings.

Closes:

* https://github.com/dart-lang/native/issues/1072