### PR TITLE
Copy part files and sourcemaps when building with dart2js.

### DIFF
--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -170,6 +170,8 @@ void main() {
       ..writeAsStringSync('A');
     environment.buildDir.childFile('main.dart.js').createSync();
     environment.buildDir.childFile('main.dart.js.map').createSync();
+    environment.buildDir.childFile('main.dart.js_1.part.js').createSync();
+    environment.buildDir.childFile('main.dart.js_1.part.js.map').createSync();
 
     await WebReleaseBundle(<WebCompilerConfig>[
         const JsCompilerConfig()
@@ -180,6 +182,10 @@ void main() {
     expect(environment.outputDir.childFile('main.dart.js')
       .existsSync(), true);
     expect(environment.outputDir.childFile('main.dart.js.map')
+      .existsSync(), true);
+    expect(environment.outputDir.childFile('main.dart.js_1.part.js')
+      .existsSync(), true);
+    expect(environment.outputDir.childFile('main.dart.js_1.part.js.map')
       .existsSync(), true);
     expect(environment.outputDir.childDirectory('assets')
       .childFile('AssetManifest.bin.json').existsSync(), true);


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/145653

When dart2js emits deferred part files, they need to be copied from the build folder to the output folder.