### PR TITLE
print traces when transforming an asset

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -148,6 +148,7 @@ Future<Depfile> copyAssets(
                   outputPath: file.path,
                   workingDirectory: environment.projectDir.path,
                   transformerEntries: entry.value.transformers,
+                  logger: environment.logger,
                 );
                 doCopy = false;
                 if (failure != null) {

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -88,10 +88,11 @@ final class AssetTransformer {
           ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
         }
       }
+
+      logger.printTrace("Finished transforming asset at path '${asset.path}' (${stopwatch.elapsedMilliseconds}ms)");
     } finally {
       ErrorHandlingFileSystem.deleteIfExists(tempInputFile);
       ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
-      logger.printTrace("Finished transforming asset at path '${asset.path}' (${stopwatch.elapsedMilliseconds}ms)");
     }
 
     return null;

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -46,6 +46,7 @@ final class AssetTransformer {
     required String outputPath,
     required String workingDirectory,
     required List<AssetTransformerEntry> transformerEntries,
+    required Logger logger,
   }) async {
 
     String getTempFilePath(int transformStep) {
@@ -66,6 +67,7 @@ final class AssetTransformer {
           output: tempOutputFile,
           transformer: transformer,
           workingDirectory: workingDirectory,
+          logger: logger,
         );
 
         if (transformerFailure != null) {
@@ -98,6 +100,7 @@ final class AssetTransformer {
     required File output,
     required AssetTransformerEntry transformer,
     required String workingDirectory,
+    required Logger logger,
   }) async {
     final List<String> transformerArguments = <String>[
       '--input=${asset.absolute.path}',
@@ -112,6 +115,7 @@ final class AssetTransformer {
       ...transformerArguments,
     ];
 
+    logger.printTrace("Transforming asset using command '${command.join(' ')}'");
     final ProcessResult result = await _processManager.run(
       command,
       workingDirectory: workingDirectory,
@@ -190,6 +194,7 @@ final class DevelopmentAssetTransformer {
         outputPath: output.path,
         transformerEntries: transformerEntries,
         workingDirectory: workingDirectory,
+        logger: _logger,
       );
       if (failure != null) {
         _logger.printError(failure.message);

--- a/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
+++ b/packages/flutter_tools/lib/src/build_system/tools/asset_transformer.dart
@@ -60,6 +60,7 @@ final class AssetTransformer {
     File tempOutputFile = _fileSystem.systemTempDirectory.childFile(getTempFilePath(1));
     ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
 
+    final Stopwatch stopwatch = Stopwatch()..start();
     try {
       for (final (int i, AssetTransformerEntry transformer) in transformerEntries.indexed) {
         final AssetTransformationFailure? transformerFailure = await _applyTransformer(
@@ -90,6 +91,7 @@ final class AssetTransformer {
     } finally {
       ErrorHandlingFileSystem.deleteIfExists(tempInputFile);
       ErrorHandlingFileSystem.deleteIfExists(tempOutputFile);
+      logger.printTrace("Finished transforming asset at path '${asset.path}' (${stopwatch.elapsedMilliseconds}ms)");
     }
 
     return null;

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -207,6 +207,7 @@ Future<void> writeBundle(
               outputPath: file.path,
               workingDirectory: projectDir.path,
               transformerEntries: entry.value.transformers,
+              logger: logger,
             );
             doCopy = false;
             if (failure != null) {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/asset_transformer_test.dart
@@ -69,6 +69,7 @@ void main() {
           ],
         )
       ],
+      logger: logger,
     );
 
     expect(transformationFailure, isNull, reason: logger.errorText);
@@ -124,6 +125,7 @@ void main() {
           args: <String>[],
         )
       ],
+      logger: BufferLogger.test(),
     );
 
     expect(asset, exists);
@@ -183,6 +185,7 @@ Something went wrong''');
           args: <String>[],
         )
       ],
+      logger: BufferLogger.test(),
     );
 
     expect(processManager, hasNoRemainingExpectations);
@@ -281,6 +284,7 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
           args: <String>[],
         ),
       ],
+      logger: BufferLogger.test(),
     );
 
     expect(processManager, hasNoRemainingExpectations);
@@ -355,6 +359,7 @@ Transformation failed, but I forgot to exit with a non-zero code.'''
           args: <String>[],
         ),
       ],
+      logger: BufferLogger.test(),
     );
 
     expect(failure, isNotNull);


### PR DESCRIPTION
From https://github.com/flutter/flutter/issues/143348#issuecomment-2016047148:

> before we ship, we should add a printTrace to the tool about each asset transformer we're invoking and the path/arguments we called it with

I think this is a good idea since asset transformers can be arbitrary Dart programs—meaning that a lot can go wrong when running them. For example, they can hang indefinitely or perform some sort of I/O that later results in a tool crash. Knowing that asset transformation was involved when debugging a crash (or a slow/stuck `flutter build`) could be useful, so I think adding a `printTrace` or two is a good idea (or at least not a bad one).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
