### PR TITLE
[Fix]: MenuAnchor is close when screen size change (#146380)

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -350,7 +350,7 @@ class _MenuAnchorState extends State<MenuAnchor> {
     final Size newSize = MediaQuery.sizeOf(context);
     if (_viewSize != null && newSize != _viewSize) {
       // Close the menus if the view changes size.
-      if (_topLevel.widget.closeMenuWhenViewChange) {
+      if (_root.widget.closeMenuWhenViewChange) {
         _root._close();
       }
     }
@@ -764,6 +764,7 @@ class MenuBar extends StatelessWidget {
     this.clipBehavior = Clip.none,
     this.controller,
     required this.children,
+    this.closeMenuWhenViewChange = true,
   });
 
   /// The [MenuStyle] that defines the visual attributes of the menu bar.
@@ -791,6 +792,10 @@ class MenuBar extends StatelessWidget {
   /// {@macro flutter.material.MenuBar.shortcuts_note}
   final List<Widget> children;
 
+  /// Close the menus if the view changes size.
+  /// Defaults to true.
+  final bool closeMenuWhenViewChange;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasOverlay(context));
@@ -799,6 +804,7 @@ class MenuBar extends StatelessWidget {
       clipBehavior: clipBehavior,
       style: style,
       menuChildren: children,
+      closeMenuWhenViewChange: closeMenuWhenViewChange,
     );
   }
 
@@ -2308,6 +2314,7 @@ class _MenuBarAnchor extends MenuAnchor {
     super.controller,
     super.clipBehavior,
     super.style,
+    super.closeMenuWhenViewChange,
   });
 
   @override

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -142,6 +142,7 @@ class MenuAnchor extends StatefulWidget {
     required this.menuChildren,
     this.builder,
     this.child,
+    this.closeMenuWhenViewChange = true,
   });
 
   /// An optional controller that allows opening and closing of the menu from
@@ -267,6 +268,10 @@ class MenuAnchor extends StatefulWidget {
   /// to rebuild this child when those change.
   final Widget? child;
 
+  /// Close the menus if the view changes size.
+  /// Defaults to true.
+  final bool closeMenuWhenViewChange;
+
   @override
   State<MenuAnchor> createState() => _MenuAnchorState();
 
@@ -345,7 +350,9 @@ class _MenuAnchorState extends State<MenuAnchor> {
     final Size newSize = MediaQuery.sizeOf(context);
     if (_viewSize != null && newSize != _viewSize) {
       // Close the menus if the view changes size.
-      _root._close();
+      if (_topLevel.widget.closeMenuWhenViewChange) {
+        _root._close();
+      }
     }
     _viewSize = newSize;
   }

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -79,6 +79,7 @@ void main() {
     Offset alignmentOffset = Offset.zero,
     TextDirection textDirection = TextDirection.ltr,
     bool consumesOutsideTap = false,
+    bool closeMenuWhenViewChange = true,
     void Function(TestMenu)? onPressed,
     void Function(TestMenu)? onOpen,
     void Function(TestMenu)? onClose,
@@ -102,6 +103,7 @@ void main() {
                 controller: controller,
                 alignmentOffset: alignmentOffset,
                 consumeOutsideTap: consumesOutsideTap,
+                closeMenuWhenViewChange: closeMenuWhenViewChange,
                 style: MenuStyle(alignment: alignment),
                 onOpen: () {
                   onOpen?.call(TestMenu.anchorButton);
@@ -573,6 +575,13 @@ void main() {
 
     expect(focusInOnPressed, equals(buttonFocus));
     expect(FocusManager.instance.primaryFocus, equals(buttonFocus));
+  });
+
+  testWidgets('Menu functions Menus will not close when the view changes size if closeMenuWhenViewChange is false', (WidgetTester tester) async {
+    await tester.pumpWidget(buildTestApp(closeMenuWhenViewChange: false,));
+    await changeSurfaceSize(tester, const Size(800, 800));
+    await tester.pump();
+    expect(controller.isOpen, isFalse);
   });
 
   group('Menu functions', () {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -577,13 +577,6 @@ void main() {
     expect(FocusManager.instance.primaryFocus, equals(buttonFocus));
   });
 
-  testWidgets('Menu functions Menus will not close when the view changes size if closeMenuWhenViewChange is false', (WidgetTester tester) async {
-    await tester.pumpWidget(buildTestApp(closeMenuWhenViewChange: false,));
-    await changeSurfaceSize(tester, const Size(800, 800));
-    await tester.pump();
-    expect(controller.isOpen, isFalse);
-  });
-
   group('Menu functions', () {
     testWidgets('basic menu structure', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -1751,6 +1744,29 @@ void main() {
 
       expect(opened, isEmpty);
       expect(closed, isNotEmpty);
+    });
+
+    testWidgets('Menu functions Menus will not close when the view changes size if closeMenuWhenViewChange is false', (WidgetTester tester) async {
+      final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.view);
+      Widget build(Size size) {
+        return MaterialApp(
+          home: Material(
+            child: MediaQuery(
+              data: mediaQueryData.copyWith(size: size),
+              child: buildTestApp(closeMenuWhenViewChange: false),
+            ),
+          ),
+        );
+      }
+      await tester.pumpWidget(build(mediaQueryData.size));
+      controller.open();
+      await tester.pump();
+
+      const Size smallSize = Size(200, 200);
+      await changeSurfaceSize(tester, smallSize);
+      await tester.pumpWidget(build(smallSize));
+      await tester.pump();
+      expect(controller.isOpen, isTrue);
     });
   });
 

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -1746,7 +1746,7 @@ void main() {
       expect(closed, isNotEmpty);
     });
 
-    testWidgets('Menu functions Menus will not close when the view changes size if closeMenuWhenViewChange is false', (WidgetTester tester) async {
+    testWidgets('menus not close on view size change if closeMenuWhenViewChange is false', (WidgetTester tester) async {
       final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.view);
       Widget build(Size size) {
         return MaterialApp(


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/146380

Pre-launch Checklist
- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/wiki/Tree-hygiene#overview) and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo), including [Features we expect every widget to implement](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement).
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with ///).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord](https://github.com/flutter/flutter/wiki/Chat).