### PR TITLE
Remove double heading

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1412,8 +1412,6 @@ void runApp(Widget app) {
 /// calling [runWidget] with a [ViewCollection] that does not specify any
 /// [ViewCollection.views].
 ///
-/// ## Dismissing Flutter UI via platform native methods
-///
 /// {@macro flutter.widgets.runApp.dismissal}
 ///
 /// To release resources more eagerly, establish a [platform channel](https://flutter.dev/platform-channels/)


### PR DESCRIPTION
The heading is already included in the macro.

## Old:
![Screenshot 2024-04-08 at 10 03 12 AM](https://github.com/flutter/flutter/assets/1227763/30108439-59e7-43b3-9ba5-fe57e04e7f10)
