### PR TITLE
Update gen_keycodes templates

### DIFF
--- a/dev/tools/gen_keycodes/bin/gen_keycodes.dart
+++ b/dev/tools/gen_keycodes/bin/gen_keycodes.dart
@@ -26,14 +26,14 @@ import 'package:path/path.dart' as path;
 /// Get contents of the file that contains the physical key mapping in Chromium
 /// source.
 Future<String> getChromiumCodes() async {
-  final Uri keyCodesUri = Uri.parse('https://chromium.googlesource.com/codesearch/chromium/src/+/refs/heads/master/ui/events/keycodes/dom/dom_code_data.inc?format=TEXT');
+  final Uri keyCodesUri = Uri.parse('https://chromium.googlesource.com/codesearch/chromium/src/+/refs/heads/main/ui/events/keycodes/dom/dom_code_data.inc?format=TEXT');
   return utf8.decode(base64.decode(await http.read(keyCodesUri)));
 }
 
 /// Get contents of the file that contains the logical key mapping in Chromium
 /// source.
 Future<String> getChromiumKeys() async {
-  final Uri keyCodesUri = Uri.parse('https://chromium.googlesource.com/codesearch/chromium/src/+/refs/heads/master/ui/events/keycodes/dom/dom_key_data.inc?format=TEXT');
+  final Uri keyCodesUri = Uri.parse('https://chromium.googlesource.com/codesearch/chromium/src/+/refs/heads/main/ui/events/keycodes/dom/dom_key_data.inc?format=TEXT');
   return utf8.decode(base64.decode(await http.read(keyCodesUri)));
 }
 

--- a/dev/tools/gen_keycodes/data/ios_key_code_map_mm.tmpl
+++ b/dev/tools/gen_keycodes/data/ios_key_code_map_mm.tmpl
@@ -49,8 +49,8 @@ const std::set<uint32_t> functionKeyCodes = {
 };
 
 API_AVAILABLE(ios(13.4))
-NSDictionary<NSString*, NSNumber*>* specialKeyMapping = [[NSDictionary alloc] initWithDictionary:@{
+NSDictionary<NSString*, NSNumber*>* specialKeyMapping = @{
 @@@SPECIAL_KEY_MAPPING@@@
-}];
+};
 
 @@@SPECIAL_KEY_CONSTANTS@@@

--- a/dev/tools/gen_keycodes/data/key_codes_h.tmpl
+++ b/dev/tools/gen_keycodes/data/key_codes_h.tmpl
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_COMMON_TESTING_KEY_CODES_H_
-#define FLUTTER_SHELL_PLATFORM_COMMON_TESTING_KEY_CODES_H_
+#ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_TEST_UTILS_KEY_CODES_G_H_
+#define FLUTTER_SHELL_PLATFORM_EMBEDDER_TEST_UTILS_KEY_CODES_G_H_
 
 #include <cinttypes>
 
@@ -37,4 +37,4 @@ namespace keycodes {
 
 }  // namespace flutter
 
-#endif  // FLUTTER_SHELL_PLATFORM_COMMON_TESTING_KEY_CODES_H_
+#endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_TEST_UTILS_KEY_CODES_G_H_


### PR DESCRIPTION
1. Change chromium default branch from master (404) to main.
2. When I migrated the template to ARC is triggered a `-Wobjc-redundant-literal-use` error, so fix that.  Engine PR is https://github.com/flutter/engine/pull/51981
3. Update to `FLUTTER_SHELL_PLATFORM_EMBEDDER_TEST_UTILS_KEY_CODES_G_H_` to match https://github.com/flutter/engine/pull/49006

This only updates the template and the script--I ran the script to validate it worked and built in the engine, but did not check in the actual generated key code changes (filed https://github.com/flutter/flutter/issues/146480 for that).
