### PR TITLE
Fix chips delete icon override the default icon size and ignores `IconTheme` from the chip property and `ChipThemeData`

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1202,7 +1202,7 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     final double effectiveIconSize = widget.iconTheme?.size
       ?? chipTheme.iconTheme?.size
       ?? theme.chipTheme.iconTheme?.size
-      ?? _kDeleteIconSize;
+      ?? _ChipDefaultsM3(context, widget.isEnabled).iconTheme!.size!;
     return Semantics(
       container: true,
       button: true,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1192,7 +1192,7 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     final IconThemeData iconTheme = widget.iconTheme
       ?? chipTheme.iconTheme
       ?? theme.chipTheme.iconTheme
-      ?? const IconThemeData(size: _kDeleteIconSize);
+      ?? _ChipDefaultsM3(context, widget.isEnabled).iconTheme!;
     final Color? effectiveDeleteIconColor = widget.deleteIconColor
       ?? chipTheme.deleteIconColor
       ?? theme.chipTheme.deleteIconColor

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -41,7 +41,7 @@ const Duration _kReverseDrawerDuration = Duration(milliseconds: 100);
 const Duration _kDisableDuration = Duration(milliseconds: 75);
 
 const Color _kSelectScrimColor = Color(0x60191919);
-const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
+const Icon _kDefaultDeleteIcon = Icon(Icons.cancel);
 
 /// An interface defining the base attributes for a Material Design chip.
 ///
@@ -262,7 +262,17 @@ abstract interface class ChipAttributes {
 abstract interface class DeletableChipAttributes {
   /// The icon displayed when [onDeleted] is set.
   ///
-  /// Defaults to an [Icon] widget set to use [Icons.cancel].
+  /// If [deleteIconColor] is provided, it will be used as the color of the
+  /// delete icon. If [deleteIconColor] is null, then the icon will use the
+  /// color specified in the chip [IconTheme]. If the [IconTheme] is null, then
+  /// the icon will use the color specified in the [ThemeData.iconTheme].
+  ///
+  /// If a size is specified in the chip [IconTheme], then the delete icon will
+  /// use that size. Otherwise, defaults to 18 pixels.
+  ///
+  /// Defaults to an [Icon] widget set to use [Icons.clear].
+  /// If [ThemeData.useMaterial3] is false, then defaults to an [Icon] widget
+  /// set to use [Icons.cancel].
   Widget? get deleteIcon;
 
   /// Called when the user taps the [deleteIcon] to delete the chip.
@@ -1179,6 +1189,20 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     if (!hasDeleteButton) {
       return null;
     }
+    final IconThemeData iconTheme = widget.iconTheme
+      ?? chipTheme.iconTheme
+      ?? theme.chipTheme.iconTheme
+      ?? const IconThemeData(size: _kDeleteIconSize);
+    final Color? effectiveDeleteIconColor = widget.deleteIconColor
+      ?? chipTheme.deleteIconColor
+      ?? theme.chipTheme.deleteIconColor
+      ?? widget.iconTheme?.color
+      ?? chipTheme.iconTheme?.color
+      ?? chipDefaults.deleteIconColor;
+    final double effectiveIconSize = widget.iconTheme?.size
+      ?? chipTheme.iconTheme?.size
+      ?? theme.chipTheme.iconTheme?.size
+      ?? _kDeleteIconSize;
     return Semantics(
       container: true,
       button: true,
@@ -1194,11 +1218,9 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
           customBorder: const CircleBorder(),
           onTap: widget.isEnabled ? widget.onDeleted : null,
           child: IconTheme(
-            data: theme.iconTheme.copyWith(
-              color: widget.deleteIconColor
-                ?? chipTheme.deleteIconColor
-                ?? theme.chipTheme.deleteIconColor
-                ?? chipDefaults.deleteIconColor,
+            data: iconTheme.copyWith(
+              color: effectiveDeleteIconColor,
+              size: effectiveIconSize,
             ),
             child: widget.deleteIcon,
           ),

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -27,7 +27,6 @@ import 'tooltip.dart';
 
 // Some design constants
 const double _kChipHeight = 32.0;
-const double _kDeleteIconSize = 18.0;
 
 const int _kCheckmarkAlpha = 0xde; // 87%
 const int _kDisabledAlpha = 0x61; // 38%

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -57,6 +57,13 @@ DefaultTextStyle getLabelStyle(WidgetTester tester, String labelText) {
   );
 }
 
+TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
+  final RichText iconRichText = tester.widget<RichText>(
+    find.descendant(of: find.byIcon(icon).first, matching: find.byType(RichText)),
+  );
+  return iconRichText.text.style;
+}
+
 dynamic getRenderChip(WidgetTester tester) {
   if (!tester.any(findRenderChipElement())) {
     return null;
@@ -1794,7 +1801,7 @@ void main() {
     expect(Focus.of(labelKey.currentContext!).hasPrimaryFocus, isTrue);
   });
 
-  testWidgets('Material2 - Delete button creates non-centered, unique ripple when tapped', (WidgetTester tester) async {
+  testWidgets('Material2 - Delete button creates centered, unique ripple when tapped', (WidgetTester tester) async {
     final UniqueKey labelKey = UniqueKey();
     final UniqueKey deleteButtonKey = UniqueKey();
 
@@ -1820,8 +1827,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     // There should be one unique ink ripple.
-    expect(box, ripplePattern(const Offset(3.0, 3.0), 1.44));
-    expect(box, uniqueRipplePattern(const Offset(3.0, 3.0), 1.44));
+    expect(box, ripplePattern(Offset.zero, 1.44));
+    expect(box, uniqueRipplePattern(Offset.zero, 1.44));
 
     // There should be no tooltip.
     expect(findTooltipContainer('Delete'), findsNothing);
@@ -1832,8 +1839,8 @@ void main() {
 
     // The ripple should grow, but the center should move,
     // Towards the center of the delete icon.
-    expect(box, ripplePattern(const Offset(5.0, 5.0), 4.32));
-    expect(box, uniqueRipplePattern(const Offset(5.0, 5.0), 4.32));
+    expect(box, ripplePattern(const Offset(2.0, 2.0), 4.32));
+    expect(box, uniqueRipplePattern(const Offset(2.0, 2.0), 4.32));
 
     // There should be no tooltip.
     expect(findTooltipContainer('Delete'), findsNothing);
@@ -1925,8 +1932,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     // There should be one unique ink ripple.
-    expect(box, ripplePattern(const Offset(3.0, 3.0), 1.44));
-    expect(box, uniqueRipplePattern(const Offset(3.0, 3.0), 1.44));
+    expect(box, ripplePattern(Offset.zero, 1.44));
+    expect(box, uniqueRipplePattern(Offset.zero, 1.44));
 
     // There should be no tooltip.
     expect(findTooltipContainer('Delete'), findsNothing);
@@ -1937,8 +1944,8 @@ void main() {
 
     // The ripple should grow, but the center should move,
     // Towards the center of the delete icon.
-    expect(box, ripplePattern(const Offset(5.0, 5.0), 4.32));
-    expect(box, uniqueRipplePattern(const Offset(5.0, 5.0), 4.32));
+    expect(box, ripplePattern(const Offset(2.0, 2.0), 4.32));
+    expect(box, uniqueRipplePattern(const Offset(2.0, 2.0), 4.32));
 
     // There should be no tooltip.
     expect(findTooltipContainer('Delete'), findsNothing);
@@ -4476,7 +4483,7 @@ void main() {
     Rect avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 32.0 + 16.0)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(24, 24)));
     expect(textBox.top, equals(17));
     expect(box.bottom - textBox.bottom, equals(17));
@@ -4491,7 +4498,7 @@ void main() {
     avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 60)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(24, 24)));
     expect(textBox.top, equals(23));
     expect(box.bottom - textBox.bottom, equals(23));
@@ -4506,7 +4513,7 @@ void main() {
     avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 36)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(24, 24)));
     expect(textBox.top, equals(11));
     expect(box.bottom - textBox.bottom, equals(11));
@@ -4523,7 +4530,7 @@ void main() {
     avatarBox = tester.getRect(find.byKey(avatarKey));
     expect(box.size, equals(const Size(128, 36)));
     expect(textBox.size, equals(const Size(56, 14)));
-    expect(iconBox.size, equals(const Size(24, 24)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(24, 24)));
     expect(textBox.top, equals(11));
     expect(box.bottom - textBox.bottom, equals(11));
@@ -4583,7 +4590,7 @@ void main() {
     expect(box.size.height, equals(32.0 + 16.0));
     expect(textBox.size.width, moreOrLessEquals(56.4, epsilon: 0.1));
     expect(textBox.size.height, equals(20.0));
-    expect(iconBox.size, equals(const Size(20, 20)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(18, 18)));
     expect(textBox.top, equals(14));
     expect(box.bottom - textBox.bottom, equals(14));
@@ -4600,7 +4607,7 @@ void main() {
     expect(box.size.height, equals(60));
     expect(textBox.size.width, moreOrLessEquals(56.4, epsilon: 0.1));
     expect(textBox.size.height, equals(20.0));
-    expect(iconBox.size, equals(const Size(20, 20)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(18, 18)));
     expect(textBox.top, equals(20));
     expect(box.bottom - textBox.bottom, equals(20));
@@ -4617,7 +4624,7 @@ void main() {
     expect(box.size.height, equals(36));
     expect(textBox.size.width, moreOrLessEquals(56.4, epsilon: 0.1));
     expect(textBox.size.height, equals(20.0));
-    expect(iconBox.size, equals(const Size(20, 20)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(18, 18)));
     expect(textBox.top, equals(8));
     expect(box.bottom - textBox.bottom, equals(8));
@@ -4636,7 +4643,7 @@ void main() {
     expect(box.size.height, equals(36));
     expect(textBox.size.width, moreOrLessEquals(56.4, epsilon: 0.1));
     expect(textBox.size.height, equals(20.0));
-    expect(iconBox.size, equals(const Size(20, 20)));
+    expect(iconBox.size, equals(const Size(18, 18)));
     expect(avatarBox.size, equals(const Size(18, 18)));
     expect(textBox.top, equals(8));
     expect(box.bottom - textBox.bottom, equals(8));
@@ -5704,6 +5711,75 @@ void main() {
       tester.getTopLeft(find.text('A').first).dy,
       tester.getTopLeft(find.text('A').last).dy,
     );
+  });
+
+  testWidgets('ChipThemeData.iconTheme updates avatar and delete icons', (WidgetTester tester) async {
+    const Color iconColor = Color(0xffff00ff);
+    const double iconSize = 28.0;
+    const IconData avatarIcon = Icons.favorite;
+    const IconData deleteIcon = Icons.delete;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Center(
+          child: RawChip(
+            iconTheme: const IconThemeData(
+              color: iconColor,
+              size: iconSize,
+            ),
+            avatar: const Icon(Icons.favorite),
+            deleteIcon: const Icon(Icons.delete),
+            onDeleted: () { },
+            label: const SizedBox(height: 100),
+          ),
+        ),
+      ),
+    ));
+
+    // Test rendered icon size.
+    final RenderBox avatarIconBox = tester.renderObject(find.byIcon(avatarIcon));
+    final RenderBox deleteIconBox = tester.renderObject(find.byIcon(deleteIcon));
+    expect(avatarIconBox.size.width, equals(iconSize));
+    expect(deleteIconBox.size.width, equals(iconSize));
+
+    // Test rendered icon color.
+    expect(getIconStyle(tester, avatarIcon)?.color, iconColor);
+    expect(getIconStyle(tester, deleteIcon)?.color, iconColor);
+  });
+
+  testWidgets('RawChip.deleteIconColor overrides iconTheme color', (WidgetTester tester) async {
+    const Color iconColor = Color(0xffff00ff);
+    const Color deleteIconColor = Color(0xffff00ff);
+    const IconData deleteIcon = Icons.delete;
+
+    Widget buildChip({ Color? deleteIconColor, Color? iconColor }) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: RawChip(
+              deleteIconColor: deleteIconColor,
+              iconTheme: IconThemeData(color: iconColor),
+              deleteIcon: const Icon(Icons.delete),
+              onDeleted: () { },
+              label: const SizedBox(height: 100),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildChip(iconColor: iconColor));
+
+    // Test rendered icon color.
+    expect(getIconStyle(tester, deleteIcon)?.color, iconColor);
+
+    await tester.pumpWidget(buildChip(
+      deleteIconColor: deleteIconColor,
+      iconColor: iconColor,
+    ));
+
+    // Test rendered icon color.
+    expect(getIconStyle(tester, deleteIcon)?.color, deleteIconColor);
   });
 }
 


### PR DESCRIPTION
fixes [Provided delete icon overrides the default delete icon size](https://github.com/flutter/flutter/issues/146404)
fixes [Chips delete icon ignores `IconTheme` from `Chip.iconTheme` and `ChipThemeData.iconTheme`](https://github.com/flutter/flutter/issues/146501)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(
        chipTheme: const ChipThemeData(
          iconTheme: IconThemeData(
            color: Colors.red,
          ),
        ),
      ),
      home: Scaffold(
        body: Center(
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: [
              FilterChip(
                avatar: const Icon(Icons.favorite),
                onDeleted: () {},
                label: const Text('Filter Chip'),
                onSelected: (value) {},
              ),
              const SizedBox(height: 10),
              FilterChip(
                avatar: const Icon(Icons.favorite),
                // ignore: prefer_const_constructors
                deleteIcon: const Icon(Icons.delete),
                onDeleted: () {},
                label: const Text('Filter Chip'),
                onSelected: (value) {},
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```

</details>

### Before
![Screenshot 2024-04-09 at 16 48 48](https://github.com/flutter/flutter/assets/48603081/79d14a63-3c24-4f3e-bda4-5de76b319160)


### After

![Screenshot 2024-04-09 at 16 48 31](https://github.com/flutter/flutter/assets/48603081/8d54373f-53f1-4908-bd9c-2ee351227f27)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
