### PR TITLE
Convert ProjectMigration and ProjectMigrator to be async

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -316,7 +316,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
     ];
 
     final ProjectMigration migration = ProjectMigration(migrators);
-    migration.run();
+    await migration.run();
 
     final bool usesAndroidX = isAppUsingAndroidX(project.android.hostAppGradleRoot);
     if (usesAndroidX) {

--- a/packages/flutter_tools/lib/src/android/migrations/android_studio_java_gradle_conflict_migration.dart
+++ b/packages/flutter_tools/lib/src/android/migrations/android_studio_java_gradle_conflict_migration.dart
@@ -84,7 +84,7 @@ class AndroidStudioJavaGradleConflictMigration extends ProjectMigrator {
   final Java? _java;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     try {
       if (!_gradleWrapperPropertiesFile.existsSync()) {
         logger.printTrace(gradleWrapperNotFound);

--- a/packages/flutter_tools/lib/src/android/migrations/min_sdk_version_migration.dart
+++ b/packages/flutter_tools/lib/src/android/migrations/min_sdk_version_migration.dart
@@ -27,7 +27,7 @@ class MinSdkVersionMigration extends ProjectMigrator {
   final AndroidProject _project;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     // Skip applying migration in modules as the FlutterExtension is not applied.
     if (_project.isModule) {
       return;

--- a/packages/flutter_tools/lib/src/android/migrations/top_level_gradle_build_file_migration.dart
+++ b/packages/flutter_tools/lib/src/android/migrations/top_level_gradle_build_file_migration.dart
@@ -28,7 +28,7 @@ class TopLevelGradleBuildFileMigration extends ProjectMigrator {
   final File _topLevelGradleBuildFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_topLevelGradleBuildFile.existsSync()) {
       logger.printTrace('Top-level Gradle build file not found, skipping migration of task "clean".');
       return;

--- a/packages/flutter_tools/lib/src/base/project_migrator.dart
+++ b/packages/flutter_tools/lib/src/base/project_migrator.dart
@@ -16,7 +16,7 @@ abstract class ProjectMigrator {
   @protected
   final Logger logger;
 
-  void migrate();
+  Future<void> migrate();
 
   /// Return null if the line should be deleted.
   @protected
@@ -79,9 +79,9 @@ class ProjectMigration {
 
   final List<ProjectMigrator> migrators;
 
-  void run() {
+  Future<void> run() async {
     for (final ProjectMigrator migrator in migrators) {
-      migrator.migrate();
+      await migrator.migrate();
     }
   }
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -161,7 +161,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);
-  migration.run();
+  await migration.run();
 
   if (!_checkXcodeVersion()) {
     return XcodeBuildResult(success: false);

--- a/packages/flutter_tools/lib/src/ios/migrations/host_app_info_plist_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/host_app_info_plist_migration.dart
@@ -19,7 +19,7 @@ class HostAppInfoPlistMigration extends ProjectMigrator {
   final File _infoPlist;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_infoPlist.existsSync()) {
       logger.printTrace('Info.plist not found, skipping host app Info.plist migration.');
       return;

--- a/packages/flutter_tools/lib/src/ios/migrations/ios_deployment_target_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/ios_deployment_target_migration.dart
@@ -20,7 +20,7 @@ class IOSDeploymentTargetMigration extends ProjectMigrator {
   final File _appFrameworkInfoPlist;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (_xcodeProjectInfoFile.existsSync()) {
       processFileLines(_xcodeProjectInfoFile);
     } else {

--- a/packages/flutter_tools/lib/src/ios/migrations/project_base_configuration_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/project_base_configuration_migration.dart
@@ -16,7 +16,7 @@ class ProjectBaseConfigurationMigration extends ProjectMigrator {
   final File _xcodeProjectInfoFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_xcodeProjectInfoFile.existsSync()) {
       logger.printTrace('Xcode project not found, skipping Runner project build settings and configuration migration');
       return;

--- a/packages/flutter_tools/lib/src/ios/migrations/project_build_location_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/project_build_location_migration.dart
@@ -16,7 +16,7 @@ class ProjectBuildLocationMigration extends ProjectMigrator {
   final File _xcodeProjectWorkspaceData;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_xcodeProjectWorkspaceData.existsSync()) {
       logger.printTrace('Xcode project workspace data not found, skipping build location migration.');
       return;

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_bitcode_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_bitcode_migration.dart
@@ -16,7 +16,7 @@ class RemoveBitcodeMigration extends ProjectMigrator {
   final File _xcodeProjectInfoFile;
 
   @override
-  bool migrate() {
+  Future<bool> migrate() async {
     if (_xcodeProjectInfoFile.existsSync()) {
       processFileLines(_xcodeProjectInfoFile);
     } else {

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -28,7 +28,7 @@ class RemoveFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
   final Analytics _analytics;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_xcodeProjectInfoFile.existsSync()) {
       logger.printTrace('Xcode project not found, skipping framework link and embedding migration');
       return;

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -18,7 +18,7 @@ class XcodeBuildSystemMigration extends ProjectMigrator {
   final File? _xcodeWorkspaceSharedSettings;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     final File? xcodeWorkspaceSharedSettings = _xcodeWorkspaceSharedSettings;
     if (xcodeWorkspaceSharedSettings == null || !xcodeWorkspaceSharedSettings.existsSync()) {
       logger.printTrace('Xcode workspace settings not found, skipping build system migration');

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -53,7 +53,7 @@ Future<void> buildLinux(
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);
-  migration.run();
+  await migration.run();
 
   // Build the environment that needs to be set for the re-entrant flutter build
   // step.

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -86,7 +86,7 @@ Future<void> buildMacOS({
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);
-  migration.run();
+  await migration.run();
 
   final Directory flutterBuildDir = globals.fs.directory(getMacOSBuildDirectory());
   if (!flutterBuildDir.existsSync()) {

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -185,7 +185,7 @@ class CocoaPods {
           _logger,
         ),
       ]);
-      postPodMigration.run();
+      await postPodMigration.run();
 
       podsProcessed = true;
     }

--- a/packages/flutter_tools/lib/src/macos/migrations/flutter_application_migration.dart
+++ b/packages/flutter_tools/lib/src/macos/migrations/flutter_application_migration.dart
@@ -24,7 +24,7 @@ class FlutterApplicationMigration extends ProjectMigrator {
   final File _infoPlistFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (_infoPlistFile.existsSync()) {
       final String? principalClass =
           globals.plistParser.getValueFromFile<String>(_infoPlistFile.path, PlistParser.kNSPrincipalClassKey);

--- a/packages/flutter_tools/lib/src/macos/migrations/macos_deployment_target_migration.dart
+++ b/packages/flutter_tools/lib/src/macos/migrations/macos_deployment_target_migration.dart
@@ -18,7 +18,7 @@ class MacOSDeploymentTargetMigration extends ProjectMigrator {
   final File _podfile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (_xcodeProjectInfoFile.existsSync()) {
       processFileLines(_xcodeProjectInfoFile);
     } else {

--- a/packages/flutter_tools/lib/src/macos/migrations/remove_macos_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/macos/migrations/remove_macos_framework_link_and_embedding_migration.dart
@@ -26,7 +26,7 @@ class RemoveMacOSFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
   final Analytics _analytics;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_xcodeProjectInfoFile.existsSync()) {
       logger.printTrace(
           'Xcode project not found, skipping framework link and embedding migration');

--- a/packages/flutter_tools/lib/src/migrations/cmake_custom_command_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/cmake_custom_command_migration.dart
@@ -16,7 +16,7 @@ class CmakeCustomCommandMigration extends ProjectMigrator {
   final File _cmakeFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_cmakeFile.existsSync()) {
       logger.printTrace('CMake project not found, skipping add_custom_command() VERBATIM migration');
       return;

--- a/packages/flutter_tools/lib/src/migrations/cmake_native_assets_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/cmake_native_assets_migration.dart
@@ -23,7 +23,7 @@ class CmakeNativeAssetsMigration extends ProjectMigrator {
   final String os;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_cmakeFile.existsSync()) {
       logger.printTrace('CMake project not found, skipping install() NATIVE_ASSETS_DIR migration.');
       return;

--- a/packages/flutter_tools/lib/src/migrations/cocoapods_script_symlink.dart
+++ b/packages/flutter_tools/lib/src/migrations/cocoapods_script_symlink.dart
@@ -25,7 +25,7 @@ class CocoaPodsScriptReadlink extends ProjectMigrator {
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_podRunnerFrameworksScript.existsSync()) {
       logger.printTrace('CocoaPods Pods-Runner-frameworks.sh script not found, skipping "readlink -f" workaround.');
       return;

--- a/packages/flutter_tools/lib/src/migrations/cocoapods_toolchain_directory_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/cocoapods_toolchain_directory_migration.dart
@@ -26,7 +26,7 @@ class CocoaPodsToolchainDirectoryMigration extends ProjectMigrator {
   final XcodeProjectInterpreter _xcodeProjectInterpreter;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_podRunnerTargetSupportFiles.existsSync()) {
       logger.printTrace('CocoaPods Pods-Runner Target Support Files not found, skipping TOOLCHAIN_DIR workaround.');
       return;

--- a/packages/flutter_tools/lib/src/migrations/xcode_project_object_version_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/xcode_project_object_version_migration.dart
@@ -18,7 +18,7 @@ class XcodeProjectObjectVersionMigration extends ProjectMigrator {
   final File _xcodeProjectSchemeFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (_xcodeProjectInfoFile.existsSync()) {
       processFileLines(_xcodeProjectInfoFile);
     } else {

--- a/packages/flutter_tools/lib/src/migrations/xcode_script_build_phase_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/xcode_script_build_phase_migration.dart
@@ -15,7 +15,7 @@ class XcodeScriptBuildPhaseMigration extends ProjectMigrator {
   final File _xcodeProjectInfoFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_xcodeProjectInfoFile.existsSync()) {
       logger.printTrace('Xcode project not found, skipping script build phase dependency analysis removal.');
       return;

--- a/packages/flutter_tools/lib/src/migrations/xcode_thin_binary_build_phase_input_paths_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/xcode_thin_binary_build_phase_input_paths_migration.dart
@@ -16,7 +16,7 @@ class XcodeThinBinaryBuildPhaseInputPathsMigration extends ProjectMigrator {
   final File _xcodeProjectInfoFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     if (!_xcodeProjectInfoFile.existsSync()) {
       logger.printTrace('Xcode project not found, skipping script build phase dependency analysis removal.');
       return;

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -84,7 +84,7 @@ class WebBuilder {
     ];
 
     final ProjectMigration migration = ProjectMigration(migrators);
-    migration.run();
+    await migration.run();
 
     final Status status = _logger.startProgress('Compiling $target for the Web...');
     final Stopwatch sw = Stopwatch()..start();

--- a/packages/flutter_tools/lib/src/web/migrations/scrub_generated_plugin_registrant.dart
+++ b/packages/flutter_tools/lib/src/web/migrations/scrub_generated_plugin_registrant.dart
@@ -18,7 +18,7 @@ class ScrubGeneratedPluginRegistrant extends ProjectMigrator {
   final Logger _logger;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     final File registrant = _project.libDirectory.childFile('generated_plugin_registrant.dart');
     final File gitignore = _project.parent.directory.childFile('.gitignore');
 

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -73,7 +73,7 @@ Future<void> buildWindows(
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);
-  migration.run();
+  await migration.run();
 
   // Ensure that necessary ephemeral files are generated and up to date.
   _writeGeneratedFlutterConfig(windowsProject, buildInfo, target);

--- a/packages/flutter_tools/lib/src/windows/migrations/build_architecture_migration.dart
+++ b/packages/flutter_tools/lib/src/windows/migrations/build_architecture_migration.dart
@@ -71,7 +71,7 @@ class BuildArchitectureMigration extends ProjectMigrator {
   final Directory _buildDirectory;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     final Directory oldRunnerDirectory = _buildDirectory
       .parent
       .childDirectory('runner');

--- a/packages/flutter_tools/lib/src/windows/migrations/show_window_migration.dart
+++ b/packages/flutter_tools/lib/src/windows/migrations/show_window_migration.dart
@@ -39,7 +39,7 @@ class ShowWindowMigration extends ProjectMigrator {
   final File _file;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     // Skip this migration if the affected file does not exist. This indicates
     // the app has done non-trivial changes to its runner and this migration
     // might not work as expected if applied.

--- a/packages/flutter_tools/lib/src/windows/migrations/version_migration.dart
+++ b/packages/flutter_tools/lib/src/windows/migrations/version_migration.dart
@@ -69,7 +69,7 @@ class VersionMigration extends ProjectMigrator {
   final File _resourceFile;
 
   @override
-  void migrate() {
+  Future<void> migrate() async {
     // Skip this migration if the affected files do not exist. This indicates
     // the app has done non-trivial changes to its runner and this migration
     // might not work as expected if applied.

--- a/packages/flutter_tools/test/general.shard/android/android_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_project_migration_test.dart
@@ -137,17 +137,17 @@ void main() {
         topLevelGradleBuildFile = project.hostAppGradleRoot.childFile('build.gradle');
       });
 
-      testUsingContext('skipped if files are missing', () {
+      testUsingContext('skipped if files are missing', () async {
         final TopLevelGradleBuildFileMigration androidProjectMigration = TopLevelGradleBuildFileMigration(
           project,
           bufferLogger,
         );
-        androidProjectMigration.migrate();
+        await androidProjectMigration.migrate();
         expect(topLevelGradleBuildFile.existsSync(), isFalse);
         expect(bufferLogger.traceText, contains('Top-level Gradle build file not found, skipping migration of task "clean".'));
       });
 
-      testUsingContext('skipped if nothing to upgrade', () {
+      testUsingContext('skipped if nothing to upgrade', () async {
         topLevelGradleBuildFile.writeAsStringSync('''
 tasks.register("clean", Delete) {
   delete rootProject.buildDir
@@ -159,12 +159,12 @@ tasks.register("clean", Delete) {
           bufferLogger,
         );
         final DateTime previousLastModified = topLevelGradleBuildFile.lastModifiedSync();
-        androidProjectMigration.migrate();
+        await androidProjectMigration.migrate();
 
         expect(topLevelGradleBuildFile.lastModifiedSync(), previousLastModified);
       });
 
-      testUsingContext('top-level build.gradle is migrated', () {
+      testUsingContext('top-level build.gradle is migrated', () async {
         topLevelGradleBuildFile.writeAsStringSync('''
 task clean(type: Delete) {
     delete rootProject.buildDir
@@ -175,7 +175,7 @@ task clean(type: Delete) {
           project,
           bufferLogger,
         );
-        androidProjectMigration.migrate();
+        await androidProjectMigration.migrate();
 
         expect(bufferLogger.traceText, contains('Migrating "clean" Gradle task to lazy declaration style.'));
         expect(topLevelGradleBuildFile.readAsStringSync(), equals('''
@@ -208,33 +208,33 @@ tasks.register("clean", Delete) {
             .childFile(gradleWrapperPropertiesFilename);
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion17),
           bufferLogger,
           project: project,
           androidStudio: FakeAndroidStudio(version: androidStudioDolphin),
         );
-        migration.migrate();
+        await migration.migrate();
         expect(gradleWrapperPropertiesFile.existsSync(), isFalse);
         expect(bufferLogger.traceText, contains(gradleWrapperNotFound));
       });
 
 
-      testWithoutContext('skipped if android studio is null', () {
+      testWithoutContext('skipped if android studio is null', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion17),
           bufferLogger,
           project: project,
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate);
-        migration.migrate();
+        await migration.migrate();
         expect(bufferLogger.traceText, contains(androidStudioNotFound));
         expect(gradleWrapperPropertiesFile.readAsStringSync(),
             gradleWrapperToMigrate);
       });
 
-      testWithoutContext('skipped if android studio version is null', () {
+      testWithoutContext('skipped if android studio version is null', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion17),
           bufferLogger,
@@ -242,13 +242,13 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: null),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate);
-        migration.migrate();
+        await migration.migrate();
         expect(bufferLogger.traceText, contains(androidStudioNotFound));
         expect(gradleWrapperPropertiesFile.readAsStringSync(),
             gradleWrapperToMigrate);
       });
 
-      testWithoutContext('skipped if error is encountered in migrate()', () {
+      testWithoutContext('skipped if error is encountered in migrate()', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeErroringJava(),
           bufferLogger,
@@ -256,13 +256,13 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: androidStudioFlamingo),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate);
-        migration.migrate();
+        await migration.migrate();
         expect(bufferLogger.traceText, contains(errorWhileMigrating));
         expect(gradleWrapperPropertiesFile.readAsStringSync(),
             gradleWrapperToMigrate);
       });
 
-      testWithoutContext('skipped if android studio version is less than flamingo', () {
+      testWithoutContext('skipped if android studio version is less than flamingo', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(),
           bufferLogger,
@@ -270,12 +270,12 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: androidStudioDolphin),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate);
-        migration.migrate();
+        await migration.migrate();
         expect(gradleWrapperPropertiesFile.readAsStringSync(), gradleWrapperToMigrate);
         expect(bufferLogger.traceText, contains(androidStudioVersionBelowFlamingo));
       });
 
-      testWithoutContext('skipped if bundled java version is less than 17', () {
+      testWithoutContext('skipped if bundled java version is less than 17', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion16),
           bufferLogger,
@@ -283,13 +283,13 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: androidStudioFlamingo),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate);
-        migration.migrate();
+        await migration.migrate();
         expect(gradleWrapperPropertiesFile.readAsStringSync(), gradleWrapperToMigrate);
         expect(bufferLogger.traceText, contains(javaVersionNot17));
       });
 
       testWithoutContext('nothing is changed if gradle version not one that was '
-          'used by flutter create', () {
+          'used by flutter create', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion17),
           bufferLogger,
@@ -297,13 +297,13 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: androidStudioFlamingo),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(otherGradleVersionWrapper);
-        migration.migrate();
+        await migration.migrate();
         expect(gradleWrapperPropertiesFile.readAsStringSync(), otherGradleVersionWrapper);
         expect(bufferLogger.traceText, isEmpty);
       });
 
       testWithoutContext('change is made with one of the specific gradle versions'
-          ' we migrate for', () {
+          ' we migrate for', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion17),
           bufferLogger,
@@ -311,14 +311,14 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: androidStudioFlamingo),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate);
-        migration.migrate();
+        await migration.migrate();
         expect(gradleWrapperPropertiesFile.readAsStringSync(), gradleWrapperToMigrateTo);
         expect(bufferLogger.statusText, contains('Conflict detected between '
             'Android Studio Java version and Gradle version, upgrading Gradle '
             'version from 6.7 to $gradleVersion7_6_1.'));
       });
 
-      testWithoutContext('change is not made when opt out flag is set', () {
+      testWithoutContext('change is not made when opt out flag is set', () async {
         final AndroidStudioJavaGradleConflictMigration migration = AndroidStudioJavaGradleConflictMigration(
           java: FakeJava(version: _javaVersion17),
           bufferLogger,
@@ -326,7 +326,7 @@ tasks.register("clean", Delete) {
           androidStudio: FakeAndroidStudio(version: androidStudioFlamingo),
         );
         gradleWrapperPropertiesFile.writeAsStringSync(gradleWrapperToMigrate + optOutFlag);
-        migration.migrate();
+        await migration.migrate();
         expect(gradleWrapperPropertiesFile.readAsStringSync(), gradleWrapperToMigrate + optOutFlag);
         expect(bufferLogger.traceText, contains(optOutFlagEnabled));
       });
@@ -354,48 +354,48 @@ tasks.register("clean", Delete) {
         );
       });
 
-      testWithoutContext('do nothing when files missing', () {
-        migration.migrate();
+      testWithoutContext('do nothing when files missing', () async {
+        await migration.migrate();
         expect(bufferLogger.traceText, contains(appGradleNotFoundWarning));
       });
 
-      testWithoutContext('replace when api 19', () {
+      testWithoutContext('replace when api 19', () async {
         const String minSdkVersion19 = 'minSdkVersion 19';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(minSdkVersion19));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(replacementMinSdkText));
       });
 
-      testWithoutContext('replace when api 20', () {
+      testWithoutContext('replace when api 20', () async {
         const String minSdkVersion20 = 'minSdkVersion 20';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(minSdkVersion20));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(replacementMinSdkText));
       });
 
-      testWithoutContext('do nothing when >=api 21', () {
+      testWithoutContext('do nothing when >=api 21', () async {
         const String minSdkVersion21 = 'minSdkVersion 21';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(minSdkVersion21));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(minSdkVersion21));
       });
 
       testWithoutContext('do nothing when already using '
-          'flutter.minSdkVersion', () {
+          'flutter.minSdkVersion', () async {
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(replacementMinSdkText));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(replacementMinSdkText));
       });
 
-      testWithoutContext('avoid rewriting comments', () {
+      testWithoutContext('avoid rewriting comments', () async {
         const String code = '// minSdkVersion 19  // old default\n'
             '        minSdkVersion 23  // new version';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(code));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(code));
       });
 
-      testWithoutContext('do nothing when project is a module', () {
+      testWithoutContext('do nothing when project is a module', () async {
         project = FakeAndroidProject(
           root: memoryFileSystem.currentDirectory.childDirectory('android'),
           module: true,
@@ -406,23 +406,23 @@ tasks.register("clean", Delete) {
         );
         const String minSdkVersion19 = 'minSdkVersion 19';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(minSdkVersion19));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(minSdkVersion19));
       });
 
       testWithoutContext('do nothing when minSdkVersion is set '
-          'to a constant', () {
+          'to a constant', () async {
         const String minSdkVersionConstant = 'minSdkVersion kMinSdkversion';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(minSdkVersionConstant));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(minSdkVersionConstant));
       });
 
       testWithoutContext('do nothing when minSdkVersion is set '
-          'using = syntax', () {
+          'using = syntax', () async {
         const String equalsSyntaxMinSdkVersion19 = 'minSdkVersion = 19';
         project.appGradleFile.writeAsStringSync(sampleModuleGradleBuildFile(equalsSyntaxMinSdkVersion19));
-        migration.migrate();
+        await migration.migrate();
         expect(project.appGradleFile.readAsStringSync(), sampleModuleGradleBuildFile(equalsSyntaxMinSdkVersion19));
       });
     });

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -64,14 +64,14 @@ void main () {
         project.xcodeProjectInfoFile = xcodeProjectInfoFile;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final RemoveFrameworkLinkAndEmbeddingMigration iosProjectMigration = RemoveFrameworkLinkAndEmbeddingMigration(
           project,
           testLogger,
           testUsage,
           fakeAnalytics,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(testUsage.events, isEmpty);
         expect(fakeAnalytics.sentEvents, isEmpty);
 
@@ -81,7 +81,7 @@ void main () {
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String contents = 'Nothing to upgrade';
         xcodeProjectInfoFile.writeAsStringSync(contents);
         final DateTime projectLastModified = xcodeProjectInfoFile.lastModifiedSync();
@@ -92,7 +92,7 @@ void main () {
           testUsage,
           fakeAnalytics,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(testUsage.events, isEmpty);
         expect(fakeAnalytics.sentEvents, isEmpty);
 
@@ -102,7 +102,7 @@ void main () {
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skips migrating script with embed', () {
+      testWithoutContext('skips migrating script with embed', () async {
         const String contents = r'''
 shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
 			''';
@@ -114,12 +114,12 @@ shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.
           testUsage,
           fakeAnalytics,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectInfoFile.readAsStringSync(), contents);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated', () {
+      testWithoutContext('Xcode project is migrated', () async {
         xcodeProjectInfoFile.writeAsStringSync(r'''
 prefix 3B80C3941E831B6300D905FE
 3B80C3951E831B6300D905FE suffix
@@ -142,7 +142,7 @@ keep this 2
           testUsage,
           fakeAnalytics,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(testUsage.events, isEmpty);
         expect(fakeAnalytics.sentEvents, isEmpty);
 
@@ -242,33 +242,33 @@ keep this 2
         project.xcodeWorkspaceSharedSettings = xcodeWorkspaceSharedSettings;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final XcodeBuildSystemMigration iosProjectMigration = XcodeBuildSystemMigration(
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeWorkspaceSharedSettings.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode workspace settings not found, skipping build system migration'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if _xcodeWorkspaceSharedSettings is null', () {
+      testWithoutContext('skipped if _xcodeWorkspaceSharedSettings is null', () async {
         final XcodeBuildSystemMigration iosProjectMigration = XcodeBuildSystemMigration(
           project,
           testLogger,
         );
         project.xcodeWorkspaceSharedSettings = null;
 
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeWorkspaceSharedSettings.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode workspace settings not found, skipping build system migration'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String contents = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -284,12 +284,12 @@ keep this 2
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeWorkspaceSharedSettings.existsSync(), isTrue);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated', () {
+      testWithoutContext('Xcode project is migrated', () async {
         const String contents = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -307,7 +307,7 @@ keep this 2
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeWorkspaceSharedSettings.existsSync(), isFalse);
 
         expect(testLogger.statusText, contains('Legacy build system detected, removing'));
@@ -328,19 +328,19 @@ keep this 2
         project.xcodeProjectWorkspaceData = xcodeProjectWorkspaceData;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final ProjectBuildLocationMigration iosProjectMigration = ProjectBuildLocationMigration(
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectWorkspaceData.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode project workspace data not found, skipping build location migration.'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String contents = '''
  <?xml version="1.0" encoding="UTF-8"?>
  <Workspace
@@ -355,12 +355,12 @@ keep this 2
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectWorkspaceData.existsSync(), isTrue);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated', () {
+      testWithoutContext('Xcode project is migrated', () async {
         const String contents = '''
  <?xml version="1.0" encoding="UTF-8"?>
  <Workspace
@@ -379,7 +379,7 @@ keep this 2
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectWorkspaceData.readAsStringSync(), '''
  <?xml version="1.0" encoding="UTF-8"?>
  <Workspace
@@ -407,19 +407,19 @@ keep this 2
         project.xcodeProjectInfoFile = xcodeProjectInfoFile;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final ProjectBaseConfigurationMigration iosProjectMigration = ProjectBaseConfigurationMigration(
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectInfoFile.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode project not found, skipping Runner project build settings and configuration migration'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String contents = 'Nothing to upgrade';
         xcodeProjectInfoFile.writeAsStringSync(contents);
         final DateTime projectLastModified = xcodeProjectInfoFile.lastModifiedSync();
@@ -428,7 +428,7 @@ keep this 2
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
         expect(xcodeProjectInfoFile.readAsStringSync(), contents);
@@ -436,7 +436,7 @@ keep this 2
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated with template identifiers', () {
+      testWithoutContext('Xcode project is migrated with template identifiers', () async {
         xcodeProjectInfoFile.writeAsStringSync('''
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -456,7 +456,7 @@ keep this 3
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.readAsStringSync(), '''
 		97C147031CF9000F007C117D /* Debug */ = {
@@ -472,7 +472,7 @@ keep this 3
         expect(testLogger.statusText, contains('Project base configurations detected, removing.'));
       });
 
-      testWithoutContext('Xcode project is migrated with custom identifiers', () {
+      testWithoutContext('Xcode project is migrated with custom identifiers', () async {
         xcodeProjectInfoFile.writeAsStringSync('''
 		97C147031CF9000F007C1171 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -511,7 +511,7 @@ keep this 3
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.readAsStringSync(), '''
 		97C147031CF9000F007C1171 /* Debug */ = {
@@ -569,12 +569,12 @@ keep this 3
         project.podfile = podfile;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final IOSDeploymentTargetMigration iosProjectMigration = IOSDeploymentTargetMigration(
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectInfoFile.existsSync(), isFalse);
         expect(appFrameworkInfoPlist.existsSync(), isFalse);
         expect(podfile.existsSync(), isFalse);
@@ -585,7 +585,7 @@ keep this 3
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String xcodeProjectInfoFileContents = 'IPHONEOS_DEPLOYMENT_TARGET = 12.0;';
         xcodeProjectInfoFile.writeAsStringSync(xcodeProjectInfoFileContents);
 
@@ -605,7 +605,7 @@ keep this 3
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
         expect(xcodeProjectInfoFile.readAsStringSync(), xcodeProjectInfoFileContents);
@@ -616,7 +616,7 @@ keep this 3
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated to 12', () {
+      testWithoutContext('Xcode project is migrated to 12', () async {
         xcodeProjectInfoFile.writeAsStringSync('''
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -656,7 +656,7 @@ platform :ios, '11.0'
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.readAsStringSync(), '''
 				GCC_WARN_UNUSED_VARIABLE = YES;
@@ -715,12 +715,12 @@ platform :ios, '12.0'
         project.schemeFile = xcodeProjectSchemeFile;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final XcodeProjectObjectVersionMigration iosProjectMigration = XcodeProjectObjectVersionMigration(
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(xcodeProjectInfoFile.existsSync(), isFalse);
         expect(xcodeProjectSchemeFile.existsSync(), isFalse);
 
@@ -729,7 +729,7 @@ platform :ios, '12.0'
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String xcodeProjectInfoFileContents = '''
 	classes = {
 	};
@@ -752,7 +752,7 @@ platform :ios, '12.0'
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
         expect(xcodeProjectInfoFile.readAsStringSync(), xcodeProjectInfoFileContents);
@@ -761,7 +761,7 @@ platform :ios, '12.0'
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated to newest objectVersion', () {
+      testWithoutContext('Xcode project is migrated to newest objectVersion', () async {
         xcodeProjectInfoFile.writeAsStringSync('''
 	classes = {
 	};
@@ -782,7 +782,7 @@ platform :ios, '12.0'
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(xcodeProjectInfoFile.readAsStringSync(), '''
 	classes = {
@@ -818,19 +818,19 @@ platform :ios, '12.0'
         project.defaultHostInfoPlist = infoPlistFile;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final HostAppInfoPlistMigration iosProjectMigration = HostAppInfoPlistMigration(
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(infoPlistFile.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Info.plist not found, skipping host app Info.plist migration.'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String infoPlistFileContent = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -850,13 +850,13 @@ platform :ios, '12.0'
           testLogger,
         );
         final DateTime infoPlistFileLastModified = infoPlistFile.lastModifiedSync();
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(infoPlistFile.lastModifiedSync(), infoPlistFileLastModified);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('info.plist is migrated', () {
+      testWithoutContext('info.plist is migrated', () async {
         const String infoPlistFileContent = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -871,7 +871,7 @@ platform :ios, '12.0'
           project,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(infoPlistFile.readAsStringSync(), equals('''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -975,20 +975,20 @@ platform :ios, '12.0'
         project.podRunnerFrameworksScript = podRunnerFrameworksScript;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final CocoaPodsScriptReadlink iosProjectMigration = CocoaPodsScriptReadlink(
           project,
           xcode143ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(podRunnerFrameworksScript.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('CocoaPods Pods-Runner-frameworks.sh script not found'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String contents = r'''
   if [ -L "${source}" ]; then
     echo "Symlinked..."
@@ -1001,13 +1001,13 @@ platform :ios, '12.0'
           xcode143ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(podRunnerFrameworksScript.existsSync(), isTrue);
         expect(testLogger.traceText, isEmpty);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if Xcode version below 14.3', () {
+      testWithoutContext('skipped if Xcode version below 14.3', () async {
         const String contents = r'''
   if [ -L "${source}" ]; then
     echo "Symlinked..."
@@ -1025,13 +1025,13 @@ platform :ios, '12.0'
           xcode142ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(podRunnerFrameworksScript.existsSync(), isTrue);
         expect(testLogger.traceText, contains('Detected Xcode version is 14.2.0, below 14.3, skipping "readlink -f" workaround'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated', () {
+      testWithoutContext('Xcode project is migrated', () async {
         const String contents = r'''
   if [ -L "${source}" ]; then
     echo "Symlinked..."
@@ -1044,7 +1044,7 @@ platform :ios, '12.0'
           xcode143ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(podRunnerFrameworksScript.readAsStringSync(), r'''
   if [ -L "${source}" ]; then
     echo "Symlinked..."
@@ -1073,33 +1073,33 @@ platform :ios, '12.0'
         project.podRunnerTargetSupportFiles = podRunnerTargetSupportFiles;
       });
 
-      testWithoutContext('skip if directory is missing', () {
+      testWithoutContext('skip if directory is missing', () async {
         final CocoaPodsToolchainDirectoryMigration iosProjectMigration = CocoaPodsToolchainDirectoryMigration(
           project,
           xcode15ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(podRunnerTargetSupportFiles.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('CocoaPods Pods-Runner Target Support Files not found'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skip if xcconfig files are missing', () {
+      testWithoutContext('skip if xcconfig files are missing', () async {
         podRunnerTargetSupportFiles.createSync();
         final CocoaPodsToolchainDirectoryMigration iosProjectMigration = CocoaPodsToolchainDirectoryMigration(
           project,
           xcode15ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(podRunnerTargetSupportFiles.existsSync(), isTrue);
         expect(testLogger.traceText, isEmpty);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skip if nothing to upgrade', () {
+      testWithoutContext('skip if nothing to upgrade', () async {
         podRunnerTargetSupportFiles.createSync();
         final File debugConfig = podRunnerTargetSupportFiles.childFile('Pods-Runner.debug.xcconfig');
         const String contents = r'''
@@ -1119,13 +1119,13 @@ LIBRARY_SEARCH_PATHS = $(inherited) "${TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_N
           xcode15ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(debugConfig.existsSync(), isTrue);
         expect(testLogger.traceText, isEmpty);
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if Xcode version below 15', () {
+      testWithoutContext('skipped if Xcode version below 15', () async {
         podRunnerTargetSupportFiles.createSync();
         final File debugConfig = podRunnerTargetSupportFiles.childFile('Pods-Runner.debug.xcconfig');
         const String contents = r'''
@@ -1150,13 +1150,13 @@ LIBRARY_SEARCH_PATHS = $(inherited) "${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFOR
           xcode14ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
         expect(debugConfig.existsSync(), isTrue);
         expect(testLogger.traceText, contains('Detected Xcode version is 14.0.0, below 15.0'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('Xcode project is migrated and ignores leading whitespace', () {
+      testWithoutContext('Xcode project is migrated and ignores leading whitespace', () async {
         podRunnerTargetSupportFiles.createSync();
         final File debugConfig = podRunnerTargetSupportFiles.childFile('Pods-Runner.debug.xcconfig');
         const String contents = r'''
@@ -1176,7 +1176,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
           xcode15ProjectInterpreter,
           testLogger,
         );
-        iosProjectMigration.migrate();
+        await iosProjectMigration.migrate();
 
         expect(debugConfig.existsSync(), isTrue);
         expect(debugConfig.readAsStringSync(), r'''
@@ -1214,19 +1214,19 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
       project.xcodeProjectInfoFile = xcodeProjectInfoFile;
     });
 
-    testWithoutContext('skipped if files are missing', () {
+    testWithoutContext('skipped if files are missing', () async {
       final XcodeScriptBuildPhaseMigration iosProjectMigration = XcodeScriptBuildPhaseMigration(
         project,
         testLogger,
       );
-      iosProjectMigration.migrate();
+      await iosProjectMigration.migrate();
       expect(xcodeProjectInfoFile.existsSync(), isFalse);
 
       expect(testLogger.traceText, contains('Xcode project not found, skipping script build phase dependency analysis removal'));
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to upgrade', () {
+    testWithoutContext('skipped if nothing to upgrade', () async {
       const String xcodeProjectInfoFileContents = '''
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
@@ -1245,7 +1245,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
         project,
         testLogger,
       );
-      iosProjectMigration.migrate();
+      await iosProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
       expect(xcodeProjectInfoFile.readAsStringSync(), xcodeProjectInfoFileContents);
@@ -1253,7 +1253,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('alwaysOutOfDate is migrated', () {
+    testWithoutContext('alwaysOutOfDate is migrated', () async {
       xcodeProjectInfoFile.writeAsStringSync('''
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
@@ -1276,7 +1276,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
         project,
         testLogger,
       );
-      iosProjectMigration.migrate();
+      await iosProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.readAsStringSync(), '''
 /* Begin PBXShellScriptBuildPhase section */
@@ -1315,19 +1315,19 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
       project.xcodeProjectInfoFile = xcodeProjectInfoFile;
     });
 
-    testWithoutContext('skipped if files are missing', () {
+    testWithoutContext('skipped if files are missing', () async {
       final XcodeThinBinaryBuildPhaseInputPathsMigration iosProjectMigration = XcodeThinBinaryBuildPhaseInputPathsMigration(
         project,
         testLogger,
       );
-      iosProjectMigration.migrate();
+      await iosProjectMigration.migrate();
       expect(xcodeProjectInfoFile.existsSync(), isFalse);
 
       expect(testLogger.traceText, contains('Xcode project not found, skipping script build phase dependency analysis removal'));
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to upgrade', () {
+    testWithoutContext('skipped if nothing to upgrade', () async {
       const String xcodeProjectInfoFileContents = r'''
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
@@ -1348,7 +1348,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
         project,
         testLogger,
       );
-      iosProjectMigration.migrate();
+      await iosProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
       expect(xcodeProjectInfoFile.readAsStringSync(), xcodeProjectInfoFileContents);
@@ -1356,7 +1356,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('Thin Binary inputPaths is migrated', () {
+    testWithoutContext('Thin Binary inputPaths is migrated', () async {
       xcodeProjectInfoFile.writeAsStringSync(r'''
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
@@ -1382,7 +1382,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) /usr/lib/swift '@executable_path/../Frame
         project,
         testLogger,
       );
-      iosProjectMigration.migrate();
+      await iosProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.readAsStringSync(), r'''
 /* Begin PBXShellScriptBuildPhase section */

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -44,10 +44,10 @@ void main () {
       );
     });
 
-    testWithoutContext('migrators succeed', () {
+    testWithoutContext('migrators succeed', () async {
       final FakeIOSMigrator fakeIOSMigrator = FakeIOSMigrator();
       final ProjectMigration migration = ProjectMigration(<ProjectMigrator>[fakeIOSMigrator]);
-      migration.run();
+      await migration.run();
     });
 
     group('remove framework linking and embedding migration', () {
@@ -901,19 +901,19 @@ platform :ios, '12.0'
         project.xcodeProjectInfoFile = xcodeProjectInfoFile;
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final RemoveBitcodeMigration migration = RemoveBitcodeMigration(
           project,
           testLogger,
         );
-        expect(migration.migrate(), isTrue);
+        expect(await migration.migrate(), isTrue);
         expect(xcodeProjectInfoFile.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode project not found, skipping removing bitcode migration'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to upgrade', () {
+      testWithoutContext('skipped if nothing to upgrade', () async {
         const String xcodeProjectInfoFileContents = 'IPHONEOS_DEPLOYMENT_TARGET = 12.0;';
         xcodeProjectInfoFile.writeAsStringSync(xcodeProjectInfoFileContents);
         final DateTime projectLastModified = xcodeProjectInfoFile.lastModifiedSync();
@@ -922,7 +922,7 @@ platform :ios, '12.0'
           project,
           testLogger,
         );
-        expect(migration.migrate(), isTrue);
+        expect(await migration.migrate(), isTrue);
 
         expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
         expect(xcodeProjectInfoFile.readAsStringSync(), xcodeProjectInfoFileContents);
@@ -930,7 +930,7 @@ platform :ios, '12.0'
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('bitcode build setting is removed', () {
+      testWithoutContext('bitcode build setting is removed', () async {
         xcodeProjectInfoFile.writeAsStringSync('''
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = YES;
@@ -943,7 +943,7 @@ platform :ios, '12.0'
           project,
           testLogger,
         );
-        expect(migration.migrate(), isTrue);
+        expect(await migration.migrate(), isTrue);
 
         expect(xcodeProjectInfoFile.readAsStringSync(), '''
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -1446,7 +1446,7 @@ class FakeIOSMigrator extends ProjectMigrator {
     : super(BufferLogger.test());
 
   @override
-  void migrate() {}
+  Future<void> migrate() async {}
 
   @override
   String migrateLine(String line) {

--- a/packages/flutter_tools/test/general.shard/macos/macos_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_project_migration_test.dart
@@ -40,7 +40,7 @@ void main() {
       macOSProject.xcodeProjectInfoFile = xcodeProjectInfoFile;
     });
 
-    testWithoutContext('skipped if files are missing', () {
+    testWithoutContext('skipped if files are missing', () async {
       final RemoveMacOSFrameworkLinkAndEmbeddingMigration macosProjectMigration =
           RemoveMacOSFrameworkLinkAndEmbeddingMigration(
         macOSProject,
@@ -48,7 +48,7 @@ void main() {
         testUsage,
         fakeAnalytics,
       );
-      macosProjectMigration.migrate();
+      await macosProjectMigration.migrate();
       expect(testUsage.events, isEmpty);
       expect(fakeAnalytics.sentEvents, isEmpty);
 
@@ -61,7 +61,7 @@ void main() {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to upgrade', () {
+    testWithoutContext('skipped if nothing to upgrade', () async {
       const String contents = 'Nothing to upgrade';
       xcodeProjectInfoFile.writeAsStringSync(contents);
       final DateTime projectLastModified =
@@ -74,7 +74,7 @@ void main() {
         testUsage,
         fakeAnalytics,
       );
-      macosProjectMigration.migrate();
+      await macosProjectMigration.migrate();
       expect(testUsage.events, isEmpty);
       expect(fakeAnalytics.sentEvents, isEmpty);
 
@@ -84,7 +84,7 @@ void main() {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skips migrating script with embed', () {
+    testWithoutContext('skips migrating script with embed', () async {
       const String contents = r'''
 shellScript = "echo \"$PRODUCT_NAME.app\" > \"$PROJECT_DIR\"/Flutter/ephemeral/.app_filename && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh embed\n";
 			''';
@@ -97,12 +97,12 @@ shellScript = "echo \"$PRODUCT_NAME.app\" > \"$PROJECT_DIR\"/Flutter/ephemeral/.
         testUsage,
         fakeAnalytics,
       );
-      macosProjectMigration.migrate();
+      await macosProjectMigration.migrate();
       expect(xcodeProjectInfoFile.readAsStringSync(), contents);
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('Xcode project is migrated', () {
+    testWithoutContext('Xcode project is migrated', () async {
       xcodeProjectInfoFile.writeAsStringSync(r'''
 prefix D73912F022F37F9E000D13A0
 D73912F222F3801D000D13A0 suffix
@@ -121,7 +121,7 @@ keep this 2
         testUsage,
         fakeAnalytics,
       );
-      macosProjectMigration.migrate();
+      await macosProjectMigration.migrate();
       expect(testUsage.events, isEmpty);
       expect(fakeAnalytics.sentEvents, isEmpty);
 
@@ -206,12 +206,12 @@ keep this 2
       project.podfile = podfile;
     });
 
-    testWithoutContext('skipped if files are missing', () {
+    testWithoutContext('skipped if files are missing', () async {
       final MacOSDeploymentTargetMigration macOSProjectMigration = MacOSDeploymentTargetMigration(
         project,
         testLogger,
       );
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
       expect(xcodeProjectInfoFile.existsSync(), isFalse);
       expect(podfile.existsSync(), isFalse);
 
@@ -220,7 +220,7 @@ keep this 2
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to upgrade', () {
+    testWithoutContext('skipped if nothing to upgrade', () async {
       const String xcodeProjectInfoFileContents = 'MACOSX_DEPLOYMENT_TARGET = 10.14;';
       xcodeProjectInfoFile.writeAsStringSync(xcodeProjectInfoFileContents);
 
@@ -234,7 +234,7 @@ keep this 2
         project,
         testLogger,
       );
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.lastModifiedSync(), projectLastModified);
       expect(xcodeProjectInfoFile.readAsStringSync(), xcodeProjectInfoFileContents);
@@ -244,7 +244,7 @@ keep this 2
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('Xcode project is migrated from 10.11 to 10.14', () {
+    testWithoutContext('Xcode project is migrated from 10.11 to 10.14', () async {
       xcodeProjectInfoFile.writeAsStringSync('''
  				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
@@ -260,7 +260,7 @@ platform :osx, '10.11'
         project,
         testLogger,
       );
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.readAsStringSync(), '''
  				GCC_WARN_UNUSED_VARIABLE = YES;
@@ -276,7 +276,7 @@ platform :osx, '10.14'
       expect('Updating minimum macOS deployment target to 10.14'.allMatches(testLogger.statusText).length, 1);
     });
 
-    testWithoutContext('Xcode project is migrated from 10.13 to 10.14', () {
+    testWithoutContext('Xcode project is migrated from 10.13 to 10.14', () async {
       xcodeProjectInfoFile.writeAsStringSync('''
  				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
@@ -292,7 +292,7 @@ platform :osx, '10.13'
         project,
         testLogger,
       );
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
 
       expect(xcodeProjectInfoFile.readAsStringSync(), '''
  				GCC_WARN_UNUSED_VARIABLE = YES;
@@ -344,7 +344,7 @@ platform :osx, '10.14'
         project,
         testLogger,
       );
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
       expect(infoPlistFile.existsSync(), isFalse);
 
       expect(testLogger.traceText, isEmpty);
@@ -357,7 +357,7 @@ platform :osx, '10.14'
         testLogger,
       );
       infoPlistFile.writeAsStringSync('contents'); // Just so it exists: parser is a fake.
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
       expect(fakePlistParser.getValueFromFile<String>(infoPlistFile.path, PlistParser.kNSPrincipalClassKey), isNull);
       expect(testLogger.statusText, isEmpty);
     });
@@ -369,7 +369,7 @@ platform :osx, '10.14'
         testLogger,
       );
       infoPlistFile.writeAsStringSync('contents'); // Just so it exists: parser is a fake.
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
       expect(fakePlistParser.getValueFromFile<String>(infoPlistFile.path, PlistParser.kNSPrincipalClassKey), 'NSApplication');
       expect(testLogger.statusText, isEmpty);
     });
@@ -381,7 +381,7 @@ platform :osx, '10.14'
         testLogger,
       );
       infoPlistFile.writeAsStringSync('contents'); // Just so it exists: parser is a fake.
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
       expect(fakePlistParser.getValueFromFile<String>(infoPlistFile.path, PlistParser.kNSPrincipalClassKey), 'NSApplication');
       // Only print once.
       expect('Updating ${infoPlistFile.basename} to use NSApplication instead of FlutterApplication.'.allMatches(testLogger.statusText).length, 1);
@@ -395,7 +395,7 @@ platform :osx, '10.14'
         testLogger,
       );
       infoPlistFile.writeAsStringSync('contents'); // Just so it exists: parser is a fake.
-      macOSProjectMigration.migrate();
+      await macOSProjectMigration.migrate();
       expect(fakePlistParser.getValueFromFile<String>(infoPlistFile.path, PlistParser.kNSPrincipalClassKey), differentApp);
       expect(testLogger.traceText, isEmpty);
     });

--- a/packages/flutter_tools/test/general.shard/migrations/cmake_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrations/cmake_project_migration_test.dart
@@ -33,19 +33,19 @@ void main () {
         mockCmakeProject = FakeCmakeProject(managedCmakeFile);
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final CmakeCustomCommandMigration cmakeProjectMigration = CmakeCustomCommandMigration(
           mockCmakeProject,
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
         expect(managedCmakeFile.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('CMake project not found, skipping add_custom_command() VERBATIM migration'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to migrate', () {
+      testWithoutContext('skipped if nothing to migrate', () async {
         const String contents = 'Nothing to migrate';
         managedCmakeFile.writeAsStringSync(contents);
         final DateTime projectLastModified = managedCmakeFile.lastModifiedSync();
@@ -54,7 +54,7 @@ void main () {
           mockCmakeProject,
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
 
         expect(managedCmakeFile.lastModifiedSync(), projectLastModified);
         expect(managedCmakeFile.readAsStringSync(), contents);
@@ -62,7 +62,7 @@ void main () {
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if already migrated', () {
+      testWithoutContext('skipped if already migrated', () async {
         const String contents = r'''
 add_custom_command(
   OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
@@ -81,7 +81,7 @@ add_custom_command(
           mockCmakeProject,
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
 
         expect(managedCmakeFile.lastModifiedSync(), projectLastModified);
         expect(managedCmakeFile.readAsStringSync(), contents);
@@ -89,7 +89,7 @@ add_custom_command(
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('is migrated to use VERBATIM', () {
+      testWithoutContext('is migrated to use VERBATIM', () async {
         managedCmakeFile.writeAsStringSync(r'''
 add_custom_command(
   OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
@@ -105,7 +105,7 @@ add_custom_command(
           mockCmakeProject,
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
 
         expect(managedCmakeFile.readAsStringSync(), r'''
 add_custom_command(
@@ -122,7 +122,7 @@ add_custom_command(
         expect(testLogger.statusText, contains('add_custom_command() missing VERBATIM or FLUTTER_TARGET_PLATFORM, updating.'));
       });
 
-      testWithoutContext('is migrated to use FLUTTER_TARGET_PLATFORM', () {
+      testWithoutContext('is migrated to use FLUTTER_TARGET_PLATFORM', () async {
         managedCmakeFile.writeAsStringSync(r'''
 add_custom_command(
   OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
@@ -139,7 +139,7 @@ add_custom_command(
           mockCmakeProject,
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
 
         expect(managedCmakeFile.readAsStringSync(), r'''
 add_custom_command(
@@ -175,20 +175,20 @@ add_custom_command(
         mockCmakeProject = FakeCmakeProject(managedCmakeFile);
       });
 
-      testWithoutContext('skipped if files are missing', () {
+      testWithoutContext('skipped if files are missing', () async {
         final CmakeNativeAssetsMigration cmakeProjectMigration = CmakeNativeAssetsMigration(
           mockCmakeProject,
           'linux',
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
         expect(managedCmakeFile.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('CMake project not found, skipping install() NATIVE_ASSETS_DIR migration.'));
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if nothing to migrate', () {
+      testWithoutContext('skipped if nothing to migrate', () async {
         const String contents = 'Nothing to migrate';
         managedCmakeFile.writeAsStringSync(contents);
         final DateTime projectLastModified = managedCmakeFile.lastModifiedSync();
@@ -198,7 +198,7 @@ add_custom_command(
           'linux',
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
 
         expect(managedCmakeFile.lastModifiedSync(), projectLastModified);
         expect(managedCmakeFile.readAsStringSync(), contents);
@@ -206,7 +206,7 @@ add_custom_command(
         expect(testLogger.statusText, isEmpty);
       });
 
-      testWithoutContext('skipped if already migrated', () {
+      testWithoutContext('skipped if already migrated', () async {
         const String contents = r'''
 # Copy the native assets provided by the build.dart from all packages.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
@@ -222,7 +222,7 @@ install(DIRECTORY "${NATIVE_ASSETS_DIR}"
           'linux',
           testLogger,
         );
-        cmakeProjectMigration.migrate();
+        await cmakeProjectMigration.migrate();
 
         expect(managedCmakeFile.lastModifiedSync(), projectLastModified);
         expect(managedCmakeFile.readAsStringSync(), contents);
@@ -231,7 +231,7 @@ install(DIRECTORY "${NATIVE_ASSETS_DIR}"
       });
 
       for (final String os in <String>['linux', 'windows']) {
-        testWithoutContext('is migrated to copy native assets', () {
+        testWithoutContext('is migrated to copy native assets', () async {
           managedCmakeFile.writeAsStringSync(r'''
 foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
   install(FILES "${bundled_library}"
@@ -254,7 +254,7 @@ install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
             os,
             testLogger,
           );
-          cmakeProjectMigration.migrate();
+          await cmakeProjectMigration.migrate();
 
           expect(managedCmakeFile.readAsStringSync(), '''
 foreach(bundled_library \${PLUGIN_BUNDLED_LIBRARIES})

--- a/packages/flutter_tools/test/general.shard/windows/migrations/build_architecture_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/migrations/build_architecture_migration_test.dart
@@ -33,7 +33,7 @@ void main () {
       mockProject = FakeWindowsProject(cmakeFile);
     });
 
-    testWithoutContext('delete old runner directory', () {
+    testWithoutContext('delete old runner directory', () async {
       buildDirectory.createSync();
       final Directory oldRunnerDirectory =
         buildDirectory
@@ -49,7 +49,7 @@ void main () {
         buildDirectory,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(oldRunnerDirectory.existsSync(), isFalse);
       expect(testLogger.traceText,
@@ -61,13 +61,13 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if CMake file is missing', () {
+    testWithoutContext('skipped if CMake file is missing', () async {
       final BuildArchitectureMigration migration = BuildArchitectureMigration(
         mockProject,
         buildDirectory,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
       expect(cmakeFile.existsSync(), isFalse);
 
       expect(testLogger.traceText,
@@ -75,7 +75,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to migrate', () {
+    testWithoutContext('skipped if nothing to migrate', () async {
       const String cmakeFileContents = 'Nothing to migrate';
 
       cmakeFile.writeAsStringSync(cmakeFileContents);
@@ -87,14 +87,14 @@ void main () {
         buildDirectory,
         testLogger,
       );
-      buildArchitectureMigration.migrate();
+      await buildArchitectureMigration.migrate();
 
       expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
       expect(cmakeFile.readAsStringSync(), cmakeFileContents);
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if already migrated', () {
+    testWithoutContext('skipped if already migrated', () async {
       const String cmakeFileContents =
         '# TODO: Move the rest of this into files in ephemeral. See\n'
         '# https://github.com/flutter/flutter/issues/57146.\n'
@@ -128,7 +128,7 @@ void main () {
         buildDirectory,
         testLogger,
       );
-      buildArchitectureMigration.migrate();
+      await buildArchitectureMigration.migrate();
 
       expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
       expect(cmakeFile.readAsStringSync(), cmakeFileContents);
@@ -136,7 +136,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if already migrated (CRLF)', () {
+    testWithoutContext('skipped if already migrated (CRLF)', () async {
       const String cmakeFileContents =
         '# TODO: Move the rest of this into files in ephemeral. See\r\n'
         '# https://github.com/flutter/flutter/issues/57146.\r\n'
@@ -170,7 +170,7 @@ void main () {
         buildDirectory,
         testLogger,
       );
-      buildArchitectureMigration.migrate();
+      await buildArchitectureMigration.migrate();
 
       expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
       expect(cmakeFile.readAsStringSync(), cmakeFileContents);
@@ -178,7 +178,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('migrates project to set the target platform', () {
+    testWithoutContext('migrates project to set the target platform', () async {
       cmakeFile.writeAsStringSync(
         '# TODO: Move the rest of this into files in ephemeral. See\n'
         '# https://github.com/flutter/flutter/issues/57146.\n'
@@ -203,7 +203,7 @@ void main () {
         buildDirectory,
         testLogger,
       );
-      buildArchitectureMigration.migrate();
+      await buildArchitectureMigration.migrate();
 
       expect(cmakeFile.readAsStringSync(),
         '# TODO: Move the rest of this into files in ephemeral. See\n'
@@ -233,7 +233,7 @@ void main () {
       expect(testLogger.statusText, contains('windows/flutter/CMakeLists.txt does not use FLUTTER_TARGET_PLATFORM, updating.'));
     });
 
-    testWithoutContext('migrates project to set the target platform (CRLF)', () {
+    testWithoutContext('migrates project to set the target platform (CRLF)', () async {
       cmakeFile.writeAsStringSync(
         '# TODO: Move the rest of this into files in ephemeral. See\r\n'
         '# https://github.com/flutter/flutter/issues/57146.\r\n'
@@ -259,7 +259,7 @@ void main () {
         buildDirectory,
         testLogger,
       );
-      buildArchitectureMigration.migrate();
+      await buildArchitectureMigration.migrate();
 
       expect(cmakeFile.readAsStringSync(),
         '# TODO: Move the rest of this into files in ephemeral. See\r\n'

--- a/packages/flutter_tools/test/general.shard/windows/migrations/show_window_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/migrations/show_window_migration_test.dart
@@ -31,12 +31,12 @@ void main () {
       mockProject = FakeWindowsProject(flutterWindowFile);
     });
 
-    testWithoutContext('skipped if Flutter window file is missing', () {
+    testWithoutContext('skipped if Flutter window file is missing', () async {
       final ShowWindowMigration migration = ShowWindowMigration(
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(flutterWindowFile.existsSync(), isFalse);
 
@@ -50,7 +50,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to migrate', () {
+    testWithoutContext('skipped if nothing to migrate', () async {
       const String flutterWindowContents = 'Nothing to migrate';
 
       flutterWindowFile.writeAsStringSync(flutterWindowContents);
@@ -60,7 +60,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(flutterWindowFile.lastModifiedSync(), updatedAt);
       expect(flutterWindowFile.readAsStringSync(), flutterWindowContents);
@@ -68,7 +68,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if already migrated', () {
+    testWithoutContext('skipped if already migrated', () async {
       const String flutterWindowContents =
         '  flutter_controller_->engine()->SetNextFrameCallback([&]() {\n'
         '    this->Show();\n'
@@ -88,7 +88,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(flutterWindowFile.lastModifiedSync(), updatedAt);
       expect(flutterWindowFile.readAsStringSync(), flutterWindowContents);
@@ -96,7 +96,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if already migrated (CRLF)', () {
+    testWithoutContext('skipped if already migrated (CRLF)', () async {
       const String flutterWindowContents =
         '  flutter_controller_->engine()->SetNextFrameCallback([&]() {\r\n'
         '    this->Show();\r\n'
@@ -116,7 +116,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(flutterWindowFile.lastModifiedSync(), updatedAt);
       expect(flutterWindowFile.readAsStringSync(), flutterWindowContents);
@@ -124,7 +124,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('migrates project to ensure window is shown', () {
+    testWithoutContext('migrates project to ensure window is shown', () async {
       flutterWindowFile.writeAsStringSync(
         '  flutter_controller_->engine()->SetNextFrameCallback([&]() {\n'
         '    this->Show();\n'
@@ -137,7 +137,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(flutterWindowFile.readAsStringSync(),
         '  flutter_controller_->engine()->SetNextFrameCallback([&]() {\n'
@@ -155,7 +155,7 @@ void main () {
       expect(testLogger.statusText, contains('windows/runner/flutter_window.cpp does not ensure the show window callback is called, updating.'));
     });
 
-    testWithoutContext('migrates project to ensure window is shown (CRLF)', () {
+    testWithoutContext('migrates project to ensure window is shown (CRLF)', () async {
       flutterWindowFile.writeAsStringSync(
         '  flutter_controller_->engine()->SetNextFrameCallback([&]() {\r\n'
         '    this->Show();\r\n'
@@ -168,7 +168,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
 
       expect(flutterWindowFile.readAsStringSync(),
         '  flutter_controller_->engine()->SetNextFrameCallback([&]() {\r\n'

--- a/packages/flutter_tools/test/general.shard/windows/migrations/version_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/migrations/version_migration_test.dart
@@ -33,7 +33,7 @@ void main () {
       mockProject = FakeWindowsProject(cmakeFile, resourceFile);
     });
 
-    testWithoutContext('skipped if CMake file is missing', () {
+    testWithoutContext('skipped if CMake file is missing', () async {
       const String resourceFileContents = 'Hello world';
 
       resourceFile.writeAsStringSync(resourceFileContents);
@@ -41,7 +41,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
       expect(cmakeFile.existsSync(), isFalse);
       expect(resourceFile.existsSync(), isTrue);
 
@@ -50,7 +50,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if resource file is missing', () {
+    testWithoutContext('skipped if resource file is missing', () async {
       const String cmakeFileContents = 'Hello world';
 
       cmakeFile.writeAsStringSync(cmakeFileContents);
@@ -58,7 +58,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      migration.migrate();
+      await migration.migrate();
       expect(cmakeFile.existsSync(), isTrue);
       expect(resourceFile.existsSync(), isFalse);
 
@@ -67,7 +67,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if nothing to migrate', () {
+    testWithoutContext('skipped if nothing to migrate', () async {
       const String cmakeFileContents = 'Nothing to migrate';
       const String resourceFileContents = 'Nothing to migrate';
 
@@ -81,7 +81,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      versionMigration.migrate();
+      await versionMigration.migrate();
 
       expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
       expect(cmakeFile.readAsStringSync(), cmakeFileContents);
@@ -91,7 +91,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if already migrated', () {
+    testWithoutContext('skipped if already migrated', () async {
       const String cmakeFileContents =
         '# Apply the standard set of build settings. This can be removed for applications\n'
         '# that need different build settings.\n'
@@ -129,7 +129,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      versionMigration.migrate();
+      await versionMigration.migrate();
 
       expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
       expect(cmakeFile.readAsStringSync(), cmakeFileContents);
@@ -139,7 +139,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('skipped if already migrated (CRLF)', () {
+    testWithoutContext('skipped if already migrated (CRLF)', () async {
       const String cmakeFileContents =
         '# Apply the standard set of build settings. This can be removed for applications\r\n'
         '# that need different build settings.\r\n'
@@ -177,7 +177,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      versionMigration.migrate();
+      await versionMigration.migrate();
 
       expect(cmakeFile.lastModifiedSync(), cmakeUpdatedAt);
       expect(cmakeFile.readAsStringSync(), cmakeFileContents);
@@ -187,7 +187,7 @@ void main () {
       expect(testLogger.statusText, isEmpty);
     });
 
-    testWithoutContext('migrates project to set version information', () {
+    testWithoutContext('migrates project to set version information', () async {
       cmakeFile.writeAsStringSync(
         '# Apply the standard set of build settings. This can be removed for applications\n'
         '# that need different build settings.\n'
@@ -214,7 +214,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      versionMigration.migrate();
+      await versionMigration.migrate();
 
       expect(cmakeFile.readAsStringSync(),
         '# Apply the standard set of build settings. This can be removed for applications\n'
@@ -249,7 +249,7 @@ void main () {
       expect(testLogger.statusText, contains('windows/runner/Runner.rc does not use Flutter version information, updating.'));
     });
 
-    testWithoutContext('migrates project to set version information (CRLF)', () {
+    testWithoutContext('migrates project to set version information (CRLF)', () async {
       cmakeFile.writeAsStringSync(
         '# Apply the standard set of build settings. This can be removed for applications\r\n'
         '# that need different build settings.\r\n'
@@ -276,7 +276,7 @@ void main () {
         mockProject,
         testLogger,
       );
-      versionMigration.migrate();
+      await versionMigration.migrate();
 
       expect(cmakeFile.readAsStringSync(),
         '# Apply the standard set of build settings. This can be removed for applications\r\n'


### PR DESCRIPTION
Convert `ProjectMigration.run()` and `ProjectMigrator.migrate()` to be async.

Needed for Swift Package Manager migration, which requires some async processes: https://github.com/flutter/flutter/pull/146256

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
