### PR TITLE
Prepare integration test driver to pass a destination directory.

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/measure_scroll_smoothness_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/measure_scroll_smoothness_test.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
-  responseDataCallback: (Map<String, dynamic>? data) async {
+  responseDataCallback: (Map<String, dynamic>? data, {String? destinationDirectory}) async {
     await driver.writeResponseData(
       data,
       testOutputFilename: 'scroll_smoothness_test',

--- a/dev/benchmarks/macrobenchmarks/test_driver/e2e_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/e2e_test.dart
@@ -5,7 +5,7 @@
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
-  responseDataCallback: (Map<String, dynamic>? data) async {
+  responseDataCallback: (Map<String, dynamic>? data, {String? destinationDirectory}) async {
     await driver.writeResponseData(
       data?['performance'] as Map<String, dynamic>,
       testOutputFilename: 'e2e_perf_summary',

--- a/dev/benchmarks/macrobenchmarks/test_driver/frame_policy_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/frame_policy_test.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
-  responseDataCallback: (Map<String, dynamic>? data) async {
+  responseDataCallback: (Map<String, dynamic>? data, {String? destinationDirectory}) async {
     final Map<String, dynamic> benchmarkLiveResult =
         data?['benchmarkLive'] as Map<String,dynamic>;
     final Map<String, dynamic> fullyLiveResult =

--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_e2e_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_e2e_test.dart
@@ -5,7 +5,7 @@
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
-  responseDataCallback: (Map<String, dynamic>? data) async {
+  responseDataCallback: (Map<String, dynamic>? data, {String? destinationDirectory}) async {
     await driver.writeResponseData(
       data!['performance'] as Map<String, dynamic>,
       testOutputFilename: 'e2e_perf_summary',

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -326,7 +326,7 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   ///
   /// Future<void> main() {
   ///   return integrationDriver(
-  ///     responseDataCallback: (Map<String, dynamic>? data) async {
+  ///     responseDataCallback: (Map<String, dynamic>? data, {String? destinationDirectory}) async {
   ///       if (data != null) {
   ///         for (final MapEntry<String, dynamic> entry in data.entries) {
   ///           print('Writing ${entry.key} to the disk.');

--- a/packages/integration_test/lib/integration_test_driver.dart
+++ b/packages/integration_test/lib/integration_test_driver.dart
@@ -24,7 +24,7 @@ String testOutputsDirectory =
 
 /// The callback type to handle [Response.data] after the test
 /// succeeds.
-typedef ResponseDataCallback = FutureOr<void> Function(Map<String, dynamic>?);
+typedef ResponseDataCallback = FutureOr<void> Function(Map<String, dynamic>?, {String? destinationDirectory});
 
 /// Writes a json-serializable data to
 /// [testOutputsDirectory]/`testOutputFilename.json`.
@@ -75,6 +75,7 @@ Future<void> integrationDriver({
   Duration timeout = const Duration(minutes: 20),
   ResponseDataCallback? responseDataCallback = writeResponseData,
   bool writeResponseOnFailure = false,
+  String? destinationDirectory,
 }) async {
   final FlutterDriver driver = await FlutterDriver.connect();
   final String jsonResult = await driver.requestData(null, timeout: timeout);
@@ -85,13 +86,13 @@ Future<void> integrationDriver({
   if (response.allTestsPassed) {
     print('All tests passed.');
     if (responseDataCallback != null) {
-      await responseDataCallback(response.data);
+      await responseDataCallback(response.data, destinationDirectory: destinationDirectory);
     }
     exit(0);
   } else {
     print('Failure Details:\n${response.formattedFailureDetails}');
     if (responseDataCallback != null && writeResponseOnFailure) {
-      await responseDataCallback(response.data);
+      await responseDataCallback(response.data, destinationDirectory: destinationDirectory);
     }
     exit(1);
   }

--- a/packages/integration_test/lib/integration_test_driver_extended.dart
+++ b/packages/integration_test/lib/integration_test_driver_extended.dart
@@ -24,7 +24,7 @@ String testOutputsDirectory =
 
 /// The callback type to handle [Response.data] after the test
 /// succeeds.
-typedef ResponseDataCallback = FutureOr<void> Function(Map<String, dynamic>?);
+typedef ResponseDataCallback = FutureOr<void> Function(Map<String, dynamic>?, {String? destinationDirectory});
 
 /// Writes a json-serializable data to
 /// [testOutputsDirectory]/`testOutputFilename.json`.
@@ -88,6 +88,7 @@ Future<void> integrationDriver({
   ScreenshotCallback? onScreenshot,
   ResponseDataCallback? responseDataCallback = writeResponseData,
   bool writeResponseOnFailure = false,
+  String? destinationDirectory,
 }) async {
   driver ??= await FlutterDriver.connect();
   // Test states that it's waiting on web driver commands.
@@ -175,13 +176,13 @@ Future<void> integrationDriver({
   if (response.allTestsPassed) {
     print('All tests passed.');
     if (responseDataCallback != null) {
-      await responseDataCallback(response.data);
+      await responseDataCallback(response.data, destinationDirectory: destinationDirectory);
     }
     exit(0);
   } else {
     print('Failure Details:\n${response.formattedFailureDetails}');
     if (responseDataCallback != null && writeResponseOnFailure) {
-      await responseDataCallback(response.data);
+      await responseDataCallback(response.data, destinationDirectory: destinationDirectory);
     }
     exit(1);
   }


### PR DESCRIPTION
This is the first step to allow tests to provide a directory where to place logs and test outputs.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
