### PR TITLE
Scrollbar thumb drag gestures now produce one start and one end scroll notification

### DIFF
--- a/examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.0.dart
+++ b/examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.0.dart
@@ -1,0 +1,131 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+/// Flutter code sample for [ScrollEndNotification].
+
+void main() {
+  runApp(const ScrollEndNotificationApp());
+}
+
+class ScrollEndNotificationApp extends StatelessWidget {
+  const ScrollEndNotificationApp({ super.key });
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: ScrollEndNotificationExample(),
+    );
+  }
+}
+
+class ScrollEndNotificationExample extends StatefulWidget {
+  const ScrollEndNotificationExample({ super.key });
+
+  @override
+  State<ScrollEndNotificationExample> createState() => _ScrollEndNotificationExampleState();
+}
+
+class _ScrollEndNotificationExampleState extends State<ScrollEndNotificationExample> {
+  static const int itemCount = 25;
+  static const double itemExtent = 100;
+
+  late final ScrollController scrollController;
+  late double lastScrollOffset;
+
+  @override
+  void initState() {
+    scrollController = ScrollController();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    scrollController.dispose();
+  }
+
+  // After an interactive scroll "ends", auto-scroll so that last item in the
+  // viewport is completely visible. To accomodate mouse-wheel scrolls, other small
+  // adjustments, and scrolling to the top, scrolls that put the scroll offset at
+  // zero or change the scroll offset by less than itemExtent don't trigger
+  // an auto-scroll. This also prevents the auto-scroll from triggering itself,
+  // since the alignedScrollOffset is guaranteed to be less than itemExtent.
+  bool handleScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification) {
+      lastScrollOffset = scrollController.position.pixels;
+    }
+    if (notification is ScrollEndNotification) {
+      final ScrollMetrics m = notification.metrics;
+      final int lastIndex = ((m.extentBefore + m.extentInside) ~/ itemExtent).clamp(0, itemCount - 1);
+      final double alignedScrollOffset = itemExtent * (lastIndex + 1) - m.extentInside;
+      final double scrollOffset = scrollController.position.pixels;
+      if (scrollOffset > 0 && (scrollOffset - lastScrollOffset).abs() > itemExtent) {
+        SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
+          scrollController.animateTo(
+            alignedScrollOffset,
+            duration: const Duration(milliseconds: 400),
+            curve: Curves.fastOutSlowIn,
+          );
+        });
+      }
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Scrollbar(
+          controller: scrollController,
+          thumbVisibility: true,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: NotificationListener<ScrollNotification>(
+              onNotification: handleScrollNotification,
+              child: CustomScrollView(
+                controller: scrollController,
+                slivers: <Widget>[
+                  SliverFixedExtentList(
+                    itemExtent: itemExtent,
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        return Item(
+                          title: 'Item $index',
+                          color: Color.lerp(Colors.red, Colors.blue, index / itemCount)!
+                        );
+                      },
+                      childCount: itemCount,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class Item extends StatelessWidget {
+  const Item({ super.key, required this.title, required this.color });
+
+  final String title;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: color,
+      child: ListTile(
+        textColor: Colors.white,
+        title: Text(title),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/widgets/scroll_position/is_scrolling_listener.0.dart
+++ b/examples/api/lib/widgets/scroll_position/is_scrolling_listener.0.dart
@@ -1,0 +1,139 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+/// Flutter code sample for [IsScrollingListener].
+void main() {
+  runApp(const IsScrollingListenerApp());
+}
+
+class IsScrollingListenerApp extends StatelessWidget {
+  const IsScrollingListenerApp({ super.key });
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: IsScrollingListenerExample(),
+    );
+  }
+}
+
+class IsScrollingListenerExample extends StatefulWidget {
+  const IsScrollingListenerExample({ super.key });
+
+  @override
+  State<IsScrollingListenerExample> createState() => _IsScrollingListenerExampleState();
+}
+
+class _IsScrollingListenerExampleState extends State<IsScrollingListenerExample> {
+  static const int itemCount = 25;
+  static const double itemExtent = 100;
+
+  late final ScrollController scrollController;
+  late double lastScrollOffset;
+  bool isScrolling = false;
+
+  @override
+  void initState() {
+    scrollController = ScrollController(
+      onAttach: (ScrollPosition position) {
+        position.isScrollingNotifier.addListener(handleScrollChange);
+      },
+      onDetach: (ScrollPosition position) {
+        position.isScrollingNotifier.removeListener(handleScrollChange);
+      },
+    );
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  // After an interactive scroll "ends", auto-scroll so that last item in the
+  // viewport is completely visible. To accomodate mouse-wheel scrolls, other small
+  // adjustments, and scrolling to the top, scrolls that put the scroll offset at
+  // zero or change the scroll offset by less than itemExtent don't trigger
+  // an auto-scroll.
+  void handleScrollChange() {
+    final bool isScrollingNow = scrollController.position.isScrollingNotifier.value;
+    if (isScrolling == isScrollingNow) {
+      return;
+    }
+    isScrolling = isScrollingNow;
+    if (isScrolling) {
+      // scroll-start
+      lastScrollOffset = scrollController.position.pixels;
+    } else {
+      // scroll-end
+      final ScrollPosition p = scrollController.position;
+      final int lastIndex = ((p.extentBefore + p.extentInside) ~/ itemExtent).clamp(0, itemCount - 1);
+      final double alignedScrollOffset = itemExtent * (lastIndex + 1) - p.extentInside;
+      final double scrollOffset = scrollController.position.pixels;
+      if (scrollOffset > 0 && (scrollOffset - lastScrollOffset).abs() > itemExtent) {
+        SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
+          scrollController.animateTo(
+            alignedScrollOffset,
+            duration: const Duration(milliseconds: 400),
+            curve: Curves.fastOutSlowIn,
+          );
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Scrollbar(
+          controller: scrollController,
+          thumbVisibility: true,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: CustomScrollView(
+              controller: scrollController,
+              slivers: <Widget>[
+                SliverFixedExtentList(
+                  itemExtent: itemExtent,
+                  delegate: SliverChildBuilderDelegate(
+                    (BuildContext context, int index) {
+                      return Item(
+                        title: 'Item $index',
+                        color: Color.lerp(Colors.red, Colors.blue, index / itemCount)!
+                      );
+                    },
+                    childCount: itemCount,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class Item extends StatelessWidget {
+  const Item({ super.key, required this.title, required this.color });
+
+  final String title;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: color,
+      child: ListTile(
+        textColor: Colors.white,
+        title: Text(title),
+      ),
+    );
+  }
+}

--- a/examples/api/test/widgets/scroll_end_notification/scroll_end_notification.0_test.dart
+++ b/examples/api/test/widgets/scroll_end_notification/scroll_end_notification.0_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/scroll_end_notification/scroll_end_notification.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('IsScrollingListenerApp smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ScrollEndNotificationApp(),
+    );
+
+    expect(find.byType(CustomScrollView), findsOneWidget);
+    expect(find.byType(Scrollbar), findsOneWidget);
+
+    ScrollPosition getScrollPosition() {
+      return tester.widget<CustomScrollView>(find.byType(CustomScrollView)).controller!.position;
+    }
+
+    // Viewport is 600 pixels high, each item's height is 100, 6 items are visible.
+    expect(getScrollPosition().viewportDimension, 600);
+    expect(getScrollPosition().pixels, 0);
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 5'), findsOneWidget);
+
+    // Small (< 100) scrolls don't trigger an auto-scroll
+    await tester.drag(find.byType(Scrollbar), const Offset(0, -20.0));
+    await tester.pumpAndSettle();
+    expect(getScrollPosition().pixels, 20);
+    expect(find.text('Item 0'), findsOneWidget);
+
+    // Initial scroll is to 220: items 0,1 are scrolled off the top,
+    // the bottom 80 pixels of item 2 are visible, items 4-7 are
+    // completely visible, the first 20 pixels of item 8 are visible.
+    // After the auto-scroll, items 3-8 are completely visible.
+    await tester.drag(find.byType(Scrollbar), const Offset(0, -200.0));
+    await tester.pumpAndSettle();
+    expect(getScrollPosition().pixels, 300);
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 3'), findsOneWidget);
+    expect(find.text('Item 8'), findsOneWidget);
+  });
+}

--- a/examples/api/test/widgets/scroll_position/is_scrolling_listener.0_test.dart
+++ b/examples/api/test/widgets/scroll_position/is_scrolling_listener.0_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/scroll_position/is_scrolling_listener.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('IsScrollingListenerApp smoke test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.IsScrollingListenerApp(),
+    );
+
+    expect(find.byType(CustomScrollView), findsOneWidget);
+    expect(find.byType(Scrollbar), findsOneWidget);
+
+    ScrollPosition getScrollPosition() {
+      return tester.widget<CustomScrollView>(find.byType(CustomScrollView)).controller!.position;
+    }
+
+    // Viewport is 600 pixels high, each item's height is 100, 6 items are visible.
+    expect(getScrollPosition().viewportDimension, 600);
+    expect(getScrollPosition().pixels, 0);
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 5'), findsOneWidget);
+
+    // Small (< 100) scrolls don't trigger an auto-scroll
+    await tester.drag(find.byType(Scrollbar), const Offset(0, -20.0));
+    await tester.pumpAndSettle();
+    expect(getScrollPosition().pixels, 20);
+    expect(find.text('Item 0'), findsOneWidget);
+
+    // Initial scroll is to 220: items 0,1 are scrolled off the top,
+    // the bottom 80 pixels of item 2 are visible, items 4-7 are
+    // completely visible, the first 20 pixels of item 8 are visible.
+    // After the auto-scroll, items 3-8 are completely visible.
+    await tester.drag(find.byType(Scrollbar), const Offset(0, -200.0));
+    await tester.pumpAndSettle();
+    expect(getScrollPosition().pixels, 300);
+    expect(find.text('Item 0'), findsNothing);
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 3'), findsOneWidget);
+    expect(find.text('Item 8'), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/widgets/scroll_notification.dart
+++ b/packages/flutter/lib/src/widgets/scroll_notification.dart
@@ -263,6 +263,17 @@ class OverscrollNotification extends ScrollNotification {
 
 /// A notification that a [Scrollable] widget has stopped scrolling.
 ///
+/// {@tool dartpad}
+/// This sample shows how you can trigger an auto-scroll, which aligns the last
+/// partially visible fixed-height list item, by listening for this
+/// notification with a [NotificationListener]. This sort of thing can also
+/// be done by listening to the [ScrollController]'s
+/// [ScrollPosition.isScrollingNotifier]. An alternative example is provided
+/// with [ScrollPosition.isScrollingNotifier].
+///
+/// ** See code in examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ScrollStartNotification], which indicates that scrolling has started.

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -849,6 +849,16 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   ///
   /// Listeners added by stateful widgets should be removed in the widget's
   /// [State.dispose] method.
+  ///
+  /// {@tool dartpad}
+  /// This sample shows how you can trigger an auto-scroll, which aligns the last
+  /// partially visible fixed-height list item, by listening to this
+  /// notifier's value. This sort of thing can also be done by listening for
+  /// [ScrollEndNotification]s with a [NotificationListener]. An alternative
+  /// example is provided with [ScrollEndNotification].
+  ///
+  /// ** See code in examples/api/lib/widgets/scroll_position/is_scrolling_listener.0.dart **
+  /// {@end-tool}
   final ValueNotifier<bool> isScrollingNotifier = ValueNotifier<bool>(false);
 
   /// Animates the position from its current value to the given value.

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1955,27 +1955,31 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
   Map<Type, GestureRecognizerFactory> get _gestures {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
-    if (_axis == null || !enableGestures) {
+    if (!enableGestures) {
       return gestures;
     }
-    if (_axis == Axis.horizontal) {
-      gestures[_HorizontalThumbDragGestureRecognizer] =
-        GestureRecognizerFactoryWithHandlers<_HorizontalThumbDragGestureRecognizer>(
-          () => _HorizontalThumbDragGestureRecognizer(
-            debugOwner: this,
-            customPaintKey: _scrollbarPainterKey,
-          ),
-          _initThumbDragGestureRecognizer,
-        );
-    } else {
-      gestures[_VerticalThumbDragGestureRecognizer] =
-        GestureRecognizerFactoryWithHandlers<_VerticalThumbDragGestureRecognizer>(
-          () => _VerticalThumbDragGestureRecognizer(
-            debugOwner: this,
-            customPaintKey: _scrollbarPainterKey,
-          ),
-          _initThumbDragGestureRecognizer,
-        );
+
+    switch (_axis) {
+      case Axis.horizontal:
+        gestures[_HorizontalThumbDragGestureRecognizer] =
+          GestureRecognizerFactoryWithHandlers<_HorizontalThumbDragGestureRecognizer>(
+            () => _HorizontalThumbDragGestureRecognizer(
+              debugOwner: this,
+              customPaintKey: _scrollbarPainterKey,
+            ),
+            _initThumbDragGestureRecognizer,
+          );
+      case Axis.vertical:
+        gestures[_VerticalThumbDragGestureRecognizer] =
+          GestureRecognizerFactoryWithHandlers<_VerticalThumbDragGestureRecognizer>(
+            () => _VerticalThumbDragGestureRecognizer(
+              debugOwner: this,
+              customPaintKey: _scrollbarPainterKey,
+            ),
+            _initThumbDragGestureRecognizer,
+          );
+      case null:
+        return gestures;
     }
 
     gestures[_TrackTapGestureRecognizer] =

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1673,7 +1673,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
   /// Handler called when a long press gesture has started.
   ///
-  /// Begins the fade out animation and creates the
+  /// Begins the fade out animation and creates the thumb's DragScrollController.
   @protected
   @mustCallSuper
   void handleThumbPressStart(Offset localPosition) {

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1575,15 +1575,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   }
 
   /// Returns the [Axis] of the child scroll view, or null if the
-  /// current scroll controller does not have any attached positions.
+  /// we haven't seen a ScrollMetrics notification yet.
   @protected
-  Axis? getScrollbarDirection() {
-    assert(_cachedController != null);
-    if (_cachedController!.hasClients) {
-      return _cachedController!.position.axis;
-    }
-    return null;
-  }
+  Axis? getScrollbarDirection() => _axis;
 
   void _disposeThumbDrag() {
     _thumbDrag = null;

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1955,7 +1955,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
   Map<Type, GestureRecognizerFactory> get _gestures {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
-    if (!enableGestures) {
+    if (_effectiveScrollController == null || !enableGestures) {
       return gestures;
     }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1637,7 +1637,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
       // The physics may allow overscroll when actually *scrolling*, but
       // dragging on the scrollbar does not always allow us to enter overscroll.
-      switch(ScrollConfiguration.of(context).getPlatform(context)) {
+      switch (ScrollConfiguration.of(context).getPlatform(context)) {
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.macOS:
@@ -1729,7 +1729,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       return;
     }
 
-    final Offset delta = switch(direction) {
+    final Offset delta = switch (direction) {
       Axis.horizontal => Offset(primaryDelta, 0),
       Axis.vertical => Offset(0, primaryDelta),
     };
@@ -1741,6 +1741,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       localPosition: localPosition,
     );
     _thumbDrag!.update(scrollDetails); // Triggers updates to the ScrollPosition and ScrollbarPainter
+
     _lastDragUpdateOffset = localPosition;
   }
 
@@ -1769,7 +1770,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     final (Velocity adjustedVelocity, double primaryVelocity) = switch (platform) {
       TargetPlatform.iOS || TargetPlatform.android => (
         -velocity,
-        switch(direction) {
+        switch (direction) {
           Axis.horizontal => -velocity.pixelsPerSecond.dx,
           Axis.vertical => -velocity.pixelsPerSecond.dy,
         },
@@ -1959,15 +1960,15 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       return gestures;
     }
     _cachedController = _effectiveScrollController;
-
     if (getScrollbarDirection() == Axis.horizontal) {
-      GestureRecognizerFactoryWithHandlers<_HorizontalThumbDragGestureRecognizer>(
-        () => _HorizontalThumbDragGestureRecognizer(
-          debugOwner: this,
-          customPaintKey: _scrollbarPainterKey,
-        ),
-        _initThumbDragGestureRecognizer,
-      );
+      gestures[_HorizontalThumbDragGestureRecognizer] =
+        GestureRecognizerFactoryWithHandlers<_HorizontalThumbDragGestureRecognizer>(
+          () => _HorizontalThumbDragGestureRecognizer(
+            debugOwner: this,
+            customPaintKey: _scrollbarPainterKey,
+          ),
+          _initThumbDragGestureRecognizer,
+        );
     } else {
       gestures[_VerticalThumbDragGestureRecognizer] =
         GestureRecognizerFactoryWithHandlers<_VerticalThumbDragGestureRecognizer>(
@@ -2200,6 +2201,7 @@ bool _isThumbEvent(GlobalKey customPaintKey, PointerEvent event) {
   if (customPaintKey.currentContext == null) {
     return false;
   }
+
   final CustomPaint customPaint = customPaintKey.currentContext!.widget as CustomPaint;
   final ScrollbarPainter painter = customPaint.foregroundPainter! as ScrollbarPainter;
   final Offset localOffset = _getLocalOffset(customPaintKey, event.position);

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1325,6 +1325,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   bool _hoverIsActive = false;
   Drag? _thumbDrag;
   ScrollHoldController? _thumbHold;
+  Axis? _axis;
   final GlobalKey<RawGestureDetectorState> _gestureDetectorKey = GlobalKey<RawGestureDetectorState>();
 
   ScrollController? get _effectiveScrollController => widget.controller ?? PrimaryScrollController.maybeOf(context);
@@ -1871,6 +1872,10 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     if (_shouldUpdatePainter(metrics.axis)) {
       scrollbarPainter.update(metrics, metrics.axisDirection);
     }
+    if (metrics.axis != _axis) {
+      setState(() { _axis = metrics.axis; });
+    }
+
     return false;
   }
 
@@ -1956,11 +1961,10 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
 
   Map<Type, GestureRecognizerFactory> get _gestures {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
-    if (_effectiveScrollController == null || !enableGestures) {
+    if (_axis == null || !enableGestures) {
       return gestures;
     }
-    _cachedController = _effectiveScrollController;
-    if (getScrollbarDirection() == Axis.horizontal) {
+    if (_axis == Axis.horizontal) {
       gestures[_HorizontalThumbDragGestureRecognizer] =
         GestureRecognizerFactoryWithHandlers<_HorizontalThumbDragGestureRecognizer>(
           () => _HorizontalThumbDragGestureRecognizer(

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2809,7 +2809,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
   });
 
   testWidgets('The thumb should follow the pointer when the scroll metrics changed during dragging', (WidgetTester tester) async {
-    // Regressing test for https://github.com/flutter/flutter/issues/112072
+    // Regression test for https://github.com/flutter/flutter/issues/112072
     final ScrollController scrollController = ScrollController();
     addTearDown(scrollController.dispose);
     await tester.pumpWidget(
@@ -2880,7 +2880,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
   });
 
   testWidgets('The scrollable should not stutter when the scroll metrics shrink during dragging', (WidgetTester tester) async {
-    // Regressing test for https://github.com/flutter/flutter/issues/121574
+    // Regression test for https://github.com/flutter/flutter/issues/121574
     final ScrollController scrollController = ScrollController();
     addTearDown(scrollController.dispose);
     await tester.pumpWidget(
@@ -2989,5 +2989,79 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     await tester.pumpAndSettle();
 
     expect(scrollController.offset, 100.0);
+  }, variant: TargetPlatformVariant.all());
+
+  testWidgets('Flinging a vertical scrollbar thumb does not cause a ballistic scroll - non-mobile platforms', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    bool isMobilePlatform() {
+      return const <TargetPlatform>{TargetPlatform.iOS, TargetPlatform.android}
+        .contains(debugDefaultTargetPlatformOverride);
+    }
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: PrimaryScrollController(
+            controller: scrollController,
+            child: RawScrollbar(
+              thumbVisibility: true,
+              controller: scrollController,
+              child: CustomScrollView(
+                controller: scrollController,
+                slivers: <Widget>[
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        return Container(
+                          height: 100,
+                          alignment: Alignment.center,
+                          child: Text('$index'),
+                        );
+                      },
+                      childCount: 10,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Try flinging downward. The flingFrom() method generates 50 moves of about 2
+    // pixels and then a fling with the indicated velocity.
+    await tester.flingFrom(const Offset(797.0, 45.0), const Offset(0, 60.0), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, greaterThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 100.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
+
+    // Tap at the top of the track to scroll back to the origin.
+    await tester.tapAt(const Offset(797.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Drag the thumb to the bottom.
+    await tester.dragFrom(const Offset(797.0, 45.0), const Offset(0, 1000.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 400.0);
+
+    // Try flinging upward.
+    await tester.flingFrom(const Offset(797.0, 545.0), const Offset(0, -60), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, lessThan(300.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 300.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
   }, variant: TargetPlatformVariant.all());
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -3000,8 +3000,8 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
         .contains(debugDefaultTargetPlatformOverride);
     }
 
-    await tester.pumpWidget(
-      Directionality(
+    Widget buildFrame({ required bool reverse }) {
+      return Directionality(
         textDirection: TextDirection.ltr,
         child: MediaQuery(
           data: const MediaQueryData(),
@@ -3012,6 +3012,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
               controller: scrollController,
               child: CustomScrollView(
                 controller: scrollController,
+                reverse: reverse,
                 slivers: <Widget>[
                   SliverList(
                     delegate: SliverChildBuilderDelegate(
@@ -3030,8 +3031,10 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
             ),
           ),
         ),
-      ),
-    );
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(reverse: false));
     await tester.pumpAndSettle();
     expect(scrollController.offset, 0.0);
 
@@ -3039,6 +3042,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     // pixels and then a fling with the indicated velocity.
     await tester.flingFrom(const Offset(797.0, 45.0), const Offset(0, 60.0), 500.0);
     await tester.pumpAndSettle();
+
     if (isMobilePlatform()) {
       expect(scrollController.offset, greaterThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
     } else {
@@ -3063,5 +3067,149 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
     } else {
       expect(scrollController.offset, 300.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
     }
+
+    // Tap at the top of the track to scroll back to the origin.
+    await tester.tapAt(const Offset(797.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Same tests with reverse: true
+
+    await tester.pumpWidget(buildFrame(reverse: true));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Try flinging upward.
+    await tester.flingFrom(const Offset(797.0, 545.0), const Offset(0, -60), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, greaterThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 100.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
+
+    // Tap at the top of the track to scroll to the limit
+    await tester.tapAt(const Offset(797.0, 5.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 400.0);
+
+    // Try flinging downward.
+    await tester.flingFrom(const Offset(797.0, 45.0), const Offset(0, 60.0), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, lessThan(300.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 300.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
   }, variant: TargetPlatformVariant.all());
+
+  testWidgets('Flinging a horizontal scrollbar thumb does not cause a ballistic scroll - non-mobile platforms', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    bool isMobilePlatform() {
+      return const <TargetPlatform>{TargetPlatform.iOS, TargetPlatform.android}
+        .contains(debugDefaultTargetPlatformOverride);
+    }
+
+    Widget buildFrame({ required bool reverse }) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: PrimaryScrollController(
+            controller: scrollController,
+            child: RawScrollbar(
+              thumbVisibility: true,
+              controller: scrollController,
+              child: CustomScrollView(
+                controller: scrollController,
+                reverse: reverse,
+                scrollDirection: Axis.horizontal,
+                slivers: <Widget>[
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        return Container(
+                          width: 100,
+                          alignment: Alignment.center,
+                          child: Text('$index'),
+                        );
+                      },
+                      childCount: 10,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(reverse: false));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Try flinging to the right.
+    await tester.flingFrom(const Offset(45.0, 597.0), const Offset(80, 0.0), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, greaterThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 100.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
+
+    // Tap at the end of the track to scroll to the limit.
+    await tester.tapAt(const Offset(794.0, 597.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 200.0);
+
+    // Try flinging to the left.
+    await tester.flingFrom(const Offset(794.0, 597.0), const Offset(-80, 0), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, lessThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 100.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
+
+    // Tap at the beginning of the track to scroll back to the origin.
+    await tester.tapAt(const Offset(6.0, 597.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Same tests with reverse: true
+
+    await tester.pumpWidget(buildFrame(reverse: true));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+
+    // Try flinging to the left.
+    await tester.flingFrom(const Offset(794.0, 597.0), const Offset(-80, 0), 500.0);
+    await tester.pumpAndSettle();
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, greaterThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 100.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
+
+    // Tap at the beginning of the track to scroll to the limit.
+    await tester.tapAt(const Offset(6.0, 597.0));
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 200.0);
+
+    // Try flinging to the right.
+    await tester.flingFrom(const Offset(6.0, 597.0), const Offset(80, 0), 500.0);
+    await tester.pumpAndSettle();
+
+    if (isMobilePlatform()) {
+      expect(scrollController.offset, lessThan(100.0), reason: 'Ballistic scroll expected on $debugDefaultTargetPlatformOverride');
+    } else {
+      expect(scrollController.offset, 100.0, reason: 'Ballistic scroll not expected on $debugDefaultTargetPlatformOverride');
+    }
+
+  },
+    variant: TargetPlatformVariant.all(),
+  );
 }


### PR DESCRIPTION
The scroll notification events reported for a press-drag-release gesture within a scrollable on a touch screen device begin with a `ScrollStartNotification`, followed by a series of `ScrollUpdateNotifications`, and conclude with a `ScrollEndNotification`. This protocol can be used to defer work until an interactive scroll gesture ends. For example, you might defer updating a scrollable's contents via network requests until the scroll has ended, or you might want to automatically auto-scroll at that time. 

In the example that follows the CustomScrollView automatically scrolls so that the last partially visible fixed-height item is completely visible when the scroll gesture ends. Many iOS applications do this kind of thing. It only makes sense to auto-scroll when the user isn't actively dragging the scrollable around.

It's easy enough to do this by reacting to a ScrollEndNotifcation by auto-scrolling to align the last fixed-height list item ([source code](https://gist.github.com/HansMuller/13e2a7adadc9afb3803ba7848b20c410)).

https://github.com/flutter/flutter/assets/1377460/a6e6fc77-6742-4f98-81ba-446536535f73

Dragging the scrollbar thumb in a desktop application is a similar user gesture. Currently it's not possible to defer work or auto-scroll (or whatever) while the scrollable is actively being dragged via the scrollbar thumb because each scrollbar thumb motion is mapped to a scroll start - scroll update - scroll end series of notifications.  On a desktop platform, the same code behaves quite differently when the scrollbar thumb is dragged.

https://github.com/flutter/flutter/assets/1377460/2593d8a3-639c-407f-80c1-6e6f67fb8c5f

The stream of scroll-end events triggers auto-scrolling every time the thumb moves. From the user's perspective this feels like a losing struggle.

One can also detect the beginning and end of a touch-drag by listening to the value of a ScrollPosition's `isScrollingNotifier`. This approach suffers from a similar problem: during a scrollbar thumb-drag, the `isScrollingNotifier` value isn't updated at all.

This PR refactors the RawScrollbar implementation to effectively use a ScrollDragController to manage scrolls caused by dragging the scrollbar's thumb. Doing so means that dragging the thumb will produce the same notifications as dragging the scrollable on a touch device.

Now desktop applications can choose to respond to scrollbar thumb drags in the same that they respond to drag scrolling on a touch screen. With the changes included here, the desktop or web version of the app works as expected, whether you're listing to scroll notifications or the scroll position's `isScrollingNotifier`.

https://github.com/flutter/flutter/assets/1377460/67435c40-a866-4735-a19b-e3d68eac8139

This PR also makes the second [ScrollPosition API doc example](https://api.flutter.dev/flutter/widgets/ScrollPosition-class.html#cupertino.ScrollPosition.2) work as expected when used with the DartPad that's  part of API doc page.

Desktop applications also see scroll start-update-end notifications due to the mouse wheel.  There is no touch screen analog for the mouse wheel, so an application that wanted to enable this kind of auto-scrolling alignment would have to include a heuristic that dealt with the sequence of small scrolls triggered by the mouse wheel. Here's an example of that: [source code](https://gist.github.com/HansMuller/ce5c474a458f5f4bcc07b0d621843165). This version of the app does not auto-align in response to small changes, wether they're triggered by dragging the scrollbar thumb of the mouse wheel.

Related sliver utility PRs: https://github.com/flutter/flutter/pull/143538,  https://github.com/flutter/flutter/pull/143196, https://github.com/flutter/flutter/pull/143325.

Part of #127334.