### PR TITLE
[Doctor] Improve CocoaPods messages

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -193,19 +193,19 @@ class UserMessages {
   String cocoaPodsMissing(String consequence, String installInstructions) =>
       'CocoaPods not installed.\n'
       '$consequence\n'
-      'To install $installInstructions';
+      'For installation instructions, $installInstructions';
   String cocoaPodsUnknownVersion(String consequence, String upgradeInstructions) =>
       'Unknown CocoaPods version installed.\n'
       '$consequence\n'
-      'To upgrade $upgradeInstructions';
+      'To update CocoaPods, $upgradeInstructions';
   String cocoaPodsOutdated(String currentVersion, String recVersion, String consequence, String upgradeInstructions) =>
       'CocoaPods $currentVersion out of date ($recVersion is recommended).\n'
       '$consequence\n'
-      'To upgrade $upgradeInstructions';
+      'To update CocoaPods, $upgradeInstructions';
   String cocoaPodsBrokenInstall(String consequence, String reinstallInstructions) =>
       'CocoaPods installed but not working.\n'
       '$consequence\n'
-      'To re-install $reinstallInstructions';
+      'For re-installation instructions, $reinstallInstructions';
 
   // Messages used in VisualStudioValidator
   String visualStudioVersion(String name, String version) => '$name version $version';

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -25,7 +25,7 @@ import '../reporting/reporting.dart';
 import '../xcode_project.dart';
 
 const String noCocoaPodsConsequence = '''
-  CocoaPods is used to retrieve the iOS and macOS platform side's plugin code that responds to your plugin usage on the Dart side.
+  CocoaPods is a package manager for iOS or macOS platform code.
   Without CocoaPods, plugins will not work on iOS or macOS.
   For more info, see https://flutter.dev/platform-plugins''';
 
@@ -47,9 +47,9 @@ const String outOfDatePluginsPodfileConsequence = '''
   See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms for details.
   If you have local Podfile edits you would like to keep, see https://github.com/flutter/flutter/issues/45197 for instructions.''';
 
-const String cocoaPodsInstallInstructions = 'see https://guides.cocoapods.org/using/getting-started.html#installation for instructions.';
+const String cocoaPodsInstallInstructions = 'see https://guides.cocoapods.org/using/getting-started.html#installation';
 
-const String cocoaPodsUpdateInstructions = 'see https://guides.cocoapods.org/using/getting-started.html#updating-cocoapods for instructions.';
+const String cocoaPodsUpdateInstructions = 'see https://guides.cocoapods.org/using/getting-started.html#updating-cocoapods';
 
 const String podfileIosMigrationInstructions = '''
   rm ios/Podfile''';
@@ -200,7 +200,7 @@ class CocoaPods {
         _logger.printWarning(
           'Warning: CocoaPods not installed. Skipping pod install.\n'
           '$noCocoaPodsConsequence\n'
-          'To install $cocoaPodsInstallInstructions\n',
+          'For installation instructions, $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -208,7 +208,7 @@ class CocoaPods {
         _logger.printWarning(
           'Warning: CocoaPods is installed but broken. Skipping pod install.\n'
           '$brokenCocoaPodsConsequence\n'
-          'To re-install $cocoaPodsInstallInstructions\n',
+          'For re-installation instructions, $cocoaPodsInstallInstructions\n',
           emphasis: true,
         );
         return false;
@@ -216,14 +216,14 @@ class CocoaPods {
         _logger.printWarning(
           'Warning: Unknown CocoaPods version installed.\n'
           '$unknownCocoaPodsConsequence\n'
-          'To upgrade $cocoaPodsInstallInstructions\n',
+          'To update CocoaPods, $cocoaPodsUpdateInstructions\n',
           emphasis: true,
         );
       case CocoaPodsStatus.belowMinimumVersion:
         _logger.printWarning(
           'Warning: CocoaPods minimum required version $cocoaPodsMinimumVersion or greater not installed. Skipping pod install.\n'
           '$noCocoaPodsConsequence\n'
-          'To upgrade $cocoaPodsInstallInstructions\n',
+          'To update CocoaPods, $cocoaPodsUpdateInstructions\n',
           emphasis: true,
         );
         return false;
@@ -231,7 +231,7 @@ class CocoaPods {
         _logger.printWarning(
           'Warning: CocoaPods recommended version $cocoaPodsRecommendedVersion or greater not installed.\n'
           'Pods handling may fail on some projects involving plugins.\n'
-          'To upgrade $cocoaPodsInstallInstructions\n',
+          'To update CocoaPods, $cocoaPodsUpdateInstructions\n',
           emphasis: true,
         );
       case CocoaPodsStatus.recommended:

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -43,7 +43,7 @@ class CocoaPodsValidator extends DoctorValidator {
       case CocoaPodsStatus.unknownVersion:
         status = ValidationType.partial;
         messages.add(ValidationMessage.hint(
-          _userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+          _userMessages.cocoaPodsUnknownVersion(unknownCocoaPodsConsequence, cocoaPodsUpdateInstructions)));
       case CocoaPodsStatus.belowMinimumVersion:
       case CocoaPodsStatus.belowRecommendedVersion:
         status = ValidationType.partial;

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
@@ -16,18 +16,32 @@ void main() {
       final CocoaPodsValidator workflow = CocoaPodsValidator(FakeCocoaPods(CocoaPodsStatus.recommended, '1000.0.0'), UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.success);
+      expect(result.messages.length, 1);
+      final ValidationMessage message = result.messages.first;
+      expect(message.type, ValidationMessageType.information);
+      expect(message.message, contains('CocoaPods version 1000.0.0'));
     });
 
     testWithoutContext('Emits missing status when CocoaPods is not installed', () async {
       final CocoaPodsValidator workflow = CocoaPodsValidator(FakeCocoaPods(CocoaPodsStatus.notInstalled), UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.missing);
+      expect(result.messages.length, 1);
+      final ValidationMessage message = result.messages.first;
+      expect(message.type, ValidationMessageType.error);
+      expect(message.message, contains('CocoaPods not installed'));
+      expect(message.message, contains('getting-started.html#installation'));
     });
 
     testWithoutContext('Emits partial status when CocoaPods is installed with unknown version', () async {
       final CocoaPodsValidator workflow = CocoaPodsValidator(FakeCocoaPods(CocoaPodsStatus.unknownVersion), UserMessages());
       final ValidationResult result = await workflow.validate();
       expect(result.type, ValidationType.partial);
+      expect(result.messages.length, 1);
+      final ValidationMessage message = result.messages.first;
+      expect(message.type, ValidationMessageType.hint);
+      expect(message.message, contains('Unknown CocoaPods version installed'));
+      expect(message.message, contains('getting-started.html#updating-cocoapods'));
     });
 
     testWithoutContext('Emits partial status when CocoaPods version is too low', () async {


### PR DESCRIPTION
This tweaks the Flutter doctor messages for CocoaPods.

This also switches the "unknown version" error to link to the update instructions instead of the installation instructions; the user has already installed CocoaPods in this scenario.

Example error before:

```
    ✗ CocoaPods not installed.
        CocoaPods is used to retrieve the iOS and macOS platform side's plugin code that responds to your plugin usage on the Dart side.
        Without CocoaPods, plugins will not work on iOS or macOS.
        For more info, see https://flutter.dev/platform-plugins
      To install see https://guides.cocoapods.org/using/getting-started.html#installation for instructions.
```

Example error after:

```
    ✗ CocoaPods not installed.
        CocoaPods is a package manager for iOS or macOS platform code.
        Without CocoaPods, plugins will not work on iOS or macOS.
        For more info, see https://flutter.dev/platform-plugins
      For installation instructions, see https://guides.cocoapods.org/using/getting-started.html#installation
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
