### PR TITLE
Switch to relevant `Remote` constructors

### DIFF
--- a/dev/conductor/core/lib/src/next.dart
+++ b/dev/conductor/core/lib/src/next.dart
@@ -93,10 +93,7 @@ class NextContext extends Context {
     ];
     switch (state.currentPhase) {
       case pb.ReleasePhase.APPLY_ENGINE_CHERRYPICKS:
-        final Remote upstream = Remote(
-            name: RemoteName.upstream,
-            url: state.engine.upstream.url,
-        );
+        final Remote upstream = Remote.upstream(state.engine.upstream.url);
         final EngineRepository engine = EngineRepository(
             checkouts,
             initialRef: state.engine.workingBranch,
@@ -153,10 +150,7 @@ class NextContext extends Context {
           }
         }
       case pb.ReleasePhase.APPLY_FRAMEWORK_CHERRYPICKS:
-        final Remote engineUpstreamRemote = Remote(
-            name: RemoteName.upstream,
-            url: state.engine.upstream.url,
-        );
+        final Remote engineUpstreamRemote = Remote.upstream(state.engine.upstream.url);
         final EngineRepository engine = EngineRepository(
             checkouts,
             // We explicitly want to check out the merged version from upstream
@@ -167,10 +161,7 @@ class NextContext extends Context {
 
         final String engineRevision = await engine.reverseParse('HEAD');
 
-        final Remote upstream = Remote(
-          name: RemoteName.upstream,
-          url: state.framework.upstream.url,
-        );
+        final Remote upstream = Remote.upstream(state.framework.upstream.url);
         final FrameworkRepository framework = FrameworkRepository(
           checkouts,
           initialRef: state.framework.workingBranch,

--- a/dev/conductor/core/lib/src/repository.dart
+++ b/dev/conductor/core/lib/src/repository.dart
@@ -520,8 +520,7 @@ class FrameworkRepository extends Repository {
   FrameworkRepository(
     this.checkouts, {
     super.name = 'framework',
-    super.upstreamRemote = const Remote(
-        name: RemoteName.upstream, url: FrameworkRepository.defaultUpstream),
+    super.upstreamRemote = const Remote.upstream(FrameworkRepository.defaultUpstream),
     super.localUpstream,
     super.previousCheckoutLocation,
     String super.initialRef = FrameworkRepository.defaultBranch,
@@ -553,10 +552,7 @@ class FrameworkRepository extends Repository {
     return FrameworkRepository(
       checkouts,
       name: name,
-      upstreamRemote: Remote(
-        name: RemoteName.upstream,
-        url: 'file://$upstreamPath/',
-      ),
+      upstreamRemote: Remote.upstream('file://$upstreamPath/'),
       previousCheckoutLocation: previousCheckoutLocation,
       initialRef: initialRef,
     );
@@ -581,9 +577,7 @@ class FrameworkRepository extends Repository {
     return FrameworkRepository(
       checkouts,
       name: cloneName,
-      upstreamRemote: Remote(
-          name: RemoteName.upstream,
-          url: 'file://${(await checkoutDirectory).path}/'),
+      upstreamRemote: Remote.upstream('file://${(await checkoutDirectory).path}/'),
     );
   }
 
@@ -737,10 +731,7 @@ class HostFrameworkRepository extends FrameworkRepository {
   }) : super(
           checkouts,
           name: name,
-          upstreamRemote: Remote(
-            name: RemoteName.upstream,
-            url: 'file://$upstreamPath/',
-          ),
+          upstreamRemote: Remote.upstream('file://$upstreamPath/'),
           localUpstream: false,
         ) {
     _checkoutDirectory = checkouts.fileSystem.directory(upstreamPath);
@@ -795,8 +786,7 @@ class EngineRepository extends Repository {
     this.checkouts, {
     super.name = 'engine',
     String super.initialRef = EngineRepository.defaultBranch,
-    super.upstreamRemote = const Remote(
-        name: RemoteName.upstream, url: EngineRepository.defaultUpstream),
+    super.upstreamRemote = const Remote.upstream(EngineRepository.defaultUpstream),
     super.localUpstream,
     super.previousCheckoutLocation,
     super.mirrorRemote,
@@ -847,9 +837,7 @@ class EngineRepository extends Repository {
     return EngineRepository(
       checkouts,
       name: cloneName,
-      upstreamRemote: Remote(
-          name: RemoteName.upstream,
-          url: 'file://${(await checkoutDirectory).path}/'),
+      upstreamRemote: Remote.upstream('file://${(await checkoutDirectory).path}/'),
     );
   }
 }

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -218,26 +218,14 @@ class StartContext extends Context {
         engine = EngineRepository(
           checkouts,
           initialRef: 'upstream/$candidateBranch',
-          upstreamRemote: Remote(
-            name: RemoteName.upstream,
-            url: engineUpstream,
-          ),
-          mirrorRemote: Remote(
-            name: RemoteName.mirror,
-            url: engineMirror,
-          ),
+          upstreamRemote: Remote.upstream(engineUpstream),
+          mirrorRemote: Remote.mirror(engineMirror),
         ),
         framework = FrameworkRepository(
           checkouts,
           initialRef: 'upstream/$candidateBranch',
-          upstreamRemote: Remote(
-            name: RemoteName.upstream,
-            url: frameworkUpstream,
-          ),
-          mirrorRemote: Remote(
-            name: RemoteName.mirror,
-            url: frameworkMirror,
-          ),
+          upstreamRemote: Remote.upstream(frameworkUpstream),
+          mirrorRemote: Remote.mirror(frameworkMirror),
         );
 
   final String candidateBranch;

--- a/dev/conductor/core/test/next_test.dart
+++ b/dev/conductor/core/test/next_test.dart
@@ -1002,7 +1002,7 @@ class _TestRepository extends Repository {
     name: name,
     requiredLocalBranches: <String>[],
     stdio: checkouts.stdio,
-    upstreamRemote: const Remote(name: RemoteName.upstream, url: 'git@github.com:upstream/repo.git'),
+    upstreamRemote: const Remote.upstream('git@github.com:upstream/repo.git'),
   );
 
   @override

--- a/dev/conductor/core/test/packages_autoroller_test.dart
+++ b/dev/conductor/core/test/packages_autoroller_test.dart
@@ -50,10 +50,7 @@ void main() {
     );
     framework = FrameworkRepository(
       checkouts,
-      mirrorRemote: const Remote(
-        name: RemoteName.mirror,
-        url: mirrorUrl,
-      ),
+      mirrorRemote: const Remote.mirror(mirrorUrl),
     );
 
     autoroller = PackageAutoroller(


### PR DESCRIPTION
[A previous PR](https://github.com/flutter/flutter/pull/144279) implemented `const` constructors in the `Remote` class, so I wanted to follow up and use those constructors in the appropriate places.