### PR TITLE
Added missing tests for OverflowBar example.

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -463,7 +463,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/tween_animation_builder/tween_animation_builder.0_test.dart',
   'examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.1_test.dart',
   'examples/api/test/widgets/single_child_scroll_view/single_child_scroll_view.0_test.dart',
-  'examples/api/test/widgets/overflow_bar/overflow_bar.0_test.dart',
   'examples/api/test/widgets/restoration/restoration_mixin.0_test.dart',
   'examples/api/test/widgets/actions/actions.0_test.dart',
   'examples/api/test/widgets/actions/action_listener.0_test.dart',

--- a/examples/api/test/widgets/overflow_bar/overflow_bar.0_test.dart
+++ b/examples/api/test/widgets/overflow_bar/overflow_bar.0_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/overflow_bar/overflow_bar.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('OverflowBar displays buttons', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.OverflowBarExampleApp(),
+    );
+
+    // Creates a finder that matches widgets of the given
+    // `widgetType`, ensuring that the given widgets exist
+    // inside of an OverflowBar.
+    Finder buttonsFinder(Type widgetType) {
+      return find.descendant(
+        of: find.byType(OverflowBar),
+        matching: find.byType(widgetType),
+      );
+    }
+
+    expect(buttonsFinder(TextButton), findsNWidgets(2));
+    expect(buttonsFinder(OutlinedButton), findsOne);
+  });
+}


### PR DESCRIPTION
Added missing tests for OverflowBar example. Issue #130459 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
