### PR TITLE
Add a breadcrumb for the pub autoroller

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -21,6 +21,11 @@ import '../runner/flutter_command.dart';
 import '../update_packages_pins.dart';
 import '../version.dart';
 
+// Pub packages are rolled automatically by the flutter-pub-roller-bot
+// by using the `flutter update-packages --force-upgrade`.
+// For the latest status, see:
+//   https://github.com/pulls?q=author%3Aflutter-pub-roller-bot
+
 class UpdatePackagesCommand extends FlutterCommand {
   UpdatePackagesCommand() {
     argParser
@@ -32,7 +37,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       )
       ..addOption(
         'cherry-pick-package',
-        help: 'Attempt to update only the specified package. The "-cherry-pick-version" version must be specified also.',
+        help: 'Attempt to update only the specified package. The "--cherry-pick-version" version must be specified also.',
       )
       ..addOption(
         'cherry-pick-version',
@@ -64,7 +69,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         'consumer-only',
         help: 'Only prints the dependency graph that is the transitive closure '
               'that a consumer of the Flutter SDK will observe (when combined '
-              'with transitive-closure).',
+              'with "--transitive-closure").',
         negatable: false,
       )
       ..addFlag(

--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -2,9 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// This constant is in its own library so that the test exemption bot knows
+// Th constant below is in its own library so that the test exemption bot knows
 // that changing a pin does not require a new test. These pins are already
 // tested as part of the analysis shard.
+
+// Pub packages are rolled automatically by the flutter-pub-roller-bot.
+// For the latest status, see:
+//   https://github.com/pulls?q=author%3Aflutter-pub-roller-bot
 
 /// Map from package name to package version, used to artificially pin a pub
 /// package version in cases when upgrading to the latest breaks Flutter.

--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Th constant below is in its own library so that the test exemption bot knows
+// The constant below is in its own library so that the test exemption bot knows
 // that changing a pin does not require a new test. These pins are already
 // tested as part of the analysis shard.
 


### PR DESCRIPTION
Adds some breadcrumbs to update-packages so that people can easily figure out how to tell what's going on with the pub autoroller.