### PR TITLE
Fix doc reference to RendererBinding.renderViews

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -638,7 +638,7 @@ String _debugCollectRenderTrees() {
 ///
 /// {@template flutter.rendering.debugDumpRenderTree}
 /// It prints the trees associated with every [RenderView] in
-/// [RendererBinding.renderView], separated by two blank lines.
+/// [RendererBinding.renderViews], separated by two blank lines.
 /// {@endtemplate}
 void debugDumpRenderTree() {
   debugPrint(_debugCollectRenderTrees());


### PR DESCRIPTION
`RendererBinding.renderView` is deprecated. The doc should link to `RendererBinding.renderViews`, which also matches the context since the sentence is talking about multiple `RenderView`s and not just the legacy singleton.