### PR TITLE
Makes badge to auto size with content

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -38,7 +38,7 @@ class MainWidgetState extends State<MainWidget> {
           label: Text(
             '5',
             semanticsLabel: '5 new messages',
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(color: Colors.white, fontSize: 5),
           ),
           backgroundColor: Colors.green,
           child: Icon(Icons.mail, semanticLabel: 'Messages'),

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -38,7 +38,7 @@ class MainWidgetState extends State<MainWidget> {
           label: Text(
             '5',
             semanticsLabel: '5 new messages',
-            style: TextStyle(color: Colors.white, fontSize: 5),
+            style: TextStyle(color: Colors.white),
           ),
           backgroundColor: Colors.green,
           child: Icon(Icons.mail, semanticLabel: 'Messages'),

--- a/packages/flutter/lib/src/material/badge.dart
+++ b/packages/flutter/lib/src/material/badge.dart
@@ -332,10 +332,10 @@ class _RenderBadge extends RenderAligningShiftedBox {
   }
 }
 
-/// A widget to grab smallest horizontal stadium rect to fit the child's
-/// intrinsic size.
+/// A widget size itself to the smallest horizontal stadium rect that can still
+/// fit the child's intrinsic size.
 ///
-/// A horizontal stadium means and rect that width >= height.
+/// A horizontal stadium means a rect that has width >= height.
 ///
 /// Uses [minSize] to set the min size of width and height.
 class _IntrinsicHorizontalStadium extends SingleChildRenderObjectWidget {

--- a/packages/flutter/lib/src/material/badge.dart
+++ b/packages/flutter/lib/src/material/badge.dart
@@ -203,8 +203,11 @@ class Badge extends StatelessWidget {
 
     final AlignmentGeometry effectiveAlignment = alignment ?? badgeTheme.alignment ?? defaults.alignment!;
     final TextDirection textDirection = Directionality.of(context);
-    final Offset defaultOffset = textDirection == TextDirection.ltr ? const Offset(4, 4) : const Offset(-4, 4);
-    final Offset effectiveOffset = offset ?? badgeTheme.offset ?? defaultOffset;
+    final Offset defaultOffset = textDirection == TextDirection.ltr ? const Offset(4, -4) : const Offset(-4, -4);
+    // Adds a offset const Offset(0, 8) to avoiding breaking customers after
+    // the offset calculation changes.
+    // See https://github.com/flutter/flutter/pull/146853.
+    final Offset effectiveOffset = (offset ?? badgeTheme.offset ?? defaultOffset) + const Offset(0, 8);
 
     return
       Stack(

--- a/packages/flutter/lib/src/material/badge.dart
+++ b/packages/flutter/lib/src/material/badge.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -161,27 +163,39 @@ class Badge extends StatelessWidget {
 
     final BadgeThemeData badgeTheme = BadgeTheme.of(context);
     final BadgeThemeData defaults = _BadgeDefaultsM3(context);
-    final double effectiveSmallSize = smallSize ?? badgeTheme.smallSize ?? defaults.smallSize!;
-    final double effectiveLargeSize = largeSize ?? badgeTheme.largeSize ?? defaults.largeSize!;
-
-    final Widget badge = DefaultTextStyle(
-      style: (textStyle ?? badgeTheme.textStyle ?? defaults.textStyle!).copyWith(
-        color: textColor ?? badgeTheme.textColor ?? defaults.textColor!,
-      ),
-      child: IntrinsicWidth(
-        child: Container(
-          height: label == null ? effectiveSmallSize : effectiveLargeSize,
-          clipBehavior: Clip.antiAlias,
-          decoration: ShapeDecoration(
-            color: backgroundColor ?? badgeTheme.backgroundColor ?? defaults.backgroundColor!,
-            shape: const StadiumBorder(),
-          ),
-          padding: label == null ? null : (padding ?? badgeTheme.padding ?? defaults.padding!),
-          alignment: label == null ? null : Alignment.center,
-          child: label ?? SizedBox(width: effectiveSmallSize, height: effectiveSmallSize),
-        ),
-      ),
+    final Decoration effectiveDecoration = ShapeDecoration(
+      color: backgroundColor ?? badgeTheme.backgroundColor ?? defaults.backgroundColor!,
+      shape: const StadiumBorder(),
     );
+    final double effectiveWidthOffset;
+    final Widget badge;
+    final bool hasLabel = label != null;
+    if (hasLabel) {
+      final double minSize = effectiveWidthOffset = largeSize ?? badgeTheme.largeSize ?? defaults.largeSize!;
+      badge = DefaultTextStyle(
+        style: (textStyle ?? badgeTheme.textStyle ?? defaults.textStyle!).copyWith(
+          color: textColor ?? badgeTheme.textColor ?? defaults.textColor!,
+        ),
+        child: _IntrinsicHorizontalStadium(
+          minSize: minSize,
+          child: Container(
+            clipBehavior: Clip.antiAlias,
+            decoration: effectiveDecoration,
+            padding: padding ?? badgeTheme.padding ?? defaults.padding!,
+            alignment: Alignment.center,
+            child: label,
+          ),
+        ),
+      );
+    } else {
+      final double effectiveSmallSize = effectiveWidthOffset = smallSize ?? badgeTheme.smallSize ?? defaults.smallSize!;
+      badge = Container(
+        width: effectiveSmallSize,
+        height: effectiveSmallSize,
+        clipBehavior: Clip.antiAlias,
+        decoration: effectiveDecoration,
+      );
+    }
 
     if (child == null) {
       return badge;
@@ -189,7 +203,7 @@ class Badge extends StatelessWidget {
 
     final AlignmentGeometry effectiveAlignment = alignment ?? badgeTheme.alignment ?? defaults.alignment!;
     final TextDirection textDirection = Directionality.of(context);
-    final Offset defaultOffset = textDirection == TextDirection.ltr ? const Offset(4, -4) : const Offset(-4, -4);
+    final Offset defaultOffset = textDirection == TextDirection.ltr ? const Offset(4, 4) : const Offset(-4, 4);
     final Offset effectiveOffset = offset ?? badgeTheme.offset ?? defaultOffset;
 
     return
@@ -200,7 +214,9 @@ class Badge extends StatelessWidget {
           Positioned.fill(
             child: _Badge(
               alignment: effectiveAlignment,
-              offset: label == null ? Offset.zero : effectiveOffset,
+              offset: hasLabel ? effectiveOffset : Offset.zero,
+              hasLabel: hasLabel,
+              widthOffset: effectiveWidthOffset,
               textDirection: textDirection,
               child: badge,
             ),
@@ -214,18 +230,24 @@ class _Badge extends SingleChildRenderObjectWidget {
   const _Badge({
     required this.alignment,
     required this.offset,
+    required this.widthOffset,
     required this.textDirection,
+    required this.hasLabel,
     super.child, // the badge
   });
 
   final AlignmentGeometry alignment;
   final Offset offset;
+  final double widthOffset;
   final TextDirection textDirection;
+  final bool hasLabel;
 
   @override
   _RenderBadge createRenderObject(BuildContext context) {
     return _RenderBadge(
       alignment: alignment,
+      widthOffset: widthOffset,
+      hasLabel: hasLabel,
       offset: offset,
       textDirection: Directionality.maybeOf(context),
     );
@@ -236,6 +258,8 @@ class _Badge extends SingleChildRenderObjectWidget {
     renderObject
       ..alignment = alignment
       ..offset = offset
+      ..widthOffset = widthOffset
+      ..hasLabel = hasLabel
       ..textDirection = Directionality.maybeOf(context);
   }
 
@@ -252,7 +276,11 @@ class _RenderBadge extends RenderAligningShiftedBox {
     super.textDirection,
     super.alignment,
     required Offset offset,
-  }) : _offset = offset;
+    required bool hasLabel,
+    required double widthOffset,
+  }) : _offset = offset,
+       _hasLabel = hasLabel,
+       _widthOffset = widthOffset;
 
   Offset get offset => _offset;
   Offset _offset;
@@ -261,6 +289,26 @@ class _RenderBadge extends RenderAligningShiftedBox {
       return;
     }
     _offset = value;
+    markNeedsLayout();
+  }
+
+  bool get hasLabel => _hasLabel;
+  bool _hasLabel;
+  set hasLabel(bool value) {
+    if (_hasLabel == value) {
+      return;
+    }
+    _hasLabel = value;
+    markNeedsLayout();
+  }
+
+  double get widthOffset => _widthOffset;
+  double _widthOffset;
+  set widthOffset(double value) {
+    if (_widthOffset == value) {
+      return;
+    }
+    _widthOffset = value;
     markNeedsLayout();
   }
 
@@ -275,7 +323,104 @@ class _RenderBadge extends RenderAligningShiftedBox {
     final double badgeSize = child!.size.height;
     final Alignment resolvedAlignment = alignment.resolve(textDirection);
     final BoxParentData childParentData = child!.parentData! as BoxParentData;
-    childParentData.offset = offset + resolvedAlignment.alongOffset(Offset(size.width - badgeSize, size.height - badgeSize));
+    Offset badgeLocation = offset + resolvedAlignment.alongOffset(Offset(size.width - widthOffset, size.height));
+    if (hasLabel) {
+      // Adjust for label height.
+      badgeLocation = badgeLocation - Offset(0, badgeSize / 2);
+    }
+    childParentData.offset = badgeLocation;
+  }
+}
+
+/// A widget to grab smallest horizontal stadium rect to fit the child's
+/// intrinsic size.
+///
+/// A horizontal stadium means and rect that width >= height.
+///
+/// Uses [minSize] to set the min size of width and height.
+class _IntrinsicHorizontalStadium extends SingleChildRenderObjectWidget {
+  const _IntrinsicHorizontalStadium({super.child, required this.minSize});
+  final double minSize;
+
+  @override
+  _RenderIntrinsicHorizontalStadium createRenderObject(BuildContext context) {
+    return _RenderIntrinsicHorizontalStadium(minSize: minSize);
+  }
+}
+
+class _RenderIntrinsicHorizontalStadium extends RenderProxyBox {
+  _RenderIntrinsicHorizontalStadium({
+    RenderBox? child,
+    required double minSize,
+  }) : _minSize = minSize,
+       super(child);
+
+  double get minSize => _minSize;
+  double _minSize;
+  set minSize(double value) {
+    if (_minSize == value) {
+      return;
+    }
+    _minSize = value;
+    markNeedsLayout();
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    return getMaxIntrinsicWidth(height);
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    return math.max(getMaxIntrinsicHeight(double.infinity), super.computeMaxIntrinsicWidth(height));
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    return getMaxIntrinsicHeight(width);
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    return math.max(minSize, super.computeMaxIntrinsicHeight(width));
+  }
+
+  BoxConstraints _childConstraints(RenderBox child, BoxConstraints constraints) {
+    final double childHeight = math.max(minSize, child.getMaxIntrinsicHeight(constraints.maxWidth));
+    final double childWidth = child.getMaxIntrinsicWidth(constraints.maxHeight);
+    return constraints.tighten(width: math.max(childWidth, childHeight), height: childHeight);
+  }
+
+  Size _computeSize({required ChildLayouter layoutChild, required BoxConstraints constraints}) {
+    final RenderBox child = this.child!;
+    final Size childSize = layoutChild(child, _childConstraints(child, constraints));
+    if (childSize.height > childSize.width) {
+      return Size(childSize.height, childSize.height);
+    }
+    return childSize;
+  }
+
+  @override
+  @protected
+  Size computeDryLayout(covariant BoxConstraints constraints) {
+    return _computeSize(
+      layoutChild: ChildLayoutHelper.dryLayoutChild,
+      constraints: constraints,
+    );
+  }
+
+  @override
+  double? computeDryBaseline(BoxConstraints constraints, TextBaseline baseline) {
+    final RenderBox child = this.child!;
+    return child.getDryBaseline(_childConstraints(child, constraints), baseline);
+  }
+
+  @override
+  void performLayout() {
+    size = _computeSize(
+      layoutChild: ChildLayoutHelper.layoutChild,
+      constraints: constraints,
+    );
   }
 }
 

--- a/packages/flutter/test/material/badge_test.dart
+++ b/packages/flutter/test/material/badge_test.dart
@@ -297,54 +297,54 @@ void main() {
 
     await tester.pumpWidget(buildFrame(Alignment.topLeft));
     final RenderBox box = tester.renderObject(find.byType(Badge));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -8, 16, 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 0, 16, 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.topCenter));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, -8, 100 + 8, 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 0, 100 + 8, 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.topRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, -8, 200, 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 0, 200, 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerLeft));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100 - 8, 16, 100 + 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100, 16, 100 + 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 100 - 8, 200, 100 + 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 100, 200, 100 + 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomLeft));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 8, 16, 200 + 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200, 16, 200 + 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomCenter));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200 - 8, 100 + 8, 200 + 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200, 100 + 8, 200 + 16, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200 - 8, 200, 200 + 8, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200, 200, 200 + 16, badgeRadius)));
 
     const Offset offset = Offset(5, 10);
 
     await tester.pumpWidget(buildFrame(Alignment.topLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -8, 16, 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 0, 16, 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.topCenter, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, -8, 100 + 8, 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 0, 100 + 8, 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.topRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, -8 , 200, 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 0, 200, 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100 - 8, 16, 100 + 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100, 16, 100 + 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 100 - 8, 200, 100 + 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 100, 200, 100 + 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 8, 16, 200 + 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200, 16, 200 + 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomCenter, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200 - 8, 100 + 8, 200 + 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200, 100 + 8, 200 + 16, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200 - 8, 200, 200 + 8, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200, 200, 200 + 16, badgeRadius).shift(offset)));
   });
 
   testWidgets('Small Badge alignment', (WidgetTester tester) async {
@@ -447,6 +447,6 @@ void main() {
     await tester.pumpWidget(buildFrame(Alignment.topLeft));
     final RenderBox box = tester.renderObject(find.byType(Badge));
     // Badge should scale with content
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -15, 30 + 8, 15, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -7, 30 + 8, 23, badgeRadius)));
   });
 }

--- a/packages/flutter/test/material/badge_test.dart
+++ b/packages/flutter/test/material/badge_test.dart
@@ -297,13 +297,13 @@ void main() {
 
     await tester.pumpWidget(buildFrame(Alignment.topLeft));
     final RenderBox box = tester.renderObject(find.byType(Badge));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 0, 16, 16, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -8, 16, 8, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.topCenter));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 0, 100 + 8, 16, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, -8, 100 + 8, 8, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.topRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 0, 200, 16, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, -8, 200, 8, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerLeft));
     expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100 - 8, 16, 100 + 8, badgeRadius)));
@@ -312,24 +312,24 @@ void main() {
     expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 100 - 8, 200, 100 + 8, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomLeft));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 16, 16, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 8, 16, 200 + 8, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomCenter));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200 - 16, 100 + 8, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200 - 8, 100 + 8, 200 + 8, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200 - 16, 200, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200 - 8, 200, 200 + 8, badgeRadius)));
 
     const Offset offset = Offset(5, 10);
 
     await tester.pumpWidget(buildFrame(Alignment.topLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 0, 16, 16, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -8, 16, 8, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.topCenter, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 0, 100 + 8, 16, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, -8, 100 + 8, 8, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.topRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 0, 200, 16, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, -8 , 200, 8, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerLeft, offset));
     expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100 - 8, 16, 100 + 8, badgeRadius).shift(offset)));
@@ -338,13 +338,13 @@ void main() {
     expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 100 - 8, 200, 100 + 8, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 16, 16, 200, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 8, 16, 200 + 8, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomCenter, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200 - 16, 100 + 8, 200, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 8, 200 - 8, 100 + 8, 200 + 8, badgeRadius).shift(offset)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200 - 16, 200, 200, badgeRadius).shift(offset)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 16, 200 - 8, 200, 200 + 8, badgeRadius).shift(offset)));
   });
 
   testWidgets('Small Badge alignment', (WidgetTester tester) async {
@@ -380,19 +380,19 @@ void main() {
     expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 0, 200, 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerLeft));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100 - 3, 6, 100 + 3, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100, 6, 100 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 100 - 3, 200, 100 + 3, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 100, 200, 100 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomLeft));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 6, 6, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200, 6, 200 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomCenter));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 3, 200 - 6, 100 + 3, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 3, 200, 100 + 3, 200 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomRight));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 200 - 6, 200, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 200, 200, 200 + 6, badgeRadius)));
 
     const Offset offset = Offset(5, 10); // Not used for smallSize Badges.
 
@@ -406,18 +406,47 @@ void main() {
     expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 0, 200, 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100 - 3, 6, 100 + 3, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 100, 6, 100 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.centerRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 100 - 3, 200, 100 + 3, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 100, 200, 100 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomLeft, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200 - 6, 6, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, 200, 6, 200 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomCenter, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 3, 200 - 6, 100 + 3, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(100 - 3, 200, 100 + 3, 200 + 6, badgeRadius)));
 
     await tester.pumpWidget(buildFrame(Alignment.bottomRight, offset));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 200 - 6, 200, 200, badgeRadius)));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(200 - 6, 200, 200, 200 + 6, badgeRadius)));
+  });
+
+  testWidgets('Badge Larger than large size', (WidgetTester tester) async {
+    const Radius badgeRadius = Radius.circular(15);
+
+    Widget buildFrame(Alignment alignment, [Offset offset = Offset.zero]) {
+      return MaterialApp(
+        theme: ThemeData.light(useMaterial3: true),
+        home: Align(
+          alignment: Alignment.topLeft,
+          child: Badge(
+            // LargeSize = 16, make content of badge bigger than the default.
+            label: Container(width: 30, height: 30, color: Colors.blue),
+            alignment: alignment,
+            offset: offset,
+            child: Container(
+              color: const Color(0xFF00FF00),
+              width: 200,
+              height: 200,
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(Alignment.topLeft));
+    final RenderBox box = tester.renderObject(find.byType(Badge));
+    // Badge should scale with content
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(0, -15, 30 + 8, 15, badgeRadius)));
   });
 }

--- a/packages/flutter/test/material/badge_theme_test.dart
+++ b/packages/flutter/test/material/badge_theme_test.dart
@@ -103,7 +103,7 @@ void main() {
     // text width = 48 = fontSize * 4, text height = fontSize
     expect(tester.getSize(find.text('1234')), const Size(48, 12));
 
-    expect(tester.getTopLeft(find.text('1234')), const Offset(33, 4));
+    expect(tester.getTopLeft(find.text('1234')), const Offset(33, 2));
 
 
     expect(tester.getSize(find.byType(Badge)), const Size(24, 24)); // default Icon size
@@ -114,7 +114,7 @@ void main() {
     expect(textStyle.color, black);
 
     final RenderBox box = tester.renderObject(find.byType(Badge));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(28, 0, 86, 20, const Radius.circular(10)), color: green));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(28, -2, 86, 18, const Radius.circular(10)), color: green));
   });
 
 
@@ -150,13 +150,13 @@ void main() {
     );
 
     expect(tester.getSize(find.text('1234')), const Size(48, 12));
-    expect(tester.getTopLeft(find.text('1234')), const Offset(33, 4));
+    expect(tester.getTopLeft(find.text('1234')), const Offset(33, 2));
     expect(tester.getSize(find.byType(Badge)), const Size(24, 24)); // default Icon size
     expect(tester.getTopLeft(find.byType(Badge)), Offset.zero);
     final TextStyle textStyle = tester.renderObject<RenderParagraph>(find.text('1234')).text.style!;
     expect(textStyle.fontSize, 12);
     expect(textStyle.color, black);
     final RenderBox box = tester.renderObject(find.byType(Badge));
-    expect(box, paints..rrect(rrect: RRect.fromLTRBR(28, 0, 86, 20, const Radius.circular(10)), color: green));
+    expect(box, paints..rrect(rrect: RRect.fromLTRBR(28, -2, 86, 18, const Radius.circular(10)), color: green));
   });
 }


### PR DESCRIPTION
Makes badge sizes it self according to child.

Previously, the bubble fixed its height to 16pixel. It clip the content if it is taller than 16 pixel. This causes an issue where user can increase font size in the android setting and mess up the ui

Now, the bubble can have various height from 16 pixel to the height of the child, it also extend the width to be the same as height if the child's width < height.

There is minor changes to floating location  in the test. I can't really fix them unless I change some of the public API like `Badge(offset)` or `BadgeThemeData.largeSize`. They are used differently in the new logic since now the badge can be larger than the Badge.child. I figure they are kind of minor so i think it should be ok

Before the fix
![image](https://github.com/flutter/flutter/assets/47866232/10430cb7-513a-4425-99ee-163c494abff8)


After the fix
![image](https://github.com/flutter/flutter/assets/47866232/34390763-2778-4c4e-b468-eda972f61bb1)

fixes https://github.com/flutter/flutter/issues/146777


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
