### PR TITLE
[tools] Make SnapshotType.platform non-nullable

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -578,7 +578,7 @@ class CachedArtifacts implements Artifacts {
       case TargetPlatform.linux_arm64:
       case TargetPlatform.windows_x64:
       case TargetPlatform.windows_arm64:
-        return _getDesktopArtifactPath(artifact, platform, mode);
+        return _getDesktopArtifactPath(artifact, platform!, mode);
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
         return _getFuchsiaArtifactPath(artifact, platform!, mode!);
@@ -594,18 +594,18 @@ class CachedArtifacts implements Artifacts {
     return _fileSystem.path.basename(_getEngineArtifactsPath(platform, mode)!);
   }
 
-  String _getDesktopArtifactPath(Artifact artifact, TargetPlatform? platform, BuildMode? mode) {
+  String _getDesktopArtifactPath(Artifact artifact, TargetPlatform platform, BuildMode? mode) {
     // When platform is null, a generic host platform artifact is being requested
     // and not the gen_snapshot for darwin as a target platform.
-    if (platform != null && artifact == Artifact.genSnapshot) {
+    if (artifact == Artifact.genSnapshot) {
       final String engineDir = _getEngineArtifactsPath(platform, mode)!;
       return _fileSystem.path.join(engineDir, _artifactToFileName(artifact, _platform));
     }
-    if (platform != null && artifact == Artifact.flutterMacOSFramework) {
+    if (artifact == Artifact.flutterMacOSFramework) {
       final String engineDir = _getEngineArtifactsPath(platform, mode)!;
       return _getMacOSEngineArtifactPath(engineDir, _fileSystem, _platform);
     }
-    return _getHostArtifactPath(artifact, platform ?? _currentHostPlatform(_platform, _operatingSystemUtils), mode);
+    return _getHostArtifactPath(artifact, platform, mode);
   }
 
   String _getAndroidArtifactPath(Artifact artifact, TargetPlatform platform, BuildMode mode) {

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -16,7 +16,7 @@ import 'process.dart';
 class SnapshotType {
   SnapshotType(this.platform, this.mode);
 
-  final TargetPlatform? platform;
+  final TargetPlatform platform;
   final BuildMode mode;
 
   @override

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -49,12 +49,6 @@ const List<String> kDefaultClang = <String>[
 ];
 
 void main() {
-  group('SnapshotType', () {
-    test('does not throw, if target platform is null', () {
-      expect(() => SnapshotType(null, BuildMode.release), returnsNormally);
-    });
-  });
-
   group('GenSnapshot', () {
     late GenSnapshot genSnapshot;
     late Artifacts artifacts;


### PR DESCRIPTION
When performing artifact lookups for `Artifact.genSnapshot` for macOS desktop builds, a `TargetPlatform` is used to determine the name of the tool, typically `gen_snapshot_$TARGET_ARCH`. Formerly, this tool was always named `gen_snapshot`.

The astute reader may ask "but Chris, didn't we support TWO target architectures on iOS and therefore need TWO `gen_snapshot` binaries?" Yes, we did support both armv7 and arm64 target architectures on iOS. But no, we didn't initially have two `gen_snapshot` binaries. We did *build* two `gen_snapshots`:
   * A 32-bit x86 binary that emitted armv7 AOT code
   * A 64-bit x64 binary that emitted arm64 AOT code 

At the time, the bitness of the `gen_snapshot` tool needed to match the bitness of the target architecture, and to avoid having to do a lot of work plumbing through suffixed `gen_snapshot` names, the author of that work (who, as evidenced by this patch, is still paying for his code crimes) elected to "cleverly" lipo the two together into a single multi-architecture macOS binary still named `gen_snapshot`. See: https://github.com/flutter/engine/pull/4948

This was later remediated over the course of several patches, including:
   * https://github.com/flutter/engine/pull/10430
   * https://github.com/flutter/engine/pull/22818
   * https://github.com/flutter/flutter/pull/37445 

However, there were still cases (notably `--local-engine` workflows in the tool) where we weren't computing the target platform and thus referenced the generic `gen_snapshot` tool.
See: https://github.com/flutter/flutter/issues/38933
Fixed in: https://github.com/flutter/engine/pull/28345

The test removed in this PR, which ensured that null `SnapshotType.platform` was supported was introduced in https://github.com/flutter/flutter/pull/11924 as a followup to https://github.com/flutter/flutter/pull/11820 when the snapshotting logic was originally extracted to the `GenSnapshot` class, and most invocations still passed a null target platform.

Since there are no longer any cases where `TargetPlatform` isn't passed when looking up `Artifact.genSnapshot`, we can safely make the platform non-nullable and remove the test.

This is pre-factoring towards the removal of the generic `gen_snapshot` artifact from the macOS host binaries (which are currently unused since we never pass a null `TargetPlatform`), which is pre-factoring towards the goal of building `gen_snapshot` binaries with an arm64 host architecture, and eliminate the need to use Rosetta during iOS and macOS Flutter builds.

Part of: https://github.com/flutter/flutter/issues/101138
Umbrella issue: https://github.com/flutter/flutter/issues/103386
Umbrella issue: https://github.com/flutter/flutter/issues/69157

No new tests since the behaviour is enforced by the compiler.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
