### PR TITLE
Fix memory leaks in `MaterialBanner` [prod-leak-fix]

### DIFF
--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -267,11 +267,15 @@ class MaterialBanner extends StatefulWidget {
 
 class _MaterialBannerState extends State<MaterialBanner> {
   bool _wasVisible = false;
+  CurvedAnimation? _heightAnimation;
+  CurvedAnimation? _slideOutCurvedAnimation;
 
   @override
   void initState() {
     super.initState();
     widget.animation?.addStatusListener(_onAnimationStatusChanged);
+    _setCurvedAnimations();
+
   }
 
   @override
@@ -280,12 +284,31 @@ class _MaterialBannerState extends State<MaterialBanner> {
     if (widget.animation != oldWidget.animation) {
       oldWidget.animation?.removeStatusListener(_onAnimationStatusChanged);
       widget.animation?.addStatusListener(_onAnimationStatusChanged);
+      _setCurvedAnimations();
     }
+  }
+
+  void _setCurvedAnimations() {
+    _heightAnimation?.dispose();
+    _slideOutCurvedAnimation?.dispose();
+    if (widget.animation != null) {
+      _heightAnimation = CurvedAnimation(parent: widget.animation!, curve: _materialBannerHeightCurve);
+      _slideOutCurvedAnimation = CurvedAnimation(
+        parent: widget.animation!,
+        curve: const Threshold(0.0),
+      );
+    } else {
+      _heightAnimation = null;
+      _slideOutCurvedAnimation = null;
+    }
+
   }
 
   @override
   void dispose() {
     widget.animation?.removeStatusListener(_onAnimationStatusChanged);
+    _heightAnimation?.dispose();
+    _slideOutCurvedAnimation?.dispose();
     super.dispose();
   }
 
@@ -408,14 +431,10 @@ class _MaterialBannerState extends State<MaterialBanner> {
       child: materialBanner,
     );
 
-    final CurvedAnimation heightAnimation = CurvedAnimation(parent: widget.animation!, curve: _materialBannerHeightCurve);
     final Animation<Offset> slideOutAnimation = Tween<Offset>(
       begin: const Offset(0.0, -1.0),
       end: Offset.zero,
-    ).animate(CurvedAnimation(
-      parent: widget.animation!,
-      curve: const Threshold(0.0),
-    ));
+    ).animate(_slideOutCurvedAnimation!);
 
     materialBanner = Semantics(
       container: true,
@@ -436,11 +455,11 @@ class _MaterialBannerState extends State<MaterialBanner> {
       materialBannerTransition = materialBanner;
     } else {
       materialBannerTransition = AnimatedBuilder(
-        animation: heightAnimation,
+        animation: _heightAnimation!,
         builder: (BuildContext context, Widget? child) {
           return Align(
             alignment: AlignmentDirectional.bottomStart,
-            heightFactor: heightAnimation.value,
+            heightFactor: _heightAnimation!.value,
             child: child,
           );
         },

--- a/packages/flutter/test/material/banner_theme_test.dart
+++ b/packages/flutter/test/material/banner_theme_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 void main() {
   test('MaterialBannerThemeData copyWith, ==, hashCode basics', () {
@@ -324,7 +325,10 @@ void main() {
     expect(find.byType(Divider), findsNothing);
   });
 
-  testWidgets('MaterialBanner widget properties take priority over theme when presented by ScaffoldMessenger', (WidgetTester tester) async {
+  testWidgets('MaterialBanner widget properties take priority over theme when presented by ScaffoldMessenger',
+    // TODO(polina-c): remove when fixed https://github.com/flutter/flutter/issues/145600 [leak-tracking-opt-in]
+    experimentalLeakTesting: LeakTesting.settings.withTracked(classes: const <String>['CurvedAnimation']),
+  (WidgetTester tester) async {
     const Color backgroundColor = Colors.purple;
     const double elevation = 6.0;
     const TextStyle textStyle = TextStyle(color: Colors.green);


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/141198

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
