### PR TITLE
Changing the renderer on the web target should change its build key.

### DIFF
--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -38,6 +38,7 @@ sealed class WebCompilerConfig {
 
   Map<String, dynamic> get _buildKeyMap => <String, dynamic>{
     'optimizationLevel': optimizationLevel,
+    'webRenderer': renderer.name,
   };
 }
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -951,6 +951,68 @@ void main() {
     }
   }
 
+  test('Dart2JSTarget has unique build keys for compiler configurations', () {
+    const List<JsCompilerConfig> testConfigs = <JsCompilerConfig>[
+      // Default values
+      JsCompilerConfig(),
+
+      // Each individual property being made non-default
+      JsCompilerConfig(csp: true),
+      JsCompilerConfig(dumpInfo: true),
+      JsCompilerConfig(nativeNullAssertions: true),
+      JsCompilerConfig(optimizationLevel: 0),
+      JsCompilerConfig(noFrequencyBasedMinification: true),
+      JsCompilerConfig(sourceMaps: false),
+      JsCompilerConfig(renderer: WebRendererMode.canvaskit),
+
+      // All properties non-default
+      JsCompilerConfig(
+        csp: true,
+        dumpInfo: true,
+        nativeNullAssertions: true,
+        optimizationLevel: 0,
+        noFrequencyBasedMinification: true,
+        sourceMaps: false,
+        renderer: WebRendererMode.canvaskit,
+      ),
+    ];
+
+    final Iterable<String> buildKeys = testConfigs.map((JsCompilerConfig config) {
+      final Dart2JSTarget target = Dart2JSTarget(config);
+      return target.buildKey;
+    });
+
+    // Make sure all the build keys are unique.
+    expect(buildKeys.toSet().length, buildKeys.length);
+  });
+
+  test('Dart2Wasm has unique build keys for compiler configurations', () {
+    const List<WasmCompilerConfig> testConfigs = <WasmCompilerConfig>[
+      // Default values
+      WasmCompilerConfig(),
+
+      // Each individual property being made non-default
+      WasmCompilerConfig(optimizationLevel: 0),
+      WasmCompilerConfig(renderer: WebRendererMode.canvaskit),
+      WasmCompilerConfig(stripWasm: false),
+
+      // All properties non-default
+      WasmCompilerConfig(
+        optimizationLevel: 0,
+        stripWasm: false,
+        renderer: WebRendererMode.canvaskit,
+      ),
+    ];
+
+    final Iterable<String> buildKeys = testConfigs.map((WasmCompilerConfig config) {
+      final Dart2WasmTarget target = Dart2WasmTarget(config);
+      return target.buildKey;
+    });
+
+    // Make sure all the build keys are unique.
+    expect(buildKeys.toSet().length, buildKeys.length);
+  });
+
   test('Generated service worker is empty with none-strategy', () => testbed.run(() {
     final String fileGeneratorsPath =
         environment.artifacts.getArtifactPath(Artifact.flutterToolsFileGenerators);


### PR DESCRIPTION
Changing the web renderer doesn't directly modify the environment's dart defines, and so doesn't do a full build invalidation. We need to include the web renderer in the build key for the compiler configuration. This information is used directly by the web targets to modify the dart defines that are passed into the compiler, so we need to rebuild if this information changes. 