### PR TITLE
Fix paintOrigin for RenderSliverFloatingPersistentHeader

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -512,6 +512,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   late Animation<double> _animation;
   double? _lastActualScrollOffset;
   double? _effectiveScrollOffset;
+  double? _effectivePaintOrigin;
   // Important for pointer scrolling, which does not have the same concept of
   // a hold and release scroll movement, like dragging.
   // This keeps track of the last ScrollDirection when scrolling started.
@@ -579,7 +580,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     final double layoutExtent = maxExtent - constraints.scrollOffset;
     geometry = SliverGeometry(
       scrollExtent: maxExtent,
-      paintOrigin: math.min(constraints.overlap, 0.0),
+      paintOrigin: _effectivePaintOrigin == 0 ? 0.0 : constraints.overlap,
       paintExtent: clampDouble(paintExtent, 0.0, constraints.remainingPaintExtent),
       layoutExtent: clampDouble(layoutExtent, 0.0, constraints.remainingPaintExtent),
       maxPaintExtent: maxExtent + stretchOffset,
@@ -660,6 +661,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
         if (_effectiveScrollOffset! > maxExtent) {
           // We're scrolled off-screen, but should reveal, so pretend we're just at the limit.
           _effectiveScrollOffset = maxExtent;
+          _effectivePaintOrigin = constraints.overlap;
         }
       } else {
         if (delta > 0.0) {
@@ -668,8 +670,10 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
         }
       }
       _effectiveScrollOffset = clampDouble(_effectiveScrollOffset! - delta, 0.0, constraints.scrollOffset);
+      _effectivePaintOrigin = clampDouble(_effectivePaintOrigin!, 0, constraints.overlap);
     } else {
       _effectiveScrollOffset = constraints.scrollOffset;
+      _effectivePaintOrigin = 0.0;
     }
     final bool overlapsContent = _effectiveScrollOffset! < constraints.scrollOffset;
 

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -512,7 +512,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   late Animation<double> _animation;
   double? _lastActualScrollOffset;
   double? _effectiveScrollOffset;
-  double? _effectivePaintOrigin;
+  double _effectiveOverlap = 0.0;
   // Important for pointer scrolling, which does not have the same concept of
   // a hold and release scroll movement, like dragging.
   // This keeps track of the last ScrollDirection when scrolling started.
@@ -580,7 +580,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
     final double layoutExtent = maxExtent - constraints.scrollOffset;
     geometry = SliverGeometry(
       scrollExtent: maxExtent,
-      paintOrigin: _effectivePaintOrigin == 0 ? 0.0 : constraints.overlap,
+      paintOrigin: _effectiveOverlap == 0 ? 0.0 : constraints.overlap,
       paintExtent: clampDouble(paintExtent, 0.0, constraints.remainingPaintExtent),
       layoutExtent: clampDouble(layoutExtent, 0.0, constraints.remainingPaintExtent),
       maxPaintExtent: maxExtent + stretchOffset,
@@ -650,6 +650,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
   void performLayout() {
     final SliverConstraints constraints = this.constraints;
     final double maxExtent = this.maxExtent;
+    final double overlap = math.max(0, constraints.overlap);
     if (_lastActualScrollOffset != null && // We've laid out at least once to get an initial position, and either
         ((constraints.scrollOffset < _lastActualScrollOffset!) || // we are scrolling back, so should reveal, or
          (_effectiveScrollOffset! < maxExtent))) { // some part of it is visible, so should shrink or reveal as appropriate.
@@ -661,7 +662,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
         if (_effectiveScrollOffset! > maxExtent) {
           // We're scrolled off-screen, but should reveal, so pretend we're just at the limit.
           _effectiveScrollOffset = maxExtent;
-          _effectivePaintOrigin = constraints.overlap;
+          _effectiveOverlap = overlap;
         }
       } else {
         if (delta > 0.0) {
@@ -670,10 +671,10 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
         }
       }
       _effectiveScrollOffset = clampDouble(_effectiveScrollOffset! - delta, 0.0, constraints.scrollOffset);
-      _effectivePaintOrigin = clampDouble(_effectivePaintOrigin!, 0, constraints.overlap);
+      _effectiveOverlap = clampDouble(_effectiveOverlap, 0, overlap);
     } else {
       _effectiveScrollOffset = constraints.scrollOffset;
-      _effectivePaintOrigin = 0.0;
+      _effectiveOverlap = 0.0;
     }
     final bool overlapsContent = _effectiveScrollOffset! < constraints.scrollOffset;
 


### PR DESCRIPTION
Fix for issue: https://github.com/flutter/flutter/issues/147053


Fixes RenderSliverFloatingPersistentHeader so that it makes use of constraints.overlap when appropriate.

In the original code, paintOrigin was set like so: paintOrigin: min(0,constraints.overlap)

This would always equate to 0, so floating headers would appear hidden by pinned headers, instead of underneath when being shown.

This fix addresses that bug. I have tested with:

- Floating -> remaining slivers
- Pinned -> floating -> remaining slivers
- Floating -> pinned -> remaining slivers
- Floating -> floating -> remaining slivers

All these situations work perfectly now with proposed changes :)

Before:
https://share.cleanshot.com/tZNmLvkl

After:
https://share.cleanshot.com/NzPVhS4L

Before:
https://share.cleanshot.com/Tbd1QkXQ

After:
https://share.cleanshot.com/C3rHPtH1

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
