### PR TITLE
Replace CocoaPods deprecated `exists?` with `exist?`

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -324,12 +324,12 @@ def flutter_install_plugin_pods(application_path = nil, relative_symlink_dir, pl
 
     # If Swift Package Manager is enabled and the plugin has a Package.swift,
     # skip from installing as a pod.
-    swift_package_exists = File.exists?(File.join(relative, platform_directory, plugin_name, "Package.swift"))
+    swift_package_exists = File.exist?(File.join(relative, platform_directory, plugin_name, "Package.swift"))
     next if swift_package_manager_enabled && swift_package_exists
 
     # If a plugin is Swift Package Manager compatible but not CocoaPods compatible, skip it.
     # The tool will print an error about it.
-    next if swift_package_exists && !File.exists?(File.join(relative, platform_directory, plugin_name + ".podspec"))
+    next if swift_package_exists && !File.exist?(File.join(relative, platform_directory, plugin_name + ".podspec"))
 
     pod plugin_name, path: File.join(relative, platform_directory)
   end


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/147041.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
