### PR TITLE
Fix `Scrollable.ensureVisible` throws an error in `DropdownMenu` inside nested scroll views

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -524,7 +524,10 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final BuildContext? highlightContext = buttonItemKeys[currentHighlight!].currentContext;
       if (highlightContext != null) {
-        Scrollable.ensureVisible(highlightContext);
+        final ScrollableState? scrollable = Scrollable.maybeOf(highlightContext);
+        scrollable?.widget.controller?.position.ensureVisible(
+          highlightContext.findRenderObject()!,
+        );
       }
     }, debugLabel: 'DropdownMenu.scrollToHighlight');
   }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2129,6 +2129,32 @@ void main() {
     // No exception should be thrown.
     expect(tester.takeException(), isNull);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/146764.
+  testWidgets('Ensure visible does not throw an error in nested scroll views', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: Card(
+            child: SingleChildScrollView(
+              child: DropdownMenu<TestMenu>(
+                dropdownMenuEntries: menuChildren,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField).first, 'Item');
+    await tester.pumpAndSettle();
+
+    // No exception should be thrown.
+    expect(tester.takeException(), isNull);
+
+  }, variant: TargetPlatformVariant.desktop());
 }
 
 enum TestMenu {


### PR DESCRIPTION
fixes [DropdownMenu throws exception when nested inside nested SingleChildScrollView](https://github.com/flutter/flutter/issues/146764)

### Description 
`Scrollable.ensureVisible` in `DropdownMenu` inside nested scroll views after the `OverlayPortal` [migration](https://github.com/flutter/flutter/pull/130534) throws an error. 

The error is thrown by `getTransformTo` when `object.parent != null` is not true.  This PR fixes the error by getting `Scrollable` and call `ensureVisible`. 

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Material(
        child: SingleChildScrollView(
          child: Card(
            child: SingleChildScrollView(
              child: DropdownMenu<String>(
                label: Text('test'),
                menuHeight: 100,
                dropdownMenuEntries: <DropdownMenuEntry<String>>[
                  DropdownMenuEntry<String>(value: '1', label: 'one'),
                  DropdownMenuEntry<String>(value: '2', label: 'two'),
                  DropdownMenuEntry<String>(value: '3', label: 'three'),
                ],
              ),
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>


### Before
![Screenshot 2024-04-22 at 18 08 56](https://github.com/flutter/flutter/assets/48603081/a56d8f14-5700-48a4-b179-8f407b4027e6)

### After 
![Screenshot 2024-04-22 at 18 09 10](https://github.com/flutter/flutter/assets/48603081/1baf98fb-3c6a-44fa-be6b-2f48bd515730)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
