### PR TITLE
Make `_SelectableRegionSelectionContainerDelegate` public

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -351,7 +351,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   final LayerLink _startHandleLayerLink = LayerLink();
   final LayerLink _endHandleLayerLink = LayerLink();
   final LayerLink _toolbarLayerLink = LayerLink();
-  final _SelectableRegionContainerDelegate _selectionDelegate = _SelectableRegionContainerDelegate();
+  final MultiStaticSelectableSelectionContainerDelegate _selectionDelegate = MultiStaticSelectableSelectionContainerDelegate();
   // there should only ever be one selectable, which is the SelectionContainer.
   Selectable? _selectable;
 
@@ -1823,7 +1823,18 @@ class _DirectionallyExtendCaretSelectionAction<T extends DirectionalCaretMovemen
   }
 }
 
-class _SelectableRegionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+/// This class manages updating multiple [Selectable] children where the
+/// [Selectable]s do not change or move around frequently.
+///
+/// It keeps track of the [Selectable]s that have received start and end
+/// [SelectionEvent]s to accurately synthesize a [SelectionEvent] for the
+/// opposite edge when needed.
+///
+/// See also:
+///
+///  * [MultiSelectableSelectionContainerDelegate], for the class that provides
+///  the main implementation details of this [SelectionContainerDelegate].
+class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
   final Set<Selectable> _hasReceivedStartEvent = <Selectable>{};
   final Set<Selectable> _hasReceivedEndEvent = <Selectable>{};
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1897,8 +1897,8 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
 
   /// Tracks the internal selection state for a given [Selectable].
   ///
-  /// Registers a [Selectable] as having received both start and end events when
-  /// `forEnd` is null.
+  /// When `forEnd` is null, the [Selectable] will be registered as having received both
+  /// start and end events.
   ///
   /// When `forEnd` is true, the [Selectable] will be registered as having received
   /// an end event. When false, the [Selectable] is registered as having received

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1841,6 +1841,22 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   Offset? _lastStartEdgeUpdateGlobalPosition;
   Offset? _lastEndEdgeUpdateGlobalPosition;
 
+  void updateLastStartEdgeUpdateGlobalPosition(Offset globalPosition) {
+    _lastStartEdgeUpdateGlobalPosition = globalPosition;
+  }
+
+  void updateLastEndEdgeUpdateGlobalPosition(Offset globalPosition) {
+    _lastEndEdgeUpdateGlobalPosition = globalPosition;
+  }
+
+  bool markReceivedStartEvent(Selectable selectable) {
+    return _hasReceivedStartEvent.add(selectable);
+  }
+
+  bool markReceivedEndEvent(Selectable selectable) {
+    return _hasReceivedEndEvent.add(selectable);
+  }
+
   @override
   void remove(Selectable selectable) {
     _hasReceivedStartEvent.remove(selectable);
@@ -1848,7 +1864,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     super.remove(selectable);
   }
 
-  void _updateLastEdgeEventsFromGeometries() {
+  void updateLastEdgeEventsFromGeometries() {
     if (currentSelectionStartIndex != -1 && selectables[currentSelectionStartIndex].value.hasSelection) {
       final Selectable start = selectables[currentSelectionStartIndex];
       final Offset localStartEdge = start.value.startSelectionPoint!.localPosition +
@@ -1863,6 +1879,14 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     }
   }
 
+  void updateLastEdgeEventsFromSelectionEdgeUpdateEvent(SelectionEdgeUpdateEvent event) {
+    if (event.type == SelectionEventType.endEdgeUpdate) {
+      _lastEndEdgeUpdateGlobalPosition = event.globalPosition;
+    } else {
+      _lastStartEdgeUpdateGlobalPosition = event.globalPosition;
+    }
+  }
+
   @override
   SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
     final SelectionResult result = super.handleSelectAll(event);
@@ -1871,7 +1895,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
       _hasReceivedEndEvent.add(selectable);
     }
     // Synthesize last update event so the edge updates continue to work.
-    _updateLastEdgeEventsFromGeometries();
+    updateLastEdgeEventsFromGeometries();
     return result;
   }
 
@@ -1886,7 +1910,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     if (currentSelectionEndIndex != -1) {
       _hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
     }
-    _updateLastEdgeEventsFromGeometries();
+    updateLastEdgeEventsFromGeometries();
     return result;
   }
 
@@ -1901,7 +1925,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     if (currentSelectionEndIndex != -1) {
       _hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
     }
-    _updateLastEdgeEventsFromGeometries();
+    updateLastEdgeEventsFromGeometries();
     return result;
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1883,7 +1883,11 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     _updateLastSelectionEdgeLocationsFromGeometries();
   }
 
-  /// Clears the internal selection state.
+  /// Clears the internal selection state. 
+  /// 
+  /// This indicates that no [Selectable] child under this delegate
+  /// has received start or end events, and resets any tracked global
+  /// locations for start and end [SelectionEdgeUpdateEvent]s.
   @protected
   void clearInternalSelectionState() {
     _hasReceivedStartEvent.clear();
@@ -1893,6 +1897,9 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   }
 
   /// Clears the internal selection state for a given [Selectable].
+  /// 
+  /// This indicates that the given `selectable` has neither received a
+  /// start or end [SelectionEdgeUpdateEvent]s.
   @protected
   void clearInternalSelectionStateForSelectable(Selectable selectable) {
     _hasReceivedStartEvent.remove(selectable);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1826,7 +1826,7 @@ class _DirectionallyExtendCaretSelectionAction<T extends DirectionalCaretMovemen
 /// This class manages updating multiple [Selectable] children where the
 /// [Selectable]s do not change or move around frequently.
 ///
-/// It keeps track of the [Selectable]s that have received start and end
+/// It keeps track of the [Selectable]s that received start or end
 /// [SelectionEvent]s to accurately synthesize a [SelectionEvent] for the
 /// opposite edge when needed.
 ///

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2003,6 +2003,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
         trackInternalSelectionStateForSelectable(selectable: selectable, forEnd: true);
         ensureChildUpdated(selectable);
       case SelectionEventType.clear:
+        clearInternalSelectionStateForSelectable(selectable);
       case SelectionEventType.selectAll:
       case SelectionEventType.selectWord:
       case SelectionEventType.selectParagraph:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -351,7 +351,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   final LayerLink _startHandleLayerLink = LayerLink();
   final LayerLink _endHandleLayerLink = LayerLink();
   final LayerLink _toolbarLayerLink = LayerLink();
-  final MultiStaticSelectableSelectionContainerDelegate _selectionDelegate = MultiStaticSelectableSelectionContainerDelegate();
+  final StaticSelectionContainerDelegate _selectionDelegate = StaticSelectionContainerDelegate();
   // there should only ever be one selectable, which is the SelectionContainer.
   Selectable? _selectable;
 
@@ -1845,7 +1845,7 @@ class _DirectionallyExtendCaretSelectionAction<T extends DirectionalCaretMovemen
 ///
 ///  * [MultiSelectableSelectionContainerDelegate], for the class that provides
 ///  the main implementation details of this [SelectionContainerDelegate].
-class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainerDelegate {
   /// The set of [Selectable]s that have received start events.
   final Set<Selectable> _hasReceivedStartEvent = <Selectable>{};
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1841,29 +1841,32 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   Offset? _lastStartEdgeUpdateGlobalPosition;
   Offset? _lastEndEdgeUpdateGlobalPosition;
 
+  /// This method updates the tracked global position of the selection start edge.
+  @protected
   void updateLastStartEdgeUpdateGlobalPosition(Offset globalPosition) {
     _lastStartEdgeUpdateGlobalPosition = globalPosition;
   }
 
+  /// This method updates the tracked global position of the selection end edge.
+  @protected
   void updateLastEndEdgeUpdateGlobalPosition(Offset globalPosition) {
     _lastEndEdgeUpdateGlobalPosition = globalPosition;
   }
 
+  /// This marks the given [Selectable] as having received a start event.
+  @protected
   bool markReceivedStartEvent(Selectable selectable) {
     return _hasReceivedStartEvent.add(selectable);
   }
 
+  /// This marks the given [Selectable] as having received a end event.
+  @protected
   bool markReceivedEndEvent(Selectable selectable) {
     return _hasReceivedEndEvent.add(selectable);
   }
 
-  @override
-  void remove(Selectable selectable) {
-    _hasReceivedStartEvent.remove(selectable);
-    _hasReceivedEndEvent.remove(selectable);
-    super.remove(selectable);
-  }
-
+  /// Updates the last tracked global positions of both start and end selection
+  /// edges based on their [SelectionGeometry].
   void updateLastEdgeEventsFromGeometries() {
     if (currentSelectionStartIndex != -1 && selectables[currentSelectionStartIndex].value.hasSelection) {
       final Selectable start = selectables[currentSelectionStartIndex];
@@ -1879,12 +1882,11 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     }
   }
 
-  void updateLastEdgeEventsFromSelectionEdgeUpdateEvent(SelectionEdgeUpdateEvent event) {
-    if (event.type == SelectionEventType.endEdgeUpdate) {
-      _lastEndEdgeUpdateGlobalPosition = event.globalPosition;
-    } else {
-      _lastStartEdgeUpdateGlobalPosition = event.globalPosition;
-    }
+  @override
+  void remove(Selectable selectable) {
+    _hasReceivedStartEvent.remove(selectable);
+    _hasReceivedEndEvent.remove(selectable);
+    super.remove(selectable);
   }
 
   @override
@@ -1981,6 +1983,16 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     return super.dispatchSelectionEventToChild(selectable, event);
   }
 
+  /// Ensures the [Selectable] child has received up to date selection event.
+  ///
+  /// This method is called when:
+  ///   1. A new [Selectable] is added to the delegate, and its screen location
+  ///   falls into the previous selection.
+  ///   2. A [Selectable] is dispatched a [SelectionEvent] of type
+  ///   [SelectionEventType.startEdgeUpdate], [SelectionEventType.endEdgeUpdate],
+  ///   [SelectionEventType.granularlyExtendSelection], or
+  ///   [SelectionEventType.directionallyExtendSelection] through
+  ///   [dispatchSelectionEventToChild].
   @override
   void ensureChildUpdated(Selectable selectable) {
     if (_lastEndEdgeUpdateGlobalPosition != null && _hasReceivedEndEvent.add(selectable)) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1858,51 +1858,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// The global position of the last selection end edge update.
   Offset? _lastEndEdgeUpdateGlobalPosition;
 
-  /// Updates the internal selection state after a [SelectionEvent] that
-  /// selects a boundary such as: [SelectWordSelectionEvent],
-  /// [SelectParagraphSelectionEvent], and [SelectAllSelectionEvent].
-  ///
-  /// Call this method after determining the new selection as a result of
-  /// a [SelectionEvent] that selects a boundary. The [currentSelectionStartIndex]
-  /// and [currentSelectionEndIndex] should be set to valid values at the time
-  /// this method is called.
-  @protected
-  void didReceiveSelectionBoundaryEvents() {
-    if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
-      return;
-    }
-    final int start = min(currentSelectionStartIndex, currentSelectionEndIndex);
-    final int end = max(currentSelectionStartIndex, currentSelectionEndIndex);
-    for (int index = start; index <= end; index += 1) {
-      didReceiveSelectionEventFor(selectable: selectables[index]);
-    }
-    _updateLastSelectionEdgeLocationsFromGeometries();
-  }
-
-  /// Clears the internal selection state.
-  ///
-  /// This indicates that no [Selectable] child under this delegate
-  /// has received start or end events, and resets any tracked global
-  /// locations for start and end [SelectionEdgeUpdateEvent]s.
-  @protected
-  void clearInternalSelectionState() {
-    _hasReceivedStartEvent.clear();
-    _hasReceivedEndEvent.clear();
-    _lastStartEdgeUpdateGlobalPosition = null;
-    _lastEndEdgeUpdateGlobalPosition = null;
-  }
-
-  /// Clears the internal selection state for a given [Selectable].
-  ///
-  /// This indicates that the given `selectable` has neither received a
-  /// start or end [SelectionEdgeUpdateEvent]s.
-  @protected
-  void clearInternalSelectionStateForSelectable(Selectable selectable) {
-    _hasReceivedStartEvent.remove(selectable);
-    _hasReceivedEndEvent.remove(selectable);
-  }
-
-  /// Tracks the internal selection state for a given [Selectable].
+  /// Tracks whether a selection edge update event for a given [Selectable] was received.
   ///
   /// When `forEnd` is true, the [Selectable] will be registered as having received
   /// an end event. When false, the [Selectable] is registered as having received
@@ -1922,6 +1878,27 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     } else {
       _hasReceivedStartEvent.add(selectable);
     }
+  }
+
+  /// Updates the internal selection state after a [SelectionEvent] that
+  /// selects a boundary such as: [SelectWordSelectionEvent],
+  /// [SelectParagraphSelectionEvent], and [SelectAllSelectionEvent].
+  ///
+  /// Call this method after determining the new selection as a result of
+  /// a [SelectionEvent] that selects a boundary. The [currentSelectionStartIndex]
+  /// and [currentSelectionEndIndex] should be set to valid values at the time
+  /// this method is called.
+  @protected
+  void didReceiveSelectionBoundaryEvents() {
+    if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
+      return;
+    }
+    final int start = min(currentSelectionStartIndex, currentSelectionEndIndex);
+    final int end = max(currentSelectionStartIndex, currentSelectionEndIndex);
+    for (int index = start; index <= end; index += 1) {
+      didReceiveSelectionEventFor(selectable: selectables[index]);
+    }
+    _updateLastSelectionEdgeLocationsFromGeometries();
   }
 
   /// Updates the last selection edge location of the edge specified by `forEnd`
@@ -1956,6 +1933,29 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
         forEnd: true,
       );
     }
+  }
+
+  /// Clears the internal selection state.
+  ///
+  /// This indicates that no [Selectable] child under this delegate
+  /// has received start or end events, and resets any tracked global
+  /// locations for start and end [SelectionEdgeUpdateEvent]s.
+  @protected
+  void clearInternalSelectionState() {
+    _hasReceivedStartEvent.clear();
+    _hasReceivedEndEvent.clear();
+    _lastStartEdgeUpdateGlobalPosition = null;
+    _lastEndEdgeUpdateGlobalPosition = null;
+  }
+
+  /// Clears the internal selection state for a given [Selectable].
+  ///
+  /// This indicates that the given `selectable` has neither received a
+  /// start or end [SelectionEdgeUpdateEvent]s.
+  @protected
+  void clearInternalSelectionStateForSelectable(Selectable selectable) {
+    _hasReceivedStartEvent.remove(selectable);
+    _hasReceivedEndEvent.remove(selectable);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1866,6 +1866,9 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   ///
   /// When `forEnd` is null, the [Selectable] will be registered as having received both
   /// start and end events.
+  ///
+  /// Call this method when a [SelectionEvent] is dispatched to a child selectable managed
+  /// by this delegate.
   @protected
   void didReceiveSelectionEventFor({required Selectable selectable, bool? forEnd}) {
     if (forEnd == null) {
@@ -2035,11 +2038,11 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// This method is called when:
   ///   1. A new [Selectable] is added to the delegate, and its screen location
   ///   falls into the previous selection.
-  ///   2. A [Selectable] is dispatched a [SelectionEvent] of type
+  ///   2. Before a [SelectionEvent] of type
   ///   [SelectionEventType.startEdgeUpdate], [SelectionEventType.endEdgeUpdate],
   ///   [SelectionEventType.granularlyExtendSelection], or
-  ///   [SelectionEventType.directionallyExtendSelection] through
-  ///   [dispatchSelectionEventToChild].
+  ///   [SelectionEventType.directionallyExtendSelection] is dispatched
+  ///   to a [Selectable] child.
   @override
   void ensureChildUpdated(Selectable selectable) {
     if (_lastEndEdgeUpdateGlobalPosition != null && _hasReceivedEndEvent.add(selectable)) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1868,6 +1868,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// this method is called.
   @protected
   void updateInternalSelectionStateForBoundaryEvents() {
+    debugPrint('$currentSelectionStartIndex $currentSelectionEndIndex');
     assert(
       currentSelectionStartIndex != -1 && currentSelectionEndIndex != -1,
       'This method should only be called after determining the selection as a result of a [SelectionEvent] that selects a boundary.',
@@ -1883,8 +1884,8 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
     _updateLastSelectionEdgeLocationsFromGeometries();
   }
 
-  /// Clears the internal selection state. 
-  /// 
+  /// Clears the internal selection state.
+  ///
   /// This indicates that no [Selectable] child under this delegate
   /// has received start or end events, and resets any tracked global
   /// locations for start and end [SelectionEdgeUpdateEvent]s.
@@ -1897,7 +1898,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   }
 
   /// Clears the internal selection state for a given [Selectable].
-  /// 
+  ///
   /// This indicates that the given `selectable` has neither received a
   /// start or end [SelectionEdgeUpdateEvent]s.
   @protected

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1871,15 +1871,14 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
   /// by this delegate.
   @protected
   void didReceiveSelectionEventFor({required Selectable selectable, bool? forEnd}) {
-    if (forEnd == null) {
-      _hasReceivedStartEvent.add(selectable);
-      _hasReceivedEndEvent.add(selectable);
-      return;
-    }
-    if (forEnd) {
-      _hasReceivedEndEvent.add(selectable);
-    } else {
-      _hasReceivedStartEvent.add(selectable);
+    switch (forEnd) {
+      case true:
+        _hasReceivedEndEvent.add(selectable);
+      case false:
+        _hasReceivedStartEvent.add(selectable);
+      case null:
+        _hasReceivedStartEvent.add(selectable);
+        _hasReceivedEndEvent.add(selectable);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1868,7 +1868,6 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// this method is called.
   @protected
   void updateInternalSelectionStateForBoundaryEvents() {
-    debugPrint('$currentSelectionStartIndex $currentSelectionEndIndex');
     assert(
       currentSelectionStartIndex != -1 && currentSelectionEndIndex != -1,
       'This method should only be called after determining the selection as a result of a [SelectionEvent] that selects a boundary.',

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1867,14 +1867,14 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// and [currentSelectionEndIndex] should be set to valid values at the time
   /// this method is called.
   @protected
-  void updateInternalSelectionStateForBoundaryEvents() {
+  void didReceiveSelectionBoundaryEvents() {
     if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
       return;
     }
     final int start = min(currentSelectionStartIndex, currentSelectionEndIndex);
     final int end = max(currentSelectionStartIndex, currentSelectionEndIndex);
     for (int index = start; index <= end; index += 1) {
-      trackInternalSelectionStateForSelectable(selectable: selectables[index]);
+      didReceiveSelectionEventFor(selectable: selectables[index]);
     }
     _updateLastSelectionEdgeLocationsFromGeometries();
   }
@@ -1911,7 +1911,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// When `forEnd` is null, the [Selectable] will be registered as having received both
   /// start and end events.
   @protected
-  void trackInternalSelectionStateForSelectable({required Selectable selectable, bool? forEnd}) {
+  void didReceiveSelectionEventFor({required Selectable selectable, bool? forEnd}) {
     if (forEnd == null) {
       _hasReceivedStartEvent.add(selectable);
       _hasReceivedEndEvent.add(selectable);
@@ -1967,21 +1967,21 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   @override
   SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
     final SelectionResult result = super.handleSelectAll(event);
-    updateInternalSelectionStateForBoundaryEvents();
+    didReceiveSelectionBoundaryEvents();
     return result;
   }
 
   @override
   SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
     final SelectionResult result = super.handleSelectWord(event);
-    updateInternalSelectionStateForBoundaryEvents();
+    didReceiveSelectionBoundaryEvents();
     return result;
   }
 
   @override
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = super.handleSelectParagraph(event);
-    updateInternalSelectionStateForBoundaryEvents();
+    didReceiveSelectionBoundaryEvents();
     return result;
   }
 
@@ -2011,10 +2011,10 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   SelectionResult dispatchSelectionEventToChild(Selectable selectable, SelectionEvent event) {
     switch (event.type) {
       case SelectionEventType.startEdgeUpdate:
-        trackInternalSelectionStateForSelectable(selectable: selectable, forEnd: false);
+        didReceiveSelectionEventFor(selectable: selectable, forEnd: false);
         ensureChildUpdated(selectable);
       case SelectionEventType.endEdgeUpdate:
-        trackInternalSelectionStateForSelectable(selectable: selectable, forEnd: true);
+        didReceiveSelectionEventFor(selectable: selectable, forEnd: true);
         ensureChildUpdated(selectable);
       case SelectionEventType.clear:
         clearInternalSelectionStateForSelectable(selectable);
@@ -2024,7 +2024,7 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
         break;
       case SelectionEventType.granularlyExtendSelection:
       case SelectionEventType.directionallyExtendSelection:
-        trackInternalSelectionStateForSelectable(selectable: selectable);
+        didReceiveSelectionEventFor(selectable: selectable);
         ensureChildUpdated(selectable);
     }
     return super.dispatchSelectionEventToChild(selectable, event);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1868,10 +1868,6 @@ class MultiStaticSelectableSelectionContainerDelegate extends MultiSelectableSel
   /// this method is called.
   @protected
   void updateInternalSelectionStateForBoundaryEvents() {
-    assert(
-      currentSelectionStartIndex != -1 && currentSelectionEndIndex != -1,
-      'This method should only be called after determining the selection as a result of a [SelectionEvent] that selects a boundary.',
-    );
     if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
       return;
     }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1827,8 +1827,20 @@ class _DirectionallyExtendCaretSelectionAction<T extends DirectionalCaretMovemen
 /// [Selectable]s do not change or move around frequently.
 ///
 /// It keeps track of the [Selectable]s that received start or end
-/// [SelectionEvent]s to accurately synthesize a [SelectionEvent] for the
-/// opposite edge when needed.
+/// [SelectionEvent]s to accurately synthesize [SelectionEvent]s for the
+/// children [Selectable]s when needed.
+///
+/// When a new [SelectionEdgeUpdateEvent] is dispatched to a [Selectable], this
+/// delegate checks whether the [Selectable] has already received a selection
+/// update for each edge that currently exists, and synthesizes an event for the
+/// edges that have not yet received an update. This synthesized event is dispatched
+/// before dispatching the new event.
+///
+/// For example, if we have an existing start edge for this delegate and a
+/// [Selectable] receives an end [SelectionEdgeUpdateEvent] and it hasn't yet
+/// received a start [SelectionEdgeUpdateEvent], it synthesizes a start
+/// [SelectionEdgeUpdateEvent] and dispatches it before dispatching the original
+/// end [SelectionEdgeUpdateEvent].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1950,9 +1950,7 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
   /// locations for start and end [SelectionEdgeUpdateEvent]s.
   @protected
   void clearInternalSelectionState() {
-    for (Selectable selectable in selectables) {
-      clearInternalSelectionStateForSelectable(selectable);
-    }
+    selectables.forEach(clearInternalSelectionStateForSelectable);
     _lastStartEdgeUpdateGlobalPosition = null;
     _lastEndEdgeUpdateGlobalPosition = null;
   }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1869,6 +1869,9 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
   ///
   /// Call this method when a [SelectionEvent] is dispatched to a child selectable managed
   /// by this delegate.
+  ///
+  /// Subclasses should call [clearInternalSelectionStateForSelectable] to clean up any state
+  /// added by this method, for example when removing a [Selectable] from this delegate.
   @protected
   void didReceiveSelectionEventFor({required Selectable selectable, bool? forEnd}) {
     switch (forEnd) {
@@ -1890,6 +1893,9 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
   /// a [SelectionEvent] that selects a boundary. The [currentSelectionStartIndex]
   /// and [currentSelectionEndIndex] should be set to valid values at the time
   /// this method is called.
+  ///
+  /// Subclasses should call [clearInternalSelectionStateForSelectable] to clean up any state
+  /// added by this method, for example when removing a [Selectable] from this delegate.
   @protected
   void didReceiveSelectionBoundaryEvents() {
     if (currentSelectionStartIndex == -1 || currentSelectionEndIndex == -1) {
@@ -1944,8 +1950,9 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
   /// locations for start and end [SelectionEdgeUpdateEvent]s.
   @protected
   void clearInternalSelectionState() {
-    _hasReceivedStartEvent.clear();
-    _hasReceivedEndEvent.clear();
+    for (Selectable selectable in selectables) {
+      clearInternalSelectionStateForSelectable(selectable);
+    }
     _lastStartEdgeUpdateGlobalPosition = null;
     _lastEndEdgeUpdateGlobalPosition = null;
   }
@@ -1954,6 +1961,9 @@ class StaticSelectionContainerDelegate extends MultiSelectableSelectionContainer
   ///
   /// This indicates that the given `selectable` has neither received a
   /// start or end [SelectionEdgeUpdateEvent]s.
+  ///
+  /// Subclasses should call this method to clean up state added in
+  /// [didReceiveSelectionEventFor] and [didReceiveSelectionBoundaryEvents].
   @protected
   void clearInternalSelectionStateForSelectable(Selectable selectable) {
     _hasReceivedStartEvent.remove(selectable);

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -893,13 +893,7 @@ class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionCon
   @override
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
-    if (currentSelectionStartIndex != -1) {
-      hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
-    }
-    if (currentSelectionEndIndex != -1) {
-      hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
-    }
-    updateLastEdgeEventsFromGeometries();
+    updateInternalSelectionStateForBoundaryEvents();
     return result;
   }
 
@@ -1263,11 +1257,10 @@ class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionCon
     if (event.granularity != TextGranularity.paragraph) {
       return super.handleSelectionEdgeUpdate(event);
     }
-    if (event.type == SelectionEventType.endEdgeUpdate) {
-      lastEndEdgeUpdateGlobalPosition = event.globalPosition;
-    } else {
-      lastStartEdgeUpdateGlobalPosition = event.globalPosition;
-    }
+    updateLastSelectionEdgeLocation(
+      globalSelectionEdgeLocation: event.globalPosition,
+      forEnd: event.type == SelectionEventType.endEdgeUpdate,
+    );
     if (event.type == SelectionEventType.endEdgeUpdate) {
       return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);
     }

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -894,10 +894,10 @@ class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionCon
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
     if (currentSelectionStartIndex != -1) {
-      markReceivedStartEvent(selectables[currentSelectionStartIndex]);
+      hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
     }
     if (currentSelectionEndIndex != -1) {
-      markReceivedEndEvent(selectables[currentSelectionEndIndex]);
+      hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
     }
     updateLastEdgeEventsFromGeometries();
     return result;
@@ -1264,9 +1264,9 @@ class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionCon
       return super.handleSelectionEdgeUpdate(event);
     }
     if (event.type == SelectionEventType.endEdgeUpdate) {
-      updateLastEndEdgeUpdateGlobalPosition(event.globalPosition);
+      lastEndEdgeUpdateGlobalPosition = event.globalPosition;
     } else {
-      updateLastStartEdgeUpdateGlobalPosition(event.globalPosition);
+      lastStartEdgeUpdateGlobalPosition = event.globalPosition;
     }
     if (event.type == SelectionEventType.endEdgeUpdate) {
       return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -893,7 +893,7 @@ class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionCon
   @override
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
-    updateInternalSelectionStateForBoundaryEvents();
+    super.updateInternalSelectionStateForBoundaryEvents();
     return result;
   }
 

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -882,7 +882,7 @@ class _RichText extends StatelessWidget {
 // position to make the compareScreenOrder function more robust.
 const double _kSelectableVerticalComparingThreshold = 3.0;
 
-class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainerDelegate {
+class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionContainerDelegate {
   _SelectableTextContainerDelegate(
     GlobalKey textKey,
   ) : _textKey = textKey;
@@ -894,12 +894,12 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
     if (currentSelectionStartIndex != -1) {
-      _hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
+      markReceivedStartEvent(selectables[currentSelectionStartIndex]);
     }
     if (currentSelectionEndIndex != -1) {
-      _hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
+      markReceivedEndEvent(selectables[currentSelectionEndIndex]);
     }
-    _updateLastEdgeEventsFromGeometries();
+    updateLastEdgeEventsFromGeometries();
     return result;
   }
 
@@ -1258,162 +1258,19 @@ class _SelectableTextContainerDelegate extends MultiSelectableSelectionContainer
     }
   }
 
-  final Set<Selectable> _hasReceivedStartEvent = <Selectable>{};
-  final Set<Selectable> _hasReceivedEndEvent = <Selectable>{};
-
-  Offset? _lastStartEdgeUpdateGlobalPosition;
-  Offset? _lastEndEdgeUpdateGlobalPosition;
-
-  @override
-  void remove(Selectable selectable) {
-    _hasReceivedStartEvent.remove(selectable);
-    _hasReceivedEndEvent.remove(selectable);
-    super.remove(selectable);
-  }
-
-  void _updateLastEdgeEventsFromGeometries() {
-    if (currentSelectionStartIndex != -1 && selectables[currentSelectionStartIndex].value.hasSelection) {
-      final Selectable start = selectables[currentSelectionStartIndex];
-      final Offset localStartEdge = start.value.startSelectionPoint!.localPosition +
-          Offset(0, - start.value.startSelectionPoint!.lineHeight / 2);
-      _lastStartEdgeUpdateGlobalPosition = MatrixUtils.transformPoint(start.getTransformTo(null), localStartEdge);
-    }
-    if (currentSelectionEndIndex != -1 && selectables[currentSelectionEndIndex].value.hasSelection) {
-      final Selectable end = selectables[currentSelectionEndIndex];
-      final Offset localEndEdge = end.value.endSelectionPoint!.localPosition +
-          Offset(0, -end.value.endSelectionPoint!.lineHeight / 2);
-      _lastEndEdgeUpdateGlobalPosition = MatrixUtils.transformPoint(end.getTransformTo(null), localEndEdge);
-    }
-  }
-
-  @override
-  SelectionResult handleSelectAll(SelectAllSelectionEvent event) {
-    final SelectionResult result = super.handleSelectAll(event);
-    for (final Selectable selectable in selectables) {
-      _hasReceivedStartEvent.add(selectable);
-      _hasReceivedEndEvent.add(selectable);
-    }
-    // Synthesize last update event so the edge updates continue to work.
-    _updateLastEdgeEventsFromGeometries();
-    return result;
-  }
-
-  /// Selects a word in a selectable at the location
-  /// [SelectWordSelectionEvent.globalPosition].
-  @override
-  SelectionResult handleSelectWord(SelectWordSelectionEvent event) {
-    final SelectionResult result = super.handleSelectWord(event);
-    if (currentSelectionStartIndex != -1) {
-      _hasReceivedStartEvent.add(selectables[currentSelectionStartIndex]);
-    }
-    if (currentSelectionEndIndex != -1) {
-      _hasReceivedEndEvent.add(selectables[currentSelectionEndIndex]);
-    }
-    _updateLastEdgeEventsFromGeometries();
-    return result;
-  }
-
-  @override
-  SelectionResult handleClearSelection(ClearSelectionEvent event) {
-    final SelectionResult result = super.handleClearSelection(event);
-    _hasReceivedStartEvent.clear();
-    _hasReceivedEndEvent.clear();
-    _lastStartEdgeUpdateGlobalPosition = null;
-    _lastEndEdgeUpdateGlobalPosition = null;
-    return result;
-  }
-
   @override
   SelectionResult handleSelectionEdgeUpdate(SelectionEdgeUpdateEvent event) {
+    if (event.granularity != TextGranularity.paragraph) {
+      return super.handleSelectionEdgeUpdate(event);
+    }
     if (event.type == SelectionEventType.endEdgeUpdate) {
-      _lastEndEdgeUpdateGlobalPosition = event.globalPosition;
+      updateLastEndEdgeUpdateGlobalPosition(event.globalPosition);
     } else {
-      _lastStartEdgeUpdateGlobalPosition = event.globalPosition;
+      updateLastStartEdgeUpdateGlobalPosition(event.globalPosition);
     }
-
-    if (event.granularity == TextGranularity.paragraph) {
-      if (event.type == SelectionEventType.endEdgeUpdate) {
-        return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);
-      }
-      return currentSelectionStartIndex == -1 ? _initSelection(event, isEnd: false) : _adjustSelection(event, isEnd: false);
+    if (event.type == SelectionEventType.endEdgeUpdate) {
+      return currentSelectionEndIndex == -1 ? _initSelection(event, isEnd: true) : _adjustSelection(event, isEnd: true);
     }
-
-    return super.handleSelectionEdgeUpdate(event);
-  }
-
-  @override
-  void dispose() {
-    _hasReceivedStartEvent.clear();
-    _hasReceivedEndEvent.clear();
-    super.dispose();
-  }
-
-  @override
-  SelectionResult dispatchSelectionEventToChild(Selectable selectable, SelectionEvent event) {
-    switch (event.type) {
-      case SelectionEventType.startEdgeUpdate:
-        _hasReceivedStartEvent.add(selectable);
-        ensureChildUpdated(selectable);
-      case SelectionEventType.endEdgeUpdate:
-        _hasReceivedEndEvent.add(selectable);
-        ensureChildUpdated(selectable);
-      case SelectionEventType.clear:
-        _hasReceivedStartEvent.remove(selectable);
-        _hasReceivedEndEvent.remove(selectable);
-      case SelectionEventType.selectAll:
-      case SelectionEventType.selectWord:
-      case SelectionEventType.selectParagraph:
-        break;
-      case SelectionEventType.granularlyExtendSelection:
-      case SelectionEventType.directionallyExtendSelection:
-        _hasReceivedStartEvent.add(selectable);
-        _hasReceivedEndEvent.add(selectable);
-        ensureChildUpdated(selectable);
-    }
-    return super.dispatchSelectionEventToChild(selectable, event);
-  }
-
-  @override
-  void ensureChildUpdated(Selectable selectable) {
-    if (_lastEndEdgeUpdateGlobalPosition != null && _hasReceivedEndEvent.add(selectable)) {
-      final SelectionEdgeUpdateEvent synthesizedEvent = SelectionEdgeUpdateEvent.forEnd(
-        globalPosition: _lastEndEdgeUpdateGlobalPosition!,
-      );
-      if (currentSelectionEndIndex == -1) {
-        handleSelectionEdgeUpdate(synthesizedEvent);
-      }
-      selectable.dispatchSelectionEvent(synthesizedEvent);
-    }
-    if (_lastStartEdgeUpdateGlobalPosition != null && _hasReceivedStartEvent.add(selectable)) {
-      final SelectionEdgeUpdateEvent synthesizedEvent = SelectionEdgeUpdateEvent.forStart(
-          globalPosition: _lastStartEdgeUpdateGlobalPosition!,
-      );
-      if (currentSelectionStartIndex == -1) {
-        handleSelectionEdgeUpdate(synthesizedEvent);
-      }
-      selectable.dispatchSelectionEvent(synthesizedEvent);
-    }
-  }
-
-  @override
-  void didChangeSelectables() {
-    if (_lastEndEdgeUpdateGlobalPosition != null) {
-      handleSelectionEdgeUpdate(
-        SelectionEdgeUpdateEvent.forEnd(
-          globalPosition: _lastEndEdgeUpdateGlobalPosition!,
-        ),
-      );
-    }
-    if (_lastStartEdgeUpdateGlobalPosition != null) {
-      handleSelectionEdgeUpdate(
-        SelectionEdgeUpdateEvent.forStart(
-          globalPosition: _lastStartEdgeUpdateGlobalPosition!,
-        ),
-      );
-    }
-    final Set<Selectable> selectableSet = selectables.toSet();
-    _hasReceivedEndEvent.removeWhere((Selectable selectable) => !selectableSet.contains(selectable));
-    _hasReceivedStartEvent.removeWhere((Selectable selectable) => !selectableSet.contains(selectable));
-    super.didChangeSelectables();
+    return currentSelectionStartIndex == -1 ? _initSelection(event, isEnd: false) : _adjustSelection(event, isEnd: false);
   }
 }

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -882,7 +882,7 @@ class _RichText extends StatelessWidget {
 // position to make the compareScreenOrder function more robust.
 const double _kSelectableVerticalComparingThreshold = 3.0;
 
-class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionContainerDelegate {
+class _SelectableTextContainerDelegate extends StaticSelectionContainerDelegate {
   _SelectableTextContainerDelegate(
     GlobalKey textKey,
   ) : _textKey = textKey;

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -893,7 +893,7 @@ class _SelectableTextContainerDelegate extends MultiStaticSelectableSelectionCon
   @override
   SelectionResult handleSelectParagraph(SelectParagraphSelectionEvent event) {
     final SelectionResult result = _handleSelectParagraph(event);
-    super.updateInternalSelectionStateForBoundaryEvents();
+    super.didReceiveSelectionBoundaryEvents();
     return result;
   }
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -657,7 +657,12 @@ void main() {
   testWidgets('Can extend MultiStaticSelectableSelectionContainerDelegate', (WidgetTester tester) async {
     SelectedContent? content;
     final FocusNode focusNode = FocusNode();
+
+    // Inserts a new line between selected content of children selectables.
+    final ColumnSelectionContainerDelegate selectionDelegate = ColumnSelectionContainerDelegate();
+
     addTearDown(focusNode.dispose);
+    addTearDown(selectionDelegate.dispose);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -667,9 +672,9 @@ void main() {
           selectionControls: materialTextSelectionControls,
           child: Center(
             child: SelectionContainer(
-              delegate: ColumnSelectionContainerDelegate(), // Inserts a new line between selected content of children selectables.
+              delegate: selectionDelegate,
               child: const Column(
-                children: [
+                children: <Widget>[
                   Text('Hello World!'),
                   Text('How are you!'),
                 ],

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -670,9 +670,9 @@ void main() {
           onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
           focusNode: focusNode,
           selectionControls: materialTextSelectionControls,
-          child: Center(
-            child: SelectionContainer(
-              delegate: selectionDelegate,
+          child: SelectionContainer(
+            delegate: selectionDelegate,
+            child: Center(
               child: const Column(
                 children: <Widget>[
                   Text('Hello World!'),

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -672,8 +672,8 @@ void main() {
           selectionControls: materialTextSelectionControls,
           child: SelectionContainer(
             delegate: selectionDelegate,
-            child: Center(
-              child: const Column(
+            child: const Center(
+              child: Column(
                 children: <Widget>[
                   Text('Hello World!'),
                   Text('How are you!'),

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -654,7 +654,7 @@ void main() {
     });
   });
 
-  testWidgets('Can extend MultiStaticSelectableSelectionContainerDelegate', (WidgetTester tester) async {
+  testWidgets('Can extend StaticSelectionContainerDelegate', (WidgetTester tester) async {
     SelectedContent? content;
     final FocusNode focusNode = FocusNode();
 
@@ -5350,7 +5350,7 @@ void main() {
   });
 }
 
-class ColumnSelectionContainerDelegate extends MultiStaticSelectableSelectionContainerDelegate {
+class ColumnSelectionContainerDelegate extends StaticSelectionContainerDelegate {
   /// Copies the selected contents of all [Selectable]s, separating their
   /// contents with a new line.
   @override

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -654,6 +654,49 @@ void main() {
     });
   });
 
+  testWidgets('Can extend MultiStaticSelectableSelectionContainerDelegate', (WidgetTester tester) async {
+    SelectedContent? content;
+    final FocusNode focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectableRegion(
+          onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
+          focusNode: focusNode,
+          selectionControls: materialTextSelectionControls,
+          child: Center(
+            child: SelectionContainer(
+              delegate: ColumnSelectionContainerDelegate(), // Inserts a new line between selected content of children selectables.
+              child: const Column(
+                children: [
+                  Text('Hello World!'),
+                  Text('How are you!'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Hello World!'), matching: find.byType(RichText)));
+    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you!'), matching: find.byType(RichText)));
+    final TestGesture mouseGesture = await tester.startGesture(textOffsetToPosition(paragraph, 4), kind: PointerDeviceKind.mouse);
+
+    expect(content, isNull);
+    addTearDown(mouseGesture.removePointer);
+    await tester.pump();
+
+    // Move selection to second paragraph.
+    await mouseGesture.moveTo(textOffsetToPosition(paragraph2, 10));
+    await tester.pumpAndSettle();
+    expect(content, isNotNull);
+    expect(content!.plainText, 'o World!\nHow are yo');
+    await mouseGesture.up();
+    await tester.pump();
+  });
+
   testWidgets('dragging handle or selecting word triggers haptic feedback on Android', (WidgetTester tester) async {
     final List<MethodCall> log = <MethodCall>[];
     tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
@@ -5300,6 +5343,24 @@ void main() {
     final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
     expect(clipboardData['text'], 'Hello my name is Dash.');
   });
+}
+
+class ColumnSelectionContainerDelegate extends MultiStaticSelectableSelectionContainerDelegate {
+  /// Copies the selected contents of all [Selectable]s, separating their
+  /// contents with a new line.
+  @override
+  SelectedContent? getSelectedContent() {
+    final List<SelectedContent> selections = <SelectedContent>[
+      for (final Selectable selectable in selectables)
+        if (selectable.getSelectedContent() case final SelectedContent data) data,
+    ];
+    if (selections.isEmpty) {
+      return null;
+    }
+    return SelectedContent(
+      plainText: selections.map((SelectedContent selectedContent) => selectedContent.plainText).join('\n'),
+    );
+  }
 }
 
 class SelectionSpy extends LeafRenderObjectWidget {


### PR DESCRIPTION
This change makes `_SelectableRegionContainerDelegate` public so it can be reused and extended by users of `SelectionContainer`. Extending `MultiSelectableRegionContainerDelegate` does not by default provide selection managing across multiple selectables, so often users will copy the implementation found in `_SelectableRegionContainerDelegate`.

`_SelectableRegionContainerDelegate` -> `StaticSelectionContainerDelegate`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.