### PR TITLE
Fix ExpandIcon color when ExpansionPanel.canTapOnHeader true (#147097)

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -361,14 +361,14 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
 
       Widget expandIconContainer = Container(
         margin: const EdgeInsetsDirectional.only(end: 8.0),
-        child: IgnorePointer(
-          ignoring: child.canTapOnHeader,
-          child: ExpandIcon(
-            color: widget.expandIconColor,
-            isExpanded: _isChildExpanded(index),
-            padding: _kExpandIconPadding,
-            onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
-          ),
+        child: ExpandIcon(
+          color: widget.expandIconColor,
+          disabledColor: child.canTapOnHeader ? widget.expandIconColor : null,
+          isExpanded: _isChildExpanded(index),
+          padding: _kExpandIconPadding,
+          onPressed: !child.canTapOnHeader
+              ? (bool isExpanded) => _handlePressed(isExpanded, index)
+              : null,
         ),
       );
 

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -371,7 +371,7 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
           ),
         ),
       );
-      
+
       if (!child.canTapOnHeader) {
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
         expandIconContainer = Semantics(

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -361,15 +361,17 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
 
       Widget expandIconContainer = Container(
         margin: const EdgeInsetsDirectional.only(end: 8.0),
-        child: ExpandIcon(
-          color: widget.expandIconColor,
-          isExpanded: _isChildExpanded(index),
-          padding: _kExpandIconPadding,
-          onPressed: !child.canTapOnHeader
-              ? (bool isExpanded) => _handlePressed(isExpanded, index)
-              : null,
+        child: IgnorePointer(
+          ignoring: child.canTapOnHeader,
+          child: ExpandIcon(
+            color: widget.expandIconColor,
+            isExpanded: _isChildExpanded(index),
+            padding: _kExpandIconPadding,
+            onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+          ),
         ),
       );
+      
       if (!child.canTapOnHeader) {
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
         expandIconContainer = Semantics(

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1947,4 +1947,59 @@ void main() {
       }
     }
   });
+
+  testWidgets('Ensure ExpandIcon disabledColor becomes the expandIconColor when canTapOnHeader is set to true', (WidgetTester tester) async {
+    const Color expectedIconColor = Colors.blue;
+
+    await tester.pumpWidget(MaterialApp(
+      home: SingleChildScrollView(
+        child: ExpansionPanelList(
+          expandIconColor: expectedIconColor,
+          children: <ExpansionPanel>[
+            ExpansionPanel(
+              canTapOnHeader: true,
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return const ListTile(title: Text('Panel 1'));
+              },
+              body: const ListTile(title: Text('Content for Panel 1')),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Panel 1'));
+    await tester.pumpAndSettle();
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).first);
+    expect(expandIcon.color, expectedIconColor);
+    expect(expandIcon.disabledColor, expectedIconColor);
+  });
+
+  testWidgets('Ensure ExpandIcon does not set the disabled color if canTapOnHeader is not set to true', (WidgetTester tester) async {
+    const Color expandIconColor = Colors.blue;
+
+    await tester.pumpWidget(MaterialApp(
+      home: SingleChildScrollView(
+        child: ExpansionPanelList(
+          expandIconColor: expandIconColor,
+          children: <ExpansionPanel>[
+            ExpansionPanel(
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return const ListTile(title: Text('Panel 1'));
+              },
+              body: const ListTile(title: Text('Content for Panel 1')),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Panel 1'));
+    await tester.pumpAndSettle();
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).first);
+    expect(expandIcon.disabledColor, isNot(expandIconColor));
+    expect(expandIcon.color, expandIconColor);
+  });
 }

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1948,58 +1948,40 @@ void main() {
     }
   });
 
-  testWidgets('Ensure ExpandIcon disabledColor becomes the expandIconColor when canTapOnHeader is set to true', (WidgetTester tester) async {
-    const Color expectedIconColor = Colors.blue;
+  testWidgets('ExpandIcon.disabledColor uses expandIconColor color when canTapOnHeader is true', (WidgetTester tester) async {
+    const Color expandIconColor = Color(0xff0000ff);
 
-    await tester.pumpWidget(MaterialApp(
-      home: SingleChildScrollView(
-        child: ExpansionPanelList(
-          expandIconColor: expectedIconColor,
-          children: <ExpansionPanel>[
-            ExpansionPanel(
-              canTapOnHeader: true,
-              headerBuilder: (BuildContext context, bool isExpanded) {
-                return const ListTile(title: Text('Panel 1'));
-              },
-              body: const ListTile(title: Text('Content for Panel 1')),
-            ),
-          ],
+    Widget buildWidget({ bool canTapOnHeader = false }) {
+      return MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            expandIconColor: expandIconColor,
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                canTapOnHeader: canTapOnHeader,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content for Panel')),
+              ),
+            ],
+          ),
         ),
-      ),
-    ));
+      );
+    }
 
-    await tester.tap(find.text('Panel 1'));
+    await tester.pumpWidget(buildWidget());
+
+    await tester.tap(find.text('Panel'));
     await tester.pumpAndSettle();
 
-    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).first);
-    expect(expandIcon.color, expectedIconColor);
-    expect(expandIcon.disabledColor, expectedIconColor);
-  });
+    ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
+    expect(expandIcon.disabledColor, isNull);
 
-  testWidgets('Ensure ExpandIcon does not set the disabled color if canTapOnHeader is not set to true', (WidgetTester tester) async {
-    const Color expandIconColor = Colors.blue;
-
-    await tester.pumpWidget(MaterialApp(
-      home: SingleChildScrollView(
-        child: ExpansionPanelList(
-          expandIconColor: expandIconColor,
-          children: <ExpansionPanel>[
-            ExpansionPanel(
-              headerBuilder: (BuildContext context, bool isExpanded) {
-                return const ListTile(title: Text('Panel 1'));
-              },
-              body: const ListTile(title: Text('Content for Panel 1')),
-            ),
-          ],
-        ),
-      ),
-    ));
-
-    await tester.tap(find.text('Panel 1'));
+    await tester.pumpWidget(buildWidget(canTapOnHeader: true));
     await tester.pumpAndSettle();
 
-    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon).first);
-    expect(expandIcon.disabledColor, isNot(expandIconColor));
-    expect(expandIcon.color, expandIconColor);
+    expandIcon = tester.widget(find.byType(ExpandIcon));
+    expect(expandIcon.disabledColor, expandIconColor);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/147097. The expand/collapse icon should not be the disabled color when ExpansionPanel.canTapOnHeader is true because the ExpansionPanel is active, and we may want to keep the icon there as a visual indicator to the user that it is expandable/collapsable. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
