### PR TITLE
fixes some gesture not getting disposed

### DIFF
--- a/packages/flutter/test/gestures/recognizer_test.dart
+++ b/packages/flutter/test/gestures/recognizer_test.dart
@@ -87,11 +87,13 @@ void main() {
     testGesture('cleans up state after winning arena', (GestureTester tester) {
       final List<String> resolutions = <String>[];
       final IndefiniteGestureRecognizer indefinite = IndefiniteGestureRecognizer();
+      addTearDown(indefinite.dispose);
       final TestPrimaryPointerGestureRecognizer<PointerUpEvent> accepting = TestPrimaryPointerGestureRecognizer<PointerUpEvent>(
         GestureDisposition.accepted,
         onAcceptGesture: () => resolutions.add('accepted'),
         onRejectGesture: () => resolutions.add('rejected'),
       );
+      addTearDown(accepting.dispose);
       expect(accepting.state, GestureRecognizerState.ready);
       expect(accepting.primaryPointer, isNull);
       expect(accepting.initialPosition, isNull);
@@ -118,11 +120,13 @@ void main() {
     testGesture('cleans up state after losing arena', (GestureTester tester) {
       final List<String> resolutions = <String>[];
       final IndefiniteGestureRecognizer indefinite = IndefiniteGestureRecognizer();
+      addTearDown(indefinite.dispose);
       final TestPrimaryPointerGestureRecognizer<PointerMoveEvent> rejecting = TestPrimaryPointerGestureRecognizer<PointerMoveEvent>(
         GestureDisposition.rejected,
         onAcceptGesture: () => resolutions.add('accepted'),
         onRejectGesture: () => resolutions.add('rejected'),
       );
+      addTearDown(rejecting.dispose);
       expect(rejecting.state, GestureRecognizerState.ready);
       expect(rejecting.primaryPointer, isNull);
       expect(rejecting.initialPosition, isNull);
@@ -156,6 +160,7 @@ void main() {
     testGesture('works properly when recycled', (GestureTester tester) {
       final List<String> resolutions = <String>[];
       final IndefiniteGestureRecognizer indefinite = IndefiniteGestureRecognizer();
+      addTearDown(indefinite.dispose);
       final TestPrimaryPointerGestureRecognizer<PointerUpEvent> accepting = TestPrimaryPointerGestureRecognizer<PointerUpEvent>(
         GestureDisposition.accepted,
         preAcceptSlopTolerance: 15,
@@ -163,6 +168,7 @@ void main() {
         onAcceptGesture: () => resolutions.add('accepted'),
         onRejectGesture: () => resolutions.add('rejected'),
       );
+      addTearDown(accepting.dispose);
 
       // Send one complete pointer sequence
       indefinite.addPointer(down);

--- a/packages/flutter/test/gestures/serial_tap_test.dart
+++ b/packages/flutter/test/gestures/serial_tap_test.dart
@@ -190,6 +190,7 @@ void main() {
       ..onRelease = () {
         recognizedRelease = true;
       };
+      addTearDown(release.dispose);
 
     release.addPointer(down1);
     serial.addPointer(down1);
@@ -207,6 +208,7 @@ void main() {
       ..onRelease = () {
         recognizedRelease = true;
       };
+      addTearDown(release.dispose);
 
     serial.addPointer(down1);
     release.addPointer(down1);
@@ -220,6 +222,7 @@ void main() {
 
   testGesture('Fires cancel if competing recognizer declares victory', (GestureTester tester) {
     final WinningGestureRecognizer winner = WinningGestureRecognizer();
+    addTearDown(winner.dispose);
     winner.addPointer(down1);
     serial.addPointer(down1);
     tester.closeArena(1);


### PR DESCRIPTION
part of #141198 

Fixes some gestures not getting disposed

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
