### PR TITLE
fixes cupertino page transition leak [prod-leak-fix]

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -378,56 +378,105 @@ class CupertinoPage<T> extends Page<T> {
 ///
 /// The page slides in from the right and exits in reverse. It also shifts to the left in
 /// a parallax motion when another page enters to cover it.
-class CupertinoPageTransition extends StatelessWidget {
+class CupertinoPageTransition extends StatefulWidget {
   /// Creates an iOS-style page transition.
   ///
-  ///  * `primaryRouteAnimation` is a linear route animation from 0.0 to 1.0
-  ///    when this screen is being pushed.
-  ///  * `secondaryRouteAnimation` is a linear route animation from 0.0 to 1.0
-  ///    when another screen is being pushed on top of this one.
-  ///  * `linearTransition` is whether to perform the transitions linearly.
-  ///    Used to precisely track back gesture drags.
-  CupertinoPageTransition({
+  const CupertinoPageTransition({
     super.key,
-    required Animation<double> primaryRouteAnimation,
-    required Animation<double> secondaryRouteAnimation,
+    required this.primaryRouteAnimation,
+    required this.secondaryRouteAnimation,
     required this.child,
-    required bool linearTransition,
-  }) : _primaryPositionAnimation =
-           (linearTransition
-             ? primaryRouteAnimation
-             : CurvedAnimation(
-                 parent: primaryRouteAnimation,
-                 curve: Curves.fastEaseInToSlowEaseOut,
-                 reverseCurve: Curves.fastEaseInToSlowEaseOut.flipped,
-               )
-           ).drive(_kRightMiddleTween),
-       _secondaryPositionAnimation =
-           (linearTransition
-             ? secondaryRouteAnimation
-             : CurvedAnimation(
-                 parent: secondaryRouteAnimation,
-                 curve: Curves.linearToEaseOut,
-                 reverseCurve: Curves.easeInToLinear,
-               )
-           ).drive(_kMiddleLeftTween),
-       _primaryShadowAnimation =
-           (linearTransition
-             ? primaryRouteAnimation
-             : CurvedAnimation(
-                 parent: primaryRouteAnimation,
-                 curve: Curves.linearToEaseOut,
-               )
-           ).drive(_CupertinoEdgeShadowDecoration.kTween);
-
-  // When this page is coming in to cover another page.
-  final Animation<Offset> _primaryPositionAnimation;
-  // When this page is becoming covered by another page.
-  final Animation<Offset> _secondaryPositionAnimation;
-  final Animation<Decoration> _primaryShadowAnimation;
+    required this.linearTransition,
+  });
 
   /// The widget below this widget in the tree.
   final Widget child;
+
+  ///  * `primaryRouteAnimation` is a linear route animation from 0.0 to 1.0
+  ///    when this screen is being pushed.
+  final Animation<double> primaryRouteAnimation;
+
+  ///  * `secondaryRouteAnimation` is a linear route animation from 0.0 to 1.0
+  ///    when another screen is being pushed on top of this one.
+  final Animation<double> secondaryRouteAnimation;
+
+  ///  * `linearTransition` is whether to perform the transitions linearly.
+  ///    Used to precisely track back gesture drags.
+  final bool linearTransition;
+
+  @override
+  State<CupertinoPageTransition> createState() => _CupertinoPageTransitionState();
+}
+
+class _CupertinoPageTransitionState extends State<CupertinoPageTransition> {
+
+
+  // When this page is coming in to cover another page.
+  late Animation<Offset> _primaryPositionAnimation;
+  // When this page is becoming covered by another page.
+  late Animation<Offset> _secondaryPositionAnimation;
+  // Shadow of page which is coming in to cover another page.
+  late Animation<Decoration> _primaryShadowAnimation;
+  // Curve of primary page which is coming in to cover another page.
+  CurvedAnimation? _primaryPositionCurve;
+  // Curve of secondary page which is becoming covered by another page.
+  CurvedAnimation? _secondaryPositionCurve;
+  // Curve of primary page's shadow.
+  CurvedAnimation? _primaryShadowCurve;
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  @override
+  void didUpdateWidget(covariant CupertinoPageTransition oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _disposeCurve();
+    _init();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _disposeCurve();
+  }
+
+  void _disposeCurve() {
+    _primaryPositionCurve?.dispose();
+    _secondaryPositionCurve?.dispose();
+    _primaryShadowCurve?.dispose();
+  }
+
+  void _init() {
+    _primaryPositionAnimation =
+           (widget.linearTransition
+             ? widget.primaryRouteAnimation
+             : _primaryPositionCurve = CurvedAnimation(
+                 parent: widget.primaryRouteAnimation,
+                 curve: Curves.fastEaseInToSlowEaseOut,
+                 reverseCurve: Curves.fastEaseInToSlowEaseOut.flipped,
+               )
+           ).drive(_kRightMiddleTween);
+       _secondaryPositionAnimation =
+           (widget.linearTransition
+             ? widget.secondaryRouteAnimation
+             : _secondaryPositionCurve = CurvedAnimation(
+                 parent: widget.secondaryRouteAnimation,
+                 curve: Curves.linearToEaseOut,
+                 reverseCurve: Curves.easeInToLinear,
+               )
+           ).drive(_kMiddleLeftTween);
+       _primaryShadowAnimation =
+           (widget.linearTransition
+             ? widget.primaryRouteAnimation
+             : _secondaryPositionCurve = CurvedAnimation(
+                 parent: widget.primaryRouteAnimation,
+                 curve: Curves.linearToEaseOut,
+               )
+           ).drive(_CupertinoEdgeShadowDecoration.kTween);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -442,7 +491,7 @@ class CupertinoPageTransition extends StatelessWidget {
         textDirection: textDirection,
         child: DecoratedBoxTransition(
           decoration: _primaryShadowAnimation,
-          child: child,
+          child: widget.child,
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -427,14 +427,18 @@ class _CupertinoPageTransitionState extends State<CupertinoPageTransition> {
   @override
   void initState() {
     super.initState();
-    _init();
+    _setupAnimation();
   }
 
   @override
   void didUpdateWidget(covariant CupertinoPageTransition oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.primaryRouteAnimation != widget.primaryRouteAnimation
+    || oldWidget.secondaryRouteAnimation != widget.secondaryRouteAnimation
+    || oldWidget.child != widget.child) {
     _disposeCurve();
-    _init();
+    _setupAnimation();
+    }
   }
 
   @override
@@ -449,7 +453,7 @@ class _CupertinoPageTransitionState extends State<CupertinoPageTransition> {
     _primaryShadowCurve?.dispose();
   }
 
-  void _init() {
+  void _setupAnimation() {
     _primaryPositionAnimation =
            (widget.linearTransition
              ? widget.primaryRouteAnimation

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -435,7 +435,7 @@ class _CupertinoPageTransitionState extends State<CupertinoPageTransition> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.primaryRouteAnimation != widget.primaryRouteAnimation
     || oldWidget.secondaryRouteAnimation != widget.secondaryRouteAnimation
-    || oldWidget.child != widget.child) {
+    || oldWidget.child != widget.child || oldWidget.linearTransition != widget.linearTransition) {
     _disposeCurve();
     _setupAnimation();
     }


### PR DESCRIPTION
Part of #141198 

Fixes `CupertinoPageTransition` widget leaks

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
