### PR TITLE
Prevent test folder deletion on running `flutter create --empty` on an existing app project

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -363,8 +363,11 @@ class CreateCommand extends CreateBase {
     final PubContext pubContext;
     switch (template) {
       case FlutterProjectType.app:
+        final bool skipWidgetTestsGeneration =
+            sampleCode != null || emptyArgument;
+
         generatedFileCount += await generateApp(
-          <String>['app', 'app_test_widget'],
+          <String>['app', if (!skipWidgetTestsGeneration) 'app_test_widget'],
           relativeDir,
           templateContext,
           overwrite: overwrite,
@@ -453,9 +456,6 @@ class CreateCommand extends CreateBase {
     }
     if (sampleCode != null) {
       _applySample(relativeDir, sampleCode);
-    }
-    if (sampleCode != null || (emptyArgument && creatingNewProject)) {
-      generatedFileCount += _removeTestDir(relativeDir);
     }
     globals.printStatus('Wrote $generatedFileCount files.');
     globals.printStatus('\nAll done!');
@@ -777,20 +777,6 @@ Your $application code is in $relativeAppMain.
     final File mainDartFile = directory.childDirectory('lib').childFile('main.dart');
     mainDartFile.createSync(recursive: true);
     mainDartFile.writeAsStringSync(sampleCode);
-  }
-
-  int _removeTestDir(Directory directory) {
-    final Directory testDir = directory.childDirectory('test');
-    if (!testDir.existsSync()) {
-      return 0;
-    }
-    final List<FileSystemEntity> files = testDir.listSync(recursive: true);
-    try {
-      testDir.deleteSync(recursive: true);
-    } on FileSystemException catch (exception) {
-      throwToolExit('Failed to delete test directory: $exception');
-    }
-    return -files.length;
   }
 
   List<String> _getSupportedPlatformsFromTemplateContext(Map<String, Object?> templateContext) {

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -454,7 +454,7 @@ class CreateCommand extends CreateBase {
     if (sampleCode != null) {
       _applySample(relativeDir, sampleCode);
     }
-    if (sampleCode != null || emptyArgument) {
+    if (sampleCode != null || (emptyArgument && creatingNewProject)) {
       generatedFileCount += _removeTestDir(relativeDir);
     }
     globals.printStatus('Wrote $generatedFileCount files.');

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2110,7 +2110,7 @@ void main() {
   });
 
   testUsingContext('does not remove the test/ directory when recreating an application project with the --empty flag', () async {
-    await _createAndAnalyzeProject(
+    await _createProject(
       projectDir,
       <String>['--no-pub', '--empty'],
       <String>[],
@@ -2118,7 +2118,7 @@ void main() {
 
     projectDir.childDirectory('test').childFile('example_test.dart').createSync(recursive: true);
 
-    await _createAndAnalyzeProject(
+    return _createProject(
       projectDir,
       <String>['--no-pub', '--empty'],
       <String>['test/example_test.dart'],

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2109,7 +2109,7 @@ void main() {
     ));
   });
 
-  testUsingContext('does not remove the test/ directory when recreating an application project with the --empty flag', () async {
+  testUsingContext('does not remove an existing test/ directory when recreating an application project with the --empty flag', () async {
     await _createProject(
       projectDir,
       <String>['--no-pub', '--empty'],
@@ -2125,6 +2125,34 @@ void main() {
     );
 
     expect(projectDir.childDirectory('test').childFile('example_test.dart'), exists);
+  });
+
+  testUsingContext('does not create a test/ directory when creating a new application project with the --empty flag', () async {
+    await _createProject(
+      projectDir,
+      <String>['--no-pub', '--empty'],
+      <String>[],
+      unexpectedPaths: <String>['test'],
+    );
+
+    expect(projectDir.childDirectory('test'), isNot(exists));
+  });
+
+  testUsingContext("does not create a test/ directory, if it doesn't already exist, when recreating an application project with the --empty flag", () async {
+    await _createProject(
+      projectDir,
+      <String>['--no-pub', '--empty'],
+      <String>[],
+    );
+
+    await _createProject(
+      projectDir,
+      <String>['--no-pub', '--empty'],
+      <String>[],
+      unexpectedPaths: <String>['test'],
+    );
+
+    expect(projectDir.childDirectory('test'), isNot(exists));
   });
 
   testUsingContext('can create a sample-based project', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2118,11 +2118,13 @@ void main() {
 
     projectDir.childDirectory('test').childFile('example_test.dart').createSync(recursive: true);
 
-    return _createProject(
+    await _createProject(
       projectDir,
       <String>['--no-pub', '--empty'],
       <String>['test/example_test.dart'],
     );
+
+    expect(projectDir.childDirectory('test').childFile('example_test.dart'), exists);
   });
 
   testUsingContext('can create a sample-based project', () async {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2109,6 +2109,22 @@ void main() {
     ));
   });
 
+  testUsingContext('does not remove the test/ directory when recreating an application project with the --empty flag', () async {
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>['--no-pub', '--empty'],
+      <String>[],
+    );
+
+    projectDir.childDirectory('test').childFile('example_test.dart').createSync(recursive: true);
+
+    await _createAndAnalyzeProject(
+      projectDir,
+      <String>['--no-pub', '--empty'],
+      <String>['test/example_test.dart'],
+    );
+  });
+
   testUsingContext('can create a sample-based project', () async {
     await _createAndAnalyzeProject(
       projectDir,


### PR DESCRIPTION
This PR modifies the `flutter create --empty` command to not delete the `test/` folder when run on an existing app project. 

Before:
```bash
flutter create my_app --empty
mkdir my_app/test
if test -d my_app/test; then echo "test exists"; else echo "test does not exist"; fi # test exists
flutter create my_app --empty  
if test -d my_app/test; then echo "test exists"; else echo "test does not exist"; fi # test does not exist
```

After:
```bash
flutter create my_app --empty
mkdir my_app/test
if test -d my_app/test; then echo "test exists"; else echo "test does not exist"; fi # test exists
flutter create my_app --empty  
if test -d my_app/test; then echo "test exists"; else echo "test does not exist"; fi # test exists
```
Fixes https://github.com/flutter/flutter/issues/134928

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
