### PR TITLE
Fix frozen `StretchingOverscrollIndicator` animation

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -841,15 +841,23 @@ class _StretchController extends ChangeNotifier {
 
   double get value => _stretchSize.value;
 
+  // Constants for absorbImpact.
+  static const double _minVelocity = 1;
+  static const double _maxVelocity = 10000;
+  static const Duration _minStretchDuration = Duration(milliseconds: 50);
+
   /// Handle a fling to the edge of the viewport at a particular velocity.
   ///
   /// The velocity must be positive.
   void absorbImpact(double velocity, double totalOverscroll) {
     assert(velocity >= 0.0);
-    velocity = clampDouble(velocity, 1, 10000);
+    velocity = clampDouble(velocity, _minVelocity, _maxVelocity);
     _stretchSizeTween.begin = _stretchSize.value;
     _stretchSizeTween.end = math.min(_stretchIntensity + (_flingFriction / velocity), 1.0);
-    _stretchController.duration = Duration(milliseconds: (velocity * 0.02).round());
+    _stretchController.duration = Duration(
+      milliseconds:
+          math.max(velocity * 0.02, _minStretchDuration.inMilliseconds).round(),
+    );
     _stretchController.forward(from: 0.0);
     _state = _StretchState.absorb;
     _stretchDirection = totalOverscroll > 0 ? _StretchDirection.trailing : _StretchDirection.leading;

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -842,21 +842,21 @@ class _StretchController extends ChangeNotifier {
   double get value => _stretchSize.value;
 
   // Constants for absorbImpact.
-  static const double _minVelocity = 1;
-  static const double _maxVelocity = 10000;
-  static const Duration _minStretchDuration = Duration(milliseconds: 50);
+  static const double _kMinVelocity = 1;
+  static const double _kMaxVelocity = 10000;
+  static const Duration _kMinStretchDuration = Duration(milliseconds: 50);
 
   /// Handle a fling to the edge of the viewport at a particular velocity.
   ///
   /// The velocity must be positive.
   void absorbImpact(double velocity, double totalOverscroll) {
     assert(velocity >= 0.0);
-    velocity = clampDouble(velocity, _minVelocity, _maxVelocity);
+    velocity = clampDouble(velocity, _kMinVelocity, _kMaxVelocity);
     _stretchSizeTween.begin = _stretchSize.value;
     _stretchSizeTween.end = math.min(_stretchIntensity + (_flingFriction / velocity), 1.0);
     _stretchController.duration = Duration(
       milliseconds:
-          math.max(velocity * 0.02, _minStretchDuration.inMilliseconds).round(),
+          math.max(velocity * 0.02, _kMinStretchDuration.inMilliseconds).round(),
     );
     _stretchController.forward(from: 0.0);
     _state = _StretchState.absorb;

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -1177,4 +1177,69 @@ void main() {
 
     expect(tester.layers, contains(isA<ImageFilterLayer>()));
   });
+
+  testWidgets('Stretching animation completes after fling under scroll physics with high friction', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/146277
+    final GlobalKey box1Key = GlobalKey();
+    final GlobalKey box2Key = GlobalKey();
+    final GlobalKey box3Key = GlobalKey();
+    late final OverscrollNotification overscrollNotification;
+    final ScrollController controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(NotificationListener<OverscrollNotification>(
+      child: buildTest(
+        box1Key,
+        box2Key,
+        box3Key,
+        controller,
+        physics: const _HighFrictionClampingScrollPhysics(),
+      ),
+      onNotification: (OverscrollNotification notification) {
+        overscrollNotification = notification;
+        return false;
+      },
+    ));
+
+    expect(find.byType(StretchingOverscrollIndicator), findsOneWidget);
+    expect(find.byType(GlowingOverscrollIndicator), findsNothing);
+    final RenderBox box1 = tester.renderObject(find.byKey(box1Key));
+    final RenderBox box2 = tester.renderObject(find.byKey(box2Key));
+    final RenderBox box3 = tester.renderObject(find.byKey(box3Key));
+
+    expect(controller.offset, 0.0);
+    expect(box1.localToGlobal(Offset.zero), Offset.zero);
+    expect(box2.localToGlobal(Offset.zero), const Offset(0.0, 250.0));
+    expect(box3.localToGlobal(Offset.zero), const Offset(0.0, 500.0));
+
+    // We fling to the trailing edge and let it settle.
+    await tester.fling(find.byType(CustomScrollView), const Offset(0.0, -50.0), 10000.0);
+    await tester.pumpAndSettle();
+
+    // We are now at the trailing edge
+    expect(overscrollNotification.velocity, lessThan(25));
+    expect(controller.offset, 150.0);
+    expect(box1.localToGlobal(Offset.zero).dy, -150.0);
+    expect(box2.localToGlobal(Offset.zero).dy, 100.0);
+    expect(box3.localToGlobal(Offset.zero).dy, 350.0);
+  });
+}
+
+final class _HighFrictionClampingScrollPhysics extends ScrollPhysics {
+  const _HighFrictionClampingScrollPhysics({super.parent});
+
+  @override
+  ScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _HighFrictionClampingScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    return ClampingScrollSimulation(
+      position: position.pixels,
+      velocity: velocity,
+      friction: 0.94,
+      tolerance: tolerance,
+    );
+  }
 }


### PR DESCRIPTION
`StretchingOverscrollIndicator`'s controller does not have a minimum value for its animation duration.
When the `OverscrollNotification`'s `velocity` is small enough (< `25`) the controller's `absorbImpact` method sets this animation duration to 0ms, making the animation appear frozen to the user.

This PR sets a minimum animation duration of 50ms.

Fixes #146277

| Before | After |
| --- | --- |
| <video src="https://github.com/flutter/flutter/assets/82336674/8761f14e-d5a5-4a39-b8e7-9e77433ce2c6" width=250px />| <video src="https://github.com/flutter/flutter/assets/82336674/57b38448-29fb-41ad-a947-d7cf1c160ca3" width=250px /> |










## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
