### PR TITLE
fix DropdownMenu overflow

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -905,9 +905,11 @@ class _RenderDropdownMenuBody extends RenderBox
     double? maxHeight;
     RenderBox? child = firstChild;
 
+    final double intrinsicWidth = width ?? getMaxIntrinsicWidth(constraints.maxHeight);
+    final double widthConstraint = math.min(intrinsicWidth, constraints.maxWidth);
     final BoxConstraints innerConstraints = BoxConstraints(
-      maxWidth: width ?? getMaxIntrinsicWidth(constraints.maxWidth),
-      maxHeight: getMaxIntrinsicHeight(constraints.maxHeight),
+      maxWidth: widthConstraint,
+      maxHeight: getMaxIntrinsicHeight(widthConstraint),
     );
     while (child != null) {
       if (child == firstChild) {
@@ -947,9 +949,11 @@ class _RenderDropdownMenuBody extends RenderBox
     double maxWidth = 0.0;
     double? maxHeight;
     RenderBox? child = firstChild;
+    final double intrinsicWidth = width ?? getMaxIntrinsicWidth(constraints.maxHeight);
+    final double widthConstraint = math.min(intrinsicWidth, constraints.maxWidth);
     final BoxConstraints innerConstraints = BoxConstraints(
-      maxWidth: width ?? getMaxIntrinsicWidth(constraints.maxWidth),
-      maxHeight: getMaxIntrinsicHeight(constraints.maxHeight),
+      maxWidth: widthConstraint,
+      maxHeight: getMaxIntrinsicHeight(widthConstraint),
     );
 
     while (child != null) {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2129,6 +2129,59 @@ void main() {
     // No exception should be thrown.
     expect(tester.takeException(), isNull);
   });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/147076.
+  testWidgets('Text field does not overflow parent', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 300,
+          child: DropdownMenu<int>(
+            dropdownMenuEntries: <DropdownMenuEntry<int>>[
+              DropdownMenuEntry<int>(
+                value: 0,
+                label: 'This is a long text that is multiplied by 4 so it can overflow. ' * 4,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    await tester.pump();
+    final RenderBox box = tester.firstRenderObject(find.byType(TextField));
+    expect(box.size.width, 300.0);
+  });
+
+  // This is a regression test for https://github.com/flutter/flutter/issues/147173.
+  testWidgets('Text field with large helper text can be selected', (WidgetTester tester) async {
+    await tester.pumpWidget(
+     const MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: DropdownMenu<int>(
+            hintText: 'Hint text',
+            helperText: 'Menu Helper text',
+            inputDecorationTheme: InputDecorationTheme(
+              helperMaxLines: 2,
+              helperStyle: TextStyle(fontSize: 30),
+            ),
+            dropdownMenuEntries: <DropdownMenuEntry<int>>[
+              DropdownMenuEntry<int>(
+                value: 0,
+                label: 'MenuEntry 1',
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+  await tester.pump();
+  await tester.tapAt(tester.getCenter(find.text('Hint text')));
+  await tester.pumpAndSettle();
+  expect(find.byType(MenuItemButton), findsNWidgets(2));
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2156,8 +2156,7 @@ void main() {
   // This is a regression test for https://github.com/flutter/flutter/issues/147173.
   testWidgets('Text field with large helper text can be selected', (WidgetTester tester) async {
     const String labelText = 'MenuEntry 1';
-    await tester.pumpWidget(
-     const MaterialApp(
+    await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
         body: Center(
           child: DropdownMenu<int>(

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2155,6 +2155,7 @@ void main() {
 
   // This is a regression test for https://github.com/flutter/flutter/issues/147173.
   testWidgets('Text field with large helper text can be selected', (WidgetTester tester) async {
+    const String labelText = 'MenuEntry 1';
     await tester.pumpWidget(
      const MaterialApp(
       home: Scaffold(
@@ -2169,7 +2170,7 @@ void main() {
             dropdownMenuEntries: <DropdownMenuEntry<int>>[
               DropdownMenuEntry<int>(
                 value: 0,
-                label: 'MenuEntry 1',
+                label: labelText,
               ),
             ],
           ),
@@ -2177,10 +2178,11 @@ void main() {
       ),
     ));
 
-  await tester.pump();
-  await tester.tapAt(tester.getCenter(find.text('Hint text')));
-  await tester.pumpAndSettle();
-  expect(find.byType(MenuItemButton), findsNWidgets(2));
+    await tester.pump();
+    await tester.tapAt(tester.getCenter(find.text('Hint text')));
+    await tester.pumpAndSettle();
+    // One is layout for the _DropdownMenuBody, the other one is the real button item in the menu.
+    expect(find.widgetWithText(MenuItemButton, labelText), findsNWidgets(2));
   });
 }
 


### PR DESCRIPTION
fix `DropdownMenu` overflow issue in  https://github.com/flutter/flutter/issues/147076 and https://github.com/flutter/flutter/issues/147173
However I believe the the menu placement issue in https://github.com/flutter/flutter/issues/147076 is a separate issue. It is not fixed here.

fixes https://github.com/flutter/flutter/issues/147173

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
