### PR TITLE
Proposed solution to issue 147232.

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -28,6 +28,7 @@ import 'theme.dart';
 const double _kTabHeight = 46.0;
 const double _kTextAndIconTabHeight = 72.0;
 const double _kStartOffset = 52.0;
+const double _kMaxTabBarScale = 2.0;
 
 /// Defines how the bounds of the selected tab indicator are computed.
 ///
@@ -145,7 +146,10 @@ class Tab extends StatelessWidget implements PreferredSizeWidget {
   final double? height;
 
   Widget _buildLabelText() {
-    return child ?? Text(text!, softWrap: false, overflow: TextOverflow.fade);
+    return MediaQuery.withClampedTextScaling(
+      maxScaleFactor: _kMaxTabBarScale,
+      child: child ?? Text(text!, softWrap: false, overflow: TextOverflow.fade),
+    );
   }
 
   @override


### PR DESCRIPTION
Potential solution to the [text scaling issue for the tab bar](https://github.com/flutter/flutter/issues/13322).

Fixed the issue of text scaling cutting off tab bar text by setting a upper limit on the amount of scaling for tab bar text.

### Before

<img width="294" alt="Screenshot 2024-04-23 at 8 20 13 PM" src="https://github.com/flutter/flutter/assets/73905487/b696eef4-4140-4e3e-8147-9001c4659340">

### After

<img width="363" alt="Screenshot 2024-04-23 at 8 19 53 PM" src="https://github.com/flutter/flutter/assets/73905487/1b2ac45f-29d2-47d3-8134-301e7dd57315">

## Pre-launch Checklist

- [✅] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✅] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✅] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [✅] I listed at least one issue that this PR fixes in the description above.
- [✅] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [✅] All existing and new tests are passing.