### PR TITLE
Mark firebase tests as `bringup: true`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -506,6 +506,7 @@ targets:
 
   - name: Linux firebase_abstract_method_smoke_test
     presubmit: false
+    bringup: true # https://github.com/flutter/flutter/issues/147335
     recipe: firebaselab/firebaselab
     timeout: 60
     properties:
@@ -538,6 +539,7 @@ targets:
 
   - name: Linux firebase_android_embedding_v2_smoke_test
     recipe: firebaselab/firebaselab
+    bringup: true # https://github.com/flutter/flutter/issues/147335
     timeout: 60
     properties:
       dependencies: >-
@@ -569,6 +571,7 @@ targets:
 
   - name: Linux firebase_release_smoke_test
     recipe: firebaselab/firebaselab
+    bringup: true # https://github.com/flutter/flutter/issues/147335
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
This helps green the tree considering firebase outage: https://github.com/flutter/flutter/issues/147335