### PR TITLE
Fix `FloatingActionButton` docs for `background` and `foreground` properties

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -266,19 +266,20 @@ class FloatingActionButton extends StatelessWidget {
 
   /// The default foreground color for icons and text within the button.
   ///
-  /// If this property is null, then the
-  /// [FloatingActionButtonThemeData.foregroundColor] of
-  /// [ThemeData.floatingActionButtonTheme] is used. If that property is also
-  /// null, then the [ColorScheme.onSecondary] color of [ThemeData.colorScheme]
-  /// is used.
+  /// If this property is null, then the [FloatingActionButtonThemeData.foregroundColor]
+  /// of [ThemeData.floatingActionButtonTheme] is used. If that property is also
+  /// null, then the [ColorScheme.onPrimaryContainer] color of [ThemeData.colorScheme]
+  /// is used. If [ThemeData.useMaterial3] is set to false, then the
+  /// [ColorScheme.onSecondary] color of [ThemeData.colorScheme] is used.
   final Color? foregroundColor;
 
   /// The button's background color.
   ///
-  /// If this property is null, then the
-  /// [FloatingActionButtonThemeData.backgroundColor] of
-  /// [ThemeData.floatingActionButtonTheme] is used. If that property is also
-  /// null, then the [Theme]'s [ColorScheme.secondary] color is used.
+  /// If this property is null, then the [FloatingActionButtonThemeData.backgroundColor]
+  /// of [ThemeData.floatingActionButtonTheme] is used. If that property is also
+  /// null, then the [ColorScheme.primaryContainer] color of [ThemeData.colorScheme]
+  /// is used. If [ThemeData.useMaterial3] is set to false, then the
+  /// [ColorScheme.secondary] color of [ThemeData.colorScheme] is used.
   final Color? backgroundColor;
 
   /// The color to use for filling the button when the button has input focus.


### PR DESCRIPTION
fixes [Material 3 `FloatingActionButton` background/foreground docs are inconsistent](https://github.com/flutter/flutter/issues/147368)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
