### PR TITLE
[devicelab] explicitly enable vulkan validation in test.

### DIFF
--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -54,6 +54,7 @@ Future<TaskResult> run() async {
       'run',
       options: <String>[
         '--enable-impeller',
+        '--enable-vulkan-validation',
         '-d',
         device.deviceId,
       ],


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142659

this test expects validation layers on, so we need to explicitly enable them before we can turn them off by default.
