### PR TITLE
[macOS] Eliminate flutter_gallery_macos__start_up benchmark

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3604,17 +3604,6 @@ targets:
         ]
       task_name: flutter_gallery_macos__compile
 
-  - name: Mac_benchmark flutter_gallery_macos__start_up
-    presubmit: false
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
-        ]
-      task_name: flutter_gallery_macos__start_up
-
   - name: Mac flutter_packaging_test
     recipe: packaging/packaging
     presubmit: false


### PR DESCRIPTION
The macOS devicelab machines are not physically configured for benchmarking at a 60 Hz refresh rate. With Flutter vsync wired up via CVDisplayLink (rather than a hardcoded 60 Hz rate as previously), the bot shows 0 monitors configured and syncs at 30 Hz. This is not a meaningful target to measure against but consumes devicelab CPU cycles.

Given that there is currently no plan in place to acquire and configure a consistent pool of physical benchmarking desktop machines, disabling this test to reduce load on the bots.

See https://github.com/flutter/engine/pull/51210 for a discussion of the decision to move forward with wiring up vsync from macOS and ignore this benchmark.

For future archaeologists, I don't think it's worth removing all the plumbing in the Dart code (in [dev/devicelab/lib/tasks/perf_tests.dart](https://github.com/flutter/flutter/blob/9d47055640a90879cfb45b2da55283504bedc354/dev/devicelab/lib/tasks/perf_tests.dart#L963)) that supports running this benchmark on macOS. If we ever acquire hardware suitable for benchmarking with the appropriate HDMI dongle to simulate a 60Hz 4k display, for example, it would be reasonable to re-enable this benchmark.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
