### PR TITLE
Added missing tests for ButtonStyle example

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -317,7 +317,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/selectable_region/selectable_region.0_test.dart',
   'examples/api/test/material/text_field/text_field.2_test.dart',
   'examples/api/test/material/text_field/text_field.1_test.dart',
-  'examples/api/test/material/button_style/button_style.0_test.dart',
   'examples/api/test/material/range_slider/range_slider.0_test.dart',
   'examples/api/test/material/selection_container/selection_container_disabled.0_test.dart',
   'examples/api/test/material/selection_container/selection_container.0_test.dart',

--- a/examples/api/test/material/button_style/button_style.0_test.dart
+++ b/examples/api/test/material/button_style/button_style.0_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/button_style/button_style.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+      'Shows ElevatedButtons, FilledButtons, OutlinedButtons and TextButtons in enabled and disabled states',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const example.ButtonApp());
+
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is ElevatedButton && widget.onPressed == null;
+      }),
+      findsOne,
+    );
+
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is ElevatedButton && widget.onPressed != null;
+      }),
+      findsOne,
+    );
+
+    //one OutlinedButton with onPressed null
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is OutlinedButton && widget.onPressed == null;
+      }),
+      findsOne,
+    );
+
+    //one OutlinedButton with onPressed not null
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is OutlinedButton && widget.onPressed != null;
+      }),
+      findsOne,
+    );
+
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is TextButton && widget.onPressed == null;
+      }),
+      findsOne,
+    );
+
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is TextButton && widget.onPressed != null;
+      }),
+      findsOne,
+    );
+
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is FilledButton && widget.onPressed != null;
+      }),
+      findsNWidgets(2),
+    );
+
+    expect(
+      find.byWidgetPredicate((Widget widget) {
+        return widget is FilledButton && widget.onPressed == null;
+      }),
+      findsNWidgets(2),
+    );
+  });
+}

--- a/examples/api/test/material/button_style/button_style.0_test.dart
+++ b/examples/api/test/material/button_style/button_style.0_test.dart
@@ -27,7 +27,7 @@ void main() {
       findsOne,
     );
 
-    //one OutlinedButton with onPressed null
+    // One OutlinedButton with onPressed null.
     expect(
       find.byWidgetPredicate((Widget widget) {
         return widget is OutlinedButton && widget.onPressed == null;
@@ -35,7 +35,7 @@ void main() {
       findsOne,
     );
 
-    //one OutlinedButton with onPressed not null
+    // One OutlinedButton with onPressed not null.
     expect(
       find.byWidgetPredicate((Widget widget) {
         return widget is OutlinedButton && widget.onPressed != null;


### PR DESCRIPTION
Added missing tests for ButtonStyle example. Issue #130459 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
