### PR TITLE
Catch exceptions when trying to decode state restoration saved datas

### DIFF
--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -319,7 +319,18 @@ class RestorationManager extends ChangeNotifier {
       return null;
     }
     final ByteData encoded = data.buffer.asByteData(data.offsetInBytes, data.lengthInBytes);
-    return const StandardMessageCodec().decodeMessage(encoded) as Map<Object?, Object?>?;
+    Map<Object?, Object?>? decodedMessage;
+    try {
+      decodedMessage = const StandardMessageCodec().decodeMessage(encoded) as Map<Object?, Object?>?;
+    } catch (exception, stack) {
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: exception,
+        stack: stack,
+        library: 'services library',
+        context: ErrorDescription('during restoration data decoding from the engine'),
+      ));
+    }
+    return decodedMessage;
   }
 
   Uint8List _encodeRestorationData(Map<Object?, Object?> data) {

--- a/packages/flutter/lib/src/services/restoration.dart
+++ b/packages/flutter/lib/src/services/restoration.dart
@@ -321,7 +321,7 @@ class RestorationManager extends ChangeNotifier {
     final ByteData encoded = data.buffer.asByteData(data.offsetInBytes, data.lengthInBytes);
     Map<Object?, Object?>? decodedMessage;
     try {
-      decodedMessage = const StandardMessageCodec().decodeMessage(encoded) as Map<Object?, Object?>?;
+      return const StandardMessageCodec().decodeMessage(encoded) as Map<Object?, Object?>?;
     } catch (exception, stack) {
       FlutterError.reportError(FlutterErrorDetails(
         exception: exception,


### PR DESCRIPTION
In packages/flutter/lib/src/services/restoration.dart's `_decodeRestorationData` function, this function adds a try-catch block to catch any errors happening when calling `StandardMessageCodec().decodeMessage()`. A FormatException can occur in `StandardMessageCodec().decodeMessage()` if the data saved for state restoration is corrupted.

This fixes #147456.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
