### PR TITLE
add lang attribute to the a11y_assessments app

### DIFF
--- a/dev/a11y_assessments/web/index.html
+++ b/dev/a11y_assessments/web/index.html
@@ -3,7 +3,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
-<html>
+<html lang="en_US">
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the


### PR DESCRIPTION
Since the app is used to assess Flutter's overall accessibility, the app should follow at many guidelines as possible, including setting the `lang` attribute.

Fixes b/338044851