### PR TITLE
Move docs_test and docs_publish to bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -449,6 +449,7 @@ targets:
 
   - name: Linux docs_publish
     recipe: flutter/docs
+    bringup: true # https://github.com/flutter/flutter/issues/147609
     presubmit: false
     timeout: 60
     dimensions:
@@ -473,6 +474,7 @@ targets:
 
   - name: Linux docs_test
     recipe: flutter/flutter_drone
+    bringup: true # https://github.com/flutter/flutter/issues/147609
     timeout: 90 # https://github.com/flutter/flutter/issues/120901
     properties:
       cores: "32"


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/147609 to unblock the tree.

@gspencergoog @jason-simmons 