### PR TITLE
[framework] dont clip navigator by default.

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1698,7 +1698,6 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
         debugLabel: 'Navigator Scope',
         autofocus: true,
         child: Navigator(
-          clipBehavior: Clip.none,
           restorationScopeId: 'nav',
           key: _navigator,
           initialRoute: _initialRouteName,

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1461,7 +1461,7 @@ class Navigator extends StatefulWidget {
     this.onUnknownRoute,
     this.transitionDelegate = const DefaultTransitionDelegate<dynamic>(),
     this.reportsRouteUpdateToEngine = false,
-    this.clipBehavior = Clip.hardEdge,
+    this.clipBehavior = Clip.none,
     this.observers = const <NavigatorObserver>[],
     this.requestFocus = true,
     this.restorationScopeId,

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -220,8 +220,8 @@ void main() {
         ),
       ),
     );
-    // Default to hard edge.
-    expect(tester.widget<Overlay>(find.byType(Overlay)).clipBehavior, Clip.hardEdge);
+    // Default to none.
+    expect(tester.widget<Overlay>(find.byType(Overlay)).clipBehavior, Clip.none);
 
     await tester.pumpWidget(
       MediaQuery(
@@ -230,13 +230,14 @@ void main() {
           textDirection: TextDirection.ltr,
           child: Navigator(
             pages: const <Page<void>>[page],
-            clipBehavior: Clip.none,
+            clipBehavior: Clip.hardEdge,
             onPopPage: (_, __) => false,
           ),
         ),
       ),
     );
-    expect(tester.widget<Overlay>(find.byType(Overlay)).clipBehavior, Clip.none);
+
+    expect(tester.widget<Overlay>(find.byType(Overlay)).clipBehavior, Clip.hardEdge);
   });
 
   testWidgets('Zero transition page-based route correctly notifies observers when it is popped', (WidgetTester tester) async {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/136510

The navigator clips by themself are not slow, but they are disabling clear color optimizations. The clear color optimization detects that a draw's geometry full covers the surface that is being rendered to. Clipping disables this as we can't be sure if the clip impacts the result. Because most route backgrounds are implemented as a large drawRect or drawPaint, losing clear color adds about 3-4ms of GPU time.
