### PR TITLE
add verbose logging to select hot reload/hot restart tests

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -732,6 +732,7 @@ class DevFS {
       return UpdateFSReport();
     }
 
+    _logger.printTrace('Pending asset builds completed. Writing dirty entries.');
     if (dirtyEntries.isNotEmpty) {
       await (devFSWriter ?? _httpWriter).write(dirtyEntries, _baseUri!, _httpWriter);
     }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -573,6 +573,7 @@ class FlutterDevice {
   }) async {
     final Status devFSStatus = globals.logger.startProgress(
       'Syncing files to device ${device!.name}...',
+      progressId: 'devFS.update',
     );
     UpdateFSReport report;
     try {

--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -81,7 +81,7 @@ void main() {
   });
 
   testWithoutContext('hot restart works without error', () async {
-    await flutter.run();
+    await flutter.run(verbose: true);
     await flutter.hotRestart();
   });
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -90,12 +90,13 @@ abstract class FlutterTestDriver {
     List<String> arguments, {
     String? script,
     bool withDebugger = false,
+    bool verbose = false,
   }) async {
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     if (withDebugger) {
       arguments.add('--start-paused');
     }
-    if (_printDebugOutputToStdOut) {
+    if (verbose) {
       arguments.add('--verbose');
     }
     if (script != null) {
@@ -509,6 +510,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     bool expressionEvaluation = true,
     bool structuredErrors = false,
     bool serveObservatory = false,
+    bool verbose = false,
     String? script,
     List<String>? additionalCommandArgs,
   }) async {
@@ -538,6 +540,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       startPaused: startPaused,
       pauseOnExceptions: pauseOnExceptions,
       script: script,
+      verbose: verbose,
     );
   }
 
@@ -578,6 +581,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     bool withDebugger = false,
     bool startPaused = false,
     bool pauseOnExceptions = false,
+    bool verbose = false,
     int? attachPort,
   }) async {
     assert(!startPaused || withDebugger);
@@ -585,6 +589,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       args,
       script: script,
       withDebugger: withDebugger,
+      verbose: verbose,
     );
 
     final Completer<void> prematureExitGuard = Completer<void>();
@@ -796,12 +801,14 @@ class FlutterTestTestDriver extends FlutterTestDriver {
     String? script,
     bool withDebugger = false,
     bool pauseOnExceptions = false,
+    bool verbose = false,
     Future<void> Function()? beforeStart,
   }) async {
     await super._setupProcess(
       args,
       script: script,
       withDebugger: withDebugger,
+      verbose: verbose,
     );
 
     // Stash the PID so that we can terminate the VM more reliably than using

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -96,7 +96,7 @@ abstract class FlutterTestDriver {
     if (withDebugger) {
       arguments.add('--start-paused');
     }
-    if (verbose) {
+    if (verbose || _printDebugOutputToStdOut) {
       arguments.add('--verbose');
     }
     if (script != null) {

--- a/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/vmservice_integration_test.dart
@@ -25,7 +25,7 @@ void main() {
       await project.setUpIn(tempDir);
 
       flutter = FlutterRunTestDriver(tempDir);
-      await flutter.run(withDebugger: true);
+      await flutter.run(withDebugger: true, verbose: true);
       final int? port = flutter.vmServicePort;
       expect(port != null, true);
       vmService = await vmServiceConnectUri('ws://localhost:$port/ws');


### PR DESCRIPTION
In service of https://github.com/flutter/flutter/issues/146879 and https://github.com/flutter/flutter/issues/145812. In these issues, we see what appears to be the flutter tool getting stuck somewhere during hot reload. It may help if we knew were exactly where we are getting stuck (preparing assets, writing them to device, etc.).

This PR adds a new parameter to `FlutterTestDriver::run`, `verbose`. When verbose is set, `FlutterTestDriver` will run `flutter` with `--verbose` in its tests. Keep in mind that `FlutterTestDriver` only prints logs from `flutter` when a test fails, so this shouldn't spam the logs of passing tests.

This PR sets the parameter when invoking the flaky tests from https://github.com/flutter/flutter/issues/146879 and #145812, so we should see more detailed logs in future flakes.

While this is a low risk PR, you can verify the change by intentionally breaking hot reload code, clearing the cached tool binaries, and then running either of these tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
