### PR TITLE
Improve Android SDK and NDK mistmatch warning message

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -837,6 +837,8 @@ class FlutterPlugin implements Plugin<Project> {
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified
             String maxPluginNdkVersion = projectNdkVersion
             int numProcessedPlugins = getPluginList(project).size()
+            List<Tuple2<String, String>> pluginsToNdkVersions = []
+            List<Tuple2<String, String>> pluginsToSdkVersions = []
 
             getPluginList(project).each { pluginObject ->
                 assert(pluginObject.name instanceof String)
@@ -851,8 +853,13 @@ class FlutterPlugin implements Plugin<Project> {
                     if (getCompileSdkFromProject(pluginProject).isInteger()) {
                         pluginCompileSdkVersion = getCompileSdkFromProject(pluginProject) as int
                     }
+
+                    pluginsToSdkVersions.add(new Tuple(pluginProject.name, pluginProject.android.compileSdkVersion))
+
                     maxPluginCompileSdkVersion = Math.max(pluginCompileSdkVersion, maxPluginCompileSdkVersion)
                     String pluginNdkVersion = pluginProject.android.ndkVersion ?: ndkVersionIfUnspecified
+                    pluginsToNdkVersions.add(new Tuple(pluginProject.name, pluginNdkVersion))
+                    // project.logger.quiet("NDK version for plugin ${pluginProject.name} is ${pluginProject.android.ndkVersion}")
                     maxPluginNdkVersion = mostRecentSemanticVersion(pluginNdkVersion, maxPluginNdkVersion)
 
                     numProcessedPlugins--

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -868,13 +868,21 @@ class FlutterPlugin implements Plugin<Project> {
                     numProcessedPlugins--
                     if (numProcessedPlugins == 0) {
                         if (maxPluginCompileSdkVersion > projectCompileSdkVersion) {
-                            project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugins(s) require to be compiled against a higher Android SDK version:")s
+                            project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugins(s) require to be compiled against a higher Android SDK version:")
                             for (Tuple2<String, String> pluginToCompileSdkVersion : pluginsWithHigherSdkVersion) {
                                 if (pluginToCompileSdkVersion.second > projectCompileSdkVersion) {
                                     project.logger.error("- ${pluginToCompileSdkVersion.first} compiles against Android SDK ${pluginToCompileSdkVersion.second}")
                                 }
                             }
-                            project.logger.error("Fix this issue by compiling against the highest Android SDK version.\nAdd the following to ${project.projectDir}${File.separator}build.gradle:\nandroid {\n  compileSdkVersion ${maxPluginCompileSdkVersion}\n  ...\n}\n")
+                            project.logger.error("""\
+                                Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
+                                Add the following to ${project.projectDir}${File.separator}build.gradle:
+                                
+                                    android {
+                                        compileSdk = ${maxPluginCompileSdkVersion}
+                                        ...
+                                    }
+                                """.stripIndent())
                         }
                         if (maxPluginNdkVersion != projectNdkVersion) {
                             project.logger.error("Your project is configured with Android NDK $projectNdkVersion, but the following plugin(s) depend a different Android NDK version:")
@@ -883,7 +891,15 @@ class FlutterPlugin implements Plugin<Project> {
                                     project.logger.error("- ${pluginToNdkVersion.first} requires Android NDK ${pluginToNdkVersion.second}")
                                 }
                             }
-                            project.logger.error("Fix this issue by using the highest Android NDK version.\nAdd the following to ${project.projectDir}${File.separator}build.gradle:\nandroid {\n  ndkVersion = \"${maxPluginNdkVersion}\"\n  ...\n}\n")
+                            project.logger.error("""\
+                                Fix this issue by using the highest Android NDK version (they are backward compatible).
+                                Add the following to ${project.projectDir}${File.separator}build.gradle:
+                                
+                                    android {
+                                        ndkVersion = \"${maxPluginNdkVersion}\"
+                                        ...
+                                    }
+                                """.stripIndent())
                         }
                     }
                 }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -881,9 +881,7 @@ class FlutterPlugin implements Plugin<Project> {
                         if (maxPluginCompileSdkVersion > projectCompileSdkVersion) {
                             project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugin(s) require to be compiled against a higher Android SDK version:")
                             for (Tuple2<String, String> pluginToCompileSdkVersion : pluginsWithHigherSdkVersion) {
-                                if (pluginToCompileSdkVersion.second > projectCompileSdkVersion) {
-                                    project.logger.error("- ${pluginToCompileSdkVersion.first} compiles against Android SDK ${pluginToCompileSdkVersion.second}")
-                                }
+                                project.logger.error("- ${pluginToCompileSdkVersion.first} compiles against Android SDK ${pluginToCompileSdkVersion.second}")
                             }
                             project.logger.error("""\
                                 Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
@@ -898,9 +896,7 @@ class FlutterPlugin implements Plugin<Project> {
                         if (maxPluginNdkVersion != projectNdkVersion) {
                             project.logger.error("Your project is configured with Android NDK $projectNdkVersion, but the following plugin(s) depend on a different Android NDK version:")
                             for (Tuple2<String, String> pluginToNdkVersion : pluginsWithDifferentNdkVersion) {
-                                if (pluginToNdkVersion.second != projectNdkVersion) {
-                                    project.logger.error("- ${pluginToNdkVersion.first} requires Android NDK ${pluginToNdkVersion.second}")
-                                }
+                                project.logger.error("- ${pluginToNdkVersion.first} requires Android NDK ${pluginToNdkVersion.second}")
                             }
                             project.logger.error("""\
                                 Fix this issue by using the highest Android NDK version (they are backward compatible).

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -894,7 +894,7 @@ class FlutterPlugin implements Plugin<Project> {
                                 """.stripIndent())
                         }
                         if (maxPluginNdkVersion != projectNdkVersion) {
-                            project.logger.error("Your project is configured with Android NDK $projectNdkVersion, but the following plugin(s) depend a different Android NDK version:")
+                            project.logger.error("Your project is configured with Android NDK $projectNdkVersion, but the following plugin(s) depend on a different Android NDK version:")
                             for (Tuple2<String, String> pluginToNdkVersion : pluginsWithDifferentNdkVersion) {
                                 if (pluginToNdkVersion.second != projectNdkVersion) {
                                     project.logger.error("- ${pluginToNdkVersion.first} requires Android NDK ${pluginToNdkVersion.second}")

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -879,7 +879,7 @@ class FlutterPlugin implements Plugin<Project> {
                     numProcessedPlugins--
                     if (numProcessedPlugins == 0) {
                         if (maxPluginCompileSdkVersion > projectCompileSdkVersion) {
-                            project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugin(s) require to be compiled against a higher Android SDK version:")
+                            project.logger.error("Your project is configured to compile using Android SDK $projectCompileSdkVersion, but the following plugin(s) require a higher Android SDK version:")
                             for (Tuple2<String, String> pluginToCompileSdkVersion : pluginsWithHigherSdkVersion) {
                                 if (pluginToCompileSdkVersion.second > projectCompileSdkVersion) {
                                     project.logger.error("- ${pluginToCompileSdkVersion.first} compiles against Android SDK ${pluginToCompileSdkVersion.second}")

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -877,7 +877,7 @@ class FlutterPlugin implements Plugin<Project> {
                     numProcessedPlugins--
                     if (numProcessedPlugins == 0) {
                         if (maxPluginCompileSdkVersion > projectCompileSdkVersion) {
-                            project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugins(s) require to be compiled against a higher Android SDK version:")
+                            project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugin(s) require to be compiled against a higher Android SDK version:")
                             for (Tuple2<String, String> pluginToCompileSdkVersion : pluginsWithHigherSdkVersion) {
                                 if (pluginToCompileSdkVersion.second > projectCompileSdkVersion) {
                                     project.logger.error("- ${pluginToCompileSdkVersion.first} compiles against Android SDK ${pluginToCompileSdkVersion.second}")

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -693,7 +693,7 @@ class FlutterPlugin implements Plugin<Project> {
             if (pluginProject == null) {
                 // Plugin was not included in `settings.gradle`, but is listed in `.flutter-plugins`.
                 project.logger.error("Plugin project :${it.name} listed, but not found. Please fix your settings.gradle/settings.gradle.kts.")
-            } else if (doesSupportAndroidPlatform(pluginProject.projectDir.parentFile.path as String)) {
+            } else if (doesSupportAndroidPlatform(pluginProject)) {
                 // Plugin has a functioning `android` folder and is included successfully, although it's not supported.
                 // It must be configured nonetheless, to not throw an "Unresolved reference" exception.
                 configurePluginProject(it)
@@ -709,9 +709,18 @@ class FlutterPlugin implements Plugin<Project> {
      * Returns `true` if the given path contains an `android` directory
      * containing a `build.gradle` or `build.gradle.kts` file.
      */
-    private Boolean doesSupportAndroidPlatform(String path) {
-        File buildGradle = new File(path, 'android' + File.separator + 'build.gradle')
-        File buildGradleKts = new File(path, 'android' + File.separator + 'build.gradle.kts')
+    private Boolean doesSupportAndroidPlatform(Project project) {
+        return buildGradleFile(project).exists()
+    }
+
+    /**
+     * Returns the Gradle build script for the build. When both Groovy and
+     * Kotlin variants exist, then Groovy (build.gradle) is preferred over
+     * Kotlin (build.gradle.kts). This is the same behavior as Gradle 8.5.
+     */
+    private File buildGradleFile(Project project) {
+        File buildGradle = new File(project.projectDir.parentFile, "android" + File.separator + "build.gradle")
+        File buildGradleKts = new File(project.projectDir.parentFile, "android" + File.separator + "build.gradle")
         if (buildGradle.exists() && buildGradleKts.exists()) {
             project.logger.error(
                 "Both build.gradle and build.gradle.kts exist, so " +
@@ -719,7 +728,7 @@ class FlutterPlugin implements Plugin<Project> {
             )
         }
 
-        return buildGradle.exists() || buildGradleKts.exists()
+        return buildGradle.exists() ? buildGradle : buildGradleKts
     }
 
     /**
@@ -876,7 +885,7 @@ class FlutterPlugin implements Plugin<Project> {
                             }
                             project.logger.error("""\
                                 Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
-                                Add the following to ${project.projectDir}${File.separator}build.gradle:
+                                Add the following to ${buildGradleFile(project).path}:
                                 
                                     android {
                                         compileSdk = ${maxPluginCompileSdkVersion}
@@ -893,8 +902,8 @@ class FlutterPlugin implements Plugin<Project> {
                             }
                             project.logger.error("""\
                                 Fix this issue by using the highest Android NDK version (they are backward compatible).
-                                Add the following to ${project.projectDir}${File.separator}build.gradle:
-                                
+                                Add the following to ${buildGradleFile(project).path}:
+
                                     android {
                                         ndkVersion = \"${maxPluginNdkVersion}\"
                                         ...

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -879,7 +879,7 @@ class FlutterPlugin implements Plugin<Project> {
                     numProcessedPlugins--
                     if (numProcessedPlugins == 0) {
                         if (maxPluginCompileSdkVersion > projectCompileSdkVersion) {
-                            project.logger.error("Your project is configured to compile using Android SDK $projectCompileSdkVersion, but the following plugin(s) require a higher Android SDK version:")
+                            project.logger.error("Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugin(s) require to be compiled against a higher Android SDK version:")
                             for (Tuple2<String, String> pluginToCompileSdkVersion : pluginsWithHigherSdkVersion) {
                                 if (pluginToCompileSdkVersion.second > projectCompileSdkVersion) {
                                     project.logger.error("- ${pluginToCompileSdkVersion.first} compiles against Android SDK ${pluginToCompileSdkVersion.second}")

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -719,8 +719,8 @@ class FlutterPlugin implements Plugin<Project> {
      * Kotlin (build.gradle.kts). This is the same behavior as Gradle 8.5.
      */
     private File buildGradleFile(Project project) {
-        File buildGradle = new File(project.projectDir.parentFile, "android" + File.separator + "build.gradle")
-        File buildGradleKts = new File(project.projectDir.parentFile, "android" + File.separator + "build.gradle")
+        File buildGradle = new File(project.projectDir.parentFile, "app" + File.separator + "build.gradle")
+        File buildGradleKts = new File(project.projectDir.parentFile, "app" + File.separator + "build.gradle.kts")
         if (buildGradle.exists() && buildGradleKts.exists()) {
             project.logger.error(
                 "Both build.gradle and build.gradle.kts exist, so " +
@@ -886,7 +886,7 @@ class FlutterPlugin implements Plugin<Project> {
                             project.logger.error("""\
                                 Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
                                 Add the following to ${buildGradleFile(project).path}:
-                                
+
                                     android {
                                         compileSdk = ${maxPluginCompileSdkVersion}
                                         ...

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -693,7 +693,7 @@ class FlutterPlugin implements Plugin<Project> {
             if (pluginProject == null) {
                 // Plugin was not included in `settings.gradle`, but is listed in `.flutter-plugins`.
                 project.logger.error("Plugin project :${it.name} listed, but not found. Please fix your settings.gradle/settings.gradle.kts.")
-            } else if (doesSupportAndroidPlatform(pluginProject)) {
+            } else if (pluginSupportsAndroidPlatform(pluginProject)) {
                 // Plugin has a functioning `android` folder and is included successfully, although it's not supported.
                 // It must be configured nonetheless, to not throw an "Unresolved reference" exception.
                 configurePluginProject(it)
@@ -706,11 +706,13 @@ class FlutterPlugin implements Plugin<Project> {
 
     // TODO(54566): Can remove this function and its call sites once resolved.
     /**
-     * Returns `true` if the given path contains an `android` directory
+     * Returns `true` if the given project is a plugin project having an `android` directory
      * containing a `build.gradle` or `build.gradle.kts` file.
      */
-    private Boolean doesSupportAndroidPlatform(Project project) {
-        return buildGradleFile(project).exists()
+    private Boolean pluginSupportsAndroidPlatform(Project project) {
+        File buildGradle = new File(project.projectDir.parentFile, "android" + File.separator + "build.gradle")
+        File buildGradleKts = new File(project.projectDir.parentFile, "android" + File.separator + "build.gradle.kts")
+        return buildGradle.exists() || buildGradleKts.exists()
     }
 
     /**

--- a/packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
@@ -75,16 +75,20 @@ void main() {
 
     // Check error message is thrown
     expect(
-        result.stdout,
+        result.stderr,
         contains(
-            'Warning: The plugin test_plugin requires Android SDK version 31 or higher.'));
+            'Your project is configured to compile against Android SDK 30, but '
+            'the following plugin(s) require to be compiled against a higher Android SDK version:'));
     expect(
       result.stderr,
-      contains('One or more plugins require a higher Android SDK version.'),
+      contains('- test_plugin compiles against Android SDK 31'),
     );
     expect(
         result.stderr,
         contains(
-            'Fix this issue by adding the following to ${projectGradleFile.path}'));
+            'Fix this issue by compiling against the highest Android SDK version (they are backward compatible).'));
+    expect(
+        result.stderr,
+        contains('Add the following to ${projectGradleFile.path}:'));
   });
 }

--- a/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
@@ -74,13 +74,15 @@ void main() {
 
     // Check that an error message is thrown.
     expect(result.stderr, contains('''
-One or more plugins require a higher Android NDK version.
-Fix this issue by adding the following to ${projectGradleFile.path}:
-android {
-  ndkVersion "21.4.7075529"
-  ...
-}
+Your project is configured with Android NDK 21.1.6352462, but the following plugin(s) depend a different Android NDK version:
+- test_plugin requires Android NDK 21.4.7075529
+Fix this issue by using the highest Android NDK version (they are backward compatible).
+Add the following to ${projectGradleFile.path}:
 
+    android {
+        ndkVersion = "21.4.7075529"
+        ...
+    }
 '''));
   });
 }

--- a/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_ndkversion_mismatch_test.dart
@@ -74,7 +74,7 @@ void main() {
 
     // Check that an error message is thrown.
     expect(result.stderr, contains('''
-Your project is configured with Android NDK 21.1.6352462, but the following plugin(s) depend a different Android NDK version:
+Your project is configured with Android NDK 21.1.6352462, but the following plugin(s) depend on a different Android NDK version:
 - test_plugin requires Android NDK 21.4.7075529
 Fix this issue by using the highest Android NDK version (they are backward compatible).
 Add the following to ${projectGradleFile.path}:


### PR DESCRIPTION
This PR resolves #147806

- List plugin that want to be compiled against a higher Android SDK version
- List plugins that depend on a different NDK version (we don't have a way to compare them)
- Small formatting and wording improvements
- Update syntax to work for both Groovy and Kotlin
- If project uses `build.gradle.kts`, then it is mentioned in the warning message (previously always `build.gradle` was mentioned)

<img width="1209" alt="demo" src="https://github.com/flutter/flutter/assets/40357511/be3522b5-d1b4-4983-9fed-8aaa0f0bc7f7">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.