### PR TITLE
Add test for animated_size.0.dart API example.

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -409,7 +409,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/async/stream_builder.0_test.dart',
   'examples/api/test/widgets/async/future_builder.0_test.dart',
   'examples/api/test/widgets/restoration_properties/restorable_value.0_test.dart',
-  'examples/api/test/widgets/animated_size/animated_size.0_test.dart',
   'examples/api/test/widgets/animated_switcher/animated_switcher.0_test.dart',
   'examples/api/test/widgets/transitions/relative_positioned_transition.0_test.dart',
   'examples/api/test/widgets/transitions/positioned_transition.0_test.dart',

--- a/examples/api/lib/widgets/animated_size/animated_size.0.dart
+++ b/examples/api/lib/widgets/animated_size/animated_size.0.dart
@@ -11,13 +11,19 @@ void main() => runApp(const AnimatedSizeExampleApp());
 class AnimatedSizeExampleApp extends StatelessWidget {
   const AnimatedSizeExampleApp({super.key});
 
+  static const Duration duration = Duration(seconds: 1);
+  static const Curve curve = Curves.easeIn;
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text('AnimatedSize Sample')),
         body: const Center(
-          child: AnimatedSizeExample(),
+          child: AnimatedSizeExample(
+            duration: duration,
+            curve: curve,
+          ),
         ),
       ),
     );
@@ -25,33 +31,42 @@ class AnimatedSizeExampleApp extends StatelessWidget {
 }
 
 class AnimatedSizeExample extends StatefulWidget {
-  const AnimatedSizeExample({super.key});
+  const AnimatedSizeExample({
+    required this.duration,
+    required this.curve,
+    super.key,
+  });
+
+  final Duration duration;
+
+  final Curve curve;
 
   @override
   State<AnimatedSizeExample> createState() => _AnimatedSizeExampleState();
 }
 
 class _AnimatedSizeExampleState extends State<AnimatedSizeExample> {
-  double _size = 50.0;
-  bool _large = false;
-
-  void _updateSize() {
-    setState(() {
-      _size = _large ? 250.0 : 100.0;
-      _large = !_large;
-    });
-  }
+  bool _isSelected = false;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => _updateSize(),
+      onTap: () {
+        setState(() {
+          _isSelected = !_isSelected;
+        });
+      },
       child: ColoredBox(
         color: Colors.amberAccent,
         child: AnimatedSize(
-          curve: Curves.easeIn,
-          duration: const Duration(seconds: 1),
-          child: FlutterLogo(size: _size),
+          duration: widget.duration,
+          curve: widget.curve,
+          child: SizedBox.square(
+            dimension: _isSelected ? 250.0 : 100.0,
+            child: const Center(
+              child: FlutterLogo(size: 75.0),
+            ),
+          ),
         ),
       ),
     );

--- a/examples/api/test/widgets/animated_size/animated_size.0_test.dart
+++ b/examples/api/test/widgets/animated_size/animated_size.0_test.dart
@@ -8,72 +8,69 @@ import 'package:flutter_api_samples/widgets/animated_size/animated_size.0.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets(
-    'AnimatedSize animates on tap',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const example.AnimatedSizeExampleApp(),
-      );
+  testWidgets('AnimatedSize animates on tap', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.AnimatedSizeExampleApp(),
+    );
 
-      const Size beginSize = Size.square(100.0);
-      const Size endSize = Size.square(250.0);
+    const Size beginSize = Size.square(100.0);
+    const Size endSize = Size.square(250.0);
 
-      RenderBox box = tester.renderObject(find.byType(AnimatedSize));
-      expect(box.size, equals(beginSize));
+    RenderBox box = tester.renderObject(find.byType(AnimatedSize));
+    expect(box.size, equals(beginSize));
 
-      // Tap on the AnimatedSize to start the forward animation.
-      await tester.tap(find.byType(AnimatedSize));
-      await tester.pump();
+    // Tap on the AnimatedSize to start the forward animation.
+    await tester.tap(find.byType(AnimatedSize));
+    await tester.pump();
 
-      box = tester.renderObject(find.byType(AnimatedSize));
-      expect(box.size, equals(beginSize));
+    box = tester.renderObject(find.byType(AnimatedSize));
+    expect(box.size, equals(beginSize));
 
-      // Advance animation to the middle.
-      await tester.pump(
-        example.AnimatedSizeExampleApp.duration ~/ 2,
-      );
+    // Advance animation to the middle.
+    await tester.pump(
+      example.AnimatedSizeExampleApp.duration ~/ 2,
+    );
 
-      final double t = example.AnimatedSizeExampleApp.curve.transform(0.5);
+    final double t = example.AnimatedSizeExampleApp.curve.transform(0.5);
 
-      box = tester.renderObject(find.byType(AnimatedSize));
-      expect(
-        box.size,
-        equals(Size.lerp(beginSize, endSize, t)),
-      );
+    box = tester.renderObject(find.byType(AnimatedSize));
+    expect(
+      box.size,
+      equals(Size.lerp(beginSize, endSize, t)),
+    );
 
-      // Advance animation to the end.
-      await tester.pump(
-        example.AnimatedSizeExampleApp.duration ~/ 2,
-      );
+    // Advance animation to the end.
+    await tester.pump(
+      example.AnimatedSizeExampleApp.duration ~/ 2,
+    );
 
-      box = tester.renderObject(find.byType(AnimatedSize));
-      expect(box.size, equals(endSize));
+    box = tester.renderObject(find.byType(AnimatedSize));
+    expect(box.size, equals(endSize));
 
-      // Tap on the AnimatedSize again to start the reverse animation.
-      await tester.tap(find.byType(AnimatedSize));
-      await tester.pump();
+    // Tap on the AnimatedSize again to start the reverse animation.
+    await tester.tap(find.byType(AnimatedSize));
+    await tester.pump();
 
-      box = tester.renderObject(find.byType(AnimatedSize));
-      expect(box.size, equals(endSize));
+    box = tester.renderObject(find.byType(AnimatedSize));
+    expect(box.size, equals(endSize));
 
-      // Advance animation to the middle.
-      await tester.pump(
-        example.AnimatedSizeExampleApp.duration ~/ 2,
-      );
+    // Advance animation to the middle.
+    await tester.pump(
+      example.AnimatedSizeExampleApp.duration ~/ 2,
+    );
 
-      box = tester.renderObject(find.byType(AnimatedSize));
-      expect(
-        box.size,
-        equals(Size.lerp(endSize, beginSize, t)),
-      );
+    box = tester.renderObject(find.byType(AnimatedSize));
+    expect(
+      box.size,
+      equals(Size.lerp(endSize, beginSize, t)),
+    );
 
-      // Advance animation to the end.
-      await tester.pump(
-        example.AnimatedSizeExampleApp.duration ~/ 2,
-      );
+    // Advance animation to the end.
+    await tester.pump(
+      example.AnimatedSizeExampleApp.duration ~/ 2,
+    );
 
-      box = tester.renderObject(find.byType(AnimatedSize));
-      expect(box.size, equals(beginSize));
-    },
-  );
+    box = tester.renderObject(find.byType(AnimatedSize));
+    expect(box.size, equals(beginSize));
+  });
 }

--- a/examples/api/test/widgets/animated_size/animated_size.0_test.dart
+++ b/examples/api/test/widgets/animated_size/animated_size.0_test.dart
@@ -1,0 +1,79 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/animated_size/animated_size.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'AnimatedSize animates on tap',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const example.AnimatedSizeExampleApp(),
+      );
+
+      const Size beginSize = Size.square(100.0);
+      const Size endSize = Size.square(250.0);
+
+      RenderBox box = tester.renderObject(find.byType(AnimatedSize));
+      expect(box.size, equals(beginSize));
+
+      // Tap on the AnimatedSize to start the forward animation.
+      await tester.tap(find.byType(AnimatedSize));
+      await tester.pump();
+
+      box = tester.renderObject(find.byType(AnimatedSize));
+      expect(box.size, equals(beginSize));
+
+      // Advance animation to the middle.
+      await tester.pump(
+        example.AnimatedSizeExampleApp.duration ~/ 2,
+      );
+
+      final double t = example.AnimatedSizeExampleApp.curve.transform(0.5);
+
+      box = tester.renderObject(find.byType(AnimatedSize));
+      expect(
+        box.size,
+        equals(Size.lerp(beginSize, endSize, t)),
+      );
+
+      // Advance animation to the end.
+      await tester.pump(
+        example.AnimatedSizeExampleApp.duration ~/ 2,
+      );
+
+      box = tester.renderObject(find.byType(AnimatedSize));
+      expect(box.size, equals(endSize));
+
+      // Tap on the AnimatedSize again to start the reverse animation.
+      await tester.tap(find.byType(AnimatedSize));
+      await tester.pump();
+
+      box = tester.renderObject(find.byType(AnimatedSize));
+      expect(box.size, equals(endSize));
+
+      // Advance animation to the middle.
+      await tester.pump(
+        example.AnimatedSizeExampleApp.duration ~/ 2,
+      );
+
+      box = tester.renderObject(find.byType(AnimatedSize));
+      expect(
+        box.size,
+        equals(Size.lerp(endSize, beginSize, t)),
+      );
+
+      // Advance animation to the end.
+      await tester.pump(
+        example.AnimatedSizeExampleApp.duration ~/ 2,
+      );
+
+      box = tester.renderObject(find.byType(AnimatedSize));
+      expect(box.size, equals(beginSize));
+    },
+  );
+}

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -12,8 +12,8 @@ import 'ticker_provider.dart';
 /// duration whenever the given child's size changes.
 ///
 /// {@tool dartpad}
-/// This example makes a [Container] react to being touched, causing the child
-/// of the [AnimatedSize] widget, here a [FlutterLogo], to animate.
+/// This example defines a widget that uses [AnimatedSize] to change the size of
+/// the [SizedBox] on tap.
 ///
 /// ** See code in examples/api/lib/widgets/animated_size/animated_size.0.dart **
 /// {@end-tool}


### PR DESCRIPTION
This PR contributes to https://github.com/flutter/flutter/issues/130459

### Description
- Updates `examples/api/lib/widgets/animated_size/animated_size.0.dart` API example by using `SizedBox` to size the surrounding of the `FlutterLogo` while setting the constant `FlutterLogo` size. This was done because `FlutterLogo` already has size animation under the hood, and the main goal of this example is to show `AnimatedSize` usage
- Adds test for `examples/api/lib/widgets/animated_size/animated_size.0.dart`

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.