### PR TITLE
Fix IDE Gradle sync being slow because of lockfile generation

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -217,11 +217,17 @@ class FlutterPlugin implements Plugin<Project> {
         Project rootProject = project.rootProject
         boolean lockfilesExist = true
         rootProject.subprojects.each { subproject ->
-            if (!(subproject.file("project-{subproject.name}.lockfile").exists() &&
-                  subproject.file("buildscript-gradle.lockfile").exists())) {
+            File projectLockfile = subproject.file("project-${subproject.name}.lockfile")
+            File buildscriptLockfile = subproject.file("buildscript-gradle.lockfile")
+
+            project.logger.quiet("Project lockfile: ${projectLockfile}")
+            project.logger.quiet("Buildscript lockfile: ${buildscriptLockfile}")
+
+            if (!(projectLockfile.exists() && subprojectLockfile.exists())) {
                 lockfilesExist = false
             }
         }
+        
         if (isFlutterAppProject() && !lockfilesExist) {
             rootProject.tasks.register("generateLockfiles") {
                 rootProject.subprojects.each { subproject ->

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -215,7 +215,15 @@ class FlutterPlugin implements Plugin<Project> {
         this.project = project
 
         Project rootProject = project.rootProject
-        if (isFlutterAppProject()) {
+        boolean lockfilesExist = true
+        rootProject.subprojects.each { subproject ->
+            if (!(subproject.file("project-{subproject.name}.lockfile").exists() &&
+                  subproject.file("buildscript-gradle.lockfile").exists())) {
+                lockfilesExist = false
+                break
+            }
+        }
+        if (isFlutterAppProject() && !lockfilesExist) {
             rootProject.tasks.register("generateLockfiles") {
                 rootProject.subprojects.each { subproject ->
                     String gradlew = (OperatingSystem.current().isWindows()) ?

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -220,8 +220,8 @@ class FlutterPlugin implements Plugin<Project> {
             File projectLockfile = subproject.file("project-${subproject.name}.lockfile")
             File buildscriptLockfile = subproject.file("buildscript-gradle.lockfile")
 
-            project.logger.quiet("Project lockfile: ${projectLockfile}")
-            project.logger.quiet("Buildscript lockfile: ${buildscriptLockfile}")
+            // project.logger.quiet("Project lockfile: ${projectLockfile}")
+            // project.logger.quiet("Buildscript lockfile: ${buildscriptLockfile}")
 
             if (!(projectLockfile.exists() && subprojectLockfile.exists())) {
                 lockfilesExist = false

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -220,7 +220,6 @@ class FlutterPlugin implements Plugin<Project> {
             if (!(subproject.file("project-{subproject.name}.lockfile").exists() &&
                   subproject.file("buildscript-gradle.lockfile").exists())) {
                 lockfilesExist = false
-                break
             }
         }
         if (isFlutterAppProject() && !lockfilesExist) {


### PR DESCRIPTION
I lost way too much time waiting for Gradle syncs to finish because of this problem, so I decided to take a stab at it.

This PR attempts to fix #110559

Revival of #112723

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.