### PR TITLE
[new gallery] Reisze gallery images

### DIFF
--- a/dev/integration_tests/new_gallery/lib/demos/material/cards_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/material/cards_demo.dart
@@ -298,6 +298,8 @@ class TravelDestinationContent extends StatelessWidget {
                     package: destination.assetPackage,
                   ),
                   fit: BoxFit.cover,
+                  width: 184,
+                  height: 184,
                   child: Container(),
                 ),
               ),

--- a/dev/integration_tests/new_gallery/lib/demos/material/cards_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/material/cards_demo.dart
@@ -298,8 +298,6 @@ class TravelDestinationContent extends StatelessWidget {
                     package: destination.assetPackage,
                   ),
                   fit: BoxFit.cover,
-                  width: 184,
-                  height: 184,
                   child: Container(),
                 ),
               ),

--- a/dev/integration_tests/new_gallery/lib/studies/crane/backdrop.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/crane/backdrop.dart
@@ -337,9 +337,13 @@ class _CraneAppBarState extends State<CraneAppBar> {
           children: <Widget>[
             const ExcludeSemantics(
               child: FadeInImagePlaceholder(
-                image: AssetImage(
-                  'crane/logo/logo.png',
-                  package: 'flutter_gallery_assets',
+                image: ResizeImage(
+                  AssetImage(
+                    'crane/logo/logo.png',
+                    package: 'flutter_gallery_assets',
+                  ),
+                  width: 40,
+                  height: 60,
                 ),
                 placeholder: SizedBox(
                   width: 40,

--- a/dev/integration_tests/new_gallery/lib/studies/crane/item_cards.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/crane/item_cards.dart
@@ -101,9 +101,13 @@ class _DestinationImage extends StatelessWidget {
       label: destination.assetSemanticLabel,
       child: ExcludeSemantics(
         child: FadeInImagePlaceholder(
-          image: AssetImage(
-            destination.assetName,
-            package: 'flutter_gallery_assets',
+          image: ResizeImage(
+            AssetImage(
+              destination.assetName,
+              package: 'flutter_gallery_assets',
+            ),
+            width: isDesktop ? null : mobileThumbnailSize.toInt(),
+            height: isDesktop ? null : mobileThumbnailSize.toInt(),
           ),
           fit: BoxFit.cover,
           width: isDesktop ? null : mobileThumbnailSize,


### PR DESCRIPTION
Some cause of jank on both Skia and Impeller are these massive images. We should just resize them so that the noise is reduced and we can see other performance issues.

Fixes https://github.com/flutter/flutter/issues/147797

Tested: this is a test!
