### PR TITLE
Revert "Move docs_test and docs_publish to bringup (#147645)"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -449,7 +449,6 @@ targets:
 
   - name: Linux docs_publish
     recipe: flutter/docs
-    bringup: true # https://github.com/flutter/flutter/issues/147609
     presubmit: false
     timeout: 60
     dimensions:
@@ -474,7 +473,6 @@ targets:
 
   - name: Linux docs_test
     recipe: flutter/flutter_drone
-    bringup: true # https://github.com/flutter/flutter/issues/147609
     timeout: 90 # https://github.com/flutter/flutter/issues/120901
     properties:
       cores: "32"


### PR DESCRIPTION
## Description

This reverts commit cb2197e9b3b179929b9f775b4263938dd823d491 to move `docs_test` and `docs_publish` back to normal mode after being fixed.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/147609
 - https://github.com/flutter/flutter/pull/147645
