### PR TITLE
Properly guard context access in then clauses

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/dialog_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/dialog_demo.dart
@@ -71,7 +71,7 @@ class DialogDemoState extends State<DialogDemo> {
       builder: (BuildContext context) => child!,
     )
     .then((T? value) { // The value passed to Navigator.pop() or null.
-      if (value != null) {
+      if (context.mounted && value != null) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text('You selected: $value'),
         ));
@@ -179,6 +179,9 @@ class DialogDemoState extends State<DialogDemo> {
                 initialTime: _selectedTime!,
               )
               .then((TimeOfDay? value) {
+                if (!mounted) {
+                  return;
+                }
                 if (value != null && value != _selectedTime) {
                   _selectedTime = value;
                   ScaffoldMessenger.of(context).showSnackBar(SnackBar(


### PR DESCRIPTION
Prepares for a fix to the `use_build_context_synchronously` lint (https://dart-review.googlesource.com/c/sdk/+/365541) that will complain about these unsafe usages.