### PR TITLE
Fix semantic debugger

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1219,30 +1219,24 @@ class PipelineOwner with DiagnosticableTreeMixin {
   SemanticsOwner? get semanticsOwner => _semanticsOwner;
   SemanticsOwner? _semanticsOwner;
 
-  /// The number of clients registered to listen for semantics.
+  /// Deprecated.
   ///
-  /// The number is increased whenever [ensureSemantics] is called and decreased
-  /// when [SemanticsHandle.dispose] is called.
+  /// Use [SemanticsBinding.debugOutstandingSemanticsHandles] instead.
+  @Deprecated(
+    'Use SemanticsBinding.debugOutstandingSemanticsHandles instead. '
+    'This feature was deprecated after 3.22.0-23.0.pre.',
+  )
   int get debugOutstandingSemanticsHandles => _outstandingSemanticsHandles;
   int _outstandingSemanticsHandles = 0;
 
-  /// Opens a [SemanticsHandle] and calls [listener] whenever the semantics tree
-  /// generated from the render tree owned by this [PipelineOwner] updates.
+  /// Deprecated.
   ///
-  /// Calling this method only ensures that this particular [PipelineOwner] will
-  /// generate a semantics tree. Consider calling
-  /// [SemanticsBinding.ensureSemantics] instead to turn on semantics globally
-  /// for the entire app.
-  ///
-  /// The [PipelineOwner] updates the semantics tree only when there are clients
-  /// that wish to use the semantics tree. These clients express their interest
-  /// by holding [SemanticsHandle] objects that notify them whenever the
-  /// semantics tree updates.
-  ///
-  /// Clients can close their [SemanticsHandle] by calling
-  /// [SemanticsHandle.dispose]. Once all the outstanding [SemanticsHandle]
-  /// objects for a given [PipelineOwner] are closed, the [PipelineOwner] stops
-  /// maintaining the semantics tree.
+  /// Call [SemanticsBinding.ensureSemantics] instead and optionally add a
+  /// listener to [PipelineOwner.semanticsOwner].
+  @Deprecated(
+    'Call SemanticsBinding.ensureSemantics instead and optionally add a listener to PipelineOwner.semanticsOwner. '
+    'This feature was deprecated after 3.22.0-23.0.pre.',
+  )
   SemanticsHandle ensureSemantics({ VoidCallback? listener }) {
     _outstandingSemanticsHandles += 1;
     _updateSemanticsOwner();

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1221,9 +1221,12 @@ class PipelineOwner with DiagnosticableTreeMixin {
 
   /// Deprecated.
   ///
-  /// Use [SemanticsBinding.debugOutstandingSemanticsHandles] instead.
+  /// Use [SemanticsBinding.debugOutstandingSemanticsHandles] instead. This
+  /// API is broken because an outstanding semantics handle on a given pipeline
+  /// owner doesn't mean that semantics are actually produced.
   @Deprecated(
     'Use SemanticsBinding.debugOutstandingSemanticsHandles instead. '
+    'This API is broken (see ensureSemantics).'
     'This feature was deprecated after 3.22.0-23.0.pre.',
   )
   int get debugOutstandingSemanticsHandles => _outstandingSemanticsHandles;
@@ -1232,9 +1235,11 @@ class PipelineOwner with DiagnosticableTreeMixin {
   /// Deprecated.
   ///
   /// Call [SemanticsBinding.ensureSemantics] instead and optionally add a
-  /// listener to [PipelineOwner.semanticsOwner].
+  /// listener to [PipelineOwner.semanticsOwner]. This API is broken as calling
+  /// it does not guarantee that semantics are produced.
   @Deprecated(
     'Call SemanticsBinding.ensureSemantics instead and optionally add a listener to PipelineOwner.semanticsOwner. '
+    'This API is broken; it does not guarantee that semantics are actually produced. '
     'This feature was deprecated after 3.22.0-23.0.pre.',
   )
   SemanticsHandle ensureSemantics({ VoidCallback? listener }) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1226,7 +1226,7 @@ class PipelineOwner with DiagnosticableTreeMixin {
   /// owner doesn't mean that semantics are actually produced.
   @Deprecated(
     'Use SemanticsBinding.debugOutstandingSemanticsHandles instead. '
-    'This API is broken (see ensureSemantics).'
+    'This API is broken (see ensureSemantics). '
     'This feature was deprecated after 3.22.0-23.0.pre.',
   )
   int get debugOutstandingSemanticsHandles => _outstandingSemanticsHandles;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1226,8 +1226,8 @@ class PipelineOwner with DiagnosticableTreeMixin {
   /// owner doesn't mean that semantics are actually produced.
   @Deprecated(
     'Use SemanticsBinding.debugOutstandingSemanticsHandles instead. '
-    'This API is broken, see ensureSemantics. '
-    'This feature was deprecated after 3.22.0-23.0.pre.'
+    'This API is broken (see ensureSemantics). '
+    'This feature was deprecated after v3.22.0-23.0.pre.'
   )
   int get debugOutstandingSemanticsHandles => _outstandingSemanticsHandles;
   int _outstandingSemanticsHandles = 0;
@@ -1239,8 +1239,8 @@ class PipelineOwner with DiagnosticableTreeMixin {
   /// it does not guarantee that semantics are produced.
   @Deprecated(
     'Call SemanticsBinding.ensureSemantics instead and optionally add a listener to PipelineOwner.semanticsOwner. '
-    'This API is broken. It does not guarantee that semantics are actually produced. '
-    'This feature was deprecated after 3.22.0-23.0.pre.'
+    'This API is broken; it does not guarantee that semantics are actually produced. '
+    'This feature was deprecated after v3.22.0-23.0.pre.'
   )
   SemanticsHandle ensureSemantics({ VoidCallback? listener }) {
     _outstandingSemanticsHandles += 1;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1226,8 +1226,8 @@ class PipelineOwner with DiagnosticableTreeMixin {
   /// owner doesn't mean that semantics are actually produced.
   @Deprecated(
     'Use SemanticsBinding.debugOutstandingSemanticsHandles instead. '
-    'This API is broken (see ensureSemantics). '
-    'This feature was deprecated after 3.22.0-23.0.pre.',
+    'This API is broken, see ensureSemantics. '
+    'This feature was deprecated after 3.22.0-23.0.pre.'
   )
   int get debugOutstandingSemanticsHandles => _outstandingSemanticsHandles;
   int _outstandingSemanticsHandles = 0;
@@ -1239,8 +1239,8 @@ class PipelineOwner with DiagnosticableTreeMixin {
   /// it does not guarantee that semantics are produced.
   @Deprecated(
     'Call SemanticsBinding.ensureSemantics instead and optionally add a listener to PipelineOwner.semanticsOwner. '
-    'This API is broken; it does not guarantee that semantics are actually produced. '
-    'This feature was deprecated after 3.22.0-23.0.pre.',
+    'This API is broken. It does not guarantee that semantics are actually produced. '
+    'This feature was deprecated after 3.22.0-23.0.pre.'
   )
   SemanticsHandle ensureSemantics({ VoidCallback? listener }) {
     _outstandingSemanticsHandles += 1;

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -45,31 +45,32 @@ class SemanticsDebugger extends StatefulWidget {
 }
 
 class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindingObserver {
-  _SemanticsClient? _client;
   PipelineOwner? _pipelineOwner;
+  SemanticsHandle? _semanticsHandle;
+  int _generation = 0;
 
   @override
   void initState() {
     super.initState();
+    _semanticsHandle = SemanticsBinding.instance.ensureSemantics();
     WidgetsBinding.instance.addObserver(this);
   }
 
-  @override
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final PipelineOwner newOwner = View.pipelineOwnerOf(context);
     if (newOwner != _pipelineOwner) {
-      _client?.dispose();
-      _client = _SemanticsClient(newOwner)
-        ..addListener(_update);
+      _pipelineOwner?.semanticsOwner?.removeListener(_update);
+      newOwner.semanticsOwner!.addListener(_update);
       _pipelineOwner = newOwner;
     }
   }
 
   @override
   void dispose() {
-    _client?.dispose();
+    _pipelineOwner?.semanticsOwner?.removeListener(_update);
+    _semanticsHandle?.dispose();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -82,6 +83,7 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
   }
 
   void _update() {
+    _generation++;
     SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
       // Semantic information are only available at the end of a frame and our
       // only chance to paint them on the screen is the next frame. To achieve
@@ -157,7 +159,7 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
     return CustomPaint(
       foregroundPainter: _SemanticsDebuggerPainter(
         _pipelineOwner!,
-        _client!.generation,
+        _generation,
         _lastPointerDownLocation, // in physical pixels
         View.of(context).devicePixelRatio,
         widget.labelStyle,
@@ -177,42 +179,6 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
         ),
       ),
     );
-  }
-}
-
-class _SemanticsClient extends ChangeNotifier {
-  _SemanticsClient(PipelineOwner pipelineOwner) {
-    // TODO(polina-c): stop duplicating code across disposables
-    // https://github.com/flutter/flutter/issues/137435
-    if (kFlutterMemoryAllocationsEnabled) {
-      FlutterMemoryAllocations.instance.dispatchObjectCreated(
-        library: 'package:flutter/widgets.dart',
-        className: '$_SemanticsClient',
-        object: this,
-      );
-    }
-    _semanticsHandle = pipelineOwner.ensureSemantics(
-      listener: _didUpdateSemantics,
-    );
-  }
-
-  SemanticsHandle? _semanticsHandle;
-
-  @override
-  void dispose() {
-    if (kFlutterMemoryAllocationsEnabled) {
-      FlutterMemoryAllocations.instance.dispatchObjectDisposed(object: this);
-    }
-    _semanticsHandle!.dispose();
-    _semanticsHandle = null;
-    super.dispose();
-  }
-
-  int generation = 0;
-
-  void _didUpdateSemantics() {
-    generation += 1;
-    notifyListeners();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -60,6 +60,7 @@ class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindi
   void didChangeDependencies() {
     super.didChangeDependencies();
     final PipelineOwner newOwner = View.pipelineOwnerOf(context);
+    assert(newOwner.semanticsOwner != null);
     if (newOwner != _pipelineOwner) {
       _pipelineOwner?.semanticsOwner?.removeListener(_update);
       newOwner.semanticsOwner!.addListener(_update);

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1415,11 +1415,10 @@ void main() {
     );
 
     int semanticsUpdateCount = 0;
-    TestRenderingFlutterBinding.instance.pipelineOwner.ensureSemantics(
-      listener: () {
-        ++semanticsUpdateCount;
-      },
-    );
+    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.ensureSemantics();
+    TestRenderingFlutterBinding.instance.pipelineOwner.semanticsOwner!.addListener(() {
+      ++semanticsUpdateCount;
+    });
 
     layout(paragraph);
 
@@ -1453,6 +1452,8 @@ void main() {
     data = children.single.getSemanticsData();
     expect(data.hasAction(SemanticsAction.longPress), true);
     expect(data.hasAction(SemanticsAction.tap), false);
+
+    semanticsHandle.dispose();
   });
 }
 

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -47,11 +47,10 @@ void main() {
         child: platformViewRenderBox,
       );
       int semanticsUpdateCount = 0;
-      final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.rootPipelineOwner.ensureSemantics(
-        listener: () {
-          ++semanticsUpdateCount;
-        },
-      );
+      final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.ensureSemantics();
+      TestRenderingFlutterBinding.instance.pipelineOwner.semanticsOwner!.addListener(() {
+        ++semanticsUpdateCount;
+      });
       layout(tree, phase: EnginePhase.flushSemantics);
       // Initial semantics update
       expect(semanticsUpdateCount, 1);

--- a/packages/flutter/test/rendering/reattach_test.dart
+++ b/packages/flutter/test/rendering/reattach_test.dart
@@ -135,11 +135,10 @@ void main() {
   test('objects can be detached and re-attached: semantics (no change)', () {
     final TestTree testTree = TestTree();
     int semanticsUpdateCount = 0;
-    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.pipelineOwner.ensureSemantics(
-      listener: () {
-        ++semanticsUpdateCount;
-      },
-    );
+    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.ensureSemantics();
+    TestRenderingFlutterBinding.instance.pipelineOwner.semanticsOwner!.addListener(() {
+      ++semanticsUpdateCount;
+    });
     // Lay out, composite, paint, and update semantics
     layout(testTree.root, phase: EnginePhase.flushSemantics);
     expect(semanticsUpdateCount, 1);
@@ -158,11 +157,10 @@ void main() {
   test('objects can be detached and re-attached: semantics (with change)', () {
     final TestTree testTree = TestTree();
     int semanticsUpdateCount = 0;
-    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.pipelineOwner.ensureSemantics(
-      listener: () {
-        ++semanticsUpdateCount;
-      },
-    );
+    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.ensureSemantics();
+    TestRenderingFlutterBinding.instance.pipelineOwner.semanticsOwner!.addListener(() {
+      ++semanticsUpdateCount;
+    });
     // Lay out, composite, paint, and update semantics
     layout(testTree.root, phase: EnginePhase.flushSemantics);
     expect(semanticsUpdateCount, 1);

--- a/packages/flutter/test/rendering/simple_semantics_test.dart
+++ b/packages/flutter/test/rendering/simple_semantics_test.dart
@@ -20,8 +20,9 @@ void main() {
       child: testRender,
     );
     int semanticsUpdateCount = 0;
-    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.pipelineOwner.ensureSemantics(
-      listener: () {
+    final SemanticsHandle semanticsHandle = TestRenderingFlutterBinding.instance.ensureSemantics();
+    TestRenderingFlutterBinding.instance.pipelineOwner.semanticsOwner!.addListener(
+      () {
         ++semanticsUpdateCount;
       },
     );

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -545,6 +545,22 @@ void main() {
 
     expect(_getMessageShownInSemanticsDebugger(widgetKey: label, debuggerKey: debugger, tester: tester), '\u2067ملصق\u2069');
   });
+
+  testWidgets('SemanticsDebugger turns on semantics.', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/147665.
+    expect(tester.binding.semanticsEnabled, isFalse);
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: SemanticsDebugger(
+          child: Semantics(
+            label: 'Hello World',
+          ),
+        ),
+      ),
+    );
+    expect(tester.binding.semanticsEnabled, isTrue);
+  }, semanticsEnabled: false);
 }
 
 String _getMessageShownInSemanticsDebugger({

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -713,11 +713,9 @@ void main() {
   testWidgets('Actions can be replaced without triggering semantics update', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     int semanticsUpdateCount = 0;
-    final SemanticsHandle handle = tester.binding.pipelineOwner.ensureSemantics(
-      listener: () {
-        semanticsUpdateCount += 1;
-      },
-    );
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
+      semanticsUpdateCount += 1;
+    });
 
     final List<String> performedActions = <String>[];
 
@@ -803,7 +801,6 @@ void main() {
     expect(semantics, hasSemantics(expectedSemantics));
     expect(semanticsUpdateCount, 1);
 
-    handle.dispose();
     semantics.dispose();
   });
 
@@ -887,11 +884,9 @@ void main() {
   testWidgets('Semantics widgets built in a widget tree are sorted properly', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     int semanticsUpdateCount = 0;
-    final SemanticsHandle handle = tester.binding.pipelineOwner.ensureSemantics(
-      listener: () {
-        semanticsUpdateCount += 1;
-      },
-    );
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
+      semanticsUpdateCount += 1;
+    });
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -963,18 +958,15 @@ void main() {
       ignoreRect: true,
     ));
 
-    handle.dispose();
     semantics.dispose();
   });
 
   testWidgets('Semantics widgets built with explicit sort orders are sorted properly', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     int semanticsUpdateCount = 0;
-    final SemanticsHandle handle = tester.binding.pipelineOwner.ensureSemantics(
-      listener: () {
-        semanticsUpdateCount += 1;
-      },
-    );
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
+      semanticsUpdateCount += 1;
+    });
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -1021,18 +1013,15 @@ void main() {
       ignoreRect: true,
     ));
 
-    handle.dispose();
     semantics.dispose();
   });
 
   testWidgets('Semantics widgets without sort orders are sorted properly', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     int semanticsUpdateCount = 0;
-    final SemanticsHandle handle = tester.binding.pipelineOwner.ensureSemantics(
-      listener: () {
-        semanticsUpdateCount += 1;
-      },
-    );
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
+      semanticsUpdateCount += 1;
+    });
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -1082,18 +1071,15 @@ void main() {
       ignoreId: true,
     ));
 
-    handle.dispose();
     semantics.dispose();
   });
 
   testWidgets('Semantics widgets that are transformed are sorted properly', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     int semanticsUpdateCount = 0;
-    final SemanticsHandle handle = tester.binding.pipelineOwner.ensureSemantics(
-      listener: () {
-        semanticsUpdateCount += 1;
-      },
-    );
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
+      semanticsUpdateCount += 1;
+    });
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
@@ -1146,14 +1132,13 @@ void main() {
       ignoreId: true,
     ));
 
-    handle.dispose();
     semantics.dispose();
   });
 
   testWidgets('Semantics widgets without sort orders are sorted properly when no Directionality is present', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     int semanticsUpdateCount = 0;
-    final SemanticsHandle handle = tester.binding.pipelineOwner.ensureSemantics(listener: () {
+    tester.binding.pipelineOwner.semanticsOwner!.addListener(() {
       semanticsUpdateCount += 1;
     });
     await tester.pumpWidget(
@@ -1247,7 +1232,6 @@ void main() {
       ),
     );
 
-    handle.dispose();
     semantics.dispose();
   });
 


### PR DESCRIPTION
This was broken in https://github.com/flutter/flutter/pull/122452. The culprit is that `PipelineOwner.ensureSemantics` doesn't turn on semantics for the entire app, it pretends to only turn it on for the local `PipelineOwner`. Unfortunately, that local `PipelineOwner` is never informed that it should produce semantics when semantics are not turned on globally. So, `PipelineOwner.ensureSemantics` is essentially without effect if semantics are not already turned on globally.

I can't think of a use case where it would be useful to only turn on semantics for a particular pipeline owner and fixing `PipelineOwner.ensureSemantics` would get pretty messy with performance implications even if semantics are turned off. So, this PR deprecates that functionality and moves the `SemanticsDebugger` to the global semantics API.

Fixes https://github.com/flutter/flutter/issues/147665.