### PR TITLE
Tweak to fix context.mounted in dialog_demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/dialog_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/dialog_demo.dart
@@ -179,7 +179,7 @@ class DialogDemoState extends State<DialogDemo> {
                 initialTime: _selectedTime!,
               )
               .then((TimeOfDay? value) {
-                if (!mounted) {
+                if (!context.mounted) {
                   return;
                 }
                 if (value != null && value != _selectedTime) {


### PR DESCRIPTION
Prepares for a fix to the `use_build_context_synchronously` lint (https://dart-review.googlesource.com/c/sdk/+/365541) that will complain about these unsafe usages.

The lint rule cannot tell that the `mounted` field is shorthand for `context.mounted`.

