### PR TITLE
Fix the second TextFormField to trigger onTapOutside.

### DIFF
--- a/packages/flutter/lib/src/widgets/tap_region.dart
+++ b/packages/flutter/lib/src/widgets/tap_region.dart
@@ -277,6 +277,9 @@ class RenderTapRegionSurface extends RenderProxyBoxWithHitTestBehavior implement
     for (final RenderTapRegion region in insideRegions) {
       assert(_tapRegionDebug('Calling onTapInside for $region'));
       region.onTapInside?.call(event);
+      if(!hitRegions.contains(region)) {
+        region.onTapOutside?.call(event);
+      }
     }
 
     // If any of the "outside" regions have consumeOutsideTaps set, then stop

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -193,6 +193,77 @@ void main() {
     skip: kIsWeb, // [intended]
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/127597
+  testWidgets(
+    'TapRegionSurface detects outside right click',
+        (WidgetTester tester) async {
+      String tappedOutside = '';
+      final GlobalKey keyA = GlobalKey();
+      final GlobalKey keyB = GlobalKey();
+      final GlobalKey keyC = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: Column(
+              children: <Widget>[
+                const Text('Outside'),
+                Material(
+                  child: TextFormField(
+                    key: keyA,
+                    onTapOutside: (PointerDownEvent event) {
+                      tappedOutside = 'outside callback A';
+                    },
+                  ),
+                ),
+                Material(
+                  child: TextFormField(
+                    key: keyB,
+                    onTapOutside: (PointerDownEvent event) {
+                      tappedOutside = 'outside callback B';
+                    },
+                  ),
+                ),
+                Material(
+                  child: TextFormField(
+                    key: keyC,
+                    onTapOutside: (PointerDownEvent event) {
+                      tappedOutside = 'outside callback C';
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      Future<void> click(Finder finder) async {
+        await tester.tap(finder);
+        await tester.enterText(finder, 'Hello');
+        await tester.pump();
+      }
+
+      expect(tappedOutside, isEmpty);
+
+      await click(find.byKey(keyA));
+      await tester.showKeyboard(find.byKey(keyA));
+      await tester.idle();
+      expect(tappedOutside, isEmpty);
+
+      await click(find.byKey(keyB));
+      expect(tappedOutside == 'outside callback A', true);
+
+      await click(find.byKey(keyC));
+      expect(tappedOutside == 'outside callback B', true);
+
+      await tester.tap(find.text('Outside'));
+      expect(tappedOutside == 'outside callback C', true);
+    },
+  );
+
   // Regression test for https://github.com/flutter/flutter/issues/126312.
   testWidgets('when open input connection in didUpdateWidget, should not throw', (WidgetTester tester) async {
     final Key key = GlobalKey();


### PR DESCRIPTION
This PR attempts to fix https://github.com/flutter/flutter/issues/127597

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
