### PR TITLE
SelectionArea's selection should not be cleared on loss of window focus

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1884,8 +1884,8 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   /// a test environment where the [BuildOwner] which initializes its own
   /// [FocusManager], may not have the accurate platform context during its
   /// initialization. In this case it is necessary for the test framework to call
-  /// method after it has setup the test variant for a given test, so the
-  /// [FocusManager] can accurately listen to application lifecycle changes if
+  /// this method after it has set up the test variant for a given test, so the
+  /// [FocusManager] can accurately listen to application lifecycle changes, if
   /// supported.
   @visibleForTesting
   void listenToApplicationLifecycleChangesIfSupported() {

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1873,6 +1873,33 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
     }());
   }
 
+  /// Enables this [FocusManager] to listen to changes of the application
+  /// lifecycle if it does not already have an application lifecycle listener
+  /// active, and the current platform is detected as [kIsWeb] or non-Android.
+  ///
+  /// Typically, the application lifecycle listener for this [FocusManager] is
+  /// setup at construction, but sometimes it is necessary to manually initialize
+  /// it when the [FocusManager] does not have the relevant platform context in
+  /// [defaultTargetPlatform] at the time of construction. This can happen in
+  /// a test environment where the [BuildOwner] which initializes its own
+  /// [FocusManager], may not have the accurate platform context during its
+  /// initialization. In this case it is necessary for the test framework to call
+  /// method after it has setup the test variant for a given test, so the
+  /// [FocusManager] can accurately listen to application lifecycle changes if
+  /// supported.
+  void listenToApplicationLifecycleChangesIfSupported() {
+    if (_appLifecycleListener == null && (kIsWeb || defaultTargetPlatform != TargetPlatform.android)) {
+      // It appears that some Android keyboard implementations can cause
+      // app lifecycle state changes: adding this listener would cause the
+      // text field to unfocus as the user is trying to type.
+      //
+      // Until this is resolved, we won't be adding the listener to Android apps.
+      // https://github.com/flutter/flutter/pull/142930#issuecomment-1981750069
+      _appLifecycleListener = _AppLifecycleListener(_appLifecycleChange);
+      WidgetsBinding.instance.addObserver(_appLifecycleListener!);
+    }
+  }
+
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
     return <DiagnosticsNode>[

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1887,6 +1887,7 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   /// method after it has setup the test variant for a given test, so the
   /// [FocusManager] can accurately listen to application lifecycle changes if
   /// supported.
+  @visibleForTesting
   void listenToApplicationLifecycleChangesIfSupported() {
     if (_appLifecycleListener == null && (kIsWeb || defaultTargetPlatform != TargetPlatform.android)) {
       // It appears that some Android keyboard implementations can cause

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -454,7 +454,11 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       if (kIsWeb) {
         PlatformSelectableRegionContextMenu.detach(_selectionDelegate);
       }
-      _clearSelection();
+      if (SchedulerBinding.instance.lifecycleState == AppLifecycleState.resumed) {
+        // We should only clear the selection when this SelectableRegion loses
+        // focus while the application is currently running.
+        _clearSelection();
+      }
     }
     if (kIsWeb) {
       PlatformSelectableRegionContextMenu.attach(_selectionDelegate);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -456,7 +456,12 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       }
       if (SchedulerBinding.instance.lifecycleState == AppLifecycleState.resumed) {
         // We should only clear the selection when this SelectableRegion loses
-        // focus while the application is currently running.
+        // focus while the application is currently running. It is possible
+        // that the application is not currently running, for example on desktop
+        // platforms, clicking on a different window switches the focus to
+        // the new window causing the Flutter application to go inactive. In this
+        // case we want to retain the selection so it remains when we return to
+        // the Flutter application.
         _clearSelection();
       }
     }

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -416,7 +416,7 @@ void main() {
 
       await setAppLifecycleState(AppLifecycleState.resumed);
       expect(focusNode.hasPrimaryFocus, isTrue);
-    });
+    }, variant: TargetPlatformVariant.desktop());
 
     testWidgets('Node is removed completely even if app is paused.', (WidgetTester tester) async {
       Future<void> setAppLifecycleState(AppLifecycleState state) async {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -254,19 +254,14 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _testTextInput.register();
     }
     CustomSemanticsAction.resetForTests(); // ignore: invalid_use_of_visible_for_testing_member
-    _resetFocusManager();
+    _enableFocusManagerLifecycleAwarenessIfSupported();
   }
 
-  void _resetFocusManager() {
+  void _enableFocusManagerLifecycleAwarenessIfSupported() {
     if (buildOwner == null) {
       return;
     }
-    // It's necessary to save the highlight strategy as it may have been changed
-    // in the setUp method.
-    final FocusHighlightStrategy savedFocusHighlightStrategy = buildOwner!.focusManager.highlightStrategy;
-    buildOwner!.focusManager.dispose();
-    buildOwner!.focusManager = FocusManager()..registerGlobalHandlers();
-    buildOwner!.focusManager.highlightStrategy = savedFocusHighlightStrategy;
+    buildOwner!.focusManager.listenToApplicationLifecycleChangesIfSupported();
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -261,8 +261,12 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     if (buildOwner == null) {
       return;
     }
+    // It's necessary to save the highlight strategy as it may have been changed
+    // in the setUp method.
+    final FocusHighlightStrategy savedFocusHighlightStrategy = buildOwner!.focusManager.highlightStrategy;
     buildOwner!.focusManager.dispose();
     buildOwner!.focusManager = FocusManager()..registerGlobalHandlers();
+    buildOwner!.focusManager.highlightStrategy = savedFocusHighlightStrategy;
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -261,7 +261,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     if (buildOwner == null) {
       return;
     }
-    buildOwner!.focusManager.listenToApplicationLifecycleChangesIfSupported();
+    buildOwner!.focusManager.listenToApplicationLifecycleChangesIfSupported(); // ignore: invalid_use_of_visible_for_testing_member
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -254,6 +254,15 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _testTextInput.register();
     }
     CustomSemanticsAction.resetForTests(); // ignore: invalid_use_of_visible_for_testing_member
+    _resetFocusManager();
+  }
+
+  void _resetFocusManager() {
+    if (buildOwner == null) {
+      return;
+    }
+    buildOwner!.focusManager.dispose();
+    buildOwner!.focusManager = FocusManager()..registerGlobalHandlers();
   }
 
   @override

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -151,9 +151,9 @@ void testWidgets(
   LeakTesting? experimentalLeakTesting,
 }) {
   assert(variant.values.isNotEmpty, 'There must be at least one value to test in the testing variant.');
+  final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+  final WidgetTester tester = WidgetTester._(binding);
   for (final dynamic value in variant.values) {
-    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-    final WidgetTester tester = WidgetTester._(binding);
     final String variationDescription = variant.describeValue(value);
     // IDEs may make assumptions about the format of this suffix in order to
     // support running tests directly from the editor (where they may have

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -151,9 +151,9 @@ void testWidgets(
   LeakTesting? experimentalLeakTesting,
 }) {
   assert(variant.values.isNotEmpty, 'There must be at least one value to test in the testing variant.');
-  final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-  final WidgetTester tester = WidgetTester._(binding);
   for (final dynamic value in variant.values) {
+    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+    final WidgetTester tester = WidgetTester._(binding);
     final String variationDescription = variant.describeValue(value);
     // IDEs may make assumptions about the format of this suffix in order to
     // support running tests directly from the editor (where they may have
@@ -174,11 +174,11 @@ void testWidgets(
         test_package.addTearDown(binding.postTest);
         return binding.runTest(
           () async {
-            binding.reset(); // TODO(ianh): the binding should just do this itself in _runTest
             debugResetSemanticsIdCounter();
             Object? memento;
             try {
               memento = await variant.setUp(value);
+              binding.reset(); // TODO(ianh): the binding should just do this itself in _runTest
               maybeSetupLeakTrackingForTest(experimentalLeakTesting, combinedDescription);
               await callback(tester);
             } finally {


### PR DESCRIPTION
This change fixes an issue where SelectionArea would clear its selection when the application window lost focus by first checking if the application is running. This is needed because `FocusManager` is aware of the application lifecycle as of https://github.com/flutter/flutter/pull/142930 , and triggers a focus lost if the application is not active.

Also fixes an issue where the `FocusManager` was not being reset on tests at the right time, causing it always to build with `TargetPlatform.android` as its context.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.