### PR TITLE
Adds Getter for floatingActionButtonLocation in ScaffoldState

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2136,6 +2136,11 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   final RestorableBool _drawerOpened = RestorableBool(false);
   final RestorableBool _endDrawerOpened = RestorableBool(false);
 
+  /// The current position of [FloatingActionButton] in [Scaffold].
+  ///
+  /// defaults to [_kDefaultFloatingActionButtonLocation].
+  FloatingActionButtonLocation get floatingActionButtonLocation => _floatingActionButtonLocation!;
+
   /// Whether the [Scaffold.drawer] is opened.
   ///
   /// See also:

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3395,6 +3395,48 @@ void main() {
     // FAB is not visible.
     expect(find.byType(FloatingActionButton), findsNothing);
   });
+
+  testWidgets('Getter for floatingActionButtonLocation', (WidgetTester tester) async {
+    FloatingActionButtonLocation fabLocation = FloatingActionButtonLocation.endFloat;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              floatingActionButtonLocation: fabLocation,
+              body: Builder(
+                builder: (BuildContext context) {
+                  return Column(
+                    children: <Widget>[
+                      Text(Scaffold.of(context).floatingActionButtonLocation.toString()),
+                      ElevatedButton(
+                        onPressed: () {
+                          setState(() {
+                            fabLocation = FloatingActionButtonLocation.centerFloat;
+                          });
+                        },
+                        child: const Text('Update FAB Location'),
+                      ),
+                    ],
+                  );
+                }
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () {},
+                child: const Icon(Icons.add),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('FloatingActionButtonLocation.endFloat'), findsOneWidget);
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Update FAB Location'));
+    await tester.pump();
+    expect(find.text('FloatingActionButtonLocation.centerFloat'), findsOneWidget);
+  });
 }
 
 class _GeometryListener extends StatefulWidget {


### PR DESCRIPTION
Adds Getter for floatingActionButtonLocation in ScaffoldState.

Fixes #147804 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
