### PR TITLE
Make FileSystem dependency explicit througout (more).

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -293,6 +293,7 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
       baseDirectory,
       log: log,
       platform: platform,
+      fs: fs,
     );
     await goldens.auth();
     return FlutterPostSubmitFileComparator(
@@ -384,6 +385,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
       baseDirectory,
       platform: platform,
       log: log,
+      fs: fs,
     );
 
     await goldens.auth();
@@ -470,6 +472,7 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
       fs.directory(basedir),
       platform: platform,
       log: log,
+      fs: fs,
     );
     return FlutterSkippingFileComparator(
       basedir,
@@ -571,6 +574,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
       baseDirectory,
       platform: platform,
       log: log,
+      fs: fs,
     );
     try {
       // Check if we can reach Gold.

--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -8,7 +8,6 @@ import 'dart:io' as io;
 
 import 'package:crypto/crypto.dart';
 import 'package:file/file.dart';
-import 'package:file/local.dart';
 import 'package:path/path.dart' as path;
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
@@ -50,7 +49,7 @@ class SkiaGoldClient {
   /// override the defaults for [fs], [process], and [httpClient].
   SkiaGoldClient(
     this.workDirectory, {
-    this.fs = const LocalFileSystem(),
+    required this.fs,
     this.process = const LocalProcessManager(),
     required this.platform,
     Abi? abi,


### PR DESCRIPTION
This is part 14 of a broken down version of the #140101 refactor.

This is an extension of part 8 (#146008), which had omitted removing the filesystem dependency in the SkiaGoldClient class.

This only makes one dependency explicit. Further PRs will do the same for other dependencies, until these APIs have no hidden dependencies.

This particular change attempts to be minimal. I made no effort to keep the order of parameters reasonable here. I have a TODO to do a refactor sweep later that does nothing but reorder arguments/parameters/fields to be consistent.
