### PR TITLE
Fix `MaterialStateBorderSide` lerp in the `Checkbox` and chips

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_theme.dart
+++ b/packages/flutter/lib/src/material/checkbox_theme.dart
@@ -201,7 +201,13 @@ class CheckboxThemeData with Diagnosticable {
     if (identical(a, b)) {
       return a;
     }
-    return BorderSide.lerp(a, b, t);
+    if (a is MaterialStateBorderSide) {
+      a = a.resolve(<WidgetState>{});
+    }
+    if (b is MaterialStateBorderSide) {
+      b = b.resolve(<WidgetState>{});
+    }
+    return BorderSide.lerp(a!, b!, t);
   }
 }
 

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -546,6 +546,12 @@ class ChipThemeData with Diagnosticable {
     if (a == null && b == null) {
       return null;
     }
+    if (a is MaterialStateBorderSide) {
+      a = a.resolve(<WidgetState>{});
+    }
+    if (b is MaterialStateBorderSide) {
+      b = b.resolve(<WidgetState>{});
+    }
     if (a == null) {
       return BorderSide.lerp(BorderSide(width: 0, color: b!.color.withAlpha(0)), b, t);
     }

--- a/packages/flutter/test/material/checkbox_theme_test.dart
+++ b/packages/flutter/test/material/checkbox_theme_test.dart
@@ -471,6 +471,47 @@ void main() {
     expect(lerped.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2.5))));
     expect(lerped.side, const BorderSide(width: 3.5));
   });
+
+  testWidgets('MaterialStateBorderSide properly lerp in CheckboxThemeData.side', (WidgetTester tester) async {
+    late ColorScheme colorScheme;
+
+    Widget buildCheckbox({ required  Color seedColor }) {
+      colorScheme = ColorScheme.fromSeed(seedColor: seedColor);
+      return MaterialApp(
+        theme: ThemeData(
+          colorScheme: colorScheme,
+          checkboxTheme: CheckboxThemeData(
+            side: MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
+              return BorderSide(
+                color: colorScheme.primary,
+                width: 4.0,
+              );
+            }),
+          ),
+        ),
+        home: Scaffold(
+          body: Checkbox(
+            value: false,
+            onChanged: (_) { },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildCheckbox(seedColor: Colors.red));
+    await tester.pumpAndSettle();
+
+    RenderBox getCheckboxRendeBox() {
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
+    }
+
+    expect(getCheckboxRendeBox(), paints..drrect(color: colorScheme.primary));
+
+    await tester.pumpWidget(buildCheckbox(seedColor: Colors.blue));
+    await tester.pump(kPressTimeout);
+
+    expect(getCheckboxRendeBox(), paints..drrect(color: colorScheme.primary));
+  });
 }
 
 Future<void> _pointGestureToCheckbox(WidgetTester tester) async {

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -1483,6 +1483,44 @@ void main() {
     expect(getIconStyle(tester, deleteIcon)?.color, deleteIconColor);
   });
 
+   // This is a regression test for https://github.com/flutter/flutter/issues/135136.
+  testWidgets('MaterialStateBorderSide properly lerp in ChipThemeData.side', (WidgetTester tester) async {
+    late ColorScheme colorScheme;
+
+    Widget buildChip({ required  Color seedColor }) {
+      colorScheme = ColorScheme.fromSeed(seedColor: seedColor);
+      return MaterialApp(
+        theme: ThemeData(
+          colorScheme: colorScheme,
+          chipTheme: ChipThemeData(
+            side: MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
+              return BorderSide(
+                color: colorScheme.primary,
+                width: 4.0,
+              );
+            }),
+          ),
+        ),
+        home: const Scaffold(
+          body: RawChip(label: Text('Chip')),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildChip(seedColor: Colors.red));
+    await tester.pumpAndSettle();
+
+    RenderBox getChipRenderBox() {
+      return tester.renderObject<RenderBox>(find.byType(RawChip));
+    }
+
+    expect(getChipRenderBox(), paints..drrect(color: colorScheme.primary));
+
+    await tester.pumpWidget(buildChip(seedColor: Colors.blue));
+    await tester.pump(kPressTimeout);
+
+    expect(getChipRenderBox(), paints..drrect(color: colorScheme.primary));
+  });
 }
 
 class _MaterialStateOutlinedBorder extends StadiumBorder implements MaterialStateOutlinedBorder {


### PR DESCRIPTION
fixes [`Checkbox` and Chips side with `MaterialStateBorderSide` doesn't lerp in their theme](https://github.com/flutter/flutter/issues/135136)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';
import 'package:flutter_test/flutter_test.dart';

void main() {
  testWidgets('test', (WidgetTester tester) async {
    late ColorScheme colorScheme;

    Widget buildCheckbox({required Color seedColor}) {
      colorScheme = ColorScheme.fromSeed(seedColor: seedColor);
      return MaterialApp(
        theme: ThemeData(
          colorScheme: colorScheme,
          checkboxTheme: CheckboxThemeData(
            side: MaterialStateBorderSide.resolveWith(
                (Set<MaterialState> states) {
              return BorderSide(
                color: colorScheme.primary,
                width: 4.0,
              );
            }),
          ),
        ),
        home: Scaffold(
          body: Center(
            child: Checkbox(
              value: false,
              onChanged: (_) {},
            ),
          ),
        ),
      );
    }

    await tester.pumpWidget(buildCheckbox(seedColor: Colors.red));
    await tester.pumpAndSettle();

    RenderBox getCheckboxRenderer() {
      return tester.renderObject<RenderBox>(find.byType(Checkbox));
    }

    expect(getCheckboxRenderer(), paints..drrect(color: colorScheme.primary));

    await Future<void>.delayed(const Duration(seconds: 3));

    await tester.pumpWidget(buildCheckbox(seedColor: Colors.blue));
    await tester.pump();

    await Future<void>.delayed(const Duration(seconds: 3));

    expect(getCheckboxRenderer(), paints..drrect(color: colorScheme.primary));
  });
}
```

</details>

| Before | After |
| --------------- | --------------- |
| <img src="https://github.com/flutter/flutter/assets/48603081/6df34104-37ba-4a82-b5cb-7ed4f887992a" /> | <img src="https://github.com/flutter/flutter/assets/48603081/44359248-a101-46eb-a85a-77f976da5f0f"  /> |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
