### PR TITLE
Add DropdownButton.menuWidth

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -237,6 +237,7 @@ class _DropdownMenu<T> extends StatefulWidget {
     required this.enableFeedback,
     this.borderRadius,
     required this.scrollController,
+    this.menuWidth,
   });
 
   final _DropdownRoute<T> route;
@@ -247,6 +248,7 @@ class _DropdownMenu<T> extends StatefulWidget {
   final bool enableFeedback;
   final BorderRadius? borderRadius;
   final ScrollController scrollController;
+  final double? menuWidth;
 
   @override
   _DropdownMenuState<T> createState() => _DropdownMenuState<T>();
@@ -371,11 +373,13 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     required this.buttonRect,
     required this.route,
     required this.textDirection,
+    this.menuWidth,
   });
 
   final Rect buttonRect;
   final _DropdownRoute<T> route;
   final TextDirection? textDirection;
+  final double? menuWidth;
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
@@ -389,7 +393,7 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     }
     // The width of a menu should be at most the view width. This ensures that
     // the menu does not extend past the left and right edges of the screen.
-    final double width = math.min(constraints.maxWidth, buttonRect.width);
+    final double width = math.min(constraints.maxWidth, menuWidth ?? buttonRect.width);
     return BoxConstraints(
       minWidth: width,
       maxWidth: width,
@@ -465,6 +469,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     required this.style,
     this.barrierLabel,
     this.itemHeight,
+    this.menuWidth,
     this.dropdownColor,
     this.menuMaxHeight,
     required this.enableFeedback,
@@ -479,6 +484,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   final CapturedThemes capturedThemes;
   final TextStyle style;
   final double? itemHeight;
+  final double? menuWidth;
   final Color? dropdownColor;
   final double? menuMaxHeight;
   final bool enableFeedback;
@@ -515,6 +521,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
           dropdownColor: dropdownColor,
           enableFeedback: enableFeedback,
           borderRadius: borderRadius,
+          menuWidth: menuWidth,
         );
       },
     );
@@ -624,6 +631,7 @@ class _DropdownRoutePage<T> extends StatefulWidget {
     required this.dropdownColor,
     required this.enableFeedback,
     this.borderRadius,
+    this.menuWidth,
   });
 
   final _DropdownRoute<T> route;
@@ -638,6 +646,7 @@ class _DropdownRoutePage<T> extends StatefulWidget {
   final Color? dropdownColor;
   final bool enableFeedback;
   final BorderRadius? borderRadius;
+  final double? menuWidth;
 
   @override
   State<_DropdownRoutePage<T>> createState() => _DropdownRoutePageState<T>();
@@ -690,6 +699,7 @@ class _DropdownRoutePageState<T> extends State<_DropdownRoutePage<T>> {
               buttonRect: widget.buttonRect,
               route: widget.route,
               textDirection: textDirection,
+              menuWidth: widget.menuWidth,
             ),
             child: widget.capturedThemes.wrap(menu),
           );
@@ -966,6 +976,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.isDense = false,
     this.isExpanded = false,
     this.itemHeight = kMinInteractiveDimension,
+    this.menuWidth,
     this.focusColor,
     this.focusNode,
     this.autofocus = false,
@@ -1010,6 +1021,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.isDense = false,
     this.isExpanded = false,
     this.itemHeight = kMinInteractiveDimension,
+    this.menuWidth,
     this.focusColor,
     this.focusNode,
     this.autofocus = false,
@@ -1189,6 +1201,12 @@ class DropdownButton<T> extends StatefulWidget {
   /// offset is computed as if all of the menu item heights were
   /// [kMinInteractiveDimension].
   final double? itemHeight;
+
+  /// The width of the menu.
+  ///
+  /// If it is not provided, the width of the menu is the width of the
+  /// dropdown button.
+  final double? menuWidth;
 
   /// The color for the button's [Material] when it has the input focus.
   final Color? focusColor;
@@ -1381,6 +1399,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       style: _textStyle!,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       itemHeight: widget.itemHeight,
+      menuWidth: widget.menuWidth,
       dropdownColor: widget.dropdownColor,
       menuMaxHeight: widget.menuMaxHeight,
       enableFeedback: widget.enableFeedback ?? true,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -59,6 +59,7 @@ Widget buildDropdown({
     List<String>? items = menuItems,
     List<Widget> Function(BuildContext)? selectedItemBuilder,
     double? itemHeight = kMinInteractiveDimension,
+    double? menuWidth,
     AlignmentDirectional alignment = AlignmentDirectional.centerStart,
     TextDirection textDirection = TextDirection.ltr,
     Size? mediaSize,
@@ -127,6 +128,7 @@ Widget buildDropdown({
     items: listItems,
     selectedItemBuilder: selectedItemBuilder,
     itemHeight: itemHeight,
+    menuWidth: menuWidth,
     alignment: alignment,
     menuMaxHeight: menuMaxHeight,
     padding: padding,
@@ -150,6 +152,7 @@ Widget buildFrame({
   List<String>? items = menuItems,
   List<Widget> Function(BuildContext)? selectedItemBuilder,
   double? itemHeight = kMinInteractiveDimension,
+  double? menuWidth,
   AlignmentDirectional alignment = AlignmentDirectional.centerStart,
   TextDirection textDirection = TextDirection.ltr,
   Size? mediaSize,
@@ -194,6 +197,7 @@ Widget buildFrame({
               items: items,
               selectedItemBuilder: selectedItemBuilder,
               itemHeight: itemHeight,
+              menuWidth: menuWidth,
               alignment: alignment,
               menuMaxHeight: menuMaxHeight,
               padding: padding,
@@ -285,6 +289,21 @@ void checkSelectedItemTextGeometry(WidgetTester tester, String value) {
   final RenderBox box1 = boxes[1];
   expect(box0.localToGlobal(Offset.zero), equals(box1.localToGlobal(Offset.zero)));
   expect(box0.size, equals(box1.size));
+}
+
+// The dropdown menu isn't readily accessible. To find it we're assuming that it
+// contains a ListView and that it's an instance of _DropdownMenu.
+Rect getMenuRect(WidgetTester tester) {
+  late Rect menuRect;
+  tester.element(find.byType(ListView)).visitAncestorElements((Element element) {
+    if (element.toString().startsWith('_DropdownMenu')) {
+      final RenderBox box = element.findRenderObject()! as RenderBox;
+      menuRect = box.localToGlobal(Offset.zero) & box.size;
+      return false;
+    }
+    return true;
+  });
+  return menuRect;
 }
 
 Future<void> checkDropdownColor(WidgetTester tester, {Color? color, bool isFormField = false }) async {
@@ -1142,22 +1161,6 @@ void main() {
   });
 
   testWidgets('Dropdown menus must fit within the screen', (WidgetTester tester) async {
-
-    // The dropdown menu isn't readily accessible. To find it we're assuming that it
-    // contains a ListView and that it's an instance of _DropdownMenu.
-    Rect getMenuRect() {
-      late Rect menuRect;
-      tester.element(find.byType(ListView)).visitAncestorElements((Element element) {
-        if (element.toString().startsWith('_DropdownMenu')) {
-          final RenderBox box = element.findRenderObject()! as RenderBox;
-          menuRect = box.localToGlobal(Offset.zero) & box.size;
-          return false;
-        }
-        return true;
-      });
-      return menuRect;
-    }
-
     // In all of the tests that follow we're assuming that the dropdown menu
     // is horizontally aligned with the center of the dropdown button and padded
     // on the top, left, and right.
@@ -1176,7 +1179,7 @@ void main() {
       await tester.pumpWidget(frame);
       await tester.tap(find.byType(dropdownButtonType));
       await tester.pumpAndSettle();
-      menuRect = getMenuRect();
+      menuRect = getMenuRect(tester);
       buttonRect = getExpandedButtonRect();
       await tester.tap(find.byType(dropdownButtonType, skipOffstage: false), warnIfMissed: false);
     }
@@ -1846,6 +1849,33 @@ void main() {
       expect(dropdownButtonRenderBox.size.width, 125 + 24.0);
     },
   );
+
+  testWidgets('Menu width is correct when set', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/133267.
+    final List<String> items = <String>['25', '50', '100'];
+    const String selectedItem = '25';
+
+    await tester.pumpWidget(buildFrame(
+      value: selectedItem,
+      items: items,
+      menuWidth: 200,
+      selectedItemBuilder: (BuildContext context) {
+        return items.map<Widget>((String item) {
+          return SizedBox(
+            height: double.parse(item),
+            width: double.parse(item),
+            child: Center(child: Text(item)),
+          );
+        }).toList();
+      },
+      onChanged: (String? newValue) {},
+    ));
+
+    await tester.tap(find.text('25'));
+    await tester.pumpAndSettle();
+
+    expect(getMenuRect(tester).width, 200);
+  });
 
   testWidgets('Dropdown in middle showing middle item', (WidgetTester tester) async {
     final List<DropdownMenuItem<int>> items = List<DropdownMenuItem<int>>.generate(


### PR DESCRIPTION
## Description

This PRs add a new parameter to `DropdownButton` which allows to set the menu width.
This can be useful when `DropdownButton.selectedItemBuilder` is provided and builds small items, see https://github.com/flutter/flutter/issues/133267.

I’m not fond of adding new property, especially for a widget which is supposed to be replaced on M3, but in this case it might makes sense because it is a way to not break existing code while addressing a legitimate issue.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/133267.

## Tests

Adds 1 test.