### PR TITLE
Docs on TextField disposed by a scrollable

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -126,9 +126,14 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// disposed.
 /// {@endtemplate}
 ///
-/// Remember to call [TextEditingController.dispose] of the [TextEditingController]
+/// Remember to call [TextEditingController.dispose] on the [TextEditingController]
 /// when it is no longer needed. This will ensure we discard any resources used
 /// by the object.
+///
+/// If this field is part of a scrolling container that lazily constructs its
+/// children, like a [ListView] or a [CustomScrollView], then a [controller]
+/// should be specified. The controller's lifetime should be managed by a
+/// stateful widget ancestor of the scrolling container.
 ///
 /// ## Obscured Input
 ///


### PR DESCRIPTION
TextFormField already has [some docs](https://github.com/flutter/flutter/blob/8e53ad917ce2218a235e7bee0a3f5a576e7ebd16/packages/flutter/lib/src/material/text_form_field.dart#L30-L34) about making sure that your TextEditingController isn't disposed in a ListView.builder. This PR just mentions the same thing in TextField's docs too.

Fixes https://github.com/flutter/flutter/issues/14104