### PR TITLE
When polling `adb` for devices, run `adb reconnect` first

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -85,6 +85,9 @@ void main() {
   testWithoutContext('AndroidDevices throwsToolExit on failing adb', () {
     final ProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
+        command: <String>['adb', 'reconnect'],
+      ),
+      const FakeCommand(
         command: <String>['adb', 'devices', '-l'],
         exitCode: 1,
         stderr: '<stderr from adb>'
@@ -105,6 +108,7 @@ void main() {
       throwsToolExit(
         message:
           'Unable to run "adb", check your Android SDK installation and ANDROID_HOME environment variable: adb\n'
+          'Command: adb devices -l\n'
           'Error details: Process exited abnormally with exit code 1:\n'
           '<stderr from adb>',
       ),
@@ -138,6 +142,9 @@ void main() {
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
+          command: <String>['adb', 'reconnect'],
+        ),
+        const FakeCommand(
           command: <String>['adb', 'devices', '-l'],
           stdout: '''
 List of devices attached
@@ -166,6 +173,9 @@ List of devices attached
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
+          command: <String>['adb', 'reconnect'],
+        ),
+        const FakeCommand(
           command: <String>['adb', 'devices', '-l'],
           stdout: '''
 List of devices attached
@@ -193,6 +203,9 @@ List of devices attached
       androidSdk: FakeAndroidSdk(),
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['adb', 'reconnect'],
+        ),
         const FakeCommand(
           command: <String>['adb', 'devices', '-l'],
           stdout: '''
@@ -223,6 +236,9 @@ emulator-5612          host features:shell_2
       androidSdk: FakeAndroidSdk(),
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['adb', 'reconnect'],
+        ),
         const FakeCommand(
           command: <String>['adb', 'devices', '-l'],
           stdout: '''


### PR DESCRIPTION
Attempts to resolve https://github.com/flutter/flutter/issues/148193

See https://github.com/flutter/flutter/issues/125971#issuecomment-2101147423 for the inspiration of this code change. To summarize, we will call `adb reconnect` before running `adb devices -l`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
