### PR TITLE
PageController: added default [duration] and [curve] values to animateToPage, nextPage and previousPage methods

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart' show clampDouble, precisionErrorTolerance;
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/material/motion.dart';
 
 import 'basic.dart';
 import 'debug.dart';
@@ -182,11 +183,12 @@ class PageController extends ScrollController {
   /// Animates the controlled [PageView] from the current page to the given page.
   ///
   /// The animation lasts for the given duration and follows the given curve.
+  /// By default, [curve] is [Easing.standard] and [duration] is 400ms.
   /// The returned [Future] resolves when the animation completes.
   Future<void> animateToPage(
     int page, {
-    required Duration duration,
-    required Curve curve,
+    Duration duration = Durations.medium4,
+    Curve curve = Easing.standard,
   }) {
     final _PagePosition position = this.position as _PagePosition;
     if (position._cachedPage != null) {
@@ -218,16 +220,24 @@ class PageController extends ScrollController {
   /// Animates the controlled [PageView] to the next page.
   ///
   /// The animation lasts for the given duration and follows the given curve.
+  /// By default, [curve] is [Easing.standard] and [duration] is 400ms.
   /// The returned [Future] resolves when the animation completes.
-  Future<void> nextPage({ required Duration duration, required Curve curve }) {
+  Future<void> nextPage({
+    Duration duration = Durations.medium4,
+    Curve curve = Easing.standard,
+  }) {
     return animateToPage(page!.round() + 1, duration: duration, curve: curve);
   }
 
   /// Animates the controlled [PageView] to the previous page.
   ///
   /// The animation lasts for the given duration and follows the given curve.
+  /// By default, [curve] is [Easing.standard] and [duration] is 400ms.
   /// The returned [Future] resolves when the animation completes.
-  Future<void> previousPage({ required Duration duration, required Curve curve }) {
+  Future<void> previousPage({
+    Duration duration = Durations.medium4,
+    Curve curve = Easing.standard,
+  }) {
     return animateToPage(page!.round() - 1, duration: duration, curve: curve);
   }
 

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -187,7 +187,7 @@ class PageController extends ScrollController {
   /// The returned [Future] resolves when the animation completes.
   Future<void> animateToPage(
     int page, {
-    Duration duration = Durations.medium4,
+    Duration duration = Durations.medium2,
     Curve curve = Easing.standard,
   }) {
     final _PagePosition position = this.position as _PagePosition;
@@ -223,7 +223,7 @@ class PageController extends ScrollController {
   /// By default, [curve] is [Easing.standard] and [duration] is 400ms.
   /// The returned [Future] resolves when the animation completes.
   Future<void> nextPage({
-    Duration duration = Durations.medium4,
+    Duration duration = Durations.medium2,
     Curve curve = Easing.standard,
   }) {
     return animateToPage(page!.round() + 1, duration: duration, curve: curve);
@@ -235,7 +235,7 @@ class PageController extends ScrollController {
   /// By default, [curve] is [Easing.standard] and [duration] is 400ms.
   /// The returned [Future] resolves when the animation completes.
   Future<void> previousPage({
-    Duration duration = Durations.medium4,
+    Duration duration = Durations.medium2,
     Curve curve = Easing.standard,
   }) {
     return animateToPage(page!.round() - 1, duration: duration, curve: curve);

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -6,8 +6,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show clampDouble, precisionErrorTolerance;
 import 'package:flutter/gestures.dart' show DragStartBehavior;
+import 'package:flutter/material.dart' show Durations, Easing;
 import 'package:flutter/rendering.dart';
-import 'package:flutter/src/material/motion.dart';
 
 import 'basic.dart';
 import 'debug.dart';


### PR DESCRIPTION
This PR adds default [duration] and [curve] parameters to the animateToPage, nextPage and previousPage methods in the PageController

This PR addresses the issue: https://github.com/flutter/flutter/issues/37568

This change doesn't require changing any tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
