### PR TITLE
Add test for undo_history_controller.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -443,7 +443,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/notification_listener/notification.0_test.dart',
   'examples/api/test/widgets/editable_text/text_editing_controller.0_test.dart',
   'examples/api/test/widgets/editable_text/editable_text.on_changed.0_test.dart',
-  'examples/api/test/widgets/undo_history/undo_history_controller.0_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.1_test.dart',
   'examples/api/test/widgets/overscroll_indicator/glowing_overscroll_indicator.0_test.dart',
   'examples/api/test/widgets/tween_animation_builder/tween_animation_builder.0_test.dart',

--- a/examples/api/test/widgets/undo_history/undo_history_controller.0_test.dart
+++ b/examples/api/test/widgets/undo_history/undo_history_controller.0_test.dart
@@ -12,20 +12,23 @@ void main() {
       const example.UndoHistoryControllerExampleApp(),
     );
 
+    // Equals to UndoHistoryState._kThrottleDuration.
+    const Duration kThrottleDuration = Duration(milliseconds: 500);
+
     expect(find.byType(TextField), findsOne);
     expect(find.widgetWithText(TextButton, 'Undo'), findsOne);
     expect(find.widgetWithText(TextButton, 'Redo'), findsOne);
 
     await tester.enterText(find.byType(TextField), '1st change');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(kThrottleDuration);
     expect(find.text('1st change'), findsOne);
 
     await tester.enterText(find.byType(TextField), '2nd change');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(kThrottleDuration);
     expect(find.text('2nd change'), findsOne);
 
     await tester.enterText(find.byType(TextField), '3rd change');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(kThrottleDuration);
     expect(find.text('3rd change'), findsOne);
 
     await tester.tap(find.text('Undo'));

--- a/examples/api/test/widgets/undo_history/undo_history_controller.0_test.dart
+++ b/examples/api/test/widgets/undo_history/undo_history_controller.0_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/undo_history/undo_history_controller.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The undo history controller should undo and redo the history changes', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.UndoHistoryControllerExampleApp(),
+    );
+
+    expect(find.byType(TextField), findsOne);
+    expect(find.widgetWithText(TextButton, 'Undo'), findsOne);
+    expect(find.widgetWithText(TextButton, 'Redo'), findsOne);
+
+    await tester.enterText(find.byType(TextField), '1st change');
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('1st change'), findsOne);
+
+    await tester.enterText(find.byType(TextField), '2nd change');
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('2nd change'), findsOne);
+
+    await tester.enterText(find.byType(TextField), '3rd change');
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('3rd change'), findsOne);
+
+    await tester.tap(find.text('Undo'));
+    await tester.pump();
+    expect(find.text('2nd change'), findsOne);
+
+    await tester.tap(find.text('Undo'));
+    await tester.pump();
+    expect(find.text('1st change'), findsOne);
+
+    await tester.tap(find.text('Redo'));
+    await tester.pump();
+    expect(find.text('2nd change'), findsOne);
+
+    await tester.tap(find.text('Redo'));
+    await tester.pump();
+    expect(find.text('3rd change'), findsOne);
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds test for `examples/api/test/widgets/undo_history/undo_history_controller.0_test.dart`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
