### PR TITLE
Fix the second TextFormField to trigger onTapOutside

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -221,6 +221,7 @@ class CupertinoTextField extends StatefulWidget {
   ///    characters" and how it may differ from the intuitive meaning.
   const CupertinoTextField({
     super.key,
+    this.groupId = EditableText,
     this.controller,
     this.focusNode,
     this.undoController,
@@ -351,6 +352,7 @@ class CupertinoTextField extends StatefulWidget {
   ///    characters" and how it may differ from the intuitive meaning.
   const CupertinoTextField.borderless({
     super.key,
+    this.groupId = EditableText,
     this.controller,
     this.focusNode,
     this.undoController,
@@ -445,6 +447,9 @@ class CupertinoTextField extends StatefulWidget {
        ),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        enableInteractiveSelection = enableInteractiveSelection ?? (!readOnly || !obscureText);
+
+  /// {@macro flutter.widgets.editableText.groupId}
+  final Object? groupId;
 
   /// Controls the text being edited.
   ///
@@ -1387,6 +1392,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
             selectionColor: _effectiveFocusNode.hasFocus ? selectionColor : null,
             selectionControls: widget.selectionEnabled
               ? textSelectionControls : null,
+            groupId: widget.groupId,
             onChanged: widget.onChanged,
             onSelectionChanged: _handleSelectionChanged,
             onEditingComplete: widget.onEditingComplete,

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -449,7 +449,7 @@ class CupertinoTextField extends StatefulWidget {
        enableInteractiveSelection = enableInteractiveSelection ?? (!readOnly || !obscureText);
 
   /// {@macro flutter.widgets.editableText.groupId}
-  final Object? groupId;
+  final Object groupId;
 
   /// Controls the text being edited.
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -370,7 +370,7 @@ class TextField extends StatefulWidget {
   final TextMagnifierConfiguration? magnifierConfiguration;
 
   /// {@macro flutter.widgets.editableText.groupId}
-  final Object? groupId;
+  final Object groupId;
 
   /// Controls the text being edited.
   ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -259,7 +259,7 @@ class TextField extends StatefulWidget {
   ///    characters" and how it may differ from the intuitive meaning.
   const TextField({
     super.key,
-    this.groupId,
+    this.groupId = EditableText,
     this.controller,
     this.focusNode,
     this.undoController,
@@ -369,11 +369,7 @@ class TextField extends StatefulWidget {
   /// {@end-tool}
   final TextMagnifierConfiguration? magnifierConfiguration;
 
-  /// {@template flutter.widgets.editableText.groupId}
-  /// Assign a separate click area to each text field, groupId object.
-  ///
-  /// If this property is null, [EditableText] will be used.
-  /// {@endtemplate}
+  /// {@macro flutter.widgets.editableText.groupId}
   final Object? groupId;
 
   /// Controls the text being edited.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -259,6 +259,7 @@ class TextField extends StatefulWidget {
   ///    characters" and how it may differ from the intuitive meaning.
   const TextField({
     super.key,
+    this.groupId,
     this.controller,
     this.focusNode,
     this.undoController,
@@ -367,6 +368,13 @@ class TextField extends StatefulWidget {
   /// ** See code in examples/api/lib/widgets/text_magnifier/text_magnifier.0.dart **
   /// {@end-tool}
   final TextMagnifierConfiguration? magnifierConfiguration;
+
+  /// {@template flutter.widgets.editableText.groupId}
+  /// Assign a separate click area to each text field, groupId object.
+  ///
+  /// If this property is null, [EditableText] will be used.
+  /// {@endtemplate}
+  final Object? groupId;
 
   /// Controls the text being edited.
   ///
@@ -1499,6 +1507,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           onEditingComplete: widget.onEditingComplete,
           onSubmitted: widget.onSubmitted,
           onAppPrivateCommand: widget.onAppPrivateCommand,
+          groupId: widget.groupId,
           onSelectionHandleTapped: _handleSelectionHandleTapped,
           onTapOutside: widget.onTapOutside,
           inputFormatters: formatters,

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -101,7 +101,7 @@ class TextFormField extends FormField<String> {
   /// and [TextField.new], the constructor.
   TextFormField({
     super.key,
-    this.groupId,
+    this.groupId = EditableText,
     this.controller,
     String? initialValue,
     FocusNode? focusNode,
@@ -281,11 +281,7 @@ class TextFormField extends FormField<String> {
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
 
-  /// {@template flutter.widgets.editableText.groupId}
-  /// Assign a separate click area to each text field, groupId object.
-  ///
-  /// If this property is null, [EditableText] will be used.
-  /// {@endtemplate}
+  /// {@macro flutter.widgets.editableText.groupId}
   final Object? groupId;
 
   /// {@template flutter.material.TextFormField.onChanged}

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -101,6 +101,7 @@ class TextFormField extends FormField<String> {
   /// and [TextField.new], the constructor.
   TextFormField({
     super.key,
+    this.groupId,
     this.controller,
     String? initialValue,
     FocusNode? focusNode,
@@ -203,6 +204,7 @@ class TextFormField extends FormField<String> {
            return UnmanagedRestorationScope(
              bucket: field.bucket,
              child: TextField(
+               groupId: groupId,
                restorationId: restorationId,
                controller: state._effectiveController,
                focusNode: focusNode,
@@ -278,6 +280,13 @@ class TextFormField extends FormField<String> {
   /// If null, this widget will create its own [TextEditingController] and
   /// initialize its [TextEditingController.text] with [initialValue].
   final TextEditingController? controller;
+
+  /// {@template flutter.widgets.editableText.groupId}
+  /// Assign a separate click area to each text field, groupId object.
+  ///
+  /// If this property is null, [EditableText] will be used.
+  /// {@endtemplate}
+  final Object? groupId;
 
   /// {@template flutter.material.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -282,7 +282,7 @@ class TextFormField extends FormField<String> {
   final TextEditingController? controller;
 
   /// {@macro flutter.widgets.editableText.groupId}
-  final Object? groupId;
+  final Object groupId;
 
   /// {@template flutter.material.TextFormField.onChanged}
   /// Called when the user initiates a change to the TextField's

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1479,7 +1479,8 @@ class EditableText extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///  * [TextFieldTapRegion], for the provision of a separate tap region.
+  ///  * [TextFieldTapRegion], to give a [groupId] to a widget that is to be
+  ///    included in a [EditableText]'s tap region that has [groupId] set.
   /// {@endtemplate}
   final Object groupId;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1476,6 +1476,10 @@ class EditableText extends StatefulWidget {
   ///
   /// Text fields with the same group identifier share the same tap region.
   /// Defaults to the type of [EditableText].
+  ///
+  /// See also:
+  ///
+  ///  * [TextFieldTapRegion], for the provision of a separate tap region.
   /// {@endtemplate}
   final Object groupId;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -841,7 +841,7 @@ class EditableText extends StatefulWidget {
     this.onAppPrivateCommand,
     this.onSelectionChanged,
     this.onSelectionHandleTapped,
-    this.groupId,
+    this.groupId = EditableText,
     this.onTapOutside,
     List<TextInputFormatter>? inputFormatters,
     this.mouseCursor,
@@ -1477,7 +1477,7 @@ class EditableText extends StatefulWidget {
   /// Text fields with the same group identifier share the same tap region.
   /// Defaults to the type of [EditableText].
   /// {@endtemplate}
-  final Object? groupId;
+  final Object groupId;
 
   /// {@template flutter.widgets.editableText.onTapOutside}
   /// Called for each tap that occurs outside of the[TextFieldTapRegion] group
@@ -5180,7 +5180,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       compositeCallback: _compositeCallback,
       enabled: _hasInputConnection,
       child: TextFieldTapRegion(
-        groupId: _hasFocus ? widget.groupId ?? EditableText : null,
+        groupId: _hasFocus ? widget.groupId : null,
         onTapOutside: _hasFocus ? widget.onTapOutside ?? _defaultOnTapOutside : null,
         debugLabel: kReleaseMode ? null : 'EditableText',
         child: MouseRegion(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1472,9 +1472,10 @@ class EditableText extends StatefulWidget {
   final VoidCallback? onSelectionHandleTapped;
 
   /// {@template flutter.widgets.editableText.groupId}
-  /// Assign a separate click area to each text field, groupId object.
+  /// The group identifier for the [TextFieldTapRegion] of this text field.
   ///
-  /// If this property is null, [EditableText] will be used.
+  /// Text fields with the same group identifier share the same tap region.
+  /// Defaults to the type of [EditableText].
   /// {@endtemplate}
   final Object? groupId;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -841,6 +841,7 @@ class EditableText extends StatefulWidget {
     this.onAppPrivateCommand,
     this.onSelectionChanged,
     this.onSelectionHandleTapped,
+    this.groupId,
     this.onTapOutside,
     List<TextInputFormatter>? inputFormatters,
     this.mouseCursor,
@@ -1469,6 +1470,13 @@ class EditableText extends StatefulWidget {
 
   /// {@macro flutter.widgets.SelectionOverlay.onSelectionHandleTapped}
   final VoidCallback? onSelectionHandleTapped;
+
+  /// {@template flutter.widgets.editableText.groupId}
+  /// Assign a separate click area to each text field, groupId object.
+  ///
+  /// If this property is null, [EditableText] will be used.
+  /// {@endtemplate}
+  final Object? groupId;
 
   /// {@template flutter.widgets.editableText.onTapOutside}
   /// Called for each tap that occurs outside of the[TextFieldTapRegion] group
@@ -5171,6 +5179,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       compositeCallback: _compositeCallback,
       enabled: _hasInputConnection,
       child: TextFieldTapRegion(
+        groupId: widget.groupId,
         onTapOutside: _hasFocus ? widget.onTapOutside ?? _defaultOnTapOutside : null,
         debugLabel: kReleaseMode ? null : 'EditableText',
         child: MouseRegion(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5179,7 +5179,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       compositeCallback: _compositeCallback,
       enabled: _hasInputConnection,
       child: TextFieldTapRegion(
-        groupId: widget.groupId,
+        groupId: _hasFocus ? widget.groupId ?? EditableText : null,
         onTapOutside: _hasFocus ? widget.onTapOutside ?? _defaultOnTapOutside : null,
         debugLabel: kReleaseMode ? null : 'EditableText',
         child: MouseRegion(

--- a/packages/flutter/lib/src/widgets/tap_region.dart
+++ b/packages/flutter/lib/src/widgets/tap_region.dart
@@ -636,5 +636,5 @@ class TextFieldTapRegion extends TapRegion {
     super.consumeOutsideTaps,
     super.debugLabel,
     super.groupId = EditableText,
-  }) : super();
+  });
 }

--- a/packages/flutter/lib/src/widgets/tap_region.dart
+++ b/packages/flutter/lib/src/widgets/tap_region.dart
@@ -635,5 +635,6 @@ class TextFieldTapRegion extends TapRegion {
     super.onTapInside,
     super.consumeOutsideTaps,
     super.debugLabel,
-  }) : super(groupId: EditableText);
+    super.groupId = EditableText,
+  }) : super();
 }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -910,6 +910,81 @@ void main() {
   );
 
   testWidgets(
+    'The second CupertinoTextField is clicked, triggers the onTapOutside callback of the previous CupertinoTextField',
+        (WidgetTester tester) async {
+      final GlobalKey keyA = GlobalKey();
+      final GlobalKey keyB = GlobalKey();
+      final GlobalKey keyC = GlobalKey();
+      bool outsideClickA = false;
+      bool outsideClickB = false;
+      bool outsideClickC = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: Column(
+              children: <Widget>[
+                const Text('Outside'),
+                Material(
+                  child: CupertinoTextField(
+                    key: keyA,
+                    groupId: 'Group A',
+                    onTapOutside: (PointerDownEvent event) {
+                      outsideClickA = true;
+                    },
+                  ),
+                ),
+                Material(
+                  child: CupertinoTextField(
+                    key: keyB,
+                    groupId: 'Group B',
+                    onTapOutside: (PointerDownEvent event) {
+                      outsideClickB = true;
+                    },
+                  ),
+                ),
+                Material(
+                  child: CupertinoTextField(
+                    key: keyC,
+                    groupId: 'Group C',
+                    onTapOutside: (PointerDownEvent event) {
+                      outsideClickC = true;
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      Future<void> click(Finder finder) async {
+        await tester.tap(finder);
+        await tester.enterText(finder, 'Hello');
+        await tester.pump();
+      }
+
+      expect(outsideClickA, false);
+
+      await click(find.byKey(keyA));
+      await tester.showKeyboard(find.byKey(keyA));
+      await tester.idle();
+      expect(outsideClickA, false);
+
+      await click(find.byKey(keyB));
+      expect(outsideClickA, true);
+
+      await click(find.byKey(keyC));
+      expect(outsideClickB, true);
+
+      await tester.tap(find.text('Outside'));
+      expect(outsideClickC, true);
+    },
+  );
+
+  testWidgets(
     'decoration can be overridden',
     (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -967,19 +967,29 @@ void main() {
       }
 
       expect(outsideClickA, false);
+      expect(outsideClickB, false);
+      expect(outsideClickC, false);
 
       await click(find.byKey(keyA));
       await tester.showKeyboard(find.byKey(keyA));
       await tester.idle();
       expect(outsideClickA, false);
+      expect(outsideClickB, false);
+      expect(outsideClickC, false);
 
       await click(find.byKey(keyB));
       expect(outsideClickA, true);
+      expect(outsideClickB, false);
+      expect(outsideClickC, false);
 
       await click(find.byKey(keyC));
+      expect(outsideClickA, true);
       expect(outsideClickB, true);
+      expect(outsideClickC, false);
 
       await tester.tap(find.text('Outside'));
+      expect(outsideClickA, true);
+      expect(outsideClickB, true);
       expect(outsideClickC, true);
     },
   );

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -883,19 +883,29 @@ void main() {
       }
 
       expect(outsideClickA, false);
+      expect(outsideClickB, false);
+      expect(outsideClickC, false);
 
       await click(find.byKey(keyA));
       await tester.showKeyboard(find.byKey(keyA));
       await tester.idle();
       expect(outsideClickA, false);
+      expect(outsideClickB, false);
+      expect(outsideClickC, false);
 
       await click(find.byKey(keyB));
       expect(outsideClickA, true);
+      expect(outsideClickB, false);
+      expect(outsideClickC, false);
 
       await click(find.byKey(keyC));
+      expect(outsideClickA, true);
       expect(outsideClickB, true);
+      expect(outsideClickC, false);
 
       await tester.tap(find.text('Outside'));
+      expect(outsideClickA, true);
+      expect(outsideClickB, true);
       expect(outsideClickC, true);
     },
   );

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -824,6 +824,82 @@ void main() {
     expect(tapOutsideCount, 0);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/127597.
+  testWidgets(
+    'The second TextFormField is clicked, triggers the onTapOutside callback of the previous TextFormField',
+        (WidgetTester tester) async {
+      final GlobalKey keyA = GlobalKey();
+      final GlobalKey keyB = GlobalKey();
+      final GlobalKey keyC = GlobalKey();
+      bool outsideClickA = false;
+      bool outsideClickB = false;
+      bool outsideClickC = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: Column(
+              children: <Widget>[
+                const Text('Outside'),
+                Material(
+                  child: TextFormField(
+                    key: keyA,
+                    groupId: 'Group A',
+                    onTapOutside: (PointerDownEvent event) {
+                      outsideClickA = true;
+                    },
+                  ),
+                ),
+                Material(
+                  child: TextFormField(
+                    key: keyB,
+                    groupId: 'Group B',
+                    onTapOutside: (PointerDownEvent event) {
+                      outsideClickB = true;
+                    },
+                  ),
+                ),
+                Material(
+                  child: TextFormField(
+                    key: keyC,
+                    groupId: 'Group C',
+                    onTapOutside: (PointerDownEvent event) {
+                      outsideClickC = true;
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      Future<void> click(Finder finder) async {
+        await tester.tap(finder);
+        await tester.enterText(finder, 'Hello');
+        await tester.pump();
+      }
+
+      expect(outsideClickA, false);
+
+      await click(find.byKey(keyA));
+      await tester.showKeyboard(find.byKey(keyA));
+      await tester.idle();
+      expect(outsideClickA, false);
+
+      await click(find.byKey(keyB));
+      expect(outsideClickA, true);
+
+      await click(find.byKey(keyC));
+      expect(outsideClickB, true);
+
+      await tester.tap(find.text('Outside'));
+      expect(outsideClickC, true);
+    },
+  );
+
   // Regression test for https://github.com/flutter/flutter/issues/54472.
   testWidgets('reset resets the text fields value to the initialValue', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -211,6 +211,7 @@ void main() {
                 Material(
                   child: TextFormField(
                     key: keyA,
+                    groupId: 'Group A',
                     onTapOutside: (PointerDownEvent event) {
                       tappedOutside = 'Outside Callback A';
                     },
@@ -219,6 +220,7 @@ void main() {
                 Material(
                   child: TextFormField(
                     key: keyB,
+                    groupId: 'Group B',
                     onTapOutside: (PointerDownEvent event) {
                       tappedOutside = 'Outside Callback B';
                     },
@@ -227,6 +229,7 @@ void main() {
                 Material(
                   child: TextFormField(
                     key: keyC,
+                    groupId: 'Group C',
                     onTapOutside: (PointerDownEvent event) {
                       tappedOutside = 'Outside Callback C';
                     },


### PR DESCRIPTION
This PR attempts to fix https://github.com/flutter/flutter/issues/127597

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
