### PR TITLE
Fix text button example in a11y assessment app

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -41,11 +41,11 @@ class MainWidgetState extends State<MainWidget> {
           children: <Widget>[
             TextButton(
               onPressed: () {  },
-              child: const Text('Text button'),
+              child: const Text('Press me'),
             ),
             const TextButton(
               onPressed: null,
-              child: Text('Text button disabled'),
+              child: Text('Press me'),
             ),
           ],
         ),

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:a11y_assessments/use_cases/text_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_utils.dart';
@@ -10,7 +13,26 @@ import 'test_utils.dart';
 void main() {
   testWidgets('text button can run', (WidgetTester tester) async {
     await pumpsUseCase(tester, TextButtonUseCase());
-    expect(find.text('Text button'), findsOneWidget);
-    expect(find.text('Text button disabled'), findsOneWidget);
+    final SemanticsFinder finder = find.semantics.byLabel('Press me');
+    expect(
+      finder.at(0),
+      matchesSemantics(
+        hasTapAction: true,
+        isButton: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        isFocusable: true,
+      ),
+    );
+  });
+
+  testWidgets('text button must not contain "button" in their text', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextButtonUseCase());
+    final List<Text> texts = tester.widgetList<Text>(
+      find.descendant(of: find.byType(TextButton), matching: find.byType(Text)),
+    ).toList();
+    for (final Text text in texts) {
+      expect(text.data!.contains('button'), isFalse);
+    }
   });
 }


### PR DESCRIPTION
b/317125569

text button should not have "button" in the text, it will confuse user as it button will be announced twice

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
