### PR TITLE
Fix two dimensional viewport unexpected null exception when no child is laid out

### DIFF
--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1318,7 +1318,9 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         }
     }
     _lastChild = previousChild;
-    parentDataOf(_lastChild!)._nextSibling = null;
+    if (_lastChild != null) {
+      parentDataOf(_lastChild!)._nextSibling = null;
+    }
     // Reset for next layout pass.
     _leadingXIndex = null;
     _trailingXIndex = null;

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -237,12 +237,12 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
       double yLayoutOffset = (leadingRow * 200) - verticalOffset.pixels;
       for (int row = leadingRow; row <= trailingRow; row++) {
         final ChildVicinity vicinity = ChildVicinity(xIndex: column, yIndex: row);
-        final RenderBox child = buildOrObtainChildFor(vicinity)!;
+        final RenderBox? child = buildOrObtainChildFor(vicinity);
         if (!forgetToLayoutChild) {
-          child.layout(constraints.tighten(width: 200.0, height: 200.0));
+          child?.layout(constraints.tighten(width: 200.0, height: 200.0));
         }
 
-        if (setLayoutOffset) {
+        if (setLayoutOffset && child != null) {
           parentDataOf(child).layoutOffset = Offset(xLayoutOffset, yLayoutOffset);
         }
         yLayoutOffset += 200;

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2717,21 +2717,22 @@ void main() {
         (WidgetTester tester) async {
       final TwoDimensionalChildBuilderDelegate delegate =
           TwoDimensionalChildBuilderDelegate(
-              maxXIndex: 50,
-              maxYIndex: 50,
-              addAutomaticKeepAlives: false,
-              addRepaintBoundaries: false,
-              builder: (BuildContext context, ChildVicinity vicinity) {
-                if (vicinity.xIndex > 10) {
-                  return const SizedBox.square(dimension: 200);
-                }
-                return null;
-              });
+        maxXIndex: 50,
+        maxYIndex: 50,
+        addAutomaticKeepAlives: false,
+        addRepaintBoundaries: false,
+        builder: (BuildContext context, ChildVicinity vicinity) {
+          if (vicinity.xIndex > 10) {
+            return const SizedBox.square(dimension: 200);
+          }
+          return null;
+        },
+      );
       addTearDown(delegate.dispose);
 
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate));
       expect(tester.takeException(), isNull);
-    }, variant: TargetPlatformVariant.all());
+    });
 
     testWidgets('correctly reorders children and wont throw assertion failure',
         (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2723,15 +2723,14 @@ void main() {
               addRepaintBoundaries: false,
               builder: (BuildContext context, ChildVicinity vicinity) {
                 if (vicinity.xIndex > 10) {
-                  return SizedBox.square(dimension: 200);
+                  return const SizedBox.square(dimension: 200);
                 }
                 return null;
               });
       addTearDown(delegate.dispose);
 
       await tester.pumpWidget(simpleBuilderTest(delegate: delegate));
-      // In case of exception during layout, expect is not reached
-      expect(true, isTrue);
+      expect(tester.takeException(), isNull);
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('correctly reorders children and wont throw assertion failure',

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2713,6 +2713,27 @@ void main() {
       });
     });
 
+    testWidgets('Does not throw when no child is laid out',
+        (WidgetTester tester) async {
+      final TwoDimensionalChildBuilderDelegate delegate =
+          TwoDimensionalChildBuilderDelegate(
+              maxXIndex: 50,
+              maxYIndex: 50,
+              addAutomaticKeepAlives: false,
+              addRepaintBoundaries: false,
+              builder: (BuildContext context, ChildVicinity vicinity) {
+                if (vicinity.xIndex > 10) {
+                  return SizedBox.square(dimension: 200);
+                }
+                return null;
+              });
+      addTearDown(delegate.dispose);
+
+      await tester.pumpWidget(simpleBuilderTest(delegate: delegate));
+      // In case of exception during layout, expect is not reached
+      expect(true, isTrue);
+    }, variant: TargetPlatformVariant.all());
+
     testWidgets('correctly reorders children and wont throw assertion failure',
         (WidgetTester tester) async {
       final TwoDimensionalChildBuilderDelegate delegate1 =


### PR DESCRIPTION
- Fixes #148255

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
