### PR TITLE
Mark platform_views_scroll_perf_ad_banners__timeline_summary not flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4835,7 +4835,6 @@ targets:
   - name: Mac_ios platform_views_scroll_perf_ad_banners__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
New build been consistently passing
https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_ios%20platform_views_scroll_perf_ad_banners__timeline_summary/960
