### PR TITLE
Stop running module_test_ios in devicelab and x64 Macs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3884,7 +3884,6 @@ targets:
 
   - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
-    bringup: true
     timeout: 60
     properties:
       dependencies: >-
@@ -3893,20 +3892,6 @@ targets:
         ]
       tags: >
         ["devicelab", "hostonly", "mac"]
-      task_name: module_test_ios
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Mac_arm64_ios module_test_ios # Must be run on devicelab bot for codesigning https://github.com/flutter/flutter/issues/112033
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac", "arm64"]
       task_name: module_test_ios
     runIf:
       - dev/**

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3864,24 +3864,6 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 module_test_ios
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/144680
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
-      task_name: module_test_ios
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
   - name: Mac_arm64 module_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
As of https://github.com/flutter/flutter/pull/147934 `module_test_ios` is passing on non-devicelab machines.  Remove the devicelab build and mark the arm non-devicelab build as not flaky.

@vashworth's summary from https://github.com/flutter/flutter/issues/112033#issuecomment-2108671235:

> So I believe [the idea](https://github.com/flutter/flutter/pull/141910) was to move `Mac_arm64_ios module_test_ios` to `Mac_arm64 module_test_ios` so it doesn't run on a devicelab bot.
> 
> However, it fails when running on a chromium bot due to a `Trying to load an unsigned library` issue, even though it's using a simulator:
> https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.staging/Mac_arm64%20module_test_ios
> 
> It's unclear why, but it seemed that removing the [lines](https://github.com/flutter/flutter/issues/112033#issuecomment-1652268832) that force disabling of codesigning allowed it to run. [@godofredoc was going to do a follow up PR to fix it](https://github.com/flutter/flutter/pull/141910#discussion_r1462346593), but it was probably forgotten. 



Also remove the x64 version of this test, since there's nothing arch-specific going on here and it happens to be flaky due to an infrastructure issues.

Fixes https://github.com/flutter/flutter/issues/112033
Fixes https://github.com/flutter/flutter/issues/144680