### PR TITLE
Fix TwoDimensionalViewport's keep alive child not always removed (when no longer should be kept alive)

### DIFF
--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1647,6 +1647,10 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         _children.remove(slot);
       }
       assert(_debugTrackOrphans(noLongerOrphan: child));
+      if(_keepAliveBucket[childParentData.vicinity] == child) {
+        _keepAliveBucket.remove(childParentData.vicinity);
+      }
+      assert(_keepAliveBucket[childParentData.vicinity] != child);
       dropChild(child);
       return;
     }

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -1647,7 +1647,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
         _children.remove(slot);
       }
       assert(_debugTrackOrphans(noLongerOrphan: child));
-      if(_keepAliveBucket[childParentData.vicinity] == child) {
+      if (_keepAliveBucket[childParentData.vicinity] == child) {
         _keepAliveBucket.remove(childParentData.vicinity);
       }
       assert(_keepAliveBucket[childParentData.vicinity] != child);

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -511,3 +511,39 @@ class TestParentDataWidget extends ParentDataWidget<TestExtendedParentData> {
   @override
   Type get debugTypicalAncestorWidgetClass => SimpleBuilderTableViewport;
 }
+
+class KeepAliveOnyWhenHovered extends StatefulWidget {
+  const KeepAliveOnyWhenHovered({ required this.child, super.key });
+
+  final Widget child;
+
+  @override
+  KeepAliveOnyWhenHoveredWidgetState createState() => KeepAliveOnyWhenHoveredWidgetState();
+}
+
+class KeepAliveOnyWhenHoveredWidgetState extends State<KeepAliveOnyWhenHovered> with AutomaticKeepAliveClientMixin {
+  bool _hovered = false;
+
+  @override
+  bool get wantKeepAlive => _hovered;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return MouseRegion(
+      onEnter: (_) {
+        setState(() {
+          _hovered = true;
+          updateKeepAlive();
+        });
+      },
+      onExit: (_) {
+        setState(() {
+          _hovered = false;
+          updateKeepAlive();
+        });
+      },
+      child: widget.child,
+    );
+  }
+}

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -512,16 +512,16 @@ class TestParentDataWidget extends ParentDataWidget<TestExtendedParentData> {
   Type get debugTypicalAncestorWidgetClass => SimpleBuilderTableViewport;
 }
 
-class KeepAliveOnyWhenHovered extends StatefulWidget {
-  const KeepAliveOnyWhenHovered({ required this.child, super.key });
+class KeepAliveOnlyWhenHovered extends StatefulWidget {
+  const KeepAliveOnlyWhenHovered({ required this.child, super.key });
 
   final Widget child;
 
   @override
-  KeepAliveOnyWhenHoveredState createState() => KeepAliveOnyWhenHoveredState();
+  KeepAliveOnlyWhenHoveredState createState() => KeepAliveOnlyWhenHoveredState();
 }
 
-class KeepAliveOnyWhenHoveredState extends State<KeepAliveOnyWhenHovered> with AutomaticKeepAliveClientMixin {
+class KeepAliveOnlyWhenHoveredState extends State<KeepAliveOnlyWhenHovered> with AutomaticKeepAliveClientMixin {
   bool _hovered = false;
 
   @override

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -518,10 +518,10 @@ class KeepAliveOnyWhenHovered extends StatefulWidget {
   final Widget child;
 
   @override
-  KeepAliveOnyWhenHoveredWidgetState createState() => KeepAliveOnyWhenHoveredWidgetState();
+  KeepAliveOnyWhenHoveredState createState() => KeepAliveOnyWhenHoveredState();
 }
 
-class KeepAliveOnyWhenHoveredWidgetState extends State<KeepAliveOnyWhenHovered> with AutomaticKeepAliveClientMixin {
+class KeepAliveOnyWhenHoveredState extends State<KeepAliveOnyWhenHovered> with AutomaticKeepAliveClientMixin {
   bool _hovered = false;
 
   @override

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -731,7 +731,7 @@ void main() {
       );
     });
 
-    testWidgets('ensure keep alive widget is not hold onto when it no longer should be kept alive offscreen', (WidgetTester tester) async {
+    testWidgets('Ensure KeepAlive widget is not held onto when it no longer should be kept alive offscreen', (WidgetTester tester) async {
       // Should not trigger assert in RenderTwoDimensionalViewport.performLayout
       // after child manager end layout. (https://github.com/flutter/flutter/issues/138977)
       final UniqueKey checkBoxKey = UniqueKey();

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -735,7 +735,7 @@ void main() {
       // Should not trigger assert in RenderTwoDimensionalViewport.performLayout
       // after child manager end layout. (https://github.com/flutter/flutter/issues/138977)
       final UniqueKey checkBoxKey = UniqueKey();
-      final Widget originCell = KeepAliveOnyWhenHovered(
+      final Widget originCell = KeepAliveOnlyWhenHovered(
         key: checkBoxKey,
         child: const SizedBox.square(dimension: 200),
       );

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -732,8 +732,7 @@ void main() {
     });
 
     testWidgets('Ensure KeepAlive widget is not held onto when it no longer should be kept alive offscreen', (WidgetTester tester) async {
-      // Should not trigger assert in RenderTwoDimensionalViewport.performLayout
-      // after child manager end layout. (https://github.com/flutter/flutter/issues/138977)
+      // Regression test for https://github.com/flutter/flutter/issues/138977
       final UniqueKey checkBoxKey = UniqueKey();
       final Widget originCell = KeepAliveOnlyWhenHovered(
         key: checkBoxKey,

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -731,6 +731,67 @@ void main() {
       );
     });
 
+    testWidgets('ensure keep alive widget is not hold onto when it no longer should be kept alive offscreen', (WidgetTester tester) async {
+      // Should not trigger assert in RenderTwoDimensionalViewport.performLayout
+      // after child manager end layout. https://github.com/flutter/flutter/issues/138977
+      final UniqueKey checkBoxKey = UniqueKey();
+      final Widget originCell = KeepAliveOnyWhenHovered(
+        key: checkBoxKey,
+        child: const SizedBox.square(dimension: 200),
+      );
+      const Widget otherCell = SizedBox.square(dimension: 200, child: Placeholder());
+      final ScrollController verticalController = ScrollController();
+      addTearDown(verticalController.dispose);
+      final TwoDimensionalChildListDelegate listDelegate = TwoDimensionalChildListDelegate(
+        children: <List<Widget>>[
+          <Widget>[originCell, otherCell, otherCell, otherCell, otherCell],
+          <Widget>[otherCell, otherCell, otherCell, otherCell, otherCell],
+          <Widget>[otherCell, otherCell, otherCell, otherCell, otherCell],
+          <Widget>[otherCell, otherCell, otherCell, otherCell, otherCell],
+          <Widget>[otherCell, otherCell, otherCell, otherCell, otherCell],
+        ],
+      );
+      addTearDown(listDelegate.dispose);
+
+      await tester.pumpWidget(simpleListTest(
+        delegate: listDelegate,
+        verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byKey(checkBoxKey), findsOneWidget);
+
+      // Scroll away, should not be kept alive (disposed)
+      verticalController.jumpTo(verticalController.position.maxScrollExtent);
+      await tester.pump();
+      expect(find.byKey(checkBoxKey), findsNothing);
+
+      // Bring back into view
+      verticalController.jumpTo(0.0);
+      await tester.pump();
+      expect(find.byKey(checkBoxKey), findsOneWidget);
+
+      // Hover over widget to make it keep alive
+      final TestGesture gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(find.byKey(checkBoxKey)));
+      await tester.pump();
+
+      // Scroll away, should be kept alive still
+      verticalController.jumpTo(verticalController.position.maxScrollExtent);
+      await tester.pump();
+      expect(find.byKey(checkBoxKey), findsOneWidget);
+
+      // Move the pointer outside widgets bounds to trigger exit event
+      // And thus remove it from keep alive bucket
+      await gesture.moveTo(const Offset(300, 300));
+      await tester.pump();
+      expect(find.byKey(checkBoxKey), findsNothing);
+    });
+
     testWidgets('list delegate will not add automatic keep alives', (WidgetTester tester) async {
       final UniqueKey checkBoxKey = UniqueKey();
       final Widget originCell = SizedBox.square(

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -733,7 +733,7 @@ void main() {
 
     testWidgets('ensure keep alive widget is not hold onto when it no longer should be kept alive offscreen', (WidgetTester tester) async {
       // Should not trigger assert in RenderTwoDimensionalViewport.performLayout
-      // after child manager end layout. https://github.com/flutter/flutter/issues/138977
+      // after child manager end layout. (https://github.com/flutter/flutter/issues/138977)
       final UniqueKey checkBoxKey = UniqueKey();
       final Widget originCell = KeepAliveOnyWhenHovered(
         key: checkBoxKey,
@@ -760,7 +760,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byKey(checkBoxKey), findsOneWidget);
 
-      // Scroll away, should not be kept alive (disposed)
+      // Scroll away, should not be kept alive (disposed).
       verticalController.jumpTo(verticalController.position.maxScrollExtent);
       await tester.pump();
       expect(find.byKey(checkBoxKey), findsNothing);
@@ -770,7 +770,7 @@ void main() {
       await tester.pump();
       expect(find.byKey(checkBoxKey), findsOneWidget);
 
-      // Hover over widget to make it keep alive
+      // Hover over widget to make it keep alive.
       final TestGesture gesture = await tester.createGesture(
         kind: PointerDeviceKind.mouse,
       );
@@ -780,13 +780,13 @@ void main() {
       await gesture.moveTo(tester.getCenter(find.byKey(checkBoxKey)));
       await tester.pump();
 
-      // Scroll away, should be kept alive still
+      // Scroll away, should be kept alive still.
       verticalController.jumpTo(verticalController.position.maxScrollExtent);
       await tester.pump();
       expect(find.byKey(checkBoxKey), findsOneWidget);
 
-      // Move the pointer outside widgets bounds to trigger exit event
-      // And thus remove it from keep alive bucket
+      // Move the pointer outside the widget bounds to trigger exit event
+      // and remove it from keep alive bucket.
       await gesture.moveTo(const Offset(300, 300));
       await tester.pump();
       expect(find.byKey(checkBoxKey), findsNothing);


### PR DESCRIPTION
- Fixes a child not removed from `_keepAliveBucket` when widget is no longer kept alive offscreen. Bug was triggering assert in performLayout.
- Adds test to cover the case from bug report

Fixes #138977

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
