### PR TITLE
[macOS] codesign native assets during embed

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -191,6 +191,12 @@ EmbedFrameworks() {
   local native_assets_path="${project_path}/${FLUTTER_BUILD_DIR}/native_assets/macos/"
   if [[ -d "$native_assets_path" ]]; then
     RunCommand rsync -av --filter "- .DS_Store" --filter "- native_assets.yaml" "${native_assets_path}" "${xcode_frameworks_dir}"
+
+    # Iterate through all .frameworks in native assets directory.
+    for native_asset in "${native_assets_path}"*.framework; do
+      # Codesign the framework inside the app bundle.
+      RunCommand codesign --force --verbose --sign "${EXPANDED_CODE_SIGN_IDENTITY}" -- "${xcode_frameworks_dir}/$(basename "$native_asset")"
+    done
   fi
 }
 

--- a/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/macos/native_assets.dart
@@ -304,7 +304,12 @@ Future<void> _copyNativeAssetsMacOS(
       ));
       await setInstallNameDylib(dylibFile);
       await createInfoPlist(name, resourcesDir);
-      await codesignDylib(codesignIdentity, buildMode, frameworkDir);
+      // Do not code-sign the libraries here with identity. Code-signing
+      // for bundled dylibs is done in `macos_assemble.sh embed` because the
+      // "Flutter Assemble" target does not have access to the signing identity.
+      if (codesignIdentity != null) {
+        await codesignDylib(codesignIdentity, buildMode, frameworkDir);
+      }
     }
     globals.logger.printTrace('Copying native assets done.');
   }

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -207,6 +207,7 @@ void main() {
           switch (buildSubcommand) {
             case 'macos':
               expectDylibIsBundledMacOS(exampleDirectory, buildMode);
+              expectDylibIsCodeSignedMacOS(exampleDirectory, buildMode);
             case 'ios':
               expectDylibIsBundledIos(exampleDirectory, buildMode);
             case 'linux':
@@ -288,6 +289,26 @@ void main() {
       });
     });
   }
+}
+
+void expectDylibIsCodeSignedMacOS(Directory appDirectory, String buildMode) {
+  final Directory appBundle = appDirectory.childDirectory('build/$hostOs/Build/Products/${buildMode.upperCaseFirst()}/$exampleAppName.app');
+    final Directory frameworksFolder =
+      appBundle.childDirectory('Contents/Frameworks');
+  expect(frameworksFolder, exists);
+  const String frameworkName = packageName;
+  final Directory frameworkDir =
+      frameworksFolder.childDirectory('$frameworkName.framework');
+  final ProcessResult codesign =
+      processManager.runSync(<String>['codesign', '-dv', frameworkDir.absolute.path]);
+  expect(codesign.exitCode, 0);
+
+  // Expected adhoc signature, but not linker-signed (which means no code-signing happened after linking).
+  final List<String> lines = codesign.stdout.toString().split('\n');
+  final bool isLinkerSigned = lines.any((String line) => line.contains('linker-signed'));
+  final bool isAdhoc = lines.any((String line) => line.contains('Signature=adhoc'));
+  expect(isAdhoc, isTrue);
+  expect(isLinkerSigned, isFalse);
 }
 
 /// For `flutter build` we can't easily test whether running the app works.

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -293,17 +293,15 @@ void main() {
 
 void expectDylibIsCodeSignedMacOS(Directory appDirectory, String buildMode) {
   final Directory appBundle = appDirectory.childDirectory('build/$hostOs/Build/Products/${buildMode.upperCaseFirst()}/$exampleAppName.app');
-    final Directory frameworksFolder =
-      appBundle.childDirectory('Contents/Frameworks');
+  final Directory frameworksFolder = appBundle.childDirectory('Contents/Frameworks');
   expect(frameworksFolder, exists);
   const String frameworkName = packageName;
-  final Directory frameworkDir =
-      frameworksFolder.childDirectory('$frameworkName.framework');
+  final Directory frameworkDir = frameworksFolder.childDirectory('$frameworkName.framework');
   final ProcessResult codesign =
       processManager.runSync(<String>['codesign', '-dv', frameworkDir.absolute.path]);
   expect(codesign.exitCode, 0);
 
-  // Expected adhoc signature, but not linker-signed (which means no code-signing happened after linking).
+  // Expect adhoc signature, but not linker-signed (which would mean no code-signing happened after linking).
   final List<String> lines = codesign.stdout.toString().split('\n');
   final bool isLinkerSigned = lines.any((String line) => line.contains('linker-signed'));
   final bool isAdhoc = lines.any((String line) => line.contains('Signature=adhoc'));

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -302,7 +302,7 @@ void expectDylibIsCodeSignedMacOS(Directory appDirectory, String buildMode) {
   expect(codesign.exitCode, 0);
 
   // Expect adhoc signature, but not linker-signed (which would mean no code-signing happened after linking).
-  final List<String> lines = codesign.stdout.toString().split('\n');
+  final List<String> lines = codesign.stderr.toString().split('\n');
   final bool isLinkerSigned = lines.any((String line) => line.contains('linker-signed'));
   final bool isAdhoc = lines.any((String line) => line.contains('Signature=adhoc'));
   expect(isAdhoc, isTrue);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/148051

Currently only the "embed" phase, which is run during the Runner target build have access to code-signing identity. The flutter assemble target, which does the main build (and also builds native assets) does not have access to the code-signing identity.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
