### PR TITLE
add another print trace to runInView

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -574,7 +574,11 @@ class FlutterVmService {
     _logger.printTrace('Running $main in view $viewId...');
     try {
       await service.streamListen(vm_service.EventStreams.kIsolate);
-    } on vm_service.RPCError {
+    } on vm_service.RPCError catch (e) {
+      _logger.printTrace(
+        'Unable to listen to VM service stream "${vm_service.EventStreams.kIsolate}".\n'
+        'Error: $e',
+      );
       // Do nothing, since the tool is already subscribed.
     }
     final Future<void> onRunnable = service.onIsolateEvent.firstWhere((vm_service.Event event) {
@@ -911,11 +915,9 @@ class FlutterVmService {
     Duration delay = const Duration(milliseconds: 50),
   }) async {
     while (true) {
-      _logger.printTrace('Calling _flutter.listViews...');
       final vm_service.Response? response = await callMethodWrapper(
         kListViewsMethod,
       );
-      _logger.printTrace('Response from _flutter.listViews: ${json.encode(response?.json)}');
       if (response == null) {
         // The service may have disappeared mid-request.
         // Return an empty list now, and let the shutdown logic elsewhere deal


### PR DESCRIPTION
In service of https://github.com/flutter/flutter/issues/146879. See https://github.com/flutter/flutter/issues/146879#issuecomment-2110781156. I wonder if something is going wrong in the process of subscribing to the isolate event stream in the VM service. This adds a print trace to the `catch` clause of this subscription call.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
