### PR TITLE
[Feature] Add support for Bundler to manage Gem dependencies

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3383,6 +3383,44 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Mac build_ios_framework_module_with_bundler_test
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    bringup: true
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
+        ]
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      task_name: build_ios_framework_module_with_bundler_test
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
+
+  - name: Mac_arm64 build_ios_framework_module_with_bundler_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    bringup: true
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
+        ]
+      tags: >
+        ["devicelab", "hostonly", "mac", "arm64"]
+      task_name: build_ios_framework_module_with_bundler_test
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
+
   - name: Mac_x64 build_tests_1_4
     recipe: flutter/flutter_drone
     presubmit: false # Rely on Mac_arm build_tests in presubmit.

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -229,6 +229,7 @@
 /dev/devicelab/bin/tasks/basic_material_app_macos__compile.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/build_aar_module_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/build_ios_framework_module_test.dart @jmagman @flutter/tool
+/dev/devicelab/bin/tasks/build_ios_framework_module_with_bundler_test.dart @jmagman @flutter/tool
 /dev/devicelab/bin/tasks/channels_integration_test_macos.dart @gaaclarke @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart @cbracken @flutter/desktop

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_with_bundler_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_with_bundler_test.dart
@@ -1,0 +1,981 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/ios.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+
+/// Tests that iOS and macOS .xcframeworks can be built.
+Future<void> main() async {
+  await task(() async {
+
+    section('Create module project');
+
+    final Directory tempDir = Directory.systemTemp.createTempSync('flutter_module_test.');
+    try {
+      await inDirectory(tempDir, () async {
+        section('Test iOS module template');
+
+        final Directory moduleProjectDir =
+        Directory(path.join(tempDir.path, 'hello_module'));
+        await flutter(
+          'create',
+          options: <String>[
+            '--org',
+            '--use-bundler',
+            'io.flutter.devicelab',
+            '--template',
+            'module',
+            'hello_module',
+          ],
+        );
+
+        await _addPlugin(moduleProjectDir);
+        await _testBuildIosFramework(moduleProjectDir, isModule: true);
+
+        section('Test app template');
+
+        final Directory projectDir =
+        Directory(path.join(tempDir.path, 'hello_project'));
+        await flutter(
+          'create',
+          options: <String>['--org', 'io.flutter.devicelab', 'hello_project'],
+        );
+
+        await _addPlugin(projectDir);
+        await _testBuildIosFramework(projectDir);
+        await _testBuildMacOSFramework(projectDir);
+      });
+
+      return TaskResult.success(null);
+    } on TaskResult catch (taskResult) {
+      return taskResult;
+    } catch (e) {
+      return TaskResult.failure(e.toString());
+    } finally {
+      rmTree(tempDir);
+    }
+  });
+}
+
+Future<void> _addPlugin(Directory projectDir) async {
+  section('Add plugins');
+
+  final File pubspec = File(path.join(projectDir.path, 'pubspec.yaml'));
+  String content = pubspec.readAsStringSync();
+  content = content.replaceFirst(
+    '\ndependencies:\n',
+    '\ndependencies:\n  package_info: 2.0.2\n  connectivity: 3.0.6\n',
+  );
+  pubspec.writeAsStringSync(content, flush: true);
+  await inDirectory(projectDir, () async {
+    await flutter(
+      'packages',
+      options: <String>['get'],
+    );
+  });
+}
+
+Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = false}) async {
+  // This builds all build modes' frameworks by default
+  section('Build iOS app');
+
+  const String outputDirectoryName = 'flutter-frameworks';
+
+  await inDirectory(projectDir, () async {
+    final StringBuffer outputError = StringBuffer();
+    await evalFlutter(
+      'build',
+      options: <String>[
+        'ios-framework',
+        '--verbose',
+        '--use-bundler',
+        '--output=$outputDirectoryName',
+        '--obfuscate',
+        '--split-debug-info=symbols',
+      ],
+      stderr: outputError,
+    );
+    if (!outputError.toString().contains('Bitcode support has been deprecated.')) {
+      throw TaskResult.failure('Missing bitcode deprecation warning');
+    }
+  });
+
+  final String outputPath = path.join(projectDir.path, outputDirectoryName);
+
+  checkFileExists(path.join(
+    outputPath,
+    'Debug',
+    'Flutter.xcframework',
+    'ios-arm64',
+    'Flutter.framework',
+    'Flutter',
+  ));
+
+  final String debugAppFrameworkPath = path.join(
+    outputPath,
+    'Debug',
+    'App.xcframework',
+    'ios-arm64',
+    'App.framework',
+    'App',
+  );
+  checkFileExists(debugAppFrameworkPath);
+
+  checkFileExists(path.join(
+    outputPath,
+    'Debug',
+    'App.xcframework',
+    'ios-arm64',
+    'App.framework',
+    'Info.plist',
+  ));
+
+  section('Check debug build has Dart snapshot as asset');
+
+  checkFileExists(path.join(
+    outputPath,
+    'Debug',
+    'App.xcframework',
+    'ios-arm64_x86_64-simulator',
+    'App.framework',
+    'flutter_assets',
+    'vm_snapshot_data',
+  ));
+
+  section('Check obfuscation symbols');
+
+  checkFileExists(path.join(
+    projectDir.path,
+    'symbols',
+    'app.ios-arm64.symbols',
+  ));
+
+  section('Check debug build has no Dart AOT');
+
+  final String aotSymbols = await _dylibSymbols(debugAppFrameworkPath);
+
+  if (aotSymbols.contains('architecture') ||
+      aotSymbols.contains('_kDartVmSnapshot')) {
+    throw TaskResult.failure('Debug App.framework contains AOT');
+  }
+
+  section('Check profile, release builds has Dart AOT dylib');
+
+  for (final String mode in <String>['Profile', 'Release']) {
+    final String appFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'ios-arm64',
+      'App.framework',
+      'App',
+    );
+
+    await _checkDylib(appFrameworkPath);
+
+    final String aotSymbols = await _dylibSymbols(appFrameworkPath);
+
+    if (!aotSymbols.contains('_kDartVmSnapshot')) {
+      throw TaskResult.failure('$mode App.framework missing Dart AOT');
+    }
+
+    checkFileNotExists(path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'ios-arm64',
+      'App.framework',
+      'flutter_assets',
+      'vm_snapshot_data',
+    ));
+
+    final String appFrameworkDsymPath = path.join(
+        outputPath,
+        mode,
+        'App.xcframework',
+        'ios-arm64',
+        'dSYMs',
+        'App.framework.dSYM'
+    );
+    checkDirectoryExists(appFrameworkDsymPath);
+    await _checkDsym(path.join(
+      appFrameworkDsymPath,
+      'Contents',
+      'Resources',
+      'DWARF',
+      'App',
+    ));
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'App.framework',
+      'App',
+    ));
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'App.framework',
+      'Info.plist',
+    ));
+  }
+
+  section("Check all modes' engine dylib");
+
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'Flutter.xcframework',
+      'ios-arm64',
+      'Flutter.framework',
+      'Flutter',
+    ));
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'Flutter.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'Flutter.framework',
+      'Flutter',
+    ));
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'Flutter.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'Flutter.framework',
+      'Headers',
+      'Flutter.h',
+    ));
+  }
+
+  section('Check all modes have plugins');
+
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    final String pluginFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'connectivity.xcframework',
+      'ios-arm64',
+      'connectivity.framework',
+      'connectivity',
+    );
+
+    await _checkDylib(pluginFrameworkPath);
+    if (!await _linksOnFlutter(pluginFrameworkPath)) {
+      throw TaskResult.failure('$pluginFrameworkPath does not link on Flutter');
+    }
+
+    final String transitiveDependencyFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'Reachability.xcframework',
+      'ios-arm64',
+      'Reachability.framework',
+      'Reachability',
+    );
+
+    if (!exists(File(transitiveDependencyFrameworkPath))) {
+      throw TaskResult.failure('Expected debug Flutter engine artifact binary to exist');
+    }
+
+    if (await _linksOnFlutter(transitiveDependencyFrameworkPath)) {
+      throw TaskResult.failure(
+          'Transitive dependency $transitiveDependencyFrameworkPath unexpectedly links on Flutter');
+    }
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'connectivity.xcframework',
+      'ios-arm64',
+      'connectivity.framework',
+      'Headers',
+      'FLTConnectivityPlugin.h',
+    ));
+
+    if (mode != 'Debug') {
+      checkDirectoryExists(path.join(
+        outputPath,
+        mode,
+        'connectivity.xcframework',
+        'ios-arm64',
+        'dSYMs',
+        'connectivity.framework.dSYM',
+      ));
+    }
+
+    final String simulatorFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'connectivity.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'connectivity.framework',
+      'connectivity',
+    );
+
+    final String simulatorFrameworkHeaderPath = path.join(
+      outputPath,
+      mode,
+      'connectivity.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'connectivity.framework',
+      'Headers',
+      'FLTConnectivityPlugin.h',
+    );
+
+    checkFileExists(simulatorFrameworkPath);
+    checkFileExists(simulatorFrameworkHeaderPath);
+  }
+
+  section('Check all modes have generated plugin registrant');
+
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    if (!isModule) {
+      continue;
+    }
+    final String registrantFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'FlutterPluginRegistrant.xcframework',
+      'ios-arm64',
+      'FlutterPluginRegistrant.framework',
+      'FlutterPluginRegistrant',
+    );
+    await _checkStatic(registrantFrameworkPath);
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'FlutterPluginRegistrant.xcframework',
+      'ios-arm64',
+      'FlutterPluginRegistrant.framework',
+      'Headers',
+      'GeneratedPluginRegistrant.h',
+    ));
+    final String simulatorHeaderPath = path.join(
+      outputPath,
+      mode,
+      'FlutterPluginRegistrant.xcframework',
+      'ios-arm64_x86_64-simulator',
+      'FlutterPluginRegistrant.framework',
+      'Headers',
+      'GeneratedPluginRegistrant.h',
+    );
+    checkFileExists(simulatorHeaderPath);
+  }
+
+  // This builds all build modes' frameworks by default
+  section('Build podspec and static plugins');
+
+  const String cocoapodsOutputDirectoryName = 'flutter-frameworks-cocoapods';
+
+  await inDirectory(projectDir, () async {
+    await flutter(
+      'build',
+      options: <String>[
+        'ios-framework',
+        '--use-bundler',
+        '--cocoapods',
+        '--force', // Allow podspec creation on master.
+        '--output=$cocoapodsOutputDirectoryName',
+        '--static',
+      ],
+    );
+  });
+
+  final String cocoapodsOutputPath = path.join(projectDir.path, cocoapodsOutputDirectoryName);
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    checkFileExists(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'Flutter.podspec',
+    ));
+    await _checkDylib(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'App.xcframework',
+      'ios-arm64',
+      'App.framework',
+      'App',
+    ));
+
+    if (mode != 'Debug') {
+      final String appFrameworkDsymPath = path.join(
+          cocoapodsOutputPath,
+          mode,
+          'App.xcframework',
+          'ios-arm64',
+          'dSYMs',
+          'App.framework.dSYM'
+      );
+      checkDirectoryExists(appFrameworkDsymPath);
+      await _checkDsym(path.join(
+        appFrameworkDsymPath,
+        'Contents',
+        'Resources',
+        'DWARF',
+        'App',
+      ));
+    }
+
+    if (Directory(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'FlutterPluginRegistrant.xcframework',
+    )).existsSync() !=
+        isModule) {
+      throw TaskResult.failure(
+          'Unexpected FlutterPluginRegistrant.xcframework.');
+    }
+
+    await _checkStatic(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'package_info.xcframework',
+      'ios-arm64',
+      'package_info.framework',
+      'package_info',
+    ));
+
+    await _checkStatic(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'connectivity.xcframework',
+      'ios-arm64',
+      'connectivity.framework',
+      'connectivity',
+    ));
+
+    checkDirectoryExists(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'Reachability.xcframework',
+    ));
+  }
+
+  if (File(path.join(
+    outputPath,
+    'GeneratedPluginRegistrant.h',
+  )).existsSync() ==
+      isModule) {
+    throw TaskResult.failure('Unexpected GeneratedPluginRegistrant.h.');
+  }
+
+  if (File(path.join(
+    outputPath,
+    'GeneratedPluginRegistrant.m',
+  )).existsSync() ==
+      isModule) {
+    throw TaskResult.failure('Unexpected GeneratedPluginRegistrant.m.');
+  }
+
+  section('Build frameworks without plugins');
+  await _testBuildFrameworksWithoutPlugins(projectDir, platform: 'ios');
+
+  section('check --static cannot be used with the --no-plugins flag');
+  await _testStaticAndNoPlugins(projectDir);
+}
+
+
+Future<void> _testBuildMacOSFramework(Directory projectDir) async {
+  // This builds all build modes' frameworks by default
+  section('Build macOS frameworks');
+
+  const String outputDirectoryName = 'flutter-frameworks';
+
+  await inDirectory(projectDir, () async {
+    await flutter(
+      'build',
+      options: <String>[
+        'macos-framework',
+        '--use-bundler',
+        '--verbose',
+        '--output=$outputDirectoryName',
+        '--obfuscate',
+        '--split-debug-info=symbols',
+      ],
+    );
+  });
+
+  final String outputPath = path.join(projectDir.path, outputDirectoryName);
+  final String flutterFramework = path.join(
+    outputPath,
+    'Debug',
+    'FlutterMacOS.xcframework',
+    'macos-arm64_x86_64',
+    'FlutterMacOS.framework',
+  );
+  checkDirectoryExists(flutterFramework);
+
+  final String debugAppFrameworkPath = path.join(
+    outputPath,
+    'Debug',
+    'App.xcframework',
+    'macos-arm64_x86_64',
+    'App.framework',
+    'App',
+  );
+  checkSymlinkExists(debugAppFrameworkPath);
+
+  checkFileExists(path.join(
+    outputPath,
+    'Debug',
+    'App.xcframework',
+    'macos-arm64_x86_64',
+    'App.framework',
+    'Resources',
+    'Info.plist',
+  ));
+
+  section('Check debug build has Dart snapshot as asset');
+
+  checkFileExists(path.join(
+    outputPath,
+    'Debug',
+    'App.xcframework',
+    'macos-arm64_x86_64',
+    'App.framework',
+    'Resources',
+    'flutter_assets',
+    'vm_snapshot_data',
+  ));
+
+  section('Check obfuscation symbols');
+
+  checkFileExists(path.join(
+    projectDir.path,
+    'symbols',
+    'app.darwin-arm64.symbols',
+  ));
+
+  checkFileExists(path.join(
+    projectDir.path,
+    'symbols',
+    'app.darwin-x86_64.symbols',
+  ));
+
+  section('Check debug build has no Dart AOT');
+
+  final String aotSymbols = await _dylibSymbols(debugAppFrameworkPath);
+
+  if (aotSymbols.contains('architecture') ||
+      aotSymbols.contains('_kDartVmSnapshot')) {
+    throw TaskResult.failure('Debug App.framework contains AOT');
+  }
+
+  section('Check profile, release builds has Dart AOT dylib');
+
+  for (final String mode in <String>['Profile', 'Release']) {
+    final String appFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'macos-arm64_x86_64',
+      'App.framework',
+      'App',
+    );
+
+    await _checkDylib(appFrameworkPath);
+
+    final String aotSymbols = await _dylibSymbols(appFrameworkPath);
+
+    if (!aotSymbols.contains('_kDartVmSnapshot')) {
+      throw TaskResult.failure('$mode App.framework missing Dart AOT');
+    }
+
+    checkFileNotExists(path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'macos-arm64_x86_64',
+      'App.framework',
+      'Resources',
+      'flutter_assets',
+      'vm_snapshot_data',
+    ));
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'App.xcframework',
+      'macos-arm64_x86_64',
+      'App.framework',
+      'Resources',
+      'Info.plist',
+    ));
+
+    final String appFrameworkDsymPath = path.join(
+        outputPath,
+        mode,
+        'App.xcframework',
+        'macos-arm64_x86_64',
+        'dSYMs',
+        'App.framework.dSYM'
+    );
+    checkDirectoryExists(appFrameworkDsymPath);
+    await _checkDsym(path.join(
+      appFrameworkDsymPath,
+      'Contents',
+      'Resources',
+      'DWARF',
+      'App',
+    ));
+  }
+
+  section("Check all modes' engine dylib");
+
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    final String engineBinary = path.join(
+      outputPath,
+      mode,
+      'FlutterMacOS.xcframework',
+      'macos-arm64_x86_64',
+      'FlutterMacOS.framework',
+      'FlutterMacOS',
+    );
+    checkSymlinkExists(engineBinary);
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'FlutterMacOS.xcframework',
+      'macos-arm64_x86_64',
+      'FlutterMacOS.framework',
+      'Headers',
+      'FlutterMacOS.h',
+    ));
+  }
+
+  section('Check all modes have plugins');
+
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    final String pluginFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'connectivity_macos.xcframework',
+      'macos-arm64_x86_64',
+      'connectivity_macos.framework',
+      'connectivity_macos',
+    );
+
+    await _checkDylib(pluginFrameworkPath);
+    if (!await _linksOnFlutterMacOS(pluginFrameworkPath)) {
+      throw TaskResult.failure('$pluginFrameworkPath does not link on Flutter');
+    }
+
+    final String transitiveDependencyFrameworkPath = path.join(
+      outputPath,
+      mode,
+      'Reachability.xcframework',
+      'macos-arm64_x86_64',
+      'Reachability.framework',
+      'Reachability',
+    );
+    if (await _linksOnFlutterMacOS(transitiveDependencyFrameworkPath)) {
+      throw TaskResult.failure('Transitive dependency $transitiveDependencyFrameworkPath unexpectedly links on Flutter');
+    }
+
+    checkFileExists(path.join(
+      outputPath,
+      mode,
+      'connectivity_macos.xcframework',
+      'macos-arm64_x86_64',
+      'connectivity_macos.framework',
+      'Headers',
+      'connectivity_macos-Swift.h',
+    ));
+
+    checkDirectoryExists(path.join(
+      outputPath,
+      mode,
+      'connectivity_macos.xcframework',
+      'macos-arm64_x86_64',
+      'connectivity_macos.framework',
+      'Modules',
+      'connectivity_macos.swiftmodule',
+    ));
+
+    if (mode != 'Debug') {
+      checkDirectoryExists(path.join(
+        outputPath,
+        mode,
+        'connectivity_macos.xcframework',
+        'macos-arm64_x86_64',
+        'dSYMs',
+        'connectivity_macos.framework.dSYM',
+      ));
+    }
+
+    checkSymlinkExists(path.join(
+      outputPath,
+      mode,
+      'connectivity_macos.xcframework',
+      'macos-arm64_x86_64',
+      'connectivity_macos.framework',
+      'connectivity_macos',
+    ));
+  }
+
+  // This builds all build modes' frameworks by default
+  section('Build podspec and static plugins');
+
+  const String cocoapodsOutputDirectoryName = 'flutter-frameworks-cocoapods';
+
+  await inDirectory(projectDir, () async {
+    await flutter(
+      'build',
+      options: <String>[
+        'macos-framework',
+        '--use-bundler',
+        '--cocoapods',
+        '--force', // Allow podspec creation on master.
+        '--output=$cocoapodsOutputDirectoryName',
+        '--static',
+      ],
+    );
+  });
+
+  final String cocoapodsOutputPath = path.join(projectDir.path, cocoapodsOutputDirectoryName);
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    checkFileExists(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'FlutterMacOS.podspec',
+    ));
+    await _checkDylib(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'App.xcframework',
+      'macos-arm64_x86_64',
+      'App.framework',
+      'App',
+    ));
+
+    if (mode != 'Debug') {
+      final String appFrameworkDsymPath = path.join(
+          cocoapodsOutputPath,
+          mode,
+          'App.xcframework',
+          'macos-arm64_x86_64',
+          'dSYMs',
+          'App.framework.dSYM'
+      );
+      checkDirectoryExists(appFrameworkDsymPath);
+      await _checkDsym(path.join(
+        appFrameworkDsymPath,
+        'Contents',
+        'Resources',
+        'DWARF',
+        'App',
+      ));
+    }
+
+    await _checkStatic(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'package_info.xcframework',
+      'macos-arm64_x86_64',
+      'package_info.framework',
+      'package_info',
+    ));
+
+    await _checkStatic(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'connectivity_macos.xcframework',
+      'macos-arm64_x86_64',
+      'connectivity_macos.framework',
+      'connectivity_macos',
+    ));
+
+    checkDirectoryExists(path.join(
+      cocoapodsOutputPath,
+      mode,
+      'Reachability.xcframework',
+    ));
+  }
+
+  checkFileExists(path.join(
+    outputPath,
+    'GeneratedPluginRegistrant.swift',
+  ));
+
+  section('Validate embed FlutterMacOS.framework with CocoaPods');
+
+  final File podspec = File(path.join(
+    cocoapodsOutputPath,
+    'Debug',
+    'FlutterMacOS.podspec',
+  ));
+
+  podspec.writeAsStringSync(
+    podspec.readAsStringSync().replaceFirst('null.null.0', '0.0.0'),
+  );
+
+  final Directory macosDirectory = Directory(path.join(projectDir.path, 'macos'));
+  final File podfile = File(path.join(macosDirectory.path, 'Podfile'));
+  final String currentPodfile = podfile.readAsStringSync();
+
+  // Temporarily test Add-to-App Cocoapods podspec for framework
+  podfile.writeAsStringSync('''
+target 'Runner' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  pod 'FlutterMacOS', :podspec => '${podspec.path}'
+end
+''');
+  await inDirectory(macosDirectory, () async {
+    await eval('pod', <String>['install']);
+  });
+
+  // Change podfile back to original
+  podfile.writeAsStringSync(currentPodfile);
+  await inDirectory(macosDirectory, () async {
+    await eval('pod', <String>['install']);
+  });
+
+  section('Build frameworks without plugins');
+  await _testBuildFrameworksWithoutPlugins(projectDir, platform: 'macos');
+}
+
+Future<void> _testBuildFrameworksWithoutPlugins(Directory projectDir, { required String platform}) async {
+  const String noPluginsOutputDir = 'flutter-frameworks-no-plugins';
+
+  await inDirectory(projectDir, () async {
+    await flutter(
+      'build',
+      options: <String>[
+        '$platform-framework',
+        '--use-bundler',
+        '--cocoapods',
+        '--force', // Allow podspec creation on master.
+        '--output=$noPluginsOutputDir',
+        '--no-plugins',
+      ],
+    );
+  });
+
+  final String noPluginsOutputPath = path.join(projectDir.path, noPluginsOutputDir);
+  for (final String mode in <String>['Debug', 'Profile', 'Release']) {
+    checkFileExists(path.join(
+      noPluginsOutputPath,
+      mode,
+      'Flutter${platform == 'macos' ? 'MacOS' : ''}.podspec',
+    ));
+    checkDirectoryExists(path.join(
+      noPluginsOutputPath,
+      mode,
+      'App.xcframework',
+    ));
+
+    checkDirectoryNotExists(path.join(
+      noPluginsOutputPath,
+      mode,
+      'package_info.xcframework',
+    ));
+
+    checkDirectoryNotExists(path.join(
+      noPluginsOutputPath,
+      mode,
+      'connectivity.xcframework',
+    ));
+
+    checkDirectoryNotExists(path.join(
+      noPluginsOutputPath,
+      mode,
+      'Reachability.xcframework',
+    ));
+  }
+}
+
+Future<void> _testStaticAndNoPlugins(Directory projectDir) async {
+  const String noPluginsOutputDir = 'flutter-frameworks-no-plugins-static';
+  final ProcessResult result = await inDirectory(projectDir, () async {
+    return executeFlutter(
+        'build',
+        options: <String>[
+          'ios-framework',
+          '--cocoapods',
+          '--force', // Allow podspec creation on master.
+          '--use-bundler',
+          '--output=$noPluginsOutputDir',
+          '--no-plugins',
+          '--static'
+        ],
+        canFail: true
+    );
+  });
+  if (result.exitCode == 0) {
+    throw TaskResult.failure('Build framework command did not exit with error as expected');
+  }
+  final String output = '${result.stdout}\n${result.stderr}';
+  if (!output.contains('--static cannot be used with the --no-plugins flag')) {
+    throw TaskResult.failure(output);
+  }
+}
+
+Future<void> _checkDylib(String pathToLibrary) async {
+  final String binaryFileType = await fileType(pathToLibrary);
+  if (!binaryFileType.contains('dynamically linked')) {
+    throw TaskResult.failure('$pathToLibrary is not a dylib, found: $binaryFileType');
+  }
+}
+
+Future<void> _checkDsym(String pathToSymbolFile) async {
+  final String binaryFileType = await fileType(pathToSymbolFile);
+  if (!binaryFileType.contains('dSYM companion file')) {
+    throw TaskResult.failure('$pathToSymbolFile is not a dSYM, found: $binaryFileType');
+  }
+}
+
+Future<void> _checkStatic(String pathToLibrary) async {
+  final String binaryFileType = await fileType(pathToLibrary);
+  if (!binaryFileType.contains('current ar archive random library')) {
+    throw TaskResult.failure('$pathToLibrary is not a static library, found: $binaryFileType');
+  }
+}
+
+Future<String> _dylibSymbols(String pathToDylib) {
+  return eval('nm', <String>[
+    '-g',
+    pathToDylib,
+    '-arch',
+    'arm64',
+  ]);
+}
+
+Future<bool> _linksOnFlutter(String pathToBinary) async {
+  final String loadCommands = await eval('otool', <String>[
+    '-l',
+    '-arch',
+    'arm64',
+    pathToBinary,
+  ]);
+  return loadCommands.contains('Flutter.framework');
+}
+
+Future<bool> _linksOnFlutterMacOS(String pathToBinary) async {
+  final String loadCommands = await eval('otool', <String>[
+    '-l',
+    '-arch',
+    'arm64',
+    pathToBinary,
+  ]);
+  return loadCommands.contains('FlutterMacOS.framework');
+}

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -46,6 +46,7 @@ class BuildInfo {
     this.initializeFromDill,
     this.assumeInitializeFromDillUpToDate = false,
     this.buildNativeAssets = true,
+    this.shouldUseBundler = false,
   }) : extraFrontEndOptions = extraFrontEndOptions ?? const <String>[],
        extraGenSnapshotOptions = extraGenSnapshotOptions ?? const <String>[],
        fileSystemRoots = fileSystemRoots ?? const <String>[],
@@ -179,6 +180,10 @@ class BuildInfo {
 
   /// If set, builds native assets with `build.dart` from all packages.
   final bool buildNativeAssets;
+
+  /// If set, it will use the `bundler` tool to manage Gem dependencies, including Cocoapods,
+  /// and it will execute the `bundler` commands, `bundle install` before running the build, and using `bundle exec` to run the Cocoapods install command.
+  final bool shouldUseBundler;
 
   static const BuildInfo debug = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
   static const BuildInfo profile = BuildInfo(BuildMode.profile, null, treeShakeIcons: kIconTreeShakerEnabledDefault);

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -600,6 +600,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     usesAnalyzeSizeFlag();
+    addXcodeSpecificBuildOptions();
     argParser.addFlag('codesign',
       defaultsTo: true,
       help: 'Codesign the application bundle (only available on device builds).',

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -48,6 +48,7 @@ abstract class BuildFrameworkCommand extends BuildSubCommand {
     usesExtraDartFlagOptions(verboseHelp: verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     addEnableExperimentation(hide: !verboseHelp);
+    addXcodeSpecificBuildOptions();
 
     argParser
       ..addFlag('debug',
@@ -269,6 +270,7 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
         getIosBuildDirectory(),
         buildInfo.mode,
         forceCocoaPodsOnly: true,
+        shouldUseBundler: buildInfo.shouldUseBundler,
       );
       if (boolArg('plugins') && hasPlugins(project)) {
         await _producePlugins(buildInfo.mode, xcodeBuildConfiguration, iPhoneBuildOutput, simulatorBuildOutput, modeDirectory);

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -27,6 +27,7 @@ class BuildMacosCommand extends BuildSubCommand {
           'This can be used in CI/CD process that create an archive to avoid '
           'performing duplicate work.'
     );
+    addXcodeSpecificBuildOptions();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -99,6 +99,7 @@ class BuildMacOSFrameworkCommand extends BuildFrameworkCommand {
         getMacOSBuildDirectory(),
         buildInfo.mode,
         forceCocoaPodsOnly: true,
+        shouldUseBundler: buildInfo.shouldUseBundler,
       );
       if (boolArg('plugins') && hasPlugins(project)) {
         await _producePlugins(xcodeBuildConfiguration, buildOutput, modeDirectory);

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -40,6 +40,7 @@ class CreateCommand extends CreateBase {
     super.verboseHelp = false,
   }) {
     addPlatformsOptions(customHelp: kPlatformHelp);
+    addXcodeSpecificBuildOptions();
     argParser.addOption(
       'template',
       abbr: 't',
@@ -71,6 +72,8 @@ class CreateCommand extends CreateBase {
       valueHelp: 'path',
     );
   }
+
+  bool get shouldUseBundler => boolArg('use-bundler');
 
   @override
   final String name = 'create';
@@ -448,6 +451,7 @@ class CreateCommand extends CreateBase {
           macOSPlatform: includeMacos,
           windowsPlatform: includeWindows,
           webPlatform: includeWeb,
+          shouldUseBundler: shouldUseBundler,
         );
       }
     }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -204,6 +204,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     addEnableImpellerFlag(verboseHelp: verboseHelp);
     addEnableVulkanValidationFlag(verboseHelp: verboseHelp);
     addEnableEmbedderApiFlag(verboseHelp: verboseHelp);
+    addXcodeSpecificBuildOptions();
   }
 
   bool get traceStartup => boolArg('trace-startup');

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1077,6 +1077,7 @@ Future<void> injectPlugins(
   bool linuxPlatform = false,
   bool macOSPlatform = false,
   bool windowsPlatform = false,
+  bool shouldUseBundler = false,
   Iterable<String>? allowedPlugins,
   DarwinDependencyManagement? darwinDependencyManagement,
 }) async {
@@ -1109,6 +1110,7 @@ Future<void> injectPlugins(
       ),
       fileSystem: globals.fs,
       logger: globals.logger,
+      shouldUseBundler: shouldUseBundler,
     );
     if (iosPlatform) {
       await darwinDependencyManagerSetup.setUp(

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -276,7 +276,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       );
     }
   }
-  await processPodsIfNeeded(project.ios, getIosBuildDirectory(), buildInfo.mode);
+  await processPodsIfNeeded(project.ios, getIosBuildDirectory(), buildInfo.mode, shouldUseBundler: buildInfo.shouldUseBundler);
   if (configOnly) {
     return XcodeBuildResult(success: true);
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -117,7 +117,7 @@ Future<void> buildMacOS({
   // using MACOSX_DEPLOYMENT_TARGET once https://github.com/flutter/flutter/issues/146204
   // is fixed.
 
-  await processPodsIfNeeded(flutterProject.macos, getMacOSBuildDirectory(), buildInfo.mode);
+  await processPodsIfNeeded(flutterProject.macos, getMacOSBuildDirectory(), buildInfo.mode, shouldUseBundler: buildInfo.shouldUseBundler);
   // If the xcfilelists do not exist, create empty version.
   if (!flutterProject.macos.inputFileList.existsSync()) {
     flutterProject.macos.inputFileList.createSync(recursive: true);

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -17,6 +17,7 @@ Future<void> processPodsIfNeeded(
   String buildDirectory,
   BuildMode buildMode, {
   bool forceCocoaPodsOnly = false,
+  bool shouldUseBundler = false,
 }) async {
   final FlutterProject project = xcodeProject.parent;
 
@@ -51,6 +52,11 @@ Future<void> processPodsIfNeeded(
       await globals.cocoaPods?.setupPodfile(xcodeProject);
     }
 
+    // If Bundler has been deintegrated, add it back.
+    if (shouldUseBundler) {
+      await globals.cocoaPods?.setupGemfile(xcodeProject);
+    }
+
     // Delete Swift Package Manager manifest to invalidate fingerprinter
     ErrorHandlingFileSystem.deleteIfExists(
       xcodeProject.flutterPluginSwiftPackageManifest,
@@ -82,6 +88,7 @@ Future<void> processPodsIfNeeded(
     xcodeProject: xcodeProject,
     buildMode: buildMode,
     dependenciesChanged: !fingerprinter.doesFingerprintMatch(),
+    shouldUseBundler: shouldUseBundler,
   ) ?? false;
   if (didPodInstall) {
     fingerprinter.writeFingerprint();

--- a/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
+++ b/packages/flutter_tools/lib/src/macos/darwin_dependency_management.dart
@@ -22,12 +22,14 @@ class DarwinDependencyManagement {
     required SwiftPackageManager swiftPackageManager,
     required FileSystem fileSystem,
     required Logger logger,
+    bool shouldUseBundler = false,
   })  : _project = project,
         _plugins = plugins,
         _cocoapods = cocoapods,
         _swiftPackageManager = swiftPackageManager,
         _fileSystem = fileSystem,
-        _logger = logger;
+        _logger = logger,
+        _shouldUseBundler = shouldUseBundler;
 
   final FlutterProject _project;
   final List<Plugin> _plugins;
@@ -35,6 +37,7 @@ class DarwinDependencyManagement {
   final SwiftPackageManager _swiftPackageManager;
   final FileSystem _fileSystem;
   final Logger _logger;
+  final bool _shouldUseBundler;
 
   /// Generates/updates required files and project settings for Darwin
   /// Dependency Managers (CocoaPods and Swift Package Manager). Projects may
@@ -87,6 +90,10 @@ class DarwinDependencyManagement {
       platform: platform,
       xcodeProject: xcodeProject,
     );
+
+    if (_shouldUseBundler) {
+      await _cocoapods.setupGemfile(xcodeProject);
+    }
 
     final bool useCocoapods;
     if (_project.usesSwiftPackageManager) {

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -370,6 +370,7 @@ class FlutterProject {
     bool macOSPlatform = false,
     bool windowsPlatform = false,
     bool webPlatform = false,
+    bool shouldUseBundler = false,
     DeprecationBehavior deprecationBehavior = DeprecationBehavior.none,
     Iterable<String>? allowedPlugins,
   }) async {
@@ -403,6 +404,7 @@ class FlutterProject {
       macOSPlatform: macOSPlatform,
       windowsPlatform: windowsPlatform,
       allowedPlugins: allowedPlugins,
+      shouldUseBundler: shouldUseBundler,
     );
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -157,6 +157,7 @@ abstract final class FlutterOptions {
   static const String kWebRendererFlag = 'web-renderer';
   static const String kWebResourcesCdnFlag = 'web-resources-cdn';
   static const String kWebWasmFlag = 'wasm';
+  static const String kUseBundler = 'use-bundler';
 }
 
 /// flutter command categories for usage.
@@ -989,6 +990,15 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
+  void addXcodeSpecificBuildOptions({ bool hide = false }) {
+    argParser.addFlag(
+      FlutterOptions.kUseBundler,
+      help: 'Use Bundler to control your Gems versioning. '
+          'If this option enabled it will make sure you have a proper Gemfile in your iOS project directory, '
+          'and execute "bundle install" & "bundle exec" commands before and during Cocoapods process.'
+    );
+  }
+
   void addNativeNullAssertions({ bool hide = false }) {
     argParser.addFlag('native-null-assertions',
       defaultsTo: true,
@@ -1241,6 +1251,9 @@ abstract class FlutterCommand extends Command<void> {
       ? stringsArg(FlutterOptions.kAndroidProjectArgs)
       : <String>[];
 
+    final bool shouldUseBundler = !argParser.options.containsKey(FlutterOptions.kUseBundler)
+        || boolArg(FlutterOptions.kUseBundler);
+
     if (dartObfuscation && (splitDebugInfoPath == null || splitDebugInfoPath.isEmpty)) {
       throwToolExit(
         '"--${FlutterOptions.kDartObfuscationOption}" can only be used in '
@@ -1333,6 +1346,7 @@ abstract class FlutterCommand extends Command<void> {
           : null,
       assumeInitializeFromDillUpToDate: argParser.options.containsKey(FlutterOptions.kAssumeInitializeFromDillUpToDate)
           && boolArg(FlutterOptions.kAssumeInitializeFromDillUpToDate),
+      shouldUseBundler: shouldUseBundler,
     );
   }
 

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -106,6 +106,12 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform  {
   /// The CocoaPods 'Manifest.lock'.
   File get podManifestLock => hostAppRoot.childDirectory('Pods').childFile('Manifest.lock');
 
+  /// The Ruby 'Gemfile'.
+  File get gemfile => hostAppRoot.childFile('Gemfile');
+
+  /// The Ruby 'Gemfile.lock'.
+  File get gemfileLock => hostAppRoot.childFile('Gemfile.lock');
+
   /// The CocoaPods generated 'Pods-Runner-frameworks.sh'.
   File get podRunnerFrameworksScript => podRunnerTargetSupportFiles
       .childFile('Pods-Runner-frameworks.sh');

--- a/packages/flutter_tools/templates/bundler/Gemfile-ios
+++ b/packages/flutter_tools/templates/bundler/Gemfile-ios
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+# Recommended version for `cocoapods` gem
+gem "cocoapods",  '1.13.0'

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -149,6 +149,7 @@
         "templates/cocoapods/Podfile-ios-objc",
         "templates/cocoapods/Podfile-ios-swift",
         "templates/cocoapods/Podfile-macos",
+        "templates/bundler/Gemfile-ios",
 
         "templates/module/android/deferred_component/build.gradle.tmpl",
         "templates/module/android/deferred_component/src/main/AndroidManifest.xml.tmpl",

--- a/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
@@ -540,6 +540,7 @@ class FakeCocoaPods extends Fake implements CocoaPods {
     required XcodeBasedProject xcodeProject,
     required BuildMode buildMode,
     bool dependenciesChanged = true,
+    bool shouldUseBundler = false,
   }) async {
     processedPods = true;
     return true;


### PR DESCRIPTION
What's this feature about?
-
Added `--[no]-use-bundler` flag so that you can manage Cocoapods gem using `Bundler` and execute `bundle exec pod install` rather than `pod install` if `Gemfile` exists.

Closes these issues: 
-
1. [[DISCUSSION] Use bundler to configure dependencies for iOS project](https://github.com/flutter/flutter/issues/22998)
2. [Don't rely on global `pod` installation, use bundled version](https://github.com/flutter/flutter/issues/40135)

How to Test this PR?
-
1. Checkout the branch.
2. Create new project using `--use-bundler` via this command `flutter create --platform ios,android test_case --use-bundler`. It will make sure to add the proper `Gemfile` for you inside `ios` folder.
3.  Add new dependency to the `pubspec.yaml` file that have a native counterpart. For example `webview_flutter:`
4. Build the iOS project via this command to build using `Bundler`, `flutter build ios --use-bundler`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
