### PR TITLE
feat(doctor): added filtering flag

### DIFF
--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -45,6 +45,21 @@ enum ValidationMessageType {
   information,
 }
 
+enum ValidatorType implements Enum {
+  android,
+  ios,
+  web,
+  linux,
+  macos,
+  windows,
+  intellij,
+  vscode,
+  xcode,
+  flutter,
+  devices,
+  http
+}
+
 abstract class DoctorValidator {
   const DoctorValidator(this.title);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
@@ -229,8 +229,8 @@ void main() {
 
 class FakeDoctorValidatorsProvider implements DoctorValidatorsProvider {
   @override
-  List<DoctorValidator> get validators => <DoctorValidator>[];
+  List<Workflow> get workflows => <Workflow>[];
 
   @override
-  List<Workflow> get workflows => <Workflow>[];
+  List<DoctorValidator> getValidators([Map<ValidatorType, bool>? filters]) => <DoctorValidator>[];
 }

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -397,6 +397,7 @@ class FakeDoctor extends Fake implements Doctor {
     List<ValidatorTask>? startedValidatorTasks,
     bool sendEvent = true,
     FlutterVersion? version,
+    Map<ValidatorType, bool>? filters,
   }) async {
     return diagnoseSucceeds;
   }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -323,8 +323,8 @@ class FakeDoctor extends Doctor {
   /// Replaces the android workflow with a version that overrides licensesAccepted,
   /// to prevent individual tests from having to mock out the process for
   /// the Doctor.
-  List<DoctorValidator> get validators {
-    final List<DoctorValidator> superValidators = super.validators;
+  List<DoctorValidator> getValidators([Map<ValidatorType, bool>? filters]) {
+    final List<DoctorValidator> superValidators = super.getValidators();
     return superValidators.map<DoctorValidator>((DoctorValidator v) {
       if (v is AndroidLicenseValidator) {
         return FakeAndroidLicenseValidator();


### PR DESCRIPTION
This PR adds capability to provide to `flutter doctor` a `-f` or `--filter` parameter to run only a specific subset of the total validators present.

Fixes:
- fixes #67131 
## Pre-launch Checklist

Options appear in `-h`:
![2024-05-14 at 19 47 33@2x](https://github.com/flutter/flutter/assets/12763781/191a36cc-a873-4ef0-86dd-55242cc1d768)
Passing no `-f` or `--filter` has existing behaviour:
![2024-05-14 at 20 05 31@2x](https://github.com/flutter/flutter/assets/12763781/02d12a88-fe89-4973-ada3-b51acd8f25f6)
Passing `-f http` will run only the `HttpHostValidator` validation.
![2024-05-14 at 20 09 02@2x](https://github.com/flutter/flutter/assets/12763781/e03b2d97-bddc-4472-b18c-085feb92a7ea)
Passing multiple filters will run only those:
![2024-05-14 at 20 28 17@2x](https://github.com/flutter/flutter/assets/12763781/eb4ae9c8-b060-4dcb-88dd-d7c194f24c94)

Same principle applies to other filters.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
