### PR TITLE
Add test for material_banner.0.dart and material_banner.1.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -363,8 +363,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/segmented_button/segmented_button.0_test.dart',
   'examples/api/test/material/app_bar/sliver_app_bar.2_test.dart',
   'examples/api/test/material/app_bar/sliver_app_bar.3_test.dart',
-  'examples/api/test/material/banner/material_banner.1_test.dart',
-  'examples/api/test/material/banner/material_banner.0_test.dart',
   'examples/api/test/material/navigation_rail/navigation_rail.extended_animation.0_test.dart',
   'examples/api/test/rendering/growth_direction/growth_direction.0_test.dart',
   'examples/api/test/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0_test.dart',

--- a/examples/api/test/material/banner/material_banner.0_test.dart
+++ b/examples/api/test/material/banner/material_banner.0_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/banner/material_banner.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BottomNavigationBar Updates Screen Content', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MaterialBannerExampleApp(),
+    );
+
+    expect(find.byType(MaterialBanner), findsOne);
+    expect(find.text('Hello, I am a Material Banner'), findsOne);
+    expect(find.byIcon(Icons.agriculture_outlined), findsOne);
+    expect(find.widgetWithText(TextButton, 'OPEN'), findsOne);
+    expect(find.widgetWithText(TextButton, 'DISMISS'), findsOne);
+  });
+}

--- a/examples/api/test/material/banner/material_banner.1_test.dart
+++ b/examples/api/test/material/banner/material_banner.1_test.dart
@@ -1,0 +1,25 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/banner/material_banner.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BottomNavigationBar Updates Screen Content', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MaterialBannerExampleApp(),
+    );
+
+    expect(find.byType(MaterialBanner), findsNothing);
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Show MaterialBanner'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MaterialBanner), findsOne);
+    expect(find.text('Hello, I am a Material Banner'), findsOne);
+    expect(find.byIcon(Icons.agriculture_outlined), findsOne);
+    expect(find.widgetWithText(TextButton, 'DISMISS'), findsOne);
+
+  });
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds test for
- `examples/api/lib/material/banner/material_banner.0.dart`
- `examples/api/lib/material/banner/material_banner.2.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
