### PR TITLE
Add test for image.error_builder.0.dart API example.

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -416,7 +416,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/widgets/animated_list/animated_list.0_test.dart',
   'examples/api/test/widgets/focus_traversal/focus_traversal_group.0_test.dart',
   'examples/api/test/widgets/focus_traversal/ordered_traversal_policy.0_test.dart',
-  'examples/api/test/widgets/image/image.error_builder.0_test.dart',
   'examples/api/test/widgets/image/image.frame_builder.0_test.dart',
   'examples/api/test/widgets/image/image.loading_builder.0_test.dart',
   'examples/api/test/widgets/shortcuts/logical_key_set.0_test.dart',

--- a/examples/api/test/widgets/image/image.error_builder.0_test.dart
+++ b/examples/api/test/widgets/image/image.error_builder.0_test.dart
@@ -16,7 +16,7 @@ void main() {
     HttpOverrides.global = null;
   });
 
-  testWidgets('has nonexistent url', (WidgetTester tester) async {
+  testWidgets('Has nonexistent url', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.ErrorBuilderExampleApp(),
     );

--- a/examples/api/test/widgets/image/image.error_builder.0_test.dart
+++ b/examples/api/test/widgets/image/image.error_builder.0_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/image/image.error_builder.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The app being tested loads images via HTTP which the test
+  // framework defeats by default.
+  setUpAll(() {
+    HttpOverrides.global = null;
+  });
+
+  testWidgets('has nonexistent url', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ErrorBuilderExampleApp(),
+    );
+    await tester.pumpAndSettle();
+
+    final Image image = tester.widget<Image>(find.byType(Image));
+    final NetworkImage imageProvider = image.image as NetworkImage;
+
+    expect(
+      imageProvider.url,
+      equals('https://example.does.not.exist/image.jpg'),
+    );
+  });
+
+  testWidgets('errorBuilder returns text with emoji', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.ErrorBuilderExampleApp(),
+    );
+    await tester.pumpAndSettle();
+
+    final Image image = tester.widget<Image>(find.byType(Image));
+    final ImageErrorWidgetBuilder errorBuilder = image.errorBuilder!;
+    final BuildContext context = tester.element(find.byType(Image));
+
+    expect(
+      errorBuilder(context, const HttpException('oops'), StackTrace.empty),
+      isA<Text>().having((Text text) => text.data, 'data', equals('😢')),
+    );
+  });
+}


### PR DESCRIPTION
This PR contributes to https://github.com/flutter/flutter/issues/130459

### Description
- Adds tests for `examples/api/lib/widgets/image/image.error_builder.0.dart`

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.