### PR TITLE
Fix iOS reference in macOS Cocoapods error

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -427,6 +427,24 @@ class CocoaPods {
       final ({String failingPod, String sourcePlugin, String podPluginSubdir})?
           podInfo = _parseMinDeploymentFailureInfo(stdout);
       if (podInfo != null) {
+        final Directory symlinksDir;
+        final String podPlatformString;
+        final String platformName;
+        final String docsLink;
+        if (xcodeProject is IosProject) {
+          symlinksDir = xcodeProject.symlinks;
+          podPlatformString = 'ios';
+          platformName = 'iOS';
+          docsLink = 'https://docs.flutter.dev/deployment/ios';
+        } else if (xcodeProject is MacOSProject) {
+          symlinksDir = xcodeProject.ephemeralDirectory.childDirectory('.symlinks');
+          podPlatformString = 'osx';
+          platformName = 'macOS';
+          docsLink = 'https://docs.flutter.dev/deployment/macos';
+        } else {
+          return;
+        }
+
         final String sourcePlugin = podInfo.sourcePlugin;
         // If the plugin's podfile has set its own minimum version correctly
         // based on the requirements of its dependencies the failing pod should
@@ -435,23 +453,6 @@ class CocoaPods {
         // with a minimum version of 12, then building for 11 will report that
         // pod as failing.)
         if (podInfo.failingPod == podInfo.sourcePlugin) {
-          final Directory symlinksDir;
-          final String podPlatformString;
-          final String platformName;
-          final String docsLink;
-          if (xcodeProject is IosProject) {
-            symlinksDir = xcodeProject.symlinks;
-            podPlatformString = 'ios';
-            platformName = 'iOS';
-            docsLink = 'https://docs.flutter.dev/deployment/ios';
-          } else if (xcodeProject is MacOSProject) {
-            symlinksDir = xcodeProject.ephemeralDirectory.childDirectory('.symlinks');
-            podPlatformString = 'osx';
-            platformName = 'macOS';
-            docsLink = 'https://docs.flutter.dev/deployment/macos';
-          } else {
-            return;
-          }
           final File podspec = symlinksDir
               .childDirectory('plugins')
               .childDirectory(sourcePlugin)
@@ -493,8 +494,8 @@ class CocoaPods {
           // with the plugin developer.
           _logger.printError(
             'Error: The pod "${podInfo.failingPod}" required by the plugin '
-            '"$sourcePlugin" requires a higher minimum iOS deployment version '
-            "than the plugin's reported minimum version.\n"
+            '"$sourcePlugin" requires a higher minimum $platformName deployment '
+            "version than the plugin's reported minimum version.\n"
             'To build, remove the plugin "$sourcePlugin", or contact the plugin\'s '
             'developers for assistance.',
             emphasis: true,

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -836,6 +836,75 @@ Specs satisfying the `GoogleMaps (~> 8.0)` dependency were found, but they requi
       );
     });
 
+    testUsingContext('throws if plugin has a dependency that requires a higher minimum macOS version', () async {
+      final FlutterProject projectUnderTest = setupProjectUnderTest();
+      pretendPodIsInstalled();
+      pretendPodVersionIs('100.0.0');
+      fileSystem.file(fileSystem.path.join('project', 'macos', 'Podfile'))
+        ..createSync()
+        ..writeAsStringSync('Existing Podfile');
+
+      fakeProcessManager.addCommand(
+        const FakeCommand(
+          command: <String>['pod', 'install', '--verbose'],
+          workingDirectory: 'project/macos',
+          environment: <String, String>{
+            'COCOAPODS_DISABLE_STATS': 'true',
+            'LANG': 'en_US.UTF-8',
+          },
+          exitCode: 1,
+          // This is the (very slightly abridged) output from updating the
+          // minimum version of the GoogleMaps dependency in
+          // google_maps_flutter_ios without updating the minimum iOS version to
+          // match, as an example of a misconfigured plugin, but with the paths
+          // modified to simulate a macOS plugin.
+          stdout: '''
+Analyzing dependencies
+
+Inspecting targets to integrate
+  Using `ARCHS` setting to build architectures of target `Pods-Runner`: (``)
+  Using `ARCHS` setting to build architectures of target `Pods-RunnerTests`: (``)
+
+Fetching external sources
+-> Fetching podspec for `Flutter` from `Flutter`
+-> Fetching podspec for `google_maps_flutter_ios` from `.symlinks/plugins/google_maps_flutter_ios/macos`
+
+Resolving dependencies of `Podfile`
+  CDN: trunk Relative path: CocoaPods-version.yml exists! Returning local because checking is only performed in repo update
+  CDN: trunk Relative path: Specs/a/d/d/GoogleMaps/8.0.0/GoogleMaps.podspec.json exists! Returning local because checking is only performed in repo update
+[!] CocoaPods could not find compatible versions for pod "GoogleMaps":
+  In Podfile:
+    google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/macos`) was resolved to 0.0.1, which depends on
+      GoogleMaps (~> 8.0)
+
+Specs satisfying the `GoogleMaps (~> 8.0)` dependency were found, but they required a higher minimum deployment target.''',
+        ),
+      );
+
+      await expectLater(cocoaPodsUnderTest.processPods(
+        xcodeProject: projectUnderTest.macos,
+        buildMode: BuildMode.debug,
+      ), throwsToolExit());
+      expect(
+        logger.errorText,
+        contains(
+          'The pod "GoogleMaps" required by the plugin "google_maps_flutter_ios" '
+          "requires a higher minimum macOS deployment version than the plugin's "
+          'reported minimum version.'
+        ),
+      );
+      // The error should tell the user to contact the plugin author, as this
+      // case is hard for us to give exact advice on, and should only be
+      // possible if there's a mistake in the plugin's podspec.
+      expect(
+        logger.errorText,
+        contains(
+          'To build, remove the plugin "google_maps_flutter_ios", or contact '
+          "the plugin's developers for assistance.",
+        ),
+      );
+    });
+
     testUsingContext('throws if plugin requires higher minimum macOS version using "platform"', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();


### PR DESCRIPTION
Fixes a Cocoapods error message that was hard-coded to reference iOS to instead reference iOS or macOS as appropriate.

Fixes https://github.com/flutter/flutter/issues/146744

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
