### PR TITLE
Allow users to specify CC/CXX environment variables during Linux build

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -174,8 +174,7 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
   // Warn user if C/C++ compilers are not the system default clang/clang++.
   if (!clang.startsWith('/usr/bin/clang')) {
     globals.printStatus(
-      'Warning: C compiler is set to $clang.${(cc != null) ?
-      ' CC environment variable is set to $cc.' : ''} '
+      'Warning: C compiler is set to $clang.${(cc != null) ? ' CC environment variable is set to $cc.' : ''} '
       'Please consider using the distribution-provided clang',
       color: TerminalColor.yellow,
     );
@@ -183,8 +182,7 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
 
   if (!clangPlusPlus.startsWith('/usr/bin/clang++')) {
     globals.printStatus(
-      'Warning: C++ compiler is set to $clangPlusPlus.${(cxx != null) ?
-      ' CXX environment variable is set to $cxx.' : ''} '
+      'Warning: C++ compiler is set to $clangPlusPlus.${(cxx != null) ? ' CXX environment variable is set to $cxx.' : ''} '
       'Please consider using the distribution-provided clang++',
       color: TerminalColor.yellow,
     );

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:process/src/interface/common.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 
 import '../artifacts.dart';
@@ -146,6 +149,47 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
   if (!globals.processManager.canRun('cmake')) {
     throwToolExit(globals.userMessages.cmakeMissing);
   }
+
+  final String? cc = Platform.environment['CC'];
+  final String? cxx = Platform.environment['CXX'];
+
+  final String? clang = getExecutablePath(cc ?? 'clang', null);
+  if (clang == null) {
+    if (cc != null) {
+      throwToolExit('Unable to locate $cc for CC environment variable.'
+          ' Please ensure that $cc is installed and in your PATH.');
+    } else {
+      throwToolExit('Unable to locate clang');
+    }
+  }
+  final String? clangPlusPlus = getExecutablePath(cxx ?? 'clang++', null);
+  if (clangPlusPlus == null) {
+    if (cxx != null) {
+      throwToolExit('Unable to locate $cxx for CXX environment variable.'
+          ' Please ensure that $cxx is installed and in your PATH.');
+    } else {
+      throwToolExit('Unable to locate clang++');
+    }
+  }
+  // Warn user if C/C++ compilers are not the system default clang/clang++.
+  if (!clang.startsWith('/usr/bin/clang')) {
+    globals.printStatus(
+      'Warning: C compiler is set to $clang.${(cc != null) ?
+      ' CC environment variable is set to $cc.' : ''} '
+      'Please consider using the distribution-provided clang',
+      color: TerminalColor.yellow,
+    );
+  }
+
+  if (!clangPlusPlus.startsWith('/usr/bin/clang++')) {
+    globals.printStatus(
+      'Warning: C++ compiler is set to $clangPlusPlus.${(cxx != null) ?
+      ' CXX environment variable is set to $cxx.' : ''} '
+      'Please consider using the distribution-provided clang++',
+      color: TerminalColor.yellow,
+    );
+  }
+
   result = await globals.processUtils.stream(
     <String>[
       'cmake',
@@ -165,8 +209,8 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
     ],
     workingDirectory: buildDir.path,
     environment: <String, String>{
-      'CC': 'clang',
-      'CXX': 'clang++',
+      'CC': clang,
+      'CXX': clangPlusPlus,
     },
     trace: true,
   );


### PR DESCRIPTION
This commit enables flutter uses to specify CC and CXX environment variables during the build process for Linux. Also, it warns the user if the provided C or C++ compilers are not the system's clang and clang++ compilers. If these variables are not declared, the program uses the system default compilers.

Closes #104989

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
