### PR TITLE
Shift a test on MotoG4 to staging, add it on Mokey

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2821,6 +2821,17 @@ targets:
         ["devicelab", "android", "linux", "mokey"]
       task_name: new_gallery_impeller__transition_perf
 
+  # Mokey, Impeller (OpenGL)
+  - name: Linux_mokey new_gallery_opengles_impeller__transition_perf
+    recipe: devicelab/devicelab_drone
+    bringup: true # Device exists only in staging.
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "mokey"]
+      task_name: new_gallery_opengles_impeller__transition_perf
+
   # Mokey, Skia
   - name: Linux_mokey new_gallery__transition_perf
     recipe: devicelab/devicelab_drone
@@ -2856,6 +2867,7 @@ targets:
   # Moto G4, Impeller (OpenGL)
   - name: Linux_android new_gallery_opengles_impeller__transition_perf
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
The test on MotoG4 has lots of flaky timeouts, so this PR moves it to bringup to stop turning the tree red. This PR also adds the test on Mokey in anticipation of removing the MotoG4 devices and to see if it might be flaky there as well.