### PR TITLE
Implement new `AnimationStatus` getters

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/cubic_bezier.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/cubic_bezier.dart
@@ -318,10 +318,10 @@ class AnimatedBezierState extends State<AnimatedBezier>
       ..addListener(() {
         setState(() {});
       })
-      ..addStatusListener((AnimationStatus state) {
-        if (state == AnimationStatus.completed) {
+      ..addStatusListener((AnimationStatus status) {
+        if (status.isCompleted) {
           reverseAnimation();
-        } else if (state == AnimationStatus.dismissed) {
+        } else if (status.isDismissed) {
           playAnimation();
         }
       });

--- a/dev/benchmarks/macrobenchmarks/lib/src/list_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/list_text_layout.dart
@@ -23,7 +23,7 @@ class ColumnOfTextState extends State<ColumnOfText> with SingleTickerProviderSta
       duration: const Duration(milliseconds: 300),
     )
       ..addStatusListener((AnimationStatus status) {
-        if (status == AnimationStatus.completed) {
+        if (status.isCompleted) {
           setState(() {
             _showText = !_showText;
           });

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -277,8 +277,7 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
   }
 
   void _toggleBackdropPanelVisibility() {
-    final bool backdropPanelVisible = _controller.isForwardOrCompleted;
-    _controller.fling(velocity: backdropPanelVisible ? -2.0 : 2.0);
+    _controller.fling(velocity: _controller.isForwardOrCompleted ? -2.0 : 2.0);
   }
 
   double get _backdropHeight {
@@ -290,7 +289,7 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
   // the user must either tap its heading or the backdrop's menu icon.
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    if (_controller.isAnimating || _controller.isCompleted) {
+    if (!_controller.isDismissed) {
       return;
     }
 

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -276,13 +276,9 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
     });
   }
 
-  bool get _backdropPanelVisible {
-    final AnimationStatus status = _controller.status;
-    return status == AnimationStatus.completed || status == AnimationStatus.forward;
-  }
-
   void _toggleBackdropPanelVisibility() {
-    _controller.fling(velocity: _backdropPanelVisible ? -2.0 : 2.0);
+    final bool backdropPanelVisible = _controller.isForwardOrCompleted;
+    _controller.fling(velocity: backdropPanelVisible ? -2.0 : 2.0);
   }
 
   double get _backdropHeight {
@@ -294,7 +290,7 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
   // the user must either tap its heading or the backdrop's menu icon.
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    if (_controller.isAnimating || _controller.status == AnimationStatus.completed) {
+    if (_controller.isAnimating || _controller.isCompleted) {
       return;
     }
 
@@ -302,7 +298,7 @@ class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderSt
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    if (_controller.isAnimating || _controller.status == AnimationStatus.completed) {
+    if (!_controller.isDismissed) {
       return;
     }
 

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
@@ -231,10 +231,7 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerP
   }
 
   // Returns true if the cart is open or opening and false otherwise.
-  bool get _isOpen {
-    final AnimationStatus status = _controller.status;
-    return status == AnimationStatus.completed || status == AnimationStatus.forward;
-  }
+  bool get _isOpen => _controller.isForwardOrCompleted;
 
   // Opens the ExpandingBottomSheet if it's closed, otherwise does nothing.
   void open() {

--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -241,7 +241,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    if (_controller!.isAnimating || _controller!.status == AnimationStatus.completed) {
+    if (!_controller!.isDismissed) {
       return;
     }
 
@@ -256,9 +256,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
   }
 
   void _toggleFrontLayer() {
-    final AnimationStatus status = _controller!.status;
-    final bool isOpen = status == AnimationStatus.completed || status == AnimationStatus.forward;
-    _controller!.fling(velocity: isOpen ? -2.0 : 2.0);
+    _controller!.fling(velocity: _controller!.isForwardOrCompleted ? -2.0 : 2.0);
   }
 
   Widget _buildStack(BuildContext context, BoxConstraints constraints) {
@@ -295,7 +293,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
                 AnimationStatus.dismissed,
                 controller: _controller,
                 child: Visibility(
-                  visible: _controller!.status != AnimationStatus.completed,
+                  visible: !_controller!.isCompleted,
                   maintainState: true,
                   child: widget.backLayer!,
                 ),

--- a/dev/integration_tests/new_gallery/lib/demos/reference/motion_demo_fade_scale_transition.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/reference/motion_demo_fade_scale_transition.dart
@@ -90,7 +90,7 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
           );
         },
         child: Visibility(
-          visible: _controller.status != AnimationStatus.dismissed,
+          visible: !_controller.isDismissed,
           child: FloatingActionButton(
             onPressed: () {},
             child: const Icon(Icons.add),

--- a/dev/integration_tests/new_gallery/lib/feature_discovery/feature_discovery.dart
+++ b/dev/integration_tests/new_gallery/lib/feature_discovery/feature_discovery.dart
@@ -287,10 +287,14 @@ class _FeatureDiscoveryState extends State<FeatureDiscovery>
         setState(() {});
       })
       ..addStatusListener((AnimationStatus animationStatus) {
-        if (animationStatus == AnimationStatus.forward) {
-          setState(() => status = FeatureDiscoveryStatus.open);
-        } else if (animationStatus == AnimationStatus.completed) {
-          rippleController.forward(from: 0.0);
+        switch (animationStatus) {
+          case AnimationStatus.forward:
+            setState(() => status = FeatureDiscoveryStatus.open);
+          case AnimationStatus.completed:
+            rippleController.forward(from: 0.0);
+          case AnimationStatus.reverse:
+          case AnimationStatus.dismissed:
+            break;
         }
       });
 
@@ -302,10 +306,14 @@ class _FeatureDiscoveryState extends State<FeatureDiscovery>
         setState(() {});
       })
       ..addStatusListener((AnimationStatus animationStatus) {
-        if (animationStatus == AnimationStatus.forward) {
-          setState(() => status = FeatureDiscoveryStatus.ripple);
-        } else if (animationStatus == AnimationStatus.completed) {
-          rippleController.forward(from: 0.0);
+        switch (animationStatus) {
+          case AnimationStatus.forward:
+            setState(() => status = FeatureDiscoveryStatus.ripple);
+          case AnimationStatus.completed:
+            rippleController.forward(from: 0.0);
+          case AnimationStatus.reverse:
+          case AnimationStatus.dismissed:
+            break;
         }
       });
 
@@ -317,11 +325,15 @@ class _FeatureDiscoveryState extends State<FeatureDiscovery>
         setState(() {});
       })
       ..addStatusListener((AnimationStatus animationStatus) {
-        if (animationStatus == AnimationStatus.forward) {
-          setState(() => status = FeatureDiscoveryStatus.tap);
-        } else if (animationStatus == AnimationStatus.completed) {
-          widget.onTap?.call();
-          cleanUponOverlayClose();
+        switch (animationStatus) {
+          case AnimationStatus.forward:
+            setState(() => status = FeatureDiscoveryStatus.tap);
+          case AnimationStatus.completed:
+            widget.onTap?.call();
+            cleanUponOverlayClose();
+          case AnimationStatus.reverse:
+          case AnimationStatus.dismissed:
+            break;
         }
       });
 
@@ -333,11 +345,15 @@ class _FeatureDiscoveryState extends State<FeatureDiscovery>
         setState(() {});
       })
       ..addStatusListener((AnimationStatus animationStatus) {
-        if (animationStatus == AnimationStatus.forward) {
-          setState(() => status = FeatureDiscoveryStatus.dismiss);
-        } else if (animationStatus == AnimationStatus.completed) {
-          widget.onDismiss?.call();
-          cleanUponOverlayClose();
+        switch (animationStatus) {
+          case AnimationStatus.forward:
+            setState(() => status = FeatureDiscoveryStatus.dismiss);
+          case AnimationStatus.completed:
+            widget.onDismiss?.call();
+            cleanUponOverlayClose();
+          case AnimationStatus.reverse:
+          case AnimationStatus.dismissed:
+            break;
         }
       });
   }

--- a/dev/integration_tests/new_gallery/lib/pages/category_list_item.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/category_list_item.dart
@@ -91,19 +91,8 @@ class _CategoryListItemState extends State<CategoryListItem>
     super.dispose();
   }
 
-  bool _shouldOpenList() {
-    switch (_controller.status) {
-      case AnimationStatus.completed:
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
-        return false;
-      case AnimationStatus.dismissed:
-        return true;
-    }
-  }
-
   void _handleTap() {
-    if (_shouldOpenList()) {
+    if (_controller.isDismissed) {
       _controller.forward();
       if (widget.onTap != null) {
         widget.onTap!(true);
@@ -148,7 +137,7 @@ class _CategoryListItemState extends State<CategoryListItem>
     return AnimatedBuilder(
       animation: _controller.view,
       builder: _buildHeaderWithChildren,
-      child: _shouldOpenList()
+      child: _controller.isDismissed
           ? null
           : _ExpandedCategoryDemos(
               category: widget.category,

--- a/dev/integration_tests/new_gallery/lib/pages/settings.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/settings.dart
@@ -52,7 +52,7 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   void _closeSettingId(AnimationStatus status) {
-    if (status == AnimationStatus.dismissed) {
+    if (status.isDismissed) {
       setState(() {
         _expandedSettingId = null;
       });

--- a/dev/integration_tests/new_gallery/lib/pages/splash.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/splash.dart
@@ -112,7 +112,7 @@ class _SplashPageState extends State<SplashPage>
         return true;
       },
       child: SplashPageAnimation(
-        isFinished: _controller.status == AnimationStatus.dismissed,
+        isFinished: _controller.isDismissed,
         child: LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
             final Animation<RelativeRect> animation = _getPanelAnimation(context, constraints);
@@ -122,9 +122,7 @@ class _SplashPageState extends State<SplashPage>
                 cursor: SystemMouseCursors.click,
                 child: GestureDetector(
                   behavior: HitTestBehavior.opaque,
-                  onTap: () {
-                    _controller.reverse();
-                  },
+                  onTap: _controller.reverse,
                   onVerticalDragEnd: (DragEndDetails details) {
                     if (details.velocity.pixelsPerSecond.dy < -200) {
                       _controller.reverse();
@@ -168,9 +166,7 @@ class _SplashPageState extends State<SplashPage>
                   _SplashBackLayer(
                     isSplashCollapsed: !_isSplashVisible,
                     effect: _effect,
-                    onTap: () {
-                      _controller.forward();
-                    },
+                    onTap: _controller.forward,
                   ),
                   PositionedTransition(
                     rect: animation,

--- a/dev/integration_tests/new_gallery/lib/studies/reply/adaptive_nav.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/reply/adaptive_nav.dart
@@ -520,11 +520,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
     super.dispose();
   }
 
-  bool get _bottomDrawerVisible {
-    final AnimationStatus status = _drawerController.status;
-    return status == AnimationStatus.completed ||
-        status == AnimationStatus.forward;
-  }
+  bool get _bottomDrawerVisible => _drawerController.isForwardOrCompleted;
 
   void _toggleBottomDrawerVisibility() {
     if (_drawerController.value < 0.4) {
@@ -550,8 +546,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
   }
 
   void _handleDragEnd(DragEndDetails details) {
-    if (_drawerController.isAnimating ||
-        _drawerController.status == AnimationStatus.completed) {
+    if (!_drawerController.isDismissed) {
       return;
     }
 

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/app.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/app.dart
@@ -71,8 +71,7 @@ class _ShrineAppState extends State<ShrineApp>
     // Save state restoration animation values only when the cart page
     // fully opens or closes.
     _controller.addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.completed ||
-          status == AnimationStatus.dismissed) {
+      if (!status.isAnimating) {
         _tabIndex.value = _controller.value;
       }
     });
@@ -83,8 +82,7 @@ class _ShrineAppState extends State<ShrineApp>
     // Save state restoration animation values only when the menu page
     // fully opens or closes.
     _expandingController.addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.completed ||
-          status == AnimationStatus.dismissed) {
+      if (!status.isAnimating) {
         _expandingTabIndex.value = _expandingController.value;
       }
     });
@@ -119,8 +117,7 @@ class _ShrineAppState extends State<ShrineApp>
   // Closes the bottom sheet if it is open.
   Future<bool> _onWillPop() async {
     final AnimationStatus status = _expandingController.status;
-    if (status == AnimationStatus.completed ||
-        status == AnimationStatus.forward) {
+    if (status.isForwardOrCompleted) {
       await _expandingController.reverse();
       return false;
     }

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/app.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/app.dart
@@ -116,8 +116,7 @@ class _ShrineAppState extends State<ShrineApp>
 
   // Closes the bottom sheet if it is open.
   Future<bool> _onWillPop() async {
-    final AnimationStatus status = _expandingController.status;
-    if (status.isForwardOrCompleted) {
+    if (_expandingController.isForwardOrCompleted) {
       await _expandingController.reverse();
       return false;
     }

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -338,11 +338,7 @@ class ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
   }
 
   // Returns true if the cart is open or opening and false otherwise.
-  bool get _isOpen {
-    final AnimationStatus status = _controller.status;
-    return status == AnimationStatus.completed ||
-        status == AnimationStatus.forward;
-  }
+  bool get _isOpen => _controller.isForwardOrCompleted;
 
   // Opens the ExpandingBottomSheet if it's closed, otherwise does nothing.
   void open() {

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/scrim.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/scrim.dart
@@ -11,35 +11,28 @@ class Scrim extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Size deviceSize = MediaQuery.of(context).size;
     return ExcludeSemantics(
       child: AnimatedBuilder(
         animation: controller,
         builder: (BuildContext context, Widget? child) {
-          final Color color =
-              const Color(0xFFFFF0EA).withOpacity(controller.value * 0.87);
+          final Widget scrimRectangle = ColoredBox(
+            color: Color.fromRGBO(0xFF, 0xF0, 0xEA, controller.value * 0.87),
+            child: SizedBox.fromSize(size: MediaQuery.sizeOf(context)),
+          );
 
-          final Widget scrimRectangle = Container(
-              width: deviceSize.width, height: deviceSize.height, color: color);
-
-          final bool ignorePointer =
-              (controller.status == AnimationStatus.dismissed);
-          final bool tapToRevert = (controller.status == AnimationStatus.completed);
-
-          if (tapToRevert) {
-            return MouseRegion(
-              cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                onTap: () {
-                  controller.reverse();
-                },
-                child: scrimRectangle,
-              ),
-            );
-          } else if (ignorePointer) {
-            return IgnorePointer(child: scrimRectangle);
-          } else {
-            return scrimRectangle;
+          switch (controller.status) {
+            case AnimationStatus.completed:
+              return MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: controller.reverse,
+                  child: scrimRectangle,
+                ),
+              );
+            case AnimationStatus.dismissed:
+              return IgnorePointer(child: scrimRectangle);
+            case AnimationStatus.forward || AnimationStatus.reverse:
+              return scrimRectangle;
           }
         },
       ),

--- a/examples/api/lib/animation/animation_controller/animated_digit.0.dart
+++ b/examples/api/lib/animation/animation_controller/animated_digit.0.dart
@@ -77,7 +77,7 @@ class _AnimatedDigitState extends State<AnimatedDigit> with SingleTickerProvider
   }
 
   void handleAnimationCompleted(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
+    if (status.isCompleted) {
       if (pendingValues.isNotEmpty) {
         // Display the next pending value. The duration was scaled down
         // in didUpdateWidget by the total number of pending values so

--- a/examples/api/lib/material/navigation_bar/navigation_bar.2.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.2.dart
@@ -32,18 +32,14 @@ class _HomeState extends State<Home> with TickerProviderStateMixin<Home> {
   int selectedIndex = 0;
 
   AnimationController buildFaderController() {
-    final AnimationController controller = AnimationController(
+    return AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 300),
-    );
-    controller.addStatusListener(
-      (AnimationStatus status) {
-        if (status == AnimationStatus.dismissed) {
-          setState(() {}); // Rebuild unselected destinations offstage.
-        }
-      },
-    );
-    return controller;
+    )..addStatusListener((AnimationStatus status) {
+      if (status.isDismissed) {
+        setState(() {}); // Rebuild unselected destinations offstage.
+      }
+    });
   }
 
   @override

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -36,7 +36,7 @@ enum AnimationStatus {
   bool get isCompleted => this == completed;
 
   /// Whether the animation is running in either direction.
-  bool get isRunning => switch (this) {
+  bool get isAnimating => switch (this) {
     forward   || reverse   => true,
     completed || dismissed => false,
   };
@@ -180,7 +180,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   bool get isCompleted => status.isCompleted;
 
   /// Whether this animation is running in either direction.
-  bool get isRunning => status.isRunning;
+  bool get isAnimating => status.isAnimating;
 
   /// {@macro flutter.animation.AnimationStatus.isForwardOrCompleted}
   bool get isForwardOrCompleted => status.isForwardOrCompleted;

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -432,9 +432,10 @@ class AnimationController extends Animation<double>
     } else if (_value == upperBound) {
       _status = AnimationStatus.completed;
     } else {
-      _status = (_direction == _AnimationDirection.forward) ?
-        AnimationStatus.forward :
-        AnimationStatus.reverse;
+      _status = switch (_direction) {
+        _AnimationDirection.forward => AnimationStatus.forward,
+        _AnimationDirection.reverse => AnimationStatus.reverse,
+      };
     }
   }
 
@@ -451,6 +452,7 @@ class AnimationController extends Animation<double>
   /// controller's ticker might get muted, in which case the animation
   /// controller's callbacks will no longer fire even though time is continuing
   /// to pass. See [Ticker.muted] and [TickerMode].
+  @override
   bool get isAnimating => _ticker != null && _ticker!.isActive;
 
   _AnimationDirection _direction;

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -425,7 +425,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   bool isDisposed = false;
 
   void _updateCurveDirection(AnimationStatus status) {
-    _curveDirection = status.isForwardOrCompleted ? _curveDirection ?? status : null;
+    _curveDirection = status.isAnimating ? _curveDirection ?? status : null;
   }
 
   bool get _useForwardCurve {

--- a/packages/flutter/lib/src/animation/animations.dart
+++ b/packages/flutter/lib/src/animation/animations.dart
@@ -425,10 +425,7 @@ class CurvedAnimation extends Animation<double> with AnimationWithParentMixin<do
   bool isDisposed = false;
 
   void _updateCurveDirection(AnimationStatus status) {
-    _curveDirection = switch (status) {
-      AnimationStatus.dismissed || AnimationStatus.completed => null,
-      AnimationStatus.forward || AnimationStatus.reverse => _curveDirection ?? status,
-    };
+    _curveDirection = status.isForwardOrCompleted ? _curveDirection ?? status : null;
   }
 
   bool get _useForwardCurve {
@@ -684,12 +681,7 @@ abstract class CompoundAnimation<T> extends Animation<T>
   /// The default is that if the [next] animation is moving, use its status.
   /// Otherwise, default to [first].
   @override
-  AnimationStatus get status {
-    if (next.status == AnimationStatus.forward || next.status == AnimationStatus.reverse) {
-      return next.status;
-    }
-    return first.status;
-  }
+  AnimationStatus get status => next.status.isAnimating ? next.status : first.status;
 
   @override
   String toString() {

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -502,7 +502,7 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
   // Watch for when _ContextMenuRoute is closed and return to the state where
   // the CupertinoContextMenu just behaves as a Container.
   void _routeAnimationStatusListener(AnimationStatus status) {
-    if (status != AnimationStatus.dismissed) {
+    if (!status.isDismissed) {
       return;
     }
     if (mounted) {
@@ -1125,14 +1125,14 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
     // When the scale passes the threshold, animate the sheet back in.
     if (_lastScale > _kSheetScaleThreshold) {
       _moveController.removeListener(_moveListener);
-      if (_sheetController.status != AnimationStatus.dismissed) {
+      if (!_sheetController.isDismissed) {
         _sheetController.reverse();
       }
     }
   }
 
   void _flingStatusListener(AnimationStatus status) {
-    if (status != AnimationStatus.completed) {
+    if (!status.isCompleted) {
       return;
     }
 

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -568,7 +568,7 @@ class _CupertinoTextSelectionToolbarContentState extends State<_CupertinoTextSel
   }
 
   void _statusListener(AnimationStatus status) {
-    if (status != AnimationStatus.dismissed) {
+    if (!status.isDismissed) {
       return;
     }
 

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -312,17 +312,12 @@ class _MaterialBannerState extends State<MaterialBanner> {
     super.dispose();
   }
 
-  void _onAnimationStatusChanged(AnimationStatus animationStatus) {
-    switch (animationStatus) {
-      case AnimationStatus.dismissed:
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
-        break;
-      case AnimationStatus.completed:
-        if (widget.onVisible != null && !_wasVisible) {
-          widget.onVisible!();
-        }
-        _wasVisible = true;
+  void _onAnimationStatusChanged(AnimationStatus status) {
+    if (status.isCompleted) {
+      if (widget.onVisible != null && !_wasVisible) {
+        widget.onVisible!();
+      }
+      _wasVisible = true;
     }
   }
 

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -902,22 +902,15 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
           index: index,
           color: widget.items[index].backgroundColor!,
           vsync: this,
-        )..controller.addStatusListener(
-          (AnimationStatus status) {
-            switch (status) {
-              case AnimationStatus.completed:
-                setState(() {
-                  final _Circle circle = _circles.removeFirst();
-                  _backgroundColor = circle.color;
-                  circle.dispose();
-                });
-              case AnimationStatus.dismissed:
-              case AnimationStatus.forward:
-              case AnimationStatus.reverse:
-                break;
-            }
-          },
-        ),
+        )..controller.addStatusListener((AnimationStatus status) {
+          if (status.isCompleted) {
+            setState(() {
+              final _Circle circle = _circles.removeFirst();
+              _backgroundColor = circle.color;
+              circle.dispose();
+            });
+          }
+        }),
       );
     }
   }

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1315,7 +1315,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
   }
 
   void _resetOrientationAnimation(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
+    if (status.isCompleted) {
       assert(_orientationAnimation.value == math.pi);
       _orientationOffset += math.pi;
       _orientationController.value = 0.0; // TODO(ianh): This triggers a pointless rebuild.
@@ -1328,7 +1328,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
     bool skipArrow = false;
     final bool? newUp = widget.up ?? _up;
     if (oldWidget.visible != widget.visible) {
-      if (widget.visible && (_opacityController.status == AnimationStatus.dismissed)) {
+      if (widget.visible && _opacityController.isDismissed) {
         _orientationController.stop();
         _orientationController.value = 0.0;
         _orientationOffset = newUp! ? 0.0 : math.pi;
@@ -1341,7 +1341,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
       }
     }
     if ((_up != newUp) && !skipArrow) {
-      if (_orientationController.status == AnimationStatus.dismissed) {
+      if (_orientationController.isDismissed) {
         _orientationController.forward();
       } else {
         _orientationController.reverse();

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -489,15 +489,8 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     if (widget.scrimColor != oldWidget.scrimColor) {
       _scrimColorTween = _buildScrimColorTween();
     }
-    if (widget.isDrawerOpen != oldWidget.isDrawerOpen) {
-      switch (_controller.status) {
-        case AnimationStatus.completed:
-        case AnimationStatus.dismissed:
-          _controller.value = widget.isDrawerOpen ? 1.0 : 0.0;
-        case AnimationStatus.forward:
-        case AnimationStatus.reverse:
-          break;
-      }
+    if (widget.isDrawerOpen != oldWidget.isDrawerOpen && !_controller.isAnimating) {
+      _controller.value = widget.isDrawerOpen ? 1.0 : 0.0;
     }
   }
 
@@ -529,7 +522,6 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         _historyEntry?.remove();
         _historyEntry = null;
       case AnimationStatus.dismissed:
-        break;
       case AnimationStatus.completed:
         break;
     }
@@ -671,7 +663,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
         (DrawerAlignment.end,   TextDirection.ltr) => MediaQuery.paddingOf(context).right,
       };
 
-    if (_controller.status == AnimationStatus.dismissed) {
+    if (_controller.isDismissed) {
       if (widget.enableOpenDragGesture && !isDesktop) {
         return Align(
           alignment: _drawerOuterAlignment,

--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -92,7 +92,7 @@ class InkHighlight extends InteractiveInkFeature {
   }
 
   void _handleAlphaStatusChanged(AnimationStatus status) {
-    if (status == AnimationStatus.dismissed && !_active) {
+    if (status.isDismissed && !_active) {
       dispose();
     }
   }

--- a/packages/flutter/lib/src/material/ink_ripple.dart
+++ b/packages/flutter/lib/src/material/ink_ripple.dart
@@ -209,7 +209,7 @@ class InkRipple extends InteractiveInkFeature {
   }
 
   void _handleAlphaStatusChanged(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
+    if (status.isCompleted) {
       dispose();
     }
   }

--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -212,7 +212,7 @@ class InkSparkle extends InteractiveInkFeature {
   }
 
   void _handleStatusChanged(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
+    if (status.isCompleted) {
       dispose();
     }
   }

--- a/packages/flutter/lib/src/material/ink_splash.dart
+++ b/packages/flutter/lib/src/material/ink_splash.dart
@@ -182,7 +182,7 @@ class InkSplash extends InteractiveInkFeature {
   }
 
   void _handleAlphaStatusChanged(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
+    if (status.isCompleted) {
       dispose();
     }
   }

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -295,16 +295,9 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
   }
 
   void _removeEmptyGaps() {
-    int j = 0;
-
-    while (j < _children.length) {
-      if (
-        _children[j] is MaterialGap &&
-        _animationTuples[_children[j].key]!.controller.isDismissed
-      ) {
+    for (int j = _children.length - 1; j >= 0; j -= 1) {
+      if (_children[j] is MaterialGap && _animationTuples[_children[j].key]!.controller.isDismissed) {
         _removeChild(j);
-      } else {
-        j += 1;
       }
     }
   }

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -300,7 +300,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
     while (j < _children.length) {
       if (
         _children[j] is MaterialGap &&
-        _animationTuples[_children[j].key]!.controller.status == AnimationStatus.dismissed
+        _animationTuples[_children[j].key]!.controller.isDismissed
       ) {
         _removeChild(j);
       } else {

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -403,7 +403,7 @@ class NavigationDestination extends StatelessWidget {
             _StatusTransitionWidgetBuilder(
               animation: animation,
               builder: (BuildContext context, Widget? child) {
-                return _isForwardOrCompleted(animation)
+                return animation.isForwardOrCompleted
                   ? selectedIconWidget
                   : unselectedIconWidget;
               },
@@ -420,7 +420,7 @@ class NavigationDestination extends StatelessWidget {
           ?? defaults.labelTextStyle!.resolve(disabledState);
 
         final TextStyle? textStyle = enabled
-          ? _isForwardOrCompleted(animation)
+          ? animation.isForwardOrCompleted
             ? effectiveSelectedLabelTextStyle
             : effectiveUnselectedLabelTextStyle
           : effectiveDisabledLabelTextStyle;
@@ -778,7 +778,7 @@ class NavigationIndicator extends StatelessWidget {
         animation: animation,
         builder: (BuildContext context, Widget? child) {
           return _SelectableAnimatedBuilder(
-            isSelected: _isForwardOrCompleted(animation),
+            isSelected: animation.isForwardOrCompleted,
             duration: const Duration(milliseconds: 100),
             alwaysDoFullAnimation: true,
             builder: (BuildContext context, Animation<double> fadeAnimation) {
@@ -938,7 +938,7 @@ class _NavigationBarDestinationSemantics extends StatelessWidget {
       animation: destinationInfo.selectedAnimation,
       builder: (BuildContext context, Widget? child) {
         return Semantics(
-          selected: _isForwardOrCompleted(destinationInfo.selectedAnimation),
+          selected: destinationInfo.selectedAnimation.isForwardOrCompleted,
           container: true,
           child: child,
         );
@@ -1299,13 +1299,6 @@ class _CurvedAnimationBuilderState extends State<_CurvedAnimationBuilder> {
 
     return widget.builder(context, curvedAnimation);
   }
-}
-
-/// Returns `true` if this animation is ticking forward, or has completed,
-/// based on [status].
-bool _isForwardOrCompleted(Animation<double> animation) {
-  return animation.status == AnimationStatus.forward
-      || animation.status == AnimationStatus.completed;
 }
 
 NavigationBarThemeData _defaultsFor(BuildContext context) {

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -265,7 +265,7 @@ class NavigationDrawerDestination extends StatelessWidget {
           child: icon,
         );
 
-        return _isForwardOrCompleted(animation)
+        return animation.isForwardOrCompleted
             ? selectedIconWidget
             : unselectedIconWidget;
       },
@@ -278,7 +278,7 @@ class NavigationDrawerDestination extends StatelessWidget {
             defaults.labelTextStyle!.resolve(enabled ? unselectedState : disabledState);
 
         return DefaultTextStyle(
-          style: _isForwardOrCompleted(animation)
+          style: animation.isForwardOrCompleted
             ? effectiveSelectedLabelTextStyle!
             : effectiveUnselectedLabelTextStyle!,
           child: label,
@@ -419,7 +419,7 @@ class _NavigationDestinationSemantics extends StatelessWidget {
       animation: destinationInfo.selectedAnimation,
       builder: (BuildContext context, Widget? child) {
         return Semantics(
-          selected: _isForwardOrCompleted(destinationInfo.selectedAnimation),
+          selected: destinationInfo.selectedAnimation.isForwardOrCompleted,
           container: true,
           child: child,
         );
@@ -683,12 +683,6 @@ class _SelectableAnimatedBuilderState extends State<_SelectableAnimatedBuilder>
       _controller,
     );
   }
-}
-
-/// Returns `true` if this animation is ticking forward, or has completed,
-/// based on [status].
-bool _isForwardOrCompleted(Animation<double> animation) {
-  return animation.status == AnimationStatus.forward || animation.status == AnimationStatus.completed;
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - NavigationDrawer

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -965,10 +965,7 @@ mixin _ZoomTransitionBase<S extends StatefulWidget> on State<S> {
   }
 
   void onAnimationStatusChange(AnimationStatus status) {
-    controller.allowSnapshotting = switch (status) {
-      AnimationStatus.dismissed || AnimationStatus.completed => false,
-      AnimationStatus.forward   || AnimationStatus.reverse   => useSnapshot,
-    };
+    controller.allowSnapshotting = status.isAnimating && useSnapshot;
   }
 
   @override
@@ -1016,7 +1013,7 @@ class _ZoomEnterTransitionPainter extends SnapshotPainter {
     // instead of checking that it is `forward` is that this allows
     // the interrupted reversal of the forward transition to smoothly fade
     // the scrim away. This prevents a disjointed removal of the scrim.
-    if (!reverse && animation.status != AnimationStatus.completed) {
+    if (!reverse && !animation.isCompleted) {
       scrimOpacity = _ZoomEnterTransitionState._scrimOpacityTween.evaluate(animation)!;
     }
     assert(!reverse || scrimOpacity == 0.0);
@@ -1030,12 +1027,8 @@ class _ZoomEnterTransitionPainter extends SnapshotPainter {
 
   @override
   void paint(PaintingContext context, ui.Offset offset, Size size, PaintingContextCallback painter) {
-    switch (animation.status) {
-      case AnimationStatus.completed:
-      case AnimationStatus.dismissed:
-        return painter(context, offset);
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
+    if (!animation.isAnimating) {
+      return painter(context, offset);
     }
 
     _drawScrim(context, offset, size);
@@ -1102,13 +1095,8 @@ class _ZoomExitTransitionPainter extends SnapshotPainter {
 
   @override
   void paint(PaintingContext context, ui.Offset offset, Size size, PaintingContextCallback painter) {
-    switch (animation.status) {
-      case AnimationStatus.completed:
-      case AnimationStatus.dismissed:
-        return painter(context, offset);
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
-        break;
+    if (!animation.isAnimating) {
+      return painter(context, offset);
     }
 
     _updateScaledTransform(_transform, scale.value, size);
@@ -1254,7 +1242,7 @@ class _ZoomEnterTransitionNoCache extends StatelessWidget {
     // instead of checking that it is `forward` is that this allows
     // the interrupted reversal of the forward transition to smoothly fade
     // the scrim away. This prevents a disjointed removal of the scrim.
-    if (!reverse && animation.status != AnimationStatus.completed) {
+    if (!reverse && !animation.isCompleted) {
       opacity = _ZoomEnterTransitionState._scrimOpacityTween.evaluate(animation)!;
     }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -844,7 +844,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       parent: _state.valueIndicatorController,
       curve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.dismissed) {
+      if (status.isDismissed) {
         _state.overlayEntry?.remove();
         _state.overlayEntry?.dispose();
         _state.overlayEntry = null;
@@ -1247,7 +1247,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
         _state.interactionTimer =
           Timer(_minimumInteractionTime * timeDilation, () {
             _state.interactionTimer = null;
-            if (!_active && _state.valueIndicatorController.status == AnimationStatus.completed) {
+            if (!_active && _state.valueIndicatorController.isCompleted) {
               _state.valueIndicatorController.reverse();
             }
           });

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -407,7 +407,6 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
         });
         _updateScaffolds();
       case AnimationStatus.forward:
-        break;
       case AnimationStatus.reverse:
         break;
     }
@@ -436,7 +435,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   ///
   /// The closed completer is called after the animation is complete.
   void hideCurrentSnackBar({ SnackBarClosedReason reason = SnackBarClosedReason.hide }) {
-    if (_snackBars.isEmpty || _snackBarController!.status == AnimationStatus.dismissed) {
+    if (_snackBars.isEmpty || _snackBarController!.isDismissed) {
       return;
     }
     final Completer<SnackBarClosedReason> completer = _snackBars.first._completer;
@@ -458,7 +457,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// Removes all the snackBars currently in queue by clearing the queue
   /// and running normal exit animation on the current snackBar.
   void clearSnackBars() {
-    if (_snackBars.isEmpty || _snackBarController!.status == AnimationStatus.dismissed) {
+    if (_snackBars.isEmpty || _snackBarController!.isDismissed) {
       return;
     }
     final ScaffoldFeatureController<SnackBar, SnackBarClosedReason> currentSnackbar = _snackBars.first;
@@ -538,7 +537,6 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
       case AnimationStatus.completed:
         _updateScaffolds();
       case AnimationStatus.forward:
-        break;
       case AnimationStatus.reverse:
         break;
     }
@@ -566,7 +564,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   ///
   /// The closed completer is called after the animation is complete.
   void hideCurrentMaterialBanner({ MaterialBannerClosedReason reason = MaterialBannerClosedReason.hide }) {
-    if (_materialBanners.isEmpty || _materialBannerController!.status == AnimationStatus.dismissed) {
+    if (_materialBanners.isEmpty || _materialBannerController!.isDismissed) {
       return;
     }
     final Completer<MaterialBannerClosedReason> completer = _materialBanners.first._completer;
@@ -586,7 +584,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// Removes all the [MaterialBanner]s currently in queue by clearing the queue
   /// and running normal exit animation on the current [MaterialBanner].
   void clearMaterialBanners() {
-    if (_materialBanners.isEmpty || _materialBannerController!.status == AnimationStatus.dismissed) {
+    if (_materialBanners.isEmpty || _materialBannerController!.isDismissed) {
       return;
     }
     final ScaffoldFeatureController<MaterialBanner, MaterialBannerClosedReason> currentMaterialBanner = _materialBanners.first;
@@ -606,10 +604,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
         if (_snackBarController!.isCompleted && _snackBarTimer == null) {
           final SnackBar snackBar = _snackBars.first._widget;
           _snackBarTimer = Timer(snackBar.duration, () {
-            assert(
-              _snackBarController!.status == AnimationStatus.forward ||
-                _snackBarController!.status == AnimationStatus.completed,
-            );
+            assert(_snackBarController!.isForwardOrCompleted);
             // Look up MediaQuery again in case the setting changed.
             if (snackBar.action != null && MediaQuery.accessibleNavigationOf(context)) {
               return;
@@ -1369,7 +1364,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
     if (oldChildIsNull == newChildIsNull && oldWidget.child?.key == widget.child?.key) {
       return;
     }
-    if (_previousController.status == AnimationStatus.dismissed) {
+    if (_previousController.isDismissed) {
       final double currentValue = widget.currentController.value;
       if (currentValue == 0.0 || oldWidget.child == null) {
         // The current child hasn't started its entrance animation yet. We can
@@ -1449,8 +1444,8 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 
   void _handlePreviousAnimationStatusChanged(AnimationStatus status) {
     setState(() {
-      if (widget.child != null && status == AnimationStatus.dismissed) {
-        assert(widget.currentController.status == AnimationStatus.dismissed);
+      if (widget.child != null && status.isDismissed) {
+        assert(widget.currentController.isDismissed);
         widget.currentController.forward();
       }
     });
@@ -1466,7 +1461,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
     return Stack(
       alignment: Alignment.centerRight,
       children: <Widget>[
-        if (_previousController.status != AnimationStatus.dismissed)
+        if (!_previousController.isDismissed)
           if (_isExtendedFloatingActionButton(_previousChild))
             FadeTransition(
               opacity: _previousScaleAnimation,
@@ -2407,7 +2402,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         _currentBottomSheet = null;
       });
 
-      if (animationController.status != AnimationStatus.dismissed) {
+      if (!animationController.isDismissed) {
         _dismissedBottomSheets.add(bottomSheet);
       }
       completer.complete();
@@ -3196,10 +3191,7 @@ class _StandardBottomSheetState extends State<_StandardBottomSheet> {
   @override
   void initState() {
     super.initState();
-    assert(
-      widget.animationController.status == AnimationStatus.forward
-        || widget.animationController.status == AnimationStatus.completed,
-    );
+    assert(widget.animationController.isForwardOrCompleted);
     widget.animationController.addStatusListener(_handleStatusChange);
   }
 
@@ -3234,7 +3226,7 @@ class _StandardBottomSheetState extends State<_StandardBottomSheet> {
   }
 
   void _handleStatusChange(AnimationStatus status) {
-    if (status == AnimationStatus.dismissed) {
+    if (status.isDismissed) {
       widget.onDismissed?.call();
     }
   }

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -515,7 +515,7 @@ class _SearchPageState<T> extends State<_SearchPage<T>> {
   }
 
   void _onAnimationStatusChanged(AnimationStatus status) {
-    if (status != AnimationStatus.completed) {
+    if (!status.isCompleted) {
       return;
     }
     widget.animation.removeStatusListener(_onAnimationStatusChanged);

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1110,7 +1110,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       parent: _state.valueIndicatorController,
       curve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.dismissed) {
+      if (status.isDismissed) {
         _state.overlayEntry?.remove();
         _state.overlayEntry?.dispose();
         _state.overlayEntry = null;
@@ -1509,7 +1509,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
           _state.interactionTimer?.cancel();
           _state.interactionTimer = Timer(_minimumInteractionTime * timeDilation, () {
             _state.interactionTimer = null;
-            if (!_active && _state.valueIndicatorController.status == AnimationStatus.completed) {
+            if (!_active && _state.valueIndicatorController.isCompleted) {
               _state.valueIndicatorController.reverse();
             }
           });

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -589,16 +589,11 @@ class _SnackBarState extends State<SnackBar> {
   }
 
   void _onAnimationStatusChanged(AnimationStatus animationStatus) {
-    switch (animationStatus) {
-      case AnimationStatus.dismissed:
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
-        break;
-      case AnimationStatus.completed:
-        if (widget.onVisible != null && !_wasVisible) {
-          widget.onVisible!();
-        }
-        _wasVisible = true;
+    if (animationStatus.isCompleted) {
+      if (widget.onVisible != null && !_wasVisible) {
+        widget.onVisible!();
+      }
+      _wasVisible = true;
     }
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -580,7 +580,7 @@ class _IndicatorPainter extends CustomPainter {
     // If the tab animation is completed, there is no need to stretch the indicator
     // This only works for the tab change animation via tab index, not when
     // dragging a [TabBarView], but it's still ok, to avoid unnecessary calculations.
-    if (controller.animation!.status == AnimationStatus.completed) {
+    if (controller.animation!.isCompleted) {
       return rect;
     }
 

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -505,11 +505,9 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       !(_timer?.isActive ?? false) || _controller.status != AnimationStatus.reverse,
       'timer must not be active when the tooltip is fading out',
     );
-    if (_controller.isDismissed) {
-      if (withDelay.inMicroseconds > 0) {
-        _timer?.cancel();
-        _timer = Timer(withDelay, show);
-      }
+    if (_controller.isDismissed && withDelay.inMicroseconds > 0) {
+      _timer?.cancel();
+      _timer = Timer(withDelay, show);
     } else {
       show(); // If the tooltip is already fading in or fully visible, skip the
               // animation and show the tooltip immediately.

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -472,21 +472,14 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   // a PointerDown event interacts with some other UI component.
   final Set<int> _activeHoveringPointerDevices = <int>{};
 
-  static bool _isTooltipVisible(AnimationStatus status) {
-    return switch (status) {
-      AnimationStatus.completed || AnimationStatus.forward || AnimationStatus.reverse => true,
-      AnimationStatus.dismissed                                                       => false,
-    };
-  }
-
   AnimationStatus _animationStatus = AnimationStatus.dismissed;
   void _handleStatusChanged(AnimationStatus status) {
     assert(mounted);
-    switch ((_isTooltipVisible(_animationStatus), _isTooltipVisible(status))) {
-      case (true, false):
+    switch ((_animationStatus.isDismissed, status.isDismissed)) {
+      case (false, true):
         Tooltip._openedTooltips.remove(this);
         _overlayController.hide();
-      case (false, true):
+      case (true, false):
         _overlayController.show();
         Tooltip._openedTooltips.add(this);
         SemanticsService.tooltip(_tooltipMessage);
@@ -512,17 +505,14 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       !(_timer?.isActive ?? false) || _controller.status != AnimationStatus.reverse,
       'timer must not be active when the tooltip is fading out',
     );
-    switch (_controller.status) {
-      case AnimationStatus.dismissed when withDelay.inMicroseconds > 0:
+    if (_controller.isDismissed) {
+      if (withDelay.inMicroseconds > 0) {
         _timer?.cancel();
         _timer = Timer(withDelay, show);
-      // If the tooltip is already fading in or fully visible, skip the
-      // animation and show the tooltip immediately.
-      case AnimationStatus.dismissed:
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
-      case AnimationStatus.completed:
-        show();
+      }
+    } else {
+      show(); // If the tooltip is already fading in or fully visible, skip the
+              // animation and show the tooltip immediately.
     }
   }
 
@@ -537,20 +527,14 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     _timer = null;
     // Use _backingController instead of _controller to prevent the lazy getter
     // from instantiating an AnimationController unnecessarily.
-    switch (_backingController?.status) {
-      case null:
-      case AnimationStatus.reverse:
-      case AnimationStatus.dismissed:
-        break;
+    if (_backingController?.isForwardOrCompleted ?? false) {
       // Dismiss when the tooltip is fading in: if there's a dismiss delay we'll
       // allow the fade in animation to continue until the delay timer fires.
-      case AnimationStatus.forward:
-      case AnimationStatus.completed:
-        if (withDelay.inMicroseconds > 0) {
-          _timer = Timer(withDelay, _controller.reverse);
-        } else {
-          _controller.reverse();
-        }
+      if (withDelay.inMicroseconds > 0) {
+        _timer = Timer(withDelay, _controller.reverse);
+      } else {
+        _controller.reverse();
+      }
     }
   }
 
@@ -602,7 +586,7 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       // callback (_handleTapToDismiss) will not be called.
       return;
     }
-    if ((_timer == null && _controller.status == AnimationStatus.dismissed) || event is! PointerDownEvent) {
+    if ((_timer == null && _controller.isDismissed) || event is! PointerDownEvent) {
       return;
     }
     _handleTapToDismiss();
@@ -622,7 +606,7 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     if (!_visible) {
       return;
     }
-    final bool tooltipCreated = _controller.status == AnimationStatus.dismissed;
+    final bool tooltipCreated = _controller.isDismissed;
     if (tooltipCreated && _enableFeedback) {
       assert(_triggerMode == TooltipTriggerMode.tap);
       Feedback.forTap(context);
@@ -641,7 +625,7 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     if (!_visible) {
       return;
     }
-    final bool tooltipCreated = _visible && _controller.status == AnimationStatus.dismissed;
+    final bool tooltipCreated = _visible && _controller.isDismissed;
     if (tooltipCreated && _enableFeedback) {
       assert(_triggerMode == TooltipTriggerMode.longPress);
       Feedback.forLongPress(context);
@@ -711,15 +695,11 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
     _timer?.cancel();
     _timer = null;
-    switch (_controller.status) {
-      case AnimationStatus.dismissed:
-      case AnimationStatus.reverse:
-        _scheduleShowTooltip(withDelay: Duration.zero);
-        return true;
-      case AnimationStatus.forward:
-      case AnimationStatus.completed:
-        return false;
+    if (_controller.isForwardOrCompleted) {
+      return false;
     }
+    _scheduleShowTooltip(withDelay: Duration.zero);
+    return true;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/animated_size.dart
+++ b/packages/flutter/lib/src/rendering/animated_size.dart
@@ -381,12 +381,8 @@ class RenderAnimatedSize extends RenderAligningShiftedBox {
   }
 
   void _animationStatusListener(AnimationStatus status) {
-    switch (status) {
-      case AnimationStatus.completed:
-        _onEnd?.call();
-      case AnimationStatus.dismissed:
-      case AnimationStatus.forward:
-      case AnimationStatus.reverse:
+    if (status.isCompleted) {
+      _onEnd?.call();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -310,22 +310,17 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
     }
   }
 
-  /// Whether we're in the middle of cross-fading this frame.
-  bool get _isTransitioning => _controller.status == AnimationStatus.forward || _controller.status == AnimationStatus.reverse;
-
   @override
   Widget build(BuildContext context) {
     const Key kFirstChildKey = ValueKey<CrossFadeState>(CrossFadeState.showFirst);
     const Key kSecondChildKey = ValueKey<CrossFadeState>(CrossFadeState.showSecond);
-    final bool transitioningForwards = _controller.status == AnimationStatus.completed ||
-                                       _controller.status == AnimationStatus.forward;
     final Key topKey;
     Widget topChild;
     final Animation<double> topAnimation;
     final Key bottomKey;
     Widget bottomChild;
     final Animation<double> bottomAnimation;
-    if (transitioningForwards) {
+    if (_controller.isForwardOrCompleted) {
       topKey = kSecondChildKey;
       topChild = widget.secondChild;
       topAnimation = _secondAnimation;
@@ -343,7 +338,7 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
 
     bottomChild = TickerMode(
       key: bottomKey,
-      enabled: _isTransitioning,
+      enabled: _controller.isAnimating,
       child: IgnorePointer(
         child: ExcludeSemantics( // Always exclude the semantics of the widget that's fading out.
           child: ExcludeFocus(

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -340,7 +340,7 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
       controller: controller,
     );
     animation.addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.dismissed) {
+      if (status.isDismissed) {
         setState(() {
           assert(mounted);
           assert(_outgoingEntries.contains(entry));

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -531,7 +531,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
   }
 
   Future<void> _handleDismissStatusChanged(AnimationStatus status) async {
-    if (status == AnimationStatus.completed && !_dragUnderway) {
+    if (status.isCompleted && !_dragUnderway) {
       await _handleMoveCompleted();
     }
     if (mounted) {
@@ -623,7 +623,7 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
       // we've been dragged aside, and are now resizing.
       assert(() {
         if (_resizeAnimation!.status != AnimationStatus.forward) {
-          assert(_resizeAnimation!.status == AnimationStatus.completed);
+          assert(_resizeAnimation!.isCompleted);
           throw FlutterError.fromParts(<DiagnosticsNode>[
             ErrorSummary('A dismissed Dismissible widget is still part of the tree.'),
             ErrorHint(

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -583,7 +583,7 @@ class _HeroFlight {
   }
 
   void _performAnimationUpdate(AnimationStatus status) {
-    if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
+    if (!status.isAnimating) {
       _proxyAnimation.parent = null;
 
       assert(overlayEntry != null);
@@ -595,8 +595,8 @@ class _HeroFlight {
       // fromHero hidden. If [AnimationStatus.dismissed], the animation is
       // triggered but canceled before it finishes. In this case, we keep toHero
       // hidden instead.
-      manifest.fromHero.endFlight(keepPlaceholder: status == AnimationStatus.completed);
-      manifest.toHero.endFlight(keepPlaceholder: status == AnimationStatus.dismissed);
+      manifest.fromHero.endFlight(keepPlaceholder: status.isCompleted);
+      manifest.toHero.endFlight(keepPlaceholder: status.isDismissed);
       onFlightEnded(this);
       _proxyAnimation.removeListener(onTick);
     }

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -363,12 +363,8 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   void initState() {
     super.initState();
     _controller.addStatusListener((AnimationStatus status) {
-      switch (status) {
-        case AnimationStatus.completed:
-          widget.onEnd?.call();
-        case AnimationStatus.dismissed:
-        case AnimationStatus.forward:
-        case AnimationStatus.reverse:
+      if (status.isCompleted) {
+        widget.onEnd?.call();
       }
     });
     _constructTweens();

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -216,9 +216,7 @@ class MagnifierController {
   /// either the [animationController] is null, in the
   /// [AnimationStatus.completed] state, or in the [AnimationStatus.forward]
   /// state.
-  bool get shown {
-    return overlayEntry != null && (animationController?.isForwardOrCompleted ?? true);
-  }
+  bool get shown => overlayEntry != null && (animationController?.isForwardOrCompleted ?? true);
 
   /// Displays the magnifier.
   ///

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -217,10 +217,7 @@ class MagnifierController {
   /// [AnimationStatus.completed] state, or in the [AnimationStatus.forward]
   /// state.
   bool get shown {
-    return overlayEntry != null && switch (animationController?.status) {
-      AnimationStatus.forward || AnimationStatus.completed || null => true,
-      AnimationStatus.reverse || AnimationStatus.dismissed => false,
-    };
+    return overlayEntry != null && (animationController?.isForwardOrCompleted ?? true);
   }
 
   /// Displays the magnifier.

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -453,7 +453,7 @@ class _GlowController extends ChangeNotifier {
   }
 
   void _changePhase(AnimationStatus status) {
-    if (status != AnimationStatus.completed) {
+    if (!status.isCompleted) {
       return;
     }
     switch (_state) {
@@ -901,7 +901,7 @@ class _StretchController extends ChangeNotifier {
   }
 
   void _changePhase(AnimationStatus status) {
-    if (status != AnimationStatus.completed) {
+    if (!status.isCompleted) {
       return;
     }
     switch (_state) {

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1162,7 +1162,7 @@ class _ReorderableItemState extends State<_ReorderableItem> {
           )
             ..addListener(rebuild)
             ..addStatusListener((AnimationStatus status) {
-              if (status == AnimationStatus.completed) {
+              if (status.isCompleted) {
                 _startOffset = _targetOffset;
                 _offsetAnimation!.dispose();
                 _offsetAnimation = null;
@@ -1380,7 +1380,7 @@ class _DragInfo extends Drag {
       duration: const Duration(milliseconds: 250),
     )
     ..addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.dismissed) {
+      if (status.isDismissed) {
         _dropCompleted();
       }
     })

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1406,7 +1406,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   }
 
   void _validateInteractions(AnimationStatus status) {
-    if (status == AnimationStatus.dismissed) {
+    if (status.isDismissed) {
       assert(_fadeoutOpacityAnimation.value == 0.0);
       // We do not check for a valid scroll position if the scrollbar is not
       // visible, because it cannot be interacted with.
@@ -1779,11 +1779,8 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       return false;
     }
 
-    if (showScrollbar) {
-      if (_fadeoutAnimationController.status != AnimationStatus.forward &&
-          _fadeoutAnimationController.status != AnimationStatus.completed) {
-        _fadeoutAnimationController.forward();
-      }
+    if (showScrollbar && !_fadeoutAnimationController.isForwardOrCompleted) {
+      _fadeoutAnimationController.forward();
     }
 
     final ScrollMetrics metrics = notification.metrics;
@@ -1801,8 +1798,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     final ScrollMetrics metrics = notification.metrics;
     if (metrics.maxScrollExtent <= metrics.minScrollExtent) {
       // Hide the bar when the Scrollable widget has no space to scroll.
-      if (_fadeoutAnimationController.status != AnimationStatus.dismissed &&
-          _fadeoutAnimationController.status != AnimationStatus.reverse) {
+      if (_fadeoutAnimationController.isForwardOrCompleted) {
         _fadeoutAnimationController.reverse();
       }
 
@@ -1815,8 +1811,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     if (notification is ScrollUpdateNotification ||
       notification is OverscrollNotification) {
       // Any movements always makes the scrollbar start showing up.
-      if (_fadeoutAnimationController.status != AnimationStatus.forward &&
-          _fadeoutAnimationController.status != AnimationStatus.completed) {
+      if (!_fadeoutAnimationController.isForwardOrCompleted) {
         _fadeoutAnimationController.forward();
       }
 

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -302,10 +302,7 @@ class MatrixTransition extends AnimatedWidget {
     return Transform(
       transform: onTransform(animation.value),
       alignment: alignment,
-      filterQuality: switch (animation.status) {
-        AnimationStatus.forward   || AnimationStatus.reverse   => filterQuality,
-        AnimationStatus.dismissed || AnimationStatus.completed => null,
-      },
+      filterQuality: animation.isAnimating ? filterQuality : null,
       child: child,
     );
   }

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -1319,7 +1319,7 @@ class _RefreshProgressIndicatorGoldenState extends State<_RefreshProgressIndicat
         setState(() {});
       })
     ..addStatusListener((AnimationStatus status) {
-        if (status == AnimationStatus.completed) {
+        if (status.isCompleted) {
           indeterminate = true;
         }
       });


### PR DESCRIPTION
PR #147801 introduced some convenient `AnimationStatus` getters, but I just realized that `AnimationController` now has 2 getters for the same thing: `isAnimating` and `isRunning`.

The intent of this pull request is to correct that mistake, and implement the getters in the appropriate places.