### PR TITLE
Remove add-to-app bitcode warning

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -87,8 +87,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
   const String outputDirectoryName = 'flutter-frameworks';
 
   await inDirectory(projectDir, () async {
-    final StringBuffer outputError = StringBuffer();
-    await evalFlutter(
+    await flutter(
       'build',
       options: <String>[
         'ios-framework',
@@ -97,11 +96,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
         '--obfuscate',
         '--split-debug-info=symbols',
       ],
-      stderr: outputError,
     );
-    if (!outputError.toString().contains('Bitcode support has been deprecated.')) {
-      throw TaskResult.failure('Missing bitcode deprecation warning');
-    }
   });
 
   final String outputPath = path.join(projectDir.path, outputDirectoryName);

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -330,10 +330,6 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
           'See https://flutter.dev/docs/development/add-to-app/ios/add-flutter-screen#create-a-flutterengine for more information.');
     }
 
-    globals.printWarning(
-        'Bitcode support has been deprecated. Turn off the "Enable Bitcode" build setting in your Xcode project or you may encounter compilation errors.\n'
-        'See https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes for details.');
-
     return FlutterCommandResult.success();
   }
 


### PR DESCRIPTION
Flutter deprecated bitcode in 2022 https://github.com/flutter/flutter/pull/112828, and introduced a warning in #112900 to let add-to-app devs know.

Apps should be migrated by now, remove the outdated warning.
