### PR TITLE
Adds `locale` to `DatePickerThemeData`.

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -106,7 +106,8 @@ const double _kMaxTextScaleFactor = 1.3;
 ///   * [fieldLabelText], label for the date text input field.
 ///
 /// An optional [locale] argument can be used to set the locale for the date
-/// picker. It defaults to the ambient locale provided by [Localizations].
+/// picker. If not provided [DatePickerThemeData.locale] will be used. It
+/// defaults to the ambient locale provided by [Localizations].
 ///
 /// An optional [textDirection] argument can be used to set the text direction
 /// ([TextDirection.ltr] or [TextDirection.rtl]) for the date picker. It
@@ -207,6 +208,8 @@ Future<DateTime?> showDatePicker({
   );
   assert(debugCheckHasMaterialLocalizations(context));
 
+  final Locale? resolvedLocale = locale ?? DatePickerTheme.of(context).locale;
+
   Widget dialog = DatePickerDialog(
     initialDate: initialDate,
     firstDate: firstDate,
@@ -235,10 +238,10 @@ Future<DateTime?> showDatePicker({
     );
   }
 
-  if (locale != null) {
+  if (resolvedLocale != null) {
     dialog = Localizations.override(
       context: context,
-      locale: locale,
+      locale: resolvedLocale,
       child: dialog,
     );
   }

--- a/packages/flutter/lib/src/material/date_picker_theme.dart
+++ b/packages/flutter/lib/src/material/date_picker_theme.dart
@@ -75,6 +75,7 @@ class DatePickerThemeData with Diagnosticable {
     this.inputDecorationTheme,
     this.cancelButtonStyle,
     this.confirmButtonStyle,
+    this.locale,
   });
 
   /// Overrides the default value of [Dialog.backgroundColor].
@@ -347,6 +348,9 @@ class DatePickerThemeData with Diagnosticable {
   /// Overrides the default style of the confirm (OK) button of a [DatePickerDialog].
   final ButtonStyle? confirmButtonStyle;
 
+  /// Overrides the default [Locale] for a [Dialog].
+  final Locale? locale;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   DatePickerThemeData copyWith({
@@ -387,6 +391,7 @@ class DatePickerThemeData with Diagnosticable {
     InputDecorationTheme? inputDecorationTheme,
     ButtonStyle? cancelButtonStyle,
     ButtonStyle? confirmButtonStyle,
+    Locale? locale,
   }) {
     return DatePickerThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -426,6 +431,7 @@ class DatePickerThemeData with Diagnosticable {
       inputDecorationTheme: inputDecorationTheme ?? this.inputDecorationTheme,
       cancelButtonStyle: cancelButtonStyle ?? this.cancelButtonStyle,
       confirmButtonStyle: confirmButtonStyle ?? this.confirmButtonStyle,
+      locale: locale ?? this.locale,
     );
   }
 
@@ -472,6 +478,7 @@ class DatePickerThemeData with Diagnosticable {
       inputDecorationTheme: t < 0.5 ? a?.inputDecorationTheme : b?.inputDecorationTheme,
       cancelButtonStyle: ButtonStyle.lerp(a?.cancelButtonStyle, b?.cancelButtonStyle, t),
       confirmButtonStyle: ButtonStyle.lerp(a?.confirmButtonStyle, b?.confirmButtonStyle, t),
+      locale: t < 0.5 ? a?.locale : b?.locale,
     );
   }
 
@@ -524,6 +531,7 @@ class DatePickerThemeData with Diagnosticable {
     inputDecorationTheme,
     cancelButtonStyle,
     confirmButtonStyle,
+    locale,
   ]);
 
   @override
@@ -568,7 +576,8 @@ class DatePickerThemeData with Diagnosticable {
       && other.dividerColor == dividerColor
       && other.inputDecorationTheme == inputDecorationTheme
       && other.cancelButtonStyle == cancelButtonStyle
-      && other.confirmButtonStyle == confirmButtonStyle;
+      && other.confirmButtonStyle == confirmButtonStyle
+      && other.locale == locale;
   }
 
   @override
@@ -611,6 +620,7 @@ class DatePickerThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<InputDecorationTheme>('inputDecorationTheme', inputDecorationTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<ButtonStyle>('cancelButtonStyle', cancelButtonStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<ButtonStyle>('confirmButtonStyle', confirmButtonStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<Locale>('locale', locale, defaultValue: null));
   }
 }
 

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -372,6 +372,162 @@ void main() {
     await tester.tap(find.text('Annuler'));
   });
 
+  testWidgets('locale theme overrides ambient locale', (WidgetTester tester) async {
+    Widget buildFrame() {
+      return MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          datePickerTheme: const DatePickerThemeData(
+            locale: Locale('fr', 'CA'),
+          ),
+        ),
+        locale: const Locale('en', 'US'),
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('fr', 'CA'),
+        ],
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    Element getPicker() => tester.element(find.byType(CalendarDatePicker));
+
+    await tester.pumpWidget(buildFrame());
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    expect(
+      Localizations.localeOf(getPicker()),
+      const Locale('fr', 'CA'),
+    );
+    expect(
+      Directionality.of(getPicker()),
+      TextDirection.ltr,
+    );
+
+    await tester.tap(find.text('Annuler'));
+  });
+
+  testWidgets('locale parameter overrides locale theme', (WidgetTester tester) async {
+    Widget buildFrame() {
+      return MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          datePickerTheme: const DatePickerThemeData(
+            locale: Locale('fr', 'CA'),
+          ),
+        ),
+        locale: const Locale('en', 'US'),
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('fr', 'CA'),
+          Locale('hi', 'IN'),
+        ],
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                    locale: const Locale('hi', 'IN')
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    Element getPicker() => tester.element(find.byType(CalendarDatePicker));
+
+    await tester.pumpWidget(buildFrame());
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    expect(
+      Localizations.localeOf(getPicker()),
+      const Locale('hi', 'IN'),
+    );
+    expect(
+      Directionality.of(getPicker()),
+      TextDirection.ltr,
+    );
+
+    await tester.tap(find.text('रद्द करें'));
+  });
+
+  testWidgets('ambient locale is respected when both locale parameter and locale theme are missing', (WidgetTester tester) async {
+    Widget buildFrame() {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        locale: const Locale('fr', 'CA'),
+        supportedLocales: const <Locale>[
+          Locale('en', 'US'),
+          Locale('fr', 'CA'),
+        ],
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    Element getPicker() => tester.element(find.byType(CalendarDatePicker));
+
+    await tester.pumpWidget(buildFrame());
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    expect(
+      Localizations.localeOf(getPicker()),
+      const Locale('fr', 'CA'),
+    );
+    expect(
+      Directionality.of(getPicker()),
+      TextDirection.ltr,
+    );
+
+    await tester.tap(find.text('Annuler'));
+  });
+
   group("locale fonts don't overflow layout", () {
     // Test screen layouts in various locales to ensure the fonts used
     // don't overflow the layout


### PR DESCRIPTION
This PR adds locale support to DatePickerThemeData.

Fixes: #148202

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

