### PR TITLE
Adds `lazyAnimation` property to AnimatedList and AnimatedGrid.

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -83,6 +83,7 @@ class AnimatedList extends _AnimatedScrollView {
     super.shrinkWrap = false,
     super.padding,
     super.clipBehavior = Clip.hardEdge,
+    super.lazyAnimation = false,
   }) : assert(initialItemCount >= 0);
 
   /// The state from the closest instance of this class that encloses the given
@@ -205,6 +206,7 @@ class AnimatedListState extends _AnimatedScrollViewState<AnimatedList> {
         key: _sliverAnimatedMultiBoxKey,
         itemBuilder: widget.itemBuilder,
         initialItemCount: widget.initialItemCount,
+        lazyAnimation: widget.lazyAnimation,
       ),
       widget.scrollDirection,
     );
@@ -282,6 +284,7 @@ class AnimatedGrid extends _AnimatedScrollView {
     super.physics,
     super.padding,
     super.clipBehavior = Clip.hardEdge,
+    super.lazyAnimation = false,
   })  : assert(initialItemCount >= 0);
 
   /// {@template flutter.widgets.AnimatedGrid.gridDelegate}
@@ -415,6 +418,7 @@ class AnimatedGridState extends _AnimatedScrollViewState<AnimatedGrid> {
         gridDelegate: widget.gridDelegate,
         itemBuilder: widget.itemBuilder,
         initialItemCount: widget.initialItemCount,
+        lazyAnimation: widget.lazyAnimation,
       ),
       widget.scrollDirection,
     );
@@ -436,6 +440,7 @@ abstract class _AnimatedScrollView extends StatefulWidget {
     this.shrinkWrap = false,
     this.padding,
     this.clipBehavior = Clip.hardEdge,
+    this.lazyAnimation = false,
   }) : assert(initialItemCount >= 0);
 
   /// {@template flutter.widgets.AnimatedScrollView.itemBuilder}
@@ -537,6 +542,14 @@ abstract class _AnimatedScrollView extends StatefulWidget {
   ///
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
+
+  /// Determines whether an item animation should be started the moment the
+  /// item is inserted in the [AnimatedList] or when the item is built for
+  /// the first time, that is, when it's rendered on screen. If set to true,
+  /// the animation is immediately started when the item is inserted.
+  ///
+  /// Defaults to false.
+  final bool lazyAnimation;
 }
 
 abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends State<T> with TickerProviderStateMixin {
@@ -714,6 +727,7 @@ class SliverAnimatedList extends _SliverAnimatedMultiBoxAdaptor {
     required super.itemBuilder,
     super.findChildIndexCallback,
     super.initialItemCount = 0,
+    super.lazyAnimation = false,
   }) : assert(initialItemCount >= 0);
 
   @override
@@ -863,6 +877,7 @@ class SliverAnimatedGrid extends _SliverAnimatedMultiBoxAdaptor {
     required this.gridDelegate,
     super.findChildIndexCallback,
     super.initialItemCount = 0,
+    super.lazyAnimation = false,
   })  : assert(initialItemCount >= 0);
 
   @override
@@ -986,6 +1001,7 @@ abstract class _SliverAnimatedMultiBoxAdaptor extends StatefulWidget {
     required this.itemBuilder,
     this.findChildIndexCallback,
     this.initialItemCount = 0,
+    this.lazyAnimation = false,
   })  : assert(initialItemCount >= 0);
 
   /// {@macro flutter.widgets.AnimatedScrollView.itemBuilder}
@@ -996,6 +1012,8 @@ abstract class _SliverAnimatedMultiBoxAdaptor extends StatefulWidget {
 
   /// {@macro flutter.widgets.AnimatedScrollView.initialItemCount}
   final int initialItemCount;
+
+  final bool lazyAnimation;
 }
 
 abstract class _SliverAnimatedMultiBoxAdaptorState<T extends _SliverAnimatedMultiBoxAdaptor> extends State<T> with TickerProviderStateMixin {
@@ -1084,6 +1102,11 @@ abstract class _SliverAnimatedMultiBoxAdaptorState<T extends _SliverAnimatedMult
 
     final _ActiveItem? incomingItem = _activeItemAt(_incomingItems, itemIndex);
     final Animation<double> animation = incomingItem?.controller?.view ?? kAlwaysCompleteAnimation;
+    if (widget.lazyAnimation) {
+      incomingItem?.controller?.forward().then<void>((_) {
+        _removeActiveItemAt(_incomingItems, incomingItem.itemIndex)!.controller!.dispose();
+      });
+    }
     return widget.itemBuilder(
       context,
       _itemIndexToIndex(itemIndex),
@@ -1132,9 +1155,11 @@ abstract class _SliverAnimatedMultiBoxAdaptorState<T extends _SliverAnimatedMult
       _itemsCount += 1;
     });
 
-    controller.forward().then<void>((_) {
-      _removeActiveItemAt(_incomingItems, incomingItem.itemIndex)!.controller!.dispose();
-    });
+    if (!widget.lazyAnimation) {
+      controller.forward().then<void>((_) {
+        _removeActiveItemAt(_incomingItems, incomingItem.itemIndex)!.controller!.dispose();
+      });
+    }
   }
 
   /// Insert multiple items at [index] and start an animation that will be passed


### PR DESCRIPTION
This PR adds `lazyAnimation` property to AnimatedList and AnimatedGrid to optionally start animation of item when the item is first rendered instead of starting the animation when its first inserted to the list.

Fixes: #148379 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
