### PR TITLE
Fix template manifest test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3770,7 +3770,7 @@ void main() {
         '--no-pub',
         '--template=plugin',
         '--project-name=test',
-        projectDir.path,
+        'dev/test',
       ]),
       throwsToolExit(message: 'Unable to read the template manifest at path'),
     );
@@ -3778,8 +3778,7 @@ void main() {
     FileSystem: () => MemoryFileSystem.test(
       opHandle: (String context, FileSystemOp operation) {
         if (operation == FileSystemOp.read && context.contains('template_manifest.json')) {
-          throw io.PathNotFoundException(
-              context, const OSError(), 'Cannot open file');
+          throw io.PathNotFoundException(context, const OSError(), 'Cannot open file');
         }
       },
     ),


### PR DESCRIPTION
`'flutter create should tool exit if the template manifest cannot be read'` fails consistently, as shown by #148614.

The test expects a `ToolExit` with the message "Unable to read the template manifest", but depending on how the test is being run, a different exception ("Cannot create a project within the Flutter SDK") is sometimes thrown first.

This pull request relocates the test project to `dev/` to prevent the extraneous error.