### PR TITLE
no schedule

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -628,13 +628,8 @@ abstract class _CachedImageBase {
     if (kFlutterMemoryAllocationsEnabled) {
       FlutterMemoryAllocations.instance.dispatchObjectDisposed(object: this);
     }
-    // Give any interested parties a chance to listen to the stream before we
-    // potentially dispose it.
-    SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
-      assert(handle != null);
-      handle?.dispose();
-      handle = null;
-    }, debugLabel: 'CachedImage.disposeHandle');
+    handle?.dispose();
+    handle = null;
   }
 }
 


### PR DESCRIPTION
```
06:00 +8339 ~12: /b/s/w/ir/x/w/flutter/packages/flutter/test/painting/image_cache_resize_test.dart: Image cache resizing based on count
══╡ EXCEPTION CAUGHT BY IMAGE RESOURCE SERVICE ╞════════════════════════════════════════════════════
The following StateError was thrown while resolving an image:
Bad state: Stream has been disposed.
An ImageStream is considered disposed once at least one listener has been added and subsequently all
listeners have been removed and no handles are outstanding from the keepAlive method.
To resolve this error, maintain at least one listener on the stream, or create an
ImageStreamCompleterHandle from the keepAlive method, or create a new stream for the image.

When the exception was thrown, this was the stack:
#0      ImageStreamCompleter._checkDisposed (package:flutter/src/painting/image_stream.dart:699:7)
#1      ImageStreamCompleter.addListener (package:flutter/src/painting/image_stream.dart:560:5)
#2      List.forEach (dart:core-patch/growable_array.dart:417:8)
#3      ImageStream.setCompleter (package:flutter/src/painting/image_stream.dart:366:24)
#4      ImageProvider.resolveStreamForKey (package:flutter/src/painting/image_provider.dart:534:14)
#5      ImageProvider.resolve.<anonymous closure> (package:flutter/src/painting/image_provider.dart:366:9)
#6      ImageProvider._createErrorHandlerAndKey.<anonymous closure> (package:flutter/src/painting/image_provider.dart:479:24)
(elided 17 frames from dart:async and package:stack_trace)

Image provider: TestImageProvider(1, 5)
Image configuration: ImageConfiguration()
Image key: 1
```