### PR TITLE
[iOS] fix hot restart with native assets

### DIFF
--- a/dev/devicelab/bin/tasks/native_assets_ios_simulator.dart
+++ b/dev/devicelab/bin/tasks/native_assets_ios_simulator.dart
@@ -12,12 +12,13 @@ Future<void> main() async {
   await task(() async {
     deviceOperatingSystem = DeviceOperatingSystem.ios;
     String? simulatorDeviceId;
+    TaskResult res = TaskResult.success(null);
     try {
       await testWithNewIOSSimulator(
         'TestNativeAssetsSim',
         (String deviceId) async {
           simulatorDeviceId = deviceId;
-          await createNativeAssetsTest(
+          res = await createNativeAssetsTest(
             deviceIdOverride: deviceId,
             isIosSimulator: true,
           )();
@@ -26,6 +27,6 @@ Future<void> main() async {
     } finally {
       await removeIOSSimulator(simulatorDeviceId);
     }
-    return TaskResult.success(null);
+    return res;
   });
 }

--- a/dev/devicelab/lib/tasks/native_assets_test.dart
+++ b/dev/devicelab/lib/tasks/native_assets_test.dart
@@ -54,11 +54,14 @@ TaskFunction createNativeAssetsTest({
         ];
         int transitionCount = 0;
         bool done = false;
+        bool error = false;
 
         await inDirectory<void>(exampleDirectory, () async {
           final int runFlutterResult = await runFlutter(
             options: options,
             onLine: (String line, Process process) {
+              error |= line.contains('EXCEPTION CAUGHT BY WIDGETS LIBRARY');
+              error |= line.contains("Invalid argument(s): Couldn't resolve native function 'sum'");
               if (done) {
                 return;
               }
@@ -107,6 +110,9 @@ TaskFunction createNativeAssetsTest({
             'Did not get expected number of transitions: $transitionCount '
             '(expected $expectedNumberOfTransitions)',
           );
+        }
+        if (error) {
+          return TaskResult.failure('Error during hot reload or hot restart.');
         }
         return TaskResult.success(null);
       });

--- a/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/ios/native_assets.dart
@@ -186,14 +186,23 @@ Map<KernelAssetPath, List<AssetImpl>> _fatAssetTargetLocations(
 Map<AssetImpl, KernelAsset> _assetTargetLocations(
     List<AssetImpl> nativeAssets) {
   final Set<String> alreadyTakenNames = <String>{};
-  return <AssetImpl, KernelAsset>{
-    for (final AssetImpl asset in nativeAssets)
-      asset: _targetLocationIOS(asset, alreadyTakenNames),
-  };
+  final Map<String, KernelAssetPath> idToPath = <String, KernelAssetPath>{};
+  final Map<AssetImpl, KernelAsset> result = <AssetImpl, KernelAsset>{};
+  for (final AssetImpl asset in nativeAssets) {
+    final KernelAssetPath path = idToPath[asset.id] ??
+        _targetLocationIOS(asset, alreadyTakenNames).path;
+    idToPath[asset.id] = path;
+    result[asset] = KernelAsset(
+      id: (asset as NativeCodeAssetImpl).id,
+      target: Target.fromArchitectureAndOS(asset.architecture!, asset.os),
+      path: path,
+    );
+  }
+  return result;
 }
 
 KernelAsset _targetLocationIOS(AssetImpl asset, Set<String> alreadyTakenNames) {
-  final LinkModeImpl linkMode = (asset as NativeCodeAssetImpl).linkMode;
+final LinkModeImpl linkMode = (asset as NativeCodeAssetImpl).linkMode;
 final KernelAssetPath kernelAssetPath;
   switch (linkMode) {
     case DynamicLoadingSystemImpl _:

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -65,8 +65,8 @@ String? _createIOSSimulator() {
     'xcrun',
     'simctl',
     'create',
-    'test-simulator',
-    'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
+    'native-assets-test-simulator',
+    'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
     'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
   ]);
   if (result.exitCode != 0) {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -88,7 +88,7 @@ String? iOSSimulatorId() {
   if (res != null) {
     return res;
   }
-  processManager.runSync([
+  processManager.runSync(<String>[
     'flutter',
     'emulators',
     '--launch',
@@ -105,7 +105,7 @@ void main() {
 
   final List<String> testDevices = List<String>.of(devices);
   if (platform.isMacOS) {
-    final String ? simulator = iOSSimulatorId();
+    final String? simulator = iOSSimulatorId();
     if (simulator != null) {
       testDevices.add(simulator);
     } else {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -13,6 +13,7 @@
 @Timeout(Duration(minutes: 10))
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart';
@@ -60,44 +61,40 @@ const String packageName = 'package_with_native_assets';
 
 const String exampleAppName = '${packageName}_example';
 
-String? _createIOSSimulator() {
-  ProcessResult result = processManager.runSync(<String>[
-    'xcrun',
-    'simctl',
-    'create',
-    'test-simulator',
-    'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
-    'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
-  ]);
-  if (result.exitCode != 0) {
-    throw Exception(
-        'xcrun simctl create failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
+String? iOSSimulatorId() {
+  String? findSimulator() {
+    final ProcessResult res = processManager.runSync(<String>[
+      'flutter',
+      'devices',
+      '--machine',
+      '--device-connection=attached',
+    ]);
+    if (res.exitCode != 0) {
+      throw Exception(
+          'flutter devices failed: ${res.exitCode}\n${res.stderr}\n${res.stdout}');
+    }
+    final List<Map<dynamic, dynamic>> devices =
+        (json.decode(res.stdout as String) as List<dynamic>)
+            .cast<Map<dynamic, dynamic>>();
+    for (final Map<dynamic, dynamic> device in devices) {
+      if (device['emulator'] == true && device['targetPlatform'] == 'ios') {
+        return device['id'] as String;
+      }
+    }
+    return null;
   }
-  final String deviceId = result.stdout.toString().trim();
-  result = processManager.runSync(<String>[
-    'xcrun',
-    'simctl',
-    'boot',
-    deviceId,
-  ]);
-  if (result.exitCode != 0) {
-    throw Exception(
-        'xcrun simctl boot failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
-  }
-  return deviceId;
-}
 
-void _deleteIOSSimulator(String id) {
-  final ProcessResult result = processManager.runSync(<String>[
-    'xcrun',
-    'simctl',
-    'delete',
-    id,
-  ]);
-  if (result.exitCode != 0) {
-    throw Exception(
-        'xcrun simctl delete failed: ${result.exitCode}\n${result.stderr}\n${result.stdout}');
+  final String? res = findSimulator();
+  if (res != null) {
+    return res;
   }
+  processManager.runSync(<String>[
+    'flutter',
+    'emulators',
+    '--launch',
+    'apple_ios_simulator',
+  ]);
+  return findSimulator();
 }
 
 void main() {
@@ -106,12 +103,13 @@ void main() {
     return;
   }
 
-  String? iosSimulatorId;
-
+  final List<String> testDevices = List<String>.of(devices);
   if (platform.isMacOS) {
-    iosSimulatorId = _createIOSSimulator();
-    if (iosSimulatorId == null) {
-      throw Exception('Could not create iOS Simulator');
+    final String? simulator = iOSSimulatorId();
+    if (simulator != null) {
+      testDevices.add(simulator);
+    } else {
+      throw Exception('No running iOS simulator found');
     }
   }
 
@@ -123,19 +121,9 @@ void main() {
     ]);
   });
 
-  tearDownAll(() {
-    if (iosSimulatorId != null) {
-      _deleteIOSSimulator(iosSimulatorId);
-    }
-  });
-
-  for (final String device in <String>[
-    ...devices,
-    if (iosSimulatorId != null) iosSimulatorId,
-  ]) {
+  for (final String device in testDevices) {
     for (final String buildMode in buildModes) {
-      if ((device == 'flutter-tester' || device == iosSimulatorId) &&
-          buildMode != 'debug') {
+      if (device == 'flutter-tester' && buildMode != 'debug') {
         continue;
       }
       final String hotReload = buildMode == 'debug' ? ' hot reload and hot restart' : '';

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -88,7 +88,7 @@ String? iOSSimulatorId() {
   if (res != null) {
     return res;
   }
-  processManager.runSync(<String>[
+  processManager.runSync([
     'flutter',
     'emulators',
     '--launch',
@@ -105,7 +105,7 @@ void main() {
 
   final List<String> testDevices = List<String>.of(devices);
   if (platform.isMacOS) {
-    final String? simulator = iOSSimulatorId();
+    final String ? simulator = iOSSimulatorId();
     if (simulator != null) {
       testDevices.add(simulator);
     } else {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -65,8 +65,8 @@ String? _createIOSSimulator() {
     'xcrun',
     'simctl',
     'create',
-    'native-assets-test-simulator',
-    'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
+    'test-simulator',
+    'com.apple.CoreSimulator.SimDeviceType.iPhone-11',
     'com.apple.CoreSimulator.SimRuntime.iOS-17-0',
   ]);
   if (result.exitCode != 0) {

--- a/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
+++ b/packages/flutter_tools/test/integration.shard/isolated/native_assets_test.dart
@@ -13,7 +13,6 @@
 @Timeout(Duration(minutes: 10))
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart';
@@ -61,56 +60,10 @@ const String packageName = 'package_with_native_assets';
 
 const String exampleAppName = '${packageName}_example';
 
-String? iOSSimulatorId() {
-  String? findSimulator() {
-    final ProcessResult res = processManager.runSync(<String>[
-      'flutter',
-      'devices',
-      '--machine',
-      '--device-connection=attached',
-    ]);
-    if (res.exitCode != 0) {
-      throw Exception(
-          'flutter devices failed: ${res.exitCode}\n${res.stderr}\n${res.stdout}');
-    }
-    final List<Map<dynamic, dynamic>> devices =
-        (json.decode(res.stdout as String) as List<dynamic>)
-            .cast<Map<dynamic, dynamic>>();
-    for (final Map<dynamic, dynamic> device in devices) {
-      if (device['emulator'] == true && device['targetPlatform'] == 'ios') {
-        return device['id'] as String;
-      }
-    }
-    return null;
-  }
-
-  final String? res = findSimulator();
-  if (res != null) {
-    return res;
-  }
-  processManager.runSync([
-    'flutter',
-    'emulators',
-    '--launch',
-    'apple_ios_simulator',
-  ]);
-  return findSimulator();
-}
-
 void main() {
   if (!platform.isMacOS && !platform.isLinux && !platform.isWindows) {
     // TODO(dacoharkes): Implement Fuchsia. https://github.com/flutter/flutter/issues/129757
     return;
-  }
-
-  final List<String> testDevices = List<String>.of(devices);
-  if (platform.isMacOS) {
-    final String ? simulator = iOSSimulatorId();
-    if (simulator != null) {
-      testDevices.add(simulator);
-    } else {
-      throw Exception('No running iOS simulator found');
-    }
   }
 
   setUpAll(() {
@@ -121,7 +74,7 @@ void main() {
     ]);
   });
 
-  for (final String device in testDevices) {
+  for (final String device in devices) {
     for (final String buildMode in buildModes) {
       if (device == 'flutter-tester' && buildMode != 'debug') {
         continue;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/148687

Adds support for running the hot restart and reload integration test on iOS simulator.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
