### PR TITLE
Remove hidden dependencies on HttpClient

### DIFF
--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async' show FutureOr;
-import 'dart:io' as io show OSError, SocketException;
+import 'dart:io' as io show HttpClient, OSError, SocketException;
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
@@ -58,6 +58,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePre
   const Platform platform = LocalPlatform();
   const FileSystem fs = LocalFileSystem();
   const ProcessManager process = LocalProcessManager();
+  final io.HttpClient httpClient = io.HttpClient();
   if (FlutterPostSubmitFileComparator.isForEnvironment(platform)) {
     goldenFileComparator = await FlutterPostSubmitFileComparator.fromLocalFileComparator(
       localFileComparator: goldenFileComparator as LocalFileComparator,
@@ -66,6 +67,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePre
       log: print,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
   } else if (FlutterPreSubmitFileComparator.isForEnvironment(platform)) {
     goldenFileComparator = await FlutterPreSubmitFileComparator.fromLocalFileComparator(
@@ -75,6 +77,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePre
       log: print,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
   } else if (FlutterSkippingFileComparator.isForEnvironment(platform)) {
     goldenFileComparator = FlutterSkippingFileComparator.fromLocalFileComparator(
@@ -87,6 +90,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePre
       log: print,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
   } else {
     goldenFileComparator = await FlutterLocalFileComparator.fromLocalFileComparator(
@@ -95,6 +99,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePre
       log: print,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
   }
   await testMain();
@@ -287,6 +292,7 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
     required LogCallback log,
     required FileSystem fs,
     required ProcessManager process,
+    required io.HttpClient httpClient,
   }) async {
     final Directory baseDirectory = FlutterGoldenFileComparator.getBaseDirectory(
       localFileComparator,
@@ -302,6 +308,7 @@ class FlutterPostSubmitFileComparator extends FlutterGoldenFileComparator {
       platform: platform,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
     await goldens.auth();
     return FlutterPostSubmitFileComparator(
@@ -378,6 +385,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
     required LogCallback log,
     required FileSystem fs,
     required ProcessManager process,
+    required io.HttpClient httpClient,
   }) async {
     final Directory baseDirectory = testBasedir ?? FlutterGoldenFileComparator.getBaseDirectory(
       localFileComparator,
@@ -396,6 +404,7 @@ class FlutterPreSubmitFileComparator extends FlutterGoldenFileComparator {
       log: log,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
 
     await goldens.auth();
@@ -477,6 +486,7 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
     required LogCallback log,
     required FileSystem fs,
     required ProcessManager process,
+    required io.HttpClient httpClient,
   }) {
     final Uri basedir = localFileComparator.basedir;
     final SkiaGoldClient skiaClient = SkiaGoldClient(
@@ -485,6 +495,7 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
       log: log,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
     return FlutterSkippingFileComparator(
       basedir,
@@ -572,6 +583,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
     required LogCallback log,
     required FileSystem fs,
     required ProcessManager process,
+    required io.HttpClient httpClient,
   }) async {
     baseDirectory ??= FlutterGoldenFileComparator.getBaseDirectory(
       localFileComparator,
@@ -589,6 +601,7 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
       log: log,
       fs: fs,
       process: process,
+      httpClient: httpClient,
     );
     try {
       // Check if we can reach Gold.

--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -53,10 +53,9 @@ class SkiaGoldClient {
     required this.process,
     required this.platform,
     Abi? abi,
-    io.HttpClient? httpClient,
+    required this.httpClient,
     required this.log,
-  }) : httpClient = httpClient ?? io.HttpClient(),
-       abi = abi ?? Abi.current();
+  }) : abi = abi ?? Abi.current();
 
   /// The file system to use for storing the local clone of the repository.
   ///

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -859,6 +859,7 @@ void main() {
           log: (String message) => fail('skia gold client printed unexpected output: "$message"'),
           fs: fs,
           process: FakeProcessManager(),
+          httpClient: FakeHttpClient(),
         );
         expect(fakeSkiaClient.initCalls, 0);
       });
@@ -946,6 +947,7 @@ void main() {
           log: (String message) => fail('skia gold client printed unexpected output: "$message"'),
           fs: fs,
           process: FakeProcessManager(),
+          httpClient: FakeHttpClient(),
         );
         expect(fakeSkiaClient.tryInitCalls, 0);
       });
@@ -1050,6 +1052,7 @@ void main() {
           log: (String message) => fail('skia gold client printed unexpected output: "$message"'),
           fs: fs,
           process: FakeProcessManager(),
+          httpClient: FakeHttpClient(),
         );
         expect(comparator1.runtimeType, FlutterSkippingFileComparator);
 
@@ -1062,6 +1065,7 @@ void main() {
           log: (String message) => fail('skia gold client printed unexpected output: "$message"'),
           fs: fs,
           process: FakeProcessManager(),
+          httpClient: FakeHttpClient(),
         );
         expect(comparator2.runtimeType, FlutterSkippingFileComparator);
 
@@ -1074,6 +1078,7 @@ void main() {
           log: (String message) => fail('skia gold client printed unexpected output: "$message"'),
           fs: fs,
           process: FakeProcessManager(),
+          httpClient: FakeHttpClient(),
         );
         expect(comparator3.runtimeType, FlutterSkippingFileComparator);
 


### PR DESCRIPTION
This is part 16 of a broken down version of the #140101 refactor.

This only makes one dependency explicit. Further PRs will do the same for other dependencies, until these APIs have no hidden dependencies.

This PR makes no effort to keep the order of parameters reasonable. There is an existing TODO to do a refactor sweep later that does nothing but reorder arguments/parameters/fields to be consistent.
