### PR TITLE
Add test for engine artifact framework permissions

### DIFF
--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -152,8 +152,8 @@ void main() {
 
         testWithoutContext('flutter build ios builds a valid app', () {
           // Check read/write permissions are set correctly in the framework engine artifact.
-          final String statString = frameworkArtifact.statSync().mode.toRadixString(8);
-          expect(statString, '4755');
+          final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
+          expect(artifactStat, '4755');
 
           printOnFailure('Output of flutter build ios:');
           printOnFailure(buildResult.stdout.toString());

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -153,7 +153,7 @@ void main() {
         testWithoutContext('flutter build ios builds a valid app', () {
           // Check read/write permissions are set correctly in the framework engine artifact.
           final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
-          expect(artifactStat, '4755');
+          expect(artifactStat, '40755');
 
           printOnFailure('Output of flutter build ios:');
           printOnFailure(buildResult.stdout.toString());

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -80,7 +80,6 @@ void main() {
 
     for (final BuildMode buildMode in <BuildMode>[BuildMode.debug, BuildMode.release]) {
       group('build in ${buildMode.cliName} mode', () {
-        late Directory frameworkArtifact;
         late Directory outputPath;
         late Directory outputApp;
         late Directory frameworkDirectory;
@@ -95,20 +94,6 @@ void main() {
         late ProcessResult buildResult;
 
         setUpAll(() {
-          frameworkArtifact = fileSystem.directory(
-            fileSystem.path.joinAll(<String>[
-              flutterRoot,
-              'bin',
-              'cache',
-              'artifacts',
-              'engine',
-              if (buildMode == BuildMode.debug) 'ios' else 'ios-release',
-              'Flutter.xcframework',
-              'ios-arm64',
-              'Flutter.framework',
-            ]),
-          );
-
           buildResult = processManager.runSync(<String>[
             flutterBin,
             ...getLocalEngineArguments(),
@@ -151,10 +136,6 @@ void main() {
         });
 
         testWithoutContext('flutter build ios builds a valid app', () {
-          // Check read/write permissions are set correctly in the framework engine artifact.
-          final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
-          expect(artifactStat, '40755');
-
           printOnFailure('Output of flutter build ios:');
           printOnFailure(buildResult.stdout.toString());
           printOnFailure(buildResult.stderr.toString());

--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -75,7 +75,7 @@ void main() {
       );
       // Check read/write permissions are set correctly in the framework engine artifact.
       final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
-      expect(artifactStat, '4755');
+      expect(artifactStat, '40755');
 
       final String workingDirectory = fileSystem.path.join(
         getFlutterRoot(),

--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     final Directory tempDir = createResolvedTempDirectorySync('macos_content_validation.');
 
-    // Pre-cache iOS engine Flutter.xcframework artifacts.
+    // Pre-cache macOS engine FlutterMacOS.xcframework artifacts.
     final ProcessResult result = processManager.runSync(
       <String>[
         flutterBin,
@@ -54,29 +54,23 @@ void main() {
 
     expect(result, const ProcessResultMatcher());
     expect(xcframeworkArtifact.existsSync(), isTrue);
+
+    final Directory frameworkArtifact = fileSystem.directory(
+      fileSystem.path.joinAll(<String>[
+        xcframeworkArtifact.path,
+        'macos-arm64_x86_64',
+        'FlutterMacOS.framework',
+      ]),
+    );
+    // Check read/write permissions are set correctly in the framework engine artifact.
+    final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
+    expect(artifactStat, '40755');
   });
 
   for (final String buildMode in <String>['Debug', 'Release']) {
     final String buildModeLower = buildMode.toLowerCase();
 
     test('flutter build macos --$buildModeLower builds a valid app', () {
-      final Directory frameworkArtifact = fileSystem.directory(
-        fileSystem.path.joinAll(<String>[
-          getFlutterRoot(),
-          'bin',
-          'cache',
-          'artifacts',
-          'engine',
-          if (buildMode == 'Debug') 'darwin-x64' else 'darwin-x64-release',
-          'FlutterMacOS.xcframework',
-          'macos-arm64_x86_64',
-          'FlutterMacOS.framework',
-        ]),
-      );
-      // Check read/write permissions are set correctly in the framework engine artifact.
-      final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
-      expect(artifactStat, '40755');
-
       final String workingDirectory = fileSystem.path.join(
         getFlutterRoot(),
         'dev',

--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -74,8 +74,8 @@ void main() {
         ]),
       );
       // Check read/write permissions are set correctly in the framework engine artifact.
-      final String statString = frameworkArtifact.statSync().mode.toRadixString(8);
-      expect(statString, '4755');
+      final String artifactStat = frameworkArtifact.statSync().mode.toRadixString(8);
+      expect(artifactStat, '4755');
 
       final String workingDirectory = fileSystem.path.join(
         getFlutterRoot(),
@@ -182,8 +182,8 @@ void main() {
       );
 
       // Check read/write permissions are being correctly set.
-      final String statString = outputFlutterFramework.statSync().mode.toRadixString(8);
-      expect(statString, '40755');
+      final String outputFrameworkStat = outputFlutterFramework.statSync().mode.toRadixString(8);
+      expect(outputFrameworkStat, '40755');
 
       // Check complicated macOS framework symlink structure.
       final Link current = outputFlutterFramework.childDirectory('Versions').childLink('Current');

--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -60,6 +60,23 @@ void main() {
     final String buildModeLower = buildMode.toLowerCase();
 
     test('flutter build macos --$buildModeLower builds a valid app', () {
+      final Directory frameworkArtifact = fileSystem.directory(
+        fileSystem.path.joinAll(<String>[
+          getFlutterRoot(),
+          'bin',
+          'cache',
+          'artifacts',
+          'engine',
+          if (buildMode == 'Debug') 'darwin-x64' else 'darwin-x64-release',
+          'FlutterMacOS.xcframework',
+          'macos-arm64_x86_64',
+          'FlutterMacOS.framework',
+        ]),
+      );
+      // Check read/write permissions are set correctly in the framework engine artifact.
+      final String statString = frameworkArtifact.statSync().mode.toRadixString(8);
+      expect(statString, '4755');
+
       final String workingDirectory = fileSystem.path.join(
         getFlutterRoot(),
         'dev',
@@ -164,10 +181,9 @@ void main() {
         ),
       );
 
-      // Check read/write permissions are being correctly set
-      final String rawStatString = outputFlutterFramework.statSync().modeString();
-      final String statString = rawStatString.substring(rawStatString.length - 9);
-      expect(statString, 'rwxr-xr-x');
+      // Check read/write permissions are being correctly set.
+      final String statString = outputFlutterFramework.statSync().mode.toRadixString(8);
+      expect(statString, '40755');
 
       // Check complicated macOS framework symlink structure.
       final Link current = outputFlutterFramework.childDirectory('Versions').childLink('Current');


### PR DESCRIPTION
Framework test to validate the iOS and macOS framework engine artifacts (Flutter.framework and FlutterMacOS.framework) have read and executable permissions.

~~Will fail until https://github.com/flutter/engine/pull/52961 rolls.~~ <-- it rolled https://github.com/flutter/flutter/pull/148819