### PR TITLE
Fix RenderFlex's baseline calculation with verticalDirection.up and Axis.vertical

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -680,10 +680,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
 
   @override
   double? computeDistanceToActualBaseline(TextBaseline baseline) {
-    return switch (_direction) {
-      Axis.horizontal => defaultComputeDistanceToHighestActualBaseline(baseline),
-      Axis.vertical   => defaultComputeDistanceToFirstActualBaseline(baseline),
-    };
+    return defaultComputeDistanceToHighestActualBaseline(baseline);
   }
 
   static int _getFlex(RenderBox child) {

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -648,6 +648,45 @@ void main() {
     expect(box2.localToGlobal(Offset.zero).dy, 0.0);
   });
 
+  test('Vertical Flex Baseline', () {
+    const BoxConstraints square = BoxConstraints.tightFor(width: 100.0, height: 100.0);
+    final RenderConstrainedBox box1 = RenderConstrainedBox(
+      additionalConstraints: square,
+      child: RenderFlowBaselineTestBox()
+        ..gridCount = 1
+        ..baselinePlacer = (double height) => 10,
+    );
+    final RenderConstrainedBox box2 = RenderConstrainedBox(
+      additionalConstraints: square,
+      child: RenderFlowBaselineTestBox()
+        ..gridCount = 1
+        ..baselinePlacer = (double height) => 10,
+    );
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+      children: <RenderBox>[box1, box2],
+      direction: Axis.vertical,
+    );
+    layout(flex, phase: EnginePhase.paint);
+
+    // We can't call the getDistanceToBaseline method directly. Check the dry
+    // baseline instead, and in debug mode there are asserts that verify
+    // the two methods return the same results.
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), 10);
+
+    flex.mainAxisAlignment = MainAxisAlignment.end;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), 410);
+
+    flex.verticalDirection = VerticalDirection.up;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), 10);
+
+    flex.mainAxisAlignment = MainAxisAlignment.start;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), 410);
+  });
+
   group('Intrinsics', () {
     test('main axis intrinsics with RenderAspectRatio 1', () {
       const BoxConstraints square = BoxConstraints.tightFor(width: 100.0, height: 100.0);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/145739

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
