### PR TITLE
Move Linux web_long_running_tests_2_5 to bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1294,6 +1294,7 @@ targets:
 
   - name: Linux web_long_running_tests_2_5
     recipe: flutter/flutter_drone
+    bringup: true
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Failing on nearly every run with:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8747255560298826193/+/u/run_test.dart_for_web_long_running_tests_shard_and_subshard_2_5/stdout

