### PR TITLE
[CP] [devicelab] explicitly enable vulkan validation in test. (#147382)

### DIFF
--- a/dev/devicelab/bin/tasks/hello_world_impeller.dart
+++ b/dev/devicelab/bin/tasks/hello_world_impeller.dart
@@ -54,6 +54,7 @@ Future<TaskResult> run() async {
       'run',
       options: <String>[
         '--enable-impeller',
+        '--enable-vulkan-validation',
         '-d',
         device.deviceId,
       ],


### PR DESCRIPTION
Fix for release build failure https://ci.chromium.org/ui/p/flutter/builders/prod/Linux_pixel_7pro%20hello_world_impeller/3962/overview

Part of https://github.com/flutter/flutter/issues/142659

this test expects validation layers on, so we need to explicitly enable them before we can turn them off by default.
