### PR TITLE
Fix nested `SingleChildScrollView` `ensureVisible` throws an error in an `OverlayPortal`

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -791,11 +791,16 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     }
 
     Rect? targetRect;
-    if (targetRenderObject != null && targetRenderObject != object) {
-      targetRect = MatrixUtils.transformRect(
-        targetRenderObject.getTransformTo(object),
-        object.paintBounds.intersect(targetRenderObject.paintBounds),
-      );
+    try {
+      if (targetRenderObject != null && targetRenderObject != object) {
+        targetRect = MatrixUtils.transformRect(
+          targetRenderObject.getTransformTo(object),
+          object.paintBounds.intersect(targetRenderObject.paintBounds),
+        );
+      }
+    } catch (e) {
+      // If the transform cannot be computed, return.
+      return;
     }
 
     double target;


### PR DESCRIPTION
fixes [DropdownMenu throws exception when nested inside two SingleChildScrollView](https://github.com/flutter/flutter/issues/146764)

This attempts fix the issue where calling `ensureVisible` from nested `SingleChildScrollView`  inside an `OverlayPortal` 

This happens due to `getTransformTo` for `MatrixUtils.transformRect` fails when trying to transform render object on different widget tree layers.  My solution adds a try/catch to safe guard the original fix https://github.com/flutter/flutter/pull/67773

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
