### PR TITLE
Fix `SnackBar` action text button overlay color

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'button_style.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'icon_button.dart';
@@ -204,10 +203,11 @@ class _SnackBarActionState extends State<SnackBarAction> {
     }
 
     return TextButton(
-      style: ButtonStyle(
-        foregroundColor: resolveForegroundColor(),
-        backgroundColor: resolveBackgroundColor(),
-      ),
+      style: TextButton.styleFrom(overlayColor: resolveForegroundColor())
+        .copyWith(
+          foregroundColor: resolveForegroundColor(),
+          backgroundColor: resolveBackgroundColor(),
+        ),
       onPressed: _haveTriggeredAction ? null : _handlePressed,
       child: Text(widget.label),
     );
@@ -670,9 +670,6 @@ class _SnackBarState extends State<SnackBar> {
 
     final double actionHorizontalMargin = (widget.padding?.resolve(TextDirection.ltr).right ?? horizontalPadding) / 2;
     final double iconHorizontalMargin = (widget.padding?.resolve(TextDirection.ltr).right ?? horizontalPadding) / 12.0;
-
-
-
 
     final IconButton? iconButton = showCloseIcon
         ? IconButton(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -4045,6 +4045,39 @@ testWidgets('SnackBarAction backgroundColor works as a Color', (WidgetTester tes
 
     expect(completer.isCompleted, false);
   });
+
+  testWidgets('Action text button uses correct overlay color', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return GestureDetector(
+              onTap: () {
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content: const Text('I am a snack bar.'),
+                  action: SnackBarAction(label: 'ACTION', onPressed: () { }),
+                ));
+              },
+              child: const Text('X'),
+            );
+          },
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final ButtonStyle? actionButtonStyle = tester.widget<TextButton>(
+      find.widgetWithText(TextButton, 'ACTION'),
+    ).style;
+    expect(
+      actionButtonStyle?.overlayColor?.resolve(<MaterialState>{MaterialState.hovered}),
+      theme.colorScheme.inversePrimary.withOpacity(0.08),
+    );
+  });
 }
 
 /// Start test for "SnackBar dismiss test".


### PR DESCRIPTION
fixes [`SnackBar` action hover state background too hard to see](https://github.com/flutter/flutter/issues/141343)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: Scaffold(
        body: Center(
          child: ScaffoldButton(),
        ),
      ),
    );
  }
}

class ScaffoldButton extends StatelessWidget {
  const ScaffoldButton({super.key});

  @override
  Widget build(BuildContext context) {
    return TextButton(
      onPressed: () {
        ScaffoldMessenger.of(context).showSnackBar(
          SnackBar(
            behavior: SnackBarBehavior.floating,
            width: 320,
            content: const Text('This is a snackbar!'),
            action: SnackBarAction(
              label: 'Close',
              onPressed: () {},
            ),
          ),
        );
      },
      child: const Text('Launch snackbar'),
    );
  }
}

```

</details>

### Before
<img src="https://github.com/flutter/flutter/assets/48603081/88b53c92-6184-4faf-88e1-ac70f78993b3"/> 

### After
 <img src="https://github.com/flutter/flutter/assets/48603081/3e03c903-90c0-4da4-b49a-0070208d56d1"  /> 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
