### PR TITLE
Stop autocomplete options builder from calling on text selection changes

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -353,6 +353,14 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   // Called when _textEditingController changes.
   Future<void> _onChangedField() async {
     final TextEditingValue value = _textEditingController.value;
+
+    // Make sure the options are no longer hidden if the content of the field
+    // changes (ignore selection changes).
+    if (value.text == _lastFieldText) {
+      return;
+    }
+    _lastFieldText = value.text;
+
     final Iterable<T> options = await widget.optionsBuilder(value);
     _options = options;
     _updateHighlight(_highlightedOptionIndex.value);
@@ -360,13 +368,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     if (selection != null && value.text != widget.displayStringForOption(selection)) {
       _selection = null;
     }
-
-    // Make sure the options are no longer hidden if the content of the field
-    // changes (ignore selection changes).
-    if (value.text != _lastFieldText) {
-      _lastFieldText = value.text;
-      _updateOptionsViewVisibility();
-    }
+    _updateOptionsViewVisibility();
   }
 
   // Called from fieldViewBuilder when the user submits the field.


### PR DESCRIPTION
Currently, in `RawAutocomplete`, changing the text selection also updates the options view, even when it shouldn't:

https://github.com/flutter/flutter/blob/de0fbdefe38546149e6534b9ca2c5f1f5cf0c2c0/packages/flutter/lib/src/widgets/autocomplete.dart#L364-L365

This is because `optionsBuilder` is called before checking if only the text changes and not the selection. Thus, if `optionsBuilder` is async, the options view is updated only after waiting for the `optionsBuilder` future to resolve, even when only the selection changes. This causes a loading display when highlighting in the text field.

This PR moves the check to before `optionsBuilder` is called.

Before:
![badselection-ezgif com-video-to-gif-converter](https://github.com/flutter/flutter/assets/77553258/53e3bb54-3444-4ac4-aa40-4c6971ab2cb5)
After:
![goodselection-ezgif com-video-to-gif-converter](https://github.com/flutter/flutter/assets/77553258/dd8ff38c-8c25-44b0-9f5d-801d00cf9009)


Related Issues: #108258, #147900
Related PRs: #147377  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
