### PR TITLE
Update 3.22.1 release notes to include missing fix.

### DIFF
--- a/docs/releases/Hotfixes-to-the-Stable-Channel.md
+++ b/docs/releases/Hotfixes-to-the-Stable-Channel.md
@@ -27,10 +27,11 @@ INTERNAL NOTE
 ## Flutter 3.22 Changes
 
 ### [3.22.1](https://github.com/flutter/flutter/releases/tag/3.22.1) (May 22, 2024)
-* [dart/55714](https://github.com/dart-lang/sdk/issues/55714) Fixes a bug in the CFE which could manifest as compilation errors of Flutter
+* [dart/55714](https://github.com/dart-lang/sdk/issues/55714) - Fixes a bug in the CFE which could manifest as compilation errors of Flutter
   web apps when compiled with dart2wasm.
-* [dart/55758](https://github.com/dart-lang/sdk/issues/55758) Fixes a bug in the pub client, such that `dart run` will not interfere with
+* [dart/55758](https://github.com/dart-lang/sdk/issues/55758) - Fixes a bug in the pub client, such that `dart run` will not interfere with
   Flutter l10n (at least for most cases).
+* [flutter/147142](https://github.com/flutter/flutter/issues/147142) - Fixes a read/write permission issue when building Flutter apps for MacOS.
 
 ### [3.22.0](https://github.com/flutter/flutter/releases/tag/3.22.0) (May 14, 2024)
 Initial stable release.


### PR DESCRIPTION
Update changelog to include https://github.com/flutter/flutter/pull/148580 in the list of fixes. 