### PR TITLE
[GAR][a11y] Update assessment app to unblock tester from testing dark mode

### DIFF
--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -26,10 +26,8 @@ class App extends StatelessWidget {
     );
     return MaterialApp(
       title: 'Accessibility Assessments',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
       routes: <String, WidgetBuilder>{
         '/': (_) => const HomePage(),
         ...routes

--- a/dev/a11y_assessments/test/home_page_test.dart
+++ b/dev/a11y_assessments/test/home_page_test.dart
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:a11y_assessments/main.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+
+void main() {
+  testWidgets('Has light and dark theme', (WidgetTester tester) async {
+    await tester.pumpWidget(const App());
+    final MaterialApp app = find.byType(MaterialApp).evaluate().first.widget as MaterialApp;
+    expect(app.theme!.brightness, equals(Brightness.light));
+    expect(app.darkTheme!.brightness, equals(Brightness.dark));
+  });
+}


### PR DESCRIPTION
internal: b/317130300

reopening #149004

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
