### PR TITLE
Fix the RenderFlex.computeDryBaseline implementation to match computeDistanceToActualBaseline

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -308,6 +308,8 @@ enum CrossAxisAlignment {
   /// See also:
   ///
   ///  * [RenderBox.getDistanceToBaseline], which defines the baseline of a box.
+  ///  * [IgnoreBaseline], which can be used to ignore a child for the purpose of
+  ///    baseline alignment.
   baseline;
 
   double _getChildCrossAxisOffset(double freeSpace, bool flipped) {

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -821,13 +821,17 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         final double freeSpace = math.max(0.0, sizes.mainAxisFreeSpace);
         final bool flipMainAxis = _flipMainAxis;
         final (double leadingSpaceY, double spaceBetween) = mainAxisAlignment._distributeSpace(freeSpace, childCount, flipMainAxis);
-        double y = leadingSpaceY;
-        final (_NextChild nextChild, RenderBox? topLeftChild) = flipMainAxis ? (childBefore, lastChild) : (childAfter, firstChild);
-        for (RenderBox? child = topLeftChild; child != null; child = nextChild(child)) {
+        double y = flipMainAxis
+          ? leadingSpaceY + (childCount - 1) * spaceBetween + (sizes.axisSize.mainAxisExtent - sizes.mainAxisFreeSpace)
+          : leadingSpaceY;
+        final double directionUnit = flipMainAxis ? -1.0 : 1.0;
+        for (RenderBox? child = firstChild; baselineOffset == BaselineOffset.noBaseline && child != null; child = childAfter(child)) {
           final BoxConstraints childConstraints = constraintsForChild(child);
           final Size childSize = child.getDryLayout(childConstraints);
-          baselineOffset = baselineOffset.minOf(BaselineOffset(child.getDryBaseline(childConstraints, baseline)) + y);
-          y += spaceBetween + childSize.height;
+          final double? childBaselineOffset = child.getDryBaseline(childConstraints, baseline);
+          final double additionalY = flipMainAxis ? - childSize.height : 0.0;
+          baselineOffset = BaselineOffset(childBaselineOffset) + y + additionalY;
+          y += directionUnit * (spaceBetween + childSize.height);
         }
       case Axis.horizontal:
         final bool flipCrossAxis = _flipCrossAxis;

--- a/packages/flutter/test/rendering/flex_test.dart
+++ b/packages/flutter/test/rendering/flex_test.dart
@@ -648,6 +648,53 @@ void main() {
     expect(box2.localToGlobal(Offset.zero).dy, 0.0);
   });
 
+  test('Vertical Flex Baseline', () {
+    const BoxConstraints square = BoxConstraints.tightFor(width: 100.0, height: 100.0);
+    final RenderConstrainedBox box1 = RenderConstrainedBox(
+      additionalConstraints: square,
+      child: RenderFlowBaselineTestBox()
+        ..gridCount = 1
+        ..baselinePlacer = (double height) => 10,
+    );
+    final RenderConstrainedBox box2 = RenderConstrainedBox(
+      additionalConstraints: square,
+      child: RenderFlowBaselineTestBox()
+        ..gridCount = 1
+        ..baselinePlacer = (double height) => 10,
+    );
+    RenderConstrainedBox filler() => RenderConstrainedBox(additionalConstraints: square);
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+      children: <RenderBox>[
+        filler(),
+        box1,
+        filler(),
+        box2,
+        filler(),
+      ],
+      direction: Axis.vertical,
+    );
+    layout(flex, phase: EnginePhase.paint);
+    final double flexHeight = flex.size.height;
+
+    // We can't call the getDistanceToBaseline method directly. Check the dry
+    // baseline instead, and in debug mode there are asserts that verify
+    // the two methods return the same results.
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), 100 + 10);
+
+    flex.mainAxisAlignment = MainAxisAlignment.end;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), flexHeight - 400 + 10);
+
+    flex.verticalDirection = VerticalDirection.up;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), 300 + 10);
+
+    flex.mainAxisAlignment = MainAxisAlignment.start;
+    pumpFrame(phase: EnginePhase.paint);
+    expect(flex.getDryBaseline(flex.constraints, TextBaseline.alphabetic), flexHeight - 200 + 10);
+  });
+
   group('Intrinsics', () {
     test('main axis intrinsics with RenderAspectRatio 1', () {
       const BoxConstraints square = BoxConstraints.tightFor(width: 100.0, height: 100.0);


### PR DESCRIPTION
Per Hixie's comment [here](https://github.com/flutter/flutter/issues/145739#issuecomment-2128006146), keep the current behavior

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
