### PR TITLE
Use correct type for abi version code

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -1225,7 +1225,7 @@ class FlutterPlugin implements Plugin<Project> {
                     // for only the output APK, not for the variant itself. Skipping this step simply
                     // causes Gradle to use the value of variant.versionCode for the APK.
                     // For more, see https://developer.android.com/studio/build/configure-apk-splits
-                    int abiVersionCode = ABI_VERSION.get(output.getFilter(OutputFile.ABI))
+                    Integer abiVersionCode = ABI_VERSION.get(output.getFilter(OutputFile.ABI))
                     if (abiVersionCode != null) {
                         output.versionCodeOverride =
                             abiVersionCode * 1000 + variant.versionCode


### PR DESCRIPTION
After upgrading flutter to the latest version (3.22.1), I encountered an error when building with `--split-per-abi`:

```
[   +1 ms] FAILURE: Build failed with an exception.
[        ] * Where:
[        ] Script '/home/runar/snap/flutter/common/flutter/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy' line: 1182
[        ] * What went wrong:
[        ] A problem occurred evaluating root project 'android'.
[        ] > A problem occurred configuring project ':app'.
[        ]    > org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'null' with class 'null' to class 'int'.
Try 'java.lang.Integer' instead
```

This PR changes the type used from `ìnt` to `Integer` which is what's used in the `ABI_VERSION` map.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
