### PR TITLE
fix M2 InputDecorator suffix icon doesn't turn red on error

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -4570,7 +4570,7 @@ class _InputDecoratorDefaultsM2 extends InputDecorationTheme {
 
   @override
   TextStyle? get helperStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
-    final ThemeData themeData= Theme.of(context);
+    final ThemeData themeData = Theme.of(context);
     if (states.contains(MaterialState.disabled)) {
       return themeData.textTheme.bodySmall!.copyWith(color: Colors.transparent);
     }
@@ -4580,7 +4580,7 @@ class _InputDecoratorDefaultsM2 extends InputDecorationTheme {
 
   @override
   TextStyle? get errorStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
-    final ThemeData themeData= Theme.of(context);
+    final ThemeData themeData = Theme.of(context);
     if (states.contains(MaterialState.disabled)) {
       return themeData.textTheme.bodySmall!.copyWith(color: Colors.transparent);
     }
@@ -4629,6 +4629,9 @@ class _InputDecoratorDefaultsM2 extends InputDecorationTheme {
   Color? get suffixIconColor => MaterialStateColor.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled) && !states.contains(MaterialState.focused)) {
       return Theme.of(context).disabledColor;
+    }
+    if (states.contains(MaterialState.error)) {
+      return Theme.of(context).colorScheme.error;
     }
     if (states.contains(MaterialState.focused)) {
       return Theme.of(context).colorScheme.primary;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -8885,6 +8885,29 @@ void main() {
       expect(tester.getTopRight(find.text('text')).dx, lessThanOrEqualTo(tester.getTopLeft(find.byIcon(Icons.satellite)).dx));
     });
 
+    testWidgets('Material2 - InputDecorator suffixIcon color in error state', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(useMaterial3: false),
+          home: Material(
+            child: TextField(
+              decoration: InputDecoration(
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () {},
+                ),
+                errorText: 'Error state',
+                filled: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final ThemeData theme = Theme.of(tester.element(find.byType(TextField)));
+      expect(getIconStyle(tester, Icons.close)?.color, theme.colorScheme.error);
+    });
+
     testWidgets('InputDecorator prefixIconConstraints/suffixIconConstraints', (WidgetTester tester) async {
       await tester.pumpWidget(
         buildInputDecoratorM2(


### PR DESCRIPTION
## Description

This PR fixes the suffix icon color when the field is in error state.
Per the M2 spec, it should be set to the error color, see https://m2.material.io/components/text-fields#filled-text-field.
(This is a M2 only PR, because the M3 behavior is already correct)

**Before**:

![image](https://user-images.githubusercontent.com/20682772/118683356-b22bd200-b7d7-11eb-9072-eefc5721f09e.png)

**After**:

![image](https://user-images.githubusercontent.com/20682772/118683274-a17b5c00-b7d7-11eb-94b4-62cb430f43dd.png)


## Related Issue

Fixes https://github.com/flutter/flutter/issues/82823

## Tests

Adds 1 tests.
