### PR TITLE
Change `android_plugin_new_output_dir_test.dart` test description

### DIFF
--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -25,7 +25,7 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  test("error logged when plugin's build output dir was not private.", () async {
+  test('plugins use individualized build directories.', () async {
     final String flutterBin = fileSystem.path.join(
       getFlutterRoot(),
       'bin',

--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -25,7 +25,7 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  test('plugins use individualized build directories.', () async {
+  test('plugins use individualized build directories based on their name.', () async {
     final String flutterBin = fileSystem.path.join(
       getFlutterRoot(),
       'bin',


### PR DESCRIPTION
Changes the test description to what I understand it is testing. 

Context at https://discord.com/channels/608014603317936148/846507907876257822/1245077048599515157.

cc @chunfengyao as the original author, as I see you are still active on Github 🙂 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
