### PR TITLE
Add test for standard_fab_location.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -323,7 +323,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/menu_anchor/menu_anchor.2_test.dart',
   'examples/api/test/material/stepper/stepper.controls_builder.0_test.dart',
   'examples/api/test/material/flexible_space_bar/flexible_space_bar.0_test.dart',
-  'examples/api/test/material/floating_action_button_location/standard_fab_location.0_test.dart',
   'examples/api/test/material/chip/deletable_chip_attributes.on_deleted.0_test.dart',
   'examples/api/test/material/icon_button/icon_button.3_test.dart',
   'examples/api/test/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0_test.dart',

--- a/examples/api/test/material/floating_action_button_location/standard_fab_location.0_test.dart
+++ b/examples/api/test/material/floating_action_button_location/standard_fab_location.0_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/floating_action_button_location/standard_fab_location.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('FloatingActionButton', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.StandardFabLocationExampleApp(),
+    );
+
+    expect(find.widgetWithIcon(FloatingActionButton, Icons.add), findsOne);
+    final double right = tester.getCenter(find.byType(FloatingActionButton)).dx;
+    expect(right, closeTo(706, 1));
+  });
+}

--- a/examples/api/test/material/floating_action_button_location/standard_fab_location.0_test.dart
+++ b/examples/api/test/material/floating_action_button_location/standard_fab_location.0_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_api_samples/material/floating_action_button_location/sta
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('FloatingActionButton', (WidgetTester tester) async {
+  testWidgets('The FloatingActionButton should have a right padding', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.StandardFabLocationExampleApp(),
     );


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/floating_action_button_location/standard_fab_location.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
