### PR TITLE
Allow null registrarForPlugin on iOS

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -397,7 +397,10 @@ const String _objcPluginRegistryImplementationTemplate = '''
 
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
 {{#methodChannelPlugins}}
-  [{{prefix}}{{class}} registerWithRegistrar:[registry registrarForPlugin:@"{{prefix}}{{class}}"]];
+  id<FlutterPluginRegistrar> registrar{{prefix}}{{class}} = [registry registrarForPlugin:@"{{prefix}}{{class}}"];
+  if (registrar{{prefix}}{{class}} != nil) {
+    [{{prefix}}{{class}} registerWithRegistrar:registrar{{prefix}}{{class}}];
+  }
 {{/methodChannelPlugins}}
 }
 


### PR DESCRIPTION
Expands to:
```objc
  id<FlutterPluginRegistrar> registrarInAppPurchasePlugin = [registry registrarForPlugin:@"InAppPurchasePlugin"];
  if (registrarInAppPurchasePlugin != nil) {
    [InAppPurchasePlugin registerWithRegistrar:registrarInAppPurchasePlugin];
  }
  id<FlutterPluginRegistrar> registrarIntegrationTestPlugin = [registry registrarForPlugin:@"IntegrationTestPlugin"];
  if (registrarIntegrationTestPlugin != nil) {
    [IntegrationTestPlugin registerWithRegistrar:registrarIntegrationTestPlugin];
  }
  id<FlutterPluginRegistrar> registrarSharedPreferencesPlugin = [registry registrarForPlugin:@"SharedPreferencesPlugin"];
  if (registrarSharedPreferencesPlugin != nil) {
    [SharedPreferencesPlugin registerWithRegistrar:registrarSharedPreferencesPlugin];
  }
```
Fixes https://github.com/flutter/flutter/issues/149214
