### PR TITLE
Enable SelectionArea double tap/triple tap gesture support for mobile platforms

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -490,9 +490,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
         if (_lastPointerDeviceKind != null && _lastPointerDeviceKind != PointerDeviceKind.mouse) {
-          // When the pointer device kind is not precise like a mouse,
-          // native Android resets the tap count at 2. For example, this is so
-          // the selection can collapse on the third tap.
+          // When the pointer device kind is not precise like a mouse, native
+          // Android resets the tap count at 2. For example, this is so the
+          // selection can collapse on the third tap.
           maxConsecutiveTap = 2;
         }
         // From observation, these platforms reset their tap count to 0 when

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -724,16 +724,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             break;
         }
       case 2:
-        if (details.kind != null 
-            && details.kind != PointerDeviceKind.mouse 
+        if (details.kind != PointerDeviceKind.mouse 
             && defaultTargetPlatform == TargetPlatform.android) {
           // On Android, a double tap will only show the selection overlay after
           // the following tap up when the pointer device kind is not precise.
           _showHandles();
           _showToolbar();
         }
-        if (details.kind != null 
-            && details.kind != PointerDeviceKind.mouse 
+        if (details.kind != PointerDeviceKind.mouse 
             && defaultTargetPlatform == TargetPlatform.iOS) {
           // On iOS, a double tap will only show the selection toolbar after
           // the following tap up when the pointer device kind is not precise.
@@ -799,8 +797,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.windows:
         // If _lastSecondaryTapDownPosition is within the current selection then
         // keep the current selection, if not then collapse it.
-        final bool _lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
-        if (!_lastSecondaryTapDownPositionWasOnActiveSelection) {
+        final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
+        if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
           _collapseSelectionAt(offset: _lastSecondaryTapDownPosition!);
         }
         _showHandles();
@@ -824,8 +822,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         }
         // If _lastSecondaryTapDownPosition is within the current selection then
         // keep the current selection, if not then collapse it.
-        final bool _lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
-        if (!_lastSecondaryTapDownPositionWasOnActiveSelection) {
+        final bool lastSecondaryTapDownPositionWasOnActiveSelection = _positionIsOnActiveSelection(globalPosition: details.globalPosition);
+        if (!lastSecondaryTapDownPositionWasOnActiveSelection) {
           _collapseSelectionAt(offset: _lastSecondaryTapDownPosition!);
         }
         _showHandles();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -678,16 +678,16 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleMouseDragEnd(TapDragEndDetails details) {
-    if (_lastPointerDeviceKind != null 
-        && _lastPointerDeviceKind != PointerDeviceKind.mouse 
+    if (_lastPointerDeviceKind != null
+        && _lastPointerDeviceKind != PointerDeviceKind.mouse
         && defaultTargetPlatform == TargetPlatform.android) {
       // On Android, a drag gesture will only show the selection overlay when
       // the drag has finished and the pointer device kind is not precise.
       _showHandles();
       _showToolbar();
     }
-    if (_lastPointerDeviceKind != null 
-        && _lastPointerDeviceKind != PointerDeviceKind.mouse 
+    if (_lastPointerDeviceKind != null
+        && _lastPointerDeviceKind != PointerDeviceKind.mouse
         && defaultTargetPlatform == TargetPlatform.iOS) {
       // On iOS, a drag gesture will only show the selection toolbar when
       // the drag has finished and the pointer device kind is not precise.
@@ -724,14 +724,14 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             break;
         }
       case 2:
-        if (details.kind != PointerDeviceKind.mouse 
+        if (details.kind != PointerDeviceKind.mouse
             && defaultTargetPlatform == TargetPlatform.android) {
           // On Android, a double tap will only show the selection overlay after
           // the following tap up when the pointer device kind is not precise.
           _showHandles();
           _showToolbar();
         }
-        if (details.kind != PointerDeviceKind.mouse 
+        if (details.kind != PointerDeviceKind.mouse
             && defaultTargetPlatform == TargetPlatform.iOS) {
           // On iOS, a double tap will only show the selection toolbar after
           // the following tap up when the pointer device kind is not precise.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -690,20 +690,27 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleMouseDragEnd(TapDragEndDetails details) {
-    if (_lastPointerDeviceKind != null
-        && _lastPointerDeviceKind != PointerDeviceKind.mouse
-        && defaultTargetPlatform == TargetPlatform.android) {
-      // On Android, a drag gesture will only show the selection overlay when
-      // the drag has finished and the pointer device kind is not precise.
-      _showHandles();
-      _showToolbar();
-    }
-    if (_lastPointerDeviceKind != null
-        && _lastPointerDeviceKind != PointerDeviceKind.mouse
-        && defaultTargetPlatform == TargetPlatform.iOS) {
-      // On iOS, a drag gesture will only show the selection toolbar when
-      // the drag has finished and the pointer device kind is not precise.
-      _showToolbar();
+    final bool isPointerPrecise = _lastPointerDeviceKind != null && _lastPointerDeviceKind == PointerDeviceKind.mouse;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        if (!isPointerPrecise) {
+          // On Android, a drag gesture will only show the selection overlay when
+          // the drag has finished and the pointer device kind is not precise.
+          _showHandles();
+          _showToolbar();
+        }
+      case TargetPlatform.iOS:
+        if (!isPointerPrecise) {
+          // On iOS, a drag gesture will only show the selection toolbar when
+          // the drag has finished and the pointer device kind is not precise.
+          _showToolbar();
+        }
+      case TargetPlatform.macOS:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+          // The selection overlay is not shown on desktop platforms after a drag.
+          break;
     }
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
@@ -736,18 +743,28 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             break;
         }
       case 2:
-        if (details.kind != PointerDeviceKind.mouse
-            && defaultTargetPlatform == TargetPlatform.android) {
-          // On Android, a double tap will only show the selection overlay after
-          // the following tap up when the pointer device kind is not precise.
-          _showHandles();
-          _showToolbar();
-        }
-        if (details.kind != PointerDeviceKind.mouse
-            && defaultTargetPlatform == TargetPlatform.iOS) {
-          // On iOS, a double tap will only show the selection toolbar after
-          // the following tap up when the pointer device kind is not precise.
-          _showToolbar();
+        final bool isPointerPrecise = details.kind == PointerDeviceKind.mouse;
+        switch (defaultTargetPlatform) {
+          case TargetPlatform.android:
+          case TargetPlatform.fuchsia:
+            if (!isPointerPrecise) {
+              // On Android, a double tap will only show the selection overlay after
+              // the following tap up when the pointer device kind is not precise.
+              _showHandles();
+              _showToolbar();
+            }
+          case TargetPlatform.iOS:
+            if (!isPointerPrecise) {
+              // On iOS, a double tap will only show the selection toolbar after
+              // the following tap up when the pointer device kind is not precise.
+              _showToolbar();
+            }
+          case TargetPlatform.macOS:
+          case TargetPlatform.linux:
+          case TargetPlatform.windows:
+              // The selection overlay is not shown on desktop platforms
+              // on a double click.
+              break;
         }
     }
     _updateSelectedContentIfNeeded();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -491,7 +491,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.fuchsia:
         if (_lastPointerDeviceKind != null && _lastPointerDeviceKind != PointerDeviceKind.mouse) {
           // When the pointer device kind is not precise like a mouse,
-          // native Android resets the tap count at 2.
+          // native Android resets the tap count at 2. For example, this is so
+          // the selection can collapse on the third tap.
           maxConsecutiveTap = 2;
         }
         // From observation, these platforms reset their tap count to 0 when
@@ -512,7 +513,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
-        // From observation, these platforms either hold their tap count at the max
+        // From observation, these platforms hold their tap count at the max
         // consecutive tap supported. For example on macOS, when going past a triple
         // click, the selection should be retained at the paragraph that was first
         // selected on triple click.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -373,20 +373,12 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     _initMouseGestureRecognizer();
     _initTouchGestureRecognizer();
     // Right clicks.
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        _gestureRecognizers[TapGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
-              () => TapGestureRecognizer(debugOwner: this),
-              (TapGestureRecognizer instance) {
-            instance.onSecondaryTapDown = _handleRightClickDown;
-          },
-        );
-    }
+    _gestureRecognizers[TapGestureRecognizer] = GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+          () => TapGestureRecognizer(debugOwner: this),
+          (TapGestureRecognizer instance) {
+        instance.onSecondaryTapDown = _handleRightClickDown;
+      },
+    );
     _initProcessTextActions();
   }
 

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -588,7 +588,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         switch (defaultTargetPlatform) {
           case TargetPlatform.iOS:
             if (kIsWeb && details.kind != null && details.kind != PointerDeviceKind.mouse) {
-              // Double tap on iOS web only works with a precise pointer device.
+              // Double tap on iOS web is only enabled with a precise pointer device.
               break;
             }
             _selectWordAt(offset: details.globalPosition);
@@ -625,6 +625,10 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleMouseDragStart(TapDragStartDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
+        if (details.kind != null && details.kind != PointerDeviceKind.mouse) {
+          // Drag to select is only enabled with a precise pointer device.
+          return;
+        }
         _selectStartTo(offset: details.globalPosition);
     }
     _updateSelectedContentIfNeeded();
@@ -633,6 +637,10 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
+        if (details.kind != null && details.kind != PointerDeviceKind.mouse) {
+          // Drag to select is only enabled with a precise pointer device.
+          return;
+        }
         _selectEndTo(offset: details.globalPosition, continuous: true);
       case 2:
         switch (defaultTargetPlatform) {
@@ -645,7 +653,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             }
           case TargetPlatform.iOS:
             if (kIsWeb && details.kind != null && details.kind != PointerDeviceKind.mouse) {
-              // Double tap + drag on iOS web only works with a precise pointer device.
+              // Double tap + drag on iOS web is only enabled with a precise
+              // pointer device.
               break;
             }
             _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -653,7 +653,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.fuchsia:
             // Double tap + drag is only supported on Android when using a precise
             // pointer device or when not on the web.
-            if (details.kind != null && details.kind == PointerDeviceKind.mouse || !kIsWeb) {
+            if (!kIsWeb || details.kind != null && details.kind == PointerDeviceKind.mouse) {
               _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
             }
           case TargetPlatform.iOS:

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -669,7 +669,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
               _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
             }
           case TargetPlatform.iOS:
-            if (kIsWeb && details.kind != null && _isPrecisePointerDevice(details.kind!)) {
+            if (kIsWeb && details.kind != null && !_isPrecisePointerDevice(details.kind!)) {
               // Double tap + drag on iOS web is only enabled with a precise
               // pointer device.
               break;

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -477,6 +477,19 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   // SelectableRegion.
   PointerDeviceKind? _lastPointerDeviceKind;
 
+  static bool _isPrecisePointerDevice(PointerDeviceKind pointerDeviceKind) {
+    switch (pointerDeviceKind) {
+      case PointerDeviceKind.mouse:
+        return true;
+      case PointerDeviceKind.trackpad:
+      case PointerDeviceKind.stylus:
+      case PointerDeviceKind.invertedStylus:
+      case PointerDeviceKind.touch:
+      case PointerDeviceKind.unknown:
+        return false;
+    }
+  }
+
   // Converts the details.consecutiveTapCount from a TapAndDrag*Details object,
   // which can grow to be infinitely large, to a value between 1 and the supported
   // max consecutive tap count. The value that the raw count is converted to is
@@ -592,13 +605,12 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
       case 2:
         switch (defaultTargetPlatform) {
           case TargetPlatform.iOS:
-            if (kIsWeb && details.kind != null && details.kind != PointerDeviceKind.mouse) {
+            if (kIsWeb && details.kind != null && !_isPrecisePointerDevice(details.kind!)) {
               // Double tap on iOS web is only enabled with a precise pointer device.
               break;
             }
             _selectWordAt(offset: details.globalPosition);
-            if (details.kind != null
-                && details.kind != PointerDeviceKind.mouse) {
+            if (details.kind != null && !_isPrecisePointerDevice(details.kind!)) {
               _showHandles();
             }
           case TargetPlatform.android:
@@ -613,7 +625,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:
-            if (details.kind != null && details.kind == PointerDeviceKind.mouse) {
+            if (details.kind != null && _isPrecisePointerDevice(details.kind!)) {
               // Triple tap on static text is only supported on mobile
               // platforms using a precise pointer device.
               _selectParagraphAt(offset: details.globalPosition);
@@ -630,7 +642,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleMouseDragStart(TapDragStartDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
-        if (details.kind != null && details.kind != PointerDeviceKind.mouse) {
+        if (details.kind != null && !_isPrecisePointerDevice(details.kind!)) {
           // Drag to select is only enabled with a precise pointer device.
           return;
         }
@@ -642,7 +654,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   void _handleMouseDragUpdate(TapDragUpdateDetails details) {
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
       case 1:
-        if (details.kind != null && details.kind != PointerDeviceKind.mouse) {
+        if (details.kind != null && !_isPrecisePointerDevice(details.kind!)) {
           // Drag to select is only enabled with a precise pointer device.
           return;
         }
@@ -653,17 +665,17 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.fuchsia:
             // Double tap + drag is only supported on Android when using a precise
             // pointer device or when not on the web.
-            if (!kIsWeb || details.kind != null && details.kind == PointerDeviceKind.mouse) {
+            if (!kIsWeb || details.kind != null && _isPrecisePointerDevice(details.kind!)) {
               _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
             }
           case TargetPlatform.iOS:
-            if (kIsWeb && details.kind != null && details.kind != PointerDeviceKind.mouse) {
+            if (kIsWeb && details.kind != null && _isPrecisePointerDevice(details.kind!)) {
               // Double tap + drag on iOS web is only enabled with a precise
               // pointer device.
               break;
             }
             _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.word);
-            if (details.kind != null && details.kind != PointerDeviceKind.mouse) {
+            if (details.kind != null && !_isPrecisePointerDevice(details.kind!)) {
               _showHandles();
             }
           case TargetPlatform.macOS:
@@ -678,7 +690,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
           case TargetPlatform.iOS:
             // Triple tap + drag is only supported on mobile devices when using
             // a precise pointer device.
-            if (details.kind != null && details.kind == PointerDeviceKind.mouse) {
+            if (details.kind != null && _isPrecisePointerDevice(details.kind!)) {
               _selectEndTo(offset: details.globalPosition, continuous: true, textGranularity: TextGranularity.paragraph);
             }
           case TargetPlatform.macOS:
@@ -744,7 +756,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
             break;
         }
       case 2:
-        final bool isPointerPrecise = details.kind == PointerDeviceKind.mouse;
+        final bool isPointerPrecise = _isPrecisePointerDevice(details.kind);
         switch (defaultTargetPlatform) {
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -627,7 +627,7 @@ void main() {
       expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
     }, variant: TargetPlatformVariant.desktop());
 
-    testWidgets('touch can select word-by-word on double click drag on mobile platforms', (WidgetTester tester) async {
+    testWidgets('touch can select word-by-word on double tap drag on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -700,10 +700,10 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
-    testWidgets('touch can select multiple widgets on double click drag on mobile platforms', (WidgetTester tester) async {
+    testWidgets('touch can select multiple widgets on double tap drag on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -752,10 +752,10 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
-    testWidgets('touch can select multiple widgets on double click drag and return to origin word on mobile platforms', (WidgetTester tester) async {
+    testWidgets('touch can select multiple widgets on double tap drag and return to origin word on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -816,10 +816,10 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
-    testWidgets('touch can reverse selection across multiple widgets on double click drag on mobile platforms', (WidgetTester tester) async {
+    testWidgets('touch can reverse selection across multiple widgets on double tap drag on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -867,10 +867,10 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
-    testWidgets('touch cannot triple click or triple click drag on Android and iOS', (WidgetTester tester) async {
+    testWidgets('touch cannot triple tap or triple tap drag on Android and iOS', (WidgetTester tester) async {
       const String longText = 'Hello world this is some long piece of text '
           'that will represent a long paragraph, when triple clicking this block '
           'of text all of it will be selected.\n'
@@ -976,10 +976,10 @@ void main() {
       expect(paragraph.selections[0], defaultTargetPlatform == TargetPlatform.iOS ? const TextSelection(baseOffset: 0, extentOffset: 5) : const TextSelection.collapsed(offset: 2));
     },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
-      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
-    testWidgets('touch cannot select word-by-word on double click drag when on Android web', (WidgetTester tester) async {
+    testWidgets('touch cannot select word-by-word on double tap drag when on Android web', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -110,6 +110,37 @@ void main() {
       expect(selectionEvent.globalPosition, const Offset(200.0, 200.0));
     });
 
+    testWidgets('touch double click sends select-word event', (WidgetTester tester) async {
+      final UniqueKey spy = UniqueKey();
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+          MaterialApp(
+            home: SelectableRegion(
+              focusNode: focusNode,
+              selectionControls: materialTextSelectionControls,
+              child: SelectionSpy(key: spy),
+            ),
+          )
+      );
+
+      final RenderSelectionSpy renderSelectionSpy = tester.renderObject<RenderSelectionSpy>(find.byKey(spy));
+      final TestGesture gesture = await tester.startGesture(const Offset(200.0, 200.0));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      renderSelectionSpy.events.clear();
+      await gesture.down(const Offset(200.0, 200.0));
+      await tester.pump();
+      await gesture.up();
+      expect(renderSelectionSpy.events.length, 1);
+      expect(renderSelectionSpy.events[0], isA<SelectWordSelectionEvent>());
+      final SelectWordSelectionEvent selectionEvent = renderSelectionSpy.events[0] as SelectWordSelectionEvent;
+      expect(selectionEvent.globalPosition, const Offset(200.0, 200.0));
+    });
+
     testWidgets('Does not crash when using Navigator pages', (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/119776
       final FocusNode focusNode = FocusNode();
@@ -595,6 +626,249 @@ void main() {
       expect(focusNode.hasFocus, isFalse);
       expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
     }, variant: TargetPlatformVariant.desktop());
+
+    testWidgets('touch can select word-by-word on double click drag on mobile platforms', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: focusNode,
+            selectionControls: materialTextSelectionControls,
+            child: const Center(
+              child: Text('How are you'),
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 2));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph, 2));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph, 3));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 4));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph, 4));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph, 7));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 8));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph, 8));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
+
+      // Check backward selection.
+      await gesture.moveTo(textOffsetToPosition(paragraph, 1));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+      // Start a new double-click drag.
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textOffsetToPosition(paragraph, 5));
+      await tester.pump();
+      await gesture.up();
+      expect(paragraph.selections.isEmpty, isFalse);
+      expect(paragraph.selections[0], const TextSelection.collapsed(offset: 5));
+      await tester.pump(kDoubleTapTimeout);
+
+      // Double-click.
+      await gesture.down(textOffsetToPosition(paragraph, 5));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      await gesture.down(textOffsetToPosition(paragraph, 5));
+      await tester.pumpAndSettle();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+
+      // Selecting across line should select to the end.
+      await gesture.moveTo(textOffsetToPosition(paragraph, 5) + const Offset(0.0, 200.0));
+      await tester.pump();
+      expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 11));
+      await gesture.up();
+    }, 
+      variant: TargetPlatformVariant.mobile(),
+      skip: kIsWeb,
+    ); // https://github.com/flutter/flutter/issues/125582.
+
+    testWidgets('touch can select multiple widgets on double click drag on mobile platforms', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: focusNode,
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?'),
+                Text('Good, and you?'),
+                Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph1, 2));
+      await tester.pumpAndSettle();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 4));
+      await tester.pump();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      // Should select the rest of paragraph 1.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 6));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
+
+      await gesture.up();
+    }, 
+      variant: TargetPlatformVariant.mobile(),
+      skip: kIsWeb,
+    ); // https://github.com/flutter/flutter/issues/125582.
+
+    testWidgets('touch can select multiple widgets on double click drag and return to origin word on mobile platforms', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: focusNode,
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?'),
+                Text('Good, and you?'),
+                Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph1, 2));
+      await tester.pumpAndSettle();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 4));
+      await tester.pump();
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      // Should select the rest of paragraph 1.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 6));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      // Should clear the selection on paragraph 3.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 12));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+      expect(paragraph3.selections.isEmpty, isTrue);
+
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 4));
+      // Should clear the selection on paragraph 2.
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
+      expect(paragraph2.selections.isEmpty, isTrue);
+      expect(paragraph3.selections.isEmpty, isTrue);
+
+      await gesture.up();
+    }, 
+      variant: TargetPlatformVariant.mobile(),
+      skip: kIsWeb,
+    ); // https://github.com/flutter/flutter/issues/125582.
+
+    testWidgets('touch can reverse selection across multiple widgets on double click drag on mobile platforms', (WidgetTester tester) async {
+      final FocusNode focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SelectableRegion(
+            focusNode: focusNode,
+            selectionControls: materialTextSelectionControls,
+            child: const Column(
+              children: <Widget>[
+                Text('How are you?'),
+                Text('Good, and you?'),
+                Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      );
+      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph3, 10));
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      await gesture.down(textOffsetToPosition(paragraph3, 10));
+      await tester.pumpAndSettle();
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 6, extentOffset: 11));
+
+      await gesture.moveTo(textOffsetToPosition(paragraph3, 4));
+      await tester.pump();
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 4));
+
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 5));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 5));
+
+      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+      await gesture.moveTo(textOffsetToPosition(paragraph1, 6));
+      expect(paragraph3.selections[0], const TextSelection(baseOffset: 11, extentOffset: 0));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 14, extentOffset: 0));
+      expect(paragraph1.selections[0], const TextSelection(baseOffset: 12, extentOffset: 4));
+
+      await gesture.up();
+    }, 
+      variant: TargetPlatformVariant.mobile(),
+      skip: kIsWeb,
+    ); // https://github.com/flutter/flutter/issues/125582.
 
     testWidgets('mouse can select single text on desktop platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -980,10 +980,6 @@ void main() {
     );
 
     testWidgets('touch cannot select word-by-word on double click drag when on Android web', (WidgetTester tester) async {
-      if (!kIsWeb) {
-        // This test is verifying web behavior.
-        return;
-      }
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -1032,13 +1028,11 @@ void main() {
       expect(paragraph.selections[0], const TextSelection(baseOffset: 0, extentOffset: 3));
       await gesture.up();
       await tester.pumpAndSettle();
-    });
+    },
+      skip: !kIsWeb, // This test verifies web behavior.
+    );
 
     testWidgets('touch cannot double tap or double tap drag when on iOS web', (WidgetTester tester) async {
-      if (!kIsWeb) {
-        // This test is verifying web behavior.
-        return;
-      }
       final FocusNode focusNode = FocusNode();
       addTearDown(focusNode.dispose);
 
@@ -1089,7 +1083,10 @@ void main() {
       expect(paragraph.selections[0], const TextSelection.collapsed(offset: 2));
       await gesture.up();
       await tester.pumpAndSettle();
-    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+    },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+      skip: !kIsWeb, // This test verifies web behavior.
+    );
 
     testWidgets('mouse can select single text on desktop platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -60,14 +60,14 @@ void main() {
       await tester.pumpAndSettle();
       renderSelectionSpy.events.clear();
 
-      await gesture.moveTo(const Offset(200.0, 100.0));
+      await gesture.moveTo(const Offset(100.0, 200.0));
       expect(renderSelectionSpy.events.length, 2);
       expect(renderSelectionSpy.events[0].type, SelectionEventType.startEdgeUpdate);
       final SelectionEdgeUpdateEvent startEdge = renderSelectionSpy.events[0] as SelectionEdgeUpdateEvent;
       expect(startEdge.globalPosition, const Offset(200.0, 200.0));
       expect(renderSelectionSpy.events[1].type, SelectionEventType.endEdgeUpdate);
       SelectionEdgeUpdateEvent endEdge = renderSelectionSpy.events[1] as SelectionEdgeUpdateEvent;
-      expect(endEdge.globalPosition, const Offset(200.0, 100.0));
+      expect(endEdge.globalPosition, const Offset(100.0, 200.0));
       renderSelectionSpy.events.clear();
 
       await gesture.moveTo(const Offset(100.0, 100.0));

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -698,10 +698,10 @@ void main() {
       await tester.pump();
       expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 11));
       await gesture.up();
-    }, 
+    },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb,
-    ); // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('touch can select multiple widgets on double click drag on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -750,10 +750,10 @@ void main() {
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 11));
 
       await gesture.up();
-    }, 
+    },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb,
-    ); // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('touch can select multiple widgets on double click drag and return to origin word on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -814,10 +814,10 @@ void main() {
       expect(paragraph3.selections.isEmpty, isTrue);
 
       await gesture.up();
-    }, 
+    },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb,
-    ); // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('touch can reverse selection across multiple widgets on double click drag on mobile platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();
@@ -865,10 +865,10 @@ void main() {
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 12, extentOffset: 4));
 
       await gesture.up();
-    }, 
+    },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb,
-    ); // https://github.com/flutter/flutter/issues/125582.
+      skip: kIsWeb, // https://github.com/flutter/flutter/issues/125582.
+    );
 
     testWidgets('mouse can select single text on desktop platforms', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -700,7 +700,7 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
+      skip: kIsWeb, // [intended] Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
     testWidgets('touch can select multiple widgets on double tap drag on mobile platforms', (WidgetTester tester) async {
@@ -752,7 +752,7 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
+      skip: kIsWeb, // [intended] Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
     testWidgets('touch can select multiple widgets on double tap drag and return to origin word on mobile platforms', (WidgetTester tester) async {
@@ -816,7 +816,7 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
+      skip: kIsWeb, // [intended] Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
     testWidgets('touch can reverse selection across multiple widgets on double tap drag on mobile platforms', (WidgetTester tester) async {
@@ -867,7 +867,7 @@ void main() {
       await gesture.up();
     },
       variant: TargetPlatformVariant.mobile(),
-      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
+      skip: kIsWeb, // [intended] Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
     testWidgets('touch cannot triple tap or triple tap drag on Android and iOS', (WidgetTester tester) async {
@@ -976,7 +976,7 @@ void main() {
       expect(paragraph.selections[0], defaultTargetPlatform == TargetPlatform.iOS ? const TextSelection(baseOffset: 0, extentOffset: 5) : const TextSelection.collapsed(offset: 2));
     },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
-      skip: kIsWeb, // Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
+      skip: kIsWeb, // [intended] Double tap / double tap + drag gestures are not fully enabled on the web for mobile platforms.
     );
 
     testWidgets('touch cannot select word-by-word on double tap drag when on Android web', (WidgetTester tester) async {
@@ -1029,7 +1029,7 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
     },
-      skip: !kIsWeb, // This test verifies web behavior.
+      skip: !kIsWeb, // [intended] This test verifies web behavior.
     );
 
     testWidgets('touch cannot double tap or double tap drag when on iOS web', (WidgetTester tester) async {
@@ -1085,7 +1085,7 @@ void main() {
       await tester.pumpAndSettle();
     },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-      skip: !kIsWeb, // This test verifies web behavior.
+      skip: !kIsWeb, // [intended] This test verifies web behavior.
     );
 
     testWidgets('mouse can select single text on desktop platforms', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1085,7 +1085,7 @@ void main() {
       await tester.pumpAndSettle();
     },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-      skip: !kIsWeb, // [intended] This test verifies web behavior.
+      skip: true, // https://github.com/flutter/flutter/issues/125582.
     );
 
     testWidgets('touch cannot double tap on iOS web', (WidgetTester tester) async {


### PR DESCRIPTION
This change enables double tap / triple tap support in SelectionArea for mobile platforms:
Android / Fuchsia: 
- On native, these platforms allow for double tap / double tap + drag to select word-by-word.
- On web using touch, these platforms only support double tap to select word.
- On web and native using a mouse, these platforms support double click / double click + drag to select word-by-word, and triple click / triple click + drag to select paragraph-by-paragraph.

iOS:
- On native, these platforms allow for double tap / double tap + drag to select word-by-word.
- On web using touch, these platforms do not support double tap/triple tap gestures.
- On web using touch, these platforms allow support double tap + drag gestures.
- On web and native using a mouse, these platforms support double click / double click + drag to select word-by-word, and triple click / triple click + drag to select paragraph-by-paragraph.

Part of: https://github.com/flutter/flutter/issues/129583

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.