### PR TITLE
Place `flutter_gpu` in the package cache.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -231,7 +231,7 @@ class FlutterSdk extends EngineCachedArtifact {
   final Platform _platform;
 
   @override
-  List<String> getPackageDirs() => const <String>['sky_engine'];
+  List<String> getPackageDirs() => const <String>['sky_engine', 'flutter_gpu'];
 
   @override
   List<List<String>> getBinaryDirs() {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -427,7 +427,6 @@ void main() {
         .listSync(recursive: true)
         .whereType<Directory>()
         .singleWhereOrNull((Directory directory) => directory.basename == 'pkg')!;
-    expect(dir, isNotNull);
     expect(dir.path, artifactDir.childDirectory('pkg').path);
     expect(dir.childDirectory('package_dir').existsSync(), isTrue);
   });

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -393,7 +393,7 @@ void main() {
     expect(operatingSystemUtils.chmods, <List<String>>[<String>['/.tmp_rand0/flutter_cache_test_artifact.rand0/bin_dir', 'a+r,a+x']]);
   });
 
-  testWithoutContext('EngineCachedArtifact makes cached package dirs readable and executable by all', () async {
+  testWithoutContext('EngineCachedArtifact downloads package zip from expected URL', () async {
     final FakeOperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Directory artifactDir = fileSystem.systemTempDirectory.createTempSync('flutter_cache_test_artifact.');
@@ -401,7 +401,7 @@ void main() {
     final FakeSecondaryCache cache = FakeSecondaryCache()
       ..artifactDirectory = artifactDir
       ..downloadDir = downloadDir;
-    artifactDir.childDirectory('package_dir').createSync();
+    artifactDir.childDirectory('pkg').createSync();
 
     final FakeCachedArtifact artifact = FakeCachedArtifact(
       cache: cache,
@@ -411,15 +411,25 @@ void main() {
       ],
       requiredArtifacts: DevelopmentArtifact.universal,
     );
-    await artifact.updateInner(FakeArtifactUpdater(), fileSystem, operatingSystemUtils);
+
+    Uri? packageUrl;
+    final ArtifactUpdater artifactUpdater = FakeArtifactUpdater()
+      ..onDownloadZipArchive = (String message, Uri url, Directory location) {
+        location.childDirectory('package_dir').createSync();
+        packageUrl = url;
+      };
+
+    await artifact.updateInner(artifactUpdater, fileSystem, operatingSystemUtils);
+    expect(packageUrl, isNotNull);
+    expect(packageUrl.toString(), 'https://storage.googleapis.com/flutter_infra_release/flutter/null/package_dir.zip');
+
     final Directory dir = fileSystem.systemTempDirectory
         .listSync(recursive: true)
         .whereType<Directory>()
-        .singleWhereOrNull((Directory directory) => directory.basename == 'package_dir')!;
-
+        .singleWhereOrNull((Directory directory) => directory.basename == 'pkg')!;
     expect(dir, isNotNull);
-    expect(dir.path, artifactDir.childDirectory('package_dir').path);
-    expect(operatingSystemUtils.chmods, <List<String>>[<String>['/.tmp_rand0/flutter_cache_test_artifact.rand0/package_dir', 'a+r,a+x']]);
+    expect(dir.path, artifactDir.childDirectory('pkg').path);
+    expect(dir.childDirectory('package_dir').existsSync(), isTrue);
   });
 
   testWithoutContext('Try to remove without a parent', () async {


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/131711.

Fetch https://storage.googleapis.com/flutter_infra_release/flutter/${engine_version}/flutter_gpu.zip and extract it into the package cache.

Cannot function until https://github.com/flutter/engine/pull/53107 has been merged/rolled into the framework.