### PR TITLE
Rewrite CupertinoActionSheet

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -837,7 +837,6 @@ class _ActionSheetButtonBackgroundState extends State<_ActionSheetButtonBackgrou
 // of its neighbor button is pressed.
 class _ActionSheetDivider extends StatelessWidget {
   const _ActionSheetDivider({
-    super.key,
     required this.dividerColor,
     required this.hidden,
   });
@@ -855,15 +854,6 @@ class _ActionSheetDivider extends StatelessWidget {
       ),
     );
   }
-}
-
-// The keys used by the dividers in the action section of an action sheet.
-//
-// The buttons and the dividers are placed alternately, both keyed by indexes.
-// Dividers use this special class so that the two lists of indexes can be told
-// apart.
-class _DividerKey extends ValueKey<int> {
-  const _DividerKey(super.value);
 }
 
 typedef _PressedUpdateHandler = void Function(int actionIndex, bool state);
@@ -900,13 +890,11 @@ class _ActionSheetActionSection extends StatelessWidget {
     for (int actionIndex = 0; actionIndex < actions!.length; actionIndex += 1) {
       if (actionIndex != 0) {
         column.add(_ActionSheetDivider(
-          key: _DividerKey(actionIndex),
           dividerColor: dividerColor,
           hidden: pressedIndex == actionIndex - 1 || pressedIndex == actionIndex,
         ));
       }
       column.add(_ActionSheetButtonBackground(
-        key: ValueKey<int>(actionIndex),
         onPressStateChange: (bool state) {
           onPressedUpdate(actionIndex, state);
         },

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -90,7 +90,7 @@ const double _kActionSheetEdgeVerticalPadding = 10.0;
 const double _kActionSheetContentHorizontalPadding = 16.0;
 const double _kActionSheetContentVerticalPadding = 12.0;
 const double _kActionSheetButtonHeight = 56.0;
-const double _kActionSheetBActionsSectionMinHeight = 84.0;
+const double _kActionSheetActionsSectionMinHeight = 84.0;
 
 // A translucent color that is painted on top of the blurred backdrop as the
 // dialog's background color
@@ -663,14 +663,10 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
               ),
               child: SizedBox(
                 width: actionSheetWidth - _kActionSheetEdgeHorizontalPadding * 2,
-                child: Semantics(
-                  explicitChildNodes: true,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: children,
-                  ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: children,
                 ),
               ),
             ),
@@ -861,7 +857,8 @@ class _ActionSheetDivider extends StatelessWidget {
 // The keys used by the dividers in the action section of an action sheet.
 //
 // The buttons and the dividers are placed alternately, both keyed by indexes.
-// Dividers use this special class so that their indexes can be told apart.
+// Dividers use this special class so that the two lists of indexes can be told
+// apart.
 class _DividerKey extends ValueKey<int> {
   const _DividerKey(super.value);
 }
@@ -1024,7 +1021,7 @@ class _ActionSheetMainSheetState extends State<_ActionSheetMainSheet> {
           children: <Widget>[
             _buildContent(
               hasActions: _hasActions(),
-              maxHeight: constraints.maxHeight - _kActionSheetBActionsSectionMinHeight - _kDividerThickness,
+              maxHeight: constraints.maxHeight - _kActionSheetActionsSectionMinHeight - _kDividerThickness,
             ),
             if (widget.hasContent && _hasActions())
               _ActionSheetDivider(

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -90,7 +90,7 @@ const double _kActionSheetEdgeVerticalPadding = 10.0;
 const double _kActionSheetContentHorizontalPadding = 16.0;
 const double _kActionSheetContentVerticalPadding = 12.0;
 const double _kActionSheetButtonHeight = 56.0;
-const double _kActionSheetActionsSectionMinHeight = 84.0;
+const double _kActionSheetActionsSectionMinHeight = 84.3;
 
 // A translucent color that is painted on top of the blurred backdrop as the
 // dialog's background color

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -562,11 +562,11 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
     super.dispose();
   }
 
-  bool hasContent() => widget.title != null || widget.message != null;
+  bool get hasContent => widget.title != null || widget.message != null;
 
   Widget _buildContent(BuildContext context) {
     final List<Widget> content = <Widget>[];
-    if (hasContent()) {
+    if (hasContent) {
       final Widget titleSection = _CupertinoAlertContentSection(
         title: widget.title,
         message: widget.message,
@@ -612,7 +612,7 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
       padding: EdgeInsets.only(top: cancelPadding),
       child: _ActionSheetButtonBackground(
         isCancel: true,
-        onStateChange: (_) {},
+        onPressStateChange: (_) {},
         child: widget.cancelButton!,
       ),
     );
@@ -630,7 +630,7 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
             filter: ImageFilter.blur(sigmaX: _kBlurAmount, sigmaY: _kBlurAmount),
             child: _ActionSheetMainSheet(
               scrollController: _effectiveActionScrollController,
-              hasContent: hasContent(),
+              hasContent: hasContent,
               contentSection: Builder(builder: _buildContent),
               actions: widget.actions,
               dividerColor: _kActionSheetButtonDividerColor,
@@ -677,7 +677,7 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
   }
 }
 
-/// The content of a typical button in a [CupertinoActionSheet].
+/// The content of a typical action button in a [CupertinoActionSheet].
 ///
 /// This widget draws the content of a button, i.e. the text, while the
 /// background of the button is drawn by [CupertinoActionSheet].
@@ -755,20 +755,22 @@ class CupertinoActionSheetAction extends StatelessWidget {
   }
 }
 
-// This widget renders the background (pressed or not) of a button, and sends
-// whether the button is pressed to the parent.
+// Renders the background of a button (both the pressed background and the idle
+// background) and reports its state to the parent with `onPressStateChange`.
 class _ActionSheetButtonBackground extends StatefulWidget {
   const _ActionSheetButtonBackground({
     super.key,
     this.isCancel = false,
-    required this.onStateChange,
+    this.onPressStateChange,
     required this.child,
   });
 
   final bool isCancel;
 
-  /// The callback that is called when the button is tapped.
-  final ValueSetter<bool> onStateChange;
+  /// Called when the user taps down or lifts up on the button.
+  ///
+  /// The boolean value is true if the user is tapping down on the button.
+  final ValueSetter<bool>? onPressStateChange;
 
   /// The widget below this widget in the tree.
   ///
@@ -784,17 +786,17 @@ class _ActionSheetButtonBackgroundState extends State<_ActionSheetButtonBackgrou
 
   void _onTapDown(TapDownDetails event) {
     setState(() { isBeingPressed = true; });
-    widget.onStateChange(true);
+    widget.onPressStateChange?.call(true);
   }
 
   void _onTapUp(TapUpDetails event) {
     setState(() { isBeingPressed = false; });
-    widget.onStateChange(false);
+    widget.onPressStateChange?.call(false);
   }
 
   void _onTapCancel() {
     setState(() { isBeingPressed = false; });
-    widget.onStateChange(false);
+    widget.onPressStateChange?.call(false);
   }
 
   @override
@@ -904,7 +906,7 @@ class _ActionSheetActionSection extends StatelessWidget {
       }
       column.add(_ActionSheetButtonBackground(
         key: ValueKey<int>(actionIndex),
-        onStateChange: (bool state) {
+        onPressStateChange: (bool state) {
           onPressedUpdate(actionIndex, state);
         },
         child: actions![actionIndex],

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -760,7 +760,6 @@ class CupertinoActionSheetAction extends StatelessWidget {
 // background) and reports its state to the parent with `onPressStateChange`.
 class _ActionSheetButtonBackground extends StatefulWidget {
   const _ActionSheetButtonBackground({
-    super.key,
     this.isCancel = false,
     this.onPressStateChange,
     required this.child,

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -623,8 +623,8 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
     assert(debugCheckHasMediaQuery(context));
 
     final List<Widget> children = <Widget>[
-      Flexible(child:
-        ClipRRect(
+      Flexible(
+        child: ClipRRect(
           borderRadius: const BorderRadius.all(Radius.circular(12.0)),
           child: BackdropFilter(
             filter: ImageFilter.blur(sigmaX: _kBlurAmount, sigmaY: _kBlurAmount),

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -631,6 +631,7 @@ class _CupertinoActionSheetState extends State<CupertinoActionSheet> {
             child: _ActionSheetMainSheet(
               scrollController: _effectiveActionScrollController,
               hasContent: hasContent,
+              hasCancelButton: widget.cancelButton != null,
               contentSection: Builder(builder: _buildContent),
               actions: widget.actions,
               dividerColor: _kActionSheetButtonDividerColor,
@@ -930,6 +931,7 @@ class _ActionSheetMainSheet extends StatefulWidget {
     required this.scrollController,
     required this.actions,
     required this.hasContent,
+    required this.hasCancelButton,
     required this.contentSection,
     required this.dividerColor,
   });
@@ -937,6 +939,7 @@ class _ActionSheetMainSheet extends StatefulWidget {
   final ScrollController? scrollController;
   final List<Widget>? actions;
   final bool hasContent;
+  final bool hasCancelButton;
   final Widget contentSection;
   final Color dividerColor;
 
@@ -1023,11 +1026,14 @@ class _ActionSheetMainSheetState extends State<_ActionSheetMainSheet> {
   Widget build(BuildContext context) {
     // The layout rule:
     //
-    // 1. If there are <= 3 buttons, then the buttons should never scroll.
-    // 2. If there are >3 buttons, then the content section takes priority to
-    //    take over spaces but must leave at least `actionsMinHeight` for the
-    //    actions section.
-    final bool actionsMightScroll = (widget.actions?.length ?? 0) > 3;
+    // 1. If there are <= 3 buttons and a cancel button, or 1 button without a
+    //    cancel button, then the actions section should never scroll.
+    // 2. Otherwise, then the content section takes priority to take over spaces
+    //    but must leave at least `actionsMinHeight` for the actions section.
+    final int numActions = widget.actions?.length ?? 0;
+    final bool actionsMightScroll =
+        (numActions > 3 && widget.hasCancelButton) ||
+        (numActions > 1 && !widget.hasCancelButton) ;
     final Color backgroundColor = CupertinoDynamicColor.resolve(_kActionSheetBackgroundColor, context);
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -749,7 +749,7 @@ void main() {
     await tester.tap(find.text('Go'));
     await tester.pump();
 
-    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(84.0));
+    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(84.3));
   });
 
   testWidgets('1 action button without cancel button', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -470,16 +470,18 @@ void main() {
     await gesture.moveBy(const Offset(0, 40));
     await tester.pumpAndSettle();
     await gesture.moveBy(const Offset(0, 100));
-    await tester.pumpAndSettle();
-    // Test the top overscroll.
+    // Test the top overscroll. Use `pump` not `pumpAndSettle` to verify the
+    // rendering result of the immediate next frame.
+    await tester.pump();
     await expectLater(
       find.byType(CupertinoActionSheet),
       matchesGoldenFile('cupertinoActionSheet.overscroll.1.png'),
     );
 
     await gesture.moveBy(const Offset(0, -300));
-    await tester.pumpAndSettle();
-    // Test the bottom overscroll.
+    // Test the bottom overscroll. Use `pump` not `pumpAndSettle` to verify the
+    // rendering result of the immediate next frame.
+    await tester.pump();
     await expectLater(
       find.byType(CupertinoActionSheet),
       matchesGoldenFile('cupertinoActionSheet.overscroll.2.png'),

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -797,7 +797,7 @@ void main() {
     await tester.tap(find.text('Go'));
     await tester.pump();
 
-    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(112.3));
+    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(84.3));
   });
 
   testWidgets('Action sheet with just cancel button is correct', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -677,7 +677,7 @@ void main() {
     await tester.tap(find.text('Go'));
     await tester.pump();
 
-    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(84.0));
+    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(112.3));
   });
 
   testWidgets('3 action buttons with cancel button', (WidgetTester tester) async {
@@ -711,7 +711,7 @@ void main() {
     await tester.tap(find.text('Go'));
     await tester.pump();
 
-    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(84.0));
+    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(168.6));
   });
 
   testWidgets('4+ action buttons with cancel button', (WidgetTester tester) async {
@@ -797,7 +797,7 @@ void main() {
     await tester.tap(find.text('Go'));
     await tester.pump();
 
-    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(84.0));
+    expect(findScrollableActionsSectionRenderBox(tester).size.height, moreOrLessEquals(112.3));
   });
 
   testWidgets('Action sheet with just cancel button is correct', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+library;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';


### PR DESCRIPTION
This PR rewrite `CupertinoActionSheet` to be based on layout widgets instead of the custom layout code in `_CupertinoDialogRenderWidget`, making it much easier to understand. It also fixes a layout deviation from SwiftUI, and add a few tests.

`_CupertinoDialogRenderWidget` is a custom layout widget that contains too much boilerplate code and is hard to understand where is customized. The plan is to replace it with widgets as much as possible. (Since this widget is used by both `CupertinoActionSheet` and `CupertinoAlertDialog`, this PR only removes the branches related to `isActionSheet`).

The need to use custom layout widget probably came from the following difficulties:
1. The parent needs to know whether an action button is being pressed to correctly render or hide each divider, but the action button is provided by the user as a built widget that also needs to respond to the tap gesture.
2. The main sheet's column needs to _prioritize_ allocating the space to the content section before allocating the remaining to the actions section, while also leaving the actions section a minimum height. This is not supported by simply `Column`.
3. The minimum height of the action section is a non-trivial algorithm.

Luckily, I've found out that all these problems are solvable with widgets.

All existing tests pass.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
