### PR TITLE
Refactor how we handle errors around imgtestInit/tryjobInit

### DIFF
--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi' show Abi;
 import 'dart:io' as io;
@@ -39,6 +40,8 @@ class SkiaException implements Exception {
   @override
   String toString() => 'SkiaException: $message';
 }
+
+enum _SkiaInitState { none, tryJobs, postSubmitTests }
 
 /// A client for uploading image tests and making baseline requests to the
 /// Flutter Gold Dashboard.
@@ -135,69 +138,73 @@ class SkiaGoldClient {
     }
   }
 
-  /// Signals if this client is initialized for uploading images to the Gold
-  /// service.
-  ///
-  /// Since Flutter framework tests are executed in parallel, and in random
-  /// order, this will signal is this instance of the Gold client has been
-  /// initialized.
-  bool _initialized = false;
+  _SkiaInitState _debugInitState = _SkiaInitState.none;
+  Future<void>? _initFuture;
 
   /// Executes the `imgtest init` command in the goldctl tool.
   ///
   /// The `imgtest` command collects and uploads test results to the Skia Gold
   /// backend, the `init` argument initializes the current test. Used by the
   /// [FlutterPostSubmitFileComparator].
-  Future<void> imgtestInit() async {
-    // This client has already been initialized
-    if (_initialized) {
-      return;
+  ///
+  /// It is safe to call this multiple times, including reentrantly; all calls
+  /// will return the same future and initialization will only happen once.
+  ///
+  /// This method is mutually exclusive with [tryjobInit].
+  Future<void> imgtestInit() {
+    if (_initFuture != null) {
+      assert(_debugInitState == _SkiaInitState.postSubmitTests, 'Cannot call both imgtestInit and tryjobInit');
+      return _initFuture!;
     }
+    assert(_debugInitState == _SkiaInitState.none);
+    assert(() { _debugInitState = _SkiaInitState.postSubmitTests; return true; }());
+    final Completer<void> completer = Completer<void>();
+    _initFuture = completer.future;
+    completer.complete(() async {
+      final File keys = workDirectory.childFile('keys.json');
+      final File failures = workDirectory.childFile('failures.json');
 
-    final File keys = workDirectory.childFile('keys.json');
-    final File failures = workDirectory.childFile('failures.json');
+      await keys.writeAsString(_getKeysJSON());
+      await failures.create();
+      final String commitHash = await _getCurrentCommit();
 
-    await keys.writeAsString(_getKeysJSON());
-    await failures.create();
-    final String commitHash = await _getCurrentCommit();
+      final List<String> imgtestInitCommand = <String>[
+        _goldctl,
+        'imgtest', 'init',
+        '--instance', 'flutter',
+        '--work-dir', workDirectory
+          .childDirectory('temp')
+          .path,
+        '--commit', commitHash,
+        '--keys-file', keys.path,
+        '--failure-file', failures.path,
+        '--passfail',
+      ];
 
-    final List<String> imgtestInitCommand = <String>[
-      _goldctl,
-      'imgtest', 'init',
-      '--instance', 'flutter',
-      '--work-dir', workDirectory
-        .childDirectory('temp')
-        .path,
-      '--commit', commitHash,
-      '--keys-file', keys.path,
-      '--failure-file', failures.path,
-      '--passfail',
-    ];
+      if (imgtestInitCommand.contains(null)) {
+        final StringBuffer buf = StringBuffer()
+          ..writeln('A null argument was provided for Skia Gold imgtest init.')
+          ..writeln('Please confirm the settings of your golden file test.')
+          ..writeln('Arguments provided:');
+        imgtestInitCommand.forEach(buf.writeln);
+        throw SkiaException(buf.toString());
+      }
 
-    if (imgtestInitCommand.contains(null)) {
-      final StringBuffer buf = StringBuffer()
-        ..writeln('A null argument was provided for Skia Gold imgtest init.')
-        ..writeln('Please confirm the settings of your golden file test.')
-        ..writeln('Arguments provided:');
-      imgtestInitCommand.forEach(buf.writeln);
-      throw SkiaException(buf.toString());
-    }
+      final io.ProcessResult result = await process.run(imgtestInitCommand);
 
-    final io.ProcessResult result = await process.run(imgtestInitCommand);
-
-    if (result.exitCode != 0) {
-      _initialized = false;
-      final StringBuffer buf = StringBuffer()
-        ..writeln('Skia Gold imgtest init failed.')
-        ..writeln('An error occurred when initializing golden file test with ')
-        ..writeln('goldctl.')
-        ..writeln()
-        ..writeln('Debug information for Gold --------------------------------')
-        ..writeln('stdout: ${result.stdout}')
-        ..writeln('stderr: ${result.stderr}');
-      throw SkiaException(buf.toString());
-    }
-    _initialized = true;
+      if (result.exitCode != 0) {
+        final StringBuffer buf = StringBuffer()
+          ..writeln('Skia Gold imgtest init failed.')
+          ..writeln('An error occurred when initializing golden file test with ')
+          ..writeln('goldctl.')
+          ..writeln()
+          ..writeln('Debug information for Gold --------------------------------')
+          ..writeln('stdout: ${result.stdout}')
+          ..writeln('stderr: ${result.stderr}');
+        throw SkiaException(buf.toString());
+      }
+    }());
+    return _initFuture!;
   }
 
   /// Executes the `imgtest add` command in the goldctl tool.
@@ -256,72 +263,73 @@ class SkiaGoldClient {
     return true;
   }
 
-  /// Signals if this client is initialized for uploading tryjobs to the Gold
-  /// service.
-  ///
-  /// Since Flutter framework tests are executed in parallel, and in random
-  /// order, this will signal is this instance of the Gold client has been
-  /// initialized for tryjobs.
-  bool _tryjobInitialized = false;
-
   /// Executes the `imgtest init` command in the goldctl tool for tryjobs.
   ///
   /// The `imgtest` command collects and uploads test results to the Skia Gold
   /// backend, the `init` argument initializes the current tryjob. Used by the
   /// [FlutterPreSubmitFileComparator].
-  Future<void> tryjobInit() async {
-    // This client has already been initialized
-    if (_tryjobInitialized) {
-      return;
+  ///
+  /// It is safe to call this multiple times, including reentrantly; all calls
+  /// will return the same future and initialization will only happen once.
+  ///
+  /// This method is mutually exclusive with [imgtestInit].
+  Future<void> tryjobInit() {
+    if (_initFuture != null) {
+      assert(_debugInitState == _SkiaInitState.tryJobs, 'Cannot call both imgtestInit and tryjobInit');
+      return _initFuture!;
     }
+    assert(_debugInitState == _SkiaInitState.none);
+    assert(() { _debugInitState = _SkiaInitState.tryJobs; return true; }());
+    final Completer<void> completer = Completer<void>();
+    _initFuture = completer.future;
+    completer.complete(() async {
+      final File keys = workDirectory.childFile('keys.json');
+      final File failures = workDirectory.childFile('failures.json');
 
-    final File keys = workDirectory.childFile('keys.json');
-    final File failures = workDirectory.childFile('failures.json');
+      await keys.writeAsString(_getKeysJSON());
+      await failures.create();
+      final String commitHash = await _getCurrentCommit();
 
-    await keys.writeAsString(_getKeysJSON());
-    await failures.create();
-    final String commitHash = await _getCurrentCommit();
+      final List<String> imgtestInitCommand = <String>[
+        _goldctl,
+        'imgtest', 'init',
+        '--instance', 'flutter',
+        '--work-dir', workDirectory
+          .childDirectory('temp')
+          .path,
+        '--commit', commitHash,
+        '--keys-file', keys.path,
+        '--failure-file', failures.path,
+        '--passfail',
+        '--crs', 'github',
+        '--patchset_id', commitHash,
+        ...getCIArguments(),
+      ];
 
-    final List<String> imgtestInitCommand = <String>[
-      _goldctl,
-      'imgtest', 'init',
-      '--instance', 'flutter',
-      '--work-dir', workDirectory
-        .childDirectory('temp')
-        .path,
-      '--commit', commitHash,
-      '--keys-file', keys.path,
-      '--failure-file', failures.path,
-      '--passfail',
-      '--crs', 'github',
-      '--patchset_id', commitHash,
-      ...getCIArguments(),
-    ];
+      if (imgtestInitCommand.contains(null)) {
+        final StringBuffer buf = StringBuffer()
+          ..writeln('A null argument was provided for Skia Gold tryjob init.')
+          ..writeln('Please confirm the settings of your golden file test.')
+          ..writeln('Arguments provided:');
+        imgtestInitCommand.forEach(buf.writeln);
+        throw SkiaException(buf.toString());
+      }
 
-    if (imgtestInitCommand.contains(null)) {
-      final StringBuffer buf = StringBuffer()
-        ..writeln('A null argument was provided for Skia Gold tryjob init.')
-        ..writeln('Please confirm the settings of your golden file test.')
-        ..writeln('Arguments provided:');
-      imgtestInitCommand.forEach(buf.writeln);
-      throw SkiaException(buf.toString());
-    }
+      final io.ProcessResult result = await process.run(imgtestInitCommand);
 
-    final io.ProcessResult result = await process.run(imgtestInitCommand);
-
-    if (result.exitCode != 0) {
-      _tryjobInitialized = false;
-      final StringBuffer buf = StringBuffer()
-        ..writeln('Skia Gold tryjobInit failure.')
-        ..writeln('An error occurred when initializing golden file tryjob with ')
-        ..writeln('goldctl.')
-        ..writeln()
-        ..writeln('Debug information for Gold --------------------------------')
-        ..writeln('stdout: ${result.stdout}')
-        ..writeln('stderr: ${result.stderr}');
-      throw SkiaException(buf.toString());
-    }
-    _tryjobInitialized = true;
+      if (result.exitCode != 0) {
+        final StringBuffer buf = StringBuffer()
+          ..writeln('Skia Gold tryjobInit failure.')
+          ..writeln('An error occurred when initializing golden file tryjob with ')
+          ..writeln('goldctl.')
+          ..writeln()
+          ..writeln('Debug information for Gold --------------------------------')
+          ..writeln('stdout: ${result.stdout}')
+          ..writeln('stderr: ${result.stderr}');
+        throw SkiaException(buf.toString());
+      }
+    }());
+    return _initFuture!;
   }
 
   /// Executes the `imgtest add` command in the goldctl tool for tryjobs.

--- a/packages/flutter_goldens/test/skia_client_test.dart
+++ b/packages/flutter_goldens/test/skia_client_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi' show Abi;
+import 'dart:io' hide Directory;
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_goldens/flutter_goldens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform/platform.dart';
+import 'package:process/process.dart';
+
+void main() {
+  test('initialization - imgtestInit first', () async {
+    final FileSystem fs = MemoryFileSystem();
+    final Directory dir = fs.directory('/');
+    final List<String> log = <String>[];
+    final SkiaGoldClient client = SkiaGoldClient(dir,
+      fs: fs,
+      process: FakeProcessManager(),
+      platform: FakePlatform(environment: <String, String>{'FLUTTER_ROOT': '/'}, operatingSystem: Platform.fuchsia),
+      abi: Abi.fuchsiaRiscv64,
+      httpClient: FakeHttpClient(),
+      log: log.add,
+    );
+    expect(identical(client.imgtestInit(), client.imgtestInit()), isTrue); // re-entrant calls return the same future
+    try {
+      // Don't await this (even indirectly using `throwsA`) because in the failure case, we'd hang the test
+      // because the FakeProcessManager we use never returns.
+      // Using a synchronous try/catch works because the assertion is not asynchronous.
+      client.tryjobInit();
+      fail('Missing assertion.');
+    } on AssertionError catch (e) {
+      expect('$e', contains('imgtestInit')); // can't call different initializers
+    }
+  });
+
+  test('initialization - tryjobInit first', () async {
+    final FileSystem fs = MemoryFileSystem();
+    final Directory dir = fs.directory('/');
+    final List<String> log = <String>[];
+    final SkiaGoldClient client = SkiaGoldClient(dir,
+      fs: fs,
+      process: FakeProcessManager(),
+      platform: FakePlatform(environment: <String, String>{'FLUTTER_ROOT': '/'}, operatingSystem: Platform.fuchsia),
+      abi: Abi.fuchsiaRiscv64,
+      httpClient: FakeHttpClient(),
+      log: log.add,
+    );
+    expect(identical(client.tryjobInit(), client.tryjobInit()), isTrue); // re-entrant calls return the same future
+    try {
+      // Don't await this (even indirectly using `throwsA`) because in the failure case, we'd hang the test
+      // because the FakeProcessManager we use never returns.
+      // Using a synchronous try/catch works because the assertion is not asynchronous.
+      client.imgtestInit();
+      fail('Missing assertion.');
+    } on AssertionError catch (e) {
+      expect('$e', contains('tryjobInit')); // can't call different initializers
+    }
+  });
+}
+
+// all calls just hang
+class FakeProcessManager extends Fake implements ProcessManager {
+  @override
+  Future<ProcessResult> run(
+    List<Object> command, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    Encoding? stdoutEncoding = systemEncoding,
+    Encoding? stderrEncoding = systemEncoding,
+  }) {
+    return Completer<ProcessResult>().future;
+  }
+}
+
+class FakeHttpClient extends Fake implements HttpClient { }


### PR DESCRIPTION
I noticed that we don't really assert that these aren't called in ways that conflict with their internal logic, and that there were some redundant initializers and some race conditions. This patch makes it so that calling them reentrantly is always safe and always returns the same future, while also explicitly asserting that they're not called in conflicting ways.

Diff is much more readable if you enable "ignore whitespace changes".