### PR TITLE
Always codesign when running native Xcode tests in CI

### DIFF
--- a/dev/devicelab/bin/tasks/native_ui_tests_macos.dart
+++ b/dev/devicelab/bin/tasks/native_ui_tests_macos.dart
@@ -31,7 +31,6 @@ Future<void> main() async {
       platformDirectory: path.join(projectDirectory, 'macos'),
       destination: 'platform=macOS',
       testName: 'native_ui_tests_macos',
-      skipCodesign: true,
     )) {
       return TaskResult.failure('Platform unit tests failed');
     }

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -183,8 +183,6 @@ Future<bool> runXcodeTests({
   final Map<String, String> environment = Platform.environment;
   // Inject the Flutter team code signing properties.
   final String developmentTeam = environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'] ?? 'S8QB4VV633';
-  final String codeSignStyle = environment['FLUTTER_XCODE_CODE_SIGN_STYLE'] ?? 'Manual';
-  final String provisioningProfile = environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'] ?? 'match Development *';
   final String resultBundleTemp = Directory.systemTemp.createTempSync('flutter_xcresult.').path;
   final String resultBundlePath = path.join(resultBundleTemp, 'result');
   final int testResultExit = await exec(
@@ -203,8 +201,9 @@ Future<bool> runXcodeTests({
       'test',
       'COMPILER_INDEX_STORE_ENABLE=NO',
       'DEVELOPMENT_TEAM=$developmentTeam',
-      'CODE_SIGN_STYLE=$codeSignStyle',
-      'PROVISIONING_PROFILE_SPECIFIER=$provisioningProfile',
+      // To run the test don't bother with provisioning profiles since this isn't being archived.
+      'CODE_SIGN_STYLE=Automatic',
+      'CODE_SIGN_IDENTITY=Apple Development',
     ],
     workingDirectory: platformDirectory,
     canFail: true,

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -179,18 +179,12 @@ Future<bool> runXcodeTests({
   required String destination,
   required String testName,
   String configuration = 'Release',
-  bool skipCodesign = false,
 }) async {
   final Map<String, String> environment = Platform.environment;
-  String? developmentTeam;
-  String? codeSignStyle;
-  String? provisioningProfile;
-  if (!skipCodesign) {
-    // If not running on CI, inject the Flutter team code signing properties.
-    developmentTeam = environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'] ?? 'S8QB4VV633';
-    codeSignStyle = environment['FLUTTER_XCODE_CODE_SIGN_STYLE'];
-    provisioningProfile = environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'];
-  }
+  // Inject the Flutter team code signing properties.
+  final String developmentTeam = environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'] ?? 'S8QB4VV633';
+  final String codeSignStyle = environment['FLUTTER_XCODE_CODE_SIGN_STYLE'] ?? 'Manual';
+  final String provisioningProfile = environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'] ?? 'match Development *';
   final String resultBundleTemp = Directory.systemTemp.createTempSync('flutter_xcresult.').path;
   final String resultBundlePath = path.join(resultBundleTemp, 'result');
   final int testResultExit = await exec(
@@ -208,12 +202,9 @@ Future<bool> runXcodeTests({
       resultBundlePath,
       'test',
       'COMPILER_INDEX_STORE_ENABLE=NO',
-      if (developmentTeam != null)
-        'DEVELOPMENT_TEAM=$developmentTeam',
-      if (codeSignStyle != null)
-        'CODE_SIGN_STYLE=$codeSignStyle',
-      if (provisioningProfile != null)
-        'PROVISIONING_PROFILE_SPECIFIER=$provisioningProfile',
+      'DEVELOPMENT_TEAM=$developmentTeam',
+      'CODE_SIGN_STYLE=$codeSignStyle',
+      'PROVISIONING_PROFILE_SPECIFIER=$provisioningProfile',
     ],
     workingDirectory: platformDirectory,
     canFail: true,

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -308,7 +308,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
               destination: 'id=$deviceId',
               configuration: 'Debug',
               testName: 'native_plugin_unit_tests_ios',
-              skipCodesign: true,
             )) {
               throw TaskResult.failure('Platform unit tests failed');
             }
@@ -330,7 +329,6 @@ public class $pluginClass: NSObject, FlutterPlugin {
           destination: 'platform=macOS',
           configuration: 'Debug',
           testName: 'native_plugin_unit_tests_macos',
-          skipCodesign: true,
         )) {
           throw TaskResult.failure('Platform unit tests failed');
         }


### PR DESCRIPTION
macOS 14 added new requirements that sandbox apps should be codesigned to avoid this popup:
![Screenshot 2024-05-30 at 2 41 33 PM](https://github.com/flutter/flutter/assets/682784/1bc32620-5edb-420a-866c-5cc529b2ac55)

Waiting for this UI caused macOS tests to fail on macOS 14 because the test runner forced codesigning off.  The chromium bots have the codesigning certs on them b/326078082#comment4, so always run `xcodebuild test` with codesigning.

On this PR:
[Passing `plugin_test_macos`](https://ci.chromium.org/ui/p/flutter/builders/try/Mac%20plugin_test_macos/17320/overview)
[Passing `native_ui_tests_macos`](https://ci.chromium.org/ui/p/flutter/builders/try/Mac_arm64%20native_ui_tests_macos/3832/overview)

Fixes framework part of https://github.com/flutter/flutter/issues/149264. I still need to investigate a fix for packages `macos_platform_tests` test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
