### PR TITLE
[a11y] Add semantics: button to bottom navigation bar items and dropdown menu items

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -605,6 +605,7 @@ class _BottomNavigationTile extends StatelessWidget {
 
     result = Semantics(
       selected: selected,
+      button: true,
       container: true,
       child: Stack(
         children: <Widget>[

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -785,9 +785,12 @@ class _DropdownMenuItemContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: _kMenuItemHeight),
-      child: Align(alignment: alignment, child: child),
+    return Semantics(
+      button: true,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: _kMenuItemHeight),
+        child: Align(alignment: alignment, child: child),
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1601,10 +1601,12 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       ),
     );
-    if(items.isEmpty) result = Semantics(
-      button: true,
-      child: result,
-    );
+    if(items.isEmpty) {
+        result = Semantics(
+          button: true,
+          child: result,
+      );
+    }
     return result;
   }
 }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1587,27 +1587,23 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       );
     }
 
-    result = Actions(
-      actions: _actionMap,
-      child: InkWell(
-        mouseCursor: effectiveMouseCursor,
-        onTap: _enabled ? _handleTap : null,
-        canRequestFocus: _enabled,
-        borderRadius: widget.borderRadius,
-        focusNode: focusNode,
-        autofocus: widget.autofocus,
-        focusColor: widget.focusColor ?? Theme.of(context).focusColor,
-        enableFeedback: false,
-        child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
+    return Semantics(
+      button: items.isEmpty,
+      child:Actions(
+        actions: _actionMap,
+        child: InkWell(
+          mouseCursor: effectiveMouseCursor,
+          onTap: _enabled ? _handleTap : null,
+          canRequestFocus: _enabled,
+          borderRadius: widget.borderRadius,
+          focusNode: focusNode,
+          autofocus: widget.autofocus,
+          focusColor: widget.focusColor ?? Theme.of(context).focusColor,
+          enableFeedback: false,
+          child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
+        ),
       ),
     );
-    if(items.isEmpty) {
-        result = Semantics(
-          button: true,
-          child: result,
-      );
-    }
-    return result;
   }
 }
 

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1586,7 +1586,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         child: result,
       );
     }
-    final childHasButtonSemantic = hintIndex!= null || (_selectedIndex != null && widget.selectedItemBuilder == null);
+    final childHasButtonSemantic = hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
     return Semantics(
       button: !childHasButtonSemantic,
       child: Actions(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1587,21 +1587,18 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       );
     }
 
-    return Semantics(
-      button: true,
-      child: Actions(
-        actions: _actionMap,
-        child: InkWell(
-          mouseCursor: effectiveMouseCursor,
-          onTap: _enabled ? _handleTap : null,
-          canRequestFocus: _enabled,
-          borderRadius: widget.borderRadius,
-          focusNode: focusNode,
-          autofocus: widget.autofocus,
-          focusColor: widget.focusColor ?? Theme.of(context).focusColor,
-          enableFeedback: false,
-          child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
-        ),
+    return Actions(
+      actions: _actionMap,
+      child: InkWell(
+        mouseCursor: effectiveMouseCursor,
+        onTap: _enabled ? _handleTap : null,
+        canRequestFocus: _enabled,
+        borderRadius: widget.borderRadius,
+        focusNode: focusNode,
+        autofocus: widget.autofocus,
+        focusColor: widget.focusColor ?? Theme.of(context).focusColor,
+        enableFeedback: false,
+        child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1588,7 +1588,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
 
     return Semantics(
-      button: items.isEmpty,
+      button: _selectedIndex == null,
       child: Actions(
         actions: _actionMap,
         child: InkWell(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1589,7 +1589,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     return Semantics(
       button: items.isEmpty,
-      child:Actions(
+      child: Actions(
         actions: _actionMap,
         child: InkWell(
           mouseCursor: effectiveMouseCursor,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1586,7 +1586,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         child: result,
       );
     }
-    final childHasButtonSemantic = hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
+    final bool childHasButtonSemantic = hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
     return Semantics(
       button: !childHasButtonSemantic,
       child: Actions(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1586,7 +1586,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         child: result,
       );
     }
-    final childHasButtonSemantic = hintIndex!=null || (_selectedIndex !=null && widget.selectedItemBuilder ==null);
+    final childHasButtonSemantic = hintIndex!= null || (_selectedIndex != null && widget.selectedItemBuilder == null);
     return Semantics(
       button: !childHasButtonSemantic,
       child: Actions(

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1587,7 +1587,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       );
     }
 
-    return Actions(
+    result = Actions(
       actions: _actionMap,
       child: InkWell(
         mouseCursor: effectiveMouseCursor,
@@ -1601,6 +1601,11 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       ),
     );
+    if(items.isEmpty) result = Semantics(
+      button: true,
+      child: result,
+    );
+    return result;
   }
 }
 

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1586,9 +1586,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         child: result,
       );
     }
-
+    final childHasButtonSemantic = hintIndex!=null || (_selectedIndex !=null && widget.selectedItemBuilder ==null);
     return Semantics(
-      button: _selectedIndex == null,
+      button: !childHasButtonSemantic,
       child: Actions(
         actions: _actionMap,
         child: InkWell(

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -2108,6 +2108,7 @@ void main() {
       matchesSemantics(
         label: 'AC\nTab 1 of 3',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         isSelected: true,
         hasTapAction: true,
@@ -2119,6 +2120,7 @@ void main() {
       matchesSemantics(
         label: 'Alarm\nTab 2 of 3',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         hasTapAction: true,
         hasFocusAction: true,
@@ -2129,6 +2131,7 @@ void main() {
       matchesSemantics(
         label: 'Hot Tub\nTab 3 of 3',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         hasTapAction: true,
         hasFocusAction: true,
@@ -2165,6 +2168,7 @@ void main() {
       matchesSemantics(
         label: 'AC\nTab 1 of 3',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         isSelected: true,
         hasTapAction: true,
@@ -2176,6 +2180,7 @@ void main() {
       matchesSemantics(
         label: 'Alarm\nTab 2 of 3',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         hasTapAction: true,
         hasFocusAction: true,
@@ -2186,6 +2191,7 @@ void main() {
       matchesSemantics(
         label: 'Hot Tub\nTab 3 of 3',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         hasTapAction: true,
         hasFocusAction: true,
@@ -2518,6 +2524,7 @@ void main() {
       matchesSemantics(
         label: 'Red\nTab 1 of 2',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         isSelected: true,
         hasTapAction: true,
@@ -2529,6 +2536,7 @@ void main() {
       matchesSemantics(
         label: 'Green\nTab 2 of 2',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         hasTapAction: true,
         hasFocusAction: true,
@@ -2563,6 +2571,7 @@ void main() {
       matchesSemantics(
         label: 'Red\nTab 1 of 2',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         isSelected: true,
         hasTapAction: true,
@@ -2574,6 +2583,7 @@ void main() {
       matchesSemantics(
         label: 'Green\nTab 2 of 2',
         textDirection: TextDirection.ltr,
+        isButton: true,
         isFocusable: true,
         hasTapAction: true,
         hasFocusAction: true,
@@ -2754,6 +2764,7 @@ void main() {
                           children: <TestSemantics>[
                             TestSemantics(
                               flags: <SemanticsFlag>[
+                                SemanticsFlag.isButton,
                                 SemanticsFlag.isSelected,
                                 SemanticsFlag.isFocusable,
                               ],
@@ -2762,7 +2773,10 @@ void main() {
                               textDirection: TextDirection.ltr,
                             ),
                             TestSemantics(
-                              flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                              flags: <SemanticsFlag>[
+                                SemanticsFlag.isButton,
+                                SemanticsFlag.isFocusable,
+                              ],
                               actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
                               label: 'B\nTab 2 of 2',
                               textDirection: TextDirection.ltr,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1296,7 +1296,7 @@ void main() {
     ));
 
     // By default the hint contributes the label.
-    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+    expect(tester.getSemantics(find.text('test')), matchesSemantics(
       isButton: true,
       label: 'test',
       hasTapAction: true,
@@ -1311,8 +1311,8 @@ void main() {
       hint: const Text('test'),
     ));
 
-    // Displays label of select item and is no longer tappable.
-    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+    // Displays label of select item.
+    expect(tester.getSemantics(find.text('three')), matchesSemantics(
       isButton: true,
       label: 'three',
       hasTapAction: true,
@@ -1358,6 +1358,7 @@ void main() {
                           label: 'one',
                           textDirection: TextDirection.ltr,
                           flags: <SemanticsFlag>[
+                            SemanticsFlag.isButton,
                             SemanticsFlag.isFocused,
                             SemanticsFlag.isFocusable,
                           ],
@@ -1367,21 +1368,30 @@ void main() {
                         TestSemantics(
                           label: 'two',
                           textDirection: TextDirection.ltr,
-                          flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isButton,
+                            SemanticsFlag.isFocusable,
+                          ],
                           tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                           actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
                         ),
                         TestSemantics(
                           label: 'three',
                           textDirection: TextDirection.ltr,
-                          flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isButton,
+                            SemanticsFlag.isFocusable,
+                          ],
                           tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                           actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
                         ),
                         TestSemantics(
                           label: 'four',
                           textDirection: TextDirection.ltr,
-                          flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                          flags: <SemanticsFlag>[
+                            SemanticsFlag.isButton,
+                            SemanticsFlag.isFocusable,
+                          ],
                           tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                           actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
                         ),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1296,7 +1296,7 @@ void main() {
     ));
 
     // By default the hint contributes the label.
-    expect(tester.getSemantics(find.text('test')), matchesSemantics(
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
       isButton: true,
       label: 'test',
       hasTapAction: true,
@@ -1312,7 +1312,7 @@ void main() {
     ));
 
     // Displays label of select item.
-    expect(tester.getSemantics(find.text('three')), matchesSemantics(
+    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
       isButton: true,
       label: 'three',
       hasTapAction: true,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1296,7 +1296,7 @@ void main() {
     ));
 
     // By default the hint contributes the label.
-    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+    expect(tester.getSemantics(find.text('test')), matchesSemantics(
       isButton: true,
       label: 'test',
       hasTapAction: true,
@@ -1312,7 +1312,7 @@ void main() {
     ));
 
     // Displays label of select item.
-    expect(tester.getSemantics(find.byKey(key)), matchesSemantics(
+    expect(tester.getSemantics(find.text('three')), matchesSemantics(
       isButton: true,
       label: 'three',
       hasTapAction: true,


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/117997

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
