### PR TITLE
Add test for dropdown_menu.1.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -338,7 +338,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/input_decorator/input_decoration.material_state.1_test.dart',
   'examples/api/test/material/text_form_field/text_form_field.1_test.dart',
   'examples/api/test/material/scrollbar/scrollbar.1_test.dart',
-  'examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.0_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.1_test.dart',
   'examples/api/test/material/search_anchor/search_anchor.2_test.dart',

--- a/examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/dropdown_menu/dropdown_menu.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DropdownMenu', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.DropdownMenuApp(),
+    );
+
+    expect(find.widgetWithText(TextField, 'One'), findsOne);
+    final Finder menu = find.byType(DropdownMenu<String>);
+    expect(menu, findsOne);
+
+    Finder findMenuItem(String label) {
+      return find.widgetWithText(MenuItemButton, label).last;
+    }
+
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
+    expect(findMenuItem('One'), findsOne);
+    expect(findMenuItem('Two'), findsOne);
+    expect(findMenuItem('Three'), findsOne);
+    expect(findMenuItem('Four'), findsOne);
+
+    await tester.tap(findMenuItem('Two'));
+
+    // The DropdownMenu's onSelected callback is delayed
+    // with SchedulerBinding.instance.addPostFrameCallback
+    // to give the focus a chance to return to where it was
+    // before the menu appeared. The pumpAndSettle()
+    // give the callback a chance to run.
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextField, 'Two'), findsOne);
+  });
+
+  testWidgets('DropdownMenu has focus when tapping on the text field', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.DropdownMenuApp(),
+    );
+
+    // Make sure the dropdown menus are there.
+    final Finder menu = find.byType(DropdownMenu<String>);
+    expect(menu, findsOne);
+
+    // Tap on the menu and make sure it is focused.
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
+    expect(FocusScope.of(tester.element(menu)).hasFocus, isTrue);
+  });
+}

--- a/examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart
+++ b/examples/api/test/material/dropdown_menu/dropdown_menu.1_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/material/dropdown_menu/dropdown_menu.1.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('DropdownMenu', (WidgetTester tester) async {
+  testWidgets('The DropdownMenu should display a menu with the list of entries the user can select', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.DropdownMenuApp(),
     );


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/dropdown_menu/dropdown_menu.1.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
