### PR TITLE
Move some benchmarks from MotoG4 to Mokey

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1969,64 +1969,70 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: android_stack_size_test
 
-  # linux motog4 benchmark
-  - name: Linux_android android_view_scroll_perf__timeline_summary
+  # linux mokey benchmark
+  - name: Linux_mokey android_view_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: android_view_scroll_perf__timeline_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android animated_image_gc_perf
+  # linux mokey benchmark
+  - name: Linux_mokey animated_image_gc_perf
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: animated_image_gc_perf
 
-  # linux motog4 benchmark
-  - name: Linux_android animated_complex_opacity_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey animated_complex_opacity_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: animated_complex_opacity_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android animated_complex_image_filtered_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey animated_complex_image_filtered_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: animated_complex_image_filtered_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android animated_placeholder_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey animated_placeholder_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: animated_placeholder_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android backdrop_filter_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey backdrop_filter_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: backdrop_filter_perf__e2e_summary
 
   - name: Linux_pixel_7pro backdrop_filter_perf__timeline_summary
@@ -2106,116 +2112,126 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: channels_integration_test
 
-  # linux motog4 benchmark
-  - name: Linux_android clipper_cache_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey clipper_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab","android","linux","mokey"]
       task_name: clipper_cache_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android color_filter_and_fade_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey color_filter_and_fade_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: color_filter_and_fade_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android color_filter_cache_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey color_filter_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: color_filter_cache_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android color_filter_with_unstable_child_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey color_filter_with_unstable_child_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab","android","linux","mokey"]
       task_name: color_filter_with_unstable_child_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android raster_cache_use_memory_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey raster_cache_use_memory_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab","android","linux","mokey"]
       task_name: raster_cache_use_memory_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android shader_mask_cache_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey shader_mask_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: shader_mask_cache_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android complex_layout_android__scroll_smoothness
+  # linux mokey benchmark
+  - name: Linux_mokey complex_layout_android__scroll_smoothness
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: complex_layout_android__scroll_smoothness
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "version:17"}
         ]
 
-  # linux motog4 benchmark
-  - name: Linux_android complex_layout_scroll_perf__devtools_memory
+  # linux mokey benchmark
+  - name: Linux_mokey complex_layout_scroll_perf__devtools_memory
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab","android","linux","mokey"]
       task_name: complex_layout_scroll_perf__devtools_memory
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "version:17"}
         ]
 
-  # linux motog4 benchmark
-  - name: Linux_android complex_layout_scroll_perf__memory
+  # linux mokey benchmark
+  - name: Linux_mokey complex_layout_scroll_perf__memory
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab","android","linux","mokey"]
       task_name: complex_layout_scroll_perf__memory
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "version:17"}
         ]
 
-  # linux motog4 benchmark
-  - name: Linux_android complex_layout_scroll_perf__timeline_summary
+  # linux mokey benchmark
+  - name: Linux_mokey complex_layout_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab","android","linux","mokey"]
       task_name: complex_layout_scroll_perf__timeline_summary
       dependencies: >-
         [
@@ -2261,42 +2277,45 @@ targets:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
 
-  # linux motog4 benchmark
-  - name: Linux_android complex_layout_semantics_perf
+  # linux mokey benchmark
+  - name: Linux_mokey complex_layout_semantics_perf
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: complex_layout_semantics_perf
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "version:17"}
         ]
 
-  # linux motog4 benchmark
-  - name: Linux_android complex_layout__start_up
+  # linux mokey benchmark
+  - name: Linux_mokey complex_layout__start_up
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: complex_layout__start_up
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "version:17"}
         ]
 
-  # linux motog4 benchmark
-  - name: Linux_android cubic_bezier_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey cubic_bezier_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: cubic_bezier_perf__e2e_summary
 
   - name: Linux_pixel_7pro cubic_bezier_perf__timeline_summary
@@ -2308,14 +2327,15 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: cubic_bezier_perf__timeline_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android cull_opacity_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey cull_opacity_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: cull_opacity_perf__e2e_summary
 
   - name: Linux_pixel_7pro cull_opacity_perf__timeline_summary
@@ -2327,14 +2347,15 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: cull_opacity_perf__timeline_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android devtools_profile_start_test
+  # linux mokey benchmark
+  - name: Linux_mokey devtools_profile_start_test
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: devtools_profile_start_test
 
   - name: Linux_pixel_7pro drive_perf_debug_warning
@@ -2369,9 +2390,10 @@ targets:
         ["devicelab", "linux"]
       task_name: external_textures_integration_test
 
-  # linux motog4 benchmark
-  - name: Linux_android fading_child_animation_perf__timeline_summary
+  # linux mokey benchmark
+  - name: Linux_mokey fading_child_animation_perf__timeline_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2379,24 +2401,26 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: fading_child_animation_perf__timeline_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android fast_scroll_heavy_gridview__memory
+  # linux mokey benchmark
+  - name: Linux_mokey fast_scroll_heavy_gridview__memory
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: fast_scroll_heavy_gridview__memory
 
-  # linux motog4 benchmark
-  - name: Linux_android fast_scroll_large_images__memory
+  # linux mokey benchmark
+  - name: Linux_mokey fast_scroll_large_images__memory
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: fast_scroll_large_images__memory
 
   - name: Linux_pixel_7pro flavors_test
@@ -2408,49 +2432,54 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: flavors_test
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_engine_group_performance
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_engine_group_performance
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_engine_group_performance
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_gallery__back_button_memory
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_gallery__back_button_memory
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_gallery__back_button_memory
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_gallery__image_cache_memory
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_gallery__image_cache_memory
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_gallery__image_cache_memory
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_gallery__memory_nav
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_gallery__memory_nav
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab" ,"android", "linux"]
+        ["devicelab" ,"android", "linux", "mokey"]
       task_name: flutter_gallery__memory_nav
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_gallery__start_up
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_gallery__start_up
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2458,14 +2487,15 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: flutter_gallery__start_up
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_gallery__start_up_delayed
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_gallery__start_up_delayed
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_gallery__start_up_delayed
 
   - name: Linux_pixel_7pro flutter_gallery_android__compile
@@ -2495,9 +2525,10 @@ targets:
         ["devicelab", "hostonly", "linux"]
       task_name: flutter_gallery_v2_web_compile_test
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_test_performance
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_test_performance
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -2505,14 +2536,15 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: flutter_test_performance
 
-  # linux motog4 benchmark
-  - name: Linux_android flutter_view__start_up
+  # linux mokey benchmark
+  - name: Linux_mokey flutter_view__start_up
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: flutter_view__start_up
 
   - name: Linux_pixel_7pro frame_policy_delay_test_android
@@ -2524,34 +2556,37 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: frame_policy_delay_test_android
 
-  # linux motog4 benchmark
-  - name: Linux_android fullscreen_textfield_perf
+  # linux mokey benchmark
+  - name: Linux_mokey fullscreen_textfield_perf
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: fullscreen_textfield_perf
 
-  # linux motog4 benchmark
-  - name: Linux_android fullscreen_textfield_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey fullscreen_textfield_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: fullscreen_textfield_perf__e2e_summary
 
-  # linux motog4 benchmark
-  - name: Linux_android very_long_picture_scrolling_perf__e2e_summary
+  # linux mokey benchmark
+  - name: Linux_mokey very_long_picture_scrolling_perf__e2e_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 120
     properties:
       tags: >
-        ["devicelab", "android", "linux"]
+        ["devicelab", "android", "linux", "mokey"]
       task_name: very_long_picture_scrolling_perf__e2e_summary
 
   # linux motog4 benchmark
@@ -2706,7 +2741,6 @@ targets:
   - name: Linux_mokey list_text_layout_impeller_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # Device exists only in staging.
     timeout: 60
     properties:
       ignore_flakiness: "true"
@@ -2803,7 +2837,6 @@ targets:
   # Mokey, Impeller
   - name: Linux_mokey new_gallery_impeller__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true # Device exists only in staging.
     presubmit: false
     timeout: 60
     properties:
@@ -2814,7 +2847,6 @@ targets:
   # Mokey, Impeller (OpenGL)
   - name: Linux_mokey new_gallery_opengles_impeller__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true # Device exists only in staging.
     presubmit: false
     timeout: 60
     properties:
@@ -2825,7 +2857,6 @@ targets:
   # Mokey, Skia
   - name: Linux_mokey new_gallery__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true # Device exists only in staging.
     presubmit: false
     timeout: 60
     properties:
@@ -2983,7 +3014,6 @@ targets:
 
   # linux mokey benchmark
   - name: Linux_mokey platform_views_scroll_perf_impeller__timeline_summary
-    bringup: true # Device exists only in staging.
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
@@ -3185,7 +3215,6 @@ targets:
   - name: Linux_mokey animated_blur_backdrop_filter_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # Device exists only in staging.
     timeout: 60
     properties:
       ignore_flakiness: "true"


### PR DESCRIPTION
On Linux hosts, there are currently 5 mokey's in staging and 7 in prod.
On Linux hosts, there is currently 1 MotoG4 in staging and 11 in prod.

This PR shifts the ~5 tests that have been running on mokey's for awhile now from staging to prod, and shifts about half of the MotoG4 benchmarks from MotoG4's in prod to mokey's in staging.

Following this change, we can disconnect half of the Linux/MotoG4's in the prod pool and replace them with mokey's in the prod pool.

Part of https://github.com/flutter/flutter/issues/148085