### PR TITLE
[Reland] - Enable `explicitChildNodes` for the `AlertDialog` content

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -812,6 +812,7 @@ class AlertDialog extends StatelessWidget {
           style: contentTextStyle ?? dialogTheme.contentTextStyle ?? defaults.contentTextStyle!,
           child: Semantics(
             container: true,
+            explicitChildNodes: true,
             child: content,
           ),
         ),

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -1722,7 +1722,12 @@ void main() {
         theme: ThemeData(platform: TargetPlatform.iOS),
         home: const AlertDialog(
           title: Text('title'),
-          content: Text('content'),
+          content: Column(
+            children: <Widget>[
+              Text('some content'),
+              Text('more content'),
+            ],
+          ),
           actions: <Widget>[ TextButton(onPressed: null, child: Text('action')) ],
         ),
       ),
@@ -1753,11 +1758,21 @@ void main() {
                         // node 4.
                         TestSemantics(
                           id: 6,
-                          label: 'content',
-                          textDirection: TextDirection.ltr,
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              id: 7,
+                              label: 'some content',
+                              textDirection: TextDirection.ltr,
+                            ),
+                            TestSemantics(
+                              id: 8,
+                              label: 'more content',
+                              textDirection: TextDirection.ltr,
+                            ),
+                          ],
                         ),
                         TestSemantics(
-                          id: 7,
+                          id: 9,
                           flags: <SemanticsFlag>[
                             SemanticsFlag.isButton,
                             SemanticsFlag.hasEnabledState,


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/149130
(With no change for now, waiting for actual Google testing results to make any changes if needed)
---

fixes [AlertDialog content semantics merged](https://github.com/flutter/flutter/issues/147574)


### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      // showSemanticsDebugger: true,
      home: Scaffold(
        body: SafeArea(
          child: Center(
            child: Column(
              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
              children: <Widget>[
                const Column(
                  mainAxisAlignment: MainAxisAlignment.center,
                  children: <Widget>[
                    Text('Some text'),
                    Text('More text'),
                  ],
                ),
                Builder(builder: (BuildContext context) {
                  return ElevatedButton(
                    onPressed: () {
                      showDialog<void>(
                        context: context,
                        builder: (BuildContext context) {
                          return AlertDialog(
                            title: const Text('Dialog Title'),
                            content: const Column(
                              children: <Widget>[
                                Text('Some text'),
                                Text('More text'),
                              ],
                            ),
                            actions: <Widget>[
                              TextButton(
                                onPressed: () {
                                  Navigator.of(context).pop();
                                },
                                child: const Text('Close'),
                              ),
                            ],
                          );
                        },
                      );
                    },
                    child: const Text('Open Dialog'),
                  );
                }),
              ],
            ),
          ),
        ),
      ),
    );
  }
}
```

</details>

### Before vs After

![Screenshot 2024-05-27 at 14 59 57](https://github.com/flutter/flutter/assets/48603081/3b231a7a-db71-4dbf-bd4a-dd44a537cae8)

![Screenshot 2024-05-27 at 14 56 04](https://github.com/flutter/flutter/assets/48603081/219c1de5-ad35-49b3-a80f-4f036184e22b)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
