### PR TITLE
Switch to triage-* labels for platform package triage

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -199,7 +199,7 @@ For more guidance on reviewing PRs, see [Tree Hygiene](../contributing/Tree-hygi
 - [Incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-android%2Cfyi-android+-label%3Atriaged-android+no%3Aassignee+-label%3A%22will+need+additional+triage%22+sort%3Aupdated-asc)
 - [P0 list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-android+label%3AP0+sort%3Aupdated-asc)
 - [P1, No Assignee list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-android+label%3Ap1+no%3Aassignee+sort%3Aupdated-asc)
-- PRs: [Engine](https://github.com/flutter/engine/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+-label%3A%22Work+in+progress+%28WIP%29%22+sort%3Aupdated-asc), [Framework/Tool](https://github.com/flutter/flutter/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+-label%3A%22work+in+progress%3B+do+not+review%22+sort%3Aupdated-asc+), [Plugins \(non-dependabot\)](https://github.com/flutter/packages/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+sort%3Aupdated-asc+-author%3Aapp%2Fdependabot+), [Plugins \(dependabot\)](https://github.com/flutter/packages/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+sort%3Aupdated-asc+author%3Aapp%2Fdependabot+)
+- PRs: [Engine](https://github.com/flutter/engine/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+-label%3A%22Work+in+progress+%28WIP%29%22+sort%3Aupdated-asc), [Framework/Tool](https://github.com/flutter/flutter/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+-label%3A%22work+in+progress%3B+do+not+review%22+sort%3Aupdated-asc+), [Plugins \(non-dependabot\)](https://github.com/flutter/packages/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Atriage-android+sort%3Aupdated-asc+-author%3Aapp%2Fdependabot+), [Plugins \(dependabot\)](https://github.com/flutter/packages/pulls?q=is%3Aopen+draft%3Afalse+is%3Apr+label%3Aplatform-android+sort%3Aupdated-asc+author%3Aapp%2Fdependabot+)
 
 ### Codelabs team (`team-codelabs`)
 
@@ -218,6 +218,7 @@ For more guidance on reviewing PRs, see [Tree Hygiene](../contributing/Tree-hygi
 - [P0 list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3Ateam-desktop+label%3AP0+sort%3Aupdated-asc)
 - [Desktop PRs on the engine](https://github.com/flutter/engine/pulls?q=is%3Aopen+is%3Apr+label%3A%22affects%3A+desktop%22+sort%3Aupdated-asc)
 - [Desktop PRs on the framework](https://github.com/flutter/flutter/pulls?q=is%3Aopen+is%3Apr+label%3A%22a%3A+desktop%22+sort%3Aupdated-asc)
+- [Desktop PRs on packages](https://github.com/flutter/packages/pulls?q=is%3Aopen+is%3Apr+label%3Atriage-linux%2Ctriage-macos%2Ctriage-windows+sort%3Aupdated-asc)
 
 ### Ecosystem team (`team-ecosystem`)
 
@@ -276,7 +277,7 @@ Apple's https://developer.apple.com/news should be periodically checked for upda
 PRs are reviewed weekly across the framework, packages, and engine repositories:
 
 * [iOS Framework PRs](https://github.com/flutter/flutter/pulls?q=is%3Aopen+is%3Apr+label%3Aplatform-ios+sort%3Acreated-asc+-is%3Adraft)
-* [iOS Plugins PRs](https://github.com/flutter/packages/pulls?q=is%3Aopen+is%3Apr+label%3Aplatform-ios+draft%3Afalse+sort%3Aupdated-asc)
+* [iOS Plugins PRs](https://github.com/flutter/packages/pulls?q=is%3Aopen+is%3Apr+label%3Atriage-ios+draft%3Afalse+sort%3Aupdated-asc)
 * [iOS Engine PRs](https://github.com/flutter/engine/pulls?q=is%3Aopen+is%3Apr+label%3Aplatform-ios+sort%3Acreated-asc+-is%3Adraft)
 
 ### News Toolkit team (`team-news`)


### PR DESCRIPTION
Currently the ecosystem team triages all PRs in the packages repository, but the platform teams also triage all PRs with their platform label. Due to the way PRs in packages work, however, it's relatively common for a PR to not be relevant to all the teams' triages at all times. Common examples:
- One platform team may LGTM a multi-platform PR for their platform's portion, while another platform goes through review for several more weeks.
- A cross-platform PR may not have high-level design approval from the ecosystem owner, at which point platform implementation review is premature.

To avoid PRs showing up repeatedly in a platform team's triage when it's not relevant, this adjusts the triage structure:
- Queries for PRs in platform teams query `triage-<platform name>` rather than `platform-<platform name>`
- Ecosystem triage will add the `triage-<platform name>` label during triage when a PR is ready for that platform team's consideration.
- Platform teams can remove the label when it's not relevant to them (e..g, after it's been LGTM'd for that platform).

This also adds a desktop PR query, since there wasn't one, covering the separate platforms. They are separated to allow for more triage flexibility in the future.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
