### PR TITLE
Include transform in static Gradient lerp methods

### DIFF
--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -507,6 +507,7 @@ class LinearGradient extends Gradient {
       colors: interpolated.colors,
       stops: interpolated.stops,
       tileMode: t < 0.5 ? a.tileMode : b.tileMode, // TODO(ianh): interpolate tile mode
+      transform: t < 0.5 ? a.transform : b.transform,
     );
   }
 
@@ -787,6 +788,7 @@ class RadialGradient extends Gradient {
       tileMode: t < 0.5 ? a.tileMode : b.tileMode, // TODO(ianh): interpolate tile mode
       focal: AlignmentGeometry.lerp(a.focal, b.focal, t),
       focalRadius: math.max(0.0, ui.lerpDouble(a.focalRadius, b.focalRadius, t)!),
+      transform: t < 0.5 ? a.transform : b.transform,
     );
   }
 
@@ -1052,6 +1054,7 @@ class SweepGradient extends Gradient {
       colors: interpolated.colors,
       stops: interpolated.stops,
       tileMode: t < 0.5 ? a.tileMode : b.tileMode, // TODO(ianh): interpolate tile mode
+      transform: t < 0.5 ? a.transform : b.transform,
     );
   }
 

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -191,6 +191,32 @@ void main() {
     ));
   });
 
+  test('LinearGradient lerp test with transforms', () {
+    const LinearGradient testGradient1 = LinearGradient(
+      transform: GradientRotation(math.pi/4),
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+      stops: <double>[0, 1],
+    );
+    const LinearGradient testGradient2 = LinearGradient(
+      transform: GradientRotation(math.pi/2),
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+      stops: <double>[0, 1],
+    );
+
+    final LinearGradient? actual0 = LinearGradient.lerp(testGradient1, testGradient2, 0.0);
+    final LinearGradient? actual1 = LinearGradient.lerp(testGradient1, testGradient2, 1.0);
+    final LinearGradient? actual2 = LinearGradient.lerp(testGradient1, testGradient2, 0.5);
+    expect(testGradient1, equals(actual0));
+    expect(testGradient2, equals(actual1));
+    expect(testGradient2, equals(actual2));
+  });
+
   test('LinearGradient toString', () {
     expect(
       const LinearGradient(
@@ -481,6 +507,32 @@ void main() {
     ));
   });
 
+  test('RadialGradient lerp test with transforms', () {
+    const RadialGradient testGradient1 = RadialGradient(
+      transform: GradientRotation(math.pi/4),
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+      stops: <double>[0, 1],
+    );
+    const RadialGradient testGradient2 = RadialGradient(
+      transform: GradientRotation(math.pi/2),
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+      stops: <double>[0, 1],
+    );
+
+    final RadialGradient? actual0 = RadialGradient.lerp(testGradient1, testGradient2, 0.0);
+    final RadialGradient? actual1 = RadialGradient.lerp(testGradient1, testGradient2, 1.0);
+    final RadialGradient? actual2 = RadialGradient.lerp(testGradient1, testGradient2, 0.5);
+    expect(testGradient1, equals(actual0));
+    expect(testGradient2, equals(actual1));
+    expect(testGradient2, equals(actual2));
+  });
+
   test('RadialGradient lerp test with focal', () {
     const RadialGradient testGradient1 = RadialGradient(
       center: Alignment.topLeft,
@@ -704,6 +756,32 @@ void main() {
         1.0,
       ],
     ));
+  });
+
+  test('SweepGradient lerp test with transforms', () {
+    const SweepGradient testGradient1 = SweepGradient(
+      transform: GradientRotation(math.pi/4),
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+      stops: <double>[0, 1],
+    );
+    const SweepGradient testGradient2 = SweepGradient(
+      transform: GradientRotation(math.pi/2),
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+      stops: <double>[0, 1],
+    );
+
+    final SweepGradient? actual0 = SweepGradient.lerp(testGradient1, testGradient2, 0.0);
+    final SweepGradient? actual1 = SweepGradient.lerp(testGradient1, testGradient2, 1.0);
+    final SweepGradient? actual2 = SweepGradient.lerp(testGradient1, testGradient2, 0.5);
+    expect(testGradient1, equals(actual0));
+    expect(testGradient2, equals(actual1));
+    expect(testGradient2, equals(actual2));
   });
 
   test('SweepGradient scale test)', () {


### PR DESCRIPTION
*Fixes #149534 Gradient subclasses' static lerp methods drop the GradientTransform of both `a` and `b`*

LinearGradient.lerp(), RadialGradient.lerp() and SweepGradient.lerp() no longer drop the GradientTransform of `a` and/or `b`.

The primitive interpolation is performed the same way TileMode is handled:  `transform: t < 0.5 ? a.transform : b.transform`.

## Media

<details>
<summary>Video demonstration</summary>

### Before
https://github.com/flutter/flutter/assets/65806473/de14e201-b1a7-44ba-95ff-e62587c7f6ac

### After
https://github.com/flutter/flutter/assets/65806473/d48f40e2-1b0f-4ac8-a45c-b3c423e3fd64

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
  - Changed no documentation.
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
  - Non-breaking change.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
