### PR TITLE
Use --(no-)strip-wams instead of --(no-)-name-section in `dart compile wasm`

### DIFF
--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -152,7 +152,7 @@ class WasmCompilerConfig extends WebCompilerConfig {
     final bool stripSymbols = buildMode == BuildMode.release && stripWasm;
     return <String>[
       '-O$optimizationLevel',
-      '--${stripSymbols ? 'no-' : ''}name-section',
+      '--${stripSymbols ? '' : 'no-'}strip-wasm',
     ];
   }
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -925,7 +925,7 @@ void main() {
                   ],
                   '--extra-compiler-option=--depfile=${depFile.absolute.path}',
                   '-O$level',
-                  if (strip && buildMode == 'release') '--no-name-section' else '--name-section',
+                  if (strip && buildMode == 'release') '--strip-wasm' else '--no-strip-wasm',
                   '-o',
                   environment.buildDir.childFile('main.dart.wasm').absolute.path,
                   environment.buildDir.childFile('main.dart').absolute.path,


### PR DESCRIPTION
The Dart SDK change in [0] introduced the `--(no-)strip-wasm` flag to align with the flag name in `flutter build web`, so we can use that flag now in flutter tools.

[0] https://dart-review.googlesource.com/c/sdk/+/369062