### PR TITLE
make output of flutter run web tests verbose

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -521,6 +521,7 @@ class WebTestsSuite {
       flutter,
       <String>[
         'run',
+        '--verbose',
         '--debug',
         '-d',
         'chrome',


### PR DESCRIPTION
This is to make debugging flakes on LUCI easier. Right now, when the tool crashes it saves the error output into a file and prints the file path, but the file is not accessible from LUCI.

Example: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8746361237956626577/+/u/run_test.dart_for_web_long_running_tests_shard_and_subshard_5_5/stdout
