### PR TITLE
Remove abi key from local golden file testing

### DIFF
--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -579,7 +579,11 @@ class SkiaGoldClient {
     final Map<String, Object?> parameters = <String, Object?>{
       if (_isBrowserTest)
         'Browser' : _browserKey,
-      'Abi': '$abi',
+      // This method is only used in local testing to look up the given image.
+      // CI is not comprehensive in possible abi keys, so false negatives can
+      // be produced if we include it in local testing, for example CI uses
+      // macos_x64 but a contributor could have macos_arm64
+      // 'Abi': '$abi',
       'CI' : 'luci',
       'Platform' : platform.operatingSystem,
       if (webRenderer != null)

--- a/packages/flutter_goldens/lib/skia_client.dart
+++ b/packages/flutter_goldens/lib/skia_client.dart
@@ -581,8 +581,8 @@ class SkiaGoldClient {
         'Browser' : _browserKey,
       // This method is only used in local testing to look up the given image.
       // CI is not comprehensive in possible abi keys, so false negatives can
-      // be produced if we include it in local testing, for example CI uses
-      // macos_x64 but a contributor could have macos_arm64
+      // be produced if we include it in local testing. For example CI uses
+      // macos_x64 but a contributor could have macos_arm64.
       // 'Abi': '$abi',
       'CI' : 'luci',
       'Platform' : platform.operatingSystem,

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -514,7 +514,7 @@ void main() {
 
        expect(
          skiaClient.getTraceID('flutter.golden.1'),
-         equals('d8867d66b8f0be8d0c31598d8370f5dd'),
+         equals('ae18c7a6aa48e0685525dfe8fdf79003'),
        );
      });
 
@@ -548,7 +548,7 @@ void main() {
 
        expect(
          skiaClient.getTraceID('flutter.golden.1'),
-         equals('febd0e8ef6512c2a82c964b2a9e60012'),
+         equals('e9d5c296c48e7126808520e9cc191243'),
        );
      });
 
@@ -576,7 +576,7 @@ void main() {
       );
       expect(
         skiaClient.getTraceID('flutter.golden.1'),
-        equals('2e3d3f41cb4470748fa1c941f7762823'),
+        equals('9968695b9ae78cdb77cbb2be621ca2d6'),
       );
     });
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/149435

CI does not comprehensively cover all of the possible abi keys, so some folks can't test locally if their machine's abi does not match CI. This just removes it from the local testing look up. The right image will be summoned, and in CI we can still keep track of it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
