### PR TITLE
Add `contrastLevel` parameter to `ColorScheme.fromSeed`

### DIFF
--- a/examples/api/lib/material/color_scheme/color_scheme.0.dart
+++ b/examples/api/lib/material/color_scheme/color_scheme.0.dart
@@ -173,6 +173,7 @@ class _SettingsState extends State<Settings> {
                   const Text('Contrast level: '),
                   Expanded(
                     child: Slider(
+                      divisions: 4,
                       label: selectedContrast.toString(),
                       min: -1,
                       value: selectedContrast,

--- a/examples/api/lib/material/color_scheme/color_scheme.0.dart
+++ b/examples/api/lib/material/color_scheme/color_scheme.0.dart
@@ -10,7 +10,6 @@ const Widget divider = SizedBox(height: 10);
 
 void main() => runApp(const ColorSchemeExample());
 
-
 class ColorSchemeExample extends StatefulWidget {
   const ColorSchemeExample({super.key});
 

--- a/examples/api/lib/material/color_scheme/color_scheme.0.dart
+++ b/examples/api/lib/material/color_scheme/color_scheme.0.dart
@@ -8,7 +8,11 @@ import 'package:flutter/material.dart';
 
 const Widget divider = SizedBox(height: 10);
 
-void main() => runApp(const ColorSchemeExample());
+void main() => runApp(const MaterialApp(
+  debugShowCheckedModeBanner: false,
+  home: ColorSchemeExample()
+));
+
 
 class ColorSchemeExample extends StatefulWidget {
   const ColorSchemeExample({super.key});
@@ -20,7 +24,16 @@ class ColorSchemeExample extends StatefulWidget {
 class _ColorSchemeExampleState extends State<ColorSchemeExample> {
   Color selectedColor = ColorSeed.baseColor.color;
   Brightness selectedBrightness = Brightness.light;
+  double selectedContrast = 0.0;
   static const List<DynamicSchemeVariant> schemeVariants = DynamicSchemeVariant.values;
+
+  void updateTheme(Brightness brightness, Color color, double contrastLevel) {
+    setState(() {
+      selectedBrightness = brightness;
+      selectedColor = color;
+      selectedContrast = contrastLevel;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,86 +43,150 @@ class _ColorSchemeExampleState extends State<ColorSchemeExample> {
         colorScheme: ColorScheme.fromSeed(
           seedColor: selectedColor,
           brightness: selectedBrightness,
+          contrastLevel: selectedContrast,
         )
       ),
-      home: Builder(
-        builder: (BuildContext context) => Scaffold(
-          appBar: AppBar(
-            title: const Text('ColorScheme'),
-            actions: <Widget>[
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('ColorScheme'),
+          actions: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.settings),
+              onPressed: () {
+                showModalBottomSheet<void>(
+                  barrierColor: Colors.transparent,
+                  context: context,
+                  builder: (BuildContext context) => Settings(
+                    selectedColor: selectedColor,
+                    selectedBrightness: selectedBrightness,
+                    selectedContrast: selectedContrast,
+                    updateTheme: updateTheme
+                  )
+                );
+              },
+            ),
+          ],
+        ),
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 5),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: List<Widget>.generate(schemeVariants.length, (int index) {
+                      return ColorSchemeVariantColumn(
+                        selectedColor: selectedColor,
+                        brightness: selectedBrightness,
+                        schemeVariant: schemeVariants[index],
+                        contrastLevel: selectedContrast,
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class Settings extends StatefulWidget {
+  const Settings({
+    super.key,
+    required this.updateTheme,
+    required this.selectedBrightness,
+    required this.selectedContrast,
+    required this.selectedColor,
+  });
+
+  final Brightness selectedBrightness;
+  final double selectedContrast;
+  final Color selectedColor;
+
+  final void Function(Brightness, Color, double) updateTheme;
+
+  @override
+  State<Settings> createState() => _SettingsState();
+}
+
+class _SettingsState extends State<Settings> {
+  late Brightness selectedBrightness = widget.selectedBrightness;
+  late Color selectedColor = widget.selectedColor;
+  late double selectedContrast = widget.selectedContrast;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(colorScheme: ColorScheme.fromSeed(
+        seedColor: selectedColor,
+        contrastLevel: selectedContrast,
+        brightness: selectedBrightness,
+      )),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxHeight: 200),
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: ListView(
+            children: <Widget>[
+              Center(child: Text('Settings', style: Theme.of(context).textTheme.titleLarge)),
               Row(
                 children: <Widget>[
-                  const Text('Color Seed'),
-                  MenuAnchor(
-                    builder: (BuildContext context, MenuController controller, Widget? widget) {
-                      return IconButton(
-                        icon: Icon(Icons.circle, color: selectedColor),
-                        onPressed: () {
-                          setState(() {
-                            if (!controller.isOpen) {
-                              controller.open();
-                            }
-                          });
-                        },
-                      );
+                  const Text('Brightness: '),
+                  Switch(
+                    value: selectedBrightness == Brightness.light,
+                    onChanged: (bool value) {
+                      setState(() {
+                        selectedBrightness = value ? Brightness.light : Brightness.dark;
+                      });
+                      widget.updateTheme.call(selectedBrightness, selectedColor, selectedContrast);
                     },
-                    menuChildren: List<Widget>.generate(ColorSeed.values.length, (int index) {
-                      final Color itemColor = ColorSeed.values[index].color;
-                      return MenuItemButton(
-                        leadingIcon: selectedColor == ColorSeed.values[index].color
-                          ? Icon(Icons.circle, color: itemColor)
-                          : Icon(Icons.circle_outlined, color: itemColor),
-                        onPressed: () {
-                          setState(() {
-                            selectedColor = itemColor;
-                          });
-                        },
-                        child: Text(ColorSeed.values[index].label),
-                      );
-                    }),
+                  )
+                ],
+              ),
+              Wrap(
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  const Text('Seed color: '),
+                  ...List<Widget>.generate(ColorSeed.values.length, (int index) {
+                    final Color itemColor = ColorSeed.values[index].color;
+                    return IconButton(
+                      icon: selectedColor == ColorSeed.values[index].color
+                        ? Icon(Icons.circle, color: itemColor)
+                        : Icon(Icons.circle_outlined, color: itemColor),
+                      onPressed: () {
+                        setState(() {
+                          selectedColor = itemColor;
+                        });
+                        widget.updateTheme.call(selectedBrightness, selectedColor, selectedContrast);
+                      },
+                    );
+                  }),
+                ]
+              ),
+              Row(
+                children: <Widget>[
+                  const Text('Contrast level: '),
+                  Expanded(
+                    child: Slider(
+                      label: selectedContrast.toString(),
+                      min: -1,
+                      value: selectedContrast,
+                      onChanged: (double value) {
+                        setState(() {
+                          selectedContrast = value;
+                        });
+                        widget.updateTheme.call(selectedBrightness, selectedColor, selectedContrast);
+                      },
+                    ),
                   ),
                 ],
               ),
             ],
-          ),
-          body: SingleChildScrollView(
-            child: Padding(
-              padding: const EdgeInsets.only(top: 5),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                    child: Row(
-                      children: <Widget>[
-                        const Text('Brightness'),
-                        const SizedBox(width: 10),
-                        Switch(
-                          value: selectedBrightness == Brightness.light,
-                          onChanged: (bool value) {
-                            setState(() {
-                              selectedBrightness = value ? Brightness.light : Brightness.dark;
-                            });
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                  SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      children: List<Widget>.generate(schemeVariants.length, (int index) {
-                        return ColorSchemeVariantColumn(
-                          selectedColor: selectedColor,
-                          brightness: selectedBrightness,
-                          schemeVariant: schemeVariants[index],
-                        );
-                      }).toList(),
-                    ),
-                  ),
-                ],
-              ),
-            ),
           ),
         ),
       ),
@@ -122,11 +199,13 @@ class ColorSchemeVariantColumn extends StatelessWidget {
     super.key,
     this.schemeVariant = DynamicSchemeVariant.tonalSpot,
     this.brightness = Brightness.light,
+    this.contrastLevel = 0.0,
     required this.selectedColor,
   });
 
   final DynamicSchemeVariant schemeVariant;
   final Brightness brightness;
+  final double contrastLevel;
   final Color selectedColor;
 
   @override
@@ -148,6 +227,7 @@ class ColorSchemeVariantColumn extends StatelessWidget {
               colorScheme: ColorScheme.fromSeed(
                 seedColor: selectedColor,
                 brightness: brightness,
+                contrastLevel: contrastLevel,
                 dynamicSchemeVariant: schemeVariant,
               ),
             ),

--- a/examples/api/lib/material/color_scheme/color_scheme.0.dart
+++ b/examples/api/lib/material/color_scheme/color_scheme.0.dart
@@ -8,10 +8,7 @@ import 'package:flutter/material.dart';
 
 const Widget divider = SizedBox(height: 10);
 
-void main() => runApp(const MaterialApp(
-  debugShowCheckedModeBanner: false,
-  home: ColorSchemeExample()
-));
+void main() => runApp(const ColorSchemeExample());
 
 
 class ColorSchemeExample extends StatefulWidget {

--- a/examples/api/test/material/color_scheme/color_scheme.0_test.dart
+++ b/examples/api/test/material/color_scheme/color_scheme.0_test.dart
@@ -30,9 +30,9 @@ void main() {
       );
     }
     expect(coloredBox().color, const Color(0xff65558f));
-    await tester.tap(find.byType(MenuAnchor));
+    await tester.tap(find.byIcon(Icons.settings));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(MenuItemButton, 'Yellow'));
+    await tester.tap(find.byType(IconButton).at(6));
     await tester.pumpAndSettle();
 
     expect(coloredBox().color, const Color(0xFF685F12));

--- a/examples/api/test/material/color_scheme/color_scheme.0_test.dart
+++ b/examples/api/test/material/color_scheme/color_scheme.0_test.dart
@@ -9,7 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('ColorScheme Smoke Test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const example.ColorSchemeExample(),
+      const MaterialApp(home: example.ColorSchemeExample()
+    ),
     );
     expect(find.text('tonalSpot (Default)'), findsOneWidget);
 
@@ -18,7 +19,7 @@ void main() {
 
   testWidgets('Change color seed', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const example.ColorSchemeExample(),
+      const MaterialApp(home: example.ColorSchemeExample()),
     );
 
     ColoredBox coloredBox() {

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -695,7 +695,8 @@ class ColorScheme with Diagnosticable {
   /// This constructor shouldn't be used to update the Material 3 color scheme.
   ///
   /// For Material 3, use [ColorScheme.fromSeed] to create a color scheme
-  /// from a single seed color based on the Material 3 color system.
+  /// from a single seed color based on the Material 3 color system. To create a
+  /// high-contrast color scheme, set `contrastLevel` to 1.0.
   ///
   /// {@tool snippet}
   /// This example demonstrates how to create a color scheme similar to [ColorScheme.highContrastLight]
@@ -826,7 +827,8 @@ class ColorScheme with Diagnosticable {
   /// For Material 3, use [ColorScheme.fromSeed] to create a color scheme
   /// from a single seed color based on the Material 3 color system.
   /// Override the `brightness` property of [ColorScheme.fromSeed] to create a
-  /// dark color scheme.
+  /// dark color scheme. To create a high-contrast color scheme, set
+  /// `contrastLevel` to 1.0.
   ///
   /// {@tool snippet}
   /// This example demonstrates how to create a color scheme similar to [ColorScheme.highContrastDark]

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -283,9 +283,14 @@ class ColorScheme with Diagnosticable {
   /// If the resulting color scheme is too dark, consider setting `dynamicSchemeVariant`
   /// to [DynamicSchemeVariant.fidelity], whose palettes match the seed color.
   ///
+  /// The `contrastLevel` parameter indicates the contrast level between color
+  /// pairs, such as [primary] and [onPrimary]. 0.0 is the default (normal);
+  /// -1.0 is the lowest; 1.0 is the highest.
+  ///
   /// {@tool dartpad}
   /// This sample shows how to use [ColorScheme.fromSeed] to create dynamic
-  /// color schemes with different [DynamicSchemeVariant]s.
+  /// color schemes with different [DynamicSchemeVariant]s and different
+  /// contrast level.
   ///
   /// ** See code in examples/api/lib/material/color_scheme/color_scheme.0.dart **
   /// {@end-tool}
@@ -300,6 +305,7 @@ class ColorScheme with Diagnosticable {
     required Color seedColor,
     Brightness brightness = Brightness.light,
     DynamicSchemeVariant dynamicSchemeVariant = DynamicSchemeVariant.tonalSpot,
+    double contrastLevel = 0.0,
     Color? primary,
     Color? onPrimary,
     Color? primaryContainer,
@@ -362,7 +368,7 @@ class ColorScheme with Diagnosticable {
     )
     Color? surfaceVariant,
   }) {
-    final DynamicScheme scheme = _buildDynamicScheme(brightness, seedColor, dynamicSchemeVariant);
+    final DynamicScheme scheme = _buildDynamicScheme(brightness, seedColor, dynamicSchemeVariant, contrastLevel);
 
     return ColorScheme(
       primary: primary ?? Color(MaterialDynamicColors.primary.getArgb(scheme)),
@@ -1672,6 +1678,7 @@ class ColorScheme with Diagnosticable {
     required ImageProvider provider,
     Brightness brightness = Brightness.light,
     DynamicSchemeVariant dynamicSchemeVariant = DynamicSchemeVariant.tonalSpot,
+    double contrastLevel = 0.0,
     Color? primary,
     Color? onPrimary,
     Color? primaryContainer,
@@ -1745,7 +1752,7 @@ class ColorScheme with Diagnosticable {
     final List<int> scoredResults = Score.score(colorToCount, desired: 1);
     final ui.Color baseColor = Color(scoredResults.first);
 
-    final DynamicScheme scheme = _buildDynamicScheme(brightness, baseColor, dynamicSchemeVariant);
+    final DynamicScheme scheme = _buildDynamicScheme(brightness, baseColor, dynamicSchemeVariant, contrastLevel);
 
     return ColorScheme(
       primary: primary ?? Color(MaterialDynamicColors.primary.getArgb(scheme)),
@@ -1882,19 +1889,24 @@ class ColorScheme with Diagnosticable {
     return (abgr & exceptRMask & exceptBMask) | (b << 16) | r;
   }
 
-  static DynamicScheme _buildDynamicScheme(Brightness brightness, Color seedColor, DynamicSchemeVariant schemeVariant) {
+  static DynamicScheme _buildDynamicScheme(
+    Brightness brightness,
+    Color seedColor,
+    DynamicSchemeVariant schemeVariant,
+    double contrastLevel,
+  ) {
     final bool isDark = brightness == Brightness.dark;
     final Hct sourceColor =  Hct.fromInt(seedColor.value);
     return switch (schemeVariant) {
-      DynamicSchemeVariant.tonalSpot => SchemeTonalSpot(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.fidelity => SchemeFidelity(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.content => SchemeContent(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.monochrome => SchemeMonochrome(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.neutral => SchemeNeutral(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.vibrant => SchemeVibrant(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.expressive => SchemeExpressive(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.rainbow => SchemeRainbow(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
-      DynamicSchemeVariant.fruitSalad => SchemeFruitSalad(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: 0.0),
+      DynamicSchemeVariant.tonalSpot => SchemeTonalSpot(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.fidelity => SchemeFidelity(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.content => SchemeContent(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.monochrome => SchemeMonochrome(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.neutral => SchemeNeutral(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.vibrant => SchemeVibrant(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.expressive => SchemeExpressive(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.rainbow => SchemeRainbow(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      DynamicSchemeVariant.fruitSalad => SchemeFruitSalad(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
     };
   }
 }

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -285,7 +285,8 @@ class ColorScheme with Diagnosticable {
   ///
   /// The `contrastLevel` parameter indicates the contrast level between color
   /// pairs, such as [primary] and [onPrimary]. 0.0 is the default (normal);
-  /// -1.0 is the lowest; 1.0 is the highest.
+  /// -1.0 is the lowest; 1.0 is the highest. From Material Design guideline, the
+  /// medium and high contrast correspond to 0.5 and 1.0 respectively.
   ///
   /// {@tool dartpad}
   /// This sample shows how to use [ColorScheme.fromSeed] to create dynamic

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -798,6 +798,90 @@ void main() {
       const Color(0xFF5D5F5F)
     );
   });
+
+  testWidgets('Colors in high-contrast color scheme matches colors in DynamicScheme', (WidgetTester tester) async {
+    const Color seedColor = Colors.blue;
+    final Hct sourceColor =  Hct.fromInt(seedColor.value);
+
+    void colorsMatchDynamicSchemeColors(DynamicSchemeVariant schemeVariant, Brightness brightness, double contrastLevel) {
+      final bool isDark = brightness == Brightness.dark;
+      final DynamicScheme dynamicScheme = switch (schemeVariant) {
+        DynamicSchemeVariant.tonalSpot => SchemeTonalSpot(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.fidelity => SchemeFidelity(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.content => SchemeContent(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.monochrome => SchemeMonochrome(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.neutral => SchemeNeutral(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.vibrant => SchemeVibrant(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.expressive => SchemeExpressive(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.rainbow => SchemeRainbow(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+        DynamicSchemeVariant.fruitSalad => SchemeFruitSalad(sourceColorHct: sourceColor, isDark: isDark, contrastLevel: contrastLevel),
+      };
+
+      final ColorScheme colorScheme = ColorScheme.fromSeed(
+        seedColor: seedColor,
+        brightness: brightness,
+        dynamicSchemeVariant: schemeVariant,
+        contrastLevel: contrastLevel,
+      );
+
+      expect(colorScheme.primary.value, MaterialDynamicColors.primary.getArgb(dynamicScheme));
+      expect(colorScheme.onPrimary.value, MaterialDynamicColors.onPrimary.getArgb(dynamicScheme));
+      expect(colorScheme.primaryContainer.value, MaterialDynamicColors.primaryContainer.getArgb(dynamicScheme));
+      expect(colorScheme.onPrimaryContainer.value, MaterialDynamicColors.onPrimaryContainer.getArgb(dynamicScheme));
+      expect(colorScheme.primaryFixed.value, MaterialDynamicColors.primaryFixed.getArgb(dynamicScheme));
+      expect(colorScheme.primaryFixedDim.value, MaterialDynamicColors.primaryFixedDim.getArgb(dynamicScheme));
+      expect(colorScheme.onPrimaryFixed.value, MaterialDynamicColors.onPrimaryFixed.getArgb(dynamicScheme));
+      expect(colorScheme.onPrimaryFixedVariant.value, MaterialDynamicColors.onPrimaryFixedVariant.getArgb(dynamicScheme));
+      expect(colorScheme.secondary.value, MaterialDynamicColors.secondary.getArgb(dynamicScheme));
+      expect(colorScheme.onSecondary.value, MaterialDynamicColors.onSecondary.getArgb(dynamicScheme));
+      expect(colorScheme.secondaryContainer.value, MaterialDynamicColors.secondaryContainer.getArgb(dynamicScheme));
+      expect(colorScheme.onSecondaryContainer.value, MaterialDynamicColors.onSecondaryContainer.getArgb(dynamicScheme));
+      expect(colorScheme.secondaryFixed.value, MaterialDynamicColors.secondaryFixed.getArgb(dynamicScheme));
+      expect(colorScheme.secondaryFixedDim.value, MaterialDynamicColors.secondaryFixedDim.getArgb(dynamicScheme));
+      expect(colorScheme.onSecondaryFixed.value, MaterialDynamicColors.onSecondaryFixed.getArgb(dynamicScheme));
+      expect(colorScheme.onSecondaryFixedVariant.value, MaterialDynamicColors.onSecondaryFixedVariant.getArgb(dynamicScheme));
+      expect(colorScheme.tertiary.value, MaterialDynamicColors.tertiary.getArgb(dynamicScheme));
+      expect(colorScheme.onTertiary.value, MaterialDynamicColors.onTertiary.getArgb(dynamicScheme));
+      expect(colorScheme.tertiaryContainer.value, MaterialDynamicColors.tertiaryContainer.getArgb(dynamicScheme));
+      expect(colorScheme.onTertiaryContainer.value, MaterialDynamicColors.onTertiaryContainer.getArgb(dynamicScheme));
+      expect(colorScheme.tertiaryFixed.value, MaterialDynamicColors.tertiaryFixed.getArgb(dynamicScheme));
+      expect(colorScheme.tertiaryFixedDim.value, MaterialDynamicColors.tertiaryFixedDim.getArgb(dynamicScheme));
+      expect(colorScheme.onTertiaryFixed.value, MaterialDynamicColors.onTertiaryFixed.getArgb(dynamicScheme));
+      expect(colorScheme.onTertiaryFixedVariant.value, MaterialDynamicColors.onTertiaryFixedVariant.getArgb(dynamicScheme));
+      expect(colorScheme.error.value, MaterialDynamicColors.error.getArgb(dynamicScheme));
+      expect(colorScheme.onError.value, MaterialDynamicColors.onError.getArgb(dynamicScheme));
+      expect(colorScheme.errorContainer.value, MaterialDynamicColors.errorContainer.getArgb(dynamicScheme));
+      expect(colorScheme.onErrorContainer.value, MaterialDynamicColors.onErrorContainer.getArgb(dynamicScheme));
+      expect(colorScheme.background.value, MaterialDynamicColors.background.getArgb(dynamicScheme));
+      expect(colorScheme.onBackground.value, MaterialDynamicColors.onBackground.getArgb(dynamicScheme));
+      expect(colorScheme.surface.value, MaterialDynamicColors.surface.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceDim.value, MaterialDynamicColors.surfaceDim.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceBright.value, MaterialDynamicColors.surfaceBright.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceContainerLowest.value, MaterialDynamicColors.surfaceContainerLowest.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceContainerLow.value, MaterialDynamicColors.surfaceContainerLow.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceContainer.value, MaterialDynamicColors.surfaceContainer.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceContainerHigh.value, MaterialDynamicColors.surfaceContainerHigh.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceContainerHighest.value, MaterialDynamicColors.surfaceContainerHighest.getArgb(dynamicScheme));
+      expect(colorScheme.onSurface.value, MaterialDynamicColors.onSurface.getArgb(dynamicScheme));
+      expect(colorScheme.surfaceVariant.value, MaterialDynamicColors.surfaceVariant.getArgb(dynamicScheme));
+      expect(colorScheme.onSurfaceVariant.value, MaterialDynamicColors.onSurfaceVariant.getArgb(dynamicScheme));
+      expect(colorScheme.outline.value, MaterialDynamicColors.outline.getArgb(dynamicScheme));
+      expect(colorScheme.outlineVariant.value, MaterialDynamicColors.outlineVariant.getArgb(dynamicScheme));
+      expect(colorScheme.shadow.value, MaterialDynamicColors.shadow.getArgb(dynamicScheme));
+      expect(colorScheme.scrim.value, MaterialDynamicColors.scrim.getArgb(dynamicScheme));
+      expect(colorScheme.inverseSurface.value, MaterialDynamicColors.inverseSurface.getArgb(dynamicScheme));
+      expect(colorScheme.onInverseSurface.value, MaterialDynamicColors.inverseOnSurface.getArgb(dynamicScheme));
+      expect(colorScheme.inversePrimary.value, MaterialDynamicColors.inversePrimary.getArgb(dynamicScheme));
+    }
+
+    for (final DynamicSchemeVariant schemeVariant in DynamicSchemeVariant.values) {
+      colorsMatchDynamicSchemeColors(schemeVariant, Brightness.light, 1.0); // High contrast
+      colorsMatchDynamicSchemeColors(schemeVariant, Brightness.dark, 1.0);
+
+      colorsMatchDynamicSchemeColors(schemeVariant, Brightness.light, 0.5); // Medium contrast
+      colorsMatchDynamicSchemeColors(schemeVariant, Brightness.dark, 0.5);
+    }
+  });
 }
 
 Future<void> _testFilledButtonColor(WidgetTester tester, ColorScheme scheme, Color expectation) async {


### PR DESCRIPTION
This PR is to add a parameter `contrastLevel` to `ColorScheme.fromSeed` so that we can construct high contrast `ColorScheme`.


https://github.com/flutter/flutter/assets/36861262/c609c996-5dfe-4c6c-800c-349a99de4256

Related to https://github.com/flutter/flutter/issues/149683

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
