### PR TITLE
Add `Radio.adaptive` to RadioMenuButton, `Checkbox.adaptive` to CheckboxMenuButton

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1204,6 +1204,8 @@ class _MenuItemButtonState extends State<MenuItemButton> {
   }
 }
 
+enum _CheckboxType { material, adaptive }
+
 /// A menu item that combines a [Checkbox] widget with a [MenuItemButton].
 ///
 /// To style the checkbox separately from the button, add a [CheckboxTheme]
@@ -1241,7 +1243,32 @@ class CheckboxMenuButton extends StatelessWidget {
     this.trailingIcon,
     this.closeOnActivate = true,
     required this.child,
-  });
+  }) : _checkboxType = _CheckboxType.material;
+
+
+  /// Creates an adaptive [CheckboxMenuButton] based on whether the target platform is iOS
+  /// or macOS, following Material design's
+  /// [Cross-platform guidelines](https://material.io/design/platform-guidance/cross-platform-adaptation.html).
+  ///
+  /// The target platform is based on the current [Theme]: [ThemeData.platform].
+  const CheckboxMenuButton.adaptive({
+    super.key,
+    required this.value,
+    this.tristate = false,
+    this.isError = false,
+    required this.onChanged,
+    this.onHover,
+    this.onFocusChange,
+    this.focusNode,
+    this.shortcut,
+    this.style,
+    this.statesController,
+    this.clipBehavior = Clip.none,
+    this.trailingIcon,
+    this.closeOnActivate = true,
+    required this.child,
+  }) : _checkboxType = _CheckboxType.adaptive;
+
 
   /// Whether this checkbox is checked.
   ///
@@ -1352,6 +1379,8 @@ class CheckboxMenuButton extends StatelessWidget {
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
+  final _CheckboxType _checkboxType;
+
   /// Whether the button is enabled or disabled.
   ///
   /// To enable a button, set its [onChanged] property to a non-null value.
@@ -1384,12 +1413,24 @@ class CheckboxMenuButton extends StatelessWidget {
               maxHeight: Checkbox.width,
               maxWidth: Checkbox.width,
             ),
-            child: Checkbox(
-              tristate: tristate,
-              value: value,
-              onChanged: onChanged,
-              isError: isError,
-            ),
+            child: () {
+              switch (_checkboxType) {
+                case _CheckboxType.adaptive:
+                  return Checkbox.adaptive(
+                    value: value,
+                    tristate: tristate,
+                    onChanged: onChanged,
+                    isError: isError,
+                  );
+                case _CheckboxType.material:
+                  return Checkbox(
+                    value: value,
+                    tristate: tristate,
+                    onChanged: onChanged,
+                    isError: isError,
+                  );
+              }
+            }(),
           ),
         ),
       ),
@@ -1400,6 +1441,8 @@ class CheckboxMenuButton extends StatelessWidget {
     );
   }
 }
+
+enum _RadioType { material, adaptive }
 
 /// A menu item that combines a [Radio] widget with a [MenuItemButton].
 ///
@@ -1438,7 +1481,31 @@ class RadioMenuButton<T> extends StatelessWidget {
     this.trailingIcon,
     this.closeOnActivate = true,
     required this.child,
-  });
+  }) : _radioType = _RadioType.material;
+
+  /// Creates an adaptive [RadioMenuButton] based on whether the target platform is iOS
+  /// or macOS, following Material design's
+  /// [Cross-platform guidelines](https://material.io/design/platform-guidance/cross-platform-adaptation.html).
+  ///
+  /// The target platform is based on the current [Theme]: [ThemeData.platform].
+  const RadioMenuButton.adaptive({
+    super.key,
+    required this.value,
+    required this.groupValue,
+    required this.onChanged,
+    this.toggleable = false,
+    this.onHover,
+    this.onFocusChange,
+    this.focusNode,
+    this.shortcut,
+    this.style,
+    this.statesController,
+    this.clipBehavior = Clip.none,
+    this.trailingIcon,
+    this.closeOnActivate = true,
+    required this.child,
+  }) : _radioType = _RadioType.adaptive;
+
 
   /// The value represented by this radio button.
   ///
@@ -1556,6 +1623,8 @@ class RadioMenuButton<T> extends StatelessWidget {
   /// To enable a button, set its [onChanged] property to a non-null value.
   bool get enabled => onChanged != null;
 
+  final _RadioType _radioType;
+
   @override
   Widget build(BuildContext context) {
     return MenuItemButton(
@@ -1580,12 +1649,24 @@ class RadioMenuButton<T> extends StatelessWidget {
               maxHeight: Checkbox.width,
               maxWidth: Checkbox.width,
             ),
-            child: Radio<T>(
-              value: value,
-              groupValue: groupValue,
-              onChanged: onChanged,
-              toggleable: toggleable,
-            ),
+            child: () {
+              switch (_radioType) {
+                case _RadioType.adaptive:
+                  return Radio<T>.adaptive(
+                    value: value,
+                    groupValue: groupValue,
+                    onChanged: onChanged,
+                    toggleable: toggleable,
+                  );
+                case _RadioType.material:
+                  return Radio<T>(
+                    value: value,
+                    groupValue: groupValue,
+                    onChanged: onChanged,
+                    toggleable: toggleable,
+                  );
+              }
+            }(),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1245,12 +1245,12 @@ class CheckboxMenuButton extends StatelessWidget {
     required this.child,
   }) : _checkboxType = _CheckboxType.material;
 
-
-  /// Creates an adaptive [CheckboxMenuButton] based on whether the target platform is iOS
-  /// or macOS, following Material design's
-  /// [Cross-platform guidelines](https://material.io/design/platform-guidance/cross-platform-adaptation.html).
+  /// Creates an adaptive [CheckboxMenuButton].
   ///
-  /// The target platform is based on the current [Theme]: [ThemeData.platform].
+  /// The checkbox uses [Checkbox.adaptive] to show a [CupertinoCheckbox] for
+  /// iOS platforms, or [Checkbox] for all others.
+  ///
+  /// All other properties are the same as [CheckboxMenuButton].
   const CheckboxMenuButton.adaptive({
     super.key,
     required this.value,
@@ -1483,11 +1483,12 @@ class RadioMenuButton<T> extends StatelessWidget {
     required this.child,
   }) : _radioType = _RadioType.material;
 
-  /// Creates an adaptive [RadioMenuButton] based on whether the target platform is iOS
-  /// or macOS, following Material design's
-  /// [Cross-platform guidelines](https://material.io/design/platform-guidance/cross-platform-adaptation.html).
+  /// Creates an adaptive [RadioMenuButton].
   ///
-  /// The target platform is based on the current [Theme]: [ThemeData.platform].
+  /// The radio uses [Radio.adaptive] to show a [CupertinoRadio] on iOS
+  /// and a [Radio] on other platforms.
+  ///
+  /// All other properties are the same as [RadioMenuButton].
   const RadioMenuButton.adaptive({
     super.key,
     required this.value,

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -1245,12 +1245,10 @@ class CheckboxMenuButton extends StatelessWidget {
     required this.child,
   }) : _checkboxType = _CheckboxType.material;
 
-  /// Creates an adaptive [CheckboxMenuButton].
-  ///
-  /// The checkbox uses [Checkbox.adaptive] to show a [CupertinoCheckbox] for
-  /// iOS platforms, or [Checkbox] for all others.
-  ///
-  /// All other properties are the same as [CheckboxMenuButton].
+  /// On iOS and macOS, this constructor uses a [CupertinoCheckbox], which has
+  /// matching functionality and presentation as Material checkboxes, and are the
+  /// graphics expected on iOS. On other platforms, this uses a Material
+  /// design [Checkbox].
   const CheckboxMenuButton.adaptive({
     super.key,
     required this.value,
@@ -1268,7 +1266,6 @@ class CheckboxMenuButton extends StatelessWidget {
     this.closeOnActivate = true,
     required this.child,
   }) : _checkboxType = _CheckboxType.adaptive;
-
 
   /// Whether this checkbox is checked.
   ///
@@ -1483,12 +1480,10 @@ class RadioMenuButton<T> extends StatelessWidget {
     required this.child,
   }) : _radioType = _RadioType.material;
 
-  /// Creates an adaptive [RadioMenuButton].
-  ///
-  /// The radio uses [Radio.adaptive] to show a [CupertinoRadio] on iOS
-  /// and a [Radio] on other platforms.
-  ///
-  /// All other properties are the same as [RadioMenuButton].
+  /// On iOS and macOS, this constructor uses a [CupertinoRadio], which has
+  /// matching functionality and presentation as Material radios, and are the
+  /// graphics expected on iOS. On other platforms, this uses a Material
+  /// design [Radio].
   const RadioMenuButton.adaptive({
     super.key,
     required this.value,

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3298,6 +3298,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(CupertinoCheckbox), findsOneWidget);
+        expect(find.byType(Checkbox), findsOneWidget);
       }
 
       for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows ]) {
@@ -3387,6 +3388,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(CupertinoRadio<int>), findsOneWidget);
+        expect(find.byType(Radio<int>), findsOneWidget);
       }
 
       for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows ]) {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -3274,6 +3275,40 @@ void main() {
   }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/145527
 
   group('CheckboxMenuButton', () {
+    testWidgets('CheckboxMenuButton.adaptive shows the correct CheckboxMenuButton platform widget', (WidgetTester tester) async {
+      Widget buildApp(TargetPlatform platform) {
+        return MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                return CheckboxMenuButton.adaptive(
+                  value: false,
+                  onChanged: (bool? newValue) {},
+                  child: const Text('adaptive checkbox'),
+                );
+              }),
+            ),
+          ),
+        );
+      }
+
+      for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS, TargetPlatform.macOS ]) {
+        await tester.pumpWidget(buildApp(platform));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CupertinoCheckbox), findsOneWidget);
+      }
+
+      for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows ]) {
+        await tester.pumpWidget(buildApp(platform));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CupertinoCheckbox), findsNothing);
+      }
+
+    });
+
     testWidgets('tapping toggles checkbox', (WidgetTester tester) async {
       bool? checkBoxValue;
       await tester.pumpWidget(
@@ -3328,6 +3363,41 @@ void main() {
   });
 
   group('RadioMenuButton', () {
+    testWidgets('RadioMenuButton.adaptive shows the correct RadioMenuButton platform widget', (WidgetTester tester) async {
+      Widget buildApp(TargetPlatform platform) {
+        return MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: Material(
+            child: Center(
+              child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+                return RadioMenuButton<int>.adaptive(
+                  value: 0,
+                  groupValue: null,
+                  onChanged: (int? newValue) {},
+                  child: const Text('adaptive radio'),
+                );
+              }),
+            ),
+          ),
+        );
+      }
+
+      for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.iOS, TargetPlatform.macOS ]) {
+        await tester.pumpWidget(buildApp(platform));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CupertinoRadio<int>), findsOneWidget);
+      }
+
+      for (final TargetPlatform platform in <TargetPlatform>[ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows ]) {
+        await tester.pumpWidget(buildApp(platform));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CupertinoRadio<int>), findsNothing);
+      }
+
+    });
+
     testWidgets('tapping toggles radio button', (WidgetTester tester) async {
       int? radioValue;
       await tester.pumpWidget(

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3305,8 +3305,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(CupertinoCheckbox), findsNothing);
+        expect(find.byType(Checkbox), findsOneWidget);
       }
-
     });
 
     testWidgets('tapping toggles checkbox', (WidgetTester tester) async {
@@ -3394,8 +3394,8 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(CupertinoRadio<int>), findsNothing);
+        expect(find.byType(Radio<int>), findsOneWidget);
       }
-
     });
 
     testWidgets('tapping toggles radio button', (WidgetTester tester) async {


### PR DESCRIPTION
This PR adds support for `Radio.adaptive` and `Checkbox.adaptive` for RadioMenuButton and CheckboxMenuButton.

Fixes #147975

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
