### PR TITLE
Fixes Router transaction to respect operation order

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -694,8 +694,9 @@ class _RouterState<T> extends State<Router<T>> with RestorationMixin {
     // The super.didChangeDependencies may have parsed the route information.
     // This can happen if the didChangeDependencies is triggered by state
     // restoration or first build.
-    if (widget.routeInformationProvider != null && _routeParsePending) {
-      _processRouteInformation(widget.routeInformationProvider!.value, () => widget.routerDelegate.setNewRoutePath);
+    final RouteInformation? currentRouteInformation = _routeInformation.value ?? widget.routeInformationProvider?.value;
+    if (currentRouteInformation != null && _routeParsePending) {
+      _processRouteInformation(currentRouteInformation, () => widget.routerDelegate.setNewRoutePath);
     }
     _routeParsePending = false;
     _maybeNeedToReportRouteInformation();

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -41,6 +41,44 @@ void main() {
     expect(find.text('update'), findsOneWidget);
   });
 
+  testWidgets('Router respects update order', (WidgetTester tester) async {
+    final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
+    addTearDown(provider.dispose);
+    provider.value = RouteInformation(
+      uri: Uri.parse('initial'),
+    );
+
+    final MutableRouterDelegate delegate = MutableRouterDelegate();
+    addTearDown(delegate.dispose);
+
+    final ValueNotifier<int> notifier = ValueNotifier<int>(0);
+    await tester.pumpWidget(buildBoilerPlate(
+        IntInheritedNotifier(
+          notifier: notifier,
+          child: Router<RouteInformation>(
+            routeInformationProvider: provider,
+            routeInformationParser: CustomRouteInformationParser(
+                  (RouteInformation information, BuildContext context) {
+                IntInheritedNotifier.of(context); // create dependency
+                return information;
+              },
+            ),
+            routerDelegate: delegate,
+          ),
+        )
+    ));
+    expect(find.text('initial'), findsOneWidget);
+    expect(delegate.currentConfiguration!.uri.toString(), 'initial');
+
+    delegate.updateConfiguration(RouteInformation(uri: Uri.parse('update')));
+    notifier.value = 1;
+
+    // The delegate should still retain the update.
+    await tester.pumpAndSettle();
+    expect(find.text('update'), findsOneWidget);
+    expect(delegate.currentConfiguration!.uri.toString(), 'update');
+  });
+
   testWidgets('Simple router basic functionality - asynchronized', (WidgetTester tester) async {
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
     addTearDown(provider.dispose);
@@ -1932,5 +1970,45 @@ class RedirectingInformationParser extends RouteInformationParser<RouteInformati
   @override
   RouteInformation restoreRouteInformation(RouteInformation configuration) {
     return configuration;
+  }
+}
+
+class MutableRouterDelegate extends RouterDelegate<RouteInformation> with ChangeNotifier {
+  MutableRouterDelegate() {
+    if (kFlutterMemoryAllocationsEnabled) {
+      ChangeNotifier.maybeDispatchObjectCreation(this);
+    }
+  }
+
+  @override
+  RouteInformation? currentConfiguration;
+
+  @override
+  Future<void> setNewRoutePath(RouteInformation configuration) {
+    currentConfiguration = configuration;
+    return SynchronousFuture<void>(null);
+  }
+
+  void updateConfiguration(RouteInformation newConfig) {
+    currentConfiguration = newConfig;
+    notifyListeners();
+  }
+
+  @override
+  Future<bool> popRoute() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(currentConfiguration?.uri.toString() ?? '');
+  }
+}
+
+class IntInheritedNotifier extends InheritedNotifier<ValueListenable<int>> {
+  const IntInheritedNotifier({super.key,  required super.notifier, required super.child});
+
+  static int of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<IntInheritedNotifier>()!.notifier!.value;
   }
 }


### PR DESCRIPTION

fixes https://github.com/flutter/flutter/issues/142393

The issue is that if routerdelegate mutate its currentConfiguration outside of Router's workflow, the change will be propagate back to routeinformationprovider at the end of the frame.
However if another things trigger router's dependencies change within the same frame. The dependencies will trigger a reparse of the current route which would end up override the currentConfiguration in routerDelegate.

This change introduce a transaction system that each operation will be add to the end of the transaction future so everything will be execute inorder

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
