### PR TITLE
Revert "make output of flutter run web tests verbose (#149694)"

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -521,7 +521,6 @@ class WebTestsSuite {
       flutter,
       <String>[
         'run',
-        '--verbose',
         '--debug',
         '-d',
         'chrome',


### PR DESCRIPTION
This reverts commit cd8e84f46511462fdc7ae8ffee2c9c1f7971fba3.

Can't tell why, but it seems to have broken some web tests.