### PR TITLE
Send q once

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -521,6 +521,7 @@ class WebTestsSuite {
       flutter,
       <String>[
         'run',
+        '--verbose',
         '--debug',
         '-d',
         'chrome',

--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -534,10 +534,15 @@ class WebTestsSuite {
       ],
       outputMode: OutputMode.capture,
       outputListener: (String line, Process process) {
+        bool shutdownFlutterTool = false;
         if (line.contains('--- TEST SUCCEEDED ---')) {
           success = true;
+          shutdownFlutterTool = true;
         }
-        if (success || line.contains('--- TEST FAILED ---')) {
+        if (line.contains('--- TEST FAILED ---')) {
+          shutdownFlutterTool = true;
+        }
+        if (shutdownFlutterTool) {
           process.stdin.add('q'.codeUnits);
         }
       },


### PR DESCRIPTION
The previous expression `success || line.contains('--- TEST FAILED ---')` made it such that as soon as success is reported, the test would send "q" on every line of stdout, which is wrong. This fixes the condition such that "q" is sent once, only when `--- TEST SUCCEEDED ---` or `--- TEST FAILED ---` is printed.