### PR TITLE
`ScaffoldBackgroundColor` should default to `ColorScheme.surface`

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -404,11 +404,11 @@ class ThemeData with Diagnosticable {
 
       // Default some of the color settings to values from the color scheme
       primaryColor ??= primarySurfaceColor;
-      canvasColor ??= colorScheme.background;
-      scaffoldBackgroundColor ??= colorScheme.background;
+      canvasColor ??= colorScheme.surface;
+      scaffoldBackgroundColor ??= colorScheme.surface;
       cardColor ??= colorScheme.surface;
       dividerColor ??= colorScheme.outline;
-      dialogBackgroundColor ??= colorScheme.background;
+      dialogBackgroundColor ??= colorScheme.surface;
       indicatorColor ??= onPrimarySurfaceColor;
       applyElevationOverlayColor ??= brightness == Brightness.dark;
     }
@@ -776,11 +776,11 @@ class ThemeData with Diagnosticable {
       colorScheme: colorScheme,
       brightness: colorScheme.brightness,
       primaryColor: primarySurfaceColor,
-      canvasColor: colorScheme.background,
-      scaffoldBackgroundColor: colorScheme.background,
+      canvasColor: colorScheme.surface,
+      scaffoldBackgroundColor: colorScheme.surface,
       cardColor: colorScheme.surface,
       dividerColor: colorScheme.onSurface.withOpacity(0.12),
-      dialogBackgroundColor: colorScheme.background,
+      dialogBackgroundColor: colorScheme.surface,
       indicatorColor: onPrimarySurfaceColor,
       textTheme: textTheme,
       applyElevationOverlayColor: isDark,

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -111,6 +111,28 @@ void main() {
     expect(materialWidget.color, customColor);
   });
 
+  testWidgets('dialogBackground defaults to ColorScheme.surface', (WidgetTester tester) async {
+    const Dialog dialog = Dialog(
+      child: SizedBox(
+        width: 200,
+        height: 200
+      ),
+    );
+    await tester.pumpWidget(_buildAppWithDialog(
+      dialog,
+      theme: ThemeData(colorScheme: ThemeData().colorScheme.copyWith(
+        surface: Colors.orange,
+      ))
+    ));
+
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle();
+
+    final Material materialWidget = _getMaterialFromDialog(tester);
+    expect(materialWidget.color, Colors.orange);
+  });
+
+
   testWidgets('Material2 - Dialog Defaults', (WidgetTester tester) async {
     const AlertDialog dialog = AlertDialog(
       title: Text('Title'),

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -111,27 +111,27 @@ void main() {
     expect(materialWidget.color, customColor);
   });
 
-  testWidgets('dialogBackground defaults to ColorScheme.surface', (WidgetTester tester) async {
+  testWidgets('Dialog background defaults to ColorScheme.surface', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      colorScheme: ThemeData().colorScheme.copyWith(
+        surface: Colors.orange,
+        background: Colors.green,
+      )
+    );
     const Dialog dialog = Dialog(
       child: SizedBox(
         width: 200,
         height: 200
       ),
     );
-    await tester.pumpWidget(_buildAppWithDialog(
-      dialog,
-      theme: ThemeData(colorScheme: ThemeData().colorScheme.copyWith(
-        surface: Colors.orange,
-      ))
-    ));
+    await tester.pumpWidget(_buildAppWithDialog(dialog, theme: theme));
 
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle();
 
     final Material materialWidget = _getMaterialFromDialog(tester);
-    expect(materialWidget.color, Colors.orange);
+    expect(materialWidget.color, theme.colorScheme.surface);
   });
-
 
   testWidgets('Material2 - Dialog Defaults', (WidgetTester tester) async {
     const AlertDialog dialog = AlertDialog(

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3396,7 +3396,7 @@ void main() {
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 
-  testWidgets('Scaffold background color desults to ColorScheme.surface', (WidgetTester tester) async {
+  testWidgets('scaffoldBackgroundColor defaults to ColorScheme.surface', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3395,6 +3395,27 @@ void main() {
     // FAB is not visible.
     expect(find.byType(FloatingActionButton), findsNothing);
   });
+
+  testWidgets('Scaffold background color desults to ColorScheme.surface', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          colorScheme: ThemeData().colorScheme.copyWith(
+            surface: Colors.orange,
+            background: Colors.green,
+          )),
+        home: const Scaffold(
+          body: SizedBox.expand(),
+        ),
+      ),
+    );
+
+    final Material scaffoldMaterial = tester.widget<Material>(find.descendant(
+      of: find.byType(Scaffold),
+      matching: find.byType(Material).first,
+    ));
+    expect(scaffoldMaterial.color, Colors.orange);
+  });
 }
 
 class _GeometryListener extends StatefulWidget {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3396,14 +3396,16 @@ void main() {
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 
-  testWidgets('scaffoldBackgroundColor defaults to ColorScheme.surface', (WidgetTester tester) async {
+  testWidgets('Scaffold background color defaults to ColorScheme.surface', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      colorScheme: ThemeData().colorScheme.copyWith(
+        surface: Colors.orange,
+        background: Colors.green,
+      )
+    );
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(
-          colorScheme: ThemeData().colorScheme.copyWith(
-            surface: Colors.orange,
-            background: Colors.green,
-          )),
+        theme: theme,
         home: const Scaffold(
           body: SizedBox.expand(),
         ),
@@ -3414,7 +3416,7 @@ void main() {
       of: find.byType(Scaffold),
       matching: find.byType(Material).first,
     ));
-    expect(scaffoldMaterial.color, Colors.orange);
+    expect(scaffoldMaterial.color, theme.colorScheme.surface);
   });
 }
 

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -190,11 +190,11 @@ void main() {
     expect(theme.colorScheme.brightness, Brightness.light);
 
     expect(theme.primaryColor, theme.colorScheme.primary);
-    expect(theme.canvasColor, theme.colorScheme.background);
-    expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
+    expect(theme.canvasColor, theme.colorScheme.surface);
+    expect(theme.scaffoldBackgroundColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.dialogBackgroundColor, theme.colorScheme.background);
+    expect(theme.dialogBackgroundColor, theme.colorScheme.surface);
     expect(theme.indicatorColor, theme.colorScheme.onPrimary);
     expect(theme.applyElevationOverlayColor, false);
   });
@@ -257,11 +257,11 @@ void main() {
     expect(theme.colorScheme.brightness, Brightness.dark);
 
     expect(theme.primaryColor, theme.colorScheme.surface);
-    expect(theme.canvasColor, theme.colorScheme.background);
-    expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
+    expect(theme.canvasColor, theme.colorScheme.surface);
+    expect(theme.scaffoldBackgroundColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.dialogBackgroundColor, theme.colorScheme.background);
+    expect(theme.dialogBackgroundColor, theme.colorScheme.surface);
     expect(theme.indicatorColor, theme.colorScheme.onSurface);
     expect(theme.applyElevationOverlayColor, true);
   });
@@ -319,11 +319,11 @@ void main() {
     expect(theme.colorScheme.brightness, Brightness.light);
 
     expect(theme.primaryColor, theme.colorScheme.primary);
-    expect(theme.canvasColor, theme.colorScheme.background);
-    expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
+    expect(theme.canvasColor, theme.colorScheme.surface);
+    expect(theme.scaffoldBackgroundColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.dialogBackgroundColor, theme.colorScheme.background);
+    expect(theme.dialogBackgroundColor, theme.colorScheme.surface);
     expect(theme.indicatorColor, theme.colorScheme.onPrimary);
     expect(theme.applyElevationOverlayColor, false);
   });
@@ -382,11 +382,11 @@ void main() {
     expect(theme.colorScheme.brightness, Brightness.light);
 
     expect(theme.primaryColor, theme.colorScheme.primary);
-    expect(theme.canvasColor, theme.colorScheme.background);
-    expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
+    expect(theme.canvasColor, theme.colorScheme.surface);
+    expect(theme.scaffoldBackgroundColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.dialogBackgroundColor, theme.colorScheme.background);
+    expect(theme.dialogBackgroundColor, theme.colorScheme.surface);
     expect(theme.indicatorColor, theme.colorScheme.onPrimary);
     expect(theme.applyElevationOverlayColor, false);
   });
@@ -444,11 +444,11 @@ void main() {
     expect(theme.colorScheme.brightness, Brightness.dark);
 
     expect(theme.primaryColor, theme.colorScheme.surface);
-    expect(theme.canvasColor, theme.colorScheme.background);
-    expect(theme.scaffoldBackgroundColor, theme.colorScheme.background);
+    expect(theme.canvasColor, theme.colorScheme.surface);
+    expect(theme.scaffoldBackgroundColor, theme.colorScheme.surface);
     expect(theme.cardColor, theme.colorScheme.surface);
     expect(theme.dividerColor, theme.colorScheme.outline);
-    expect(theme.dialogBackgroundColor, theme.colorScheme.background);
+    expect(theme.dialogBackgroundColor, theme.colorScheme.surface);
     expect(theme.indicatorColor, theme.colorScheme.onSurface);
     expect(theme.applyElevationOverlayColor, true);
   });
@@ -460,9 +460,9 @@ void main() {
     expect(theme.brightness, equals(Brightness.light));
     expect(theme.primaryColor, equals(lightColors.primary));
     expect(theme.cardColor, equals(lightColors.surface));
-    expect(theme.canvasColor, equals(lightColors.background));
-    expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
-    expect(theme.dialogBackgroundColor, equals(lightColors.background));
+    expect(theme.canvasColor, equals(lightColors.surface));
+    expect(theme.scaffoldBackgroundColor, equals(lightColors.surface));
+    expect(theme.dialogBackgroundColor, equals(lightColors.surface));
     expect(theme.applyElevationOverlayColor, isFalse);
   });
 
@@ -474,9 +474,9 @@ void main() {
     // in dark theme's the color used for main components is surface instead of primary
     expect(theme.primaryColor, equals(darkColors.surface));
     expect(theme.cardColor, equals(darkColors.surface));
-    expect(theme.canvasColor, equals(darkColors.background));
-    expect(theme.scaffoldBackgroundColor, equals(darkColors.background));
-    expect(theme.dialogBackgroundColor, equals(darkColors.background));
+    expect(theme.canvasColor, equals(darkColors.surface));
+    expect(theme.scaffoldBackgroundColor, equals(darkColors.surface));
+    expect(theme.dialogBackgroundColor, equals(darkColors.surface));
     expect(theme.applyElevationOverlayColor, isTrue);
   });
 
@@ -1223,9 +1223,9 @@ void main() {
     expect(theme.colorScheme.brightness, equals(Brightness.dark));
     expect(theme.primaryColor, equals(lightColors.primary));
     expect(theme.cardColor, equals(lightColors.surface));
-    expect(theme.canvasColor, equals(lightColors.background));
-    expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
-    expect(theme.dialogBackgroundColor, equals(lightColors.background));
+    expect(theme.canvasColor, equals(lightColors.surface));
+    expect(theme.scaffoldBackgroundColor, equals(lightColors.surface));
+    expect(theme.dialogBackgroundColor, equals(lightColors.surface));
     expect(theme.applyElevationOverlayColor, isFalse);
   });
 


### PR DESCRIPTION
`ThemeData.ScaffoldBackgroundColor` originally defaults to `ColorScheme.background`. As background in ColorScheme is deprecated, customizing background is not able to change scaffold background color. This PR is to make `scaffoldBackgroundColor` defaults to `ColorScheme.surface` which is the replacement of `ColorScheme.background`.

Fixes https://github.com/flutter/flutter/issues/149158

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
