### PR TITLE
Clear its _focusedChildren when unfocus is actively called on FocusScopeNode.

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -901,6 +901,11 @@ class FocusNode with DiagnosticableTreeMixin, ChangeNotifier {
       // is not yet in the tree, neither of which do anything when unfocused.
       return;
     }
+    if (nearestScope == this) {
+      // If this is a scope, then we need to clear the focused children of the
+      // scope, since we are unfocusing the scope itself.
+      nearestScope?._focusedChildren.clear();
+    }
     switch (disposition) {
       case UnfocusDisposition.scope:
         // If it can't request focus, then don't modify its focused children.

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -785,7 +785,7 @@ void main() {
       await tester.pump();
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child2)));
       expect(tester.binding.focusManager.primaryFocus, isNot(equals(child1)));
-      expect(scope.focusedChild, equals(child1));
+      expect(scope.focusedChild, isNull);
       expect(scope.traversalDescendants.contains(child1), isFalse);
       expect(scope.traversalDescendants.contains(child2), isFalse);
       expect(scope.traversalChildren.contains(parent1), isFalse);
@@ -1107,7 +1107,7 @@ void main() {
       await tester.pump();
       scope1.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       await tester.pump();
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasFocus, isFalse);
       expect(scope2.hasFocus, isTrue);
@@ -1199,7 +1199,7 @@ void main() {
       await tester.pump();
       scope1.unfocus();
       await tester.pump();
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasFocus, isFalse);
       expect(scope2.hasFocus, isFalse);
@@ -1257,14 +1257,14 @@ void main() {
       scope1.canRequestFocus = false;
       await tester.pump();
 
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       expect(child3.hasPrimaryFocus, isTrue);
 
       child1.unfocus();
       await tester.pump();
       expect(child3.hasPrimaryFocus, isTrue);
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasPrimaryFocus, isFalse);
       expect(scope2.hasFocus, isTrue);
@@ -1274,7 +1274,7 @@ void main() {
       child1.unfocus(disposition: UnfocusDisposition.previouslyFocusedChild);
       await tester.pump();
       expect(child3.hasPrimaryFocus, isTrue);
-      expect(scope1.focusedChild, equals(child1));
+      expect(scope1.focusedChild, isNull);
       expect(scope2.focusedChild, equals(child3));
       expect(scope1.hasPrimaryFocus, isFalse);
       expect(scope2.hasFocus, isTrue);
@@ -2299,6 +2299,26 @@ void main() {
       debugFocusChanges = oldDebugFocusChanges;
       debugPrint = oldDebugPrint;
     }
+  });
+
+  testWidgets('After calling unfocus on FocusScopeNode, it should not refocus on the child when refocused.', (WidgetTester tester) async {
+    final BuildContext context = await setupWidget(tester);
+    final FocusScopeNode parent = FocusScopeNode();
+    addTearDown(parent.dispose);
+    final FocusAttachment parentAttachment = parent.attach(context);
+    final FocusNode child1 = FocusNode();
+    addTearDown(child1.dispose);
+    final FocusAttachment child1Attachment = child1.attach(context);
+    parentAttachment.reparent(parent: tester.binding.focusManager.rootScope);
+    child1Attachment.reparent(parent: parent);
+    child1.requestFocus();
+    await tester.pump();
+    expect(parent.focusedChild, equals(child1));
+    parent.unfocus();
+    await tester.pump();
+    parent.requestFocus();
+    await tester.pump();
+    expect(parent.focusedChild, isNull);
   });
 }
 


### PR DESCRIPTION
Fixes #145155 

I believe when users actively call unfocus on FocusScopeNode, they don't expect it to remember its focused children. I'm not sure if this would be a breaking change, it does break some tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
