### PR TITLE
Run tests on macOS 13 or 14

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -109,7 +109,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       device_type: none
       $flutter/osx_sdk : >-
         {
@@ -125,7 +125,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       device_type: none
       cpu: arm64
       $flutter/osx_sdk : >-
@@ -144,7 +144,7 @@ platform_properties:
         ]
       device_type: none
       mac_model: "Macmini8,1"
-      os: Mac-13
+      os: Mac-13|Mac-14
       tags: >
         ["devicelab", "hostonly", "mac"]
       $flutter/osx_sdk : >-
@@ -161,7 +161,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -179,7 +179,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -194,7 +194,7 @@ platform_properties:
           {"dependency": "chrome_and_driver", "version": "version:119.0.6045.9"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13|Mac-14
       cpu: x86
       device_type: "msm8952"
   mac_arm64_android:
@@ -204,7 +204,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:34v3"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13|Mac-14
       cpu: arm64
       device_type: "msm8952"
   mac_pixel_7pro:
@@ -214,7 +214,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:34v3"},
           {"dependency": "open_jdk", "version": "version:17"}
         ]
-      os: Mac-12|Mac-13
+      os: Mac-13|Mac-14
       cpu: x86
       device_type: "Pixel 7 Pro"
   mac_ios:
@@ -228,7 +228,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       cpu: x86
       device_os: iOS-17
       $flutter/osx_sdk : >-
@@ -246,7 +246,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2024"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       cpu: x86
       device_os: iOS-17
       $flutter/osx_sdk : >-
@@ -264,7 +264,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "none"}
         ]
-      os: Mac-13
+      os: Mac-13|Mac-14
       cpu: arm64
       device_os: iOS-17
       $flutter/osx_sdk : >-
@@ -4946,7 +4946,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
       drone_dimensions: >
-        ["device_os=iOS-17","os=Mac-13", "cpu=x86"]
+        ["device_os=iOS-17","os=Mac-13|Mac-14", "cpu=x86"]
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
In preparation of upgrading our fleet to macOS 14, allow tests to run on either macOS 13 or 14.

Fixes https://github.com/flutter/flutter/issues/148871.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
