### PR TITLE
[CP] Point kotlin message in `gradle_errors.dart` towards new place

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -441,10 +441,17 @@ final GradleHandledError incompatibleKotlinVersionHandler = GradleHandledError(
     final File gradleFile = project.directory
         .childDirectory('android')
         .childFile('build.gradle');
+    final File settingsFile = project.directory
+        .childDirectory('android')
+        .childFile('settings.gradle');
     globals.printBox(
       '${globals.logger.terminal.warningMark} Your project requires a newer version of the Kotlin Gradle plugin.\n'
-      'Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then update ${gradleFile.path}:\n'
-      "ext.kotlin_version = '<latest-version>'",
+          'Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then update the \n'
+          'version number of the plugin with id "org.jetbrains.kotlin.android" in the plugins block of \n'
+          '${settingsFile.path}.\n\n'
+          'Alternatively (if your project was created before Flutter 3.19), update \n'
+          '${gradleFile.path}\n'
+          "ext.kotlin_version = '<latest-version>'",
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -814,13 +814,18 @@ Execution failed for task ':app:generateDebugFeatureTransitiveDeps'.
       expect(
         testLogger.statusText,
         contains(
-          '\n'
-          '┌─ Flutter Fix ──────────────────────────────────────────────────────────────────────────────┐\n'
-          '│ [!] Your project requires a newer version of the Kotlin Gradle plugin.                     │\n'
-          '│ Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then │\n'
-          '│ update /android/build.gradle:                                                              │\n'
-          "│ ext.kotlin_version = '<latest-version>'                                                    │\n"
-          '└────────────────────────────────────────────────────────────────────────────────────────────┘\n'
+            '\n'
+                '┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────────┐\n'
+                '│ [!] Your project requires a newer version of the Kotlin Gradle plugin.                       │\n'
+                '│ Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then   │\n'
+                '│ update the                                                                                   │\n'
+                '│ version number of the plugin with id "org.jetbrains.kotlin.android" in the plugins block of  │\n'
+                '│ /android/settings.gradle.                                                                    │\n'
+                '│                                                                                              │\n'
+                '│ Alternatively (if your project was created before Flutter 3.19), update                      │\n'
+                '│ /android/build.gradle                                                                        │\n'
+                "│ ext.kotlin_version = '<latest-version>'                                                      │\n"
+                '└──────────────────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
Cherry pick request of https://github.com/flutter/flutter/pull/145936 to stable

Update Flutter Fix log on how to update Kotlin Gradle Plugin that was introduced in Flutter 3.19.x

Closes #149856