### PR TITLE
Introduce `Switch.padding`

### DIFF
--- a/dev/tools/gen_defaults/lib/switch_template.dart
+++ b/dev/tools/gen_defaults/lib/switch_template.dart
@@ -137,6 +137,9 @@ class _${blockName}DefaultsM3 extends SwitchThemeData {
 
   @override
   double get splashRadius => ${getToken('md.comp.switch.state-layer.size')} / 2;
+
+  @override
+  EdgeInsetsGeometry? get padding => const EdgeInsets.symmetric(horizontal: 4);
 }
 
 class _SwitchConfigM3 with _SwitchConfig {

--- a/dev/tools/gen_defaults/lib/switch_template.dart
+++ b/dev/tools/gen_defaults/lib/switch_template.dart
@@ -192,13 +192,13 @@ class _SwitchConfigM3 with _SwitchConfig {
   double get pressedThumbRadius => ${getToken('md.comp.switch.pressed.handle.width')} / 2;
 
   @override
-  double get switchHeight => _kSwitchMinSize + 8.0;
+  double get switchHeight => switchMinSize.height + 8.0;
 
   @override
-  double get switchHeightCollapsed => _kSwitchMinSize;
+  double get switchHeightCollapsed => switchMinSize.height;
 
   @override
-  double get switchWidth => trackWidth - 2 * (trackHeight / 2.0) + _kSwitchMinSize;
+  double get switchWidth => 52.0;
 
   @override
   double get thumbRadiusWithIcon => ${getToken('md.comp.switch.with-icon.handle.width')} / 2;
@@ -223,6 +223,9 @@ class _SwitchConfigM3 with _SwitchConfig {
   // Hand coded default based on the animation specs.
   @override
   double? get thumbOffset => null;
+
+  @override
+  Size get switchMinSize => const Size(kMinInteractiveDimension, kMinInteractiveDimension - 8.0);
 }
 ''';
 

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -552,7 +552,7 @@ class Switch extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  /// The amount of space to surround the child inside the bounds of the switch.
+  /// The amount of space to surround the child inside the bounds of the [Switch].
   ///
   /// Defaults to horizontal padding of 4 pixels. If [ThemeData.useMaterial3] is false,
   /// then there is no padding by default.
@@ -561,6 +561,7 @@ class Switch extends StatelessWidget {
   Size _getSwitchSize(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     SwitchThemeData switchTheme = SwitchTheme.of(context);
+    final SwitchThemeData defaults = theme.useMaterial3 ? _SwitchDefaultsM3(context) : _SwitchDefaultsM2(context);
     if (_switchType == _SwitchType.adaptive) {
       final Adaptation<SwitchThemeData> switchAdaptation = theme.getAdaptation<SwitchThemeData>()
         ?? const _SwitchThemeAdaptation();
@@ -573,9 +574,7 @@ class Switch extends StatelessWidget {
       ?? theme.materialTapTargetSize;
     final EdgeInsetsGeometry effectivePadding = padding
       ?? switchTheme.padding
-      ?? (theme.useMaterial3
-          ? const EdgeInsets.symmetric(horizontal: 4)
-          : EdgeInsets.zero);
+      ?? defaults.padding!;
     return switch (effectiveMaterialTapTargetSize) {
       MaterialTapTargetSize.padded     => Size(
         switchConfig.switchWidth + effectivePadding.horizontal,
@@ -2053,6 +2052,9 @@ class _SwitchDefaultsM2 extends SwitchThemeData {
 
   @override
   double get splashRadius => kRadialReactionRadius;
+
+  @override
+  EdgeInsetsGeometry? get padding => EdgeInsets.zero;
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - Switch
@@ -2188,6 +2190,9 @@ class _SwitchDefaultsM3 extends SwitchThemeData {
 
   @override
   double get splashRadius => 40.0 / 2;
+
+  @override
+  EdgeInsetsGeometry? get padding => const EdgeInsets.symmetric(horizontal: 4);
 }
 
 class _SwitchConfigM3 with _SwitchConfig {

--- a/packages/flutter/lib/src/material/switch_theme.dart
+++ b/packages/flutter/lib/src/material/switch_theme.dart
@@ -46,6 +46,7 @@ class SwitchThemeData with Diagnosticable {
     this.overlayColor,
     this.splashRadius,
     this.thumbIcon,
+    this.padding,
   });
 
   /// {@macro flutter.material.switch.thumbColor}
@@ -94,6 +95,9 @@ class SwitchThemeData with Diagnosticable {
   /// It is overridden by [Switch.thumbIcon].
   final MaterialStateProperty<Icon?>? thumbIcon;
 
+  /// If specified, overrides the default value of [Switch.padding].
+  final EdgeInsetsGeometry? padding;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   SwitchThemeData copyWith({
@@ -106,6 +110,7 @@ class SwitchThemeData with Diagnosticable {
     MaterialStateProperty<Color?>? overlayColor,
     double? splashRadius,
     MaterialStateProperty<Icon?>? thumbIcon,
+    EdgeInsetsGeometry? padding,
   }) {
     return SwitchThemeData(
       thumbColor: thumbColor ?? this.thumbColor,
@@ -117,6 +122,7 @@ class SwitchThemeData with Diagnosticable {
       overlayColor: overlayColor ?? this.overlayColor,
       splashRadius: splashRadius ?? this.splashRadius,
       thumbIcon: thumbIcon ?? this.thumbIcon,
+      padding: padding ?? this.padding,
     );
   }
 
@@ -137,6 +143,7 @@ class SwitchThemeData with Diagnosticable {
       overlayColor: MaterialStateProperty.lerp<Color?>(a?.overlayColor, b?.overlayColor, t, Color.lerp),
       splashRadius: lerpDouble(a?.splashRadius, b?.splashRadius, t),
       thumbIcon: t < 0.5 ? a?.thumbIcon : b?.thumbIcon,
+      padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
     );
   }
 
@@ -151,6 +158,7 @@ class SwitchThemeData with Diagnosticable {
     overlayColor,
     splashRadius,
     thumbIcon,
+    padding,
   );
 
   @override
@@ -170,7 +178,8 @@ class SwitchThemeData with Diagnosticable {
       && other.mouseCursor == mouseCursor
       && other.overlayColor == overlayColor
       && other.splashRadius == splashRadius
-      && other.thumbIcon == thumbIcon;
+      && other.thumbIcon == thumbIcon
+      && other.padding == padding;
   }
 
   @override
@@ -185,6 +194,7 @@ class SwitchThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('overlayColor', overlayColor, defaultValue: null));
     properties.add(DoubleProperty('splashRadius', splashRadius, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Icon?>>('thumbIcon', thumbIcon, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -4091,6 +4091,34 @@ void main() {
 
     focusNode.dispose();
   });
+
+  testWidgets('Switch.padding is respected', (WidgetTester tester) async {
+    Widget buildSwitch({ EdgeInsets? padding }) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: Switch(
+              padding: padding,
+              value: true,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSwitch());
+
+    expect(tester.getSize(find.byType(Switch)), const Size(60.0, 48.0));
+
+    await tester.pumpWidget(buildSwitch(padding: EdgeInsets.zero));
+
+    expect(tester.getSize(find.byType(Switch)), const Size(52.0, 48.0));
+
+    await tester.pumpWidget(buildSwitch(padding: const EdgeInsets.all(4.0)));
+
+    expect(tester.getSize(find.byType(Switch)), const Size(60.0, 56.0));
+  });
 }
 
 class DelayedImageProvider extends ImageProvider<DelayedImageProvider> {

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -29,6 +29,7 @@ void main() {
     expect(themeData.overlayColor, null);
     expect(themeData.splashRadius, null);
     expect(themeData.thumbIcon, null);
+    expect(themeData.padding, null);
 
     const SwitchTheme theme = SwitchTheme(data: SwitchThemeData(), child: SizedBox());
     expect(theme.data.thumbColor, null);
@@ -40,6 +41,7 @@ void main() {
     expect(theme.data.overlayColor, null);
     expect(theme.data.splashRadius, null);
     expect(theme.data.thumbIcon, null);
+    expect(theme.data.padding, null);
   });
 
   testWidgets('Default SwitchThemeData debugFillProperties', (WidgetTester tester) async {
@@ -66,6 +68,7 @@ void main() {
       overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
       splashRadius: 1.0,
       thumbIcon: MaterialStatePropertyAll<Icon>(Icon(IconData(123))),
+      padding: EdgeInsets.all(4.0),
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -82,6 +85,7 @@ void main() {
     expect(description[6], 'overlayColor: WidgetStatePropertyAll(Color(0xfffffff2))');
     expect(description[7], 'splashRadius: 1.0');
     expect(description[8], 'thumbIcon: WidgetStatePropertyAll(Icon(IconData(U+0007B)))');
+    expect(description[9], 'padding: EdgeInsets.all(4.0)');
   });
 
   testWidgets('Material2 - Switch is themeable', (WidgetTester tester) async {
@@ -1040,6 +1044,40 @@ void main() {
         ..rrect(color: localThemeOutlineColor, strokeWidth: localThemeOutlineWidth)
         ..rrect(color: localThemeThumbColor)
     );
+  });
+
+  testWidgets('SwitchTheme padding is respected', (WidgetTester tester) async {
+    Widget buildSwitch({ EdgeInsets? padding }) {
+      return MaterialApp(
+        theme: ThemeData(
+          switchTheme: SwitchThemeData(
+            padding: padding,
+          ),
+        ),
+        home: Scaffold(
+          body: Center(
+            child: Switch(
+              value: true,
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSwitch());
+
+    expect(tester.getSize(find.byType(Switch)), const Size(60.0, 48.0));
+
+    await tester.pumpWidget(buildSwitch(padding: EdgeInsets.zero));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byType(Switch)), const Size(52.0, 48.0));
+
+    await tester.pumpWidget(buildSwitch(padding: const EdgeInsets.all(4.0)));
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byType(Switch)), const Size(60.0, 56.0));
   });
 }
 


### PR DESCRIPTION
fixes [Switch has some padding that leads to uncentered UI](https://github.com/flutter/flutter/issues/148498)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Scaffold(
        body: Center(
          child: Column(
            mainAxisSize: MainAxisSize.min,
            children: <Widget>[
              ColoredBox(
                color: Colors.amber,
                child: Switch(
                  padding: EdgeInsets.zero,
                  value: true,
                  materialTapTargetSize: MaterialTapTargetSize.padded,
                  onChanged: (bool value) {},
                ),
              ),
              const SizedBox(height: 16),
              ColoredBox(
                color: Colors.amber,
                child: Switch(
                  value: true,
                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                  onChanged: (bool value) {},
                ),
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```

</details>

### Default Switch size

<img width="476" alt="Screenshot 2024-07-11 at 13 25 05" src="https://github.com/flutter/flutter/assets/48603081/f9f3f6c6-443d-4bd5-81d4-5e314554b032">


### Update Switch size using the new `Switch.padding` to address  [Switch has some padding that leads to uncentered UI](https://github.com/flutter/flutter/issues/148498)

<img width="476" alt="Screenshot 2024-07-11 at 13 24 40" src="https://github.com/flutter/flutter/assets/48603081/aea0717b-e852-4b8d-b703-c8c4999d4863">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
