### PR TITLE
Revert "Identify and re-throw our dependency checking errors in `flutter.groovy` (#149609)"

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -98,6 +98,7 @@ class FlutterExtension {
 
         return flutterVersionName
     }
+
 }
 
 // This buildscript block supplies dependencies for this file's own import
@@ -339,27 +340,10 @@ class FlutterPlugin implements Plugin<Project> {
                         "packages", "flutter_tools", "gradle", "src", "main", "kotlin",
                         "dependency_version_checker.gradle.kts")
                 project.apply from: dependencyCheckerPluginPath
-            } catch (Exception e) {
-                // If the exception was thrown by us in the dependency version checker plugin then
-                // re-throw it.
-                Exception outer = e.getCause()
-                if (outer != null) {
-                    Exception inner = outer.getCause()
-                    if (inner != null) {
-                        Exception unwrapped = inner.getCause()
-                        if (unwrapped != null) {
-                            if (unwrapped instanceof DependencyValidationException) {
-                                throw e
-                            }
-                        }
-                    }
-                }
-
-                // Otherwise, dependency version checking has failed. Log and continue
-                // the build.
+            } catch (Exception ignored) {
                 project.logger.error("Warning: Flutter was unable to detect project Gradle, Java, " +
                         "AGP, and KGP versions. Skipping dependency version checking. Error was: "
-                        + e)
+                        + ignored)
             }
         }
 
@@ -1829,16 +1813,4 @@ class FlutterTask extends BaseFlutterTask {
         buildBundle()
     }
 
-}
-
-// Custom error for when the dependency_version_checker.kts script finds a dependency out of
-// the defined support range.
-class DependencyValidationException extends Exception {
-    public DependencyValidationException(String errorMessage) {
-        super(errorMessage);
-    }
-
-    public DependencyValidationException(String errorMessage, Throwable cause) {
-        super(errorMessage, cause);
-    }
 }

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -235,7 +235,7 @@ class DependencyVersionChecker {
                         errorGradleVersion.toString(),
                         getPotentialGradleFix(project.getRootDir().getPath())
                     )
-                throw DependencyValidationException(errorMessage)
+                throw GradleException(errorMessage)
             } else if (version < warnGradleVersion) {
                 val warnMessage: String =
                     getWarnMessage(
@@ -260,7 +260,7 @@ class DependencyVersionChecker {
                         errorJavaVersion.toString(),
                         POTENTIAL_JAVA_FIX
                     )
-                throw DependencyValidationException(errorMessage)
+                throw GradleException(errorMessage)
             } else if (version < warnJavaVersion) {
                 val warnMessage: String =
                     getWarnMessage(
@@ -285,7 +285,7 @@ class DependencyVersionChecker {
                         errorAGPVersion.toString(),
                         getPotentialAGPFix(project.getRootDir().getPath())
                     )
-                throw DependencyValidationException(errorMessage)
+                throw GradleException(errorMessage)
             } else if (version < warnAGPVersion) {
                 val warnMessage: String =
                     getWarnMessage(
@@ -310,7 +310,7 @@ class DependencyVersionChecker {
                         errorKGPVersion.toString(),
                         getPotentialKGPFix(project.getRootDir().getPath())
                     )
-                throw DependencyValidationException(errorMessage)
+                throw GradleException(errorMessage)
             } else if (version < warnKGPVersion) {
                 val warnMessage: String =
                     getWarnMessage(


### PR DESCRIPTION
This reverts commit 9d1de7b674866e3c8726aa5c949200eb3eb886ea.

Reverts due to log spam and crashing of the dependency version checker (which doesn't block the build but still isn't the desired outcome).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
