### PR TITLE
Fix test case in "getRootWidgetSummaryTree" test

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2027,9 +2027,9 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
               'objectGroup': group
             },
           ))! as List<Object?>;
+          childrenJson = childJson['children']! as List<Object?>;
           expect(alternateChildrenJson.length, equals(0));
-          // Tests are failing when this typo is fixed.
-          expect(childJson['chidlren'], isNull);
+          expect(childrenJson.length, equals(0));
         });
 
         testWidgets(


### PR DESCRIPTION
The test case currently checks if a non-existent field on the JSON response from `getRootWidgetSummaryTree` is `null`. 

The field it's checking is `chidlren` when it should be `children` and the actual value is an empty list not `null`. 

- Work towards https://github.com/flutter/devtools/issues/7894
- Follow up to https://github.com/flutter/flutter/pull/149850

Noticed this while pulling some of the shared logic between multiple tests into helper functions, will be sending out a PR with those changes afterwards. 