### PR TITLE
Retain the toString method for subclasses of Key in profile/release mode

### DIFF
--- a/dev/integration_tests/release_smoke_test/lib/main.dart
+++ b/dev/integration_tests/release_smoke_test/lib/main.dart
@@ -17,6 +17,14 @@ Future<void> main() async {
   // regression test for https://github.com/flutter/flutter/issues/49601
   final List<int> computed = await compute(_utf8Encode, 'test');
   print(computed);
+
+  // regression test for https://github.com/flutter/flutter/issues/148983
+  const String value = 'testValueKey';
+  const ValueKey<String> valueKey = ValueKey<String>(value);
+  if (!valueKey.toString().contains(value)) {
+    throw Exception('ValueKey string does not contain the value');
+  }
+
   runApp(
     const Center(
       child: text,

--- a/packages/flutter/lib/src/foundation/key.dart
+++ b/packages/flutter/lib/src/foundation/key.dart
@@ -21,6 +21,7 @@ import 'diagnostics.dart';
 ///
 ///  * [Widget.key], which discusses how widgets use keys.
 @immutable
+@pragma('flutter:keep-to-string-in-subtypes')
 abstract class Key {
   /// Construct a [ValueKey<String>] with the given [String].
   ///


### PR DESCRIPTION
toString methods are removed in AOT builds by the optimization in https://github.com/flutter/flutter/pull/144763

This PR disables that for Key subclasses because some applications rely on the previous behavior.

Fixes https://github.com/flutter/flutter/issues/148983