### PR TITLE
Refactor `getRootWidgetSummaryTree` tests in `widget_inspector_test.dart`

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1916,7 +1916,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
         group('Widget Tree APIs', () {
 
-          /// Gets the widget using [WidgetInspectorServiceExtensions.getSelectedWidget] 
+          /// Gets the widget using [WidgetInspectorServiceExtensions.getSelectedWidget]
           /// for the given [element].
           Future<Map<String, dynamic>> selectedWidgetResponseForElement(
               Element element) async {
@@ -1977,7 +1977,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             ))! as List<Object?>;
           }
 
-          /// Verifies that the children from the JSON response are identical to 
+          /// Verifies that the children from the JSON response are identical to
           /// those from [WidgetInspectorServiceExtensions.getChildrenSummaryTree].
           Future<void> verifyChildrenMatchOtherApi(Map<String, Object?> jsonResponse,
               {required String group, bool checkForPreviews = false}) async {
@@ -2117,8 +2117,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             ))! as Map<String, Object?>;
 
             await verifyChildrenMatchOtherApi(
-              rootJson, 
-              group: group, 
+              rootJson,
+              group: group,
               checkForPreviews: true,
             );
           });


### PR DESCRIPTION
Pulls shared logic out of the two test cases into helper functions:
* `ext.flutter.inspector.getRootWidgetSummaryTree`
* `ext.flutter.inspector.getRootWidgetSummaryTreeWithPreviews`

Also adds a lot of comments to make it clearer what these tests are actually testing. 

- Work towards https://github.com/flutter/devtools/issues/7894
- Follow up to https://github.com/flutter/flutter/pull/149850
