### PR TITLE
Leaky test investigation.

### DIFF
--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -1384,7 +1384,7 @@ void main() {
       expect(find.text('Page 2 of tab 2'), findsNothing);
       expect(lastFrameworkHandlesBack, isFalse);
       testEnded = true;
-      print('!!! test testEnded');
+      print('!!! test ended');
     },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
       skip: kIsWeb, // [intended] frameworkHandlesBack not used on web.

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
@@ -1286,6 +1287,13 @@ void main() {
     testWidgets('System back navigation inside of tabs',
     // experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
     (WidgetTester tester) async {
+      addTearDown((){
+        print('!!! looping handleEventLoopCallback');
+        while(SchedulerBinding.instance.handleEventLoopCallback()){
+          print('!!! handleEventLoopCallback returned true');
+        }
+        print('!!! loop handleEventLoopCallback completed');
+      });
       testStarted = true;
       print('!!! test started');
       await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -1284,16 +1284,21 @@ void main() {
           .setMockMethodCallHandler(SystemChannels.platform, null);
     });
 
+    void _completeCallbacks(){
+      print('!!! looping handleEventLoopCallback');
+      while(SchedulerBinding.instance.handleEventLoopCallback()){
+        print('!!! handleEventLoopCallback returned true');
+      }
+      print('!!! loop handleEventLoopCallback completed');
+    }
+
+    tearDownAll(() {
+      _completeCallbacks();
+    });
+
     testWidgets('System back navigation inside of tabs',
     // experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
     (WidgetTester tester) async {
-      addTearDown((){
-        print('!!! looping handleEventLoopCallback');
-        while(SchedulerBinding.instance.handleEventLoopCallback()){
-          print('!!! handleEventLoopCallback returned true');
-        }
-        print('!!! loop handleEventLoopCallback completed');
-      });
       testStarted = true;
       print('!!! test started');
       await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+import 'package:meta/meta.dart';
 
 import '../image_data.dart';
 import '../rendering/rendering_tester.dart' show TestCallbackPainter;
@@ -41,7 +42,7 @@ class MockCupertinoTabController extends CupertinoTabController {
 
 void main() {
   // TODO(polina-c): dispose ImageStreamCompleterHandle, https://github.com/flutter/flutter/issues/145599 [leaks-to-clean]
-  LeakTesting.settings = LeakTesting.settings.withIgnoredAll();
+  //LeakTesting.settings = LeakTesting.settings.withIgnoredAll();
 
   setUp(() {
     selectedTabs = <int>[];
@@ -1277,11 +1278,16 @@ void main() {
     });
 
     tearDown(() {
+      imageCache.clear();
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null);
     });
 
-    testWidgets('System back navigation inside of tabs', (WidgetTester tester) async {
+    testWidgets('System back navigation inside of tabs',
+    // experimentalLeakTesting: LeakTesting.settings.withCreationStackTrace(),
+    (WidgetTester tester) async {
+      testStarted = true;
+      print('!!! test started');
       await tester.pumpWidget(
         CupertinoApp(
           home: MediaQuery(
@@ -1377,6 +1383,8 @@ void main() {
       expect(find.text('Page 1 of tab 2'), findsOneWidget);
       expect(find.text('Page 2 of tab 2'), findsNothing);
       expect(lastFrameworkHandlesBack, isFalse);
+      testEnded = true;
+      print('!!! test testEnded');
     },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
       skip: kIsWeb, // [intended] frameworkHandlesBack not used on web.


### PR DESCRIPTION
`flutter test test/cupertino/tab_scaffold_test.dart --dart-define LEAK_TRACKING=true`

I tried to turn off scheduling for idle. It failed with usage of images after disposal: https://github.com/flutter/flutter/pull/149964

Output from this PR with debug prints:
```
!!! test started
!!! created handle: 768279805
!!! created handle: 104331199
!!! test ended
!!! scheduled for dispose: 768279805, SchedulerPhase.idle
!!! scheduled for dispose: 104331199, SchedulerPhase.idle
00:04 +26: Android Predictive Back (tearDownAll)                                                                                                                                                                        
!!! looping handleEventLoopCallback
!!! loop handleEventLoopCallback completed
00:04 +26 -1: (tearDownAll) [E]                                                                                                                                                                                         
  Expected: leak free
    Actual: <Instance of 'Leaks'>
     Which: contains leaks:
            # The text is generated by leak_tracker.
            # For leak troubleshooting tips open:
            # https://github.com/dart-lang/leak_tracker/blob/main/doc/TROUBLESHOOT.md
            notDisposed:
              total: 2
              objects:
                ImageStreamCompleterHandle:
                  test: System back navigation inside of tabs (variant: TargetPlatform.android)
                  identityHashCode: 768279805
                ImageStreamCompleterHandle:
                  test: System back navigation inside of tabs (variant: TargetPlatform.android)
                  identityHashCode: 104331199
```