### PR TITLE
Implementing `AnimationController.toggle()`

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/color_filter_and_fade.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/color_filter_and_fade.dart
@@ -96,10 +96,8 @@ class _ColorFilterAndFadePageState extends State<ColorFilterAndFadePage> with Ti
     _controller = AnimationController(duration: const Duration(seconds: 3), vsync: this);
     _opacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(_controller);
     _opacityAnimation.addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.completed) {
-        _controller.reverse();
-      } else if (status == AnimationStatus.dismissed) {
-        _controller.forward();
+      if (!status.isAnimating) {
+        _controller.toggle();
       }
     });
     _controller.forward();

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -143,7 +143,7 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
               ],
               margin: EdgeInsets.zero,
               onDetailsPressed: () {
-                _controller.toggle(_showDrawerContents);
+                _controller.toggle(forward: _showDrawerContents);
                 _showDrawerContents = !_showDrawerContents;
               },
             ),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -143,12 +143,8 @@ class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {
               ],
               margin: EdgeInsets.zero,
               onDetailsPressed: () {
+                _controller.toggle(_showDrawerContents);
                 _showDrawerContents = !_showDrawerContents;
-                if (_showDrawerContents) {
-                  _controller.reverse();
-                } else {
-                  _controller.forward();
-                }
               },
             ),
             MediaQuery.removePadding(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -33,10 +33,8 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with Sing
       curve: const Interval(0.0, 0.9, curve: Curves.fastOutSlowIn),
       reverseCurve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.dismissed) {
-        _controller.forward();
-      } else if (status == AnimationStatus.completed) {
-        _controller.reverse();
+      if (!status.isAnimating) {
+        _controller.toggle();
       }
     });
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
@@ -46,7 +46,7 @@ class _ShrineAppState extends State<ShrineApp> with SingleTickerProviderStateMix
       home: HomePage(
         backdrop: Backdrop(
           frontLayer: const ProductPage(),
-          backLayer: CategoryMenuPage(onCategoryTap: () => _controller.forward()),
+          backLayer: CategoryMenuPage(onCategoryTap: _controller.forward),
           frontTitle: const Text('SHRINE'),
           backTitle: const Text('MENU'),
           controller: _controller,

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
@@ -230,15 +230,10 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
     super.dispose();
   }
 
-  bool get _frontLayerVisible {
-    final AnimationStatus status = _controller!.status;
-    return status == AnimationStatus.completed || status == AnimationStatus.forward;
-  }
-
   void _toggleBackdropLayerVisibility() {
     // Call setState here to update layerAnimation if that's necessary
     setState(() {
-      _frontLayerVisible ? _controller!.reverse() : _controller!.forward();
+      _controller!.toggle();
     });
   }
 
@@ -252,7 +247,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
     double secondWeight; // Weight of second TweenSequenceItem
     Animation<double> animation; // Animation on which TweenSequence runs
 
-    if (_frontLayerVisible) {
+    if (_controller!.isForwardOrCompleted) {
       firstCurve = _kAccelerateCurve;
       secondCurve = _kDecelerateCurve;
       firstWeight = _kPeakVelocityTime;

--- a/dev/integration_tests/new_gallery/lib/demos/material/progress_indicator_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/material/progress_indicator_demo.dart
@@ -36,10 +36,8 @@ class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo>
       curve: const Interval(0.0, 0.9, curve: Curves.fastOutSlowIn),
       reverseCurve: Curves.fastOutSlowIn,
     )..addStatusListener((AnimationStatus status) {
-        if (status == AnimationStatus.dismissed) {
-          _controller.forward();
-        } else if (status == AnimationStatus.completed) {
-          _controller.reverse();
+        if (!status.isAnimating) {
+          _controller.toggle();
         }
       });
   }

--- a/dev/integration_tests/new_gallery/lib/demos/reference/motion_demo_fade_scale_transition.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/reference/motion_demo_fade_scale_transition.dart
@@ -43,17 +43,6 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
     super.dispose();
   }
 
-  bool get _isAnimationRunningForwardsOrComplete {
-    switch (_controller.status) {
-      case AnimationStatus.forward:
-      case AnimationStatus.completed:
-        return true;
-      case AnimationStatus.reverse:
-      case AnimationStatus.dismissed:
-        return false;
-    }
-  }
-
   Widget _showExampleAlertDialog() {
     return Theme(
       data: Theme.of(context),
@@ -116,15 +105,9 @@ class _FadeScaleTransitionDemoState extends State<FadeScaleTransitionDemo>
                 ),
                 const SizedBox(width: 10),
                 ElevatedButton(
-                  onPressed: () {
-                    if (_isAnimationRunningForwardsOrComplete) {
-                      _controller.reverse();
-                    } else {
-                      _controller.forward();
-                    }
-                  },
+                  onPressed: _controller.toggle,
                   child: Text(
-                    _isAnimationRunningForwardsOrComplete
+                    _controller.isForwardOrCompleted
                         ? localizations.demoFadeScaleHideFabButton
                         : localizations.demoFadeScaleShowFabButton,
                   ),

--- a/dev/integration_tests/new_gallery/lib/pages/category_list_item.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/category_list_item.dart
@@ -93,7 +93,7 @@ class _CategoryListItemState extends State<CategoryListItem>
 
   void _handleTap() {
     final bool shouldOpenList = _controller.isDismissed;
-    _controller.toggle(shouldOpenList);
+    _controller.toggle(forward: shouldOpenList);
     widget.onTap?.call(shouldOpenList);
   }
 

--- a/dev/integration_tests/new_gallery/lib/pages/category_list_item.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/category_list_item.dart
@@ -92,17 +92,9 @@ class _CategoryListItemState extends State<CategoryListItem>
   }
 
   void _handleTap() {
-    if (_controller.isDismissed) {
-      _controller.forward();
-      if (widget.onTap != null) {
-        widget.onTap!(true);
-      }
-    } else {
-      _controller.reverse();
-      if (widget.onTap != null) {
-        widget.onTap!(false);
-      }
-    }
+    final bool shouldOpenList = _controller.isDismissed;
+    _controller.toggle(shouldOpenList);
+    widget.onTap?.call(shouldOpenList);
   }
 
   Widget _buildHeaderWithChildren(BuildContext context, Widget? child) {

--- a/dev/integration_tests/new_gallery/lib/pages/demo.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/demo.dart
@@ -133,11 +133,9 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
   void setStateAndUpdate(VoidCallback callback) {
     setState(() {
       callback();
-      if (_demoStateIndex.value == _DemoState.code.index) {
-        _codeBackgroundColorController.forward();
-      } else {
-        _codeBackgroundColorController.reverse();
-      }
+      _codeBackgroundColorController.toggle(
+        _demoStateIndex.value == _DemoState.code.index,
+      );
     });
   }
 

--- a/dev/integration_tests/new_gallery/lib/pages/demo.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/demo.dart
@@ -134,7 +134,7 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
     setState(() {
       callback();
       _codeBackgroundColorController.toggle(
-        _demoStateIndex.value == _DemoState.code.index,
+        forward: _demoStateIndex.value == _DemoState.code.index,
       );
     });
   }

--- a/dev/integration_tests/new_gallery/lib/pages/home.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/home.dart
@@ -360,9 +360,7 @@ class _AnimatedHomePageState extends State<_AnimatedHomePage>
       // Start our animation halfway through the splash page animation.
       _launchTimer = Timer(
         halfSplashPageAnimationDuration,
-        () {
-          _animationController.forward();
-        },
+        _animationController.forward,
       );
     }
   }

--- a/dev/integration_tests/new_gallery/lib/pages/splash.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/splash.dart
@@ -65,11 +65,6 @@ class _SplashPageState extends State<SplashPage>
     10: 6,
   };
 
-  bool get _isSplashVisible {
-    return _controller.status == AnimationStatus.completed ||
-        _controller.status == AnimationStatus.forward;
-  }
-
   @override
   void initState() {
     super.initState();
@@ -77,11 +72,10 @@ class _SplashPageState extends State<SplashPage>
     // If the number of included effects changes, this number should be changed.
     _effect = _random.nextInt(_effectDurations.length) + 1;
 
-    _controller =
-        AnimationController(duration: splashPageAnimationDuration, vsync: this)
-          ..addListener(() {
-            setState(() {});
-          });
+    _controller = AnimationController(
+      duration: splashPageAnimationDuration,
+      vsync: this,
+    )..addListener(() => setState(() {}));
   }
 
   @override
@@ -104,6 +98,8 @@ class _SplashPageState extends State<SplashPage>
 
   @override
   Widget build(BuildContext context) {
+    final bool isSplashVisible = _controller.isForwardOrCompleted;
+
     return NotificationListener<ToggleSplashNotification>(
       onNotification: (_) {
         _controller.forward();
@@ -115,7 +111,7 @@ class _SplashPageState extends State<SplashPage>
           builder: (BuildContext context, BoxConstraints constraints) {
             final Animation<RelativeRect> animation = _getPanelAnimation(context, constraints);
             Widget frontLayer = widget.child;
-            if (_isSplashVisible) {
+            if (isSplashVisible) {
               frontLayer = MouseRegion(
                 cursor: SystemMouseCursors.click,
                 child: GestureDetector(
@@ -146,7 +142,7 @@ class _SplashPageState extends State<SplashPage>
             return Stack(
               children: <Widget>[
                 _SplashBackLayer(
-                  isSplashCollapsed: !_isSplashVisible,
+                  isSplashCollapsed: !isSplashVisible,
                   effect: _effect,
                   onTap: _controller.forward,
                 ),

--- a/dev/integration_tests/new_gallery/lib/studies/rally/home.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/rally/home.dart
@@ -306,7 +306,7 @@ class _RallyTabState extends State<_RallyTab>
   @override
   void didUpdateWidget(_RallyTab oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _controller.toggle(widget.isExpanded);
+    _controller.toggle(forward: widget.isExpanded);
   }
 
   @override

--- a/dev/integration_tests/new_gallery/lib/studies/rally/home.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/rally/home.dart
@@ -306,11 +306,7 @@ class _RallyTabState extends State<_RallyTab>
   @override
   void didUpdateWidget(_RallyTab oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.isExpanded) {
-      _controller.forward();
-    } else {
-      _controller.reverse();
-    }
+    _controller.toggle(widget.isExpanded);
   }
 
   @override

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/app.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/app.dart
@@ -100,7 +100,7 @@ class _ShrineAppState extends State<ShrineApp>
   Widget mobileBackdrop() {
     return Backdrop(
       frontLayer: const ProductPage(),
-      backLayer: CategoryMenuPage(onCategoryTap: () => _controller.forward()),
+      backLayer: CategoryMenuPage(onCategoryTap: _controller.forward),
       frontTitle: const Text('SHRINE'),
       backTitle: Text(GalleryLocalizations.of(context)!.shrineMenuCaption),
       controller: _controller,

--- a/dev/integration_tests/new_gallery/lib/studies/shrine/backdrop.dart
+++ b/dev/integration_tests/new_gallery/lib/studies/shrine/backdrop.dart
@@ -209,16 +209,12 @@ class _BackdropState extends State<Backdrop>
     _controller = widget.controller;
   }
 
-  bool get _frontLayerVisible {
-    final AnimationStatus status = _controller.status;
-    return status == AnimationStatus.completed ||
-        status == AnimationStatus.forward;
-  }
+  bool get _frontLayerVisible => _controller.isForwardOrCompleted;
 
   void _toggleBackdropLayerVisibility() {
     // Call setState here to update layerAnimation if that's necessary
     setState(() {
-      _frontLayerVisible ? _controller.reverse() : _controller.forward();
+      _controller.toggle();
     });
   }
 

--- a/examples/api/lib/material/animated_icon/animated_icon.0.dart
+++ b/examples/api/lib/material/animated_icon/animated_icon.0.dart
@@ -44,9 +44,7 @@ class _AnimatedIconExampleState extends State<AnimatedIconExample> with SingleTi
     controller = AnimationController(
       vsync: this,
       duration: const Duration(seconds: 2),
-    )
-      ..forward()
-      ..repeat(reverse: true);
+    )..repeat(reverse: true);
     animation = Tween<double>(begin: 0.0, end: 1.0).animate(controller);
   }
 

--- a/examples/api/lib/material/animated_icon/animated_icons_data.0.dart
+++ b/examples/api/lib/material/animated_icon/animated_icons_data.0.dart
@@ -52,20 +52,12 @@ class AnimatedIconExample extends StatefulWidget {
 }
 
 class _AnimatedIconExampleState extends State<AnimatedIconExample> with SingleTickerProviderStateMixin {
-  late AnimationController controller;
-  late Animation<double> animation;
+  late AnimationController controller = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 2),
+  )..repeat(reverse: true);
 
-  @override
-  void initState() {
-    super.initState();
-    controller = AnimationController(
-      vsync: this,
-      duration: const Duration(seconds: 2),
-    )
-      ..forward()
-      ..repeat(reverse: true);
-    animation = Tween<double>(begin: 0.0, end: 1.0).animate(controller);
-  }
+  late Animation<double> animation = Tween<double>(begin: 0.0, end: 1.0).animate(controller);
 
   @override
   void dispose() {

--- a/examples/api/lib/material/progress_indicator/circular_progress_indicator.1.dart
+++ b/examples/api/lib/material/progress_indicator/circular_progress_indicator.1.dart
@@ -85,9 +85,7 @@ class _ProgressIndicatorExampleState extends State<ProgressIndicatorExample> wit
                       if (determinate) {
                         controller.stop();
                       } else {
-                        controller
-                          ..forward(from: controller.value)
-                          ..repeat();
+                        controller.repeat();
                       }
                     });
                   },

--- a/examples/api/lib/material/progress_indicator/linear_progress_indicator.1.dart
+++ b/examples/api/lib/material/progress_indicator/linear_progress_indicator.1.dart
@@ -85,9 +85,7 @@ class _ProgressIndicatorExampleState extends State<ProgressIndicatorExample> wit
                       if (determinate) {
                         controller.stop();
                       } else {
-                        controller
-                          ..forward(from: controller.value)
-                          ..repeat();
+                        controller.repeat();
                       }
                     });
                   },

--- a/examples/api/lib/widgets/basic/flow.0.dart
+++ b/examples/api/lib/widgets/basic/flow.0.dart
@@ -68,7 +68,7 @@ class _FlowMenuState extends State<FlowMenu> with SingleTickerProviderStateMixin
         constraints: BoxConstraints.tight(Size(buttonDiameter, buttonDiameter)),
         onPressed: () {
           _updateMenu(icon);
-          menuAnimation.status == AnimationStatus.completed ? menuAnimation.reverse() : menuAnimation.forward();
+          menuAnimation.toggle(!menuAnimation.isCompleted);
         },
         child: Icon(
           icon,

--- a/examples/api/lib/widgets/basic/flow.0.dart
+++ b/examples/api/lib/widgets/basic/flow.0.dart
@@ -68,7 +68,7 @@ class _FlowMenuState extends State<FlowMenu> with SingleTickerProviderStateMixin
         constraints: BoxConstraints.tight(Size(buttonDiameter, buttonDiameter)),
         onPressed: () {
           _updateMenu(icon);
-          menuAnimation.toggle(!menuAnimation.isCompleted);
+          menuAnimation.toggle(forward: !menuAnimation.isCompleted);
         },
         child: Icon(
           icon,

--- a/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
@@ -45,10 +45,8 @@ class _SliverFadeTransitionExampleState extends State<SliverFadeTransitionExampl
   void initState() {
     super.initState();
     animation.addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.completed) {
-        controller.reverse();
-      } else if (status == AnimationStatus.dismissed) {
-        controller.forward();
+      if (!status.isAnimating) {
+        controller.toggle();
       }
     });
     controller.forward();

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -520,16 +520,17 @@ class AnimationController extends Animation<double>
 
   /// Toggles the direction of this animation.
   ///
-  /// The value of [newDirection] should toggle between `true` and `false`, and
-  /// [toggle] should be called each time it changes. This function acts like [forward]
-  /// when the [newDirection] is `true`, and [reverse] when it's `false`.
+  /// The value of `forward` should toggle between `true` and `false`, and
+  /// `toggle()` should be called each time it changes. This function acts
+  /// like `forward()` or `reverse()` based on whether the value passed is
+  /// `true` or `false`, respectively.
   ///
-  /// If no [newDirection] is provided, the controller changes direction each time,
+  /// If no argument is provided, the controller changes direction every time,
   /// based on the current [status].
   ///
   /// {@macro flutter.animation.AnimationController.ticker_canceled}
-  TickerFuture toggle([ bool? newDirection ]) {
-    return _toggle('toggle', newDirection ?? !isForwardOrCompleted, null);
+  TickerFuture toggle({ bool? forward }) {
+    return _toggle('toggle', forward ?? !isForwardOrCompleted, null);
   }
 
   /// Drives the animation from its current value to target.

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -261,8 +261,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
     }
 
     if (oldWidget.groupValue != widget.groupValue) {
-      int index = 0;
-      for (final T key in widget.children.keys) {
+      for (final (int index, T key) in widget.children.keys.indexed) {
         if (widget.groupValue == key) {
           _childTweens[index] = _forwardBackgroundColorTween;
           _selectionControllers[index].forward();
@@ -270,7 +269,6 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
           _childTweens[index] = _reverseBackgroundColorTween;
           _selectionControllers[index].reverse();
         }
-        index += 1;
       }
     }
   }

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -430,8 +430,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
         });
       }
       resolvedBackgroundColor = backgroundColor; // Defer changing the background color.
-      controller!.value = 0;
-      controller!.forward();
+      controller!.forward(from: 0);
     }
     elevation = resolvedElevation;
     backgroundColor = resolvedBackgroundColor;

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -410,7 +410,7 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
   void didUpdateWidget(_DatePickerModeToggleButton oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.mode != widget.mode) {
-      _controller.toggle(widget.mode == DatePickerMode.year);
+      _controller.toggle(forward: widget.mode == DatePickerMode.year);
     }
   }
 

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -409,14 +409,8 @@ class _DatePickerModeToggleButtonState extends State<_DatePickerModeToggleButton
   @override
   void didUpdateWidget(_DatePickerModeToggleButton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.mode == widget.mode) {
-      return;
-    }
-
-    if (widget.mode == DatePickerMode.year) {
-      _controller.forward();
-    } else {
-      _controller.reverse();
+    if (oldWidget.mode != widget.mode) {
+      _controller.toggle(widget.mode == DatePickerMode.year);
     }
   }
 

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1209,23 +1209,23 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     if (oldWidget.isEnabled != widget.isEnabled) {
       setState(() {
         setMaterialState(MaterialState.disabled, !widget.isEnabled);
-        enableController.toggle(widget.isEnabled);
+        enableController.toggle(forward: widget.isEnabled);
       });
     }
     if (oldWidget.avatar != widget.avatar || oldWidget.selected != widget.selected) {
       setState(() {
-        avatarDrawerController.toggle(hasAvatar || widget.selected);
+        avatarDrawerController.toggle(forward: hasAvatar || widget.selected);
       });
     }
     if (oldWidget.selected != widget.selected) {
       setState(() {
         setMaterialState(MaterialState.selected, widget.selected);
-        selectController.toggle(widget.selected);
+        selectController.toggle(forward: widget.selected);
       });
     }
     if (oldWidget.onDeleted != widget.onDeleted) {
       setState(() {
-        deleteDrawerController.toggle(hasDeleteButton);
+        deleteDrawerController.toggle(forward: hasDeleteButton);
       });
     }
   }

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1209,39 +1209,23 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     if (oldWidget.isEnabled != widget.isEnabled) {
       setState(() {
         setMaterialState(MaterialState.disabled, !widget.isEnabled);
-        if (widget.isEnabled) {
-          enableController.forward();
-        } else {
-          enableController.reverse();
-        }
+        enableController.toggle(widget.isEnabled);
       });
     }
     if (oldWidget.avatar != widget.avatar || oldWidget.selected != widget.selected) {
       setState(() {
-        if (hasAvatar || widget.selected) {
-          avatarDrawerController.forward();
-        } else {
-          avatarDrawerController.reverse();
-        }
+        avatarDrawerController.toggle(hasAvatar || widget.selected);
       });
     }
     if (oldWidget.selected != widget.selected) {
       setState(() {
         setMaterialState(MaterialState.selected, widget.selected);
-        if (widget.selected) {
-          selectController.forward();
-        } else {
-          selectController.reverse();
-        }
+        selectController.toggle(widget.selected);
       });
     }
     if (oldWidget.onDeleted != widget.onDeleted) {
       setState(() {
-        if (hasDeleteButton) {
-          deleteDrawerController.forward();
-        } else {
-          deleteDrawerController.reverse();
-        }
+        deleteDrawerController.toggle(hasDeleteButton);
       });
     }
   }

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1343,10 +1343,10 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
         _orientationOffset = newUp! ? 0.0 : math.pi;
         skipArrow = true;
       }
-      _opacityController.toggle(widget.visible);
+      _opacityController.toggle(forward: widget.visible);
     }
     if ((_up != newUp) && !skipArrow) {
-      _orientationController.toggle(_orientationController.isDismissed);
+      _orientationController.toggle(forward: _orientationController.isDismissed);
     }
     _up = newUp;
   }

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1343,18 +1343,10 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
         _orientationOffset = newUp! ? 0.0 : math.pi;
         skipArrow = true;
       }
-      if (widget.visible) {
-        _opacityController.forward();
-      } else {
-        _opacityController.reverse();
-      }
+      _opacityController.toggle(widget.visible);
     }
     if ((_up != newUp) && !skipArrow) {
-      if (_orientationController.isDismissed) {
-        _orientationController.forward();
-      } else {
-        _orientationController.reverse();
-      }
+      _orientationController.toggle(_orientationController.isDismissed);
     }
     _up = newUp;
   }

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -145,11 +145,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
   void didUpdateWidget(ExpandIcon oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.isExpanded != oldWidget.isExpanded) {
-      if (widget.isExpanded) {
-        _controller.forward();
-      } else {
-        _controller.reverse();
-      }
+      _controller.toggle(widget.isExpanded);
     }
   }
 

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -145,7 +145,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
   void didUpdateWidget(ExpandIcon oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.isExpanded != oldWidget.isExpanded) {
-      _controller.toggle(widget.isExpanded);
+      _controller.toggle(forward: widget.isExpanded);
     }
   }
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -242,19 +242,13 @@ class _BorderContainerState extends State<_BorderContainer> with TickerProviderS
         begin: oldWidget.border,
         end: widget.border,
       );
-      _controller
-        ..value = 0.0
-        ..forward();
+      _controller.forward(from: 0.0);
     }
     if (widget.hoverColor != oldWidget.hoverColor) {
       _hoverColorTween = ColorTween(begin: Colors.transparent, end: widget.hoverColor);
     }
     if (widget.isHovering != oldWidget.isHovering) {
-      if (widget.isHovering) {
-        _hoverColorController.forward();
-      } else {
-        _hoverColorController.reverse();
-      }
+      _hoverColorController.toggle(widget.isHovering);
     }
   }
 
@@ -400,15 +394,13 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
     final bool helperTextStateChanged = newErrorText == null && (newHelperText != null) != (oldHelperText != null);
 
     if (errorStateChanged || errorTextStateChanged || helperStateChanged || helperTextStateChanged) {
-      if (newError != null || newErrorText != null) {
+      final bool hasError = newError != null || newErrorText != null;
+      if (hasError) {
         _error = _buildError();
-        _controller.forward();
       } else if (newHelper != null || newHelperText != null) {
         _helper = _buildHelper();
-        _controller.reverse();
-      } else {
-        _controller.reverse();
       }
+      _controller.toggle(hasError);
     }
   }
 
@@ -1950,20 +1942,16 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviorChanged) {
-      if (_floatingLabelEnabled && widget._labelShouldWithdraw) {
-        _floatingLabelController.forward();
-      } else {
-        _floatingLabelController.reverse();
-      }
+      _floatingLabelController.toggle(
+        _floatingLabelEnabled && widget._labelShouldWithdraw,
+      );
     }
 
     final String? errorText = decoration.errorText;
     final String? oldErrorText = old.decoration.errorText;
 
     if (_floatingLabelController.isCompleted && errorText != null && errorText != oldErrorText) {
-      _shakingLabelController
-        ..value = 0.0
-        ..forward();
+      _shakingLabelController.forward(from: 0.0);
     }
   }
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -248,7 +248,7 @@ class _BorderContainerState extends State<_BorderContainer> with TickerProviderS
       _hoverColorTween = ColorTween(begin: Colors.transparent, end: widget.hoverColor);
     }
     if (widget.isHovering != oldWidget.isHovering) {
-      _hoverColorController.toggle(widget.isHovering);
+      _hoverColorController.toggle(forward: widget.isHovering);
     }
   }
 
@@ -400,7 +400,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
       } else if (newHelper != null || newHelperText != null) {
         _helper = _buildHelper();
       }
-      _controller.toggle(hasError);
+      _controller.toggle(forward: hasError);
     }
   }
 
@@ -1943,7 +1943,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviorChanged) {
       _floatingLabelController.toggle(
-        _floatingLabelEnabled && widget._labelShouldWithdraw,
+        forward: _floatingLabelEnabled && widget._labelShouldWithdraw,
       );
     }
 

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -411,9 +411,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
                 final MergeableMaterialItem newChild = newChildren[k];
                 if (newChild is MaterialGap) {
                   _animationTuples[newChild.key]!.gapStart = gapSize * newChild.size / gapSizeSum;
-                  _animationTuples[newChild.key]!.controller
-                    ..value = 0.0
-                    ..forward();
+                  _animationTuples[newChild.key]!.controller.forward(from: 0.0);
                 }
               }
             }
@@ -453,18 +451,18 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
                 size: gapSizeSum,
               );
               _insertChild(startOld, gap);
-              _animationTuples[gap.key]!.gapStart = 0.0;
-              _animationTuples[gap.key]!.controller
-                ..value = 1.0
-                ..reverse();
+              _animationTuples[gap.key]!
+                ..gapStart = 0.0
+                ..controller.reverse(from: 1.0);
 
               j += 1;
             }
           } else if (oldLength == 1) {
             // Shrink gap.
             final MaterialGap gap = _children[startOld] as MaterialGap;
-            _animationTuples[gap.key]!.gapStart = 0.0;
-            _animationTuples[gap.key]!.controller.reverse();
+            _animationTuples[gap.key]!
+              ..gapStart = 0.0
+              ..controller.reverse();
           }
         }
       } else {

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -661,7 +661,7 @@ class _SelectableAnimatedBuilderState extends State<_SelectableAnimatedBuilder>
       _controller.duration = widget.duration;
     }
     if (oldWidget.isSelected != widget.isSelected) {
-      _controller.toggle(widget.isSelected);
+      _controller.toggle(forward: widget.isSelected);
     }
   }
 

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -661,11 +661,7 @@ class _SelectableAnimatedBuilderState extends State<_SelectableAnimatedBuilder>
       _controller.duration = widget.duration;
     }
     if (oldWidget.isSelected != widget.isSelected) {
-      if (widget.isSelected) {
-        _controller.forward();
-      } else {
-        _controller.reverse();
-      }
+      _controller.toggle(widget.isSelected);
     }
   }
 

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -371,7 +371,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
     super.didUpdateWidget(oldWidget);
 
     if (widget.extended != oldWidget.extended) {
-      _extendedController.toggle(widget.extended);
+      _extendedController.toggle(forward: widget.extended);
     }
 
     // No animated segue if the length of the items list changes.

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -371,11 +371,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
     super.didUpdateWidget(oldWidget);
 
     if (widget.extended != oldWidget.extended) {
-      if (widget.extended) {
-        _extendedController.forward();
-      } else {
-        _extendedController.reverse();
-      }
+      _extendedController.toggle(widget.extended);
     }
 
     // No animated segue if the length of the items list changes.

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -539,7 +539,7 @@ class _CheckedPopupMenuItemState<T> extends PopupMenuItemState<T, CheckedPopupMe
   @override
   void handleTap() {
     // This fades the checkmark in or out when tapped.
-    _controller.toggle(!widget.checked);
+    _controller.toggle(forward: !widget.checked);
     super.handleTap();
   }
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -539,11 +539,7 @@ class _CheckedPopupMenuItemState<T> extends PopupMenuItemState<T, CheckedPopupMe
   @override
   void handleTap() {
     // This fades the checkmark in or out when tapped.
-    if (widget.checked) {
-      _controller.reverse();
-    } else {
-      _controller.forward();
-    }
+    _controller.toggle(!widget.checked);
     super.handleTap();
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -484,11 +484,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     final bool wasEnabled = oldWidget.onChanged != null;
     final bool isEnabled = _enabled;
     if (wasEnabled != isEnabled) {
-      if (isEnabled) {
-        enableController.forward();
-      } else {
-        enableController.reverse();
-      }
+      enableController.toggle(isEnabled);
     }
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -484,7 +484,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     final bool wasEnabled = oldWidget.onChanged != null;
     final bool isEnabled = _enabled;
     if (wasEnabled != isEnabled) {
-      enableController.toggle(isEnabled);
+      enableController.toggle(forward: isEnabled);
     }
   }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1391,9 +1391,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
         // the previous controller and run an exit animation for the previous
         // widget before running the entrance animation for the new child.
         _previousChild = oldWidget.child;
-        _previousController
-          ..value = currentValue
-          ..reverse();
+        _previousController.reverse(from: currentValue);
         widget.currentController.value = 0.0;
       }
     }

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1296,11 +1296,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final bool wasInteractive = isInteractive;
     _onChanged = value;
     if (wasInteractive != isInteractive) {
-      if (isInteractive) {
-        _state.enableController.forward();
-      } else {
-        _state.enableController.reverse();
-      }
+      _state.enableController.toggle(isInteractive);
       markNeedsPaint();
       markNeedsSemanticsUpdate();
     }
@@ -1382,11 +1378,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // Only show overlay when pointer is hovering the thumb.
     if (hovered && hoveringThumb) {
       _state.overlayController.forward();
-    } else {
+    } else if (!_active && !hasFocus) {
       // Only remove overlay when Slider is inactive and unfocused.
-      if (!_active && !hasFocus) {
-        _state.overlayController.reverse();
-      }
+      _state.overlayController.reverse();
     }
   }
 

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1296,7 +1296,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final bool wasInteractive = isInteractive;
     _onChanged = value;
     if (wasInteractive != isInteractive) {
-      _state.enableController.toggle(isInteractive);
+      _state.enableController.toggle(forward: isInteractive);
       markNeedsPaint();
       markNeedsSemanticsUpdate();
     }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1133,9 +1133,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
       tween
         ..begin = beginValue
         ..end = target;
-      controller
-        ..value = 0
-        ..forward();
+      controller.forward(from: 0);
     }
 
     animateToValue(

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -122,15 +122,9 @@ class _AccountDetailsState extends State<_AccountDetails> with SingleTickerProvi
   @override
   void didUpdateWidget (_AccountDetails oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // If the state of the arrow did not change, there is no need to trigger the animation
-    if (oldWidget.isOpen == widget.isOpen) {
-      return;
-    }
-
-    if (widget.isOpen) {
-      _controller.forward();
-    } else {
-      _controller.reverse();
+    // Triggering the animation is only necessary when the state of the arrow changes.
+    if (oldWidget.isOpen != widget.isOpen) {
+      _controller.toggle(widget.isOpen);
     }
   }
 

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -124,7 +124,7 @@ class _AccountDetailsState extends State<_AccountDetails> with SingleTickerProvi
     super.didUpdateWidget(oldWidget);
     // Triggering the animation is only necessary when the state of the arrow changes.
     if (oldWidget.isOpen != widget.isOpen) {
-      _controller.toggle(widget.isOpen);
+      _controller.toggle(forward: widget.isOpen);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -394,9 +394,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
         _updateTween(tween, targetValue);
         return tween;
       });
-      _controller
-        ..value = 0.0
-        ..forward();
+      _controller.forward(from: 0.0);
       didUpdateTweens();
     }
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1777,7 +1777,7 @@ class _SelectionToolbarWrapperState extends State<_SelectionToolbarWrapper> with
     super.dispose();
   }
 
-  void _toolbarVisibilityChanged() => _controller.toggle(widget.visibility?.value ?? true);
+  void _toolbarVisibilityChanged() => _controller.toggle(forward: widget.visibility?.value ?? true);
 
   @override
   Widget build(BuildContext context) {
@@ -1843,7 +1843,7 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay> with S
     widget.visibility?.addListener(_handleVisibilityChanged);
   }
 
-  void _handleVisibilityChanged() => _controller.toggle(widget.visibility?.value ?? true);
+  void _handleVisibilityChanged() => _controller.toggle(forward: widget.visibility?.value ?? true);
 
   @override
   void didUpdateWidget(_SelectionHandleOverlay oldWidget) {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1777,13 +1777,7 @@ class _SelectionToolbarWrapperState extends State<_SelectionToolbarWrapper> with
     super.dispose();
   }
 
-  void _toolbarVisibilityChanged() {
-    if (widget.visibility?.value ?? true) {
-      _controller.forward();
-    } else {
-      _controller.reverse();
-    }
-  }
+  void _toolbarVisibilityChanged() => _controller.toggle(widget.visibility?.value ?? true);
 
   @override
   Widget build(BuildContext context) {
@@ -1849,13 +1843,7 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay> with S
     widget.visibility?.addListener(_handleVisibilityChanged);
   }
 
-  void _handleVisibilityChanged() {
-    if (widget.visibility?.value ?? true) {
-      _controller.forward();
-    } else {
-      _controller.reverse();
-    }
-  }
+  void _handleVisibilityChanged() => _controller.toggle(widget.visibility?.value ?? true);
 
   @override
   void didUpdateWidget(_SelectionHandleOverlay oldWidget) {

--- a/packages/flutter/lib/src/widgets/toggleable.dart
+++ b/packages/flutter/lib/src/widgets/toggleable.dart
@@ -196,7 +196,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
     if (tristate && value == null) {
       _positionController.value = 0.0;
     }
-    _positionController.toggle(value ?? tristate);
+    _positionController.toggle(forward: value ?? tristate);
   }
 
   @override
@@ -254,7 +254,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   void _handleFocusHighlightChanged(bool focused) {
     if (focused != _focused) {
       setState(() { _focused = focused; });
-      _reactionFocusFadeController.toggle(focused);
+      _reactionFocusFadeController.toggle(forward: focused);
     }
   }
 
@@ -262,7 +262,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   void _handleHoverChanged(bool hovering) {
     if (hovering != _hovering) {
       setState(() { _hovering = hovering; });
-      _reactionHoverFadeController.toggle(hovering);
+      _reactionHoverFadeController.toggle(forward: hovering);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/toggleable.dart
+++ b/packages/flutter/lib/src/widgets/toggleable.dart
@@ -193,22 +193,10 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   /// This method must be called whenever [value] changes to ensure that the
   /// visual representation of the Toggleable matches the current [value].
   void animateToValue() {
-    if (tristate) {
-      if (value == null) {
-        _positionController.value = 0.0;
-      }
-      if (value ?? true) {
-        _positionController.forward();
-      } else {
-        _positionController.reverse();
-      }
-    } else {
-      if (value ?? false) {
-        _positionController.forward();
-      } else {
-        _positionController.reverse();
-      }
+    if (tristate && value == null) {
+      _positionController.value = 0.0;
     }
+    _positionController.toggle(value ?? tristate);
   }
 
   @override
@@ -266,11 +254,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   void _handleFocusHighlightChanged(bool focused) {
     if (focused != _focused) {
       setState(() { _focused = focused; });
-      if (focused) {
-        _reactionFocusFadeController.forward();
-      } else {
-        _reactionFocusFadeController.reverse();
-      }
+      _reactionFocusFadeController.toggle(focused);
     }
   }
 
@@ -278,11 +262,7 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
   void _handleHoverChanged(bool hovering) {
     if (hovering != _hovering) {
       setState(() { _hovering = hovering; });
-      if (hovering) {
-        _reactionHoverFadeController.forward();
-      } else {
-        _reactionHoverFadeController.reverse();
-      }
+      _reactionHoverFadeController.toggle(hovering);
     }
   }
 

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -260,11 +260,11 @@ void main() {
       vsync: const TestVSync(),
     );
 
-    controller.toggle(true);
+    controller.toggle(forward: true);
     tick(const Duration(milliseconds: 10));
     tick(const Duration(milliseconds: 30));
     expect(controller.value, moreOrLessEquals(0.4));
-    controller.toggle(true);
+    controller.toggle(forward: true);
     tick(const Duration(milliseconds: 10));
     tick(const Duration(milliseconds: 60));
     expect(controller.value, moreOrLessEquals(1.0));
@@ -272,7 +272,7 @@ void main() {
     expect(controller.value, moreOrLessEquals(1.0));
     controller.stop();
 
-    controller.toggle(false);
+    controller.toggle(forward: false);
     tick(const Duration(milliseconds: 210));
     tick(const Duration(milliseconds: 220));
     expect(controller.value, moreOrLessEquals(0.9));

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -42,14 +42,12 @@ void main() {
     bool didComplete = false;
     bool didDismiss = false;
     controller.addStatusListener((AnimationStatus status) {
-      if (status == AnimationStatus.completed) {
+      if (status.isCompleted) {
         didComplete = true;
-        controller.value = 0.0;
-        controller.forward();
-      } else if (status == AnimationStatus.dismissed) {
+        controller.forward(from: 0.0);
+      } else if (status.isDismissed) {
         didDismiss = true;
-        controller.value = 0.0;
-        controller.forward();
+        controller.forward(from: 0.0);
       }
     });
 
@@ -262,17 +260,19 @@ void main() {
       vsync: const TestVSync(),
     );
 
-    controller.toggle();
+    controller.toggle(true);
     tick(const Duration(milliseconds: 10));
     tick(const Duration(milliseconds: 30));
     expect(controller.value, moreOrLessEquals(0.4));
+    controller.toggle(true);
+    tick(const Duration(milliseconds: 10));
     tick(const Duration(milliseconds: 60));
     expect(controller.value, moreOrLessEquals(1.0));
     tick(const Duration(milliseconds: 90));
     expect(controller.value, moreOrLessEquals(1.0));
     controller.stop();
 
-    controller.toggle();
+    controller.toggle(false);
     tick(const Duration(milliseconds: 210));
     tick(const Duration(milliseconds: 220));
     expect(controller.value, moreOrLessEquals(0.9));


### PR DESCRIPTION
After [adding a `toggle` method](https://github.com/flutter/flutter/pull/147801), I realized that there really aren't any notable use cases for the `from` parameter; instead, it made sense to have an ability to toggle based on a boolean value other than `isForwardOrCompleted`.

This pull request updates the `toggle` method accordingly and implements it in the relevant places.

<br>

**Example (motion_demo_fade_scale_transition.dart)**:

```dart
// before
ElevatedButton(
  onPressed: () {
    if (_isAnimationRunningForwardsOrComplete) {
      _controller.reverse();
    } else {
      _controller.forward();
    }
  },
  // ...
)


// after
ElevatedButton(
  onPressed: _controller.toggle,
  // ...
)
```

<br>

And I think my favorite example is from the aptly-named **toggleable.dart**:

```dart
// before
if (tristate) {
  if (value == null) {
    _positionController.value = 0.0;
  }
  if (value ?? true) {
    _positionController.forward();
  } else {
    _positionController.reverse();
  }
} else {
  if (value ?? false) {
    _positionController.forward();
  } else {
    _positionController.reverse();
  }
}


// after
if (tristate && value == null) {
  _positionController.value = 0.0;
}
_positionController.toggle(forward: value ?? tristate);
```