### PR TITLE
Add test for icon_button.3.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -324,7 +324,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/material/stepper/stepper.controls_builder.0_test.dart',
   'examples/api/test/material/flexible_space_bar/flexible_space_bar.0_test.dart',
   'examples/api/test/material/chip/deletable_chip_attributes.on_deleted.0_test.dart',
-  'examples/api/test/material/icon_button/icon_button.3_test.dart',
   'examples/api/test/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0_test.dart',
   'examples/api/test/material/input_decorator/input_decoration.1_test.dart',
   'examples/api/test/material/input_decorator/input_decoration.prefix_icon_constraints.0_test.dart',

--- a/examples/api/test/material/icon_button/icon_button.3_test.dart
+++ b/examples/api/test/material/icon_button/icon_button.3_test.dart
@@ -13,11 +13,11 @@ void main() {
     );
     expect(find.widgetWithIcon(IconButton, Icons.settings_outlined), findsExactly(8));
     final Finder unselectedIconButtons = find.widgetWithIcon(IconButton, Icons.settings_outlined);
-    for (int i = 0; i <= 6; i += 2) {
-      expect(tester.widget<IconButton>(unselectedIconButtons.at(i)).onPressed, isA<VoidCallback>());
-      expect(tester.widget<IconButton>(unselectedIconButtons.at(i + 1)).onPressed, isNull);
+    for (int i = 0; i <= 6; i++) {
+      final IconButton button = tester.widget<IconButton>(unselectedIconButtons.at(i));
+      expect(button.onPressed, i.isEven ? isA<VoidCallback>() : isNull);
+      expect(button.isSelected, isFalse);
     }
-    expect(tester.widgetList<IconButton>(unselectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isFalse));
 
     // Select the icons buttons.
     for (int i = 0; i <= 3; i++) {
@@ -46,5 +46,4 @@ void main() {
     }
     expect(tester.widgetList<IconButton>(unselectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isFalse));
   });
-
 }

--- a/examples/api/test/material/icon_button/icon_button.3_test.dart
+++ b/examples/api/test/material/icon_button/icon_button.3_test.dart
@@ -11,6 +11,7 @@ void main() {
     await tester.pumpWidget(
       const example.IconButtonToggleApp(),
     );
+
     expect(find.widgetWithIcon(IconButton, Icons.settings_outlined), findsExactly(8));
     final Finder unselectedIconButtons = find.widgetWithIcon(IconButton, Icons.settings_outlined);
     for (int i = 0; i <= 6; i++) {
@@ -27,11 +28,11 @@ void main() {
 
     expect(find.widgetWithIcon(IconButton, Icons.settings), findsExactly(8));
     final Finder selectedIconButtons = find.widgetWithIcon(IconButton, Icons.settings);
-    for (int i = 0; i <= 6; i += 2) {
-      expect(tester.widget<IconButton>(selectedIconButtons.at(i)).onPressed, isA<VoidCallback>());
-      expect(tester.widget<IconButton>(selectedIconButtons.at(i + 1)).onPressed, isNull);
+    for (int i = 0; i <= 6; i++) {
+      final IconButton button = tester.widget<IconButton>(selectedIconButtons.at(i));
+      expect(button.onPressed, i.isEven ? isA<VoidCallback>() : isNull);
+      expect(button.isSelected, isTrue);
     }
-    expect(tester.widgetList<IconButton>(selectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isTrue));
 
     // Unselect the icons buttons.
     for (int i = 0; i <= 3; i++) {
@@ -40,10 +41,10 @@ void main() {
     await tester.pump();
 
     expect(find.widgetWithIcon(IconButton, Icons.settings_outlined), findsExactly(8));
-    for (int i = 0; i <= 6; i += 2) {
-      expect(tester.widget<IconButton>(unselectedIconButtons.at(i)).onPressed, isA<VoidCallback>());
-      expect(tester.widget<IconButton>(unselectedIconButtons.at(i + 1)).onPressed, isNull);
+    for (int i = 0; i <= 6; i++) {
+      final IconButton button = tester.widget<IconButton>(unselectedIconButtons.at(i));
+      expect(button.onPressed, i.isEven ? isA<VoidCallback>() : isNull);
+      expect(button.isSelected, isFalse);
     }
-    expect(tester.widgetList<IconButton>(unselectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isFalse));
   });
 }

--- a/examples/api/test/material/icon_button/icon_button.3_test.dart
+++ b/examples/api/test/material/icon_button/icon_button.3_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/icon_button/icon_button.3.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('It should select and unselect the icon buttons', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.IconButtonToggleApp(),
+    );
+    expect(find.widgetWithIcon(IconButton, Icons.settings_outlined), findsExactly(8));
+    final Finder unselectedIconButtons = find.widgetWithIcon(IconButton, Icons.settings_outlined);
+    for (int i = 0; i <= 6; i += 2) {
+      expect(tester.widget<IconButton>(unselectedIconButtons.at(i)).onPressed, isA<VoidCallback>());
+      expect(tester.widget<IconButton>(unselectedIconButtons.at(i + 1)).onPressed, isNull);
+    }
+    expect(tester.widgetList<IconButton>(unselectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isFalse));
+
+    // Select the icons buttons.
+    for (int i = 0; i <= 3; i++) {
+      await tester.tap(unselectedIconButtons.at(2 * i));
+    }
+    await tester.pump();
+
+    expect(find.widgetWithIcon(IconButton, Icons.settings), findsExactly(8));
+    final Finder selectedIconButtons = find.widgetWithIcon(IconButton, Icons.settings);
+    for (int i = 0; i <= 6; i += 2) {
+      expect(tester.widget<IconButton>(selectedIconButtons.at(i)).onPressed, isA<VoidCallback>());
+      expect(tester.widget<IconButton>(selectedIconButtons.at(i + 1)).onPressed, isNull);
+    }
+    expect(tester.widgetList<IconButton>(selectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isTrue));
+
+    // Unselect the icons buttons.
+    for (int i = 0; i <= 3; i++) {
+      await tester.tap(selectedIconButtons.at(2 * i));
+    }
+    await tester.pump();
+
+    expect(find.widgetWithIcon(IconButton, Icons.settings_outlined), findsExactly(8));
+    for (int i = 0; i <= 6; i += 2) {
+      expect(tester.widget<IconButton>(unselectedIconButtons.at(i)).onPressed, isA<VoidCallback>());
+      expect(tester.widget<IconButton>(unselectedIconButtons.at(i + 1)).onPressed, isNull);
+    }
+    expect(tester.widgetList<IconButton>(unselectedIconButtons).map((IconButton iconButton) => iconButton.isSelected), everyElement(isFalse));
+  });
+
+}


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/material/icon_button/icon_button.3.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
