### PR TITLE
Use const bool.fromEnvironment("dart.tool.dart2wasm") to detect dart2wasm

### DIFF
--- a/packages/flutter/lib/src/foundation/constants.dart
+++ b/packages/flutter/lib/src/foundation/constants.dart
@@ -89,4 +89,4 @@ const bool kIsWeb = bool.fromEnvironment('dart.library.js_util');
 ///   in tests with [debugDefaultTargetPlatformOverride].
 /// * [dart:io.Platform], a way to find out the browser's platform that is not
 ///   overridable in tests.
-const bool kIsWasm = kIsWeb && bool.fromEnvironment('dart.library.ffi');
+const bool kIsWasm = bool.fromEnvironment('dart.tool.dart2wasm');


### PR DESCRIPTION
Dart2Wasm doesn't officially support `dart:ffi` (only a small sketchy subset needed in flutter web engine). We have seen user reporting issues where existing packages don't work with dart2wasm due to using `dart.library.ffi` in `bool.fromEnvironment` or in conditional imports and it doing the wrong thing. So we're going to make `dart.library.ffi` `false` in the compiler.

We therefore update the code to detect whether it runs under wasm via a new `dart.tool.dart2wasm` environment variable.

This is a preparation for the change in dart2wasm which will start making `const bool.fromEnvironment('dart.library.ffi')` return `false` instead of `true`.