### PR TITLE
Revert "[CupertinoActionSheet] Match colors to native (#149568)"

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -104,35 +104,35 @@ const Color _kDialogColor = CupertinoDynamicColor.withBrightness(
 // Translucent light gray that is painted on top of the blurred backdrop as the
 // background color of a pressed button.
 // Eyeballed from iOS 13 beta simulator.
-const Color _kDialogPressedColor = CupertinoDynamicColor.withBrightness(
+const Color _kPressedColor = CupertinoDynamicColor.withBrightness(
   color: Color(0xFFE1E1E1),
   darkColor: Color(0xFF2E2E2E),
 );
 
-// Translucent light gray that is painted on top of the blurred backdrop as the
-// background color of a pressed button.
-// Eyeballed from iOS 17 simulator.
-const Color _kActionSheetPressedColor = Color(0xCAE0E0E0);
-
-const Color _kActionSheetCancelColor = Color(0xFFFFFFFF);
-const Color _kActionSheetCancelPressedColor = Color(0xFFECECEC);
+const Color _kActionSheetCancelPressedColor = CupertinoDynamicColor.withBrightness(
+  color: Color(0xFFECECEC),
+  darkColor: Color(0xFF49494B),
+);
 
 // Translucent, very light gray that is painted on top of the blurred backdrop
 // as the action sheet's background color.
 // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/39272. Use
 // System Materials once we have them.
-// Eyeballed from iOS 17 simulator.
-const Color _kActionSheetBackgroundColor = Color(0xC8FCFCFC);
+// Extracted from https://developer.apple.com/design/resources/.
+const Color _kActionSheetBackgroundColor = CupertinoDynamicColor.withBrightness(
+  color: Color(0xC7F9F9F9),
+  darkColor: Color(0xC7252525),
+);
 
 // The gray color used for text that appears in the title area.
-// Eyeballed from iOS 17 simulator.
-const Color _kActionSheetContentTextColor = Color(0x851D1D1D);
+// Extracted from https://developer.apple.com/design/resources/.
+const Color _kActionSheetContentTextColor = Color(0xFF8F8F8F);
 
 // Translucent gray that is painted on top of the blurred backdrop in the gap
 // areas between the content section and actions section, as well as between
 // buttons.
-// Eyeballed from iOS 17 simulator.
-const Color _kActionSheetButtonDividerColor = Color(0xD4C9C9C9);
+// Eye-balled from iOS 13 beta simulator.
+const Color _kActionSheetButtonDividerColor = _kActionSheetContentTextColor;
 
 // The alert dialog layout policy changes depending on whether the user is using
 // a "regular" font size vs a "large" font size. This is a spectrum. There are
@@ -1115,19 +1115,19 @@ class _ActionSheetButtonBackgroundState extends State<_ActionSheetButtonBackgrou
     BorderRadius? borderRadius;
     if (!widget.isCancel) {
       backgroundColor = isBeingPressed
-        ? _kActionSheetPressedColor
-        : _kActionSheetBackgroundColor;
+        ? _kPressedColor
+        : CupertinoDynamicColor.resolve(_kActionSheetBackgroundColor, context);
     } else {
       backgroundColor = isBeingPressed
-        ? _kActionSheetCancelPressedColor
-        : _kActionSheetCancelColor;
+          ? _kActionSheetCancelPressedColor
+        : CupertinoColors.secondarySystemGroupedBackground;
       borderRadius = const BorderRadius.all(Radius.circular(_kCornerRadius));
     }
     return MetaData(
       metaData: this,
       child: Container(
         decoration: BoxDecoration(
-          color: CupertinoDynamicColor.resolve(backgroundColor, context),
+          color: backgroundColor,
           borderRadius: borderRadius,
         ),
         child: widget.child,
@@ -2269,7 +2269,7 @@ class _CupertinoDialogActionsRenderWidget extends MultiChildRenderObjectWidget {
               : _kCupertinoDialogWidth,
       dividerThickness: _dividerThickness,
       dialogColor: CupertinoDynamicColor.resolve(_kDialogColor, context),
-      dialogPressedColor: CupertinoDynamicColor.resolve(_kDialogPressedColor, context),
+      dialogPressedColor: CupertinoDynamicColor.resolve(_kPressedColor, context),
       dividerColor: CupertinoDynamicColor.resolve(CupertinoColors.separator, context),
       hasCancelButton: _hasCancelButton,
     );
@@ -2283,7 +2283,7 @@ class _CupertinoDialogActionsRenderWidget extends MultiChildRenderObjectWidget {
             : _kCupertinoDialogWidth
       ..dividerThickness = _dividerThickness
       ..dialogColor = CupertinoDynamicColor.resolve(_kDialogColor, context)
-      ..dialogPressedColor = CupertinoDynamicColor.resolve(_kDialogPressedColor, context)
+      ..dialogPressedColor = CupertinoDynamicColor.resolve(_kPressedColor, context)
       ..dividerColor = CupertinoDynamicColor.resolve(CupertinoColors.separator, context)
       ..hasCancelButton = _hasCancelButton;
   }

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -18,69 +18,6 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
-  testWidgets('Overall looks correctly under light theme', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      TestScaffoldApp(
-        theme: const CupertinoThemeData(brightness: Brightness.light),
-        actionSheet: CupertinoActionSheet(
-          message: const Text('The title'),
-          actions: <Widget>[
-            CupertinoActionSheetAction(child: const Text('One'), onPressed: () {}),
-            CupertinoActionSheetAction(child: const Text('Two'), onPressed: () {}),
-          ],
-          cancelButton: CupertinoActionSheetAction(child: const Text('Cancel'), onPressed: () {}),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('Go'));
-    await tester.pumpAndSettle();
-
-    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('One')));
-    // This golden file also verifies the structure of an action sheet that
-    // has a message, no title, and no overscroll for any sections (in contrast
-    // to cupertinoActionSheet.dark-theme.png).
-    await expectLater(
-      find.byType(CupertinoApp),
-      matchesGoldenFile('cupertinoActionSheet.overall-light-theme.png'),
-    );
-
-    await gesture.up();
-  });
-
-  testWidgets('Overall looks correctly under dark theme', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      TestScaffoldApp(
-        theme: const CupertinoThemeData(brightness: Brightness.dark),
-        actionSheet: CupertinoActionSheet(
-          title: const Text('The title'),
-          message: const Text('The message'),
-          actions: List<Widget>.generate(20, (int i) =>
-            CupertinoActionSheetAction(
-              onPressed: () {},
-              child: Text('Button $i'),
-            ),
-          ),
-          cancelButton: CupertinoActionSheetAction(child: const Text('Cancel'), onPressed: () {}),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('Go'));
-    await tester.pumpAndSettle();
-
-    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Button 0')));
-    // This golden file also verifies the structure of an action sheet that
-    // has both a message and a title, and an overscrolled action section (in
-    // contrast to cupertinoActionSheet.light-theme.png).
-    await expectLater(
-      find.byType(CupertinoApp),
-      matchesGoldenFile('cupertinoActionSheet.overall-dark-theme.png'),
-    );
-
-    await gesture.up();
-  });
-
   testWidgets('Verify that a tap on modal barrier dismisses an action sheet', (WidgetTester tester) async {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesActionSheet(
@@ -1736,50 +1673,6 @@ Widget createAppWithButtonThatLaunchesActionSheet(Widget actionSheet) {
       }),
     ),
   );
-}
-
-// Shows an app that has a button with text "Go", and clicking this button
-// displays the `actionSheet` and hides the button.
-//
-// The `theme` will be applied to the app and determines the background.
-class TestScaffoldApp extends StatefulWidget {
-  const TestScaffoldApp({super.key, required this.theme, required this.actionSheet});
-  final CupertinoThemeData theme;
-  final Widget actionSheet;
-
-  @override
-  TestScaffoldAppState createState() => TestScaffoldAppState();
-}
-
-class TestScaffoldAppState extends State<TestScaffoldApp> {
-  bool _pressedButton = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return CupertinoApp(
-      theme: widget.theme,
-      home: Builder(builder: (BuildContext context) =>
-        CupertinoPageScaffold(
-          child: Center(
-            child: _pressedButton ? Container() : CupertinoButton(
-              onPressed: () {
-                setState(() {
-                  _pressedButton = true;
-                });
-                showCupertinoModalPopup<void>(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return widget.actionSheet;
-                  },
-                );
-              },
-              child: const Text('Go'),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }
 
 Widget boilerplate(Widget child) {


### PR DESCRIPTION
This reverts commit 32081aab69f82f88283cf43ce4cc2f9544c7c16c.

Reason for revert: Appears to be failing tests in tree
```
01:48 +2991 ~18: /Volumes/Work/s/w/ir/x/w/flutter/packages/flutter/test/cupertino/action_sheet_test.dart: Taps on a button can be slided to other buttons
 ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
 The following SkiaException was thrown while running async test code:
 Skia Gold received an unapproved image in post-submit
 testing. Golden file images in flutter/flutter are triaged
 in pre-submit during code review for the given PR.
 Visit https://flutter-gold.skia.org/ to view and approve
 the image(s), or revert the associated change. For more
 information, visit the wiki:
 https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter
 Debug information for Gold --------------------------------
 stdout: Given image with hash 601f421e3bb643f437cc12395de96152 for test
 cupertino.cupertinoActionSheet.press-drag
 Expectation for test: ce8ef79c146857d162663b1161fd6d5c (positive)
 Expectation for test: 3bb57a8782f67836c6ad3ece7f00729a (positive)
 Expectation for test: 3f8c592774caf3c760fbbd318a7dc5af (positive)
 Expectation for test: 61863f38217aa3349c239eeb49b84930 (positive)
 Expectation for test: 98af16e9b7eb3fb810b44c74bb18ffb9 (positive)
 Untriaged or negative image:
 https://flutter-gold.skia.org//detail?grouping=name%3Dcupertino.cupertinoActionSheet.press-drag%26source_type%3Dflutter&digest=601f421e3bb643f437cc12395de96152
 stderr: Test: cupertino.cupertinoActionSheet.press-drag FAIL
 result-state.json: No result file found.
 ```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
