### PR TITLE
Fixes TextField hinttext in a11y_assessment

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -32,6 +32,7 @@ class _MainWidget extends StatelessWidget {
         children: <Widget>[
           const TextField(
             key: Key('enabled text field'),
+            maxLines: null,
             decoration: InputDecoration(
               labelText: 'Email',
               suffixText: '@gmail.com',
@@ -40,6 +41,7 @@ class _MainWidget extends StatelessWidget {
           ),
           TextField(
             key: const Key('disabled text field'),
+            maxLines: null,
             decoration: const InputDecoration(
               labelText: 'Email',
               suffixText: '@gmail.com',

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -34,7 +34,6 @@ class _MainWidget extends StatelessWidget {
             key: Key('enabled password'),
             decoration: InputDecoration(
               labelText: 'Password',
-              hintText: 'Enter your password',
             ),
             obscureText: true,
           ),
@@ -42,7 +41,6 @@ class _MainWidget extends StatelessWidget {
             key: Key('disabled password'),
             decoration: InputDecoration(
               labelText: 'Password',
-              hintText: 'Enter your password',
             ),
             enabled: false,
             obscureText: true,

--- a/dev/a11y_assessments/test/text_field_password_test.dart
+++ b/dev/a11y_assessments/test/text_field_password_test.dart
@@ -30,4 +30,24 @@ void main() {
       expect(passwordField.enabled, isFalse);
     }
   });
+
+  testWidgets('text field passwords do not have hint text', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextFieldPasswordUseCase());
+    expect(find.byType(TextField), findsExactly(2));
+
+    // Test the enabled password
+    {
+      final Finder finder = find.byKey(const Key('enabled password'));
+      final TextField textField = tester.widget<TextField>(finder);
+      expect(textField.decoration?.hintText, isNull);
+
+    }
+
+    // Test the disabled password
+    {
+      final Finder finder = find.byKey(const Key('disabled password'));
+      final TextField textField = tester.widget<TextField>(finder);
+      expect(textField.decoration?.hintText, isNull);
+    }
+  });
 }

--- a/dev/a11y_assessments/test/text_field_test.dart
+++ b/dev/a11y_assessments/test/text_field_test.dart
@@ -30,4 +30,28 @@ void main() {
       expect(textField.enabled, isFalse);
     }
   });
+
+  testWidgets('font size increase does not ellipsize hint text', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextFieldUseCase());
+    await tester.pumpWidget(MaterialApp(
+      home: MediaQuery.withClampedTextScaling(
+        minScaleFactor: 3,
+        maxScaleFactor: 3,
+        child: Builder(
+          builder: (BuildContext context) {
+            return TextFieldUseCase().build(context);
+          },
+        ),
+      ),
+    ));
+    // Test the enabled text field
+    {
+      final Finder finder = find.byKey(const Key('enabled text field'));
+      await tester.tap(finder);
+      await tester.pumpAndSettle();
+      final Size size = tester.getSize(finder);
+      // Should have a multi-line height.
+      expect(size.height, 280);
+    }
+  });
 }


### PR DESCRIPTION
b/317131589

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
