### PR TITLE
Add tests for navigator.0.dart

### DIFF
--- a/dev/bots/check_code_samples.dart
+++ b/dev/bots/check_code_samples.dart
@@ -358,7 +358,6 @@ final Set<String> _knownMissingTests = <String>{
   'examples/api/test/rendering/scroll_direction/scroll_direction.0_test.dart',
   'examples/api/test/painting/star_border/star_border.0_test.dart',
   'examples/api/test/widgets/navigator/navigator.restorable_push_and_remove_until.0_test.dart',
-  'examples/api/test/widgets/navigator/navigator.0_test.dart',
   'examples/api/test/widgets/navigator/navigator.restorable_push.0_test.dart',
   'examples/api/test/widgets/navigator/navigator_state.restorable_push_replacement.0_test.dart',
   'examples/api/test/widgets/navigator/navigator_state.restorable_push_and_remove_until.0_test.dart',

--- a/examples/api/test/widgets/navigator/navigator.0_test.dart
+++ b/examples/api/test/widgets/navigator/navigator.0_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/widgets/navigator/navigator.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('It should show the home page', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.NavigatorExampleApp(),
+    );
+
+    expect(find.text('Home Page'), findsOne);
+  });
+
+  testWidgets('It should start from the sign up page and follow the flow to reach the home page', (WidgetTester tester) async {
+    tester.platformDispatcher.defaultRouteNameTestValue = '/signup';
+    await tester.pumpWidget(
+      const example.NavigatorExampleApp(),
+    );
+
+    expect(find.text('Collect Personal Info Page'), findsOne);
+
+    await tester.tap(find.text('Collect Personal Info Page'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Choose Credentials Page'), findsOne);
+
+    await tester.tap(find.text('Choose Credentials Page'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Home Page'), findsOne);
+  });
+}

--- a/examples/api/test/widgets/navigator/navigator.0_test.dart
+++ b/examples/api/test/widgets/navigator/navigator.0_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter_api_samples/widgets/navigator/navigator.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
Contributes to https://github.com/flutter/flutter/issues/130459

It adds a test for
- `examples/api/lib/widgets/navigator/navigator.0.dart`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
