### PR TITLE
made SelectionArea alignment consistent between web and other platform

### DIFF
--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -135,6 +135,9 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      // Setting fit to StackFit.passthrough will prevent the child from
+      // misaligning on web and be consistent with other platforms.
+      fit: StackFit.passthrough,
       alignment: Alignment.center,
       children: <Widget>[
         const Positioned.fill(

--- a/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
+++ b/packages/flutter/lib/src/widgets/_platform_selectable_region_context_menu_web.dart
@@ -135,10 +135,6 @@ class PlatformSelectableRegionContextMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
-      // Setting fit to StackFit.passthrough will prevent the child from
-      // misaligning on web and be consistent with other platforms.
-      fit: StackFit.passthrough,
-      alignment: Alignment.center,
       children: <Widget>[
         const Positioned.fill(
           child: HtmlElementView(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3594,7 +3594,7 @@ void main() {
     skip: kIsWeb, // [intended] Web uses its native context menu.
   );
 
-  // Regression test for https://github.com/flutter/flutter/issues/148934
+  // Regression test for https://github.com/flutter/flutter/issues/121053.
   testWidgets('Ensure consistent layout of SelectionArea children between platforms', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3594,19 +3594,24 @@ void main() {
     skip: kIsWeb, // [intended] Web uses its native context menu.
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/148934
   testWidgets('Ensure consistent layout of SelectionArea children between platforms', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
-        home: SelectionArea(
-          child: Text('Row 1'),
+        home: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+              SelectionArea(child: Text('row 1')),
+              Text('row 2'),
+            ],
         ),
       ),
     );
     await tester.pumpAndSettle();
-    final Offset offset = tester.getTopLeft(find.byType(Text));
-    expect(offset, Offset.zero);
-  },
-  );
+    final double xOffset1 = tester.getTopLeft(find.text('row 1')).dx;
+    final double xOffset2 = tester.getTopLeft(find.text('row 2')).dx;
+    expect(xOffset1, xOffset2);
+  });
 
   testWidgets('the selection behavior when clicking `Copy` item in mobile platforms', (WidgetTester tester) async {
     List<ContextMenuButtonItem> buttonItems = <ContextMenuButtonItem>[];

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3595,7 +3595,7 @@ void main() {
   );
 
   // Regression test for https://github.com/flutter/flutter/issues/121053.
-  testWidgets('Ensure consistent layout of SelectionArea children between platforms', (WidgetTester tester) async {
+  testWidgets('Ensure SelectionArea does not affect the layout of its children', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Column(
@@ -3611,7 +3611,9 @@ void main() {
     final double xOffset1 = tester.getTopLeft(find.text('row 1')).dx;
     final double xOffset2 = tester.getTopLeft(find.text('row 2')).dx;
     expect(xOffset1, xOffset2);
-  });
+  },
+    variant: TargetPlatformVariant.all(),
+  );
 
   testWidgets('the selection behavior when clicking `Copy` item in mobile platforms', (WidgetTester tester) async {
     List<ContextMenuButtonItem> buttonItems = <ContextMenuButtonItem>[];

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3594,6 +3594,20 @@ void main() {
     skip: kIsWeb, // [intended] Web uses its native context menu.
   );
 
+  testWidgets('Ensure consistent layout of SelectionArea children between platforms', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: SelectionArea(
+          child: Text('Row 1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final Offset offset = tester.getTopLeft(find.byType(Text));
+    expect(offset, Offset.zero);
+  },
+  );
+
   testWidgets('the selection behavior when clicking `Copy` item in mobile platforms', (WidgetTester tester) async {
     List<ContextMenuButtonItem> buttonItems = <ContextMenuButtonItem>[];
     final FocusNode focusNode = FocusNode();


### PR DESCRIPTION
Currently, when text is placed inside a SelectionArea widget that's nested within a Column widget, it results in misalignment, causing the text to appear centered instead of aligned as intended.

This was originally #149552 but had issues with my branch.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*
Fixes #148934 
Fixes #121053 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
