### PR TITLE
Remove double MaterialApp wrap from api samples

### DIFF
--- a/examples/api/test/material/action_buttons/action_icon_theme.0_test.dart
+++ b/examples/api/test/material/action_buttons/action_icon_theme.0_test.dart
@@ -8,14 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Action Icon Buttons', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ActionIconThemeExampleApp(),
-        ),
-      ),
-    );
-
+    await tester.pumpWidget(const example.ActionIconThemeExampleApp());
 
     expect(find.byType(DrawerButton), findsOneWidget);
     final Icon drawerButtonIcon = tester.widget(

--- a/examples/api/test/material/dialog/adaptive_alert_dialog.0_test.dart
+++ b/examples/api/test/material/dialog/adaptive_alert_dialog.0_test.dart
@@ -10,11 +10,7 @@ void main() {
   testWidgets('Show Adaptive Alert dialog', (WidgetTester tester) async {
     const String dialogTitle = 'AlertDialog Title';
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.AdaptiveAlertDialogApp(),
-        ),
-      ),
+      const example.AdaptiveAlertDialogApp(),
     );
 
     expect(find.text(dialogTitle), findsNothing);

--- a/examples/api/test/material/dialog/alert_dialog.0_test.dart
+++ b/examples/api/test/material/dialog/alert_dialog.0_test.dart
@@ -10,11 +10,7 @@ void main() {
   testWidgets('Show Alert dialog', (WidgetTester tester) async {
     const String dialogTitle = 'AlertDialog Title';
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.AlertDialogExampleApp(),
-        ),
-      ),
+      const example.AlertDialogExampleApp(),
     );
 
     expect(find.text(dialogTitle), findsNothing);

--- a/examples/api/test/material/dialog/alert_dialog.1_test.dart
+++ b/examples/api/test/material/dialog/alert_dialog.1_test.dart
@@ -10,11 +10,7 @@ void main() {
   testWidgets('Show Alert dialog', (WidgetTester tester) async {
     const String dialogTitle = 'AlertDialog Title';
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.AlertDialogExampleApp(),
-        ),
-      ),
+      const example.AlertDialogExampleApp(),
     );
 
     expect(find.text(dialogTitle), findsNothing);

--- a/examples/api/test/material/dialog/dialog.0_test.dart
+++ b/examples/api/test/material/dialog/dialog.0_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/dialog/dialog.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,11 +10,7 @@ void main() {
     const String dialogText = 'This is a typical dialog.';
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DialogExampleApp(),
-        ),
-      ),
+      const example.DialogExampleApp(),
     );
 
     expect(find.text(dialogText), findsNothing);
@@ -33,11 +28,7 @@ void main() {
     const String dialogText = 'This is a fullscreen dialog.';
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DialogExampleApp(),
-        ),
-      ),
+      const example.DialogExampleApp(),
     );
 
     expect(find.text(dialogText), findsNothing);

--- a/examples/api/test/material/dialog/show_dialog.0_test.dart
+++ b/examples/api/test/material/dialog/show_dialog.0_test.dart
@@ -10,11 +10,7 @@ void main() {
   testWidgets('Show dialog', (WidgetTester tester) async {
     const String dialogTitle = 'Basic dialog title';
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ShowDialogExampleApp(),
-        ),
-      ),
+      const example.ShowDialogExampleApp(),
     );
 
     expect(find.text(dialogTitle), findsNothing);

--- a/examples/api/test/material/dialog/show_dialog.1_test.dart
+++ b/examples/api/test/material/dialog/show_dialog.1_test.dart
@@ -10,11 +10,7 @@ void main() {
   testWidgets('Show dialog', (WidgetTester tester) async {
     const String dialogTitle = 'Basic dialog title';
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ShowDialogExampleApp(),
-        ),
-      ),
+      const example.ShowDialogExampleApp(),
     );
 
     expect(find.text(dialogTitle), findsNothing);

--- a/examples/api/test/material/dialog/show_dialog.2_test.dart
+++ b/examples/api/test/material/dialog/show_dialog.2_test.dart
@@ -10,11 +10,7 @@ void main() {
   testWidgets('Show dialog', (WidgetTester tester) async {
     const String dialogTitle = 'Basic dialog title';
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ShowDialogExampleApp(),
-        ),
-      ),
+      const example.ShowDialogExampleApp(),
     );
 
     expect(find.text(dialogTitle), findsNothing);

--- a/examples/api/test/material/divider/divider.0_test.dart
+++ b/examples/api/test/material/divider/divider.0_test.dart
@@ -9,11 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Horizontal Divider', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DividerExampleApp(),
-        ),
-      ),
+      const example.DividerExampleApp(),
     );
 
     expect(find.byType(Divider), findsOneWidget);

--- a/examples/api/test/material/divider/divider.1_test.dart
+++ b/examples/api/test/material/divider/divider.1_test.dart
@@ -9,11 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Horizontal Divider', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DividerExampleApp(),
-        ),
-      ),
+      const example.DividerExampleApp(),
     );
 
     expect(find.byType(Divider), findsOneWidget);

--- a/examples/api/test/material/divider/vertical_divider.0_test.dart
+++ b/examples/api/test/material/divider/vertical_divider.0_test.dart
@@ -9,11 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Vertical Divider', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.VerticalDividerExampleApp(),
-        ),
-      ),
+      const example.VerticalDividerExampleApp(),
     );
 
     expect(find.byType(VerticalDivider), findsOneWidget);

--- a/examples/api/test/material/divider/vertical_divider.1_test.dart
+++ b/examples/api/test/material/divider/vertical_divider.1_test.dart
@@ -9,11 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Vertical Divider', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.VerticalDividerExampleApp(),
-        ),
-      ),
+      const example.VerticalDividerExampleApp(),
     );
 
     expect(find.byType(VerticalDivider), findsOneWidget);

--- a/examples/api/test/material/dropdown/dropdown_button.0_test.dart
+++ b/examples/api/test/material/dropdown/dropdown_button.0_test.dart
@@ -2,18 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/dropdown/dropdown_button.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Select an item from DropdownButton', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DropdownButtonApp(),
-        ),
-      ),
+      const example.DropdownButtonApp(),
     );
 
     expect(find.text('One'), findsOneWidget);

--- a/examples/api/test/material/dropdown/dropdown_button.selected_item_builder.0_test.dart
+++ b/examples/api/test/material/dropdown/dropdown_button.selected_item_builder.0_test.dart
@@ -2,18 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/dropdown/dropdown_button.selected_item_builder.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Select an item from DropdownButton', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DropdownButtonApp(),
-        ),
-      ),
+      const example.DropdownButtonApp(),
     );
 
     expect(find.text('NYC'), findsOneWidget);

--- a/examples/api/test/material/dropdown/dropdown_button.style.0_test.dart
+++ b/examples/api/test/material/dropdown/dropdown_button.style.0_test.dart
@@ -2,18 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/dropdown/dropdown_button.style.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Select an item from DropdownButton', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.DropdownButtonApp(),
-        ),
-      ),
+      const example.DropdownButtonApp(),
     );
 
     expect(find.text('One'), findsOneWidget);

--- a/examples/api/test/material/popup_menu/popup_menu.0_test.dart
+++ b/examples/api/test/material/popup_menu/popup_menu.0_test.dart
@@ -11,11 +11,7 @@ void main() {
     const String menuItem = 'Item 1';
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.PopupMenuApp(),
-        ),
-      ),
+      const example.PopupMenuApp(),
     );
 
     expect(find.text(menuItem), findsNothing);

--- a/examples/api/test/material/popup_menu/popup_menu.1_test.dart
+++ b/examples/api/test/material/popup_menu/popup_menu.1_test.dart
@@ -11,11 +11,7 @@ void main() {
     const String menuItem = 'Item 1';
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.PopupMenuApp(),
-        ),
-      ),
+      const example.PopupMenuApp(),
     );
 
     expect(find.text(menuItem), findsNothing);

--- a/examples/api/test/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0_test.dart
+++ b/examples/api/test/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';
@@ -19,9 +18,7 @@ void main() {
 
   testWidgets('Reorder list item', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: example.ReorderableApp(),
-      ),
+      const example.ReorderableApp(),
     );
 
     expect(tester.getCenter(find.text('Item 3')).dy, 280.0);

--- a/examples/api/test/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0_test.dart
+++ b/examples/api/test/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';
@@ -19,9 +18,7 @@ void main() {
 
   testWidgets('Reorder list item', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: example.ReorderableApp(),
-      ),
+      const example.ReorderableApp(),
     );
 
     expect(tester.getCenter(find.text('Item 3')).dy, 252.0);

--- a/examples/api/test/material/time_picker/show_time_picker.0_test.dart
+++ b/examples/api/test/material/time_picker/show_time_picker.0_test.dart
@@ -30,11 +30,7 @@ void main() {
     ];
 
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ShowTimePickerApp(),
-        ),
-      ),
+      const example.ShowTimePickerApp(),
     );
 
     for (final String option in options) {

--- a/examples/api/test/material/toggle_buttons/toggle_buttons.0_test.dart
+++ b/examples/api/test/material/toggle_buttons/toggle_buttons.0_test.dart
@@ -13,11 +13,7 @@ void main() {
       return tester.widget<TextButton>(find.widgetWithText(TextButton, text));
     }
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ToggleButtonsExampleApp(),
-        ),
-      ),
+      const example.ToggleButtonsExampleApp(),
     );
 
     TextButton firstButton = findButton('Apple');
@@ -51,11 +47,7 @@ void main() {
       return tester.widget<TextButton>(find.widgetWithText(TextButton, text));
     }
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ToggleButtonsExampleApp(),
-        ),
-      ),
+      const example.ToggleButtonsExampleApp(),
     );
 
     TextButton firstButton = findButton('Tomatoes');
@@ -90,11 +82,7 @@ void main() {
       return tester.widget<TextButton>(find.widgetWithIcon(TextButton, iconData));
     }
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.ToggleButtonsExampleApp(),
-        ),
-      ),
+      const example.ToggleButtonsExampleApp(),
     );
 
     TextButton firstButton = findButton(Icons.sunny);

--- a/examples/api/test/widgets/basic/custom_multi_child_layout.0_test.dart
+++ b/examples/api/test/widgets/basic/custom_multi_child_layout.0_test.dart
@@ -10,11 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('has four containers', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: example.CustomMultiChildLayoutApp(),
-        ),
-      ),
+      const example.CustomMultiChildLayoutApp(),
     );
     final Finder containerFinder = find.byType(Container);
     expect(containerFinder, findsNWidgets(4));

--- a/examples/api/test/widgets/basic/mouse_region.0_test.dart
+++ b/examples/api/test/widgets/basic/mouse_region.0_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('MouseRegion detects mouse entries, exists, and location', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: example.MouseRegionApp()),
+      const example.MouseRegionApp(),
     );
 
     expect(find.text('0 Entries\n0 Exits'), findsOneWidget);

--- a/examples/api/test/widgets/basic/mouse_region.on_exit.0_test.dart
+++ b/examples/api/test/widgets/basic/mouse_region.on_exit.0_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('MouseRegion detects mouse hover', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: example.MouseRegionApp()),
+      const example.MouseRegionApp(),
     );
 
     Container container = tester.widget<Container>(find.byType(Container));

--- a/examples/api/test/widgets/basic/mouse_region.on_exit.1_test.dart
+++ b/examples/api/test/widgets/basic/mouse_region.on_exit.1_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('MouseRegion update mouse hover with a delay', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: example.MouseRegionApp()),
+      const example.MouseRegionApp(),
     );
 
     expect(find.text('Not hovering'), findsOneWidget);

--- a/examples/api/test/widgets/basic/offstage.0_test.dart
+++ b/examples/api/test/widgets/basic/offstage.0_test.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/widgets/basic/offstage.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Can off/on stage Flutter logo widget', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: example.OffstageApp()),
+      const example.OffstageApp(),
     );
 
     // The Flutter logo is off stage and not visible.

--- a/examples/api/test/widgets/basic/physical_shape.0_test.dart
+++ b/examples/api/test/widgets/basic/physical_shape.0_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('PhysicalShape is an ancestor of the text widget', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(home: example.PhysicalShapeApp()),
+      const example.PhysicalShapeApp(),
     );
 
     final PhysicalShape physicalShape = tester.widget<PhysicalShape>(


### PR DESCRIPTION
The widget under test already contains a MaterialApp, so there's no need to wrap it again with one in the test. In fact, the additional MaterialApp could hide problems in the widget under test.