### PR TITLE
Update WidgetStatesController docs

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -643,11 +643,11 @@ class WidgetStatePropertyAll<T> implements WidgetStateProperty<T> {
 /// or loses the focus it will [update] its controller's [value] and
 /// notify listeners of the change.
 ///
-/// When calling `setState` in a [MaterialStatesController] listener, use the
+/// When calling `setState` in a [WidgetStatesController] listener, use the
 /// [SchedulerBinding.addPostFrameCallback] to delay the call to `setState` after
 /// the frame has been rendered. It's generally prudent to use the
 /// [SchedulerBinding.addPostFrameCallback] because some of the widgets that
-/// depend on [MaterialStatesController] may call [update] in their build method.
+/// depend on [WidgetStatesController] may call [update] in their build method.
 /// In such cases, listener's that call `setState` - during the build phase - will cause
 /// an error.
 ///


### PR DESCRIPTION
Just updated the docs that mentioned the old name (`MaterialStatesController`) that now is another class. It was showing in the [docs website](https://api.flutter.dev/flutter/widgets/WidgetStatesController-class.html) with the deprecated line-through style so I noticed it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
