### PR TITLE
Debug physical iOS device with devicectl and lldb on Xcode 16

### DIFF
--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -1,0 +1,213 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/process.dart';
+import '../convert.dart';
+import '../globals.dart';
+
+class LLDB {
+  LLDB({
+    required Logger logger,
+    required ProcessUtils processUtils,
+  })  : _logger = logger,
+        _processUtils = processUtils;
+
+  final Logger _logger;
+  final ProcessUtils _processUtils;
+
+  _LLDBProcess? _lldbProcess;
+
+  bool get isRunning => _lldbProcess != null;
+
+  int? get processId => _lldbProcess?.processId;
+
+  // (lldb) Process 6152 stopped
+  static final RegExp _lldbProcessStopped = RegExp(r'Process \d* stopped');
+
+  // (lldb) Process 6152 detached
+  static final RegExp _lldbProcessDetached = RegExp(r'Process \d* detached');
+
+  // (lldb) Process 6152 resuming
+  static final RegExp _lldbProcessResuming = RegExp(r'Process \d+ resuming');
+
+  static const String _processResume = 'process continue';
+
+  // Print backtrace for all threads while app is stopped.
+  static const String _backTraceAll = 'thread backtrace all';
+
+  Future<bool> launchAndAttach(String deviceId, int processId) async {
+    if (isRunning) {
+      _logger.printTrace('LLDB is already running');
+      return false;
+    }
+    final Completer<bool> attachCompleter = Completer<bool>();
+    try {
+      _lldbProcess = _LLDBProcess(
+        process: await _processUtils.start(<String>['lldb']),
+        processId: processId,
+        logger: logger,
+      );
+
+      final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
+          .transform<String>(utf8.decoder)
+          .transform<String>(const LineSplitter())
+          .listen((String line) {
+
+        if (line.contains(_backTraceAll)) {
+          // Even though we're not "detached", just stopped, mark as detached so the backtrace
+          // is only show in verbose.
+          _lldbProcess?.processStatus = _AppProcessState.detached;
+        }
+
+        if (_lldbProcess?.processStatus == _AppProcessState.stopped) {
+          _logger.printError(line);
+        } else {
+          _logger.printTrace(line);
+        }
+
+        if (_lldbProcessStopped.hasMatch(line)) {
+          if (_lldbProcess?.processStatus == _AppProcessState.suspended) {
+            // Wait for process to attach. Attaching will show the process as
+            // stopped since the app starts in a suspended state. Continue
+            // execution of the process.
+            _lldbProcess?.stdinWriteln(_processResume);
+            return;
+          } else {
+            // The app has been stopped. Dump the backtrace, and detach.
+            _lldbProcess?.processStatus = _AppProcessState.stopped;
+            _lldbProcess?.stdinWriteln(_backTraceAll);
+            detach();
+            return;
+          }
+        }
+
+        if (_lldbProcessResuming.hasMatch(line)) {
+          _lldbProcess?.processStatus = _AppProcessState.resumed;
+          attachCompleter.complete(true);
+          return;
+        }
+
+        if (_lldbProcessDetached.hasMatch(line)) {
+          // The debugger has detached from the app, and there will be no more debugging messages.
+          // Kill the lldb process.
+          exit();
+          return;
+        }
+      });
+
+      final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
+          .transform<String>(utf8.decoder)
+          .transform<String>(const LineSplitter())
+          .listen((String line) {
+        _logger.printTrace('[stderr] $line');
+      });
+
+      unawaited(_lldbProcess!.exitCode.then((int status) async {
+        _logger.printTrace('lldb exited with code $exitCode');
+        await stdoutSubscription.cancel();
+        await stderrSubscription.cancel();
+      }).whenComplete(() async {
+        if (!attachCompleter.isCompleted) {
+          attachCompleter.complete(false);
+        }
+        _lldbProcess = null;
+      }));
+    } on ProcessException catch (exception) {
+      _logger.printError('Process exception running lldb:\n$exception');
+      return false;
+    } on ArgumentError catch (exception) {
+      _logger.printError('Process exception running lldb:\n$exception');
+      return false;
+    }
+
+    try {
+      await _lldbProcess?.stdinWriteln('device select $deviceId');
+      await _lldbProcess?.stdinWriteln('device process attach --pid $processId');
+    } on SocketException catch (error) {
+      _logger.printTrace('lldb failed: $error');
+      return false;
+    }
+
+    return attachCompleter.future;
+  }
+
+  Future<void> detach() async {
+    return _lldbProcess?.stdinWriteln('process detach',
+        onError: (Object error, _) {
+      // Best effort, try to detach, but maybe the app already exited or already detached.
+      _logger.printTrace('Could not detach from debugger: $error');
+    });
+  }
+
+  bool exit() {
+    final bool success = (_lldbProcess == null) || _lldbProcess!.kill();
+    _lldbProcess = null;
+    return success;
+  }
+}
+
+class _LLDBProcess {
+  _LLDBProcess({
+    required Process process,
+    required this.processId,
+    required Logger logger,
+  })  : _lldbProcess = process,
+        processStatus = _AppProcessState.suspended,
+        _logger = logger;
+
+  final Process _lldbProcess;
+  final int processId;
+  _AppProcessState processStatus;
+
+  final Logger _logger;
+
+  Stream<List<int>> get stdout => _lldbProcess.stdout;
+
+  Stream<List<int>> get stderr => _lldbProcess.stderr;
+
+  Future<int> get exitCode => _lldbProcess.exitCode;
+
+  Future<void>? _stdinWriteFuture;
+
+  bool kill() {
+    return _lldbProcess.kill();
+  }
+
+  Future<void> stdinWriteln(
+    String line, {
+    void Function(Object, StackTrace)? onError,
+  }) async {
+    Future<void> writeln() {
+      return ProcessUtils.writelnToStdinGuarded(
+        stdin: _lldbProcess.stdin,
+        line: line,
+        onError: onError ??
+            (Object error, _) {
+              _logger.printTrace('Could not write "$line" to stdin: $error');
+            },
+      );
+    }
+
+    _stdinWriteFuture = _stdinWriteFuture?.then<void>((_) => writeln()) ?? writeln();
+    return _stdinWriteFuture;
+  }
+}
+
+enum _AppProcessState {
+  /// The app process starts in a suspended state while it waits for a debugger.
+  suspended,
+
+  /// The app process is stopped when an error occurs.
+  stopped,
+
+  /// The app process is resumed on all threads.
+  resumed,
+
+  /// LLDB is detached from the app process.
+  detached,
+}


### PR DESCRIPTION
Works with connected and wireless devices.

Prototype for https://github.com/flutter/flutter/issues/133465

Note: lldb does not receive logs. Maybe there's a command to do that?

Alternatively, you can get logs via `devicectl` with this command (the key pieces being `OS_ACTIVITY_DT_MODE` and `--console`:
```
xcrun devicectl device process launch --device 00000000-0000000 --start-stopped --environment-variables '{"OS_ACTIVITY_DT_MODE": "enable"}' --console com.example.vanilla --enable-dart-profiling
```

However, using `--console` leaves the launch process running, so it doesn't print the results of what process was started.

This could be resolved by getting the processes using `devicectl`
```
xcrun devicectl device info processes --device 00000000-0000000 --json-output /path/to/a/file/processes.json
```

And matching the `executable` against the `installationURL` from the `devicectl device install app` command.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
