### PR TITLE
Reland "Identify and re-throw our dependency checking errors in flutter.groovy"

### DIFF
--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -98,7 +98,6 @@ class FlutterExtension {
 
         return flutterVersionName
     }
-
 }
 
 // This buildscript block supplies dependencies for this file's own import
@@ -340,10 +339,27 @@ class FlutterPlugin implements Plugin<Project> {
                         "packages", "flutter_tools", "gradle", "src", "main", "kotlin",
                         "dependency_version_checker.gradle.kts")
                 project.apply from: dependencyCheckerPluginPath
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                // If the exception was thrown by us in the dependency version checker plugin then
+                // re-throw it.
+                Exception outer = e.getCause()
+                if (outer != null) {
+                    Exception inner = outer.getCause()
+                    if (inner != null) {
+                        Exception unwrapped = inner.getCause()
+                        if (unwrapped != null) {
+                            if (unwrapped instanceof DependencyValidationException) {
+                                throw e
+                            }
+                        }
+                    }
+                }
+
+                // Otherwise, dependency version checking has failed. Log and continue
+                // the build.
                 project.logger.error("Warning: Flutter was unable to detect project Gradle, Java, " +
                         "AGP, and KGP versions. Skipping dependency version checking. Error was: "
-                        + ignored)
+                        + e)
             }
         }
 
@@ -1813,4 +1829,16 @@ class FlutterTask extends BaseFlutterTask {
         buildBundle()
     }
 
+}
+
+// Custom error for when the dependency_version_checker.kts script finds a dependency out of
+// the defined support range.
+class DependencyValidationException extends Exception {
+    public DependencyValidationException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public DependencyValidationException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
 }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -340,17 +340,19 @@ class FlutterPlugin implements Plugin<Project> {
                         "dependency_version_checker.gradle.kts")
                 project.apply from: dependencyCheckerPluginPath
             } catch (Exception e) {
-                // If the exception was thrown by us in the dependency version checker plugin then
-                // re-throw it.
-                if (project.hasProperty("failedDependencyChecks")) {
+
+                if (!project.failedDependencyChecks) {
+                    // Dependency version checking has failed. Log and continue
+                    // the build.
+                    project.logger.error("Warning: Flutter was unable to detect project Gradle, Java, " +
+                            "AGP, and KGP versions. Skipping dependency version checking. Error was: "
+                            + e)
+                }
+                else {
+                    // If the exception was thrown by us in the dependency version checker plugin then
+                    // re-throw it.
                     throw e
                 }
-
-                // Otherwise, dependency version checking has failed. Log and continue
-                // the build.
-                project.logger.error("Warning: Flutter was unable to detect project Gradle, Java, " +
-                        "AGP, and KGP versions. Skipping dependency version checking. Error was: "
-                        + e)
             }
         }
 

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -339,6 +339,7 @@ class FlutterPlugin implements Plugin<Project> {
                         "packages", "flutter_tools", "gradle", "src", "main", "kotlin",
                         "dependency_version_checker.gradle.kts")
                 project.apply from: dependencyCheckerPluginPath
+                project.logger.error("HI GRAY" + DependencyVersionChecker.KGP_NAME)
             } catch (Exception e) {
                 // If the exception was thrown by us in the dependency version checker plugin then
                 // re-throw it.

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -339,21 +339,11 @@ class FlutterPlugin implements Plugin<Project> {
                         "packages", "flutter_tools", "gradle", "src", "main", "kotlin",
                         "dependency_version_checker.gradle.kts")
                 project.apply from: dependencyCheckerPluginPath
-                project.logger.error("HI GRAY" + DependencyVersionChecker.KGP_NAME)
             } catch (Exception e) {
                 // If the exception was thrown by us in the dependency version checker plugin then
                 // re-throw it.
-                Exception outer = e.getCause()
-                if (outer != null) {
-                    Exception inner = outer.getCause()
-                    if (inner != null) {
-                        Exception unwrapped = inner.getCause()
-                        if (unwrapped != null) {
-                            if (unwrapped instanceof DependencyValidationException) {
-                                throw e
-                            }
-                        }
-                    }
+                if (project.hasProperty("failedDependencyChecks")) {
+                    throw e
                 }
 
                 // Otherwise, dependency version checking has failed. Log and continue
@@ -1830,16 +1820,4 @@ class FlutterTask extends BaseFlutterTask {
         buildBundle()
     }
 
-}
-
-// Custom error for when the dependency_version_checker.kts script finds a dependency out of
-// the defined support range.
-class DependencyValidationException extends Exception {
-    public DependencyValidationException(String errorMessage) {
-        super(errorMessage);
-    }
-
-    public DependencyValidationException(String errorMessage, Throwable cause) {
-        super(errorMessage, cause);
-    }
 }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -340,17 +340,15 @@ class FlutterPlugin implements Plugin<Project> {
                         "dependency_version_checker.gradle.kts")
                 project.apply from: dependencyCheckerPluginPath
             } catch (Exception e) {
-
-                if (!project.failedDependencyChecks) {
-                    // The dependency version checking script was unable to determine dependency
-                    // versions. Log and continue the build.
+                if (!project.usesUnsupportedDependencyVersions) {
+                    // Possible bug in dependency checking code - warn and do not block build.
                     project.logger.error("Warning: Flutter was unable to detect project Gradle, Java, " +
                             "AGP, and KGP versions. Skipping dependency version checking. Error was: "
                             + e)
                 }
                 else {
-                    // If the exception was thrown by us in the dependency version checker plugin then
-                    // re-throw it.
+                    // If usesUnsupportedDependencyVersions is set, the exception was thrown by us
+                    // in the dependency version checker plugin so re-throw it here.
                     throw e
                 }
             }

--- a/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
+++ b/packages/flutter_tools/gradle/src/main/groovy/flutter.groovy
@@ -342,8 +342,8 @@ class FlutterPlugin implements Plugin<Project> {
             } catch (Exception e) {
 
                 if (!project.failedDependencyChecks) {
-                    // Dependency version checking has failed. Log and continue
-                    // the build.
+                    // The dependency version checking script was unable to determine dependency
+                    // versions. Log and continue the build.
                     project.logger.error("Warning: Flutter was unable to detect project Gradle, Java, " +
                             "AGP, and KGP versions. Skipping dependency version checking. Error was: "
                             + e)

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -235,7 +235,7 @@ class DependencyVersionChecker {
                         errorGradleVersion.toString(),
                         getPotentialGradleFix(project.getRootDir().getPath())
                     )
-                throw GradleException(errorMessage)
+                throw DependencyValidationException(errorMessage)
             } else if (version < warnGradleVersion) {
                 val warnMessage: String =
                     getWarnMessage(
@@ -260,7 +260,7 @@ class DependencyVersionChecker {
                         errorJavaVersion.toString(),
                         POTENTIAL_JAVA_FIX
                     )
-                throw GradleException(errorMessage)
+                throw DependencyValidationException(errorMessage)
             } else if (version < warnJavaVersion) {
                 val warnMessage: String =
                     getWarnMessage(
@@ -285,7 +285,7 @@ class DependencyVersionChecker {
                         errorAGPVersion.toString(),
                         getPotentialAGPFix(project.getRootDir().getPath())
                     )
-                throw GradleException(errorMessage)
+                throw DependencyValidationException(errorMessage)
             } else if (version < warnAGPVersion) {
                 val warnMessage: String =
                     getWarnMessage(
@@ -310,7 +310,7 @@ class DependencyVersionChecker {
                         errorKGPVersion.toString(),
                         getPotentialKGPFix(project.getRootDir().getPath())
                     )
-                throw GradleException(errorMessage)
+                throw DependencyValidationException(errorMessage)
             } else if (version < warnKGPVersion) {
                 val warnMessage: String =
                     getWarnMessage(

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -38,7 +38,7 @@ class DependencyVersionChecker {
         private const val GRADLE_NAME: String = "Gradle"
         private const val JAVA_NAME: String = "Java"
         private const val AGP_NAME: String = "Android Gradle Plugin"
-        public const val KGP_NAME: String = "Kotlin"
+        private const val KGP_NAME: String = "Kotlin"
 
         // The following messages represent best effort guesses at where a Flutter developer should
         // look to upgrade a dependency that is below the corresponding threshold. Developers can

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -104,6 +104,7 @@ class DependencyVersionChecker {
          * we treat it as within the range for the purpose of this check.
          */
         fun checkDependencyVersions(project: Project) {
+            project.extra.set("failedDependencyChecks", false)
             var agpVersion: Version?
             var kgpVersion: Version?
 

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -38,7 +38,7 @@ class DependencyVersionChecker {
         private const val GRADLE_NAME: String = "Gradle"
         private const val JAVA_NAME: String = "Java"
         private const val AGP_NAME: String = "Android Gradle Plugin"
-        private const val KGP_NAME: String = "Kotlin"
+        public const val KGP_NAME: String = "Kotlin"
 
         // The following messages represent best effort guesses at where a Flutter developer should
         // look to upgrade a dependency that is below the corresponding threshold. Developers can

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -235,6 +235,7 @@ class DependencyVersionChecker {
                         errorGradleVersion.toString(),
                         getPotentialGradleFix(project.getRootDir().getPath())
                     )
+                project.extra.set("failedDependencyChecks", true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnGradleVersion) {
                 val warnMessage: String =
@@ -260,6 +261,7 @@ class DependencyVersionChecker {
                         errorJavaVersion.toString(),
                         POTENTIAL_JAVA_FIX
                     )
+                project.extra.set("failedDependencyChecks", true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnJavaVersion) {
                 val warnMessage: String =
@@ -285,6 +287,7 @@ class DependencyVersionChecker {
                         errorAGPVersion.toString(),
                         getPotentialAGPFix(project.getRootDir().getPath())
                     )
+                project.extra.set("failedDependencyChecks", true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnAGPVersion) {
                 val warnMessage: String =
@@ -310,6 +313,7 @@ class DependencyVersionChecker {
                         errorKGPVersion.toString(),
                         getPotentialKGPFix(project.getRootDir().getPath())
                     )
+                project.extra.set("failedDependencyChecks", true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnKGPVersion) {
                 val warnMessage: String =
@@ -358,4 +362,10 @@ class Version(val major: Int, val minor: Int, val patch: Int) : Comparable<Versi
     override fun toString(): String {
         return major.toString() + "." + minor.toString() + "." + patch.toString()
     }
+}
+
+// Custom error for when the dependency_version_checker.kts script finds a dependency out of
+// the defined support range.
+class DependencyValidationException(message: String? = null, cause: Throwable? = null) : Exception(message, cause) {
+    constructor(cause: Throwable) : this(null, cause)
 }

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -39,6 +39,7 @@ class DependencyVersionChecker {
         private const val JAVA_NAME: String = "Java"
         private const val AGP_NAME: String = "Android Gradle Plugin"
         private const val KGP_NAME: String = "Kotlin"
+        private const val OUT_OF_SUPPORT_RANGE_PROPERTY = "usesUnsupportedDependencyVersions"
 
         // The following messages represent best effort guesses at where a Flutter developer should
         // look to upgrade a dependency that is below the corresponding threshold. Developers can
@@ -104,7 +105,7 @@ class DependencyVersionChecker {
          * we treat it as within the range for the purpose of this check.
          */
         fun checkDependencyVersions(project: Project) {
-            project.extra.set("failedDependencyChecks", false)
+            project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false)
             var agpVersion: Version?
             var kgpVersion: Version?
 
@@ -236,7 +237,7 @@ class DependencyVersionChecker {
                         errorGradleVersion.toString(),
                         getPotentialGradleFix(project.getRootDir().getPath())
                     )
-                project.extra.set("failedDependencyChecks", true)
+                project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnGradleVersion) {
                 val warnMessage: String =
@@ -262,7 +263,7 @@ class DependencyVersionChecker {
                         errorJavaVersion.toString(),
                         POTENTIAL_JAVA_FIX
                     )
-                project.extra.set("failedDependencyChecks", true)
+                project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnJavaVersion) {
                 val warnMessage: String =
@@ -288,7 +289,7 @@ class DependencyVersionChecker {
                         errorAGPVersion.toString(),
                         getPotentialAGPFix(project.getRootDir().getPath())
                     )
-                project.extra.set("failedDependencyChecks", true)
+                project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnAGPVersion) {
                 val warnMessage: String =
@@ -314,7 +315,7 @@ class DependencyVersionChecker {
                         errorKGPVersion.toString(),
                         getPotentialKGPFix(project.getRootDir().getPath())
                     )
-                project.extra.set("failedDependencyChecks", true)
+                project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
                 throw DependencyValidationException(errorMessage)
             } else if (version < warnKGPVersion) {
                 val warnMessage: String =

--- a/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
+++ b/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts
@@ -39,6 +39,10 @@ class DependencyVersionChecker {
         private const val JAVA_NAME: String = "Java"
         private const val AGP_NAME: String = "Android Gradle Plugin"
         private const val KGP_NAME: String = "Kotlin"
+
+        // String constant that defines the name of the Gradle extra property that we set when
+        // detecting that the project is using versions outside of Flutter's support range.
+        // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-project/index.html#-2107180640%2FProperties%2F-1867656071.
         private const val OUT_OF_SUPPORT_RANGE_PROPERTY = "usesUnsupportedDependencyVersions"
 
         // The following messages represent best effort guesses at where a Flutter developer should


### PR DESCRIPTION
The original approach in https://github.com/flutter/flutter/pull/149609 didn't work when the Flutter Gradle plugin was applied using the deprecated script apply - the kotlin portion couldn't resolve the custom exception defined in `flutter.groovy`:
```
e: /Users/mackall/development/flutter/flutter/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts:238:23: Unresolved reference: DependencyValidationException
e: /Users/mackall/development/flutter/flutter/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts:263:23: Unresolved reference: DependencyValidationException
e: /Users/mackall/development/flutter/flutter/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts:288:23: Unresolved reference: DependencyValidationException
e: /Users/mackall/development/flutter/flutter/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts:313:23: Unresolved reference: DependencyValidationException
Warning: Flutter was unable to detect project Gradle, Java, AGP, and KGP versions. Skipping dependency version checking. Error was: org.gradle.internal.exceptions.LocationAwareException: Script '/Users/mackall/development/flutter/flutter/packages/flutter_tools/gradle/src/main/kotlin/dependency_version_checker.gradle.kts' line: 238
Script compilation errors:

  Line 238:                 throw DependencyValidationException(errorMessage)
                                  ^ Unresolved reference: DependencyValidationException

  Line 263:                 throw DependencyValidationException(errorMessage)
                                  ^ Unresolved reference: DependencyValidationException

  Line 288:                 throw DependencyValidationException(errorMessage)
                                  ^ Unresolved reference: DependencyValidationException

  Line 313:                 throw DependencyValidationException(errorMessage)
                                  ^ Unresolved reference: DependencyValidationException
```

This new approach of setting one of the [`extra` properties](https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#N14FF7) works in both cases (tested with the `camera_android` example app, which uses the script apply, and a freshly created counter app). 

It also removes some brittleness in that we don't have to unwrap the exception anymore, and aren't subject to breaking if Gradle decides one day to wrap our custom exception 1 layer deeper in additional exceptions.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
