### PR TITLE
Fixes for Style Guide for Flutter Repo

### DIFF
--- a/docs/contributing/Style-guide-for-Flutter-repo.md
+++ b/docs/contributing/Style-guide-for-Flutter-repo.md
@@ -2,7 +2,10 @@
 
 ## Summary
 
-Optimize for readability. Write detailed documentation. Make error messages useful. Never use timeouts or timers. Avoid `is`, `print`, `part of`, `extension` and `_`.
+Optimize for readability. Write detailed documentation.
+Make error messages useful.
+Never use timeouts or timers.
+Avoid `is`, `print`, `part of`, `extension` and `_`.
 
 ## Introduction
 
@@ -27,8 +30,9 @@ understanding with new team members.
 The primary goal of these style guidelines is to improve code readability so
 that everyone, whether reading the code for the first time or
 maintaining it for years, can quickly determine what the code does.
-Secondary goals are to design systems that are simple, to increase the
-likelihood of catching bugs quickly, and to avoid arguments over subjective matters.
+Secondary goals are to design systems that are simple; to increase the
+likelihood of catching bugs quickly; and to avoid arguments when there are
+disagreements over subjective matters.
 
 For anything not covered by this document, check the
 [Dart style guide](https://www.dartlang.org/guides/language/effective-dart/)
@@ -50,7 +54,7 @@ use in general.)
 
 ### A word on designing APIs
 
-API design is an art. Like all forms of art, one learns by practicing. The best way to get good at designing APIs is to spend a decade or more designing them, while working closely with people who are using your APIs. Ideally, one would first do this in very controlled situations, with small numbers of developers using one's APIs, before graduating to writing APIs that will be used by hundreds of thousands or even millions of developers.
+Designing an API is an art. Like all forms of art, one learns by practicing. The best way to get good at designing APIs is to spend a decade or more designing them, while working closely with people who are using your APIs. Ideally, one would first do this in very controlled situations, with small numbers of developers using one's APIs, before graduating to writing APIs that will be used by hundreds of thousands or even millions of developers.
 
 In the absence of one's own experience, one can attempt to rely on the experience of others. The biggest problem with this is that sometimes explaining why an API isn't optimal is a very difficult and subtle task, and sometimes the reasoning doesn't sound convincing unless you already have a lot of experience designing them.
 
@@ -1895,9 +1899,9 @@ The `dart:math` library is always imported `as math`.
 
 As a general rule, if a feature is entirely self-contained (not requiring low-level integration into the Flutter framework) and is not something with universal appeal, we would encourage that that feature be provided as a package.
 
-We try to be conservative with what we add to the framework because we have to support it. We have to document it, test it, and create samples. We have to consider the many ways people may use it. We have to fix bugs. If there are design problems, we may not find out for a long time. Once we do, we have to figure out how to fix them without breaking downstream code, or we have to migrate all our existing widgets to the new design.
+We try to be very conservative with what we put in the core framework, because there's a high cost to having anything there. We have to commit to supporting it for years to come, we have to document it, test it, create samples, we have to consider everyone's varied desires which they may have as they use the feature, we have to fix bugs. If there are design problems, we may not find out for a long time but then once we do we then have to figure out how to fix them without breaking downstream code, or we have to migrate all our existing widgets to the new architecture, etc.
 
-Basically, code is expensive. So before we take it, if possible, we like to see if we can prove the code's value. By creating a package, we can see if people use the feature, how they like it, and whether it would be useful for the framework, all without incurring support costs.
+Basically, code is expensive. So before we take it, if possible, we like to see if we can prove the code's value. By creating a package, we can see if people use the feature, how they like it, whether it would be useful for the framework, etc, without having to take on the costs.
 
 We have two main kinds of packages that are maintained by the Flutter team, both of which live in [flutter/packages](https://github.com/flutter/packages):
 

--- a/docs/contributing/Style-guide-for-Flutter-repo.md
+++ b/docs/contributing/Style-guide-for-Flutter-repo.md
@@ -31,7 +31,7 @@ understanding with new team members.
 The primary goal of these style guidelines is to improve code readability so
 that everyone, whether reading the code for the first time or
 maintaining it for years, can quickly determine what the code does.
-Secondary goals are to design systems that are simple and bug-free, 
+Secondary goals are to design systems that are simple and bug-free,
 and to avoid arguments over subjective matters.
 
 For anything not covered by this document, check the

--- a/docs/contributing/Style-guide-for-Flutter-repo.md
+++ b/docs/contributing/Style-guide-for-Flutter-repo.md
@@ -2,11 +2,7 @@
 
 ## Summary
 
-- Optimize for readability.
-- Write detailed documentation.
-- Make error messages useful.
-- Never use timeouts or timers.
-- Avoid `is`, `print`, `part of`, `extension` and `_`.
+Optimize for readability. Write detailed documentation. Make error messages useful. Never use timeouts or timers. Avoid `is`, `print`, `part of`, `extension` and `_`.
 
 ## Introduction
 
@@ -31,8 +27,8 @@ understanding with new team members.
 The primary goal of these style guidelines is to improve code readability so
 that everyone, whether reading the code for the first time or
 maintaining it for years, can quickly determine what the code does.
-Secondary goals are to design systems that are simple and bug-free,
-and to avoid arguments over subjective matters.
+Secondary goals are to design systems that are simple, to increase the
+likelihood of catching bugs quickly, and to avoid arguments over subjective matters.
 
 For anything not covered by this document, check the
 [Dart style guide](https://www.dartlang.org/guides/language/effective-dart/)
@@ -52,7 +48,7 @@ interactions with the code, and that the reader is more experienced with Dart.
 flutter/flutter and flutter/engine repositories. However, we do recommend its
 use in general.)
 
-### A word on API design
+### A word on designing APIs
 
 API design is an art. Like all forms of art, one learns by practicing. The best way to get good at designing APIs is to spend a decade or more designing them, while working closely with people who are using your APIs. Ideally, one would first do this in very controlled situations, with small numbers of developers using one's APIs, before graduating to writing APIs that will be used by hundreds of thousands or even millions of developers.
 
@@ -537,7 +533,7 @@ Example:
 abstract class Picture ...
 ```
 
-You can also use "See also" links:
+You can also use "See also" links, as in:
 
 ```dart
 /// See also:

--- a/docs/contributing/Style-guide-for-Flutter-repo.md
+++ b/docs/contributing/Style-guide-for-Flutter-repo.md
@@ -1,11 +1,12 @@
-### Style guide for Flutter repo
+# Style guide for Flutter repo
 
 ## Summary
 
-Optimize for readability. Write detailed documentation.
-Make error messages useful.
-Never use timeouts or timers.
-Avoid `is`, `print`, `part of`, `extension` and `_`.
+- Optimize for readability.
+- Write detailed documentation.
+- Make error messages useful.
+- Never use timeouts or timers.
+- Avoid `is`, `print`, `part of`, `extension` and `_`.
 
 ## Introduction
 
@@ -30,9 +31,8 @@ understanding with new team members.
 The primary goal of these style guidelines is to improve code readability so
 that everyone, whether reading the code for the first time or
 maintaining it for years, can quickly determine what the code does.
-Secondary goals are to design systems that are simple, to increase the
-likelihood of catching bugs quickly, and avoiding arguments when there are
-disagreements over subjective matters.
+Secondary goals are to design systems that are simple and bug-free, 
+and to avoid arguments over subjective matters.
 
 For anything not covered by this document, check the
 [Dart style guide](https://www.dartlang.org/guides/language/effective-dart/)
@@ -52,9 +52,9 @@ interactions with the code, and that the reader is more experienced with Dart.
 flutter/flutter and flutter/engine repositories. However, we do recommend its
 use in general.)
 
-### A word on designing APIs
+### A word on API design
 
-Designing an API is an art. Like all forms of art, one learns by practicing. The best way to get good at designing APIs is to spend a decade or more designing them, while working closely with people who are using your APIs. Ideally, one would first do this in very controlled situations, with small numbers of developers using one's APIs, before graduating to writing APIs that will be used by hundreds of thousands or even millions of developers.
+API design is an art. Like all forms of art, one learns by practicing. The best way to get good at designing APIs is to spend a decade or more designing them, while working closely with people who are using your APIs. Ideally, one would first do this in very controlled situations, with small numbers of developers using one's APIs, before graduating to writing APIs that will be used by hundreds of thousands or even millions of developers.
 
 In the absence of one's own experience, one can attempt to rely on the experience of others. The biggest problem with this is that sometimes explaining why an API isn't optimal is a very difficult and subtle task, and sometimes the reasoning doesn't sound convincing unless you already have a lot of experience designing them.
 
@@ -537,7 +537,7 @@ Example:
 abstract class Picture ...
 ```
 
-You can also use "See also" links, is in:
+You can also use "See also" links:
 
 ```dart
 /// See also:
@@ -1525,7 +1525,7 @@ String capitalize(String s) {
 If your code is passing an inline closure that merely returns a list or
 map literal, or a switch expression, or is merely calling another function,
 then if the argument is on its own line, then rather than using braces and a
-return` statement, you can instead use the `=>` form. When doing this, the
+`return` statement, you can instead use the `=>` form. When doing this, the
 closing `]`, `}`, or `)` bracket will line up with the argument name, for
 named arguments, or the `(` of the argument list, for positional arguments.
 
@@ -1870,7 +1870,7 @@ the features.
 
 ### Import conventions
 
-Under lib/src, for in-folder import use relative import. For cross-folder import,
+Under `lib/src`, for in-folder import, use relative import. For cross-folder import,
 import the entire package with absolute import.
 
 When importing the `rendering.dart` library into higher level libraries,
@@ -1899,9 +1899,9 @@ The `dart:math` library is always imported `as math`.
 
 As a general rule, if a feature is entirely self-contained (not requiring low-level integration into the Flutter framework) and is not something with universal appeal, we would encourage that that feature be provided as a package.
 
-We try to be very conservative with what we put in the core framework, because there's a high cost to having anything there. We have to commit to supporting it for years to come, we have to document it, test it, create samples, we have to consider everyone's varied desires which they may have as they use the feature, we have to fix bugs. If there's design problems, we may not find out for a long time but then once we do we then have to figure out how to fix them without breaking people, or we have to migrate all our existing widgets to the new architecture, etc.
+We try to be conservative with what we add to the framework because we have to support it. We have to document it, test it, and create samples. We have to consider the many ways people may use it. We have to fix bugs. If there are design problems, we may not find out for a long time. Once we do, we have to figure out how to fix them without breaking downstream code, or we have to migrate all our existing widgets to the new design.
 
-Basically, code is expensive. So before we take it, if possible, we like to see if we can prove the code's value. By creating a package, we can see if people use the feature, how they like it, whether it would be useful for the framework, etc, without having to take on the costs.
+Basically, code is expensive. So before we take it, if possible, we like to see if we can prove the code's value. By creating a package, we can see if people use the feature, how they like it, and whether it would be useful for the framework, all without incurring support costs.
 
 We have two main kinds of packages that are maintained by the Flutter team, both of which live in [flutter/packages](https://github.com/flutter/packages):
 


### PR DESCRIPTION
Fix broken links, typos, and inconsistent formatting in the Style Guide for Flutter Repo.

Fixes [150164](https://github.com/flutter/flutter/issues/150164).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] [*N/A*] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] [*N/A*] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] [*N/A*] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
