### PR TITLE
Update doc for `ColorScheme.surface`

### DIFF
--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -1153,7 +1153,7 @@ class ColorScheme with Diagnosticable {
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onErrorContainer => _onErrorContainer ?? onError;
 
-  /// The background color for widgets like [Card].
+  /// The background color for widgets like [Scaffold].
   final Color surface;
 
   /// A color that's clearly legible when drawn on [surface].


### PR DESCRIPTION
This PR just has a tiny doc change to correct the doc for `ColorScheme.surface`. Previously, Card background color defaults to `ColorScheme.surface` but we updated the default since we've introduced the new tone-based surface colors, like `surfaceContainer`, `surfaceContainerLow` and etc. The `surface` in ColorScheme should now replace deprecated `background` which is the default background color of Scaffold.

Related to the comment here: https://github.com/flutter/flutter/pull/149772#issuecomment-2157596540

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
