### PR TITLE
Reland fix inputDecorator hint color on M3

### DIFF
--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -34,9 +34,9 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color: Theme.of(context).disabledColor);
+      return TextStyle(color: ${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
     }
-    return TextStyle(color: Theme.of(context).hintColor);
+    return TextStyle(color: ${componentColor('md.comp.filled-text-field.supporting-text')});
   });
 
   @override

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -4671,9 +4671,9 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color: Theme.of(context).disabledColor);
+      return TextStyle(color: _colors.onSurface.withOpacity(0.38));
     }
-    return TextStyle(color: Theme.of(context).hintColor);
+    return TextStyle(color: _colors.onSurfaceVariant);
   });
 
   @override

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2879,8 +2879,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -2945,8 +2944,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.withOpacity(0.38).
-          final Color expectedColor = theme.disabledColor;
+          final Color expectedColor = theme.colorScheme.onSurface.withOpacity(0.38);
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3011,8 +3009,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3077,8 +3074,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3143,8 +3139,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3353,8 +3348,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3467,8 +3461,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3533,8 +3526,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.withOpacity(0.38).
-          final Color expectedColor = theme.disabledColor;
+          final Color expectedColor = theme.colorScheme.onSurface.withOpacity(0.38);
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3599,8 +3591,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3665,8 +3656,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3731,8 +3721,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);
@@ -3939,8 +3928,7 @@ void main() {
           expect(getHintOpacity(tester), 1.0);
 
           final ThemeData theme = Theme.of(tester.element(findDecorator()));
-          // TODO(bleroux): from M3 specification, it should be theme.colorScheme.onSurface.
-          final Color expectedColor = theme.hintColor;
+          final Color expectedColor = theme.colorScheme.onSurfaceVariant;
           // TODO(bleroux): from M3 specification, it should be textTheme.bodyLarge.
           final TextStyle expectedStyle = theme.textTheme.titleMedium!.copyWith(color: expectedColor);
           expect(getHintStyle(tester), expectedStyle);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5455,7 +5455,34 @@ void main() {
       color: Colors.pink[500],
       fontSize: 10.0,
     );
+    final ThemeData themeData = ThemeData();
+
+    await tester.pumpWidget(
+      overlay(
+        child: Theme(
+          data: themeData,
+          child: TextField(
+            decoration: const InputDecoration(
+              hintText: 'Placeholder',
+            ),
+            style: style,
+          ),
+        ),
+      ),
+    );
+
+    final Text hintText = tester.widget(find.text('Placeholder'));
+    expect(hintText.style!.color, themeData.colorScheme.onSurfaceVariant);
+    expect(hintText.style!.fontSize, style.fontSize);
+  });
+
+  testWidgets('Material2 - TextField with default hintStyle', (WidgetTester tester) async {
+    final TextStyle style = TextStyle(
+      color: Colors.pink[500],
+      fontSize: 10.0,
+    );
     final ThemeData themeData = ThemeData(
+      useMaterial3: false,
       hintColor: Colors.blue[500],
     );
 


### PR DESCRIPTION
## Description

This PR is a partial reland of https://github.com/flutter/flutter/pull/148944 which was reverted in https://github.com/flutter/flutter/pull/149448.
It makes the `InputDecoration.hintText` colors compliant with the M3 spec.
The initial PR also changed the font style, I will land the font change in another PR to better track the golden changes.

## Related Issue

Related to the color part of https://github.com/flutter/flutter/issues/148787.

## Tests

Updates several tests.