### PR TITLE
Fix flaky complex_layout_scroll_perf__memory test

### DIFF
--- a/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
+++ b/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
   final Completer<void> ready = Completer<void>();
   runApp(GestureDetector(
     onTap: () {
-      debugPrint('Received tap.');
+      debugPrint('==== MEMORY BENCHMARK ==== TAPPED ====');
       ready.complete();
     },
     behavior: HitTestBehavior.opaque,
@@ -32,11 +32,6 @@ Future<void> main() async {
     ),
   ));
   await SchedulerBinding.instance.endOfFrame;
-
-  /// Wait 50ms to allow the raster thread to actually put up the frame. (The
-  /// endOfFrame future ends when we send the data to the engine, before
-  /// the raster thread has had a chance to rasterize, etc.)
-  await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
 
   await ready.future; // waits for tap sent by devicelab task

--- a/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
+++ b/dev/benchmarks/complex_layout/test_memory/scroll_perf.dart
@@ -37,6 +37,9 @@ Future<void> main() async {
   await ready.future; // waits for tap sent by devicelab task
   debugPrint('Continuing...');
 
+  // Wait out any errant taps due to synchronization
+  await Future<void>.delayed(const Duration(milliseconds: 200));
+
   // remove onTap handler, enable pointer events for app
   runApp(GestureDetector(
     child: const IgnorePointer(

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2082,10 +2082,10 @@ class MemoryTest {
           if (tapped) {
             break;
           }
-          i += 1;
-          print('tapping device... [$i]');
+          tapCount += 1;
+          print('tapping device... [$tapCount]');
           await device!.tap(100, 100);
-          await Future<void>.delayed(const Duration(milliseconds: 250));
+          await Future<void>.delayed(const Duration(milliseconds: 100));
         }
       }(),
       () async {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2075,7 +2075,7 @@ class MemoryTest {
     // or throw an error instead of tying up the infrastructure for 30 minutes.
     prepareForNextMessage('TAPPED');
     bool tapped = false;
-    int i = 0;
+    int tapCount = 0;
     await Future.any(<Future<void>>[
       () async {
         while (true) {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2071,9 +2071,34 @@ class MemoryTest {
     await launchApp();
     await recordStart();
 
+    // Keep "tapping" the device till it responds with the string we expect,
+    // or throw an error instead of tying up the infrastructure for 30 minutes.
+    prepareForNextMessage('TAPPED');
+    bool tapped = false;
+    int i = 0;
+    await Future.any(<Future<void>>[
+      () async {
+        while (true) {
+          if (tapped) {
+            break;
+          }
+          i += 1;
+          print('tapping device... [$i]');
+          await device!.tap(100, 100);
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+        }
+      }(),
+      () async {
+        print('awaiting "tapped" message... (timeout: 10 seconds)');
+        try {
+          await receivedNextMessage?.timeout(const Duration(seconds: 10));
+        } finally {
+          tapped = true;
+        }
+      }(),
+    ]);
+
     prepareForNextMessage('DONE');
-    print('tapping device...');
-    await device!.tap(100, 100);
     print('awaiting "done" message...');
     await receivedNextMessage;
 

--- a/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
+++ b/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
@@ -26,7 +26,7 @@ Future<void> main() async {
   final Completer<void> ready = Completer<void>();
   runApp(GestureDetector(
     onTap: () {
-      debugPrint('Received tap.');
+      debugPrint('==== MEMORY BENCHMARK ==== TAPPED ====');
       ready.complete();
     },
     behavior: HitTestBehavior.opaque,
@@ -35,7 +35,6 @@ Future<void> main() async {
     ),
   ));
   await SchedulerBinding.instance.endOfFrame;
-  await Future<void>.delayed(const Duration(milliseconds: 50));
   debugPrint('==== MEMORY BENCHMARK ==== READY ====');
 
   await ready.future;

--- a/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
+++ b/dev/integration_tests/flutter_gallery/test_memory/memory_nav.dart
@@ -40,6 +40,9 @@ Future<void> main() async {
   await ready.future;
   debugPrint('Continuing...');
 
+  // Wait out any errant taps due to synchronization
+  await Future<void>.delayed(const Duration(milliseconds: 200));
+
   // remove onTap handler, enable pointer events for app
   runApp(GestureDetector(
     child: const IgnorePointer(


### PR DESCRIPTION
Initial tap is missing sometimes; either its never delivered or it is delivered before gesture controller is hooked up.

1: Update the two perf tests to output when TAPPED is received
2: Update the MemoryTest to keep tapping while waiting for TAPPED

Tested on devicelab:
* setting iterations=1
* removing the timeout before READY
* running tests in a while loop

Before this change, you could get the test to hang often. After this change you'll see "tapping device... [x]" where x is the counter.

Fixes #150096