### PR TITLE
Enhances intuitiveness of RawMagnifier's example

### DIFF
--- a/examples/api/lib/widgets/magnifier/magnifier.0.dart
+++ b/examples/api/lib/widgets/magnifier/magnifier.0.dart
@@ -14,7 +14,8 @@ class MagnifierExampleApp extends StatefulWidget {
 }
 
 class _MagnifierExampleAppState extends State<MagnifierExampleApp> {
-  Offset dragGesturePosition = Offset.zero;
+  static const double magnifierRadius = 50.0;
+  Offset dragGesturePosition = const Offset(100, 100);
 
   @override
   Widget build(BuildContext context) {
@@ -34,18 +35,23 @@ class _MagnifierExampleAppState extends State<MagnifierExampleApp> {
                           dragGesturePosition = details.localPosition;
                         },
                       ),
+                      onPanDown: (DragDownDetails details) => setState(
+                        () {
+                          dragGesturePosition = details.localPosition;
+                        },
+                      ),
                       child: const FlutterLogo(size: 200),
                     ),
                     Positioned(
-                      left: dragGesturePosition.dx,
-                      top: dragGesturePosition.dy,
+                      left: dragGesturePosition.dx - magnifierRadius,
+                      top: dragGesturePosition.dy - magnifierRadius,
                       child: const RawMagnifier(
                         decoration: MagnifierDecoration(
                           shape: CircleBorder(
                             side: BorderSide(color: Colors.pink, width: 3),
                           ),
                         ),
-                        size: Size(100, 100),
+                        size: Size(magnifierRadius * 2, magnifierRadius * 2),
                         magnificationScale: 2,
                       ),
                     )

--- a/examples/api/test/widgets/magnifier/magnifier.0_test.dart
+++ b/examples/api/test/widgets/magnifier/magnifier.0_test.dart
@@ -19,33 +19,38 @@ void main() {
       );
     }
 
-    expect(
-      tester.widget(find.byType(Positioned)),
-      isPositionedAt(Offset.zero),
-    );
+    // Make sure magnifier is present.
+    final Finder positionedWidget = find.byType(Positioned);
+    final Widget positionedWidgetInTree = tester.widget(positionedWidget);
+    final Positioned oldConcretePositioned = positionedWidgetInTree as Positioned;
+    expect(positionedWidget, findsOneWidget);
 
-    final Offset centerOfFlutterLogo = tester.getCenter(find.byType(Positioned));
-    final Offset topLeftOfFlutterLogo = tester.getTopLeft(find.byType(FlutterLogo));
+    // Confirm if magnifier is in the center of the FlutterLogo.
+    final Offset centerOfPositioned = tester.getCenter(positionedWidget);
+    final Offset centerOfFlutterLogo = tester.getCenter(find.byType(FlutterLogo));
+    expect(centerOfPositioned, equals(centerOfFlutterLogo));
 
+    // Drag the magnifier and confirm its new position is expected.
     const Offset dragDistance = Offset(10, 10);
-
-    await tester.dragFrom(centerOfFlutterLogo, dragDistance);
+    final Offset updatedPositioned = Offset(
+      oldConcretePositioned.left ?? 0.0 + 10.0,
+      oldConcretePositioned.top ?? 0.0 + 10.0,
+    );
+    await tester.dragFrom(centerOfPositioned, dragDistance);
     await tester.pump();
-
     expect(
-      tester.widget(find.byType(Positioned)),
-      // Need to adjust by the topleft since the position is local.
-      isPositionedAt((centerOfFlutterLogo - topLeftOfFlutterLogo) + dragDistance),
+      positionedWidgetInTree,
+      isPositionedAt(updatedPositioned),
     );
   });
 
   testWidgets('should match golden', (WidgetTester tester) async {
     await tester.pumpWidget(const example.MagnifierExampleApp());
 
-    final Offset centerOfFlutterLogo = tester.getCenter(find.byType(Positioned));
+    final Offset centerOfPositioned = tester.getCenter(find.byType(Positioned));
     const Offset dragDistance = Offset(10, 10);
 
-    await tester.dragFrom(centerOfFlutterLogo, dragDistance);
+    await tester.dragFrom(centerOfPositioned, dragDistance);
     await tester.pump();
 
     await expectLater(


### PR DESCRIPTION
### Demo

| Before | After |
| --------------- | --------------- |
<video src="https://github.com/flutter/flutter/assets/104349824/ee6d45f1-bcf0-4136-8d1d-a642e0767322"/> | <video src="https://github.com/flutter/flutter/assets/104349824/1e2bb33d-40f1-4cf6-9999-f67bef638633"/>

### Related issue

Fixes https://github.com/flutter/flutter/issues/150307


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Data Driven Fixes]: https://github.com/flutter/flutter/wiki/Data-driven-Fixes
