### PR TITLE
closes #150048  Autocomplete don't hide options when keyboardDismissBehavior:  ScrollViewKeyboardDismissBehavior.onDrag on desktop 

### DIFF
--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -271,7 +271,7 @@ class SingleChildScrollView extends StatelessWidget {
         child: scrollable,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode currentScope = FocusScope.of(context);
-            if (!currentScope.hasPrimaryFocus && currentScope.hasFocus ) {
+            if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
             FocusManager.instance.primaryFocus?.unfocus();
           }
           return false;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -271,7 +271,7 @@ class SingleChildScrollView extends StatelessWidget {
         child: scrollable,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode currentScope = FocusScope.of(context);
-          if (notification.dragDetails != null && !currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+            if (!currentScope.hasPrimaryFocus && currentScope.hasFocus ) {
             FocusManager.instance.primaryFocus?.unfocus();
           }
           return false;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -271,7 +271,7 @@ class SingleChildScrollView extends StatelessWidget {
         child: scrollable,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode currentScope = FocusScope.of(context);
-            if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+            if(!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
             FocusManager.instance.primaryFocus?.unfocus();
           }
           return false;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -271,7 +271,7 @@ class SingleChildScrollView extends StatelessWidget {
         child: scrollable,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode currentScope = FocusScope.of(context);
-            if(!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+            if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
             FocusManager.instance.primaryFocus?.unfocus();
           }
           return false;

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -271,7 +271,7 @@ class SingleChildScrollView extends StatelessWidget {
         child: scrollable,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode currentScope = FocusScope.of(context);
-            if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+          if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
             FocusManager.instance.primaryFocus?.unfocus();
           }
           return false;

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -16,14 +16,13 @@ class TestScrollPosition extends ScrollPositionWithSingleContext {
     double super.initialPixels,
     super.oldPosition,
   }) : super(
-          context: state,
-        );
+    context: state,
+  );
 }
 
 class TestScrollController extends ScrollController {
   @override
-  ScrollPosition createScrollPosition(ScrollPhysics physics,
-      ScrollContext context, ScrollPosition? oldPosition) {
+  ScrollPosition createScrollPosition(ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
     return TestScrollPosition(
       physics: physics,
       state: context,
@@ -33,8 +32,7 @@ class TestScrollController extends ScrollController {
   }
 }
 
-Widget primaryScrollControllerBoilerplate(
-    {required Widget child, required ScrollController controller}) {
+Widget primaryScrollControllerBoilerplate({ required Widget child, required ScrollController controller }) {
   return Directionality(
     textDirection: TextDirection.ltr,
     child: MediaQuery(
@@ -48,8 +46,7 @@ Widget primaryScrollControllerBoilerplate(
 }
 
 void main() {
-  testWidgets('SingleChildScrollView overflow and clipRect test',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView overflow and clipRect test', (WidgetTester tester) async {
     // the test widowSize is Size(800.0, 600.0)
     await tester.pumpWidget(
       Directionality(
@@ -61,13 +58,8 @@ void main() {
     );
 
     // 1st, check that the render object has received the default clip behavior.
-    final dynamic renderObject = tester.allRenderObjects
-        .where((RenderObject o) =>
-            o.runtimeType.toString() == '_RenderSingleChildViewport')
-        .first;
-    // ignore: avoid_dynamic_calls
-    expect(renderObject.clipBehavior,
-        equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
+    final dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
 
     // 2nd, height == widow.height test: check that the painting context does not call pushClipRect .
     TestClipPaintingContext context = TestClipPaintingContext();
@@ -115,7 +107,7 @@ void main() {
     expect(context.clipBehavior, equals(Clip.hardEdge));
   });
 
-  testWidgets('SingleChildScrollView with Autocomplete test',
+  testWidgets('SingleChildScrollView ScrollViewKeyboardDismissBehavior.onDrag test',
       (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -132,9 +124,9 @@ void main() {
                 Autocomplete<String>(
                   optionsBuilder: (TextEditingValue textEditingValue) {
                     return <String>[
-                      'aardvark',
-                      'bobcat',
-                      'chameleon',
+                      'flutter',
+                      'dart',
+                      'pub',
                     ].where((String option) {
                       return option
                           .contains(textEditingValue.text.toLowerCase());
@@ -156,19 +148,12 @@ void main() {
     }
   });
 
-  testWidgets('SingleChildScrollView respects clipBehavior',
-      (WidgetTester tester) async {
-    await tester
-        .pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
+  testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {
+    await tester.pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
 
     // 1st, check that the render object has received the default clip behavior.
-    final dynamic renderObject = tester.allRenderObjects
-        .where((RenderObject o) =>
-            o.runtimeType.toString() == '_RenderSingleChildViewport')
-        .first;
-    // ignore: avoid_dynamic_calls
-    expect(renderObject.clipBehavior,
-        equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
+    final dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
 
     // 2nd, check that the painting context has received the default clip behavior.
     final TestClipPaintingContext context = TestClipPaintingContext();
@@ -177,19 +162,15 @@ void main() {
 
     // 3rd, check that the underlying Scrollable has the same clipBehavior
     // Regression test for https://github.com/flutter/flutter/issues/133330
-    Finder scrollable =
-        find.byWidgetPredicate((Widget widget) => widget is Scrollable);
+    Finder scrollable = find.byWidgetPredicate((Widget widget) => widget is Scrollable);
     expect(
       (tester.widget(scrollable) as Scrollable).clipBehavior,
       Clip.hardEdge,
     );
 
     // 4th, pump a new widget to check that the render object can update its clip behavior.
-    await tester.pumpWidget(SingleChildScrollView(
-        clipBehavior: Clip.antiAlias, child: Container(height: 2000.0)));
-    // ignore: avoid_dynamic_calls
-    expect(renderObject.clipBehavior,
-        equals(Clip.antiAlias)); // ignore: avoid_dynamic_calls
+    await tester.pumpWidget(SingleChildScrollView(clipBehavior: Clip.antiAlias, child: Container(height: 2000.0)));
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias)); // ignore: avoid_dynamic_calls
 
     // 5th, check that a non-default clip behavior can be sent to the painting context.
     renderObject.paint(context, Offset.zero); // ignore: avoid_dynamic_calls
@@ -197,16 +178,14 @@ void main() {
 
     // 6th, check that the underlying Scrollable has the same clipBehavior
     // Regression test for https://github.com/flutter/flutter/issues/133330
-    scrollable =
-        find.byWidgetPredicate((Widget widget) => widget is Scrollable);
+    scrollable = find.byWidgetPredicate((Widget widget) => widget is Scrollable);
     expect(
       (tester.widget(scrollable) as Scrollable).clipBehavior,
       Clip.antiAlias,
     );
   });
 
-  testWidgets('SingleChildScrollView control test',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView control test', (WidgetTester tester) async {
     await tester.pumpWidget(SingleChildScrollView(
       child: Container(
         height: 2000.0,
@@ -217,14 +196,12 @@ void main() {
     final RenderBox box = tester.renderObject(find.byType(Container));
     expect(box.localToGlobal(Offset.zero), equals(Offset.zero));
 
-    await tester.drag(
-        find.byType(SingleChildScrollView), const Offset(-200.0, -200.0));
+    await tester.drag(find.byType(SingleChildScrollView), const Offset(-200.0, -200.0));
 
     expect(box.localToGlobal(Offset.zero), equals(const Offset(0.0, -200.0)));
   });
 
-  testWidgets('Changing controllers changes scroll position',
-      (WidgetTester tester) async {
+  testWidgets('Changing controllers changes scroll position', (WidgetTester tester) async {
     final TestScrollController controller = TestScrollController();
     addTearDown(controller.dispose);
 
@@ -247,8 +224,7 @@ void main() {
     expect(scrollable.position, isA<TestScrollPosition>());
   });
 
-  testWidgets('Sets PrimaryScrollController when primary',
-      (WidgetTester tester) async {
+  testWidgets('Sets PrimaryScrollController when primary', (WidgetTester tester) async {
     final ScrollController primaryScrollController = ScrollController();
     addTearDown(primaryScrollController.dispose);
     await tester.pumpWidget(PrimaryScrollController(
@@ -266,9 +242,8 @@ void main() {
     expect(scrollable.controller, primaryScrollController);
   });
 
-  testWidgets(
-      'Changing scroll controller inside dirty layout builder does not assert',
-      (WidgetTester tester) async {
+
+  testWidgets('Changing scroll controller inside dirty layout builder does not assert', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
 
@@ -306,22 +281,17 @@ void main() {
     ));
   });
 
-  testWidgets('Vertical SingleChildScrollViews are not primary by default',
-      (WidgetTester tester) async {
+  testWidgets('Vertical SingleChildScrollViews are not primary by default', (WidgetTester tester) async {
     const SingleChildScrollView view = SingleChildScrollView();
     expect(view.primary, isNull);
   });
 
-  testWidgets('Horizontal SingleChildScrollViews are not primary by default',
-      (WidgetTester tester) async {
-    const SingleChildScrollView view =
-        SingleChildScrollView(scrollDirection: Axis.horizontal);
+  testWidgets('Horizontal SingleChildScrollViews are not primary by default', (WidgetTester tester) async {
+    const SingleChildScrollView view = SingleChildScrollView(scrollDirection: Axis.horizontal);
     expect(view.primary, isNull);
   });
 
-  testWidgets(
-      'SingleChildScrollViews with controllers are not primary by default',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildScrollViews with controllers are not primary by default', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final SingleChildScrollView view = SingleChildScrollView(
@@ -330,9 +300,7 @@ void main() {
     expect(view.primary, isNull);
   });
 
-  testWidgets(
-      'Vertical SingleChildScrollViews use PrimaryScrollController by default on mobile',
-      (WidgetTester tester) async {
+  testWidgets('Vertical SingleChildScrollViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(primaryScrollControllerBoilerplate(
@@ -342,9 +310,7 @@ void main() {
     expect(controller.hasClients, isTrue);
   }, variant: TargetPlatformVariant.mobile());
 
-  testWidgets(
-      "Vertical SingleChildScrollViews don't use PrimaryScrollController by default on desktop",
-      (WidgetTester tester) async {
+  testWidgets("Vertical SingleChildScrollViews don't use PrimaryScrollController by default on desktop", (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(primaryScrollControllerBoilerplate(
@@ -354,8 +320,7 @@ void main() {
     expect(controller.hasClients, isFalse);
   }, variant: TargetPlatformVariant.desktop());
 
-  testWidgets('Nested scrollables have a null PrimaryScrollController',
-      (WidgetTester tester) async {
+  testWidgets('Nested scrollables have a null PrimaryScrollController', (WidgetTester tester) async {
     const Key innerKey = Key('inner');
     final ScrollController primaryScrollController = ScrollController();
     addTearDown(primaryScrollController.dispose);
@@ -406,8 +371,7 @@ void main() {
       ),
     );
 
-    List<TestSemantics> generateSemanticsChildren(
-        {int startHidden = -1, int endHidden = 30}) {
+    List<TestSemantics> generateSemanticsChildren({int startHidden = -1, int endHidden = 30}) {
       final List<TestSemantics> children = <TestSemantics>[];
       for (int index = 0; index < 30; index += 1) {
         final bool isHidden = index <= startHidden || index >= endHidden;
@@ -420,83 +384,68 @@ void main() {
       return children;
     }
 
-    expect(
-        semantics,
-        hasSemantics(
+    expect(semantics, hasSemantics(
+      TestSemantics(
+        children: <TestSemantics>[
           TestSemantics(
-            children: <TestSemantics>[
-              TestSemantics(
-                flags: <SemanticsFlag>[
-                  SemanticsFlag.hasImplicitScrolling,
-                ],
-                actions: <SemanticsAction>[
-                  SemanticsAction.scrollUp,
-                ],
-                children: generateSemanticsChildren(endHidden: 3),
-              ),
+            flags: <SemanticsFlag>[
+              SemanticsFlag.hasImplicitScrolling,
             ],
+            actions: <SemanticsAction>[
+              SemanticsAction.scrollUp,
+            ],
+            children: generateSemanticsChildren(endHidden: 3),
           ),
-          ignoreRect: true,
-          ignoreTransform: true,
-          ignoreId: true,
-        ));
+        ],
+      ),
+      ignoreRect: true, ignoreTransform: true, ignoreId: true,
+    ));
 
     controller.jumpTo(3000.0);
     await tester.pumpAndSettle();
 
-    expect(
-        semantics,
-        hasSemantics(
+    expect(semantics, hasSemantics(
+      TestSemantics(
+        children: <TestSemantics>[
           TestSemantics(
-            children: <TestSemantics>[
-              TestSemantics(
-                flags: <SemanticsFlag>[
-                  SemanticsFlag.hasImplicitScrolling,
-                ],
-                actions: <SemanticsAction>[
-                  SemanticsAction.scrollUp,
-                  SemanticsAction.scrollDown,
-                ],
-                children:
-                    generateSemanticsChildren(startHidden: 14, endHidden: 18),
-              ),
+            flags: <SemanticsFlag>[
+              SemanticsFlag.hasImplicitScrolling,
             ],
+            actions: <SemanticsAction>[
+              SemanticsAction.scrollUp,
+              SemanticsAction.scrollDown,
+            ],
+            children: generateSemanticsChildren(startHidden: 14, endHidden: 18),
           ),
-          ignoreRect: true,
-          ignoreTransform: true,
-          ignoreId: true,
-        ));
+        ],
+      ),
+      ignoreRect: true, ignoreTransform: true, ignoreId: true,
+    ));
 
     controller.jumpTo(6000.0);
     await tester.pumpAndSettle();
 
-    expect(
-        semantics,
-        hasSemantics(
+    expect(semantics, hasSemantics(
+      TestSemantics(
+        children: <TestSemantics>[
           TestSemantics(
-            children: <TestSemantics>[
-              TestSemantics(
-                flags: <SemanticsFlag>[
-                  SemanticsFlag.hasImplicitScrolling,
-                ],
-                actions: <SemanticsAction>[
-                  SemanticsAction.scrollDown,
-                ],
-                children: generateSemanticsChildren(startHidden: 26),
-              ),
+            flags: <SemanticsFlag>[
+              SemanticsFlag.hasImplicitScrolling,
             ],
+            actions: <SemanticsAction>[
+              SemanticsAction.scrollDown,
+            ],
+            children: generateSemanticsChildren(startHidden: 26),
           ),
-          ignoreRect: true,
-          ignoreTransform: true,
-          ignoreId: true,
-        ));
+        ],
+      ),
+      ignoreRect: true, ignoreTransform: true, ignoreId: true,
+    ));
 
     semantics.dispose();
   });
 
-  testWidgets(
-      'SingleChildScrollView semantics clips cover entire child vertical',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView semantics clips cover entire child vertical', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final UniqueKey scrollView = UniqueKey();
@@ -512,8 +461,7 @@ void main() {
         ),
       ),
     );
-    final RenderObject scrollRenderObject =
-        tester.renderObject(find.byKey(scrollView));
+    final RenderObject scrollRenderObject = tester.renderObject(find.byKey(scrollView));
     RenderAbstractViewport? viewport;
     void findsRenderViewPort(RenderObject child) {
       if (viewport != null) {
@@ -525,11 +473,9 @@ void main() {
       }
       child.visitChildren(findsRenderViewPort);
     }
-
     scrollRenderObject.visitChildren(findsRenderViewPort);
     expect(viewport, isNotNull);
-    final RenderObject childRenderObject =
-        tester.renderObject(find.byKey(childBox));
+    final RenderObject childRenderObject = tester.renderObject(find.byKey(childBox));
     Rect semanticsClip = viewport!.describeSemanticsClip(childRenderObject)!;
     expect(semanticsClip.size.height, length);
 
@@ -539,8 +485,7 @@ void main() {
     expect(semanticsClip.size.height, length);
   });
 
-  testWidgets('SingleChildScrollView semantics clips cover entire child',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView semantics clips cover entire child', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final UniqueKey scrollView = UniqueKey();
@@ -557,8 +502,7 @@ void main() {
         ),
       ),
     );
-    final RenderObject scrollRenderObject =
-        tester.renderObject(find.byKey(scrollView));
+    final RenderObject scrollRenderObject = tester.renderObject(find.byKey(scrollView));
     RenderAbstractViewport? viewport;
     void findsRenderViewPort(RenderObject child) {
       if (viewport != null) {
@@ -570,11 +514,9 @@ void main() {
       }
       child.visitChildren(findsRenderViewPort);
     }
-
     scrollRenderObject.visitChildren(findsRenderViewPort);
     expect(viewport, isNotNull);
-    final RenderObject childRenderObject =
-        tester.renderObject(find.byKey(childBox));
+    final RenderObject childRenderObject = tester.renderObject(find.byKey(childBox));
     Rect semanticsClip = viewport!.describeSemanticsClip(childRenderObject)!;
     expect(semanticsClip.size.width, length);
 
@@ -584,11 +526,8 @@ void main() {
     expect(semanticsClip.size.width, length);
   });
 
-  testWidgets(
-      'SingleChildScrollView getOffsetToReveal - will not assert on axis mismatch',
-      (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - will not assert on axis mismatch', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
     await tester.pumpWidget(
@@ -615,17 +554,14 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport =
-        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - down',
-      (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - down', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
     await tester.pumpWidget(
@@ -652,8 +588,7 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport =
-        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -664,21 +599,17 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 540.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 350.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - up',
-      (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - up', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     final List<Widget> children = List<Widget>.generate(20, (int i) {
       return SizedBox(
@@ -706,8 +637,7 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport =
-        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -718,21 +648,17 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 550.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 360.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - right',
-      (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - right', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
 
@@ -761,8 +687,7 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport =
-        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -773,21 +698,17 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 540.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 350.0);
     expect(revealed.rect, const Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - left',
-      (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     final List<Widget> children = List<Widget>.generate(20, (int i) {
       return SizedBox(
@@ -817,8 +738,7 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport =
-        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -829,21 +749,17 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 550.0);
     expect(revealed.rect, const Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 360.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
   });
 
-  testWidgets('Nested SingleChildScrollView showOnScreen',
-      (WidgetTester tester) async {
-    final List<List<Widget>> children =
-        List<List<Widget>>.generate(10, (int x) {
+  testWidgets('Nested SingleChildScrollView showOnScreen', (WidgetTester tester) async {
+    final List<List<Widget>> children = List<List<Widget>>.generate(10, (int x) {
       return List<Widget>.generate(10, (int y) {
         return SizedBox(
           key: UniqueKey(),
@@ -883,11 +799,9 @@ void main() {
             height: 200.0,
             width: 200.0,
             child: SingleChildScrollView(
-              controller: controllerY =
-                  ScrollController(initialScrollOffset: 400.0),
+              controller: controllerY = ScrollController(initialScrollOffset: 400.0),
               child: SingleChildScrollView(
-                controller: controllerX =
-                    ScrollController(initialScrollOffset: 400.0),
+                controller: controllerX = ScrollController(initialScrollOffset: 400.0),
                 scrollDirection: Axis.horizontal,
                 child: Column(
                   children: children.map((List<Widget> widgets) {
@@ -997,9 +911,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Below and right of viewport with animations
-    tester
-        .renderObject(find.byWidget(children[6][6]))
-        .showOnScreen(duration: const Duration(seconds: 2));
+    tester.renderObject(find.byWidget(children[6][6])).showOnScreen(duration: const Duration(seconds: 2));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(tester.hasRunningAnimations, isTrue);
@@ -1015,10 +927,7 @@ void main() {
   group('Nested SingleChildScrollView (same orientation) showOnScreen', () {
     late List<Widget> children;
 
-    Future<void> buildNestedScroller(
-        {required WidgetTester tester,
-        ScrollController? inner,
-        ScrollController? outer}) {
+    Future<void> buildNestedScroller({ required WidgetTester tester, ScrollController? inner, ScrollController? outer }) {
       return tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -1039,8 +948,7 @@ void main() {
                       child: SingleChildScrollView(
                         controller: inner,
                         child: Column(
-                          children: children =
-                              List<Widget>.generate(10, (int i) {
+                          children: children = List<Widget>.generate(10, (int i) {
                             return SizedBox(
                               height: 100.0,
                               width: 300.0,
@@ -1062,8 +970,7 @@ void main() {
       );
     }
 
-    testWidgets('in view in inner, but not in outer',
-        (WidgetTester tester) async {
+    testWidgets('in view in inner, but not in outer', (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
       final ScrollController outer = ScrollController();
@@ -1082,8 +989,7 @@ void main() {
       expect(outer.offset, 100.0);
     });
 
-    testWidgets('not in view of neither inner nor outer',
-        (WidgetTester tester) async {
+    testWidgets('not in view of neither inner nor outer', (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
       final ScrollController outer = ScrollController();
@@ -1103,11 +1009,9 @@ void main() {
     });
 
     testWidgets('in view in inner and outer', (WidgetTester tester) async {
-      final ScrollController inner =
-          ScrollController(initialScrollOffset: 200.0);
+      final ScrollController inner = ScrollController(initialScrollOffset: 200.0);
       addTearDown(inner.dispose);
-      final ScrollController outer =
-          ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer = ScrollController(initialScrollOffset: 200.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1123,13 +1027,10 @@ void main() {
       expect(inner.offset, 200.0);
     });
 
-    testWidgets('inner shown in outer, but item not visible',
-        (WidgetTester tester) async {
-      final ScrollController inner =
-          ScrollController(initialScrollOffset: 200.0);
+    testWidgets('inner shown in outer, but item not visible', (WidgetTester tester) async {
+      final ScrollController inner = ScrollController(initialScrollOffset: 200.0);
       addTearDown(inner.dispose);
-      final ScrollController outer =
-          ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer = ScrollController(initialScrollOffset: 200.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1145,12 +1046,10 @@ void main() {
       expect(inner.offset, 400.0);
     });
 
-    testWidgets('inner half shown in outer, item only visible in inner',
-        (WidgetTester tester) async {
+    testWidgets('inner half shown in outer, item only visible in inner', (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
-      final ScrollController outer =
-          ScrollController(initialScrollOffset: 100.0);
+      final ScrollController outer = ScrollController(initialScrollOffset: 100.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1168,8 +1067,7 @@ void main() {
   });
 
   testWidgets('keyboardDismissBehavior tests', (WidgetTester tester) async {
-    final List<FocusNode> focusNodes =
-        List<FocusNode>.generate(50, (int i) => FocusNode());
+    final List<FocusNode> focusNodes = List<FocusNode>.generate(50, (int i) => FocusNode());
     addTearDown(() {
       for (final FocusNode node in focusNodes) {
         node.dispose();
@@ -1222,8 +1120,7 @@ void main() {
     expect(textField.focusNode!.hasFocus, isTrue);
   });
 
-  testWidgets('keyboardDismissBehavior.OnDrag with drawer tests',
-      (WidgetTester tester) async {
+  testWidgets('keyboardDismissBehavior.OnDrag with drawer tests', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 
     await tester.pumpWidget(
@@ -1231,17 +1128,19 @@ void main() {
         home: Scaffold(
           key: scaffoldKey,
           drawer: Container(),
-          body: Column(children: <Widget>[
-            const TextField(),
-            Expanded(
-              child: SingleChildScrollView(
-                  keyboardDismissBehavior:
-                      ScrollViewKeyboardDismissBehavior.onDrag,
+          body: Column(
+            children: <Widget>[
+              const TextField(),
+              Expanded(
+                child: SingleChildScrollView(
+                  keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
                   child: Container(
                     height: 1000,
-                  )),
-            ),
-          ]),
+                  )
+                ),
+              ),
+            ]
+          ),
         ),
       ),
     );
@@ -1251,8 +1150,7 @@ void main() {
     await tester.tap(finder);
     expect(tester.testTextInput.isVisible, isTrue);
 
-    await tester.drag(
-        find.byType(SingleChildScrollView).first, const Offset(0.0, -40.0));
+    await tester.drag(find.byType(SingleChildScrollView).first, const Offset(0.0, -40.0));
     await tester.pumpAndSettle();
 
     expect(tester.testTextInput.isVisible, isFalse);

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -115,27 +115,19 @@ void main() {
           body: SingleChildScrollView(
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                ...List<Widget>.generate(
-                  10,
-                  (int index) => Text(index.toString()),
-                ),
                 Autocomplete<String>(
                   optionsBuilder: (TextEditingValue textEditingValue) {
-                    return <String>[
-                      'flutter',
-                      'dart',
-                      'pub',
-                    ].where((String option) {
-                      return option
-                          .contains(textEditingValue.text.toLowerCase());
+                    return <String>['One', 'Two', 'Three'].where((String option) {
+                      return option.contains(textEditingValue.text.toLowerCase());
                     }).toList();
                   },
-                ),
-                ...List<Widget>.generate(
-                  50,
-                  (int index) => Text(index.toString()),
+                  fieldViewBuilder: (BuildContext context, TextEditingController textEditingController, FocusNode focusNode, VoidCallback onFieldSubmitted) {
+                    return TextField(
+                      controller: textEditingController,
+                      focusNode: focusNode,
+                    );
+                  },
                 ),
               ],
             ),
@@ -143,9 +135,19 @@ void main() {
         ),
       ),
     );
-    for (int i = 10; i < 20; i++) {
-      expect(find.text(i.toString()), findsOneWidget);
-    }
+    final Finder textFieldFinder = find.byType(TextField);
+    expect(textFieldFinder, findsOneWidget);
+
+    await tester.tap(textFieldFinder);
+    await tester.pump();
+
+    final TextField textField = tester.widget(textFieldFinder);
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+    await tester.drag(textFieldFinder, const Offset(0, 500));
+    await tester.pumpAndSettle();
+
+    expect(textField.focusNode!.nextFocus(), isTrue);
   });
 
   testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -148,10 +148,8 @@ void main() {
     await tester.drag(textFieldFinder, const Offset(0, 500));
     await tester.pumpAndSettle();
 
-    expect(textField.focusNode!.hasFocus, isTrue);
-
-    final Finder widgetFinder = find.byType(TextField);
-    expect(widgetFinder, findsExactly(1));
+    expect(textField.focusNode!.nextFocus(), isTrue);
+    expect(textFieldFinder, findsExactly(1));
 
   });
 

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -107,50 +107,46 @@ void main() {
     expect(context.clipBehavior, equals(Clip.hardEdge));
   });
 
-  testWidgets('SingleChildScrollView ScrollViewKeyboardDismissBehavior.onDrag test',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SingleChildScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            child: Column(
-              children: <Widget>[
-                Autocomplete<String>(
-                  optionsBuilder: (TextEditingValue textEditingValue) {
-                    return <String>['One', 'Two', 'Three'].where((String option) {
-                      return option.contains(textEditingValue.text.toLowerCase());
-                    }).toList();
-                  },
-                  fieldViewBuilder: (BuildContext context, TextEditingController textEditingController, FocusNode focusNode, VoidCallback onFieldSubmitted) {
-                    return TextField(
-                      controller: textEditingController,
-                      focusNode: focusNode,
-                      onTapOutside:(void v) => FocusScope.of(context).requestFocus(FocusNode()),
-                    );
-                  },
-                ),
-              ],
-            ),
+testWidgets('SingleChildScrollView ScrollViewKeyboardDismissBehavior.onDrag test', (WidgetTester tester) async {
+    final Widget testWidget = MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          child: Column(
+            children: <Widget>[
+              Autocomplete<String>(
+                optionsBuilder: (TextEditingValue textEditingValue) {
+                  if (textEditingValue.text.isEmpty) {
+                    return const Iterable<String>.empty();
+                  }
+                  return<String>['apple', 'banana', 'cherry']
+                      .where((String option) {
+                    return option.contains(textEditingValue.text.toLowerCase());
+                  });
+                },
+              ),
+              Container(height: 5000.0),
+            ],
           ),
         ),
       ),
     );
-    final Finder textFieldFinder = find.byType(TextField);
-    expect(textFieldFinder, findsOneWidget);
 
-    await tester.tap(textFieldFinder);
+    await tester.pumpWidget(testWidget);
+    await tester.tap(find.byType(Autocomplete<String>));
     await tester.pump();
 
-    final TextField textField = tester.widget(textFieldFinder);
-    expect(textField.focusNode!.hasFocus, isTrue);
+    await tester.enterText(find.byType(RawAutocomplete<String>),'a');
+    await tester.pump();
 
-    await tester.drag(textFieldFinder, const Offset(0, 500));
-    await tester.pumpAndSettle();
+    expect(find.text('apple'), findsOneWidget);
+    expect(find.text('banana'), findsOneWidget);
 
-    expect(textField.focusNode!.nextFocus(), isTrue);
-    expect(textFieldFinder, findsExactly(1));
+    await tester.drag(find.byType(SingleChildScrollView), const Offset(0, -1000));
+    await tester.pump();
 
+    expect(find.text('apple'), findsNothing);
+    expect(find.text('banana'), findsNothing);
   });
 
   testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -126,6 +126,7 @@ void main() {
                     return TextField(
                       controller: textEditingController,
                       focusNode: focusNode,
+                      onTapOutside:(void v) => FocusScope.of(context).requestFocus(FocusNode()),
                     );
                   },
                 ),
@@ -147,7 +148,11 @@ void main() {
     await tester.drag(textFieldFinder, const Offset(0, 500));
     await tester.pumpAndSettle();
 
-    expect(textField.focusNode!.nextFocus(), isTrue);
+    expect(textField.focusNode!.hasFocus, isTrue);
+
+    final Finder widgetFinder = find.byType(TextField);
+    expect(widgetFinder, findsExactly(1));
+
   });
 
   testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -16,13 +16,14 @@ class TestScrollPosition extends ScrollPositionWithSingleContext {
     double super.initialPixels,
     super.oldPosition,
   }) : super(
-    context: state,
-  );
+          context: state,
+        );
 }
 
 class TestScrollController extends ScrollController {
   @override
-  ScrollPosition createScrollPosition(ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
+  ScrollPosition createScrollPosition(ScrollPhysics physics,
+      ScrollContext context, ScrollPosition? oldPosition) {
     return TestScrollPosition(
       physics: physics,
       state: context,
@@ -32,7 +33,8 @@ class TestScrollController extends ScrollController {
   }
 }
 
-Widget primaryScrollControllerBoilerplate({ required Widget child, required ScrollController controller }) {
+Widget primaryScrollControllerBoilerplate(
+    {required Widget child, required ScrollController controller}) {
   return Directionality(
     textDirection: TextDirection.ltr,
     child: MediaQuery(
@@ -46,7 +48,8 @@ Widget primaryScrollControllerBoilerplate({ required Widget child, required Scro
 }
 
 void main() {
-  testWidgets('SingleChildScrollView overflow and clipRect test', (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView overflow and clipRect test',
+      (WidgetTester tester) async {
     // the test widowSize is Size(800.0, 600.0)
     await tester.pumpWidget(
       Directionality(
@@ -58,8 +61,13 @@ void main() {
     );
 
     // 1st, check that the render object has received the default clip behavior.
-    final dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
-    expect(renderObject.clipBehavior, equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
+    final dynamic renderObject = tester.allRenderObjects
+        .where((RenderObject o) =>
+            o.runtimeType.toString() == '_RenderSingleChildViewport')
+        .first;
+    // ignore: avoid_dynamic_calls
+    expect(renderObject.clipBehavior,
+        equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
 
     // 2nd, height == widow.height test: check that the painting context does not call pushClipRect .
     TestClipPaintingContext context = TestClipPaintingContext();
@@ -107,12 +115,60 @@ void main() {
     expect(context.clipBehavior, equals(Clip.hardEdge));
   });
 
-  testWidgets('SingleChildScrollView respects clipBehavior', (WidgetTester tester) async {
-    await tester.pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
+  testWidgets('SingleChildScrollView with Autocomplete test',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                ...List<Widget>.generate(
+                  10,
+                  (int index) => Text(index.toString()),
+                ),
+                Autocomplete<String>(
+                  optionsBuilder: (TextEditingValue textEditingValue) {
+                    return <String>[
+                      'aardvark',
+                      'bobcat',
+                      'chameleon',
+                    ].where((String option) {
+                      return option
+                          .contains(textEditingValue.text.toLowerCase());
+                    }).toList();
+                  },
+                ),
+                ...List<Widget>.generate(
+                  50,
+                  (int index) => Text(index.toString()),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    for (int i = 10; i < 20; i++) {
+      expect(find.text(i.toString()), findsOneWidget);
+    }
+  });
+
+  testWidgets('SingleChildScrollView respects clipBehavior',
+      (WidgetTester tester) async {
+    await tester
+        .pumpWidget(SingleChildScrollView(child: Container(height: 2000.0)));
 
     // 1st, check that the render object has received the default clip behavior.
-    final dynamic renderObject = tester.allRenderObjects.where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChildViewport').first;
-    expect(renderObject.clipBehavior, equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
+    final dynamic renderObject = tester.allRenderObjects
+        .where((RenderObject o) =>
+            o.runtimeType.toString() == '_RenderSingleChildViewport')
+        .first;
+    // ignore: avoid_dynamic_calls
+    expect(renderObject.clipBehavior,
+        equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
 
     // 2nd, check that the painting context has received the default clip behavior.
     final TestClipPaintingContext context = TestClipPaintingContext();
@@ -121,15 +177,19 @@ void main() {
 
     // 3rd, check that the underlying Scrollable has the same clipBehavior
     // Regression test for https://github.com/flutter/flutter/issues/133330
-    Finder scrollable = find.byWidgetPredicate((Widget widget) => widget is Scrollable);
+    Finder scrollable =
+        find.byWidgetPredicate((Widget widget) => widget is Scrollable);
     expect(
       (tester.widget(scrollable) as Scrollable).clipBehavior,
       Clip.hardEdge,
     );
 
     // 4th, pump a new widget to check that the render object can update its clip behavior.
-    await tester.pumpWidget(SingleChildScrollView(clipBehavior: Clip.antiAlias, child: Container(height: 2000.0)));
-    expect(renderObject.clipBehavior, equals(Clip.antiAlias)); // ignore: avoid_dynamic_calls
+    await tester.pumpWidget(SingleChildScrollView(
+        clipBehavior: Clip.antiAlias, child: Container(height: 2000.0)));
+    // ignore: avoid_dynamic_calls
+    expect(renderObject.clipBehavior,
+        equals(Clip.antiAlias)); // ignore: avoid_dynamic_calls
 
     // 5th, check that a non-default clip behavior can be sent to the painting context.
     renderObject.paint(context, Offset.zero); // ignore: avoid_dynamic_calls
@@ -137,14 +197,16 @@ void main() {
 
     // 6th, check that the underlying Scrollable has the same clipBehavior
     // Regression test for https://github.com/flutter/flutter/issues/133330
-    scrollable = find.byWidgetPredicate((Widget widget) => widget is Scrollable);
+    scrollable =
+        find.byWidgetPredicate((Widget widget) => widget is Scrollable);
     expect(
       (tester.widget(scrollable) as Scrollable).clipBehavior,
       Clip.antiAlias,
     );
   });
 
-  testWidgets('SingleChildScrollView control test', (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView control test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(SingleChildScrollView(
       child: Container(
         height: 2000.0,
@@ -155,12 +217,14 @@ void main() {
     final RenderBox box = tester.renderObject(find.byType(Container));
     expect(box.localToGlobal(Offset.zero), equals(Offset.zero));
 
-    await tester.drag(find.byType(SingleChildScrollView), const Offset(-200.0, -200.0));
+    await tester.drag(
+        find.byType(SingleChildScrollView), const Offset(-200.0, -200.0));
 
     expect(box.localToGlobal(Offset.zero), equals(const Offset(0.0, -200.0)));
   });
 
-  testWidgets('Changing controllers changes scroll position', (WidgetTester tester) async {
+  testWidgets('Changing controllers changes scroll position',
+      (WidgetTester tester) async {
     final TestScrollController controller = TestScrollController();
     addTearDown(controller.dispose);
 
@@ -183,7 +247,8 @@ void main() {
     expect(scrollable.position, isA<TestScrollPosition>());
   });
 
-  testWidgets('Sets PrimaryScrollController when primary', (WidgetTester tester) async {
+  testWidgets('Sets PrimaryScrollController when primary',
+      (WidgetTester tester) async {
     final ScrollController primaryScrollController = ScrollController();
     addTearDown(primaryScrollController.dispose);
     await tester.pumpWidget(PrimaryScrollController(
@@ -201,8 +266,9 @@ void main() {
     expect(scrollable.controller, primaryScrollController);
   });
 
-
-  testWidgets('Changing scroll controller inside dirty layout builder does not assert', (WidgetTester tester) async {
+  testWidgets(
+      'Changing scroll controller inside dirty layout builder does not assert',
+      (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
 
@@ -240,17 +306,22 @@ void main() {
     ));
   });
 
-  testWidgets('Vertical SingleChildScrollViews are not primary by default', (WidgetTester tester) async {
+  testWidgets('Vertical SingleChildScrollViews are not primary by default',
+      (WidgetTester tester) async {
     const SingleChildScrollView view = SingleChildScrollView();
     expect(view.primary, isNull);
   });
 
-  testWidgets('Horizontal SingleChildScrollViews are not primary by default', (WidgetTester tester) async {
-    const SingleChildScrollView view = SingleChildScrollView(scrollDirection: Axis.horizontal);
+  testWidgets('Horizontal SingleChildScrollViews are not primary by default',
+      (WidgetTester tester) async {
+    const SingleChildScrollView view =
+        SingleChildScrollView(scrollDirection: Axis.horizontal);
     expect(view.primary, isNull);
   });
 
-  testWidgets('SingleChildScrollViews with controllers are not primary by default', (WidgetTester tester) async {
+  testWidgets(
+      'SingleChildScrollViews with controllers are not primary by default',
+      (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final SingleChildScrollView view = SingleChildScrollView(
@@ -259,7 +330,9 @@ void main() {
     expect(view.primary, isNull);
   });
 
-  testWidgets('Vertical SingleChildScrollViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
+  testWidgets(
+      'Vertical SingleChildScrollViews use PrimaryScrollController by default on mobile',
+      (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(primaryScrollControllerBoilerplate(
@@ -269,7 +342,9 @@ void main() {
     expect(controller.hasClients, isTrue);
   }, variant: TargetPlatformVariant.mobile());
 
-  testWidgets("Vertical SingleChildScrollViews don't use PrimaryScrollController by default on desktop", (WidgetTester tester) async {
+  testWidgets(
+      "Vertical SingleChildScrollViews don't use PrimaryScrollController by default on desktop",
+      (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(primaryScrollControllerBoilerplate(
@@ -279,7 +354,8 @@ void main() {
     expect(controller.hasClients, isFalse);
   }, variant: TargetPlatformVariant.desktop());
 
-  testWidgets('Nested scrollables have a null PrimaryScrollController', (WidgetTester tester) async {
+  testWidgets('Nested scrollables have a null PrimaryScrollController',
+      (WidgetTester tester) async {
     const Key innerKey = Key('inner');
     final ScrollController primaryScrollController = ScrollController();
     addTearDown(primaryScrollController.dispose);
@@ -330,7 +406,8 @@ void main() {
       ),
     );
 
-    List<TestSemantics> generateSemanticsChildren({int startHidden = -1, int endHidden = 30}) {
+    List<TestSemantics> generateSemanticsChildren(
+        {int startHidden = -1, int endHidden = 30}) {
       final List<TestSemantics> children = <TestSemantics>[];
       for (int index = 0; index < 30; index += 1) {
         final bool isHidden = index <= startHidden || index >= endHidden;
@@ -343,68 +420,83 @@ void main() {
       return children;
     }
 
-    expect(semantics, hasSemantics(
-      TestSemantics(
-        children: <TestSemantics>[
+    expect(
+        semantics,
+        hasSemantics(
           TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.hasImplicitScrolling,
+            children: <TestSemantics>[
+              TestSemantics(
+                flags: <SemanticsFlag>[
+                  SemanticsFlag.hasImplicitScrolling,
+                ],
+                actions: <SemanticsAction>[
+                  SemanticsAction.scrollUp,
+                ],
+                children: generateSemanticsChildren(endHidden: 3),
+              ),
             ],
-            actions: <SemanticsAction>[
-              SemanticsAction.scrollUp,
-            ],
-            children: generateSemanticsChildren(endHidden: 3),
           ),
-        ],
-      ),
-      ignoreRect: true, ignoreTransform: true, ignoreId: true,
-    ));
+          ignoreRect: true,
+          ignoreTransform: true,
+          ignoreId: true,
+        ));
 
     controller.jumpTo(3000.0);
     await tester.pumpAndSettle();
 
-    expect(semantics, hasSemantics(
-      TestSemantics(
-        children: <TestSemantics>[
+    expect(
+        semantics,
+        hasSemantics(
           TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.hasImplicitScrolling,
+            children: <TestSemantics>[
+              TestSemantics(
+                flags: <SemanticsFlag>[
+                  SemanticsFlag.hasImplicitScrolling,
+                ],
+                actions: <SemanticsAction>[
+                  SemanticsAction.scrollUp,
+                  SemanticsAction.scrollDown,
+                ],
+                children:
+                    generateSemanticsChildren(startHidden: 14, endHidden: 18),
+              ),
             ],
-            actions: <SemanticsAction>[
-              SemanticsAction.scrollUp,
-              SemanticsAction.scrollDown,
-            ],
-            children: generateSemanticsChildren(startHidden: 14, endHidden: 18),
           ),
-        ],
-      ),
-      ignoreRect: true, ignoreTransform: true, ignoreId: true,
-    ));
+          ignoreRect: true,
+          ignoreTransform: true,
+          ignoreId: true,
+        ));
 
     controller.jumpTo(6000.0);
     await tester.pumpAndSettle();
 
-    expect(semantics, hasSemantics(
-      TestSemantics(
-        children: <TestSemantics>[
+    expect(
+        semantics,
+        hasSemantics(
           TestSemantics(
-            flags: <SemanticsFlag>[
-              SemanticsFlag.hasImplicitScrolling,
+            children: <TestSemantics>[
+              TestSemantics(
+                flags: <SemanticsFlag>[
+                  SemanticsFlag.hasImplicitScrolling,
+                ],
+                actions: <SemanticsAction>[
+                  SemanticsAction.scrollDown,
+                ],
+                children: generateSemanticsChildren(startHidden: 26),
+              ),
             ],
-            actions: <SemanticsAction>[
-              SemanticsAction.scrollDown,
-            ],
-            children: generateSemanticsChildren(startHidden: 26),
           ),
-        ],
-      ),
-      ignoreRect: true, ignoreTransform: true, ignoreId: true,
-    ));
+          ignoreRect: true,
+          ignoreTransform: true,
+          ignoreId: true,
+        ));
 
     semantics.dispose();
   });
 
-  testWidgets('SingleChildScrollView semantics clips cover entire child vertical', (WidgetTester tester) async {
+  testWidgets(
+      'SingleChildScrollView semantics clips cover entire child vertical',
+      (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final UniqueKey scrollView = UniqueKey();
@@ -420,7 +512,8 @@ void main() {
         ),
       ),
     );
-    final RenderObject scrollRenderObject = tester.renderObject(find.byKey(scrollView));
+    final RenderObject scrollRenderObject =
+        tester.renderObject(find.byKey(scrollView));
     RenderAbstractViewport? viewport;
     void findsRenderViewPort(RenderObject child) {
       if (viewport != null) {
@@ -432,9 +525,11 @@ void main() {
       }
       child.visitChildren(findsRenderViewPort);
     }
+
     scrollRenderObject.visitChildren(findsRenderViewPort);
     expect(viewport, isNotNull);
-    final RenderObject childRenderObject = tester.renderObject(find.byKey(childBox));
+    final RenderObject childRenderObject =
+        tester.renderObject(find.byKey(childBox));
     Rect semanticsClip = viewport!.describeSemanticsClip(childRenderObject)!;
     expect(semanticsClip.size.height, length);
 
@@ -444,7 +539,8 @@ void main() {
     expect(semanticsClip.size.height, length);
   });
 
-  testWidgets('SingleChildScrollView semantics clips cover entire child', (WidgetTester tester) async {
+  testWidgets('SingleChildScrollView semantics clips cover entire child',
+      (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
     final UniqueKey scrollView = UniqueKey();
@@ -461,7 +557,8 @@ void main() {
         ),
       ),
     );
-    final RenderObject scrollRenderObject = tester.renderObject(find.byKey(scrollView));
+    final RenderObject scrollRenderObject =
+        tester.renderObject(find.byKey(scrollView));
     RenderAbstractViewport? viewport;
     void findsRenderViewPort(RenderObject child) {
       if (viewport != null) {
@@ -473,9 +570,11 @@ void main() {
       }
       child.visitChildren(findsRenderViewPort);
     }
+
     scrollRenderObject.visitChildren(findsRenderViewPort);
     expect(viewport, isNotNull);
-    final RenderObject childRenderObject = tester.renderObject(find.byKey(childBox));
+    final RenderObject childRenderObject =
+        tester.renderObject(find.byKey(childBox));
     Rect semanticsClip = viewport!.describeSemanticsClip(childRenderObject)!;
     expect(semanticsClip.size.width, length);
 
@@ -485,8 +584,11 @@ void main() {
     expect(semanticsClip.size.width, length);
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - will not assert on axis mismatch', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
+  testWidgets(
+      'SingleChildScrollView getOffsetToReveal - will not assert on axis mismatch',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
     await tester.pumpWidget(
@@ -513,14 +615,17 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport =
+        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - down', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - down',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
     await tester.pumpWidget(
@@ -547,7 +652,8 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport =
+        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -558,17 +664,21 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 540.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 350.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - up', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - up',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     final List<Widget> children = List<Widget>.generate(20, (int i) {
       return SizedBox(
@@ -596,7 +706,8 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport =
+        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -607,17 +718,21 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 550.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 360.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - right', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - right',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
 
@@ -646,7 +761,8 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport =
+        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -657,17 +773,21 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 540.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 350.0);
     expect(revealed.rect, const Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
   });
 
-  testWidgets('SingleChildScrollView getOffsetToReveal - left', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
+  testWidgets('SingleChildScrollView getOffsetToReveal - left',
+      (WidgetTester tester) async {
+    final ScrollController controller =
+        ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     final List<Widget> children = List<Widget>.generate(20, (int i) {
       return SizedBox(
@@ -697,7 +817,8 @@ void main() {
       ),
     );
 
-    final RenderAbstractViewport viewport = tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
+    final RenderAbstractViewport viewport =
+        tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
     RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0);
@@ -708,17 +829,21 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 0.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 550.0);
     expect(revealed.rect, const Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed = viewport.getOffsetToReveal(target, 1.0,
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 360.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
   });
 
-  testWidgets('Nested SingleChildScrollView showOnScreen', (WidgetTester tester) async {
-    final List<List<Widget>> children = List<List<Widget>>.generate(10, (int x) {
+  testWidgets('Nested SingleChildScrollView showOnScreen',
+      (WidgetTester tester) async {
+    final List<List<Widget>> children =
+        List<List<Widget>>.generate(10, (int x) {
       return List<Widget>.generate(10, (int y) {
         return SizedBox(
           key: UniqueKey(),
@@ -758,9 +883,11 @@ void main() {
             height: 200.0,
             width: 200.0,
             child: SingleChildScrollView(
-              controller: controllerY = ScrollController(initialScrollOffset: 400.0),
+              controller: controllerY =
+                  ScrollController(initialScrollOffset: 400.0),
               child: SingleChildScrollView(
-                controller: controllerX = ScrollController(initialScrollOffset: 400.0),
+                controller: controllerX =
+                    ScrollController(initialScrollOffset: 400.0),
                 scrollDirection: Axis.horizontal,
                 child: Column(
                   children: children.map((List<Widget> widgets) {
@@ -870,7 +997,9 @@ void main() {
     await tester.pumpAndSettle();
 
     // Below and right of viewport with animations
-    tester.renderObject(find.byWidget(children[6][6])).showOnScreen(duration: const Duration(seconds: 2));
+    tester
+        .renderObject(find.byWidget(children[6][6]))
+        .showOnScreen(duration: const Duration(seconds: 2));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(tester.hasRunningAnimations, isTrue);
@@ -886,7 +1015,10 @@ void main() {
   group('Nested SingleChildScrollView (same orientation) showOnScreen', () {
     late List<Widget> children;
 
-    Future<void> buildNestedScroller({ required WidgetTester tester, ScrollController? inner, ScrollController? outer }) {
+    Future<void> buildNestedScroller(
+        {required WidgetTester tester,
+        ScrollController? inner,
+        ScrollController? outer}) {
       return tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -907,7 +1039,8 @@ void main() {
                       child: SingleChildScrollView(
                         controller: inner,
                         child: Column(
-                          children: children = List<Widget>.generate(10, (int i) {
+                          children: children =
+                              List<Widget>.generate(10, (int i) {
                             return SizedBox(
                               height: 100.0,
                               width: 300.0,
@@ -929,7 +1062,8 @@ void main() {
       );
     }
 
-    testWidgets('in view in inner, but not in outer', (WidgetTester tester) async {
+    testWidgets('in view in inner, but not in outer',
+        (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
       final ScrollController outer = ScrollController();
@@ -948,7 +1082,8 @@ void main() {
       expect(outer.offset, 100.0);
     });
 
-    testWidgets('not in view of neither inner nor outer', (WidgetTester tester) async {
+    testWidgets('not in view of neither inner nor outer',
+        (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
       final ScrollController outer = ScrollController();
@@ -968,9 +1103,11 @@ void main() {
     });
 
     testWidgets('in view in inner and outer', (WidgetTester tester) async {
-      final ScrollController inner = ScrollController(initialScrollOffset: 200.0);
+      final ScrollController inner =
+          ScrollController(initialScrollOffset: 200.0);
       addTearDown(inner.dispose);
-      final ScrollController outer = ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer =
+          ScrollController(initialScrollOffset: 200.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -986,10 +1123,13 @@ void main() {
       expect(inner.offset, 200.0);
     });
 
-    testWidgets('inner shown in outer, but item not visible', (WidgetTester tester) async {
-      final ScrollController inner = ScrollController(initialScrollOffset: 200.0);
+    testWidgets('inner shown in outer, but item not visible',
+        (WidgetTester tester) async {
+      final ScrollController inner =
+          ScrollController(initialScrollOffset: 200.0);
       addTearDown(inner.dispose);
-      final ScrollController outer = ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer =
+          ScrollController(initialScrollOffset: 200.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1005,10 +1145,12 @@ void main() {
       expect(inner.offset, 400.0);
     });
 
-    testWidgets('inner half shown in outer, item only visible in inner', (WidgetTester tester) async {
+    testWidgets('inner half shown in outer, item only visible in inner',
+        (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
-      final ScrollController outer = ScrollController(initialScrollOffset: 100.0);
+      final ScrollController outer =
+          ScrollController(initialScrollOffset: 100.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1026,7 +1168,8 @@ void main() {
   });
 
   testWidgets('keyboardDismissBehavior tests', (WidgetTester tester) async {
-    final List<FocusNode> focusNodes = List<FocusNode>.generate(50, (int i) => FocusNode());
+    final List<FocusNode> focusNodes =
+        List<FocusNode>.generate(50, (int i) => FocusNode());
     addTearDown(() {
       for (final FocusNode node in focusNodes) {
         node.dispose();
@@ -1079,7 +1222,8 @@ void main() {
     expect(textField.focusNode!.hasFocus, isTrue);
   });
 
-  testWidgets('keyboardDismissBehavior.OnDrag with drawer tests', (WidgetTester tester) async {
+  testWidgets('keyboardDismissBehavior.OnDrag with drawer tests',
+      (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 
     await tester.pumpWidget(
@@ -1087,19 +1231,17 @@ void main() {
         home: Scaffold(
           key: scaffoldKey,
           drawer: Container(),
-          body: Column(
-            children: <Widget>[
-              const TextField(),
-              Expanded(
-                child: SingleChildScrollView(
-                  keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          body: Column(children: <Widget>[
+            const TextField(),
+            Expanded(
+              child: SingleChildScrollView(
+                  keyboardDismissBehavior:
+                      ScrollViewKeyboardDismissBehavior.onDrag,
                   child: Container(
                     height: 1000,
-                  )
-                ),
-              ),
-            ]
-          ),
+                  )),
+            ),
+          ]),
         ),
       ),
     );
@@ -1109,7 +1251,8 @@ void main() {
     await tester.tap(finder);
     expect(tester.testTextInput.isVisible, isTrue);
 
-    await tester.drag(find.byType(SingleChildScrollView).first, const Offset(0.0, -40.0));
+    await tester.drag(
+        find.byType(SingleChildScrollView).first, const Offset(0.0, -40.0));
     await tester.pumpAndSettle();
 
     expect(tester.testTextInput.isVisible, isFalse);


### PR DESCRIPTION
In windowsx Linux, MacOs `ScrollController().position.pixels ` will not recognize mouse pointer or scroll wheel of mouse if it's scrolled or not until its tapped on screen.
but for feature we just need to check if focus if there or not.

Now it is working for android,website,windows,macos and linux
closes #150048 
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

