### PR TITLE
Use `Isolate.packageConfigSync! to locate the packageconfig of flutter tools

### DIFF
--- a/packages/flutter_tools/lib/src/dart/package_map.dart
+++ b/packages/flutter_tools/lib/src/dart/package_map.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:package_config/package_config.dart';
@@ -9,6 +10,11 @@ import 'package:package_config/package_config.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
+
+/// Loads the package configuration of the current isolate.
+Future<PackageConfig> currentPackageConfig() async {
+  return loadPackageConfigUri(Isolate.packageConfigSync!);
+}
 
 /// Load the package configuration from [file] or throws a [ToolExit]
 /// if the operation would fail.

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -1222,14 +1222,7 @@ void log(logging.LogRecord event) {
 
 Future<Directory> _loadDwdsDirectory(
     FileSystem fileSystem, Logger logger) async {
-  final String toolPackagePath =
-      fileSystem.path.join(Cache.flutterRoot!, 'packages', 'flutter_tools');
-  final String packageFilePath =
-      fileSystem.path.join(toolPackagePath, '.dart_tool', 'package_config.json');
-  final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-    fileSystem.file(packageFilePath),
-    logger: logger,
-  );
+  final PackageConfig packageConfig = await currentPackageConfig();
   return fileSystem.directory(packageConfig['dwds']!.packageUriRoot);
 }
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -175,16 +175,7 @@ class FlutterWebPlatform extends PlatformPlugin {
   }) async {
     final shelf.Server server = await serverFactory();
     if (testPackageUri == null) {
-      final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-        fileSystem.file(fileSystem.path.join(
-          Cache.flutterRoot!,
-          'packages',
-          'flutter_tools',
-          '.dart_tool',
-          'package_config.json',
-        )),
-        logger: logger,
-      );
+      final PackageConfig packageConfig = await currentPackageConfig();
       testPackageUri = packageConfig['test']!.packageUriRoot;
     }
     final File testDartJs = fileSystem.file(fileSystem.path.join(


### PR DESCRIPTION
This is a small refactor.

Using `loadPackageConfigWithLogging` seems wrong. We should be able to assume that the flutter_tool package_config is in place.

Warm-up for https://github.com/flutter/flutter/issues/150196